### PR TITLE
Bump sleep times during tests to 100ms.

### DIFF
--- a/src/rabbit_tests.erl
+++ b/src/rabbit_tests.erl
@@ -1553,7 +1553,7 @@ test_logs_working(MainLogFile, SaslLogFile) ->
     ok = rabbit_log:error("foo bar"),
     ok = error_logger:error_report(crash_report, [foo, bar]),
     %% give the error loggers some time to catch up
-    timer:sleep(50),
+    timer:sleep(100),
     [true, true] = non_empty_files([MainLogFile, SaslLogFile]),
     ok.
 

--- a/src/test_sup.erl
+++ b/src/test_sup.erl
@@ -33,10 +33,10 @@ test_supervisor_delayed_restart() ->
 test_supervisor_delayed_restart(SupPid) ->
     ok = ping_child(SupPid),
     ok = exit_child(SupPid),
-    timer:sleep(10),
+    timer:sleep(100),
     ok = ping_child(SupPid),
     ok = exit_child(SupPid),
-    timer:sleep(10),
+    timer:sleep(100),
     timeout = ping_child(SupPid),
     timer:sleep(1010),
     ok = ping_child(SupPid),


### PR DESCRIPTION
This fixes timing issues I was seeing on OpenBSD. Solution pointed out by Matthew Sackman.

You've got my CLA on file already.
