### PR TITLE
eprotonosupport

### DIFF
--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -447,6 +447,7 @@ ipv6_status(TestPort) ->
                                                    single_stack;
                         %% IPv6-only machine. Welcome to the future.
                         {error, eafnosupport}   -> ipv6_only;
+                        {error, eprotonosupport}-> ipv6_only;
                         %% Dual stack machine with something already
                         %% on IPv4.
                         {error, _}              -> ipv6_status(TestPort + 1)
@@ -454,6 +455,9 @@ ipv6_status(TestPort) ->
             end;
         {error, eafnosupport} ->
             %% IPv4-only machine. Welcome to the 90s.
+            ipv4_only;
+        {error, eprotonosupport} ->
+            %% IPv4-only machine. Welcome to the 90s (or a minimal jail ;).
             ipv4_only;
         {error, _} ->
             %% Port in use


### PR DESCRIPTION
In a minimal FreeBSD jail this change was necessary to avoid looping through thousands of ports before failing :-P. Discovered during make test.
