### PR TITLE
Update Debian init script to use --background flag on start-stop-daemon ...

### DIFF
--- a/packaging/debs/Debian/debian/rabbitmq-server.init
+++ b/packaging/debs/Debian/debian/rabbitmq-server.init
@@ -61,9 +61,10 @@ start_rabbitmq () {
         RABBITMQ_PID_FILE=$PID_FILE start-stop-daemon --quiet \
             --chuid rabbitmq --start --exec $DAEMON \
             --pidfile "$RABBITMQ_PID_FILE" \
+            --background \
             > "${INIT_LOG_DIR}/startup_log" \
             2> "${INIT_LOG_DIR}/startup_err" \
-            0<&- &
+            0<&-
         $CONTROL wait $PID_FILE >/dev/null 2>&1
         RETVAL=$?
         set -e


### PR DESCRIPTION
...to fork and background instead of just backgrounding.

The change from `setsid` in 2.7.1 to `start-stop-daemon` in 2.8.0 introduced a regression, removing a necessary process fork. It's difficult to recreate the scenario where this is needed, but it is reproducible if bootstrapping a RabbitMQ server using Chef and Opscode's RabbitMQ cookbook.
