### PR TITLE
Expire messages more frequently

### DIFF
--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -23,6 +23,7 @@
 -define(UNSENT_MESSAGE_LIMIT,          200).
 -define(SYNC_INTERVAL,                 25). %% milliseconds
 -define(RAM_DURATION_UPDATE_INTERVAL,  5000).
+-define(EXPIRED_MESSAGE_DROP_INTERVAL, 5000).
 
 -export([start_link/1, info_keys/0]).
 
@@ -717,7 +718,7 @@ ensure_ttl_timer(State = #q{backing_queue       = BQ,
   when TTL =/= undefined ->
     case BQ:is_empty(BQS) of
         true  -> State;
-        false -> TRef = erlang:send_after(TTL, self(), drop_expired),
+        false -> TRef = erlang:send_after(?EXPIRED_MESSAGE_DROP_INTERVAL, self(), drop_expired),
                  State#q{ttl_timer_ref = TRef}
     end;
 ensure_ttl_timer(State) ->


### PR DESCRIPTION
Now it checks for expired messages every 5 seconds. Before it checked it once in a TLL, which indeed lead to a very weird behavior with large TTL values (very high latency for dead letter exchange).
