### PR TITLE
systemd service file for rabbitmq-server

### DIFF
--- a/scripts/rabbitmq.service
+++ b/scripts/rabbitmq.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=RabbitMQ Messaging Server
+After=network.target
+
+[Service]
+Type=simple
+User=rabbitmq
+SyslogIdentifier=rabbitmq
+EnvironmentFile=/etc/rabbitmq/rabbitmq-env.conf
+
+ExecStart=/usr/sbin/rabbitmq-server
+ExecStop=/usr/sbin/rabbitmqctl stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
A service file for systemd. In the file rabbitmq-env.conf are the environment variables like MNESIA_BASE=/var/lib/rabbitmq/mnesia.