### PR TITLE
Allow use of long or short names via a variable in rabbitmq-env

### DIFF
--- a/scripts/rabbitmq-plugins
+++ b/scripts/rabbitmq-plugins
@@ -23,6 +23,7 @@
 
 [ "x" = "x$RABBITMQ_ENABLED_PLUGINS_FILE" ] && RABBITMQ_ENABLED_PLUGINS_FILE=${ENABLED_PLUGINS_FILE}
 [ "x" = "x$RABBITMQ_PLUGINS_DIR" ] && RABBITMQ_PLUGINS_DIR=${PLUGINS_DIR}
+[ "xtrue" = "x$RABBITMQ_USE_LONGNAME" ] && RABBITMQ_NAME_TYPE=-name || RABBITMQ_NAME_TYPE=-sname
 
 ##--- End of overridden <var_name> variables
 
@@ -30,7 +31,7 @@ exec ${ERL_DIR}erl \
     -pa "${RABBITMQ_HOME}/ebin" \
     -noinput \
     -hidden \
-    -sname rabbitmq-plugins$$ \
+    $RABBITMQ_NAME_TYPE rabbitmq-plugins$$ \
     -boot "${CLEAN_BOOT_FILE}" \
     -s rabbit_plugins_main \
     -enabled_plugins_file "$RABBITMQ_ENABLED_PLUGINS_FILE" \

--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -49,6 +49,8 @@ DEFAULT_NODE_PORT=5672
 
 [ "x" = "x$RABBITMQ_PLUGINS_DIR" ] && RABBITMQ_PLUGINS_DIR=${PLUGINS_DIR}
 
+[ "xtrue" = "x$RABBITMQ_USE_LONGNAME" ] && RABBITMQ_NAME_TYPE=-name || RABBITMQ_NAME_TYPE=-sname
+
 ## Log rotation
 [ "x" = "x$RABBITMQ_LOGS" ] && RABBITMQ_LOGS=${LOGS}
 [ "x" = "x$RABBITMQ_LOGS" ] && RABBITMQ_LOGS="${RABBITMQ_LOG_BASE}/${RABBITMQ_NODENAME}.log"
@@ -87,7 +89,7 @@ if ! ${ERL_DIR}erl -pa "$RABBITMQ_EBIN_ROOT" \
 	    -noinput \
 	    -hidden \
 	    -s rabbit_prelaunch \
-	    -sname rabbitmqprelaunch$$ \
+	    $RABBITMQ_NAME_TYPE rabbitmqprelaunch$$ \
 	    -extra "${RABBITMQ_NODENAME}";
     then
         exit 1;
@@ -107,7 +109,7 @@ set -f
 exec ${ERL_DIR}erl \
     -pa ${RABBITMQ_EBIN_ROOT} \
     ${RABBITMQ_START_RABBIT} \
-    -sname ${RABBITMQ_NODENAME} \
+    $RABBITMQ_NAME_TYPE ${RABBITMQ_NODENAME} \
     -boot "${SASL_BOOT_FILE}" \
     ${RABBITMQ_CONFIG_ARG} \
     +W w \

--- a/scripts/rabbitmqctl
+++ b/scripts/rabbitmqctl
@@ -23,6 +23,7 @@
 
 [ "x" = "x$RABBITMQ_NODENAME" ] && RABBITMQ_NODENAME=${NODENAME}
 [ "x" = "x$RABBITMQ_CTL_ERL_ARGS" ] && RABBITMQ_CTL_ERL_ARGS=${CTL_ERL_ARGS}
+[ "xtrue" = "x$RABBITMQ_USE_LONGNAME" ] && RABBITMQ_NAME_TYPE=-name || RABBITMQ_NAME_TYPE=-sname
 
 ##--- End of overridden <var_name> variables
 
@@ -31,7 +32,7 @@ exec ${ERL_DIR}erl \
     -noinput \
     -hidden \
     ${RABBITMQ_CTL_ERL_ARGS} \
-    -sname rabbitmqctl$$ \
+    $RABBITMQ_NAME_TYPE rabbitmqctl$$ \
     -boot "${CLEAN_BOOT_FILE}" \
     -s rabbit_control_main \
     -nodename $RABBITMQ_NODENAME \


### PR DESCRIPTION
Very simple change to make it possible running with long names when needed