### PR TITLE
removed extra comma from config example

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -336,7 +336,7 @@
      %% {reconnect_delay, 2.5}
 
      %% ]} %% End of my_first_shovel
-    ]},
+    ]}%,
    %% Rather than specifying some values per-shovel, you can specify
    %% them for all shovels here.
    %%


### PR DESCRIPTION
this prevented rabbitmq-server from starting with the sample config file