### PR TITLE
Fix syntax error on unmodified example config

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -341,7 +341,7 @@
      %% {reconnect_delay, 2.5}
 
      %% ]} %% End of my_first_shovel
-    ]},
+    ]}
    %% Rather than specifying some values per-shovel, you can specify
    %% them for all shovels here.
    %%


### PR DESCRIPTION
For distributions it is nice to be able to install a fully
commented example configuration. Unfortunately the shipped
one has a syntax error (the , is only necessary if any of
the followup blocks is commented in)
