### PR TITLE
Add Upstart job to debian packaging

### DIFF
--- a/packaging/debs/Debian/debian/rabbitmq-server.upstart
+++ b/packaging/debs/Debian/debian/rabbitmq-server.upstart
@@ -1,0 +1,14 @@
+description "rabbitmq-server - High performance enterprise messaging server"
+author "Cameron Norman <camerontnorman@gmail.com>"
+
+start on filesystem and static-network-up
+stop on runlevel [016] or deconfiguring-networking
+
+respawn
+
+chdir /var/lib/rabbitmq
+setuid rabbitmq
+setgid rabbitmq
+env HOME=/var/lib/rabbitmq
+
+exec /usr/lib/rabbitmq/bin/rabbitmq-server


### PR DESCRIPTION
This does not use the /usr/sbin/rabbitmq-server wrapper. All that thing does is make sure the user is correct and the directory is correct. We can do that in the Upstart job easily.
