### PR TITLE
- Add "zip" package to Buildrequires to avoid error during build on rhel6 clone.

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -13,7 +13,7 @@ Source4: rabbitmq-server.ocf
 Source5: README
 URL: http://www.rabbitmq.com/
 BuildArch: noarch
-BuildRequires: erlang >= R13B-03, python-simplejson, xmlto, libxslt
+BuildRequires: erlang >= R13B-03, python-simplejson, xmlto, libxslt, zip
 Requires: erlang >= R13B-03, logrotate
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-%{_arch}-root
 Summary: The RabbitMQ server


### PR DESCRIPTION
  """
  (cd dist; zip -q -r rabbit_common-3.3.5.ez rabbit_common-3.3.5)
  /bin/sh: zip: command not found
  """
