### PR TITLE
Add systemd notification support

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -335,6 +335,11 @@ broker_start() ->
     Plugins = rabbit_plugins:setup(),
     ToBeLoaded = Plugins ++ ?APPS,
     start_apps(ToBeLoaded),
+    case code:load_file(sd_notify) of
+        {module, sd_notify} -> SDNotify = sd_notify,
+                               SDNotify:sd_notify(0, "READY=1");
+        {error, _} -> ok
+    end,
     ok = log_broker_started(rabbit_plugins:active()).
 
 start_it(StartFun) ->


### PR DESCRIPTION
We've been using this patch in Fedora now for a while.  It uses Peter Lemenkov's erlang-sd_notify module (if available) to notify systemd when RabbitMQ has completed startup.