### PR TITLE
Alter RabbitMQ database directory permissions for .deb and .rpm packages

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -95,6 +95,7 @@ fi
 if [ -f %{_sysconfdir}/rabbitmq/rabbitmq.conf ] && [ ! -f %{_sysconfdir}/rabbitmq/rabbitmq-env.conf ]; then
     mv %{_sysconfdir}/rabbitmq/rabbitmq.conf %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
 fi
+chmod -R o-rwx,g-w %{_localstatedir}/lib/rabbitmq/mnesia
 
 %preun
 if [ $1 = 0 ]; then

--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -33,6 +33,7 @@ fi
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
 chown -R rabbitmq:rabbitmq /var/log/rabbitmq
 chmod 750 /var/lib/rabbitmq/mnesia
+chmod -R o-rwx,g-w /var/lib/rabbitmq/mnesia
 
 case "$1" in
     configure)


### PR DESCRIPTION
 * Revoke group writing permission
 * Revoke all "others" permissions

It was decided that doing something similar for generic UNIX packages (in `rabbitmq-server`) would be too fragile because we don't know what UNIX flavour the package may be used on and what are common practices (or available tools) there.

Fixes #68.