### PR TITLE
prevent unbounded gc interval backoff

### DIFF
--- a/src/background_gc.erl
+++ b/src/background_gc.erl
@@ -26,6 +26,7 @@
 
 -define(MAX_RATIO, 0.01).
 -define(IDEAL_INTERVAL, 60000).
+-define(MAX_INTERVAL, 240000).
 
 -record(state, {last_interval}).
 
@@ -70,7 +71,7 @@ terminate(_Reason, State) -> State.
 interval_gc(State = #state{last_interval = LastInterval}) ->
     {ok, Interval} = rabbit_misc:interval_operation(
                        {?MODULE, gc, []},
-                       ?MAX_RATIO, ?IDEAL_INTERVAL, LastInterval),
+                       ?MAX_RATIO, ?MAX_INTERVAL, ?IDEAL_INTERVAL, LastInterval),
     erlang:send_after(Interval, self(), run),
     State#state{last_interval = Interval}.
 


### PR DESCRIPTION
It has been relatively common in our environment to see rabbitmq use up to 10-20x more memory (usually allocated to the queue_procs or mgmt_db heaps) than the canonical queue data should consume after the rabbitmq-server processes have been running for some time with a production workload using versions 3.3.5, 3.4.4, and 3.5.0. The memory growth rate has been slow enough that a manually gc can be run which bring the processes back to a operable state, however running gc more often would be preferable to long intervals of unbounded growth/gc delay.

@michaelklishin let me know if more context or data is needed, any feedback is greatly appreciated!