### PR TITLE
PR for rabbitmq/rabbitmq-server#88

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.init
+++ b/packaging/RPMS/Fedora/rabbitmq-server.init
@@ -25,8 +25,8 @@ CONTROL=/usr/sbin/rabbitmqctl
 DESC=rabbitmq-server
 USER=rabbitmq
 ROTATE_SUFFIX=
-INIT_LOG_DIR=/var/log/rabbitmq
 PID_FILE=/var/run/rabbitmq/pid
+RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
 
 START_PROG= # Set when building package
 LOCK_FILE=/var/lock/subsys/$NAME
@@ -38,6 +38,9 @@ RETVAL=0
 set -e
 
 [ -f /etc/default/${NAME} ] && . /etc/default/${NAME}
+
+RABBITMQ_SCRIPTS_DIR=$(dirname "$RABBITMQ_ENV")
+. "$RABBITMQ_ENV"
 
 ensure_pid_dir () {
     PID_DIR=`dirname ${PID_FILE}`
@@ -62,8 +65,8 @@ start_rabbitmq () {
         ensure_pid_dir
         set +e
         RABBITMQ_PID_FILE=$PID_FILE $START_PROG $DAEMON \
-            > "${INIT_LOG_DIR}/startup_log" \
-            2> "${INIT_LOG_DIR}/startup_err" \
+            > "${RABBITMQ_LOG_BASE}/startup_log" \
+            2> "${RABBITMQ_LOG_BASE}/startup_err" \
             0<&- &
         $CONTROL wait $PID_FILE >/dev/null 2>&1
         RETVAL=$?
@@ -77,7 +80,7 @@ start_rabbitmq () {
                 ;;
             *)
                 remove_pid
-                echo FAILED - check ${INIT_LOG_DIR}/startup_\{log, _err\}
+                echo FAILED - check ${RABBITMQ_LOG_BASE}/startup_\{log, _err\}
                 RETVAL=1
                 ;;
         esac
@@ -88,7 +91,9 @@ stop_rabbitmq () {
     status_rabbitmq quiet
     if [ $RETVAL = 0 ] ; then
         set +e
-        $CONTROL stop ${PID_FILE} > ${INIT_LOG_DIR}/shutdown_log 2> ${INIT_LOG_DIR}/shutdown_err
+        $CONTROL stop ${PID_FILE} \
+            > ${RABBITMQ_LOG_BASE}/shutdown_log \
+            2> ${RABBITMQ_LOG_BASE}/shutdown_err
         RETVAL=$?
         set -e
         if [ $RETVAL = 0 ] ; then
@@ -97,7 +102,7 @@ stop_rabbitmq () {
                 rm -f $LOCK_FILE
             fi
         else
-            echo FAILED - check ${INIT_LOG_DIR}/shutdown_log, _err
+            echo FAILED - check ${RABBITMQ_LOG_BASE}/shutdown_log, _err
         fi
     else
         echo RabbitMQ is not running

--- a/packaging/common/rabbitmq-script-wrapper
+++ b/packaging/common/rabbitmq-script-wrapper
@@ -30,6 +30,10 @@ cd /var/lib/rabbitmq
 SCRIPT=`basename $0`
 
 if [ `id -u` = `id -u rabbitmq` -a "$SCRIPT" = "rabbitmq-server" ] ; then
+    RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
+    RABBITMQ_SCRIPTS_DIR=$(dirname "$RABBITMQ_ENV")
+    . "$RABBITMQ_ENV"
+
     exec /usr/lib/rabbitmq/bin/rabbitmq-server "$@" @STDOUT_STDERR_REDIRECTION@
 elif [ `id -u` = `id -u rabbitmq` -o "$SCRIPT" = "rabbitmq-plugins" ] ; then
     if [ -f $PWD/.erlang.cookie ] ; then

--- a/packaging/debs/Debian/Makefile
+++ b/packaging/debs/Debian/Makefile
@@ -23,7 +23,7 @@ package: clean
 	cp -r debian $(UNPACKED_DIR)
 	cp $(COMMON_DIR)/* $(UNPACKED_DIR)/debian/
 	sed -i -e 's|@SU_RABBITMQ_SH_C@|su rabbitmq -s /bin/sh -c|' \
-	       -e 's|@STDOUT_STDERR_REDIRECTION@| > "/var/log/rabbitmq/startup_log" 2> "/var/log/rabbitmq/startup_err"|' \
+	       -e 's|@STDOUT_STDERR_REDIRECTION@|> "$$RABBITMQ_LOG_BASE/startup_log" 2> "$$RABBITMQ_LOG_BASE/startup_err"|' \
 	    $(UNPACKED_DIR)/debian/rabbitmq-script-wrapper
 	chmod a+x $(UNPACKED_DIR)/debian/rules
 	echo "This package was debianized by Tony Garnock-Jones <tonyg@rabbitmq.com> on\nWed,  3 Jan 2007 15:43:44 +0000.\n\nIt was downloaded from http://www.rabbitmq.com/\n\n" > $(UNPACKED_DIR)/debian/copyright

--- a/packaging/debs/Debian/debian/rabbitmq-server.init
+++ b/packaging/debs/Debian/debian/rabbitmq-server.init
@@ -23,9 +23,8 @@ CONTROL=/usr/sbin/rabbitmqctl
 DESC="message broker"
 USER=rabbitmq
 ROTATE_SUFFIX=
-INIT_LOG_DIR=/var/log/rabbitmq
 PID_FILE=/var/run/rabbitmq/pid
-
+RABBITMQ_ENV=/usr/lib/rabbitmq/bin/rabbitmq-env
 
 test -x $DAEMON || exit 0
 test -x $CONTROL || exit 0
@@ -34,6 +33,9 @@ RETVAL=0
 set -e
 
 [ -f /etc/default/${NAME} ] && . /etc/default/${NAME}
+
+RABBITMQ_SCRIPTS_DIR=$(dirname "$RABBITMQ_ENV")
+. "$RABBITMQ_ENV"
 
 . /lib/lsb/init-functions
 . /lib/init/vars.sh
@@ -76,7 +78,9 @@ stop_rabbitmq () {
     status_rabbitmq quiet
     if [ $RETVAL = 0 ] ; then
         set +e
-        $CONTROL stop ${PID_FILE} > ${INIT_LOG_DIR}/shutdown_log 2> ${INIT_LOG_DIR}/shutdown_err
+        $CONTROL stop ${PID_FILE} \
+            > ${RABBITMQ_LOG_BASE}/shutdown_log \
+            2> ${RABBITMQ_LOG_BASE}/shutdown_err
         RETVAL=$?
         set -e
         if [ $RETVAL = 0 ] ; then
@@ -143,7 +147,7 @@ start_stop_end() {
             RETVAL=0
             ;;
         *)
-            log_warning_msg "FAILED - check ${INIT_LOG_DIR}/startup_\{log, _err\}"
+            log_warning_msg "FAILED - check ${RABBITMQ_LOG_BASE}/startup_\{log, _err\}"
             log_end_msg 1
             ;;
     esac

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -15,33 +15,36 @@
 ##  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 ##
 
-# We set +e here since since our test for "readlink -f" below needs to
-# be able to fail.
-set +e
-# Determine where this script is really located (if this script is
-# invoked from another script, this is the location of the caller)
-SCRIPT_PATH="$0"
-while [ -h "$SCRIPT_PATH" ] ; do
-    # Determine if readlink -f is supported at all. TODO clean this up.
-    FULL_PATH=`readlink -f $SCRIPT_PATH 2>/dev/null`
-    if [ "$?" != "0" ]; then
-      REL_PATH=`readlink $SCRIPT_PATH`
-      if expr "$REL_PATH" : '/.*' > /dev/null; then
-        SCRIPT_PATH="$REL_PATH"
-      else
-        SCRIPT_PATH="`dirname "$SCRIPT_PATH"`/$REL_PATH"
-      fi
-    else
-      SCRIPT_PATH=$FULL_PATH
-    fi
-done
-set -e
+if [ -z "$RABBITMQ_SCRIPTS_DIR" ]; then
+    # We set +e here since since our test for "readlink -f" below needs to
+    # be able to fail.
+    set +e
+    # Determine where this script is really located (if this script is
+    # invoked from another script, this is the location of the caller)
+    SCRIPT_PATH="$0"
+    while [ -h "$SCRIPT_PATH" ] ; do
+        # Determine if readlink -f is supported at all. TODO clean this up.
+        FULL_PATH=`readlink -f $SCRIPT_PATH 2>/dev/null`
+        if [ "$?" != "0" ]; then
+          REL_PATH=`readlink $SCRIPT_PATH`
+          if expr "$REL_PATH" : '/.*' > /dev/null; then
+            SCRIPT_PATH="$REL_PATH"
+          else
+            SCRIPT_PATH="`dirname "$SCRIPT_PATH"`/$REL_PATH"
+          fi
+        else
+          SCRIPT_PATH=$FULL_PATH
+        fi
+    done
+    set -e
 
-SCRIPT_DIR=`dirname $SCRIPT_PATH`
-RABBITMQ_HOME="${SCRIPT_DIR}/.."
+    RABBITMQ_SCRIPTS_DIR=`dirname $SCRIPT_PATH`
+fi
+
+RABBITMQ_HOME="${RABBITMQ_SCRIPTS_DIR}/.."
 
 ## Set defaults
-. ${SCRIPT_DIR}/rabbitmq-defaults
+. ${RABBITMQ_SCRIPTS_DIR}/rabbitmq-defaults
 
 ## Common defaults
 SERVER_ERL_ARGS="+K true +A30 +P 1048576 \

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -15,6 +15,10 @@
 ##  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 ##
 
+if [ "$RABBITMQ_ENV_LOADED" = 1 ]; then
+    return 0;
+fi
+
 if [ -z "$RABBITMQ_SCRIPTS_DIR" ]; then
     # We set +e here since since our test for "readlink -f" below needs to
     # be able to fail.
@@ -114,6 +118,8 @@ DEFAULT_NODE_PORT=5672
 [ "x" = "x$RABBITMQ_CTL_ERL_ARGS" ] && RABBITMQ_CTL_ERL_ARGS=${CTL_ERL_ARGS}
 
 ##--- End of overridden <var_name> variables
+
+RABBITMQ_ENV_LOADED=1
 
 # Since we source this elsewhere, don't accidentally stop execution
 true


### PR DESCRIPTION
This PR addresses #88. It is against the `master` branch because it changes the behaviour as well as loading `rabbitmq-env` earlier than before. I tested it successfully on Fedora 21 and Ubunth 12.04.5.

@michaelklishin, @videlalvaro, this is ready for QA.