### PR TITLE
adds start.boot to bin folder for mac-standalone release

### DIFF
--- a/packaging/standalone/Makefile
+++ b/packaging/standalone/Makefile
@@ -53,6 +53,11 @@ dist:
 	mkdir -p $(RLS_DIR)/releases/$(OTP_RELEASE)
 	cp $(ERTS_ROOT_DIR)/releases/$(OTP_RELEASE)/OTP_VERSION $(RLS_DIR)/releases/$(OTP_RELEASE)/OTP_VERSION
 
+# copy start.boot to bin folder as Erlang does.
+# Required by rabbit_nodes:ensure_epmd/0
+	mkdir -p $(RLS_DIR)/bin/
+	cp $(ERTS_ROOT_DIR)/bin/start.boot $(RLS_DIR)/bin/
+
 # move rabbitmq files to top level folder
 	mv $(RLS_DIR)/lib/rabbit-$(VERSION)/* $(RLS_DIR)
 


### PR DESCRIPTION
This file is required by rabbit_nodes:ensure_epmd/0 in order to be
able to programatically start epmd

Fixes rabbitmq/rabbitmq-server#96