### PR TITLE
Make gm flow control configurable

### DIFF
--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -81,5 +81,5 @@
            gen_fsm, ssl]},
          {ssl_apps, [asn1, crypto, public_key, ssl]},
          %% see rabbitmq-server#114
-         {mirroring_flow_control, flow}
+         {mirroring_flow_control, true}
         ]}]}.

--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -81,5 +81,5 @@
            gen_fsm, ssl]},
          {ssl_apps, [asn1, crypto, public_key, ssl]},
          %% see rabbitmq-server#114
-         {gm_flow_control, flow}
+         {mirroring_flow_control, flow}
         ]}]}.

--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -79,5 +79,7 @@
            mnesia_lib, rpc, mnesia_tm, qlc, sofs, proplists, credit_flow,
            pmon, ssl_connection, tls_connection, ssl_record, tls_record,
            gen_fsm, ssl]},
-         {ssl_apps, [asn1, crypto, public_key, ssl]}
+         {ssl_apps, [asn1, crypto, public_key, ssl]},
+         %% see rabbitmq-server#114
+         {gm_flow_control, flow}
         ]}]}.

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -237,10 +237,8 @@ init([Channel, ReaderPid, WriterPid, ConnPid, ConnName, Protocol, User, VHost,
     process_flag(trap_exit, true),
     ?store_proc_name({ConnName, Channel}),
     ok = pg_local:join(rabbit_channels, self()),
-    Flow = case rabbit_misc:get_env(rabbit, mirroring_control, flow) of
-             flow   -> flow;
+    Flow = case rabbit_misc:get_env(rabbit, mirroring_flow_control, true) of
              true   -> flow;
-             noflow -> noflow;
              false  -> noflow
            end,
     State = #ch{state                   = starting,


### PR DESCRIPTION
Fixes #114.

Inter-node flow control sometimes has unexpected effects and it's not clear to some users whether it solves more problems than introduces or not. Fortunately we can make it optional without breaking internal communication protocol. I believe that's what we should until we can begin collecting more metrics on flow control.

Note: this is against the `stable` branch and I really would like to get it into `3.5.2`.