### PR TITLE
erlang:now/0 => os:timestamp/0 in credit_flow and rabbit_reader

### DIFF
--- a/src/credit_flow.erl
+++ b/src/credit_flow.erl
@@ -116,7 +116,7 @@ state() -> case blocked() of
                true  -> flow;
                false -> case get(credit_blocked_at) of
                             undefined -> running;
-                            B         -> Diff = timer:now_diff(erlang:now(), B),
+                            B         -> Diff = timer:now_diff(os:timestamp(), B),
                                          case Diff < 5000000 of
                                              true  -> flow;
                                              false -> running
@@ -144,7 +144,7 @@ grant(To, Quantity) ->
 
 block(From) ->
     case blocked() of
-        false -> put(credit_blocked_at, erlang:now());
+        false -> put(credit_blocked_at, os:timestamp());
         true  -> ok
     end,
     ?UPDATE(credit_blocked, [], Blocks, [From | Blocks]).

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -490,7 +490,7 @@ maybe_block(State = #v1{connection_state = blocking,
     State1 = State#v1{connection_state = blocked,
                       throttle = update_last_blocked_by(
                                    Throttle#throttle{
-                                     last_blocked_at = erlang:now()})},
+                                     last_blocked_at = os:timestamp()})},
     case {blocked_by_alarm(State), blocked_by_alarm(State1)} of
         {false, true} -> ok = send_blocked(State1);
         {_,        _} -> ok
@@ -1176,7 +1176,7 @@ i(state, #v1{connection_state = ConnectionState,
         (credit_flow:blocked() %% throttled by flow now
          orelse                %% throttled by flow recently
            (WasBlockedBy =:= flow andalso T =/= never andalso
-            timer:now_diff(erlang:now(), T) < 5000000)) of
+            timer:now_diff(os:timestamp(), T) < 5000000)) of
         true  -> flow;
         false -> ConnectionState
     end;


### PR DESCRIPTION
Fixes #135.