### PR TITLE
Introduce conditional tracing of credit_flow events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ else
 ERLC_OPTS += -DINSTR_MOD=gm
 endif
 
+ifdef CREDIT_FLOW_TRACING
+ERLC_OPTS += -DCREDIT_FLOW_TRACING=true
+endif
+
 include version.mk
 
 PLUGINS_SRC_DIR?=$(shell [ -d "plugins-src" ] && echo "plugins-src" || echo )

--- a/src/credit_flow.erl
+++ b/src/credit_flow.erl
@@ -70,9 +70,15 @@
 
 -ifdef(CREDIT_FLOW_TRACING).
 -define(TRACE_BLOCKED(THIS, FROM), rabbit_event:notify(credit_flow_blocked,
-                                      [{process, THIS}, {from, FROM}])).
+                                     [{process, THIS},
+                                      {process_info, erlang:process_info(THIS)},
+                                      {from, FROM},
+                                      {from_info, erlang:process_info(FROM)},
+                                      {timestamp, os:timestamp()}])).
 -define(TRACE_UNBLOCKED(THIS, FROM), rabbit_event:notify(credit_flow_unblocked,
-                                      [{process, THIS}, {from, FROM}])).
+                                      [{process, THIS},
+                                       {from, FROM},
+                                       {timestamp, os:timestamp()}])).
 -else.
 -define(TRACE_BLOCKED(THIS, FROM), ok).
 -define(TRACE_UNBLOCKED(THIS, FROM), ok).

--- a/src/credit_flow.erl
+++ b/src/credit_flow.erl
@@ -76,9 +76,9 @@
                                       {from_info, erlang:process_info(FROM)},
                                       {timestamp, os:timestamp()}])).
 -define(TRACE_UNBLOCKED(SELF, FROM), rabbit_event:notify(credit_flow_unblocked,
-                                      [{process, SELF},
-                                       {from, FROM},
-                                       {timestamp, os:timestamp()}])).
+                                       [{process, SELF},
+                                        {from, FROM},
+                                        {timestamp, os:timestamp()}])).
 -else.
 -define(TRACE_BLOCKED(SELF, FROM), ok).
 -define(TRACE_UNBLOCKED(SELF, FROM), ok).

--- a/src/credit_flow.erl
+++ b/src/credit_flow.erl
@@ -69,19 +69,19 @@
         end).
 
 -ifdef(CREDIT_FLOW_TRACING).
--define(TRACE_BLOCKED(THIS, FROM), rabbit_event:notify(credit_flow_blocked,
-                                     [{process, THIS},
-                                      {process_info, erlang:process_info(THIS)},
+-define(TRACE_BLOCKED(SELF, FROM), rabbit_event:notify(credit_flow_blocked,
+                                     [{process, SELF},
+                                      {process_info, erlang:process_info(SELF)},
                                       {from, FROM},
                                       {from_info, erlang:process_info(FROM)},
                                       {timestamp, os:timestamp()}])).
--define(TRACE_UNBLOCKED(THIS, FROM), rabbit_event:notify(credit_flow_unblocked,
-                                      [{process, THIS},
+-define(TRACE_UNBLOCKED(SELF, FROM), rabbit_event:notify(credit_flow_unblocked,
+                                      [{process, SELF},
                                        {from, FROM},
                                        {timestamp, os:timestamp()}])).
 -else.
--define(TRACE_BLOCKED(THIS, FROM), ok).
--define(TRACE_UNBLOCKED(THIS, FROM), ok).
+-define(TRACE_BLOCKED(SELF, FROM), ok).
+-define(TRACE_UNBLOCKED(SELF, FROM), ok).
 -endif.
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
This introduces conditional (compile time) tracing of `credit_flow` events over `rabbit_event`. This will be used to collect stats on credit flow behaviour with a tool similar to `rabbitmq_event_exchange` (which needs to be extended to convert credit flow events, because they involve compound data structures as keys).

Fixes #137.