### PR TITLE
Make credit flow state transition interval 1s instead of 5s

### DIFF
--- a/src/credit_flow.erl
+++ b/src/credit_flow.erl
@@ -68,6 +68,11 @@
             put(Key, Expr)
         end).
 
+%% If current process was blocked by credit flow in the last
+%% STATE_CHANGE_INTERVAL milliseconds, state/0 will report it as "in
+%% flow".
+-define(STATE_CHANGE_INTERVAL, 1000000).
+
 %%----------------------------------------------------------------------------
 
 %% There are two "flows" here; of messages and of credit, going in
@@ -117,7 +122,7 @@ state() -> case blocked() of
                false -> case get(credit_blocked_at) of
                             undefined -> running;
                             B         -> Diff = timer:now_diff(erlang:now(), B),
-                                         case Diff < 5000000 of
+                                         case Diff < ?STATE_CHANGE_INTERVAL of
                                              true  -> flow;
                                              false -> running
                                          end


### PR DESCRIPTION
Management UI and HTTP API currently report connections and channels
as in flow if they've been in flow for the last 5 seconds. That
can confuse the user with inter-node flow control, making them
believe the flow is permanent (it is not: the actual state
toggles many times a second).

This reduces the interval to 1s, which seems more reasonable and
accurate (in a way).

Fixes #138.