### PR TITLE
Support for 'rabbitmq-env.conf' functionality on Windows

### DIFF
--- a/scripts/rabbitmq-defaults.bat
+++ b/scripts/rabbitmq-defaults.bat
@@ -1,0 +1,35 @@
+@echo off
+
+REM ### next line potentially updated in package install steps
+REM set SYS_PREFIX=
+
+REM ### next line will be updated when generating a standalone release
+REM ERL_DIR=
+set ERL_DIR=
+
+REM These boot files don't appear to be referenced in the batch scripts
+REM set CLEAN_BOOT_FILE=start_clean
+REM set SASL_BOOT_FILE=start_sasl
+
+REM ## Set default values
+
+if "!RABBITMQ_BASE!"=="" (
+    set RABBITMQ_BASE=!APPDATA!\RabbitMQ
+)
+
+REM CONFIG_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq
+REM LOG_BASE=${SYS_PREFIX}/var/log/rabbitmq
+REM MNESIA_BASE=${SYS_PREFIX}/var/lib/rabbitmq/mnesia
+REM ENABLED_PLUGINS_FILE=${SYS_PREFIX}/etc/rabbitmq/enabled_plugins
+set CONFIG_FILE=!RABBITMQ_BASE!\rabbitmq
+set LOG_BASE=!RABBITMQ_BASE!\log
+set MNESIA_BASE=!RABBITMQ_BASE!\db
+set ENABLED_PLUGINS_FILE=!RABBITMQ_BASE!\enabled_plugins
+
+REM PLUGINS_DIR="${RABBITMQ_HOME}/plugins"
+set PLUGINS_DIR=!TDP0!..\plugins
+
+REM CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf
+if "!RABBITMQ_CONF_ENV_FILE!"=="" (
+    set CONF_ENV_FILE=!APPDATA!\RabbitMQ\rabbitmq-env-conf.bat
+)

--- a/scripts/rabbitmq-echopid.bat
+++ b/scripts/rabbitmq-echopid.bat
@@ -6,9 +6,9 @@ REM <rabbitmq_nodename> (s)name of the erlang node to connect to (required)
 
 setlocal
 
-if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
-    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
-)
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%cd%\rabbitmq-env.bat"
 
 if "%1"=="" goto fail
 
@@ -21,16 +21,6 @@ set WMIC_PATH=%SYSTEMROOT%\System32\Wbem\wmic.exe
 if not exist "%WMIC_PATH%" (
   goto fail
 )
-
-:: sets sname/name ::
-if "!RABBITMQ_USE_LONGNAME!"=="" (
-    set RABBITMQ_NAME_TYPE="-sname"
-)
-
-if "!RABBITMQ_USE_LONGNAME!"=="true" (
-    set RABBITMQ_NAME_TYPE="-name"
-)
-
 
 :getpid
 for /f "usebackq tokens=* skip=1" %%P IN (`%%WMIC_PATH%% process where "name='erl.exe' and commandline like '%%%RABBITMQ_NAME_TYPE% %1%%'" get processid 2^>nul`) do (

--- a/scripts/rabbitmq-echopid.bat
+++ b/scripts/rabbitmq-echopid.bat
@@ -6,6 +6,10 @@ REM <rabbitmq_nodename> (s)name of the erlang node to connect to (required)
 
 setlocal
 
+if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
+    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
+)
+
 if "%1"=="" goto fail
 
 :: set timeout vars ::

--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -1,0 +1,277 @@
+@echo off
+
+REM Scopes the variables to the current batch file
+REM setlocal
+
+rem Preserve values that might contain exclamation marks before
+rem enabling delayed expansion
+set TDP0=%~dp0
+set STAR=%*
+REM setlocal enabledelayedexpansion
+
+REM # Determine where this script is really located (if this script is
+REM # invoked from another script, this is the location of the caller)
+REM SCRIPT_PATH="$0"
+REM while [ -h "$SCRIPT_PATH" ] ; do
+REM     # Determine if readlink -f is supported at all. TODO clean this up.
+REM     FULL_PATH=`readlink -f $SCRIPT_PATH 2>/dev/null`
+REM     if [ "$?" != "0" ]; then
+REM       REL_PATH=`readlink $SCRIPT_PATH`
+REM       if expr "$REL_PATH" : '/.*' > /dev/null; then
+REM         SCRIPT_PATH="$REL_PATH"
+REM       else
+REM         SCRIPT_PATH="`dirname "$SCRIPT_PATH"`/$REL_PATH"
+REM       fi
+REM     else
+REM       SCRIPT_PATH=$FULL_PATH
+REM     fi
+REM done
+REM set -e
+
+REM SCRIPT_DIR=`dirname $SCRIPT_PATH`
+REM RABBITMQ_HOME="${SCRIPT_DIR}/.."
+set SCRIPT_DIR=%TDP0%
+set RABBITMQ_HOME=%SCRIPT_DIR%..
+
+REM ## Set defaults
+REM . ${SCRIPT_DIR}/rabbitmq-defaults
+call "%SCRIPT_DIR%\rabbitmq-defaults.bat"
+
+REM These common defaults aren't referenced in the batch scripts
+REM ## Common defaults
+REM SERVER_ERL_ARGS="+K true +A30 +P 1048576 \
+REM   -kernel inet_default_connect_options [{nodelay,true}]"
+REM 
+REM # warn about old rabbitmq.conf file, if no new one
+REM if [ -f /etc/rabbitmq/rabbitmq.conf ] && \
+REM    [ ! -f ${CONF_ENV_FILE} ] ; then
+REM     echo -n "WARNING: ignoring /etc/rabbitmq/rabbitmq.conf -- "
+REM     echo "location has moved to ${CONF_ENV_FILE}"
+REM fi
+
+REM ERL_ARGS aren't referenced in the batch scripts
+REM Common defaults
+REM set SERVER_ERL_ARGS=+A30 ^
+REM +P 1048576 ^
+REM -kernel inet_default_connect_options "[{nodelay, true}]" ^
+
+REM ## Get configuration variables from the configure environment file
+REM [ -f ${CONF_ENV_FILE} ] && . ${CONF_ENV_FILE} || true
+if exist "!RABBITMQ_CONF_ENV_FILE!" (
+	call !RABBITMQ_CONF_ENV_FILE!
+)
+
+REM [ "x" = "x$RABBITMQ_USE_LONGNAME" ] && RABBITMQ_USE_LONGNAME=${USE_LONGNAME}
+REM if [ "xtrue" = "x$RABBITMQ_USE_LONGNAME" ] ; then
+REM     RABBITMQ_NAME_TYPE=-name
+REM     [ "x" = "x$HOSTNAME" ] && HOSTNAME=`env hostname -f`
+REM     [ "x" = "x$NODENAME" ] && NODENAME=rabbit@${HOSTNAME}
+REM else
+REM     RABBITMQ_NAME_TYPE=-sname
+REM     [ "x" = "x$HOSTNAME" ] && HOSTNAME=`env hostname`
+REM     [ "x" = "x$NODENAME" ] && NODENAME=rabbit@${HOSTNAME%%.*}
+REM fi
+
+REM Check for the short names here too
+if "!RABBITMQ_USE_LONGNAME!"=="" (
+    if "!USE_LONGNAME!"=="" (
+	    set RABBITMQ_NAME_TYPE="-sname"
+	)
+)
+
+if "!RABBITMQ_USE_LONGNAME!"=="true" (
+    if "!USE_LONGNAME!"=="true" (
+        set RABBITMQ_NAME_TYPE="-name"
+	)
+)
+
+if "!COMPUTERNAME!"=="" (
+    set COMPUTERNAME=localhost
+)
+
+REM [ "x" = "x$RABBITMQ_NODENAME" ] && RABBITMQ_NODENAME=${NODENAME}
+if "!RABBITMQ_NODENAME!"=="" (
+    if "!NODENAME!"=="" (
+        set RABBITMQ_NODENAME=rabbit@!COMPUTERNAME!
+    ) else (
+        set RABBITMQ_NODENAME=!NODENAME!
+    )
+)
+
+REM 
+REM ##--- Set environment vars RABBITMQ_<var_name> to defaults if not set
+REM 
+REM DEFAULT_NODE_IP_ADDRESS=auto
+REM DEFAULT_NODE_PORT=5672
+REM [ "x" = "x$RABBITMQ_NODE_IP_ADDRESS" ] && RABBITMQ_NODE_IP_ADDRESS=${NODE_IP_ADDRESS}
+REM [ "x" = "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_NODE_PORT=${NODE_PORT}
+REM [ "x" = "x$RABBITMQ_NODE_IP_ADDRESS" ] && [ "x" != "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_NODE_IP_ADDRESS=${DEFAULT_NODE_IP_ADDRESS}
+REM [ "x" != "x$RABBITMQ_NODE_IP_ADDRESS" ] && [ "x" = "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_NODE_PORT=${DEFAULT_NODE_PORT}
+
+REM if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
+REM    if not "!RABBITMQ_NODE_PORT!"=="" (
+REM       set RABBITMQ_NODE_IP_ADDRESS=auto
+REM    )
+REM ) else (
+REM    if "!RABBITMQ_NODE_PORT!"=="" (
+REM       set RABBITMQ_NODE_PORT=5672
+REM    )
+REM )
+
+REM DOUBLE CHECK THIS LOGIC
+if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
+	if "!NODE_IP_ADDRESS!"=="" (
+		set RABBITMQ_NODE_IP_ADDRESS=auto
+	) else (
+		set RABBITMQ_NODE_IP_ADDRESS=!NODE_IP_ADDRESS!
+	)
+)
+
+if "!RABBITMQ_NODE_PORT!"=="" (
+	if "!NODE_PORT!"=="" (
+		set RABBITMQ_NODE_PORT=5672
+	) else (
+		set RABBITMQ_NODE_PORT=!NODE_PORT!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_DIST_PORT" ] && RABBITMQ_DIST_PORT=${DIST_PORT}
+REM [ "x" = "x$RABBITMQ_DIST_PORT" ] && [ "x" = "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_DIST_PORT=$((${DEFAULT_NODE_PORT} + 20000))
+REM [ "x" = "x$RABBITMQ_DIST_PORT" ] && [ "x" != "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_DIST_PORT=$((${RABBITMQ_NODE_PORT} + 20000))
+
+if "!RABBITMQ_DIST_PORT!"=="" (
+	if "!DIST_PORT!"=="" (
+	   if "!RABBITMQ_NODE_PORT!"=="" (
+		  set RABBITMQ_DIST_PORT=25672
+	   ) else (
+		  set /a RABBITMQ_DIST_PORT=20000+!RABBITMQ_NODE_PORT!
+	   )
+   ) else (
+		set RABBITMQ_DIST_PORT=!DIST_PORT!
+   )
+)
+
+REM [ "x" = "x$RABBITMQ_SERVER_ERL_ARGS" ] && RABBITMQ_SERVER_ERL_ARGS=${SERVER_ERL_ARGS}
+REM No Windows equivalent
+
+REM [ "x" = "x$RABBITMQ_CONFIG_FILE" ] && RABBITMQ_CONFIG_FILE=${CONFIG_FILE}
+if "!RABBITMQ_CONFIG_FILE!"=="" (
+	if "!CONFIG_FILE!"=="" (
+		set RABBITMQ_CONFIG_FILE=!RABBITMQ_BASE!\rabbitmq
+	) else (
+		set RABBITMQ_CONFIG_FILE=!CONFIG_FILE!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_LOG_BASE" ] && RABBITMQ_LOG_BASE=${LOG_BASE}
+if "!RABBITMQ_LOG_BASE!"=="" (
+	if "!LOG_BASE!"=="" (
+		set RABBITMQ_LOG_BASE=!RABBITMQ_BASE!\log
+	) else (
+		set RABBITMQ_LOG_BASE=!LOG_BASE!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_MNESIA_BASE" ] && RABBITMQ_MNESIA_BASE=${MNESIA_BASE}
+if "!RABBITMQ_MNESIA_BASE!"=="" (
+	if "!MNESIA_BASE!"=="" (
+		set RABBITMQ_MNESIA_BASE=!RABBITMQ_BASE!\db
+	) else (
+		set RABBITMQ_MNESIA_BASE=!MNESIA_BASE!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_SERVER_START_ARGS" ] && RABBITMQ_SERVER_START_ARGS=${SERVER_START_ARGS}
+REM No Windows equivalent 
+
+REM [ "x" = "x$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS" ] && RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=${SERVER_ADDITIONAL_ERL_ARGS}
+REM No Windows equivalent
+
+REM [ "x" = "x$RABBITMQ_MNESIA_DIR" ] && RABBITMQ_MNESIA_DIR=${MNESIA_DIR}
+REM [ "x" = "x$RABBITMQ_MNESIA_DIR" ] && RABBITMQ_MNESIA_DIR=${RABBITMQ_MNESIA_BASE}/${RABBITMQ_NODENAME}
+if "!RABBITMQ_MNESIA_DIR!"=="" (
+	if "!MNESIA_DIR!"=="" (
+		set RABBITMQ_MNESIA_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-mnesia
+	) else (
+		set RABBITMQ_MNESIA_DIR=!MNESIA_DIR!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_PID_FILE" ] && RABBITMQ_PID_FILE=${PID_FILE}
+REM [ "x" = "x$RABBITMQ_PID_FILE" ] && RABBITMQ_PID_FILE=${RABBITMQ_MNESIA_DIR}.pid
+REM No Windows equivalent
+
+REM [ "x" = "x$RABBITMQ_PLUGINS_EXPAND_DIR" ] && RABBITMQ_PLUGINS_EXPAND_DIR=${PLUGINS_EXPAND_DIR}
+REM [ "x" = "x$RABBITMQ_PLUGINS_EXPAND_DIR" ] && RABBITMQ_PLUGINS_EXPAND_DIR=${RABBITMQ_MNESIA_BASE}/${RABBITMQ_NODENAME}-plugins-expand
+if "!RABBITMQ_PLUGINS_EXPAND_DIR!"=="" (
+	if "!PLUGINS_EXPAND_DIR!"=="" (
+		set RABBITMQ_PLUGINS_EXPAND_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-plugins-expand
+	) else (
+		set RABBITMQ_PLUGINS_EXPAND_DIR=!PLUGINS_EXPAND_DIR!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_ENABLED_PLUGINS_FILE" ] && RABBITMQ_ENABLED_PLUGINS_FILE=${ENABLED_PLUGINS_FILE}
+if "!RABBITMQ_ENABLED_PLUGINS_FILE!"=="" (
+	if "!ENABLED_PLUGINS_FILE!"=="" (
+		set RABBITMQ_ENABLED_PLUGINS_FILE=!RABBITMQ_BASE!\enabled_plugins
+	) else (
+		set RABBITMQ_ENABLED_PLUGINS_FILE=!ENABLED_PLUGINS_FILE!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_PLUGINS_DIR" ] && RABBITMQ_PLUGINS_DIR=${PLUGINS_DIR}
+if "!RABBITMQ_PLUGINS_DIR!"=="" (
+	if "!PLUGINS_DIR!"=="" (
+		set RABBITMQ_PLUGINS_DIR=!RABBITMQ_BASE!\plugins
+	) else (
+		set RABBITMQ_PLUGINS_DIR=!PLUGINS_DIR!
+	)
+)
+
+REM ## Log rotation
+REM [ "x" = "x$RABBITMQ_LOGS" ] && RABBITMQ_LOGS=${LOGS}
+REM [ "x" = "x$RABBITMQ_LOGS" ] && RABBITMQ_LOGS="${RABBITMQ_LOG_BASE}/${RABBITMQ_NODENAME}.log"
+if "!RABBITMQ_LOGS!"=="" (
+	if "!LOGS!"=="" (
+		set LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!.log
+	) else (
+		set LOGS=!LOGS!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_SASL_LOGS" ] && RABBITMQ_SASL_LOGS=${SASL_LOGS}
+REM [ "x" = "x$RABBITMQ_SASL_LOGS" ] && RABBITMQ_SASL_LOGS="${RABBITMQ_LOG_BASE}/${RABBITMQ_NODENAME}-sasl.log"
+if "!RABBITMQ_SASL_LOGS!"=="" (
+	if "!SASL_LOGS!"=="" (
+		set SASL_LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!-sasl.log
+	) else (
+		set SASL_LOGS=!SASL_LOGS!
+	)
+)
+
+REM [ "x" = "x$RABBITMQ_CTL_ERL_ARGS" ] && RABBITMQ_CTL_ERL_ARGS=${CTL_ERL_ARGS}
+if "!$RABBITMQ_CTL_ERL_ARGS!"=="" (
+	if not "!CTL_ERL_ARGS!"=="" (
+		set RABBITMQ_CTL_ERL_ARGS=!CTL_ERL_ARGS!
+	)
+)
+
+REM ADDITIONAL WINDOWS ONLY CONFIG ITEMS
+REM rabbitmq-plugins.bat
+REM if "!RABBITMQ_SERVICENAME!"=="" (
+REM     set RABBITMQ_SERVICENAME=RabbitMQ
+REM )
+
+if "!RABBITMQ_SERVICENAME!"=="" (
+	if "!SERVICENAME!"=="" (
+		set RABBITMQ_SERVICENAME=RabbitMQ
+	) else (
+		set RABBITMQ_SERVICENAME=!SERVICENAME!
+	)
+)
+ 
+REM ##--- End of overridden <var_name> variables
+REM 
+REM # Since we source this elsewhere, don't accidentally stop execution
+REM true

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -23,6 +23,10 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
+if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
+    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
+)
+
 if "!RABBITMQ_SERVICENAME!"=="" (
     set RABBITMQ_SERVICENAME=RabbitMQ
 )

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -1,4 +1,5 @@
 @echo off
+
 REM  The contents of this file are subject to the Mozilla Public License
 REM  Version 1.1 (the "License"); you may not use this file except in
 REM  compliance with the License. You may obtain a copy of the License
@@ -23,21 +24,9 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
-if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
-    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
-)
-
-if "!RABBITMQ_SERVICENAME!"=="" (
-    set RABBITMQ_SERVICENAME=RabbitMQ
-)
-
-if "!RABBITMQ_BASE!"=="" (
-    set RABBITMQ_BASE=!APPDATA!\!RABBITMQ_SERVICENAME!
-)
-
-if "!RABBITMQ_NODENAME!"=="" (
-    set RABBITMQ_NODENAME=rabbit@!COMPUTERNAME!
-)
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%cd%\rabbitmq-env.bat"
 
 if not exist "!ERLANG_HOME!\bin\erl.exe" (
     echo.
@@ -49,14 +38,6 @@ if not exist "!ERLANG_HOME!\bin\erl.exe" (
     echo RabbitMQ server distribution in the Erlang lib folder.
     echo.
     exit /B 1
-)
-
-if "!RABBITMQ_ENABLED_PLUGINS_FILE!"=="" (
-    set RABBITMQ_ENABLED_PLUGINS_FILE=!RABBITMQ_BASE!\enabled_plugins
-)
-
-if "!RABBITMQ_PLUGINS_DIR!"=="" (
-    set RABBITMQ_PLUGINS_DIR=!TDP0!..\plugins
 )
 
 "!ERLANG_HOME!\bin\erl.exe" ^

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -23,6 +23,10 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
+if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
+    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
+)
+
 if "!RABBITMQ_USE_LONGNAME!"=="" (
     set RABBITMQ_NAME_TYPE="-sname"
 )

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -23,47 +23,9 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
-if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
-    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
-)
-
-if "!RABBITMQ_USE_LONGNAME!"=="" (
-    set RABBITMQ_NAME_TYPE="-sname"
-)
-
-if "!RABBITMQ_USE_LONGNAME!"=="true" (
-    set RABBITMQ_NAME_TYPE="-name"
-)
-
-if "!RABBITMQ_BASE!"=="" (
-    set RABBITMQ_BASE=!APPDATA!\RabbitMQ
-)
-
-if "!COMPUTERNAME!"=="" (
-    set COMPUTERNAME=localhost
-)
-
-if "!RABBITMQ_NODENAME!"=="" (
-    set RABBITMQ_NODENAME=rabbit@!COMPUTERNAME!
-)
-
-if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
-   if not "!RABBITMQ_NODE_PORT!"=="" (
-      set RABBITMQ_NODE_IP_ADDRESS=auto
-   )
-) else (
-   if "!RABBITMQ_NODE_PORT!"=="" (
-      set RABBITMQ_NODE_PORT=5672
-   )
-)
-
-if "!RABBITMQ_DIST_PORT!"=="" (
-   if "!RABBITMQ_NODE_PORT!"=="" (
-      set RABBITMQ_DIST_PORT=25672
-   ) else (
-      set /a RABBITMQ_DIST_PORT=20000+!RABBITMQ_NODE_PORT!
-   )
-)
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%cd%\rabbitmq-env.bat"
 
 if not exist "!ERLANG_HOME!\bin\erl.exe" (
     echo.
@@ -75,39 +37,6 @@ if not exist "!ERLANG_HOME!\bin\erl.exe" (
     echo RabbitMQ server distribution in the Erlang lib folder.
     echo.
     exit /B 1
-)
-
-if "!RABBITMQ_MNESIA_BASE!"=="" (
-    set RABBITMQ_MNESIA_BASE=!RABBITMQ_BASE!/db
-)
-if "!RABBITMQ_LOG_BASE!"=="" (
-    set RABBITMQ_LOG_BASE=!RABBITMQ_BASE!/log
-)
-
-
-rem We save the previous logs in their respective backup
-rem Log management (rotation, filtering based of size...) is left as an exercice for the user.
-
-set LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!.log
-set SASL_LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!-sasl.log
-
-rem End of log management
-
-
-if "!RABBITMQ_MNESIA_DIR!"=="" (
-    set RABBITMQ_MNESIA_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-mnesia
-)
-
-if "!RABBITMQ_PLUGINS_EXPAND_DIR!"=="" (
-    set RABBITMQ_PLUGINS_EXPAND_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-plugins-expand
-)
-
-if "!RABBITMQ_ENABLED_PLUGINS_FILE!"=="" (
-    set RABBITMQ_ENABLED_PLUGINS_FILE=!RABBITMQ_BASE!\enabled_plugins
-)
-
-if "!RABBITMQ_PLUGINS_DIR!"=="" (
-    set RABBITMQ_PLUGINS_DIR=!TDP0!..\plugins
 )
 
 set RABBITMQ_EBIN_ROOT=!TDP0!..\ebin
@@ -128,10 +57,6 @@ if ERRORLEVEL 2 (
 )
 
 set RABBITMQ_EBIN_PATH="-pa !RABBITMQ_EBIN_ROOT!"
-
-if "!RABBITMQ_CONFIG_FILE!"=="" (
-    set RABBITMQ_CONFIG_FILE=!RABBITMQ_BASE!\rabbitmq
-)
 
 if exist "!RABBITMQ_CONFIG_FILE!.config" (
     set RABBITMQ_CONFIG_ARG=-config "!RABBITMQ_CONFIG_FILE!"

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -24,9 +24,9 @@ set TDP0=%~dp0
 set P1=%1
 setlocal enabledelayedexpansion
 
-if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
-    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
-)
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%cd%\rabbitmq-env.bat"
 
 set STARVAR=
 shift
@@ -36,48 +36,6 @@ if "%1"=="" goto after_loop
 	shift
 goto loop1
 :after_loop
-
-if "!RABBITMQ_USE_LONGNAME!"=="" (
-    set RABBITMQ_NAME_TYPE="-sname"
-)
-
-if "!RABBITMQ_USE_LONGNAME!"=="true" (
-    set RABBITMQ_NAME_TYPE="-name"
-)
-
-if "!RABBITMQ_SERVICENAME!"=="" (
-    set RABBITMQ_SERVICENAME=RabbitMQ
-)
-
-if "!RABBITMQ_BASE!"=="" (
-    set RABBITMQ_BASE=!APPDATA!\!RABBITMQ_SERVICENAME!
-)
-
-if "!COMPUTERNAME!"=="" (
-    set COMPUTERNAME=localhost
-)
-
-if "!RABBITMQ_NODENAME!"=="" (
-    set RABBITMQ_NODENAME=rabbit@!COMPUTERNAME!
-)
-
-if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
-    if not "!RABBITMQ_NODE_PORT!"=="" (
-       set RABBITMQ_NODE_IP_ADDRESS=auto
-    )
-) else (
-    if "!RABBITMQ_NODE_PORT!"=="" (
-       set RABBITMQ_NODE_PORT=5672
-    )
-)
-
-if "!RABBITMQ_DIST_PORT!"=="" (
-   if "!RABBITMQ_NODE_PORT!"=="" (
-      set RABBITMQ_DIST_PORT=25672
-   ) else (
-      set /a RABBITMQ_DIST_PORT=20000+!RABBITMQ_NODE_PORT!
-   )
-)
 
 if "!ERLANG_SERVICE_MANAGER_PATH!"=="" (
     if not exist "!ERLANG_HOME!\bin\erl.exe" (
@@ -117,31 +75,6 @@ if not exist "!ERLANG_SERVICE_MANAGER_PATH!\erlsrv.exe" (
     exit /B 1
 )
 
-if "!RABBITMQ_MNESIA_BASE!"=="" (
-    set RABBITMQ_MNESIA_BASE=!RABBITMQ_BASE!/db
-)
-if "!RABBITMQ_LOG_BASE!"=="" (
-    set RABBITMQ_LOG_BASE=!RABBITMQ_BASE!/log
-)
-
-
-rem We save the previous logs in their respective backup
-rem Log management (rotation, filtering based on size...) is left as an exercise for the user.
-
-set LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!.log
-set SASL_LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!-sasl.log
-
-rem End of log management
-
-
-if "!RABBITMQ_MNESIA_DIR!"=="" (
-    set RABBITMQ_MNESIA_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-mnesia
-)
-
-if "!RABBITMQ_PLUGINS_EXPAND_DIR!"=="" (
-    set RABBITMQ_PLUGINS_EXPAND_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-plugins-expand
-)
-
 if "!P1!" == "install" goto INSTALL_SERVICE
 for %%i in (start stop disable enable list remove) do if "%%i" == "!P1!" goto MODIFY_SERVICE
 
@@ -178,19 +111,7 @@ if errorlevel 1 (
     echo !RABBITMQ_SERVICENAME! service is already present - only updating service parameters
 )
 
-if "!RABBITMQ_ENABLED_PLUGINS_FILE!"=="" (
-    set RABBITMQ_ENABLED_PLUGINS_FILE=!RABBITMQ_BASE!\enabled_plugins
-)
-
-if "!RABBITMQ_PLUGINS_DIR!"=="" (
-    set RABBITMQ_PLUGINS_DIR=!TDP0!..\plugins
-)
-
 set RABBITMQ_EBIN_ROOT=!TDP0!..\ebin
-
-if "!RABBITMQ_CONFIG_FILE!"=="" (
-    set RABBITMQ_CONFIG_FILE=!RABBITMQ_BASE!\rabbitmq
-)
 
 "!ERLANG_HOME!\bin\erl.exe" ^
         -pa "!RABBITMQ_EBIN_ROOT!" ^

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -24,6 +24,10 @@ set TDP0=%~dp0
 set P1=%1
 setlocal enabledelayedexpansion
 
+if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
+    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
+)
+
 set STARVAR=
 shift
 :loop1

--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -15,6 +15,7 @@ REM  The Initial Developer of the Original Code is GoPivotal, Inc.
 REM  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 REM
 
+REM Scopes the variables to the current batch file
 setlocal
 
 rem Preserve values that might contain exclamation marks before
@@ -23,42 +24,11 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
-if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
-    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
-)
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%cd%\rabbitmq-env.bat"
 
-if "!RABBITMQ_BASE!"=="" (
-    set RABBITMQ_BASE=!APPDATA!\RabbitMQ
-)
-
-if "!COMPUTERNAME!"=="" (
-    set COMPUTERNAME=localhost
-)
-
-if "!RABBITMQ_NODENAME!"=="" (
-    set RABBITMQ_NODENAME=rabbit@!COMPUTERNAME!
-)
-
-if "!RABBITMQ_MNESIA_BASE!"=="" (
-    set RABBITMQ_MNESIA_BASE=!RABBITMQ_BASE!/db
-)
-
-if "!RABBITMQ_MNESIA_DIR!"=="" (
-    set RABBITMQ_MNESIA_DIR=!RABBITMQ_MNESIA_BASE!/!RABBITMQ_NODENAME!-mnesia
-)
-
-if not exist "!ERLANG_HOME!\bin\erl.exe" (
-    echo.
-    echo ******************************
-    echo ERLANG_HOME not set correctly.
-    echo ******************************
-    echo.
-    echo Please either set ERLANG_HOME to point to your Erlang installation or place the
-    echo RabbitMQ server distribution in the Erlang lib folder.
-    echo.
-    exit /B 1
-)
-
+REM Uncomment this later, just for testing now
 "!ERLANG_HOME!\bin\erl.exe" ^
 -pa "!TDP0!..\ebin" ^
 -noinput ^

--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -23,6 +23,10 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
+if exist "%RABBITMQ_BASE%\rabbitmq-env.bat" (
+    call "%RABBITMQ_BASE%\rabbitmq-env.bat"
+)
+
 if "!RABBITMQ_BASE!"=="" (
     set RABBITMQ_BASE=!APPDATA!\RabbitMQ
 )


### PR DESCRIPTION
By adding the execution of rabbitmq-env.bat within the existing .bat scripts, we provide an area to define environment variables prior to the execution of the server/ctl.

Fixes [rabbitmq/rabbitmq-server#154](https://github.com/rabbitmq/rabbitmq-server/issues/154)