### PR TITLE
Support warn as an alias for warning (the log level)

### DIFF
--- a/src/rabbit_log.erl
+++ b/src/rabbit_log.erl
@@ -84,6 +84,7 @@ catlevel(Category) ->
 level(debug)   -> 4;
 level(info)    -> 3;
 level(warning) -> 2;
+level(warn)    -> 2;
 level(error)   -> 1;
 level(none)    -> 0.
 


### PR DESCRIPTION
As a usability improvement.

The easiest way to test: add `{log_levels, [{connection, warn}, {channel, warn}]}` to `rabbitmq.config`,
open a connection from a REPL, close the REPL (thus abruptly closing the connection), see
what comes up in RabbitMQ logs.

Fixes #186, references #185.