### PR TITLE
Update digraph type

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -217,7 +217,7 @@
         (atom()) -> [{atom(), atom(), [term()]}]).
 -spec(build_acyclic_graph/3 ::
         (graph_vertex_fun(), graph_edge_fun(), [{atom(), [term()]}])
-        -> rabbit_types:ok_or_error2(digraph:digraph(),
+        -> rabbit_types:ok_or_error2(digraph:graph(),
                                      {'vertex', 'duplicate', digraph:vertex()} |
                                      {'edge', ({bad_vertex, digraph:vertex()} |
                                                {bad_edge, [digraph:vertex()]}),


### PR DESCRIPTION
The type digraph:digraph/0 got changed to digraph:graph/0 in OTP R16B03.

To support older and newer releases a preprocessor define (with
configure-like check) would be necessary.