### PR TITLE
adds missing find_prioritisers call

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -576,10 +576,11 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
         {ok, State, Timeout, Backoff = {backoff, _, _, _}, Mod1} ->
             Backoff1 = extend_backoff(Backoff),
             proc_lib:init_ack(Starter, {ok, self()}),
-            loop(GS2State #gs2_state { mod           = Mod1,
-                                       state         = State,
-                                       time          = Timeout,
-                                       timeout_state = Backoff1 });
+            loop(find_prioritisers(
+                  GS2State #gs2_state { mod           = Mod1,
+                                        state         = State,
+                                        time          = Timeout,
+                                        timeout_state = Backoff1 }));
         {stop, Reason} ->
             %% For consistency, we must make sure that the
             %% registered name (if any) is unregistered before


### PR DESCRIPTION
Adds missing call to `find_prioritisers/1`. We need this call since the return from `init/1` on our `gen_server2` behaviour allows the app to swap the `gen_server2` behaviour module. If the module is changed we have to search for message prioritisers. 

Without this change, code like https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit_amqqueue_process.erl#L906 won't be called/used.

This bug was affecting both `rabbit_amqqueue_process` and `rabbit_mirror_queue_slave`. So mirroring performance should get enhanced as well.

Fixes #191 
