### PR TITLE
using os:timestamp/0 since erlang:now/0 is deprecated

### DIFF
--- a/src/file_handle_cache.erl
+++ b/src/file_handle_cache.erl
@@ -526,7 +526,7 @@ clear(Ref) ->
       end).
 
 set_maximum_since_use(MaximumAge) ->
-    Now = now(),
+    Now = os:timestamp(),
     case lists:foldl(
            fun ({{Ref, fhc_handle},
                  Handle = #handle { hdl = Hdl, last_used_at = Then }}, Rep) ->
@@ -695,7 +695,7 @@ get_or_reopen(RefNewOrReopens) ->
         {OpenHdls, []} ->
             {ok, [Handle || {_Ref, Handle} <- OpenHdls]};
         {OpenHdls, ClosedHdls} ->
-            Oldest = oldest(get_age_tree(), fun () -> now() end),
+            Oldest = oldest(get_age_tree(), fun () -> os:timestamp() end),
             case gen_server2:call(?SERVER, {open, self(), length(ClosedHdls),
                                             Oldest}, infinity) of
                 ok ->
@@ -731,7 +731,7 @@ reopen([{Ref, NewOrReopen, Handle = #handle { hdl          = closed,
            end,
     case prim_file:open(Path, Mode) of
         {ok, Hdl} ->
-            Now = now(),
+            Now = os:timestamp(),
             {{ok, _Offset}, Handle1} =
                 maybe_seek(Offset, reset_read_buffer(
                                      Handle#handle{hdl              = Hdl,
@@ -767,7 +767,7 @@ sort_handles([{Ref, _} | RefHdls], RefHdlsA, [{Ref, Handle} | RefHdlsB], Acc) ->
     sort_handles(RefHdls, RefHdlsA, RefHdlsB, [Handle | Acc]).
 
 put_handle(Ref, Handle = #handle { last_used_at = Then }) ->
-    Now = now(),
+    Now = os:timestamp(),
     age_tree_update(Then, Now, Ref),
     put({Ref, fhc_handle}, Handle #handle { last_used_at = Now }).
 
@@ -1398,7 +1398,7 @@ reduce(State = #fhc_state { open_pending          = OpenPending,
                             elders                = Elders,
                             clients               = Clients,
                             timer_ref             = TRef }) ->
-    Now = now(),
+    Now = os:timestamp(),
     {CStates, Sum, ClientCount} =
         ets:foldl(fun ({Pid, Eldest}, {CStatesAcc, SumAcc, CountAcc} = Accs) ->
                           [#cstate { pending_closes = PendingCloses,

--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -624,7 +624,7 @@ unregister_name(_Name) -> ok.
 extend_backoff(undefined) ->
     undefined;
 extend_backoff({backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod}) ->
-    {backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod, now()}.
+    {backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod, os:timestamp()}.
 
 %%%========================================================================
 %%% Internal functions
@@ -688,7 +688,7 @@ wake_hib(GS2State = #gs2_state { timeout_state = TS }) ->
                         undefined ->
                             undefined;
                         {SleptAt, TimeoutState} ->
-                            adjust_timeout_state(SleptAt, now(), TimeoutState)
+                            adjust_timeout_state(SleptAt, os:timestamp(), TimeoutState)
                     end,
     post_hibernate(
       drain(GS2State #gs2_state { timeout_state = TimeoutState1 })).
@@ -696,7 +696,7 @@ wake_hib(GS2State = #gs2_state { timeout_state = TS }) ->
 hibernate(GS2State = #gs2_state { timeout_state = TimeoutState }) ->
     TS = case TimeoutState of
              undefined             -> undefined;
-             {backoff, _, _, _, _} -> {now(), TimeoutState}
+             {backoff, _, _, _, _} -> {os:timestamp(), TimeoutState}
          end,
     proc_lib:hibernate(?MODULE, wake_hib,
                        [GS2State #gs2_state { timeout_state = TS }]).

--- a/src/gm.erl
+++ b/src/gm.erl
@@ -550,7 +550,7 @@ forget_group(GroupName) ->
 
 init([GroupName, Module, Args, TxnFun]) ->
     put(process_name, {?MODULE, GroupName}),
-    {MegaSecs, Secs, MicroSecs} = now(),
+    {MegaSecs, Secs, MicroSecs} = os:timestamp(),
     random:seed(MegaSecs, Secs, MicroSecs),
     Self = make_member(GroupName),
     gen_server2:cast(self(), join),

--- a/src/pg2_fixed.erl
+++ b/src/pg2_fixed.erl
@@ -146,14 +146,14 @@ get_closest_pid(Name) ->
         [Pid] ->
             Pid;
         [] ->
-            {_,_,X} = erlang:now(),
+            {_,_,X} = os:timestamp(),
             case get_members(Name) of
                 [] -> {error, {no_process, Name}};
                 Members ->
                     lists:nth((X rem length(Members))+1, Members)
             end;
         Members when is_list(Members) ->
-            {_,_,X} = erlang:now(),
+            {_,_,X} = os:timestamp(),
             lists:nth((X rem length(Members))+1, Members);
         Else ->
             Else

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -277,7 +277,7 @@ hipe_compile() ->
     Count = length(HipeModules),
     io:format("~nHiPE compiling:  |~s|~n                 |",
               [string:copies("-", Count)]),
-    T1 = erlang:now(),
+    T1 = os:timestamp(),
     PidMRefs = [spawn_monitor(fun () -> [begin
                                              {ok, M} = hipe:c(M, [o3]),
                                              io:format("#")
@@ -288,7 +288,7 @@ hipe_compile() ->
          {'DOWN', MRef, process, _, normal} -> ok;
          {'DOWN', MRef, process, _, Reason} -> exit(Reason)
      end || {_Pid, MRef} <- PidMRefs],
-    T2 = erlang:now(),
+    T2 = os:timestamp(),
     Duration = timer:now_diff(T2, T1) div 1000000,
     io:format("|~n~nCompiled ~B modules in ~Bs~n", [Count, Duration]),
     {ok, Count, Duration}.

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -803,7 +803,7 @@ stop(State) -> stop(noreply, State).
 stop(noreply, State) -> {stop, normal, State};
 stop(Reply,   State) -> {stop, normal, Reply, State}.
 
-now_micros() -> timer:now_diff(now(), {0,0,0}).
+now_micros() -> timer:now_diff(os:timestamp(), {0,0,0}).
 
 infos(Items, State) -> [{Item, i(Item, State)} || Item <- Items].
 
@@ -1306,7 +1306,7 @@ handle_pre_hibernate(State = #q{backing_queue = BQ,
     BQS3 = BQ:handle_pre_hibernate(BQS2),
     rabbit_event:if_enabled(
       State, #q.stats_timer,
-      fun () -> emit_stats(State, [{idle_since,           now()},
+      fun () -> emit_stats(State, [{idle_since,           os:timestamp()},
                                    {consumer_utilisation, ''}]) end),
     State1 = rabbit_event:stop_stats_timer(State#q{backing_queue_state = BQS3},
                                            #q.stats_timer),

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -202,7 +202,7 @@ clear_password(Username) ->
     R.
 
 hash_password(Cleartext) ->
-    {A1,A2,A3} = now(),
+    {A1,A2,A3} = os:timestamp(),
     random:seed(A1, A2, A3),
     Salt = random:uniform(16#ffffffff),
     SaltBin = <<Salt:32>>,

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -568,7 +568,7 @@ handle_pre_hibernate(State) ->
     ok = clear_permission_cache(),
     rabbit_event:if_enabled(
       State, #ch.stats_timer,
-      fun () -> emit_stats(State, [{idle_since, now()}]) end),
+      fun () -> emit_stats(State, [{idle_since, os:timestamp()}]) end),
     {hibernate, rabbit_event:stop_stats_timer(State, #ch.stats_timer)}.
 
 terminate(Reason, State) ->

--- a/src/rabbit_mirror_queue_mode_exactly.erl
+++ b/src/rabbit_mirror_queue_mode_exactly.erl
@@ -45,7 +45,7 @@ suggested_queue_nodes(Count, MNode, SNodes, _SSNodes, Poss) ->
             end}.
 
 shuffle(L) ->
-    {A1,A2,A3} = now(),
+    {A1,A2,A3} = os:timestamp(),
     random:seed(A1, A2, A3),
     {_, L1} = lists:unzip(lists:keysort(1, [{random:uniform(), N} || N <- L])),
     L1.

--- a/src/rabbit_mirror_queue_sync.erl
+++ b/src/rabbit_mirror_queue_sync.erl
@@ -100,7 +100,7 @@ master_go(Syncer, Ref, Log, HandleInfo, EmitStats, BQ, BQS) ->
 master_go0(Args, BQ, BQS) ->
     case BQ:fold(fun (Msg, MsgProps, Unacked, Acc) ->
                          master_send(Msg, MsgProps, Unacked, Args, Acc)
-                 end, {0, erlang:now()}, BQS) of
+                 end, {0, os:timestamp()}, BQS) of
         {{shutdown,  Reason}, BQS1} -> {shutdown,  Reason, BQS1};
         {{sync_died, Reason}, BQS1} -> {sync_died, Reason, BQS1};
         {_,                   BQS1} -> master_done(Args, BQS1)
@@ -108,10 +108,10 @@ master_go0(Args, BQ, BQS) ->
 
 master_send(Msg, MsgProps, Unacked,
             {Syncer, Ref, Log, HandleInfo, EmitStats, Parent}, {I, Last}) ->
-    T = case timer:now_diff(erlang:now(), Last) > ?SYNC_PROGRESS_INTERVAL of
+    T = case timer:now_diff(os:timestamp(), Last) > ?SYNC_PROGRESS_INTERVAL of
             true  -> EmitStats({syncing, I}),
                      Log("~p messages", [I]),
-                     erlang:now();
+                     os:timestamp();
             false -> Last
         end,
     HandleInfo({syncing, I}),

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -805,7 +805,7 @@ gb_trees_foreach(Fun, Tree) ->
     gb_trees_fold(fun (Key, Val, Acc) -> Fun(Key, Val), Acc end, ok, Tree).
 
 now_ms() ->
-    timer:now_diff(now(), {0,0,0}) div 1000.
+    timer:now_diff(os:timestamp(), {0,0,0}) div 1000.
 
 module_attributes(Module) ->
     case catch Module:module_info(attributes) of

--- a/src/rabbit_node_monitor.erl
+++ b/src/rabbit_node_monitor.erl
@@ -297,7 +297,7 @@ find_blocked_global_peers() ->
     find_blocked_global_peers1(Dict).
 
 find_blocked_global_peers1([{{sync_tag_his, Peer}, Timestamp} | Rest]) ->
-    Diff = timer:now_diff(erlang:now(), Timestamp),
+    Diff = timer:now_diff(os:timestamp(), Timestamp),
     if
         Diff >= 10000 -> unblock_global_peer(Peer);
         true          -> ok

--- a/src/rabbit_queue_consumers.erl
+++ b/src/rabbit_queue_consumers.erl
@@ -465,4 +465,4 @@ use_avg(Active, Inactive, Avg) ->
     Time = Inactive + Active,
     rabbit_misc:moving_average(Time, ?USE_AVG_HALF_LIFE, Active / Time, Avg).
 
-now_micros() -> timer:now_diff(now(), {0,0,0}).
+now_micros() -> timer:now_diff(os:timestamp(), {0,0,0}).

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -792,7 +792,7 @@ update_rates(State = #vqstate{ in_counter      =     InCount,
                                                ack_in    =  AckInRate,
                                                ack_out   = AckOutRate,
                                                timestamp = TS }}) ->
-    Now = erlang:now(),
+    Now = os:timestamp(),
 
     Rates = #rates { in        = update_rate(Now, TS,     InCount,     InRate),
                      out       = update_rate(Now, TS,    OutCount,    OutRate),
@@ -1190,7 +1190,7 @@ init(IsDurable, IndexState, DeltaCount, DeltaBytes, Terms,
                                     count        = DeltaCount1,
                                     end_seq_id   = NextSeqId })
             end,
-    Now = now(),
+    Now = os:timestamp(),
     State = #vqstate {
       q1                  = ?QUEUE:new(),
       q2                  = ?QUEUE:new(),

--- a/src/supervisor2.erl
+++ b/src/supervisor2.erl
@@ -1492,7 +1492,7 @@ add_restart(State) ->
     I = State#state.intensity,
     P = State#state.period,
     R = State#state.restarts,
-    Now = erlang:now(),
+    Now = os:timestamp(),
     R1 = add_restart([Now|R], Now, P),
     State1 = State#state{restarts = R1},
     case length(R1) of

--- a/test/src/gm_soak_test.erl
+++ b/test/src/gm_soak_test.erl
@@ -35,7 +35,7 @@ with_state(Fun) ->
 
 inc() ->
     case 1 + get(count) of
-        100000 -> Now = now(),
+        100000 -> Now = os:timestamp(),
                   Start = put(ts, Now),
                   Diff = timer:now_diff(Now, Start),
                   Rate = 100000 / (Diff / 1000000),
@@ -48,7 +48,7 @@ joined([], Members) ->
     io:format("Joined ~p (~p members)~n", [self(), length(Members)]),
     put(state, dict:from_list([{Member, empty} || Member <- Members])),
     put(count, 0),
-    put(ts, now()),
+    put(ts, os:timestamp()),
     ok.
 
 members_changed([], Births, Deaths) ->
@@ -101,7 +101,7 @@ handle_terminate([], Reason) ->
 spawn_member() ->
     spawn_link(
       fun () ->
-              {MegaSecs, Secs, MicroSecs} = now(),
+              {MegaSecs, Secs, MicroSecs} = os:timestamp(),
               random:seed(MegaSecs, Secs, MicroSecs),
               %% start up delay of no more than 10 seconds
               timer:sleep(random:uniform(10000)),

--- a/test/src/gm_speed_test.erl
+++ b/test/src/gm_speed_test.erl
@@ -49,9 +49,9 @@ wile_e_coyote(Time, WriteUnit) ->
     receive joined -> ok end,
     timer:sleep(1000), %% wait for all to join
     timer:send_after(Time, stop),
-    Start = now(),
+    Start = os:timestamp(),
     {Sent, Received} = loop(Pid, WriteUnit, 0, 0),
-    End = now(),
+    End = os:timestamp(),
     ok = gm:leave(Pid),
     receive terminated -> ok end,
     Elapsed = timer:now_diff(End, Start) / 1000000,


### PR DESCRIPTION
Hi guys,

This pull was opened following a suggestion I got in this one [https://github.com/jbrisbin/rabbit_common/pull/15](https://github.com/jbrisbin/rabbit_common/pull/15). It replaces the calls to `erlang:now/0` which is now deprecated ([http://www.erlang.org/news/85](http://www.erlang.org/news/85)) with a call to `os:timestamp/0`.

A CA was sent via email.

Any thoughts?

Thanks in advance.

