### PR TITLE
Bump default +A value to 64

### DIFF
--- a/scripts/rabbitmq-defaults
+++ b/scripts/rabbitmq-defaults
@@ -34,6 +34,6 @@ MNESIA_BASE=${SYS_PREFIX}/var/lib/rabbitmq/mnesia
 ENABLED_PLUGINS_FILE=${SYS_PREFIX}/etc/rabbitmq/enabled_plugins
 
 PLUGINS_DIR="${RABBITMQ_HOME}/plugins"
-IO_THREAD_POOL_SIZE=30
+IO_THREAD_POOL_SIZE=64
 
 CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf


### PR DESCRIPTION
Based on user feedback, 30 feels a bit low. We have to recommend
users with 8 or more cores per node to bump the value to around 100.

This value is not very scientific and assumes roughly 16
I/O threads per core. This is also the default Riak 2.1 uses.

Fixes #176.