### PR TITLE
remove python version detection from Makefile...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,25 +26,6 @@ WEB_MANPAGES=$(patsubst %.xml, %.man.xml, $(wildcard $(DOCS_DIR)/*.[0-9].xml) $(
 USAGES_XML=$(DOCS_DIR)/rabbitmqctl.1.xml $(DOCS_DIR)/rabbitmq-plugins.1.xml
 USAGES_ERL=$(foreach XML, $(USAGES_XML), $(call usage_xml_to_erl, $(XML)))
 
-ifeq ($(shell python -c 'import simplejson' 2>/dev/null && echo yes),yes)
-PYTHON=python
-else
-ifeq ($(shell python2.7 -c 'import json' 2>/dev/null && echo yes),yes)
-PYTHON=python2.7
-else
-ifeq ($(shell python2.6 -c 'import simplejson' 2>/dev/null && echo yes),yes)
-PYTHON=python2.6
-else
-ifeq ($(shell python2.5 -c 'import simplejson' 2>/dev/null && echo yes),yes)
-PYTHON=python2.5
-else
-# Hmm. Missing simplejson?
-PYTHON=python
-endif
-endif
-endif
-endif
-
 BASIC_PLT=basic.plt
 RABBIT_PLT=rabbit.plt
 
@@ -161,13 +142,13 @@ $(TEST_EBIN_DIR):
 	mkdir -p $(TEST_EBIN_DIR)
 
 $(INCLUDE_DIR)/rabbit_framing.hrl: codegen.py $(AMQP_CODEGEN_DIR)/amqp_codegen.py $(AMQP_SPEC_JSON_FILES_0_9_1) $(AMQP_SPEC_JSON_FILES_0_8)
-	$(PYTHON) codegen.py --ignore-conflicts header $(AMQP_SPEC_JSON_FILES_0_9_1) $(AMQP_SPEC_JSON_FILES_0_8) $@
+	./codegen.py --ignore-conflicts header $(AMQP_SPEC_JSON_FILES_0_9_1) $(AMQP_SPEC_JSON_FILES_0_8) $@
 
 $(SOURCE_DIR)/rabbit_framing_amqp_0_9_1.erl: codegen.py $(AMQP_CODEGEN_DIR)/amqp_codegen.py $(AMQP_SPEC_JSON_FILES_0_9_1)
-	$(PYTHON) codegen.py body $(AMQP_SPEC_JSON_FILES_0_9_1) $@
+	./codegen.py body $(AMQP_SPEC_JSON_FILES_0_9_1) $@
 
 $(SOURCE_DIR)/rabbit_framing_amqp_0_8.erl: codegen.py $(AMQP_CODEGEN_DIR)/amqp_codegen.py $(AMQP_SPEC_JSON_FILES_0_8)
-	$(PYTHON) codegen.py body $(AMQP_SPEC_JSON_FILES_0_8) $@
+	./codegen.py body $(AMQP_SPEC_JSON_FILES_0_8) $@
 
 dialyze: $(BEAM_TARGETS) $(BASIC_PLT)
 	dialyzer --plt $(BASIC_PLT) --no_native --fullpath \

--- a/codegen.py
+++ b/codegen.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 ##  The contents of this file are subject to the Mozilla Public License
 ##  Version 1.1 (the "License"); you may not use this file except in
 ##  compliance with the License. You may obtain a copy of the License


### PR DESCRIPTION
...and let env handle it.

Followup from #204, removes python version detection from Makefile and let the `/usr/bin/env` handle it. Brings codegen inline with what is done in [rabbitmq-amqp1.0](https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/master/codegen.py#L1)