### PR TITLE
change rabbit_channel_interceptor API

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -64,6 +64,7 @@
          prioritise_cast/3, prioritise_info/3, format_message_queue/2]).
 %% Internal
 -export([list_local/0, deliver_reply_local/3]).
+-export([get_vhost/1, get_user/1]).
 
 -record(ch, {
   %% starting | running | flow | closing
@@ -140,7 +141,8 @@
   %% used by "one shot RPC" (amq.
   reply_consumer,
   %% flow | noflow, see rabbitmq-server#114
-  delivery_flow
+  delivery_flow,
+  interceptor_state
 }).
 
 
@@ -182,6 +184,10 @@
 -export_type([channel_number/0]).
 
 -type(channel_number() :: non_neg_integer()).
+
+-export_type([channel/0]).
+
+-type(channel() :: #ch{}).
 
 -spec(start_link/11 ::
         (channel_number(), pid(), pid(), pid(), string(),
@@ -370,12 +376,15 @@ init([Channel, ReaderPid, WriterPid, ConnPid, ConnName, Protocol, User, VHost,
                 trace_state             = rabbit_trace:init(VHost),
                 consumer_prefetch       = 0,
                 reply_consumer          = none,
-                delivery_flow           = Flow},
-    State1 = rabbit_event:init_stats_timer(State, #ch.stats_timer),
-    rabbit_event:notify(channel_created, infos(?CREATION_EVENT_KEYS, State1)),
-    rabbit_event:if_enabled(State1, #ch.stats_timer,
-                            fun() -> emit_stats(State1) end),
-    {ok, State1, hibernate,
+                delivery_flow           = Flow,
+                interceptor_state       = undefined},
+    State1 = State#ch{
+               interceptor_state = rabbit_channel_interceptor:init(State)},
+    State2 = rabbit_event:init_stats_timer(State1, #ch.stats_timer),
+    rabbit_event:notify(channel_created, infos(?CREATION_EVENT_KEYS, State2)),
+    rabbit_event:if_enabled(State2, #ch.stats_timer,
+                            fun() -> emit_stats(State2) end),
+    {ok, State2, hibernate,
      {backoff, ?HIBERNATE_AFTER_MIN, ?HIBERNATE_AFTER_MIN, ?DESIRED_HIBERNATE}}.
 
 prioritise_call(Msg, _From, _Len, _State) ->
@@ -425,14 +434,15 @@ handle_call(_Request, _From, State) ->
 
 handle_cast({method, Method, Content, Flow},
             State = #ch{reader_pid   = Reader,
-                        virtual_host = VHost}) ->
+                        interceptor_state = IState}) ->
     case Flow of
         flow   -> credit_flow:ack(Reader);
         noflow -> ok
     end,
-    try handle_method(rabbit_channel_interceptor:intercept_method(
-                        expand_shortcuts(Method, State), VHost),
-                      Content, State) of
+    Method1 = expand_shortcuts(Method, State),
+    {Method2, Content1} = rabbit_channel_interceptor:intercept_in(
+                            Method1, Content, IState),
+    try handle_method(Method2, Content1, State) of
         {reply, Reply, NewState} ->
             ok = send(Reply, NewState),
             noreply(NewState);
@@ -442,7 +452,7 @@ handle_cast({method, Method, Content, Flow},
             {stop, normal, State}
     catch
         exit:Reason = #amqp_error{} ->
-            MethodName = rabbit_misc:method_record_type(Method),
+            MethodName = rabbit_misc:method_record_type(Method2),
             handle_exception(Reason#amqp_error{method = MethodName}, State);
         _:Reason ->
             {stop, {Reason, erlang:get_stacktrace()}, State}
@@ -1979,3 +1989,7 @@ erase_queue_stats(QName) ->
     [erase({queue_exchange_stats, QX}) ||
         {{queue_exchange_stats, QX = {QName0, _}}, _} <- get(),
         QName0 =:= QName].
+
+get_vhost(#ch{virtual_host = VHost}) -> VHost.
+
+get_user(#ch{user = User}) -> User.


### PR DESCRIPTION
(This PR is work in progress but I'm hoping you will give feedback as I am working on it.)

At the moment `rabbit_channel_interceptor` can only intercept a subset of the AMQP methods. This restriction was due to performance concerns. This change lifts the restriction.

See #206 for previous discussion.

#206 ("optionally inject `user_id` into messages") was the motivating use case for changing the API but I think the change has a range of other applications. My colleagues and I came up with the following ways it might be useful in a few minutes, but I imagine other people will have other ideas.

* It could be used to implement #206 without further core changes. Consumers might be interested in other connection information than the username, and this could be done too.
* Generally, it might reduce feature creep in the core. For example there are a few extensions on the hot path of message publishing, for example [direct reply-to](https://www.rabbitmq.com/direct-reply-to.html), which could perhaps be moved into plugins.
* It could be used to transparently provide things like encryption/decryption/re-encryption/message signature verification as an alternative to TLS, compression/decompression, normalization of headers/body format, etc.
* It could be used to implement more specialized authorization, eg to allow a client to create but not delete queues, or to enforce some properties of objects the client creates.
* It could be used for more detailed auditing and protocol verification than the existing tracing mechanism.