### PR TITLE
Introduce rabbitmqctl purge_queue

### DIFF
--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -590,6 +590,25 @@
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term><cmdsynopsis><command>purge_queue</command> <arg choice="req">queue</arg></cmdsynopsis>
+          </term>
+          <listitem>
+            <variablelist>
+              <varlistentry>
+                <term>queue</term>
+                <listitem>
+                  <para>
+                    The name of the queue to purge.
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+            <para>
+              Purges a queue (removes all messages in it).
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term><cmdsynopsis><command>set_cluster_name</command> <arg choice="req">name</arg></cmdsynopsis></term>
           <listitem>
             <para>

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -488,7 +488,7 @@ action(Command, Node, Args, Opts, Inform) ->
     %% the default timeout.
     action(Command, Node, Args, Opts, Inform, ?RPC_TIMEOUT).
 
-action(purge_queue, Node, [], Opts, Inform, Timeout) ->
+action(purge_queue, _Node, [], _Opts, _Inform, _Timeout) ->
     {error, "purge_queue takes queue name as an argument"};
 
 action(purge_queue, Node, [Q], Opts, Inform, Timeout) ->


### PR DESCRIPTION
For operational convenience. Against `stable`, fixes #175.