### PR TITLE
file_handle_cache: Add a config option to disable buffering

### DIFF
--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -28,6 +28,8 @@
          {channel_max, 0},
          {heartbeat, 580},
          {msg_store_file_size_limit, 16777216},
+         {fhc_write_buffering, true},
+         {fhc_read_buffering, true},
          {queue_index_max_journal_entries, 65536},
          {queue_index_embed_msgs_below, 4096},
          {default_user, <<"guest">>},

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -898,6 +898,17 @@ ensure_working_fhc() ->
     %% file_handle_cache, we spawn a separate process.
     Parent = self(),
     TestFun = fun() ->
+        ReadBuf = case application:get_env(rabbit, fhc_read_buffering) of
+            {ok, true}  -> "ON";
+            {ok, false} -> "OFF"
+        end,
+        WriteBuf = case application:get_env(rabbit, fhc_write_buffering) of
+            {ok, true}  -> "ON";
+            {ok, false} -> "OFF"
+        end,
+        rabbit_log:info(
+          "FHC read buffering:  ~s~n"
+          "FHC write buffering: ~s~n", [ReadBuf, WriteBuf]),
         Filename = filename:join(code:lib_dir(kernel, ebin), "kernel.app"),
         {ok, Fd} = file_handle_cache:open(Filename, [raw, binary, read], []),
         {ok, _} = file_handle_cache:read(Fd, 1),


### PR DESCRIPTION
To disable read buffering, one has to put the following line in
rabbitmq.config:

```erlang
[
  {rabbit, [
    {fhc_read_buffering, false}
  ]}
].
```

Fixes #226.