### PR TITLE
Modify the default path of RABBITMQ_CONF_ENV_FILE within rabbitmq-defaults.bat 

### DIFF
--- a/scripts/rabbitmq-defaults.bat
+++ b/scripts/rabbitmq-defaults.bat
@@ -33,5 +33,5 @@ set PLUGINS_DIR=!TDP0!..\plugins
 
 REM CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf
 if "!RABBITMQ_CONF_ENV_FILE!"=="" (
-    set RABBITMQ_CONF_ENV_FILE=!RABBITMQ_BASE!rabbitmq-env-conf.bat
+    set RABBITMQ_CONF_ENV_FILE=!RABBITMQ_BASE!\rabbitmq-env-conf.bat
 )

--- a/scripts/rabbitmq-defaults.bat
+++ b/scripts/rabbitmq-defaults.bat
@@ -33,5 +33,5 @@ set PLUGINS_DIR=!TDP0!..\plugins
 
 REM CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf
 if "!RABBITMQ_CONF_ENV_FILE!"=="" (
-    set CONF_ENV_FILE=!APPDATA!\RabbitMQ\rabbitmq-env-conf.bat
+    set RABBITMQ_CONF_ENV_FILE=!RABBITMQ_BASE!rabbitmq-env-conf.bat
 )

--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -35,7 +35,7 @@ REM set SERVER_ERL_ARGS=+P 1048576
 REM ## Get configuration variables from the configure environment file
 REM [ -f ${CONF_ENV_FILE} ] && . ${CONF_ENV_FILE} || true
 if exist "!RABBITMQ_CONF_ENV_FILE!" (
-	call !RABBITMQ_CONF_ENV_FILE!
+	call "!RABBITMQ_CONF_ENV_FILE!"
 )
 
 REM Check for the short names here too


### PR DESCRIPTION
Modifies the default path of `RABBITMQ_CONF_ENV_FILE` (and adds the RABBITMQ_ prefix). 

Also adds quotes around the call within `rabbitmq-env.bat`.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/239