### PR TITLE
 Fixes a logic problem with NODE_IP_ADDRESS and NODE_PORT in rabbitmq-env.bat.

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -84,21 +84,26 @@ REM       set RABBITMQ_NODE_PORT=5672
 REM    )
 REM )
 
-REM DOUBLE CHECK THIS LOGIC
 if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
-	if "!NODE_IP_ADDRESS!"=="" (
-		set RABBITMQ_NODE_IP_ADDRESS=auto
-	) else (
+	if not "!NODE_IP_ADDRESS!"=="" (
 		set RABBITMQ_NODE_IP_ADDRESS=!NODE_IP_ADDRESS!
 	)
 )
 
 if "!RABBITMQ_NODE_PORT!"=="" (
-	if "!NODE_PORT!"=="" (
-		set RABBITMQ_NODE_PORT=5672
-	) else (
+	if not "!NODE_PORT!"=="" (
 		set RABBITMQ_NODE_PORT=!NODE_PORT!
 	)
+)
+
+if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
+    if not "!RABBITMQ_NODE_PORT!"=="" (
+       set RABBITMQ_NODE_IP_ADDRESS=auto
+    )
+) else (
+    if "!RABBITMQ_NODE_PORT!"=="" (
+       set RABBITMQ_NODE_PORT=5672
+    )
 )
 
 REM [ "x" = "x$RABBITMQ_DIST_PORT" ] && RABBITMQ_DIST_PORT=${DIST_PORT}


### PR DESCRIPTION
Fixes the logic for NODE_IP_ADDRESS and NODE_PORT. First, check for the existence of the environment variable, then the definition if set via conf file, then proceed with the original logic on setting the IP/Port variables.

As it was configured, RABBITMQ_LISTEN_ARG was not getting configured properly as it was before.