### PR TITLE
Memory monitor: Log a warning if a 32-bit version of Erlang is used

### DIFF
--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -167,6 +167,15 @@ code_change(_OldVsn, State, _Extra) ->
 %%----------------------------------------------------------------------------
 
 set_mem_limits(State, MemFraction) ->
+    case erlang:system_info(wordsize) of
+        4 ->
+            error_logger:warning_msg(
+              "You are using a 32-bit version of Erlang: you may run into "
+              "memory address~n"
+              "space exhaustion or statistic counters overflow.~n");
+        _ ->
+            ok
+    end,
     TotalMemory =
         case get_total_memory() of
             unknown ->


### PR DESCRIPTION
Fixes #251.