### PR TITLE
issue #268 - gen_server2 can fail to dispatch messages sent by a process to itself

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -633,8 +633,15 @@ extend_backoff({backoff, InitialTimeout, MinimumTimeout, DesiredHibPeriod}) ->
 %%% The MAIN loop.
 %%% ---------------------------------------------------
 loop(GS2State = #gs2_state { time          = hibernate,
-                             timeout_state = undefined }) ->
-    pre_hibernate(GS2State);
+                             timeout_state = undefined,
+                             queue         = Queue }) ->
+    case priority_queue:is_empty(Queue) of
+        true  ->
+            pre_hibernate(GS2State);
+        false ->
+            process_next_msg(GS2State)
+    end;
+
 loop(GS2State) ->
     process_next_msg(drain(GS2State)).
 


### PR DESCRIPTION
It seems the gen_server2 will hibernate when there are still messages not dispatched in queue. Should we check if the queue is empty before gen_server2 hibernated?