### PR TITLE
Changing sed -E to -r to support older 'sed' versions.

### DIFF
--- a/packaging/common/rabbitmq-script-wrapper
+++ b/packaging/common/rabbitmq-script-wrapper
@@ -18,7 +18,7 @@
 # Escape spaces and quotes, because shell is revolting.
 for arg in "$@" ; do
 	# Escape quotes in parameters, so that they're passed through cleanly.
-	arg=$(sed -E -e 's/(["$])/\\\1/g' <<-END
+	arg=$(sed -r -e 's/(["$])/\\\1/g' <<-END
 		$arg
 		END
 	)


### PR DESCRIPTION
Older versions of sed (at-least those earlier than 4.2, I found) does not support the silent "-E" option.  "-r' is perhaps safer option here.

This is tested on CentOS 5.11 and CentOS 6.5.  Please let me know if more testing is required. 