### PR TITLE
Changing sed -E to -r to support older 'sed' versions.

### DIFF
--- a/packaging/common/rabbitmq-script-wrapper
+++ b/packaging/common/rabbitmq-script-wrapper
@@ -18,7 +18,7 @@
 # Escape spaces and quotes, because shell is revolting.
 for arg in "$@" ; do
 	# Escape quotes in parameters, so that they're passed through cleanly.
-	arg=$(sed -E -e 's/(["$])/\\\1/g' <<-END
+	arg=$(sed -r -e 's/(["$])/\\\1/g' <<-END
 		$arg
 		END
 	)

--- a/packaging/common/rabbitmq-script-wrapper
+++ b/packaging/common/rabbitmq-script-wrapper
@@ -16,9 +16,14 @@
 ##
 
 # Escape spaces and quotes, because shell is revolting.
+SED_OPT="-E"
+if [ $(uname -s) == "Linux" ]; then
+    SED_OPT="-r"
+fi
+
 for arg in "$@" ; do
 	# Escape quotes in parameters, so that they're passed through cleanly.
-	arg=$(sed -r -e 's/(["$])/\\\1/g' <<-END
+	arg=$(sed $SED_OPT -e 's/(["$])/\\\1/g' <<-END
 		$arg
 		END
 	)


### PR DESCRIPTION
On linux system, use "-r" option for sed (for extended regular expressions). On sed versions earlier than 4.2, the silent "-E" option is not present.  