### PR TITLE
On Linux, use -r option for 'sed'. -E is not present in versions earlier versions of 'sed'

### DIFF
--- a/packaging/common/rabbitmq-script-wrapper
+++ b/packaging/common/rabbitmq-script-wrapper
@@ -16,9 +16,14 @@
 ##
 
 # Escape spaces and quotes, because shell is revolting.
+SED_OPT="-E"
+if [ $(uname -s) == "Linux" ]; then
+    SED_OPT="-r"
+fi
+
 for arg in "$@" ; do
 	# Escape quotes in parameters, so that they're passed through cleanly.
-	arg=$(sed -E -e 's/(["$])/\\\1/g' <<-END
+	arg=$(sed $SED_OPT -e 's/(["$])/\\\1/g' <<-END
 		$arg
 		END
 	)


### PR DESCRIPTION
rabbitmq-wrapper-script uses "-E" option for sed which is not present in sed versions earlier that 4.2.

On machines with these old sed versions the script broke. I found atleast CentOS 5.11 where the script broke.