### PR TITLE
Reduce default QI journal size

### DIFF
--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -30,7 +30,7 @@
          {msg_store_file_size_limit, 16777216},
          {fhc_write_buffering, true},
          {fhc_read_buffering, true},
-         {queue_index_max_journal_entries, 8192},
+         {queue_index_max_journal_entries, 32768},
          {queue_index_embed_msgs_below, 4096},
          {default_user, <<"guest">>},
          {default_pass, <<"guest">>},

--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -30,7 +30,7 @@
          {msg_store_file_size_limit, 16777216},
          {fhc_write_buffering, true},
          {fhc_read_buffering, true},
-         {queue_index_max_journal_entries, 65536},
+         {queue_index_max_journal_entries, 8192},
          {queue_index_embed_msgs_below, 4096},
          {default_user, <<"guest">>},
          {default_pass, <<"guest">>},

--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -127,7 +127,7 @@
 %% binary generation/matching with constant vs variable lengths.
 
 -define(REL_SEQ_BITS, 14).
--define(SEGMENT_ENTRY_COUNT, 16384). %% trunc(math:pow(2,?REL_SEQ_BITS))).
+-define(SEGMENT_ENTRY_COUNT, 2048).
 
 %% seq only is binary 01 followed by 14 bits of rel seq id
 %% (range: 0 - 16383)

--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -127,6 +127,7 @@
 %% binary generation/matching with constant vs variable lengths.
 
 -define(REL_SEQ_BITS, 14).
+%% calculated as trunc(math:pow(2,?REL_SEQ_BITS))).
 -define(SEGMENT_ENTRY_COUNT, 16384).
 
 %% seq only is binary 01 followed by 14 bits of rel seq id

--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -127,7 +127,7 @@
 %% binary generation/matching with constant vs variable lengths.
 
 -define(REL_SEQ_BITS, 14).
--define(SEGMENT_ENTRY_COUNT, 2048).
+-define(SEGMENT_ENTRY_COUNT, 16384).
 
 %% seq only is binary 01 followed by 14 bits of rel seq id
 %% (range: 0 - 16383)


### PR DESCRIPTION
After some consideration I decided to not make `SEGMENT_ENTRY_COUNT` configurable. It turned out to be hairier than expected and I would rather not have such changes in `3.5.x`. As for `3.6.x`, there are more important issues to spend time on right now.

Fixes #279, see #227 for background info.