### PR TITLE
Make rabbitmqctl list_* operations display things dynamically, fixes #62

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -120,7 +120,7 @@
 -spec(info_all/2 :: (rabbit_types:vhost(), rabbit_types:info_keys())
                     -> [rabbit_types:infos()]).
 -spec(info_all/4 :: (rabbit_types:vhost(), rabbit_types:info_keys(),
-                     reference()) -> 'ok').
+                     reference(), pid()) -> 'ok').
 -spec(force_event_refresh/1 :: (reference()) -> 'ok').
 -spec(notify_policy_changed/1 :: (rabbit_types:amqqueue()) -> 'ok').
 -spec(consumers/1 :: (rabbit_types:amqqueue())
@@ -133,8 +133,7 @@
              non_neg_integer(), rabbit_framing:amqp_table()}]).
 -spec(consumers_all/3 ::
         (rabbit_types:vhost(), reference(), pid())
-        -> [{reference(), {name(), pid(), rabbit_types:ctag(), boolean(),
-             non_neg_integer(), rabbit_framing:amqp_table()}}]).
+        -> 'ok').
 -spec(stat/1 ::
         (rabbit_types:amqqueue())
         -> {'ok', non_neg_integer(), non_neg_integer()}).
@@ -633,7 +632,9 @@ consumers_all(VHostPath, Ref, Pid) ->
                                   AckRequired, Prefetch, Args]) ||
                                   {ChPid, CTag, AckRequired, Prefetch, Args}
                                       <- consumers(Q)]}
-          end)).
+          end)),
+    Pid ! {Ref, finished},
+    ok.
 
 stat(#amqqueue{pid = QPid}) -> delegate:call(QPid, stat).
 

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -597,7 +597,8 @@ info_all(VHostPath, Items, Ref, AggregatorPid) ->
       AggregatorPid, Ref, fun(Q) -> info(Q, Items) end, list(VHostPath),
       continue),
     rabbit_control_main:emitting_map(
-      AggregatorPid, Ref, fun(Q) -> info_down(Q, Items) end, list(VHostPath)).
+      AggregatorPid, Ref,
+      fun(Q) -> info_down(Q, Items) end, list_down(VHostPath)).
     
 force_event_refresh(Ref) ->
     [gen_server2:cast(Q#amqqueue.pid,

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -622,8 +622,7 @@ consumers_all(VHostPath, Ref, AggregatorPid) ->
     rabbit_control_main:emitting_map(
       AggregatorPid, Ref,
       fun(Q) -> get_queue_consumer_info(Q, ConsumerInfoKeys) end,
-      list(VHostPath)),
-    ok.
+      list(VHostPath)).
 
 get_queue_consumer_info(Q, ConsumerInfoKeys) ->
     lists:flatten(

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -612,7 +612,7 @@ consumers(#amqqueue{ pid = QPid }) -> delegate:call(QPid, consumers).
 consumer_info_keys() -> ?CONSUMER_INFO_KEYS.
 
 consumers_all(VHostPath) ->
-    ConsumerInfoKeys=consumer_info_keys(),
+    ConsumerInfoKeys = consumer_info_keys(),
     lists:append(
       map(list(VHostPath),
           fun (Q) ->
@@ -623,19 +623,19 @@ consumers_all(VHostPath) ->
           end)).
 
 consumers_all(VHostPath, Ref, AggregatorPid) ->
-    ConsumerInfoKeys=consumer_info_keys(),
+    ConsumerInfoKeys = consumer_info_keys(),
     map(list(VHostPath),
-        fun (Q) ->
-                AggregatorPid !
-                    {Ref, [lists:zip(
-                             ConsumerInfoKeys,
-                             [Q#amqqueue.name, ChPid, CTag,
-                              AckRequired, Prefetch, Args]) ||
-                              {ChPid, CTag, AckRequired, Prefetch, Args}
-                                  <- consumers(Q)]}
+        fun (Q) -> AggregatorPid !
+                       {Ref, get_queue_consumer_info(Q, ConsumerInfoKeys)}
         end),
     AggregatorPid ! {Ref, finished},
     ok.
+
+get_queue_consumer_info(Q, ConsumerInfoKeys) ->
+    lists:flatten([lists:zip(ConsumerInfoKeys,
+                             [Q#amqqueue.name, ChPid, CTag,
+                              AckRequired, Prefetch, Args]) ||
+                      {ChPid, CTag, AckRequired, Prefetch, Args} <- consumers(Q)]).
 
 stat(#amqqueue{pid = QPid}) -> delegate:call(QPid, stat).
 

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -624,17 +624,16 @@ consumers_all(VHostPath) ->
 
 consumers_all(VHostPath, Ref, AggregatorPid) ->
     ConsumerInfoKeys=consumer_info_keys(),
-    lists:append(
-      map(list(VHostPath),
-          fun (Q) ->
-                  AggregatorPid !
-                      {Ref, [lists:zip(
-                               ConsumerInfoKeys,
-                               [Q#amqqueue.name, ChPid, CTag,
-                                AckRequired, Prefetch, Args]) ||
-                                {ChPid, CTag, AckRequired, Prefetch, Args}
-                                    <- consumers(Q)]}
-          end)),
+    map(list(VHostPath),
+        fun (Q) ->
+                AggregatorPid !
+                    {Ref, [lists:zip(
+                             ConsumerInfoKeys,
+                             [Q#amqqueue.name, ChPid, CTag,
+                              AckRequired, Prefetch, Args]) ||
+                              {ChPid, CTag, AckRequired, Prefetch, Args}
+                                  <- consumers(Q)]}
+        end),
     AggregatorPid ! {Ref, finished},
     ok.
 

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -24,10 +24,11 @@
          assert_equivalence/5,
          check_exclusive_access/2, with_exclusive_access_or_die/3,
          stat/1, deliver/2, requeue/3, ack/3, reject/4]).
--export([list/0, list/1, info_keys/0, info/1, info/2, info_all/1, info_all/2]).
+-export([list/0, list/1, info_keys/0, info/1, info/2, info_all/1, info_all/2,
+         info_all/4]).
 -export([list_down/1]).
 -export([force_event_refresh/1, notify_policy_changed/1]).
--export([consumers/1, consumers_all/1, consumer_info_keys/0]).
+-export([consumers/1, consumers_all/1,  consumers_all/3, consumer_info_keys/0]).
 -export([basic_get/4, basic_consume/10, basic_cancel/4, notify_decorators/1]).
 -export([notify_sent/2, notify_sent_queue_down/1, resume/2]).
 -export([notify_down_all/2, activate_limit_all/2, credit/5]).
@@ -118,6 +119,8 @@
 -spec(info_all/1 :: (rabbit_types:vhost()) -> [rabbit_types:infos()]).
 -spec(info_all/2 :: (rabbit_types:vhost(), rabbit_types:info_keys())
                     -> [rabbit_types:infos()]).
+-spec(info_all/4 :: (rabbit_types:vhost(), rabbit_types:info_keys(),
+                     reference()) -> 'ok').
 -spec(force_event_refresh/1 :: (reference()) -> 'ok').
 -spec(notify_policy_changed/1 :: (rabbit_types:amqqueue()) -> 'ok').
 -spec(consumers/1 :: (rabbit_types:amqqueue())
@@ -128,6 +131,10 @@
         (rabbit_types:vhost())
         -> [{name(), pid(), rabbit_types:ctag(), boolean(),
              non_neg_integer(), rabbit_framing:amqp_table()}]).
+-spec(consumers_all/3 ::
+        (rabbit_types:vhost(), reference(), pid())
+        -> [{reference(), {name(), pid(), rabbit_types:ctag(), boolean(),
+             non_neg_integer(), rabbit_framing:amqp_table()}}]).
 -spec(stat/1 ::
         (rabbit_types:amqqueue())
         -> {'ok', non_neg_integer(), non_neg_integer()}).
@@ -586,6 +593,12 @@ info_all(VHostPath, Items) ->
     map(list(VHostPath), fun (Q) -> info(Q, Items) end) ++
         map(list_down(VHostPath), fun (Q) -> info_down(Q, Items, down) end).
 
+info_all(VHostPath, Items, Ref, Pid) ->
+    map(list(VHostPath), fun (Q) -> Pid ! {Ref, info(Q, Items)} end) ++
+        map(list_down(VHostPath), fun (Q) -> Pid ! {Ref, info_down(Q, Items, down)} end),
+    Pid  ! {Ref, finished},
+    ok.
+    
 force_event_refresh(Ref) ->
     [gen_server2:cast(Q#amqqueue.pid,
                       {force_event_refresh, Ref}) || Q <- list()],
@@ -607,6 +620,19 @@ consumers_all(VHostPath) ->
                  ConsumerInfoKeys,
                  [Q#amqqueue.name, ChPid, CTag, AckRequired, Prefetch, Args]) ||
                   {ChPid, CTag, AckRequired, Prefetch, Args} <- consumers(Q)]
+          end)).
+
+consumers_all(VHostPath, Ref, Pid) ->
+    ConsumerInfoKeys=consumer_info_keys(),
+    lists:append(
+      map(list(VHostPath),
+          fun (Q) ->
+                  Pid ! {Ref, [lists:zip(
+                                 ConsumerInfoKeys,
+                                 [Q#amqqueue.name, ChPid, CTag,
+                                  AckRequired, Prefetch, Args]) ||
+                                  {ChPid, CTag, AckRequired, Prefetch, Args}
+                                      <- consumers(Q)]}
           end)).
 
 stat(#amqqueue{pid = QPid}) -> delegate:call(QPid, stat).

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -365,13 +365,13 @@ list_user_vhost_permissions(Username, VHostPath) ->
         Username, VHostPath, match_user_vhost(Username, VHostPath))).
 
 extract_user_permission_params(Keys, #user_permission{
-                                user_vhost =
-                                    #user_vhost{username     = Username,
-                                                virtual_host = VHostPath},
-                                permission = #permission{
-                                                configure = ConfigurePerm,
-                                                write     = WritePerm,
-                                                read      = ReadPerm}}) ->
+                                        user_vhost =
+                                            #user_vhost{username     = Username,
+                                                        virtual_host = VHostPath},
+                                        permission = #permission{
+                                                        configure = ConfigurePerm,
+                                                        write     = WritePerm,
+                                                        read      = ReadPerm}}) ->
     filter_props(Keys, [{user,      Username},
                         {vhost,     VHostPath},
                         {configure, ConfigurePerm},

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -331,8 +331,7 @@ list_permissions(Keys, QueryThunk) ->
 list_permissions(Keys, QueryThunk, Ref, AggregatorPid) ->
     rabbit_control_main:emitting_map(
       AggregatorPid, Ref, fun(U) -> user_permission_filter(Keys, U) end,
-      rabbit_misc:execute_mnesia_transaction(QueryThunk)),
-    ok.
+      rabbit_misc:execute_mnesia_transaction(QueryThunk)).
 
 filter_props(Keys, Props) -> [T || T = {K, _} <- Props, lists:member(K, Keys)].
 

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -352,7 +352,6 @@ list_permissions(Keys, QueryThunk, Ref, Pid) ->
                                          configure = ConfigurePerm,
                                          write     = WritePerm,
                                          read      = ReadPerm}} <-
-            %% TODO: use dirty ops instead
             rabbit_misc:execute_mnesia_transaction(QueryThunk)],
     Pid ! {Ref, finished},
     ok.

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -22,7 +22,7 @@
          list_for_source_and_destination/2]).
 -export([new_deletions/0, combine_deletions/2, add_deletion/3,
          process_deletions/1]).
--export([info_keys/0, info/1, info/2, info_all/1, info_all/2]).
+-export([info_keys/0, info/1, info/2, info_all/1, info_all/2, info_all/4]).
 %% these must all be run inside a mnesia tx
 -export([has_for_source/1, remove_for_source/1,
          remove_for_destination/2, remove_transient_for_destination/1]).
@@ -78,6 +78,8 @@
 -spec(info_all/1 :: (rabbit_types:vhost()) -> [rabbit_types:infos()]).
 -spec(info_all/2 ::(rabbit_types:vhost(), rabbit_types:info_keys())
                    -> [rabbit_types:infos()]).
+-spec(info_all/4 ::(rabbit_types:vhost(), rabbit_types:info_keys(),
+                    reference(), pid()) -> 'ok').
 -spec(has_for_source/1 :: (rabbit_types:binding_source()) -> boolean()).
 -spec(remove_for_source/1 :: (rabbit_types:binding_source()) -> bindings()).
 -spec(remove_for_destination/2 ::
@@ -283,6 +285,11 @@ info(B = #binding{}, Items) -> infos(Items, B).
 info_all(VHostPath) -> map(VHostPath, fun (B) -> info(B) end).
 
 info_all(VHostPath, Items) -> map(VHostPath, fun (B) -> info(B, Items) end).
+
+info_all(VHostPath, Items, Ref, Pid) ->
+    map(VHostPath, fun (B) -> Pid ! {Ref, info(B, Items)} end),
+    Pid ! {Ref, finished},
+    ok.
 
 has_for_source(SrcName) ->
     Match = #route{binding = #binding{source = SrcName, _ = '_'}},

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -287,9 +287,8 @@ info_all(VHostPath) -> map(VHostPath, fun (B) -> info(B) end).
 info_all(VHostPath, Items) -> map(VHostPath, fun (B) -> info(B, Items) end).
 
 info_all(VHostPath, Items, Ref, AggregatorPid) ->
-    map(VHostPath, fun (B) -> AggregatorPid ! {Ref, info(B, Items)} end),
-    AggregatorPid ! {Ref, finished},
-    ok.
+    rabbit_control_main:emitting_map(
+      AggregatorPid, Ref, fun(B) -> info(B, Items) end, list(VHostPath)).
 
 has_for_source(SrcName) ->
     Match = #route{binding = #binding{source = SrcName, _ = '_'}},

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -286,9 +286,9 @@ info_all(VHostPath) -> map(VHostPath, fun (B) -> info(B) end).
 
 info_all(VHostPath, Items) -> map(VHostPath, fun (B) -> info(B, Items) end).
 
-info_all(VHostPath, Items, Ref, Pid) ->
-    map(VHostPath, fun (B) -> Pid ! {Ref, info(B, Items)} end),
-    Pid ! {Ref, finished},
+info_all(VHostPath, Items, Ref, AggregatorPid) ->
+    map(VHostPath, fun (B) -> AggregatorPid ! {Ref, info(B, Items)} end),
+    AggregatorPid ! {Ref, finished},
     ok.
 
 has_for_source(SrcName) ->

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -328,10 +328,11 @@ info_all(Items) ->
     rabbit_misc:filter_exit_map(fun (C) -> info(C, Items) end, list()).
 
 info_all(Items, Ref, AggregatorPid) ->
-    rabbit_misc:filter_exit_map(fun (C) -> AggregatorPid !
-                                               {Ref, info(C, Items)} end,
-                                list()),
-    AggregatorPid ! {Ref, finished},
+    rabbit_misc:filter_exit_map(
+      fun(E) -> rabbit_control_main:emitting_map(
+                  AggregatorPid, Ref, fun(C) -> info(C, Items) end, [E])
+      end,
+      list()),
     ok.
 
 refresh_config_local() ->

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -327,10 +327,11 @@ info_all() ->
 info_all(Items) ->
     rabbit_misc:filter_exit_map(fun (C) -> info(C, Items) end, list()).
 
-info_all(Items, Ref, Pid) ->
-    rabbit_misc:filter_exit_map(fun (C) -> Pid ! {Ref, info(C, Items)} end,
+info_all(Items, Ref, AggregatorPid) ->
+    rabbit_misc:filter_exit_map(fun (C) -> AggregatorPid !
+                                               {Ref, info(C, Items)} end,
                                 list()),
-    Pid ! {Ref, finished},
+    AggregatorPid ! {Ref, finished},
     ok.
 
 refresh_config_local() ->

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -328,12 +328,9 @@ info_all(Items) ->
     rabbit_misc:filter_exit_map(fun (C) -> info(C, Items) end, list()).
 
 info_all(Items, Ref, AggregatorPid) ->
-    rabbit_misc:filter_exit_map(
-      fun(E) -> rabbit_control_main:emitting_map(
-                  AggregatorPid, Ref, fun(C) -> info(C, Items) end, [E])
-      end,
-      list()),
-    ok.
+    rabbit_control_main:emitting_map_with_wrapper_fun(
+      AggregatorPid, Ref, fun(C) -> info(C, Items) end,
+      fun(F, L) -> rabbit_misc:filter_exit_map(F, L) end, list()).
 
 refresh_config_local() ->
     rabbit_misc:upmap(

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -55,7 +55,8 @@
 -export([start_link/11, do/2, do/3, do_flow/3, flush/1, shutdown/1]).
 -export([send_command/2, deliver/4, deliver_reply/2,
          send_credit_reply/2, send_drained/2]).
--export([list/0, info_keys/0, info/1, info/2, info_all/0, info_all/1]).
+-export([list/0, info_keys/0, info/1, info/2, info_all/0, info_all/1,
+         info_all/3]).
 -export([refresh_config_local/0, ready_for_close/1]).
 -export([force_event_refresh/1]).
 
@@ -218,6 +219,7 @@
 -spec(info/2 :: (pid(), rabbit_types:info_keys()) -> rabbit_types:infos()).
 -spec(info_all/0 :: () -> [rabbit_types:infos()]).
 -spec(info_all/1 :: (rabbit_types:info_keys()) -> [rabbit_types:infos()]).
+-spec(info_all/3 :: (rabbit_types:info_keys(), reference(), pid()) -> 'ok').
 -spec(refresh_config_local/0 :: () -> 'ok').
 -spec(ready_for_close/1 :: (pid()) -> 'ok').
 -spec(force_event_refresh/1 :: (reference()) -> 'ok').
@@ -324,6 +326,12 @@ info_all() ->
 
 info_all(Items) ->
     rabbit_misc:filter_exit_map(fun (C) -> info(C, Items) end, list()).
+
+info_all(Items, Ref, Pid) ->
+    rabbit_misc:filter_exit_map(fun (C) -> Pid ! {Ref, info(C, Items)} end,
+                                list()),
+    Pid ! {Ref, finished},
+    ok.
 
 refresh_config_local() ->
     rabbit_misc:upmap(

--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -110,7 +110,8 @@ main(ParseFun, DoFun, UsageMod) ->
             print_badrpc_diagnostics(Nodes),
             rabbit_misc:quit(2);
         function_clause ->
-            print_error("invalid parameter: ~p", [Args]),
+            print_error("operation ~w used with invalid parameter: ~p",
+                        [Command, Args]),
             usage(UsageMod);        
         Other ->
             print_error("~p", [Other]),

--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -232,9 +232,5 @@ rpc_call(Node, Mod, Fun, Args, Timeout) ->
     end.
 
 rpc_call(Node, Mod, Fun, Args, Ref, Pid, Timeout) ->
-    case rpc:call(Node, net_kernel, get_net_ticktime, [], Timeout) of
-        {badrpc, _} = E -> E;
-        Time            -> net_kernel:set_net_ticktime(Time, 0),
-                           rpc:call(Node, Mod, Fun, Args++[Ref, Pid], Timeout)
-    end.
+    rpc_call(Node, Mod, Fun, Args++[Ref, Pid], Timeout).
 

--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -38,9 +38,10 @@
 -spec(parse_arguments/4 ::
         ([{atom(), [{string(), optdef()}]} | atom()],
          [{string(), optdef()}], string(), [string()]) -> parse_result()).
--spec(rpc_call/4 :: (node(), atom(), atom(), [any()]) -> any()).
--spec(rpc_call/5 :: (node(), atom(), atom(), [any()]) -> any()).
--spec(rpc_call/7 :: (node(), atom(), atom(), [any()]) -> any()).
+-spec(rpc_call/4 :: (node(), atom(), atom(), [any()]) -> any()). 
+-spec(rpc_call/5 :: (node(), atom(), atom(), [any()], number()) -> any()).
+-spec(rpc_call/7 :: (node(), atom(), atom(), [any()], reference(), pid(),
+                     number()) -> any()).
 
 -endif.
 

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -701,8 +701,8 @@ wait_for_info_messages(Ref, InfoItemKeys) when is_reference(Ref) ->
     receive
         {Ref,  finished}     -> ok;
         {Ref,  {timeout, T}} -> exit({error, {timeout, (T / 1000)}});
-        {_Ref, []}           -> wait_for_info_messages(Ref, InfoItemKeys);
-        {_Ref, Result}       -> display_info_message(Result, InfoItemKeys),
+        {Ref,  []}           -> wait_for_info_messages(Ref, InfoItemKeys);
+        {Ref,  Result}       -> display_info_message(Result, InfoItemKeys),
                                 wait_for_info_messages(Ref, InfoItemKeys);
         _                    -> wait_for_info_messages(Ref, InfoItemKeys)
     end.

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -515,13 +515,13 @@ action(list_parameters, Node, [], Opts, Inform, Timeout) ->
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
     Inform("Listing runtime parameters", []),
     call(Node, {rabbit_runtime_parameters, list_formatted, [VHostArg]},
-         rabbit_runtime_parameters:info_keys(), false, Timeout);
+         rabbit_runtime_parameters:info_keys(), Timeout);
 
 action(list_policies, Node, [], Opts, Inform, Timeout) ->
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
     Inform("Listing policies", []),
     call(Node, {rabbit_policy, list_formatted, [VHostArg]},
-         rabbit_policy:info_keys(), false, Timeout);
+         rabbit_policy:info_keys(), Timeout);
 
 action(list_vhosts, Node, Args, _Opts, Inform, Timeout) ->
     Inform("Listing vhosts", []),
@@ -541,14 +541,14 @@ action(list_queues, Node, Args, Opts, Inform, Timeout) ->
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
     ArgAtoms = default_if_empty(Args, [name, messages]),
     call(Node, {rabbit_amqqueue, info_all, [VHostArg, ArgAtoms]},
-         ArgAtoms, false, Timeout);
+         ArgAtoms, Timeout);
 
 action(list_exchanges, Node, Args, Opts, Inform, Timeout) ->
     Inform("Listing exchanges", []),
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
     ArgAtoms = default_if_empty(Args, [name, type]),
     call(Node, {rabbit_exchange, info_all, [VHostArg, ArgAtoms]},
-         ArgAtoms, false, Timeout);
+         ArgAtoms, Timeout);
 
 action(list_bindings, Node, Args, Opts, Inform, Timeout) ->
     Inform("Listing bindings", []),
@@ -557,26 +557,26 @@ action(list_bindings, Node, Args, Opts, Inform, Timeout) ->
                                        destination_name, destination_kind,
                                        routing_key, arguments]),
     call(Node, {rabbit_binding, info_all, [VHostArg, ArgAtoms]},
-         ArgAtoms, false, Timeout);
+         ArgAtoms, Timeout);
 
 action(list_connections, Node, Args, _Opts, Inform, Timeout) ->
     Inform("Listing connections", []),
     ArgAtoms = default_if_empty(Args, [user, peer_host, peer_port, state]),
     call(Node, {rabbit_networking, connection_info_all, [ArgAtoms]},
-         ArgAtoms, false, Timeout);
+         ArgAtoms, Timeout);
 
 action(list_channels, Node, Args, _Opts, Inform, Timeout) ->
     Inform("Listing channels", []),
     ArgAtoms = default_if_empty(Args, [pid, user, consumer_count,
                                        messages_unacknowledged]),
     call(Node, {rabbit_channel, info_all, [ArgAtoms]},
-         ArgAtoms, false, Timeout);
+         ArgAtoms, Timeout);
 
 action(list_consumers, Node, _Args, Opts, Inform, Timeout) ->
     Inform("Listing consumers", []),
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
     call(Node, {rabbit_amqqueue, consumers_all, [VHostArg]},
-         rabbit_amqqueue:consumer_info_keys(), false, Timeout).
+         rabbit_amqqueue:consumer_info_keys(), Timeout).
 
 format_parse_error({_Line, Mod, Err}) -> lists:flatten(Mod:format_error(Err)).
 
@@ -766,6 +766,9 @@ notify_if_timeout(Pid, Ref, Timeout) ->
 
 call(Node, {Mod, Fun, Args}) ->
     rpc_call(Node, Mod, Fun, lists:map(fun list_to_binary_utf8/1, Args)).
+
+call(Node, {Mod, Fun, Args}, InfoKeys, Timeout) ->
+    call(Node, {Mod, Fun, Args}, InfoKeys, false, Timeout).
 
 call(Node, {Mod, Fun, Args}, InfoKeys, ToBinUtf8, Timeout) ->
     Args0 = case ToBinUtf8 of

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -501,18 +501,18 @@ action(list_users, Node, [], _Opts, Inform, Timeout) ->
     Inform("Listing users", []),
     call(Node, {rabbit_auth_backend_internal, list_users, []}, Ref=make_ref(),
          Timeout),
-    wait_info_messages(self(), Ref,
-                       rabbit_auth_backend_internal:user_info_keys(),
-                       Timeout);
+    wait_for_info_messages(self(), Ref,
+                           rabbit_auth_backend_internal:user_info_keys(),
+                           Timeout);
 
 action(list_permissions, Node, [], Opts, Inform, Timeout) ->
     VHost = proplists:get_value(?VHOST_OPT, Opts),
     Inform("Listing permissions in vhost \"~s\"", [VHost]),
     call(Node,{rabbit_auth_backend_internal, list_vhost_permissions,
                [VHost]}, Ref=make_ref(), Timeout),
-    wait_info_messages(self(), Ref,
-                       rabbit_auth_backend_internal:vhost_perms_info_keys(),
-                       Timeout);
+    wait_for_info_messages(self(), Ref,
+                           rabbit_auth_backend_internal:vhost_perms_info_keys(),
+                           Timeout);
 
 action(list_parameters, Node, [], Opts, Inform, Timeout) ->
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
@@ -520,7 +520,7 @@ action(list_parameters, Node, [], Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_runtime_parameters,
                                       list_formatted, [VHostArg], Ref=make_ref(),
                                       Pid=self(), Timeout]),
-    wait_info_messages(Pid, Ref, rabbit_runtime_parameters:info_keys(), Timeout);
+    wait_for_info_messages(Pid, Ref, rabbit_runtime_parameters:info_keys(), Timeout);
 
 action(list_policies, Node, [], Opts, Inform, Timeout) ->
     VHostArg = list_to_binary(proplists:get_value(?VHOST_OPT, Opts)),
@@ -528,13 +528,13 @@ action(list_policies, Node, [], Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_policy, list_formatted,
                                       [VHostArg], Ref=make_ref(),
                                       Pid=self(), Timeout]),
-    wait_info_messages(Pid, Ref, rabbit_policy:info_keys(), Timeout);
+    wait_for_info_messages(Pid, Ref, rabbit_policy:info_keys(), Timeout);
 
 action(list_vhosts, Node, Args, _Opts, Inform, Timeout) ->
     Inform("Listing vhosts", []),
     ArgAtoms = default_if_empty(Args, [name]),
     call(Node, {rabbit_vhost, info_all, []}, Ref=make_ref(), Timeout),
-    wait_info_messages(self(), Ref, ArgAtoms, Timeout);
+    wait_for_info_messages(self(), Ref, ArgAtoms, Timeout);
 
 action(list_user_permissions, _Node, _Args = [], _Opts, _Inform, _Timeout) ->
     {error_string,
@@ -543,9 +543,9 @@ action(list_user_permissions, Node, Args = [_Username], _Opts, Inform, Timeout) 
     Inform("Listing permissions for user ~p", Args),
     call(Node, {rabbit_auth_backend_internal, list_user_permissions, Args},
          Ref=make_ref(), Timeout),
-    wait_info_messages(self(), Ref,
-                       rabbit_auth_backend_internal:user_perms_info_keys(),
-                       Timeout);
+    wait_for_info_messages(self(), Ref,
+                           rabbit_auth_backend_internal:user_perms_info_keys(),
+                           Timeout);
 
 action(list_queues, Node, Args, Opts, Inform, Timeout) ->
     Inform("Listing queues", []),
@@ -554,7 +554,7 @@ action(list_queues, Node, Args, Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_amqqueue, info_all,
                                       [VHostArg, ArgAtoms], Ref=make_ref(),
                                        Pid=self(), Timeout]),
-    wait_info_messages(Pid, Ref, ArgAtoms, Timeout);
+    wait_for_info_messages(Pid, Ref, ArgAtoms, Timeout);
 
 action(list_exchanges, Node, Args, Opts, Inform, Timeout) ->
     Inform("Listing exchanges", []),
@@ -563,7 +563,7 @@ action(list_exchanges, Node, Args, Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_exchange, info_all,
                                       [VHostArg, ArgAtoms], Ref=make_ref(),
                                        Pid=self(), Timeout]),
-    wait_info_messages(Pid, Ref, ArgAtoms, Timeout);
+    wait_for_info_messages(Pid, Ref, ArgAtoms, Timeout);
 
 action(list_bindings, Node, Args, Opts, Inform, Timeout) ->
     Inform("Listing bindings", []),
@@ -574,7 +574,7 @@ action(list_bindings, Node, Args, Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_binding, info_all,
                                       [VHostArg, ArgAtoms], Ref=make_ref(),
                                       Pid=self(), Timeout]),
-    wait_info_messages(Pid, Ref, ArgAtoms, Timeout);
+    wait_for_info_messages(Pid, Ref, ArgAtoms, Timeout);
 
 action(list_connections, Node, Args, _Opts, Inform, Timeout) ->
     Inform("Listing connections", []),
@@ -583,7 +583,7 @@ action(list_connections, Node, Args, _Opts, Inform, Timeout) ->
                                       connection_info_all,
                                       [ArgAtoms], Ref=make_ref(), Pid=self(),
                                        Timeout]),
-    wait_info_messages(Pid, Ref, ArgAtoms, Timeout);
+    wait_for_info_messages(Pid, Ref, ArgAtoms, Timeout);
 
 action(list_channels, Node, Args, _Opts, Inform, Timeout) ->
     Inform("Listing channels", []),
@@ -592,7 +592,7 @@ action(list_channels, Node, Args, _Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_channel, info_all,
                                       [ArgAtoms], Ref=make_ref(), Pid=self(),
                                       Timeout]),
-    wait_info_messages(Pid, Ref, ArgAtoms, Timeout);
+    wait_for_info_messages(Pid, Ref, ArgAtoms, Timeout);
 
 action(list_consumers, Node, _Args, Opts, Inform, Timeout) ->
     Inform("Listing consumers", []),
@@ -600,8 +600,8 @@ action(list_consumers, Node, _Args, Opts, Inform, Timeout) ->
     spawn_link(rabbit_cli, rpc_call, [Node, rabbit_amqqueue, consumers_all,
                                       [VHostArg], Ref=make_ref(), Pid=self(),
                                       Timeout]),
-    wait_info_messages(Pid, Ref, rabbit_amqqueue:consumer_info_keys(),
-                       Timeout).
+    wait_for_info_messages(Pid, Ref, rabbit_amqqueue:consumer_info_keys(),
+                           Timeout).
 
 format_parse_error({_Line, Mod, Err}) -> lists:flatten(Mod:format_error(Err)).
 
@@ -693,18 +693,18 @@ default_if_empty(List, Default) when is_list(List) ->
        true       -> [list_to_atom(X) || X <- List]
     end.
 
-wait_info_messages(Pid, Ref, ArgAtoms, Timeout) ->
+wait_for_info_messages(Pid, Ref, ArgAtoms, Timeout) ->
     notify_if_timeout(Pid, Ref, Timeout),
-    wait_info_messages(Ref, ArgAtoms).
+    wait_for_info_messages(Ref, ArgAtoms).
 
-wait_info_messages(Ref, InfoItemKeys) when is_reference(Ref) ->
+wait_for_info_messages(Ref, InfoItemKeys) when is_reference(Ref) ->
     receive
         {Ref,  finished}     -> ok;
         {Ref,  {timeout, T}} -> exit({error, {timeout, (T / 1000)}});
-        {_Ref, []}           -> wait_info_messages(Ref, InfoItemKeys);
+        {_Ref, []}           -> wait_for_info_messages(Ref, InfoItemKeys);
         {_Ref, Result}       -> display_info_message(Result, InfoItemKeys),
-                                wait_info_messages(Ref, InfoItemKeys);
-        _                    -> wait_info_messages(Ref, InfoItemKeys)
+                                wait_for_info_messages(Ref, InfoItemKeys);
+        _                    -> wait_for_info_messages(Ref, InfoItemKeys)
     end.
 
 display_info_message(Result, InfoItemKeys) ->

--- a/src/rabbit_exchange.erl
+++ b/src/rabbit_exchange.erl
@@ -344,9 +344,8 @@ info_all(VHostPath) -> map(VHostPath, fun (X) -> info(X) end).
 info_all(VHostPath, Items) -> map(VHostPath, fun (X) -> info(X, Items) end).
 
 info_all(VHostPath, Items, Ref, AggregatorPid) ->
-    map(VHostPath, fun (X) -> AggregatorPid ! {Ref, info(X, Items)} end),
-    AggregatorPid ! {Ref, finished},
-    ok.
+    rabbit_control_main:emitting_map(
+      AggregatorPid, Ref, fun(X) -> info(X, Items) end, list(VHostPath)).
 
 route(#exchange{name = #resource{virtual_host = VHost, name = RName} = XName,
                 decorators = Decorators} = X,

--- a/src/rabbit_exchange.erl
+++ b/src/rabbit_exchange.erl
@@ -343,9 +343,9 @@ info_all(VHostPath) -> map(VHostPath, fun (X) -> info(X) end).
 
 info_all(VHostPath, Items) -> map(VHostPath, fun (X) -> info(X, Items) end).
 
-info_all(VHostPath, Items, Ref, Pid) ->
-    map(VHostPath, fun (X) -> Pid ! {Ref, info(X, Items)} end),
-    Pid ! {Ref, finished},
+info_all(VHostPath, Items, Ref, AggregatorPid) ->
+    map(VHostPath, fun (X) -> AggregatorPid ! {Ref, info(X, Items)} end),
+    AggregatorPid ! {Ref, finished},
     ok.
 
 route(#exchange{name = #resource{virtual_host = VHost, name = RName} = XName,

--- a/src/rabbit_exchange.erl
+++ b/src/rabbit_exchange.erl
@@ -22,7 +22,7 @@
          assert_equivalence/6, assert_args_equivalence/2, check_type/1,
          lookup/1, lookup_or_die/1, list/0, list/1, lookup_scratch/2,
          update_scratch/3, update_decorators/1, immutable/1,
-         info_keys/0, info/1, info/2, info_all/1, info_all/2,
+         info_keys/0, info/1, info/2, info_all/1, info_all/2, info_all/4,
          route/2, delete/2, validate_binding/2]).
 %% these must be run inside a mnesia tx
 -export([maybe_auto_delete/2, serial/1, peek_serial/1, update/2]).
@@ -82,6 +82,9 @@
 -spec(info_all/1 :: (rabbit_types:vhost()) -> [rabbit_types:infos()]).
 -spec(info_all/2 ::(rabbit_types:vhost(), rabbit_types:info_keys())
                    -> [rabbit_types:infos()]).
+-spec(info_all/4 ::(rabbit_types:vhost(), rabbit_types:info_keys(),
+                    reference(), pid())
+                   -> 'ok').
 -spec(route/2 :: (rabbit_types:exchange(), rabbit_types:delivery())
                  -> [rabbit_amqqueue:name()]).
 -spec(delete/2 ::
@@ -339,6 +342,11 @@ info(X = #exchange{}, Items) -> infos(Items, X).
 info_all(VHostPath) -> map(VHostPath, fun (X) -> info(X) end).
 
 info_all(VHostPath, Items) -> map(VHostPath, fun (X) -> info(X, Items) end).
+
+info_all(VHostPath, Items, Ref, Pid) ->
+    map(VHostPath, fun (X) -> Pid ! {Ref, info(X, Items)} end),
+    Pid ! {Ref, finished},
+    ok.
 
 route(#exchange{name = #resource{virtual_host = VHost, name = RName} = XName,
                 decorators = Decorators} = X,

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -443,8 +443,10 @@ connection_info_all() -> cmap(fun (Q) -> connection_info(Q) end).
 connection_info_all(Items) -> cmap(fun (Q) -> connection_info(Q, Items) end).
 
 connection_info_all(Items, Ref, AggregatorPid) ->
-    cmap(fun (Q) -> AggregatorPid ! {Ref, connection_info(Q, Items)} end),
-    AggregatorPid ! {Ref, finished},
+    cmap(fun(E) -> rabbit_control_main:emitting_map(
+                     AggregatorPid, Ref,
+                     fun(Q) -> connection_info(Q, Items) end, [E])
+         end),
     ok.
 
 close_connection(Pid, Explanation) ->

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -442,9 +442,9 @@ connection_info(Pid, Items) -> rabbit_reader:info(Pid, Items).
 connection_info_all() -> cmap(fun (Q) -> connection_info(Q) end).
 connection_info_all(Items) -> cmap(fun (Q) -> connection_info(Q, Items) end).
 
-connection_info_all(Items, Ref, Pid) ->
-    cmap(fun (Q) -> Pid ! {Ref, connection_info(Q, Items)} end),
-    Pid ! {Ref, finished},
+connection_info_all(Items, Ref, AggregatorPid) ->
+    cmap(fun (Q) -> AggregatorPid ! {Ref, connection_info(Q, Items)} end),
+    AggregatorPid ! {Ref, finished},
     ok.
 
 close_connection(Pid, Explanation) ->

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -443,11 +443,9 @@ connection_info_all() -> cmap(fun (Q) -> connection_info(Q) end).
 connection_info_all(Items) -> cmap(fun (Q) -> connection_info(Q, Items) end).
 
 connection_info_all(Items, Ref, AggregatorPid) ->
-    cmap(fun(E) -> rabbit_control_main:emitting_map(
-                     AggregatorPid, Ref,
-                     fun(Q) -> connection_info(Q, Items) end, [E])
-         end),
-    ok.
+    rabbit_control_main:emitting_map_with_wrapper_fun(
+      AggregatorPid, Ref, fun(Q) -> connection_info(Q, Items) end,
+      fun(F, L) -> rabbit_misc:filter_exit_map(F, L) end, connections()).
 
 close_connection(Pid, Explanation) ->
     rabbit_log:info("Closing connection ~p because ~p~n", [Pid, Explanation]),

--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -171,16 +171,13 @@ list_formatted(VHost) ->
     order_policies(list0(VHost, fun format/1)).
 
 list_formatted(VHost, Ref, AggregatorPid) ->
-    list0(VHost, fun format/1, Ref, AggregatorPid),
+    [AggregatorPid ! {Ref, p(P, fun format/1)} ||
+        P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)],
     AggregatorPid ! {Ref, finished},
     ok.
 
 list0(VHost, DefnFun) ->
     [p(P, DefnFun) || P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].
-
-list0(VHost, DefnFun, Ref, AggregatorPid) ->
-    [AggregatorPid ! {Ref, p(P, DefnFun)} ||
-        P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].
 
 order_policies(PropList) ->
     lists:sort(fun (A, B) -> pget(priority, A) < pget(priority, B) end,

--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -170,16 +170,17 @@ list(VHost) ->
 list_formatted(VHost) ->
     order_policies(list0(VHost, fun format/1)).
 
-list_formatted(VHost, Ref, Pid) ->
-    list0(VHost, fun format/1, Ref, Pid),
-    Pid ! {Ref, finished},
+list_formatted(VHost, Ref, AggregatorPid) ->
+    list0(VHost, fun format/1, Ref, AggregatorPid),
+    AggregatorPid ! {Ref, finished},
     ok.
 
 list0(VHost, DefnFun) ->
     [p(P, DefnFun) || P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].
 
-list0(VHost, DefnFun, Ref, Pid) ->
-    [Pid ! {Ref, p(P, DefnFun)} || P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].
+list0(VHost, DefnFun, Ref, AggregatorPid) ->
+    [AggregatorPid ! {Ref, p(P, DefnFun)} ||
+        P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].
 
 order_policies(PropList) ->
     lists:sort(fun (A, B) -> pget(priority, A) < pget(priority, B) end,

--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -171,9 +171,8 @@ list_formatted(VHost) ->
     order_policies(list0(VHost, fun format/1)).
 
 list_formatted(VHost, Ref, AggregatorPid) ->
-    rabbit_control_main:emitting_map(
-      AggregatorPid, Ref, fun(P) -> p(P, fun format/1) end,
-      rabbit_runtime_parameters:list(VHost, <<"policy">>)).
+    rabbit_control_main:emitting_map(AggregatorPid, Ref,
+                                     fun(P) -> P end, list_formatted(VHost)).
 
 list0(VHost, DefnFun) ->
     [p(P, DefnFun) || P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].

--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -171,10 +171,9 @@ list_formatted(VHost) ->
     order_policies(list0(VHost, fun format/1)).
 
 list_formatted(VHost, Ref, AggregatorPid) ->
-    [AggregatorPid ! {Ref, p(P, fun format/1)} ||
-        P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)],
-    AggregatorPid ! {Ref, finished},
-    ok.
+    rabbit_control_main:emitting_map(
+      AggregatorPid, Ref, fun(P) -> p(P, fun format/1) end,
+      rabbit_runtime_parameters:list(VHost, <<"policy">>)).
 
 list0(VHost, DefnFun) ->
     [p(P, DefnFun) || P <- rabbit_runtime_parameters:list(VHost, <<"policy">>)].

--- a/src/rabbit_runtime_parameters.erl
+++ b/src/rabbit_runtime_parameters.erl
@@ -200,10 +200,9 @@ list_formatted(VHost) ->
     [pset(value, format(pget(value, P)), P) || P <- list(VHost)].
 
 list_formatted(VHost, Ref, AggregatorPid) ->
-    [AggregatorPid !
-         {Ref, pset(value, format(pget(value, P)), P)} || P <- list(VHost)],
-    AggregatorPid ! {Ref, finished},
-    ok.
+    rabbit_control_main:emitting_map(
+      AggregatorPid, Ref,
+      fun(P) -> pset(value, format(pget(value, P)), P) end, list(VHost)).
 
 lookup(VHost, Component, Name) ->
     case lookup0({VHost, Component, Name}, rabbit_misc:const(not_found)) of

--- a/src/rabbit_runtime_parameters.erl
+++ b/src/rabbit_runtime_parameters.erl
@@ -199,9 +199,10 @@ list(VHost, Component) ->
 list_formatted(VHost) ->
     [pset(value, format(pget(value, P)), P) || P <- list(VHost)].
 
-list_formatted(VHost, Ref, Pid) ->
-    [Pid ! {Ref, pset(value, format(pget(value, P)), P)} || P <- list(VHost)],
-    Pid ! {Ref, finished},
+list_formatted(VHost, Ref, AggregatorPid) ->
+    [AggregatorPid !
+         {Ref, pset(value, format(pget(value, P)), P)} || P <- list(VHost)],
+    AggregatorPid ! {Ref, finished},
     ok.
 
 lookup(VHost, Component, Name) ->

--- a/src/rabbit_runtime_parameters.erl
+++ b/src/rabbit_runtime_parameters.erl
@@ -19,8 +19,8 @@
 -include("rabbit.hrl").
 
 -export([parse_set/5, set/5, set_any/5, clear/3, clear_any/3, list/0, list/1,
-         list_component/1, list/2, list_formatted/1, lookup/3,
-         value/3, value/4, info_keys/0]).
+         list_component/1, list/2, list_formatted/1, list_formatted/3,
+         lookup/3, value/3, value/4, info_keys/0]).
 
 -export([set_global/2, value_global/1, value_global/2]).
 
@@ -48,6 +48,7 @@
 -spec(list/2 :: (rabbit_types:vhost() | '_', binary() | '_')
                 -> [rabbit_types:infos()]).
 -spec(list_formatted/1 :: (rabbit_types:vhost()) -> [rabbit_types:infos()]).
+-spec(list_formatted/3 :: (rabbit_types:vhost(), reference(), pid()) -> 'ok').
 -spec(lookup/3 :: (rabbit_types:vhost(), binary(), binary())
                   -> rabbit_types:infos() | 'not_found').
 -spec(value/3 :: (rabbit_types:vhost(), binary(), binary()) -> term()).
@@ -197,6 +198,11 @@ list(VHost, Component) ->
 
 list_formatted(VHost) ->
     [pset(value, format(pget(value, P)), P) || P <- list(VHost)].
+
+list_formatted(VHost, Ref, Pid) ->
+    [Pid ! {Ref, pset(value, format(pget(value, P)), P)} || P <- list(VHost)],
+    Pid ! {Ref, finished},
+    ok.
 
 lookup(VHost, Component, Name) ->
     case lookup0({VHost, Component, Name}, rabbit_misc:const(not_found)) of

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -158,6 +158,5 @@ info_all(Items) -> [info(VHost, Items) || VHost <- list()].
 
 info_all(Ref, AggregatorPid)        -> info_all(?INFO_KEYS, Ref, AggregatorPid).
 info_all(Items, Ref, AggregatorPid) ->
-    [AggregatorPid ! {Ref, info(VHost, Items)} || VHost <- list()],
-    AggregatorPid ! {Ref, finished},
-    ok.
+    rabbit_control_main:emitting_map(
+       AggregatorPid, Ref, fun(VHost) -> info(VHost, Items) end, list()).

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -21,7 +21,7 @@
 %%----------------------------------------------------------------------------
 
 -export([add/1, delete/1, exists/1, list/0, with/2, assert/1]).
--export([info/1, info/2, info_all/0, info_all/1]).
+-export([info/1, info/2, info_all/0, info_all/1, info_all/2, info_all/3]).
 
 -ifdef(use_specs).
 
@@ -37,6 +37,8 @@
                 -> rabbit_types:infos()).
 -spec(info_all/0 :: () -> [rabbit_types:infos()]).
 -spec(info_all/1 :: (rabbit_types:info_keys()) -> [rabbit_types:infos()]).
+-spec(info_all/3 :: (rabbit_types:info_keys(), reference(), pid()) ->
+                         [rabbit_types:infos()]).
 
 -endif.
 
@@ -153,3 +155,9 @@ info(VHost, Items) -> infos(Items, VHost).
 
 info_all()      -> info_all(?INFO_KEYS).
 info_all(Items) -> [info(VHost, Items) || VHost <- list()].
+
+info_all(Pid, Ref)        -> info_all(?INFO_KEYS, Pid, Ref).
+info_all(Items, Pid, Ref) -> [Pid ! {Ref, info(VHost, Items)} ||
+                                 VHost <- list()],
+                             Pid ! {Ref, finished},
+                             ok.

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -38,7 +38,7 @@
 -spec(info_all/0 :: () -> [rabbit_types:infos()]).
 -spec(info_all/1 :: (rabbit_types:info_keys()) -> [rabbit_types:infos()]).
 -spec(info_all/3 :: (rabbit_types:info_keys(), reference(), pid()) ->
-                         [rabbit_types:infos()]).
+                         'ok').
 
 -endif.
 
@@ -156,8 +156,8 @@ info(VHost, Items) -> infos(Items, VHost).
 info_all()      -> info_all(?INFO_KEYS).
 info_all(Items) -> [info(VHost, Items) || VHost <- list()].
 
-info_all(Pid, Ref)        -> info_all(?INFO_KEYS, Pid, Ref).
-info_all(Items, Pid, Ref) -> [Pid ! {Ref, info(VHost, Items)} ||
-                                 VHost <- list()],
-                             Pid ! {Ref, finished},
-                             ok.
+info_all(Ref, AggregatorPid)        -> info_all(?INFO_KEYS, Ref, AggregatorPid).
+info_all(Items, Ref, AggregatorPid) ->
+    [AggregatorPid ! {Ref, info(VHost, Items)} || VHost <- list()],
+    AggregatorPid ! {Ref, finished},
+    ok.

--- a/test/src/rabbit_ctl_timeout_tests.erl
+++ b/test/src/rabbit_ctl_timeout_tests.erl
@@ -13,16 +13,15 @@
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
 %% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 %%
--module(timeout_tests).
+-module(rabbit_ctl_timeout_tests).
 
 -compile([export_all]).
 
 -export([all_tests/0]).
 
--import(rabbit_tests,[default_options/0, control_action/2, control_action/3,
-                      control_action/4, control_action/5, control_action_opts/1,
-                      test_channel/0, expand_options/2, find_listener/0,
-                      info_action/4]).
+-import(rabbit_tests,[control_action/2, control_action/3, control_action/4,
+                      control_action/5, control_action_opts/1, test_channel/0,
+                      find_listener/0, info_action/4]).
 
 -include("rabbit.hrl").
 

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -76,7 +76,7 @@ all_tests0() ->
     passed = test_ha_policy_validation(),
     passed = test_queue_master_location_policy_validation(),
     passed = test_server_status(),
-    passed = timeout_tests:all_tests(),
+    passed = rabbit_ctl_timeout_tests:all_tests(),
     passed = test_amqp_connection_refusal(),
     passed = test_confirms(),
     passed = test_with_state(),

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -29,7 +29,6 @@
 -define(TRANSIENT_MSG_STORE,  msg_store_transient).
 -define(CLEANUP_QUEUE_NAME, <<"cleanup-queue">>).
 -define(TIMEOUT, 30000).
--define(TIMEOUT_LIST_OPS_PASS, 1000).
 
 all_tests() ->
     try

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -29,6 +29,7 @@
 -define(TRANSIENT_MSG_STORE,  msg_store_transient).
 -define(CLEANUP_QUEUE_NAME, <<"cleanup-queue">>).
 -define(TIMEOUT, 30000).
+-define(TIMEOUT_LIST_OPS_PASS, 1000).
 
 all_tests() ->
     try
@@ -76,6 +77,7 @@ all_tests0() ->
     passed = test_ha_policy_validation(),
     passed = test_queue_master_location_policy_validation(),
     passed = test_server_status(),
+    passed = timeout_tests:all_tests(),
     passed = test_amqp_connection_refusal(),
     passed = test_confirms(),
     passed = test_with_state(),
@@ -1793,9 +1795,17 @@ dead_queue_loop(QueueName, OldPid) ->
 control_action(Command, Args) ->
     control_action(Command, node(), Args, default_options()).
 
+control_action(Command, Args, Timeout) when is_number(Timeout) ->
+    control_action(Command, node(), Args, default_options(), Timeout);
+
 control_action(Command, Args, NewOpts) ->
     control_action(Command, node(), Args,
                    expand_options(default_options(), NewOpts)).
+
+control_action(Command, Args, NewOpts, Timeout) when is_number(Timeout) ->
+    control_action(Command, node(), Args,
+                   expand_options(default_options(), NewOpts),
+                   Timeout);
 
 control_action(Command, Node, Args, Opts) ->
     case catch rabbit_control_main:action(
@@ -1803,6 +1813,20 @@ control_action(Command, Node, Args, Opts) ->
                  fun (Format, Args1) ->
                          io:format(Format ++ " ...~n", Args1)
                  end) of
+        ok ->
+            io:format("done.~n"),
+            ok;
+        Other ->
+            io:format("failed.~n"),
+            Other
+    end.
+
+control_action(Command, Node, Args, Opts, Timeout) when is_number(Timeout) ->
+    case catch rabbit_control_main:action(
+                 Command, Node, Args, Opts,
+                 fun (Format, Args1) ->
+                         io:format(Format ++ " ...~n", Args1)
+                 end, Timeout) of
         ok ->
             io:format("done.~n"),
             ok;
@@ -1830,6 +1854,13 @@ info_action(Command, Args, CheckVHost) ->
     end,
     ok = control_action(Command, lists:map(fun atom_to_list/1, Args)),
     {bad_argument, dummy} = control_action(Command, ["dummy"]),
+    ok.
+
+info_action(Command, Args, CheckVHost, Timeout) when is_number(Timeout) ->
+    if CheckVHost -> ok = control_action(Command, [], ["-p", "/"], Timeout);
+       true       -> ok
+    end,
+    ok = control_action(Command, lists:map(fun atom_to_list/1, Args), Timeout),
     ok.
 
 default_options() -> [{"-p", "/"}, {"-q", "false"}].

--- a/test/src/timeout_tests.erl
+++ b/test/src/timeout_tests.erl
@@ -92,9 +92,9 @@ test_list_operations_timeout_pass() ->
 
     %% list connections
     {H, P} = find_listener(),
-    {ok, C} = gen_tcp:connect(H, P, []),
+    {ok, C} = gen_tcp:connect(H, P, [binary, {active, false}]),
     gen_tcp:send(C, <<"AMQP", 0, 0, 9, 1>>),
-    timer:sleep(100),
+    {ok, <<1,0,0>>} = gen_tcp:recv(C, 3, 100),
     ok = info_action(list_connections,
                      rabbit_networking:connection_info_keys(),
 		     false,

--- a/test/src/timeout_tests.erl
+++ b/test/src/timeout_tests.erl
@@ -1,0 +1,131 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(timeout_tests).
+
+-compile([export_all]).
+
+-export([all_tests/0]).
+
+-import(rabbit_tests,[default_options/0, control_action/2, control_action/3,
+                      control_action/4, control_action/5, control_action_opts/1,
+                      test_channel/0, expand_options/2, find_listener/0,
+                      info_action/4]).
+
+-include("rabbit.hrl").
+
+-define(TIMEOUT_LIST_OPS_PASS, 1000).
+
+all_tests() ->
+    passed = test_list_operations_timeout_pass(),
+    passed.
+
+test_list_operations_timeout_pass() ->
+    %% create a few things so there is some useful information to list
+    {_Writer, Limiter, Ch} = test_channel(),
+    [Q, Q2] = [Queue || Name <- [<<"foo">>, <<"bar">>],
+                        {new, Queue = #amqqueue{}} <-
+                            [rabbit_amqqueue:declare(
+                               rabbit_misc:r(<<"/">>, queue, Name),
+                               false, false, [], none)]],
+    ok = rabbit_amqqueue:basic_consume(
+           Q, true, Ch, Limiter, false, 0, <<"ctag">>, true, [], undefined),
+
+    %% list users
+    ok = control_action(add_user, ["foo", "bar"]),
+    {error, {user_already_exists, _}} =
+        control_action(add_user, ["foo", "bar"]),
+    ok = control_action(list_users, [], ?TIMEOUT_LIST_OPS_PASS),
+    
+    %% list parameters
+    ok = rabbit_runtime_parameters_test:register(),
+    ok = control_action(set_parameter, ["test", "good", "123"]),
+    ok = control_action(list_parameters, [], ?TIMEOUT_LIST_OPS_PASS),
+    ok = control_action(clear_parameter, ["test", "good"]),
+    rabbit_runtime_parameters_test:unregister(),
+
+    %% list vhosts
+    ok = control_action(add_vhost, ["/testhost"]),
+    {error, {vhost_already_exists, _}} =
+        control_action(add_vhost, ["/testhost"]),
+    ok = control_action(list_vhosts, [], ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list permissions
+    ok = control_action(set_permissions, ["foo", ".*", ".*", ".*"],
+                        [{"-p", "/testhost"}]),
+    ok = control_action(list_permissions, [], [{"-p", "/testhost"}],
+                        ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list user permissions
+    ok = control_action(list_user_permissions, ["foo"],
+                        ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list policies
+    ok = control_action_opts(["set_policy", "name", ".*",
+                              "{\"ha-mode\":\"all\"}"]),
+    ok = control_action(list_policies, [], ?TIMEOUT_LIST_OPS_PASS),
+    ok = control_action(clear_policy, ["name"]),
+
+    %% list queues
+    ok = info_action(list_queues, rabbit_amqqueue:info_keys(), false,
+                     ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list exchanges
+    ok = info_action(list_exchanges, rabbit_exchange:info_keys(), true,
+                     ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list bindings
+    ok = info_action(list_bindings, rabbit_binding:info_keys(), true,
+                     ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list connections
+    {H, P} = find_listener(),
+    {ok, C} = gen_tcp:connect(H, P, []),
+    gen_tcp:send(C, <<"AMQP", 0, 0, 9, 1>>),
+    timer:sleep(100),
+    ok = info_action(list_connections,
+                     rabbit_networking:connection_info_keys(),
+		     false,
+                     ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list consumers
+    ok = info_action(list_consumers, rabbit_amqqueue:consumer_info_keys(),
+                     false, ?TIMEOUT_LIST_OPS_PASS),
+
+    %% list channels
+    ok = info_action(list_channels, rabbit_channel:info_keys(), false,
+                     ?TIMEOUT_LIST_OPS_PASS),
+
+    %% do some cleaning up
+    ok = control_action(delete_user, ["foo"]),
+    {error, {no_such_user, _}} =
+        control_action(delete_user, ["foo"]),
+
+    ok = control_action(delete_vhost, ["/testhost"]),
+    {error, {no_such_vhost, _}} =
+        control_action(delete_vhost, ["/testhost"]),
+
+    %% close_connection
+    [ConnPid] = rabbit_networking:connections(),
+    ok = control_action(close_connection, [rabbit_misc:pid_to_string(ConnPid),
+                                           "go away"]),
+
+    %% cleanup queues
+    [{ok, _} = rabbit_amqqueue:delete(QR, false, false) || QR <- [Q, Q2]],
+
+    unlink(Ch),
+    ok = rabbit_channel:shutdown(Ch),
+
+    passed.


### PR DESCRIPTION
Changes made for #62, improving on the timeout introduced in #181 for `rabbitmqctl` list_* operations. Information is now returned dynamically and in piecemeal from the rabbit nodes, as things happen, and terminates upon timeout. 