### PR TITLE
Introduce per-user hashing functions, default to SHA-256

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -120,6 +120,12 @@
    %%
    %% {ssl_handshake_timeout, 5000},
 
+   %% Password hashing implementation. Will only affect newly
+   %% created users. To recalculate hash for an existing user
+   %% it's necessary to update her password.
+   %%
+   %% {password_hashing_module, rabbit_password_hashing_sha256},
+
    %%
    %% Default User / VHost
    %% ====================

--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -38,6 +38,7 @@
          {default_vhost, <<"/">>},
          {default_permissions, [<<".*">>, <<".*">>, <<".*">>]},
          {loopback_users, [<<"guest">>]},
+         {password_hashing_mod, rabbit_password_hashing_sha256},
          {cluster_nodes, {[], disc}},
          {server_properties, []},
          {collect_statistics, none},

--- a/ebin/rabbit_app.in
+++ b/ebin/rabbit_app.in
@@ -38,7 +38,7 @@
          {default_vhost, <<"/">>},
          {default_permissions, [<<".*">>, <<".*">>, <<".*">>]},
          {loopback_users, [<<"guest">>]},
-         {password_hashing_mod, rabbit_password_hashing_sha256},
+         {password_hashing_module, rabbit_password_hashing_sha256},
          {cluster_nodes, {[], disc}},
          {server_properties, []},
          {collect_statistics, none},

--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -27,7 +27,11 @@
 -record(authz_socket_info, {sockname, peername}).
 
 %% Implementation for the internal auth backend
--record(internal_user, {username, password_hash, tags}).
+-record(internal_user, {
+    username,
+    password_hash,
+    tags,
+    hashing_algorithm}).
 -record(permission, {configure, write, read}).
 -record(user_vhost, {username, virtual_host}).
 -record(user_permission, {user_vhost, permission}).

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -80,12 +80,10 @@
 %%----------------------------------------------------------------------------
 %% Implementation of rabbit_auth_backend
 
-%% Returns a password hashing module for
-%% the user record provided. If there is no
-%% information in the record, we consider
-%% it to be legacy (inserted by a version older than
-%% 3.6.0) and fall back to MD5, the now obsolete
-%% hashing function.
+%% Returns a password hashing module for the user record provided. If
+%% there is no information in the record, we consider it to be legacy
+%% (inserted by a version older than 3.6.0) and fall back to MD5, the
+%% now obsolete hashing function.
 hashing_module_for_user(#internal_user{
     hashing_algorithm = ModOrUndefined}) ->
         rabbit_password:hashing_mod(ModOrUndefined).

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -159,10 +159,9 @@ permission_index(read)      -> #permission.read.
 
 add_user(Username, Password) ->
     rabbit_log:info("Creating user '~s'~n", [Username]),
-    %% hash_password will pick the hashing
-    %% function configured for us but we
-    %% also need to store a hint as part of the
-    %% record, so we retrieve it here one more time
+    %% hash_password will pick the hashing function configured for us
+    %% but we also need to store a hint as part of the record, so we
+    %% retrieve it here one more time
     HashingMod = rabbit_password:hashing_mod(),
     User = #internal_user{username          = Username,
                           password_hash     = hash_password(HashingMod, Password),

--- a/src/rabbit_password.erl
+++ b/src/rabbit_password.erl
@@ -45,7 +45,8 @@ salted_hash(Mod, Salt, Cleartext) ->
     Fun(<<Salt/binary, Cleartext/binary>>).
 
 hashing_mod() ->
-    rabbit_misc:get_env(rabbit, password_hashing_mod, ?DEFAULT_HASHING_MODULE).
+    rabbit_misc:get_env(rabbit, password_hashing_module,
+        ?DEFAULT_HASHING_MODULE).
 
 hashing_mod(rabbit_password_hashing_sha256) ->
     rabbit_password_hashing_sha256;

--- a/src/rabbit_password.erl
+++ b/src/rabbit_password.erl
@@ -56,11 +56,9 @@ hashing_mod(rabbit_password_hashing_sha256) ->
     rabbit_password_hashing_sha256;
 hashing_mod(rabbit_password_hashing_md5) ->
     rabbit_password_hashing_md5;
-%% fall back to the hashing function that's been
-%% used prior to 3.6.0
+%% fall back to the hashing function that's been used prior to 3.6.0
 hashing_mod(undefined) ->
     rabbit_password_hashing_md5;
-%% if a custom module is configured,
-%% simply use it
+%% if a custom module is configured, simply use it
 hashing_mod(CustomMod) when is_atom(CustomMod) ->
     CustomMod.

--- a/src/rabbit_password.erl
+++ b/src/rabbit_password.erl
@@ -13,6 +13,7 @@
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
 %% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 %%
+
 -module(rabbit_password).
 -include("rabbit.hrl").
 

--- a/src/rabbit_password.erl
+++ b/src/rabbit_password.erl
@@ -22,12 +22,15 @@
 %% API
 %%
 
--export([hash/1, generate_salt/0, salted_hash/2, salted_hash/3,
+-export([hash/1, hash/2, generate_salt/0, salted_hash/2, salted_hash/3,
          hashing_mod/0, hashing_mod/1]).
 
 hash(Cleartext) ->
+    hash(hashing_mod(), Cleartext).
+
+hash(HashingMod, Cleartext) ->
     SaltBin = generate_salt(),
-    Hash = salted_hash(SaltBin, Cleartext),
+    Hash = salted_hash(HashingMod, SaltBin, Cleartext),
     <<SaltBin/binary, Hash/binary>>.
 
 generate_salt() ->

--- a/src/rabbit_password.erl
+++ b/src/rabbit_password.erl
@@ -1,0 +1,61 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(rabbit_password).
+-include("rabbit.hrl").
+
+-define(DEFAULT_HASHING_MODULE, rabbit_password_hashing_sha256).
+
+%%
+%% API
+%%
+
+-export([hash/1, generate_salt/0, salted_hash/2, salted_hash/3,
+         hashing_mod/0, hashing_mod/1]).
+
+hash(Cleartext) ->
+    SaltBin = generate_salt(),
+    Hash = salted_hash(SaltBin, Cleartext),
+    <<SaltBin/binary, Hash/binary>>.
+
+generate_salt() ->
+    random:seed(erlang:phash2([node()]),
+        time_compat:monotonic_time(),
+        time_compat:unique_integer()),
+    Salt = random:uniform(16#ffffffff),
+    <<Salt:32>>.
+
+salted_hash(Salt, Cleartext) ->
+    salted_hash(hashing_mod(), Salt, Cleartext).
+
+salted_hash(Mod, Salt, Cleartext) ->
+    Fun = fun Mod:hash/1,
+    Fun(<<Salt/binary, Cleartext/binary>>).
+
+hashing_mod() ->
+    rabbit_misc:get_env(rabbit, password_hashing_mod, ?DEFAULT_HASHING_MODULE).
+
+hashing_mod(rabbit_password_hashing_sha256) ->
+    rabbit_password_hashing_sha256;
+hashing_mod(rabbit_password_hashing_md5) ->
+    rabbit_password_hashing_md5;
+%% fall back to the hashing function that's been
+%% used prior to 3.6.0
+hashing_mod(undefined) ->
+    rabbit_password_hashing_md5;
+%% if a custom module is configured,
+%% simply use it
+hashing_mod(CustomMod) when is_atom(CustomMod) ->
+    CustomMod.

--- a/src/rabbit_password_hashing.erl
+++ b/src/rabbit_password_hashing.erl
@@ -13,6 +13,7 @@
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
 %% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 %%
+
 -module(rabbit_password_hashing).
 -include("rabbit.hrl").
 

--- a/src/rabbit_password_hashing.erl
+++ b/src/rabbit_password_hashing.erl
@@ -1,0 +1,32 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(rabbit_password_hashing).
+-include("rabbit.hrl").
+
+-ifdef(use_specs).
+
+-callback hash(rabbit_types:password()) -> rabbit_types:password_hash().
+
+-else.
+
+-export([behaviour_info/1, ]).
+
+behaviour_info(callbacks) ->
+    [{hash, 1}];
+behaviour_info(_Other) ->
+    undefined.
+
+-endif.

--- a/src/rabbit_password_hashing_md5.erl
+++ b/src/rabbit_password_hashing_md5.erl
@@ -14,9 +14,9 @@
 %% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 %%
 
-%% Legacy hashing implementation, only used as the
-%% last resort when #internal_user.hashing_algorithm
-%% is md5 or undefined (the case in pre-3.6.0 user records).
+%% Legacy hashing implementation, only used as the last resort when
+%% #internal_user.hashing_algorithm is md5 or undefined (the case in
+%% pre-3.6.0 user records).
 
 -module(rabbit_password_hashing_md5).
 

--- a/src/rabbit_password_hashing_md5.erl
+++ b/src/rabbit_password_hashing_md5.erl
@@ -17,6 +17,7 @@
 %% Legacy hashing implementation, only used as the
 %% last resort when #internal_user.hashing_algorithm
 %% is md5 or undefined (the case in pre-3.6.0 user records).
+
 -module(rabbit_password_hashing_md5).
 
 -behaviour(rabbit_password_hashing).

--- a/src/rabbit_password_hashing_md5.erl
+++ b/src/rabbit_password_hashing_md5.erl
@@ -1,0 +1,27 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+
+%% Legacy hashing implementation, only used as the
+%% last resort when #internal_user.hashing_algorithm
+%% is md5 or undefined (the case in pre-3.6.0 user records).
+-module(rabbit_password_hashing_md5).
+
+-behaviour(rabbit_password_hashing).
+
+-export([hash/1]).
+
+hash(Binary) ->
+    erlang:md5(Binary).

--- a/src/rabbit_password_hashing_md5.erl
+++ b/src/rabbit_password_hashing_md5.erl
@@ -14,7 +14,7 @@
 %% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 %%
 
-%% Legacy hashing implementation, only used as the last resort when
+%% Legacy hashing implementation, only used as a last resort when
 %% #internal_user.hashing_algorithm is md5 or undefined (the case in
 %% pre-3.6.0 user records).
 

--- a/src/rabbit_password_hashing_sha256.erl
+++ b/src/rabbit_password_hashing_sha256.erl
@@ -1,0 +1,24 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_password_hashing_sha256).
+
+-behaviour(rabbit_password_hashing).
+
+-export([hash/1]).
+
+hash(Binary) ->
+    crypto:hash(sha256, Binary).

--- a/src/rabbit_password_hashing_sha512.erl
+++ b/src/rabbit_password_hashing_sha512.erl
@@ -1,0 +1,24 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_password_hashing_sha512).
+
+-behaviour(rabbit_password_hashing).
+
+-export([hash/1]).
+
+hash(Binary) ->
+    crypto:hash(sha512, Binary).

--- a/src/rabbit_registry.erl
+++ b/src/rabbit_registry.erl
@@ -134,7 +134,8 @@ class_module(queue_decorator)     -> rabbit_queue_decorator;
 class_module(policy_validator)    -> rabbit_policy_validator;
 class_module(ha_mode)             -> rabbit_mirror_queue_mode;
 class_module(channel_interceptor) -> rabbit_channel_interceptor;
-class_module(queue_master_locator)-> rabbit_queue_master_locator.
+class_module(queue_master_locator)-> rabbit_queue_master_locator;
+class_module(password_hashing_mod)-> rabbit_password_hashing.
 
 %%---------------------------------------------------------------------------
 

--- a/src/rabbit_registry.erl
+++ b/src/rabbit_registry.erl
@@ -134,8 +134,7 @@ class_module(queue_decorator)     -> rabbit_queue_decorator;
 class_module(policy_validator)    -> rabbit_policy_validator;
 class_module(ha_mode)             -> rabbit_mirror_queue_mode;
 class_module(channel_interceptor) -> rabbit_channel_interceptor;
-class_module(queue_master_locator)-> rabbit_queue_master_locator;
-class_module(password_hashing_mod)-> rabbit_password_hashing.
+class_module(queue_master_locator)-> rabbit_queue_master_locator.
 
 %%---------------------------------------------------------------------------
 

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -51,6 +51,7 @@
 -rabbit_upgrade({down_slave_nodes,      mnesia, [queue_decorators]}).
 -rabbit_upgrade({queue_state,           mnesia, [down_slave_nodes]}).
 -rabbit_upgrade({recoverable_slaves,    mnesia, [queue_state]}).
+-rabbit_upgrade({add_hashing_algorithm_to_internal_user, mnesia, [hash_passwords]}).
 
 %% -------------------------------------------------------------------
 
@@ -84,6 +85,7 @@
 -spec(down_slave_nodes/0      :: () -> 'ok').
 -spec(queue_state/0           :: () -> 'ok').
 -spec(recoverable_slaves/0    :: () -> 'ok').
+-spec(add_hashing_algorithm_to_internal_user/0 :: () -> 'ok').
 
 -endif.
 
@@ -431,6 +433,16 @@ recoverable_slaves(Table) ->
        sync_slave_pids, recoverable_slaves, policy, gm_pids, decorators,
        state]).
 
+%% Prior to 3.6.0, passwords were hashed using MD5.
+%% Users created with 3.6.0+
+%% will have internal_user.hashing_algorithm populated.
+add_hashing_algorithm_to_internal_user() ->
+    transform(
+      rabbit_user,
+      fun ({user, Username, Hash, IsAdmin}) ->
+              {user, Username, Hash, IsAdmin, md5}
+      end,
+      [username, password_hash, is_admin, hashing_algorithm]).
 
 %%--------------------------------------------------------------------
 

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -433,11 +433,10 @@ recoverable_slaves(Table) ->
        sync_slave_pids, recoverable_slaves, policy, gm_pids, decorators,
        state]).
 
-%% Prior to 3.6.0, passwords were hashed using MD5,
-%% this populates existing records with said default.
-%% Users created with 3.6.0+
-%% will have internal_user.hashing_algorithm populated
-%% by the internal authn backend.
+%% Prior to 3.6.0, passwords were hashed using MD5, this populates
+%% existing records with said default.  Users created with 3.6.0+ will
+%% have internal_user.hashing_algorithm populated by the internal
+%% authn backend.
 user_password_hashing() ->
     transform(
       rabbit_user,
@@ -466,8 +465,8 @@ create(Tab, TabDef) ->
 %% Dumb replacement for rabbit_exchange:declare that does not require
 %% the exchange type registry or worker pool to be running by dint of
 %% not validating anything and assuming the exchange type does not
-%% require serialisation.
-%% NB: this assumes the pre-exchange-scratch-space format
+%% require serialisation.  NB: this assumes the
+%% pre-exchange-scratch-space format
 declare_exchange(XName, Type) ->
     X = {exchange, XName, Type, true, false, false, []},
     ok = mnesia:dirty_write(rabbit_durable_exchange, X).

--- a/test/src/password_hashing_tests.erl
+++ b/test/src/password_hashing_tests.erl
@@ -1,0 +1,54 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2011-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(password_hashing_tests).
+
+-include("rabbit.hrl").
+
+-export([test_password_hashing/0]).
+
+test_password_hashing() ->
+    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(),
+    application:set_env(rabbit, password_hashing_module, rabbit_password_hashing_md5),
+    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(),
+    application:set_env(rabbit, password_hashing_module, rabbit_password_hashing_sha256),
+    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(),
+
+    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(rabbit_password_hashing_sha256),
+    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(rabbit_password_hashing_md5),
+    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(undefined),
+
+    rabbit_password_hashing_md5    =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{}),
+    rabbit_password_hashing_md5    =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{
+             hashing_algorithm = undefined
+            }),
+    rabbit_password_hashing_md5    =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{
+             hashing_algorithm = rabbit_password_hashing_md5
+            }),
+
+    rabbit_password_hashing_sha256 =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{
+             hashing_algorithm = rabbit_password_hashing_sha256
+            }),
+
+    passed.

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -92,7 +92,7 @@ all_tests0() ->
     passed = vm_memory_monitor_tests:all_tests(),
     passed = credit_flow_test:test_credit_flow_settings(),
     passed = on_disk_store_tunable_parameter_validation_test:test_msg_store_parameter_validation(),
-    passed = test_password_hashing(),
+    passed = password_hashing_tests:test_password_hashing(),
     passed.
 
 do_if_secondary_node(Up, Down) ->
@@ -1055,39 +1055,6 @@ test_user_management() ->
     ok = control_action(delete_user, ["foo"]),
     {error, {no_such_user, _}} =
         control_action(delete_user, ["foo"]),
-
-    passed.
-
-test_password_hashing() ->
-    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(),
-    application:set_env(rabbit, password_hashing_module, rabbit_password_hashing_md5),
-    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(),
-    application:set_env(rabbit, password_hashing_module, rabbit_password_hashing_sha256),
-    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(),
-
-    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(rabbit_password_hashing_sha256),
-    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(rabbit_password_hashing_md5),
-    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(undefined),
-
-    rabbit_password_hashing_md5    =
-        rabbit_auth_backend_internal:hashing_module_for_user(
-          #internal_user{}),
-    rabbit_password_hashing_md5    =
-        rabbit_auth_backend_internal:hashing_module_for_user(
-          #internal_user{
-             hashing_algorithm = undefined
-            }),
-    rabbit_password_hashing_md5    =
-        rabbit_auth_backend_internal:hashing_module_for_user(
-          #internal_user{
-             hashing_algorithm = rabbit_password_hashing_md5
-            }),
-
-    rabbit_password_hashing_sha256 =
-        rabbit_auth_backend_internal:hashing_module_for_user(
-          #internal_user{
-             hashing_algorithm = rabbit_password_hashing_sha256
-            }),
 
     passed.
 

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -92,6 +92,7 @@ all_tests0() ->
     passed = vm_memory_monitor_tests:all_tests(),
     passed = credit_flow_test:test_credit_flow_settings(),
     passed = on_disk_store_tunable_parameter_validation_test:test_msg_store_parameter_validation(),
+    passed = test_password_hashing(),
     passed.
 
 do_if_secondary_node(Up, Down) ->
@@ -1015,9 +1016,6 @@ test_user_management() ->
     TestTags([administrator]),
     TestTags([]),
 
-    %% hashing functions
-    %% TODO
-
     %% vhost creation
     ok = control_action(add_vhost, ["/testhost"]),
     {error, {vhost_already_exists, _}} =
@@ -1057,6 +1055,19 @@ test_user_management() ->
     ok = control_action(delete_user, ["foo"]),
     {error, {no_such_user, _}} =
         control_action(delete_user, ["foo"]),
+
+    passed.
+
+test_password_hashing() ->
+    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(),
+    application:set_env(rabbit, password_hashing_module, rabbit_password_hashing_md5),
+    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(),
+    application:set_env(rabbit, password_hashing_module, rabbit_password_hashing_sha256),
+    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(),
+
+    rabbit_password_hashing_sha256 = rabbit_password:hashing_mod(rabbit_password_hashing_sha256),
+    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(rabbit_password_hashing_md5),
+    rabbit_password_hashing_md5    = rabbit_password:hashing_mod(undefined),
 
     passed.
 

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -1069,6 +1069,26 @@ test_password_hashing() ->
     rabbit_password_hashing_md5    = rabbit_password:hashing_mod(rabbit_password_hashing_md5),
     rabbit_password_hashing_md5    = rabbit_password:hashing_mod(undefined),
 
+    rabbit_password_hashing_md5    =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{}),
+    rabbit_password_hashing_md5    =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{
+             hashing_algorithm = undefined
+            }),
+    rabbit_password_hashing_md5    =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{
+             hashing_algorithm = rabbit_password_hashing_md5
+            }),
+
+    rabbit_password_hashing_sha256 =
+        rabbit_auth_backend_internal:hashing_module_for_user(
+          #internal_user{
+             hashing_algorithm = rabbit_password_hashing_sha256
+            }),
+
     passed.
 
 test_runtime_parameters() ->

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -1015,6 +1015,9 @@ test_user_management() ->
     TestTags([administrator]),
     TestTags([]),
 
+    %% hashing functions
+    %% TODO
+
     %% vhost creation
     ok = control_action(add_vhost, ["/testhost"]),
     {error, {vhost_already_exists, _}} =


### PR DESCRIPTION
This is not yet ready.

With this change we switch to SHA-256 for password hashing. In order to make things compatible for existing installations, we store hashing function info in the user record. If it's missing, we fall back to the legacy function, MD5.

Fixes #270.