### PR TITLE
fixed support for arguments containing ` characters

### DIFF
--- a/packaging/common/rabbitmq-script-wrapper
+++ b/packaging/common/rabbitmq-script-wrapper
@@ -15,19 +15,15 @@
 ##  Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 ##
 
-# Escape spaces and quotes, because shell is revolting.
 SED_OPT="-E"
 if [ $(uname -s) == "Linux" ]; then
     SED_OPT="-r"
 fi
 
 for arg in "$@" ; do
-	# Escape quotes in parameters, so that they're passed through cleanly.
-	arg=$(sed $SED_OPT -e 's/(["$])/\\\1/g' <<-END
-		$arg
-		END
-	)
-	CMDLINE="${CMDLINE} \"${arg}\""
+    # Wrap each arg in single quotes and wrap single quotes in double quotes, so that they're passed through cleanly.
+    arg=`printf %s $arg | sed $SED_OPT -e "s/'/'\"'\"'/g"`
+    CMDLINE="${CMDLINE} '${arg}'"
 done
 
 cd /var/lib/rabbitmq


### PR DESCRIPTION
When rabbitmqctl extracts it's args it doesn't properly quote them before passing them along to rabbitmq. Therefor you can not create a password with a ` in it.

```shell
sudo rabbitmqctl add_user test '`pass'
sh: 1: Syntax error: EOF in backquote substitution
```

This fixes that.

### Tests:
Double quotes work:
```shell
$ echo '"pass'
"pass
$ sudo rabbitmqctl add_user test2 '"pass'
Creating user "test2" ...
```

As do single quotes:
```shell
$ echo "'pass"
'pass
$ sudo rabbitmqctl add_user test3 "'pass"
Creating user "test3" ...
```

Just to be thorough, try all the quotes:
```shell
$ echo '`"pass'"'"
`"pass'
$ sudo rabbitmqctl add_user test4 '`"pass'"'"
Creating user "test4" ...
```

https://github.com/rabbitmq/rabbitmq-server/issues/313