### PR TITLE
allow initial frame_max to be configured

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -161,6 +161,11 @@
    %%
    %% {frame_max, 131072},
 
+   %% Set the max frame size the server will accept before connection
+   %% tuning occurs
+   %%
+   %% {initial_frame_max, 4096},
+
    %% Set the max permissible number of channels per connection.
    %% 0 means "no limit".
    %%

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -336,6 +336,7 @@ start_connection(Parent, HelperSup, Deb, Sock, SockTransform) ->
                                     exit(normal)
            end,
     {ok, HandshakeTimeout} = application:get_env(rabbit, handshake_timeout),
+    InitialFrameMax = application:get_env(rabbit, initial_frame_max, ?FRAME_MIN_SIZE),
     ClientSock = socket_op(Sock, SockTransform),
     erlang:send_after(HandshakeTimeout, self(), handshake_timeout),
     {PeerHost, PeerPort, Host, Port} =
@@ -352,7 +353,7 @@ start_connection(Parent, HelperSup, Deb, Sock, SockTransform) ->
                   protocol           = none,
                   user               = none,
                   timeout_sec        = (HandshakeTimeout / 1000),
-                  frame_max          = ?FRAME_MIN_SIZE,
+                  frame_max          = InitialFrameMax,
                   vhost              = none,
                   client_properties  = none,
                   capabilities       = [],


### PR DESCRIPTION
SASL challenge/responses happen before connection tuning, at which point there is a hard-coded maximum frame size of 4 KiB. I ran into a situation where a SASL mechanism wanted to exchange challenges/responses greater than 4 KiB, but the broker would close the connection because the frame size limit was being exceeded. I couldn't see a way to fix it apart from this. The AMQP spec doesn't seem to prescribe an initial limit.