### PR TITLE
Collect tags from all authz backends

### DIFF
--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -100,7 +100,7 @@ try_authorize(Modules, Username) ->
     lists:foldr(
       fun (Module, {ok, ModsImpls, ModsTags}) ->
               case Module:user_login_authorization(Username) of
-                  {ok, Impl, Tags}-> {ok, [{Module, Impl} | ModsImpls], ModsTags++Tags};
+                  {ok, Impl, Tags}-> {ok, [{Module, Impl} | ModsImpls], ModsTags ++ Tags};
                   {ok, Impl}      -> {ok, [{Module, Impl} | ModsImpls], ModsTags};
                   {error, E}      -> {refused, Username,
                                         "~s failed authorizing ~s: ~p~n",

--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -101,6 +101,7 @@ try_authorize(Modules, Username) ->
       fun (Module, {ok, ModsImpls, ModsTags}) ->
               case Module:user_login_authorization(Username) of
                   {ok, Impl, Tags}-> {ok, [{Module, Impl} | ModsImpls], ModsTags++Tags};
+                  {ok, Impl}      -> {ok, [{Module, Impl} | ModsImpls], ModsTags};
                   {error, E}      -> {refused, Username,
                                         "~s failed authorizing ~s: ~p~n",
                                         [Module, Username, E]};

--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -113,7 +113,7 @@ try_authorize(Modules, Username) ->
 
 user(#auth_user{username = Username, tags = Tags}, {ok, ModZImpls, ModZTags}) ->
     {ok, #user{username       = Username,
-               tags           = Tags++ModZTags,
+               tags           = Tags ++ ModZTags,
                authz_backends = ModZImpls}};
 user(_AuthUser, Error) ->
     Error.

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -92,8 +92,8 @@ user_login_authentication(Username, AuthProps) ->
 
 user_login_authorization(Username) ->
     case user_login_authentication(Username, []) of
-        {ok, #auth_user{impl = Impl}} -> {ok, Impl};
-        Else                          -> Else
+        {ok, #auth_user{impl = Impl, tags = Tags}} -> {ok, Impl, Tags};
+        Else                                       -> Else
     end.
 
 internal_check_user_login(Username, Fun) ->

--- a/src/rabbit_authz_backend.erl
+++ b/src/rabbit_authz_backend.erl
@@ -28,14 +28,14 @@
 %% check_resource_access/3.
 %%
 %% Possible responses:
-%% {ok, Impl}
-%%     User authorisation succeeded, and here's the impl field.
+%% {ok, Impl, Tags}
+%%     User authorisation succeeded, and here's the impl and extra tags fields.
 %% {error, Error}
 %%     Something went wrong. Log and die.
 %% {refused, Msg, Args}
 %%     User authorisation failed. Log and die.
 -callback user_login_authorization(rabbit_types:username()) ->
-    {'ok', any()} |
+    {'ok', any(), any()} |
     {'refused', string(), [any()]} |
     {'error', any()}.
 

--- a/src/rabbit_authz_backend.erl
+++ b/src/rabbit_authz_backend.erl
@@ -28,13 +28,15 @@
 %% check_resource_access/3.
 %%
 %% Possible responses:
+%% {ok, Impl}
 %% {ok, Impl, Tags}
-%%     User authorisation succeeded, and here's the impl and extra tags fields.
+%%     User authorisation succeeded, and here's the impl and potential extra tags fields.
 %% {error, Error}
 %%     Something went wrong. Log and die.
 %% {refused, Msg, Args}
 %%     User authorisation failed. Log and die.
 -callback user_login_authorization(rabbit_types:username()) ->
+    {'ok', any()} |
     {'ok', any(), any()} |
     {'refused', string(), [any()]} |
     {'error', any()}.


### PR DESCRIPTION
Fix for issue https://github.com/rabbitmq/rabbitmq-server/issues/338

Have the authorisation code propagate tags into the user record.

A related change to the rabbitmq-auth-backend-ldap plugin propagates tags from there as well. That change also contains the test code. See https://github.com/rabbitmq/rabbitmq-auth-backend-ldap/pull/17
