### PR TITLE
Allow ERLANG_HOME to be overridden from rabbitmq-env.bat

### DIFF
--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -24,6 +24,10 @@ set TDP0=%~dp0
 set STAR=%*
 setlocal enabledelayedexpansion
 
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%TDP0%\rabbitmq-env.bat"
+
 if not exist "!ERLANG_HOME!\bin\erl.exe" (
     echo.
     echo ******************************
@@ -35,10 +39,6 @@ if not exist "!ERLANG_HOME!\bin\erl.exe" (
     echo.
     exit /B 1
 )
-
-REM Get default settings with user overrides for (RABBITMQ_)<var_name>
-REM Non-empty defaults should be set in rabbitmq-env
-call "%TDP0%\rabbitmq-env.bat"
 
 "!ERLANG_HOME!\bin\erl.exe" ^
 -pa "!TDP0!..\ebin" ^


### PR DESCRIPTION
Moving the rabbitmq-env.bat call above the ERLANG_HOME check. This grants the ability to override ERLANG_HOME within rabbitmq-env-conf.bat.