### PR TITLE
fixes failing test

### DIFF
--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -894,7 +894,8 @@ head_message_timestamp(Q3, Q4, RPA, QPA) ->
                        [ get_qs_head([Q4, Q3]),
                          get_pa_head(RPA),
                          get_pa_head(QPA) ],
-                   HeadMsgStatus /= undefined ],
+                   HeadMsgStatus /= undefined,
+                   HeadMsgStatus#msg_status.msg /= undefined ],
 
     Timestamps =
         [Timestamp || HeadMsg <- HeadMsgs,


### PR DESCRIPTION
This is a possible fix for #358 

The problem there is that sometimes a msg_status record doesn't have the msg loaded. That's expected.

We can fix it like on this patch, or read the message from disk like here: https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit_variable_queue.erl#L616 

Not sure we want to be reading msgs from the file system just to show some stats, so I pushed this fix first in case we decide for it.

Fixes #358 