### PR TITLE
Adds net_ticktime to rabbitmqctl status output.

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -459,7 +459,8 @@ status() ->
           {uptime,           begin
                                  {T,_} = erlang:statistics(wall_clock),
                                  T div 1000
-                             end}],
+                             end},
+          {kernel,           {net_ticktime, net_kernel:get_net_ticktime()}}],
     S1 ++ S2 ++ S3 ++ S4.
 
 alarms() ->


### PR DESCRIPTION
Adding `kernel.net_ticktime` to `rabbitmqctl status` output, which is also included in 
`rabbitmqctl report` output.

References #63