### PR TITLE
Port Fuel fixes for the HA rabbitmq OCF

### DIFF
--- a/packaging/common/rabbitmq-server-ha.ocf
+++ b/packaging/common/rabbitmq-server-ha.ocf
@@ -30,6 +30,9 @@ OCF_RESKEY_ctl_default="/usr/sbin/rabbitmqctl"
 OCF_RESKEY_debug_default=false
 OCF_RESKEY_username_default="rabbitmq"
 OCF_RESKEY_groupname_default="rabbitmq"
+OCF_RESKEY_admin_user_default="guest"
+OCF_RESKEY_admin_password_default="guest"
+OCF_RESKEY_definitions_dump_file_default="/etc/rabbitmq/definitions"
 OCF_RESKEY_pid_file_default="/var/run/rabbitmq/pid"
 OCF_RESKEY_log_dir_default="/var/log/rabbitmq"
 OCF_RESKEY_mnesia_base_default="/var/lib/rabbitmq/mnesia"
@@ -37,6 +40,7 @@ OCF_RESKEY_node_port_default=5672
 OCF_RESKEY_erlang_cookie_default=false
 OCF_RESKEY_erlang_cookie_file_default="/var/lib/rabbitmq/.erlang.cookie"
 OCF_RESKEY_use_fqdn_default=false
+OCF_RESKEY_max_rabbitmqctl_timeouts_default=1
 
 : ${HA_LOGTAG="lrmd"}
 : ${HA_LOGFACILITY="daemon"}
@@ -45,6 +49,9 @@ OCF_RESKEY_use_fqdn_default=false
 : ${OCF_RESKEY_debug=${OCF_RESKEY_debug_default}}
 : ${OCF_RESKEY_username=${OCF_RESKEY_username_default}}
 : ${OCF_RESKEY_groupname=${OCF_RESKEY_groupname_default}}
+: ${OCF_RESKEY_admin_user=${OCF_RESKEY_admin_user_default}}
+: ${OCF_RESKEY_admin_password=${OCF_RESKEY_admin_password_default}}
+: ${OCF_RESKEY_definitions_dump_file=${OCF_RESKEY_definitions_dump_file_default}}
 : ${OCF_RESKEY_log_dir=${OCF_RESKEY_log_dir_default}}
 : ${OCF_RESKEY_mnesia_base=${OCF_RESKEY_mnesia_base_default}}
 : ${OCF_RESKEY_pid_file=${OCF_RESKEY_pid_file_default}}
@@ -52,11 +59,14 @@ OCF_RESKEY_use_fqdn_default=false
 : ${OCF_RESKEY_erlang_cookie=${OCF_RESKEY_erlang_cookie_default}}
 : ${OCF_RESKEY_erlang_cookie_file=${OCF_RESKEY_erlang_cookie_file_default}}
 : ${OCF_RESKEY_use_fqdn=${OCF_RESKEY_use_fqdn_default}}
+: ${OCF_RESKEY_max_rabbitmqctl_timeouts=${OCF_RESKEY_max_rabbitmqctl_timeouts_default}}
 
 #######################################################################
 
 OCF_RESKEY_start_time_default=$((OCF_RESKEY_CRM_meta_timeout / 6000 + 2))
 : ${OCF_RESKEY_start_time=${OCF_RESKEY_start_time_default}}
+OCF_RESKEY_stop_time_default=${OCF_RESKEY_start_time_default}
+: ${OCF_RESKEY_stop_time=${OCF_RESKEY_start_time_default}}
 OCF_RESKEY_command_timeout_default=""
 : ${OCF_RESKEY_command_timeout=${OCF_RESKEY_command_timeout_default}}
 TIMEOUT_ARG=$((OCF_RESKEY_CRM_meta_timeout / 6000 + 30))
@@ -141,6 +151,30 @@ RabbitMQ group name
 <content type="string" default="${OCF_RESKEY_groupname_default}" />
 </parameter>
 
+<parameter name="admin_user" unique="0" required="0">
+<longdesc lang="en">
+RabbitMQ default admin user for API
+</longdesc>
+<shortdesc lang="en">RabbitMQ admin user</shortdesc>
+<content type="string" default="${OCF_RESKEY_admin_user_default}" />
+</parameter>
+
+<parameter name="admin_password" unique="0" required="0">
+<longdesc lang="en">
+RabbitMQ default admin user password for API
+</longdesc>
+<shortdesc lang="en">RabbitMQ admin password</shortdesc>
+<content type="string" default="${OCF_RESKEY_admin_password_default}" />
+</parameter>
+
+<parameter name="definitions_dump_file" unique="0" required="0">
+<longdesc lang="en">
+RabbitMQ default definitions dump file
+</longdesc>
+<shortdesc lang="en">RabbitMQ definitions dump file</shortdesc>
+<content type="string" default="${OCF_RESKEY_definitions_dump_file}" />
+</parameter>
+
 <parameter name="command_timeout" unique="0" required="0">
 <longdesc lang="en">
 Timeout command arguments for issued commands termination (value is auto evaluated)
@@ -155,6 +189,14 @@ Timeout for start rabbitmq server
 </longdesc>
 <shortdesc lang="en">Timeout for start rabbitmq server</shortdesc>
 <content type="string" default="${OCF_RESKEY_start_time_default}" />
+</parameter>
+
+<parameter name="stop_time" unique="0" required="0">
+<longdesc lang="en">
+Timeout for stopping rabbitmq server
+</longdesc>
+<shortdesc lang="en">Timeout for stopping rabbitmq server</shortdesc>
+<content type="string" default="${OCF_RESKEY_stop_time_default}" />
 </parameter>
 
 <parameter name="debug" unique="0" required="0">
@@ -207,6 +249,16 @@ Either to use FQDN or a shortname for the rabbitmq node
 <content type="boolean" default="${OCF_RESKEY_erlang_cookie_file_default}" />
 </parameter>
 
+<parameter name="max_rabbitmqctl_timeouts" unique="0" required="0">
+<longdesc lang="en">
+If during monitor call rabbitmqctl times out, the timeout is ignored
+unless it is Nth timeout in a row. Here N is the value of the current parameter.
+If too many timeouts happen in a raw, the monitor call will return with error.
+</longdesc>
+<shortdesc lang="en">Fail only if that many rabbitmqctl timeouts in a row occurred</shortdesc>
+<content type="string" default="${OCF_RESKEY_max_rabbitmqctl_timeouts_default}" />
+</parameter>
+
 </parameters>
 
 <actions>
@@ -232,6 +284,13 @@ END
 # Invokes the given command as a rabbitmq user and wrapped in the
 # timeout command.
 su_rabbit_cmd() {
+    local timeout
+    if [ "$1" = "-t" ]; then
+      timeout=="/usr/bin/timeout ${OCF_RESKEY_command_timeout} $2"
+      shift 2
+    else
+      timeout=$COMMAND_TIMEOUT
+    fi
     local cmd="${1:-status}"
     local LH="${LL} su_rabbit_cmd():"
     local rc=1
@@ -242,7 +301,7 @@ su_rabbit_cmd() {
 
     ocf_log debug "${LH} invoking a command: ${cmd}"
     su $user -s /bin/sh -c "USER=${user} MAIL=${mail} PWD=${pwd} HOME=${home} LOGNAME=${user} \
-      ${COMMAND_TIMEOUT} ${cmd}"
+      ${timeout} ${cmd}"
     rc=$?
     ocf_log info "${LH} the invoked command exited ${rc}: ${cmd}"
     return $rc
@@ -331,6 +390,7 @@ rmq_setup_env() {
     RMQ_START_TIME="${MNESIA_FILES}/ocf_server_start_time.txt"
     MASTER_FLAG_FILE="${MNESIA_FILES}/ocf_master_for_${OCF_RESOURCE_INSTANCE}"
     THIS_PCMK_NODE=`crm_node -n`
+    TOTALVMEM=`free -mt | awk '/Total:/ {print $2}'`
     # check and make PID file dir
     local PID_DIR=$( dirname $OCF_RESKEY_pid_file )
     if [ ! -d ${PID_DIR} ] ; then
@@ -994,12 +1054,17 @@ get_status() {
     rc=$?
 
     if [ $rc -ne 0 ] ; then
+        ocf_log info "get_status() failed with code ${rc}. Command output: ${body}"
         return $OCF_NOT_RUNNING
     fi
 
     if [ "${what}" ] ; then
         rc=$OCF_NOT_RUNNING
         echo "$body" | grep "\{${what}," 2>&1 > /dev/null && rc=$OCF_SUCCESS
+
+        if [ $rc -ne $OCF_SUCCESS ] ; then
+            ocf_log info "get_status(): app ${what} was not found in command output: ${body}"
+        fi
     fi
 
     return $rc
@@ -1025,6 +1090,55 @@ is_master() {
     return 0
 }
 
+# Verify if su_rabbit_cmd exited by timeout by checking its return code.
+# If it did not, return 0. If it did AND it is
+# $OCF_RESKEY_max_rabbitmqctl_timeouts'th timeout in a row,
+# return 2 to signal get_monitor that it should
+# exit with error. Otherwise return 1 to signal that there was a timeout,
+# but it should be ignored. Timeouts for different operations are tracked
+# separately. The second argument is used to distingush them.
+check_timeouts() {
+    local op_rc=$1
+    local crm_attr_name=$2
+    local op_name=$3
+
+    if [ $op_rc -ne 124 -a $op_rc -ne 137 ]; then
+        ocf_run crm_attribute -N $THIS_PCMK_NODE -l reboot --name $crm_attr_name --update 0
+        return 0
+    fi
+
+    local count
+    count=`crm_attribute -N $THIS_PCMK_NODE -l reboot --name $crm_attr_name --query 2>/dev/null | awk '{print $3}' | awk -F "=" '{print $2}' | sed -e '/(null)/d'`
+    if [ $? -ne 0 ]; then
+        # the crm_attribute exited with error. In that case most probably it printed garbage
+        # instead of the number we need. So defensively assume that it is zero.
+
+        count=0
+    fi
+
+    count=$((count+1))
+    # There is a slight chance that this piece of code will be executed twice simultaneously.
+    # As a result, $crm_attr_name's value will be one less than it should be. But we don't need
+    # precise calculation here.
+    ocf_run crm_attribute -N $THIS_PCMK_NODE -l reboot --name $crm_attr_name --update $count
+
+    if [ $count -lt $OCF_RESKEY_max_rabbitmqctl_timeouts ]; then
+        ocf_log warn "${LH} 'rabbitmqctl $op_name' timed out $count of max. $OCF_RESKEY_max_rabbitmqctl_timeouts time(s) in a row. Doing nothing for now."
+        return 1
+    else
+        ocf_log err "${LH} 'rabbitmqctl $op_name' timed out $count of max. $OCF_RESKEY_max_rabbitmqctl_timeouts time(s) in a row and is not responding. The resource is failed."
+        return 2
+    fi
+}
+
+wait_sync() {
+  wait_time=$1
+
+  queues="${COMMAND_TIMEOUT} ${OCF_RESKEY_ctl} list_queues name state"
+  su_rabbit_cmd -t "${wait_time}s" "sh -c \"while $queues | grep -q 'syncing,'; \
+      do sleep 1; done\""
+  return $?
+}
 
 get_monitor() {
     local rc=$OCF_ERR_GENERIC
@@ -1157,29 +1271,94 @@ get_monitor() {
         fi
     fi
 
+    # Skip all other checks if rabbit app is not running
+    if [ $rabbit_running -ne $OCF_SUCCESS ]; then
+        ocf_log info "${LH} RabbitMQ is not running, get_monitor function ready to return ${rc}"
+        return $rc
+    fi
+
     # Check if the rabbitmqctl control plane is alive.
-    # The rabbit app may be not running and the command
-    # will return > 0, so we only check if the command execution
-    # has timed out (which is a code 137 or 124)
+    local rc_alive
+    local timeout_alive
     su_rabbit_cmd "${OCF_RESKEY_ctl} list_channels 2>&1 > /dev/null"
-    local rc_alive=$?
-    if [ $rc_alive -eq 137 -o $rc_alive -eq 124 ]; then
-        ocf_log err "${LH} rabbitmqctl is not responding. The resource is failed."
+    rc_alive=$?
+    check_timeouts $rc_alive "rabbit_list_channels_timeouts" "list_channels"
+    timeout_alive=$?
+
+    if [ $timeout_alive -eq 2 ]; then
         return $OCF_ERR_GENERIC
+    elif [ $timeout_alive -eq 0 ]; then
+        if [ $rc_alive -ne 0 ]; then
+            ocf_log err "${LH} rabbitmqctl list_channels exited with errors."
+            rc=$OCF_ERR_GENERIC
+        fi
+    fi
+
+    # Check for memory alarms for this Master or Slave node.
+    # If alert found, reset the alarm
+    # and restart the resource as it likely means a dead end situation
+    # when rabbitmq cluster is running with blocked publishing due
+    # to high memory watermark exceeded.
+    local alarms
+    local rc_alarms
+    local timeout_alarms
+    alarms=`su_rabbit_cmd "${OCF_RESKEY_ctl} -q eval 'rabbit_alarm:get_alarms().'"`
+    rc_alarms=$?
+    check_timeouts $rc_alarms "rabbit_get_alarms_timeouts" "get_alarms"
+    timeout_alarms=$?
+
+    if [ $timeout_alarms -eq 2 ]; then
+        return $OCF_ERR_GENERIC
+
+    elif [ $timeout_alarms -eq 0 ]; then
+        if [ $rc_alarms -ne 0 ]; then
+            ocf_log err "${LH} rabbitmqctl get_alarms exited with errors."
+            rc=$OCF_ERR_GENERIC
+
+        elif [ -n "${alarms}" ]; then
+            for node in "${alarms}"; do
+                name=`echo ${node} | perl -n -e "m/memory,'(?<n>\S+)+'/ && print \"$+{n}\n\""`
+                if [ "${name}" = "${RABBITMQ_NODENAME}" ] ; then
+                    ocf_log err "${LH} Found raised memory alarm. Erasing the alarm and restarting."
+                    su_rabbit_cmd "${OCF_RESKEY_ctl} set_vm_memory_high_watermark 10 2>&1 > /dev/null"
+                    rc=$OCF_ERR_GENERIC
+                    break
+                fi
+            done
+        fi
     fi
 
     # Check if the list of all queues is available,
-    # Skip the check if rabbit app is not running yet.
-    su_rabbit_cmd "${OCF_RESKEY_ctl} -q list_queues"
-    local rc_queues=$?
+    # Also report some queues stats and total virtual memory.
+    local queues
+    local rc_queues
+    local timeout_queues
+    queues=`su_rabbit_cmd "${OCF_RESKEY_ctl} -q list_queues memory messages consumer_utilisation"`
+    rc_queues=$?
+    check_timeouts $rc_queues "rabbit_list_queues_timeouts" "list_queues"
+    timeout_queues=$?
 
-    # If the rabbit app is running,
-    # we have to additionally check here if the channels/queues list results were ok.
-    if [ $rabbit_running -eq $OCF_SUCCESS ]; then
-        # Check if the rabbitmqctl control plane returned no errors for issued requests.
-        if [ $rc_alive -ne 0 -o $rc_queues -ne 0 ]; then
-            ocf_log err "${LH} rabbitmqctl exited with errors."
+    if [ $timeout_queues -eq 2 ]; then
+        return $OCF_ERR_GENERIC
+
+    elif [ $timeout_queues -eq 0 ]; then
+        if [ $rc_queues -ne 0 ]; then
+            ocf_log err "${LH} rabbitmqctl list_queues exited with errors."
             rc=$OCF_ERR_GENERIC
+
+        elif [ -n "${queues}" ]; then
+            local q_c
+            q_c=`printf "%b\n" "${queues}" | wc -l`
+            local mem
+            mem=`printf "%b\n" "${queues}" | awk -v sum=0 '{sum+=$1} END {print (sum/1048576)}'`
+            local mes
+            mes=`printf "%b\n" "${queues}" | awk -v sum=0 '{sum+=$2} END {print sum}'`
+            local c_u
+            c_u=`printf "%b\n" "${queues}" | awk -v sum=0 -v cnt=${q_c} '{sum+=$3} END {print (sum+1)/(cnt+1)}'`
+            local status
+            status=`echo $(su_rabbit_cmd "${OCF_RESKEY_ctl} -q status")`
+            ocf_log info "${LH} RabbitMQ is running ${q_c} queues consuming ${mem}m of ${TOTALVMEM}m total, with ${mes} queued messages, average consumer utilization ${c_u}"
+            ocf_log info "${LH} RabbitMQ status: ${status}"
         fi
     fi
 
@@ -1234,6 +1413,10 @@ action_start() {
         ocf_log info "${LH} RMQ prepared for start succesfully."
     fi
 
+    ocf_run crm_attribute -N $THIS_PCMK_NODE -l reboot --name 'rabbit_list_channels_timeouts' --update '0'
+    ocf_run crm_attribute -N $THIS_PCMK_NODE -l reboot --name 'rabbit_get_alarms_timeouts' --update '0'
+    ocf_run crm_attribute -N $THIS_PCMK_NODE -l reboot --name 'rabbit_list_queues_timeouts' --update '0'
+
     ocf_log info "${LH} action end."
     return $rc
 }
@@ -1251,6 +1434,10 @@ action_stop() {
     fi
 
     ocf_log info "${LH} action begin."
+
+    # Wait for synced state first
+    ocf_log info "${LH} waiting $((OCF_RESKEY_stop_time/2)) to sync"
+    wait_sync $((OCF_RESKEY_stop_time/2))
 
     # remove master flag
     # remove master score
@@ -1346,14 +1533,15 @@ action_notify() {
         case "$OCF_RESKEY_CRM_meta_notify_operation" in
             promote)
                 ocf_log info "${LH} post-promote begin."
-                # Report not running, if the list of nodes being promoted reported empty
+                # Do nothing, if the list of nodes being promoted reported empty.
+                # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic
                 if [ -z "${OCF_RESKEY_CRM_meta_notify_promote_uname}" ] ; then
-                  ocf_log warn "${LH} there are no nodes to join to reported on post-promote. The resource will be restarted."
+                  ocf_log warn "${LH} there are no nodes to join to reported on post-promote. Nothing to do."
                   ocf_log info "${LH} post-promote end."
-                  return $OCF_NOT_RUNNING
+                  return $OCF_SUCCESS
                 fi
                 # Note, this should fail when the mnesia is inconsistent.
-                # For example, when the "old" master processing the promotion of the new one.
+                # For example, when the "old" master processing the promition of the new one.
                 # Later this ex-master node will rejoin the cluster at post-start.
                 jjj_join "${OCF_RESKEY_CRM_meta_notify_promote_uname}"
                 rc=$?
@@ -1366,23 +1554,29 @@ action_notify() {
             start)
                 ocf_log info "${LH} post-start begin."
                 local nodes_list="${OCF_RESKEY_CRM_meta_notify_start_uname} ${OCF_RESKEY_CRM_meta_notify_active_uname}"
-                # Report not running, if the list of nodes being started or running reported empty
+                # Do nothing, if the list of nodes being started or running reported empty
+                # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic
                 if [ -z "${nodes_list}" ] ; then
-                  ocf_log warn "${LH} there are no nodes to join to reported on post-promote. The resource will be restarted."
+                  ocf_log warn "${LH} I'm a last man standing and I must survive!"
                   ocf_log info "${LH} post-start end."
-                  return $OCF_NOT_RUNNING
+                  return $OCF_SUCCESS
                 fi
                 # check did this event from this host
                 my_host "${nodes_list}"
                 rc=$?
-                # Report not running, if there is no master reported
+                # Do nothing, if there is no master reported
+                # Delegate recovery, if needed, to the "running out of the cluster" monitor's logic
                 if [ -z "${OCF_RESKEY_CRM_meta_notify_master_uname}" ] ; then
-                  ocf_log warn "${LH} there are no nodes to join to reported on post-start. The resource will be restarted."
+                  ocf_log warn "${LH} there are no nodes to join to reported on post-start. Nothing to do."
                   ocf_log info "${LH} post-start end."
-                  return $OCF_NOT_RUNNING
+                  return $OCF_SUCCESS
                 fi
                 if [ $rc -eq $OCF_SUCCESS ] ; then
-                    check_need_join_to "${OCF_RESKEY_CRM_meta_notify_master_uname}"
+                    # Now we need to:
+                    # a. join to the cluster if we are not joined yet
+                    # b. start the RabbitMQ application, which is always
+                    #    stopped after start action finishes
+                    check_need_join_to ${OCF_RESKEY_CRM_meta_notify_master_uname}
                     rc_join=$?
                     if [ $rc_join -eq $OCF_SUCCESS ]; then
                       ocf_log warn "${LH} Going to join node ${OCF_RESKEY_CRM_meta_notify_master_uname}"
@@ -1390,13 +1584,27 @@ action_notify() {
                       rc2=$?
                     else
                       ocf_log warn "${LH} We are already clustered with node ${OCF_RESKEY_CRM_meta_notify_master_uname}"
-                      rc2=$OCF_SUCCESS
+                      if try_to_start_rmq_app; then
+                          rc2=$OCF_SUCCESS
+                      else
+                          rc2=$OCF_ERR_GENERIC
+                      fi
                     fi
                     ocf_log info "${LH} post-start end."
+                    if [ -s "${OCF_RESKEY_definitions_dump_file}" ] ; then
+                        ocf_log info "File ${OCF_RESKEY_definitions_dump_file} exists"
+                        ocf_run  curl -X POST -u $OCF_RESKEY_admin_user:$OCF_RESKEY_admin_password 127.0.0.1:15672/api/definitions --header "Content-Type:application/json" -d @$OCF_RESKEY_definitions_dump_file
+                        rc=$?
+                        if [ $rc -eq $OCF_SUCCESS ] ; then
+                            ocf_log info "RMQ definitions have imported succesfully."
+                        else
+                            ocf_log err "RMQ definitions have not imported."
+                        fi
+                    fi
                     if [ $rc2 -eq $OCF_ERR_GENERIC ] ; then
                         ocf_log warn "${LH} Failed to join the cluster on post-start. The resource will be restarted."
                         ocf_log info "${LH} post-start end."
-                        return $OCF_NOT_RUNNING
+                        return $OCF_ERR_GENERIC
                     fi
                 fi
                 ;;
@@ -1407,12 +1615,15 @@ action_notify() {
                 if [ -z "${OCF_RESKEY_CRM_meta_notify_stop_uname}" ] ; then
                   ocf_log warn "${LH} there are no nodes being stopped reported on post-stop. The resource will be restarted."
                   ocf_log info "${LH} post-stop end."
-                  return $OCF_NOT_RUNNING
+                  return $OCF_ERR_GENERIC
                 fi
                 my_host "${OCF_RESKEY_CRM_meta_notify_stop_uname}"
                 rc=$?
                 if [ $rc -ne $OCF_SUCCESS ] ; then
-                    # On ohter nodes processing the post-stop, make sure the stopped node will be forgotten
+                    # Wait for synced state first
+                    ocf_log info "${LH} waiting $((OCF_RESKEY_stop_time/2)) to sync"
+                    wait_sync $((OCF_RESKEY_stop_time/2))
+                    # On other nodes processing the post-stop, make sure the stopped node will be forgotten
                     unjoin_nodes_from_cluster "${OCF_RESKEY_CRM_meta_notify_stop_uname}"
                 else
                     # On the nodes being stopped, reset the master score
@@ -1429,7 +1640,7 @@ action_notify() {
                 if [ -z "${OCF_RESKEY_CRM_meta_notify_demote_uname}" ] ; then
                   ocf_log warn "${LH} there are no nodes being demoted reported on post-demote. The resource will be restarted."
                   ocf_log info "${LH} post-demote end."
-                  return $OCF_NOT_RUNNING
+                  return $OCF_ERR_GENERIC
                 fi
                 my_host "${OCF_RESKEY_CRM_meta_notify_demote_uname}"
                 rc=$?
@@ -1437,6 +1648,9 @@ action_notify() {
                     # On ohter nodes processing the post-demote, make sure the demoted node will be forgotten
                     unjoin_nodes_from_cluster "${OCF_RESKEY_CRM_meta_notify_demote_uname}"
                 else
+                    # Wait for synced state first
+                    ocf_log info "${LH} waiting $((OCF_RESKEY_stop_time/2)) to sync"
+                    wait_sync $((OCF_RESKEY_stop_time/2))
                     # On the nodes being demoted, reset the master score
                     ocf_log info "${LH} resetting the master score."
                     master_score 0
@@ -1577,6 +1791,11 @@ action_demote() {
         "$OCF_RUNNING_MASTER")
             # Running as master. Normal, expected behavior.
             ocf_log warn "${LH} Resource is currently running as Master"
+
+            # Wait for synced state first
+            ocf_log info "${LH} waiting $((OCF_RESKEY_stop_time/2)) to sync"
+            wait_sync $((OCF_RESKEY_stop_time/2))
+
             stop_rmq_server_app
             rc=$?
             crm_attribute -N $THIS_PCMK_NODE -l reboot --name 'rabbit-master' --delete


### PR DESCRIPTION
Sync OCF script changes and fixes from Fuel,
version 8.0dev/9ca5b6709cd18c8134cd8feaccf937ef49a625b4
Changelog brief:
9ca5b67 - Matthew Mosesohn, 8 days ago : Wait for rabbitmq sync before stop/demote actions
00a6a01 - Davanum Srinivas, 4 days ago : Avoid division operation in shell
c1900b4 - Dmitry Mescheryakov, 4 weeks ago : Start RabbitMQ app on notify
00f28b5 - Vladimir Kuklin, 4 weeks ago : Return NOT_RUNNING when beam is not RUNNING
2707a5e - Dmitry Mescheryakov, 7 weeks ago : Make RabbitMQ OCF script tolerate rabbitmqctl timeouts
403b28c - Bogdan Dobrelya, 6 weeks ago : Detect a last man standing for rabbit OCF agent
60d5743 - Victor Sergeyev, 7 weeks ago : Add more logs to rabbitmq get_status function
11c4e4c - Alex Schultz, 9 weeks ago : Fix rabbitmq data restore for large datasets
8ccdfc6 - Stanislav Makar, 6 months ago : Implement the dumping of rabbitMQ definitions
5097d94 - Bogdan Dobrelya, 3 months ago : Fix error return codes for rabbit OCF
b5ae83a - Bogdan Dobrelya, 3 months ago : Fix chowning for rabbit OCF
bf604f8 - Bogdan Dobrelya, 4 months ago : Restart rabbit if can't list queues or found memory alert

The changelog full, with gerrit change-ids and related LP bugs:
commit 9ca5b6709cd18c8134cd8feaccf937ef49a625b4
Author: Matthew Mosesohn <mmosesohn@mirantis.com>
Date:   Mon Oct 5 15:48:33 2015 +0300

    Wait for rabbitmq sync before stop/demote actions
    
    Added new OCF key stop_time (corresponding to start_time)
    Added wait_sync function which tries until start_time/2
    for queues on stopped/demoted node to reach synced state.
    
    Added optional [-t timeout] to su_rabbit_cmd function to
    provide arbitrary timeout
    
    Change-Id: Iae2211b3d477a9603a58d5eacb12e0fba924861a
    Closes-Bug: #1464637

commit 00a6a016d5235de4cbde26cb40db71119967d3c7
Author: Davanum Srinivas <davanum@gmail.com>
Date:   Fri Oct 9 09:42:59 2015 -0700

    Avoid division operation in shell
    
    When the data returned from 'rabbitmqctl list_queues' grows a lot
    and awk sums up all the rows especially for memory calculation it
    returns the sum in scientific notation (example from bug
    was .15997e+09), later when we want to calculate the memory in
    MB instead of bytes, the bash division does not like this string.
    
    We can just avoid the situation by doing the division into MB
    in awk itself. Since we don't need the memory in bytes anyway.
    
    Closes-Bug: #1503331
    Change-Id: I38d25406b84d0f70ed62101d5fb5ba108bcab8bd

commit c1900b49e6ddcfb84bf5c501c75f3fee80903eca
Author: Dmitry Mescheryakov <dmescheryakov@mirantis.com>
Date:   Fri Sep 18 15:05:03 2015 +0300

    Start RabbitMQ app on notify
    
    On notify, if we detect that we are a part of a cluster we still
    need to start the RabbitMQ application, because it is always
    down after action_start finishes.
    
    Closes-Bug: #1496386
    Change-Id: I307452b687a6100cc4489c8decebbc3dccdbc432

commit 00f28b5cc48bdba389922fa460e4a6e6e173589e
Author: Vladimir Kuklin <vkuklin@mirantis.com>
Date:   Tue Sep 15 14:39:08 2015 +0300

    Return NOT_RUNNING when beam is not RUNNING
    
    Change get_status to return NOT_RUNNING when
    beam is not_running. Otherwise, pacemaker
    will get stuck during rabbitmq failover and
    will not attempt to restart the failed resource
    
    Change-Id: I926a3eafa9968abdf07baa5f2d5c22480300fb30
    Closes-bug: #1484280

commit 2707a5ebbff7012a94de77b60fd594f5bcb29e05
Author: Dmitry Mescheryakov <dmescheryakov@mirantis.com>
Date:   Tue Aug 25 17:38:44 2015 +0300

    Make RabbitMQ OCF script tolerate rabbitmqctl timeouts
    
    The change makes OCF script ignore small number of timeouts of rabbitmqctl
    for 'heavy' operations: list_channels, get_alarms and list_queues.
    Number of tolerated timeouts in a row is configured through a new variable
    'max_rabbitmqctl_timeouts'. By default it is set to 1, i.e. rabbitmqctl
    timeouts are not tolerated at all.
    
    Bug #1487517 is fixed by extracting declaration of local variables
    'rc_alarms' and 'rc_queues' from assignment operations.
    
    
    Text for Operations Guide:
    
    If on node where RabbitMQ is deployed
    other processes consume significant part of CPU, RabbitMQ starts
    responding slow to queries by 'rabbitmqctl' utility. The utility is
    used by RabbitMQ's OCF script to monitor state of the RabbitMQ.
    When utility fails to return in pre-defined timeout, OCF script
    considers RabbitMQ to be down and restarts it, which might lead to
    a limited (several minutes) OpenStack downtime. Such restarts
    are undesirable as they cause downtime without benefit. To
    mitigate the issue, the OCF script might be told to tolerate
    certain amount of rabbitmqctl timeouts in a row using the following
    command:
      crm_resource --resource p_rabbitmq-server --set-parameter \
          max_rabbitmqctl_timeouts --parameter-value N
    
    Here N should be replaced with the number of timeouts. For instance,
    if it is set to 3, the OCF script will tolerate two rabbitmqctl
    timeouts in a row, but fail if the third one occurs.
    
    By default the parameter is set to 1, i.e. rabbitmqctl timeout is not
    tolerated at all. The downside of increasing the parameter is that
    if a real issue occurs which causes rabbitmqctl timeout, OCF script
    will detect that only after N monitor runs and so the restart, which
    might fix the issue, will be delayed.
    
    To understand that RabbitMQ's restart was caused by rabbitmqctl timeout
    you should examine lrmd.log of the corresponding controller on Fuel
    master node in /var/log/docker-logs/remote/ directory. Here lines like
    "the invoked command exited 137: /usr/sbin/rabbitmqctl list_channels ..."
    
    indicate rabbitmqctl timeout. The next line will explain if it
    caused restart or not. For example:
    "rabbitmqctl timed out 2 of max. 3 time(s) in a row. Doing nothing for now."
    
    DocImpact: user-guide, operations-guide
    
    Closes-Bug: #1479815
    Closes-Bug: #1487517
    Change-Id: I9dec06fc08dbeefbc67249b9e9633c8aab5e09ca

commit 403b28c2aff8aa9f37125d3ff1ac09861990da7e
Author: Bogdan Dobrelya <bdobrelia@mirantis.com>
Date:   Thu Sep 3 13:53:13 2015 +0200

    Detect a last man standing for rabbit OCF agent
    
    W/o this patch, the race condition is possible
    when there is no running rabbit nodes/resource
    master. The rabbit nodes will start/stop in an
    endless loop as a result introducing full downtime
    for AMQP cluster and cloud control plane.
    
    The solution is:
    * On post-start/post-promote notify, do nothing, if
      either of the following is a true:
      - there is no rabbit resources running or no master
      - the list of rabbit resources being started/promoted
        reported empty
    * For such cases, do not report resource failure and delegate
      recovery, if needed, to the "running out of the cluster"
      monitor's logic.
    * Additionally, report about a last man standing when
      there is no running rabbit resources around.
    
    Closes-bug: #1491306
    
    Change-Id: If1c62fac26b63410636413c49fce55c35e53dc5f
    Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>

commit 60d5743c41999a43d87374357866cd3c3c02aa64
Author: Victor Sergeyev <vsergeyev@mirantis.com>
Date:   Wed Aug 26 19:13:55 2015 +0300

    Add more logs to rabbitmq get_status function
    
    It's really hard to debug, when get_status() returns $OCF_NOT_RUNNING
    only and looses exit code and error output.
    
    Added more logs to avoid of this situation.
    
    Related-Bug: #1488999
    
    Change-Id: Id0999235d7be688f55799e2952fe22e97b678ce7

commit 11c4e4c3985949f776367dd5045102c6398aef89
Author: Alex Schultz <aschultz@mirantis.com>
Date:   Thu Aug 13 09:31:51 2015 -0500

    Fix rabbitmq data restore for large datasets
    
    Previously we were sending the json backup data on the command line
    which fails when the dataset is large. This change updates the command
    line options for curl to pass the filename directly and let it handle
    the reading of the data.
    
    Change-Id: I37f298279beca06df41fb08e1745602976c6a776
    Closes-Bug: 1383258

commit 8ccdfc62152de8212ba6a0aeed45c1e3677c70a4
Author: Stanislav Makar <smakar@mirantis.com>
Date:   Thu Apr 16 14:32:51 2015 +0000

    Implement the dumping of rabbitMQ definitions
    
    This changes leverages the rabbitmq management plugin to dump
    exchanges, queues, bindings, users, virtual hosts, permissions and
    parameters from the running system. Specifically this change adds the
    following:
    
    * The dumping rabbitMQ definitions (users/vhosts/exchanges/etc) during
      the end of the deployment
    * The possibility to restore definitions to the rabbitmq-server ocf
      script during rabbitMQ startup.
    * Enabled rabbitmq admin plugin, but restricts it to localhost traffic.
      This reverts Ic01c26200f6019a8112b1c5fb04a282e64b3b3e6 but adds
      firewall rules to mitigate the issue.
    
    DocImpact: The dump_rabbit_definitions task can be used to backup the
    rabbitmq definitions and if custom definitions (users/vhosts/etc) are
    created it must be run or the changes may be lost during the rabbitmq
    failover via pacemaker.
    
    Change-Id: I715f7c2ae527f7e105b9f6b7d82c443e8accf178
    Closes-bug: #1383258
    Related-bug: #1450443
    Co-Authored-By: Alex Schultz <aschultz@mirantis.com>

commit 5097d94f5d56fd6126ca9b7c1227961536c94399
Author: Bogdan Dobrelya <bdobrelia@mirantis.com>
Date:   Tue Jul 7 13:32:25 2015 +0200

    Fix error return codes for rabbit OCF
    
    W/o this fix the situation is possible when
    rabbit OCF returns OCF_NOT_RUNNING in the hope of
    future restart of the resource by pacemaker.
    
    But in fact, pacemaker will not trigger restart action
    if monitor returns "not running". This is an issue
    as we want resource restarted.
    
    The solution is to return OCF_ERR_GENERIC instead of
    OCF_NOT_RUNNING when we expect the resource to be restarted
    (which is action stop plus action start).
    
    Closes-bug: #1472230
    
    Change-Id: I10c6e43d92cb23596636d86932674b36864d1595
    Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>

commit b5ae83a15be191d46d4b0da3d4bc67420311896a
Author: Bogdan Dobrelya <bdobrelia@mirantis.com>
Date:   Tue Jul 7 10:16:08 2015 +0200

    Fix chowning for rabbit OCF
    
    W/o this fix, the list of file names not
    accessible by rabbitmq user will be treated
    as multiple arguments to the if command causing
    it to throw the "too many arguments" error and
    the chown command to be skipped.
    
    This is the problem as it might prevent the rabbitmq
    server from starting because of a bad files ownership.
    
    The solution is to pass the list of files as a single
    argument "${foo}".
    
    Closes-bug: #1472175
    
    Change-Id: I1d00ec3f31cd0f023bd58a4e11e5b31659977229
    Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>

commit bf604f80d72f69e771152b153973fa38fa83afd8
Author: Bogdan Dobrelya <bdobrelia@mirantis.com>
Date:   Wed Jun 10 13:44:53 2015 +0200

    Restart rabbit if can't list queues or found memory alert
    
    W/o this fix the dead end situation is possible
    when the rabbit node have no free memory resources left
    and the cluster blocks all publishing, by design.
    But the app thinks "let's wait for the publish block have
    lifted" and cannot recover.
    
    The workaround is to monitor results
    of crucial rabbitmqctl commands and restart the rabbit node,
    if queues/channels/alarms cannot be listed or if there are
    memory alarms found.
    This is the similar logic as we have for the cases when
    rabbitmqctl list_channels hangs. But the channels check is also
    fixed to verify if the exit code>0 when the rabbit app is
    running.
    
    Additional checks added to the monitor also require extending
    the timeout window for the monitor action from 60 to 180 seconds.
    
    Besides that, this patch makes the monitor action to gather the
    rabbit status and runtime stats, like consumed memory by all
    queues of total Mem+Swap, total messages in all queues and
    average queue consumer utilization. This info should help to
    troubleshoot failures better.
    
    DocImpact: ops guide. If any rabbitmq node exceeded its memory
    threshold the publish became blocked cluster-wide, by design.
    For such cases, this rabbit node would be recovered from the
    raised memory alert and immediately stopped to be restarted
    later by the pacemaker. Otherwise, this blocked publishing state
    might never have been lifted, if the pressure persists from the
    OpenStack apps side.
    
    Closes-bug: #1463433
    
    Change-Id: I91dec2d30d77b166ff9fe88109f3acdd19ce9ff9
    Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>

__

Co-authored-by: Matthew Mosesohn <mmosesohn@mirantis.com>
Co-authored-by: Davanum Srinivas <dsrinivas@mirantis.com>
Co-authored-by: Vladimir Kuklin <vkuklin@mirantis.com>
Co-authored-by: Dmitry Mescheryakov <dmescheryakov@mirantis.com>
Co-authored-by: Victor Sergeyev <vsergeyev@mirantis.com>
Co-authored-by: Alex Schultz <aschultz@mirantis.com>
Co-authored-by: Makar Stanislav <smakar@mirantis.com>
Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>