### PR TITLE
Add `exclusive` item to `rabbitmqctl list_queues`

### DIFF
--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -1230,6 +1230,11 @@
                   queue is non-exclusive.</para></listitem>
               </varlistentry>
               <varlistentry>
+                <term>exclusive</term>
+                <listitem><para>True if queue is exclusive (i.e. has
+                  owner_pid), false otherwise</para></listitem>
+              </varlistentry>
+              <varlistentry>
                 <term>exclusive_consumer_pid</term>
                 <listitem><para>Id of the Erlang process representing the channel of the
                   exclusive consumer subscribed to this queue. Empty if

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -92,7 +92,8 @@
          durable,
          auto_delete,
          arguments,
-         owner_pid
+         owner_pid,
+         exclusive
         ]).
 
 -define(INFO_KEYS, [pid | ?CREATION_EVENT_KEYS ++ ?STATISTICS_KEYS -- [name]]).
@@ -828,6 +829,8 @@ i(owner_pid, #q{q = #amqqueue{exclusive_owner = none}}) ->
     '';
 i(owner_pid, #q{q = #amqqueue{exclusive_owner = ExclusiveOwner}}) ->
     ExclusiveOwner;
+i(exclusive, #q{q = #amqqueue{exclusive_owner = ExclusiveOwner}}) ->
+    is_pid(ExclusiveOwner);
 i(policy,    #q{q = Q}) ->
     case rabbit_policy:name(Q) of
         none   -> '';


### PR DESCRIPTION
In addition to owner_pid, which makes little sense to beginners.

Just as described in #371