### PR TITLE
Fix cluster-wide alarm handling

### DIFF
--- a/src/rabbit_memory_monitor.erl
+++ b/src/rabbit_memory_monitor.erl
@@ -86,7 +86,9 @@ report_ram_duration(Pid, QueueDuration) ->
 stop() ->
     gen_server2:cast(?SERVER, stop).
 
-conserve_resources(Pid, disk, Conserve) ->
+%% Paging should be enabled/disabled only in response to disk resource alarms
+%% for current node.
+conserve_resources(Pid, disk, {_, Conserve, Node}) when node(Pid) =:= Node ->
     gen_server2:cast(Pid, {disk_alarm, Conserve});
 conserve_resources(_Pid, _Source, _Conserve) ->
     ok.

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -246,7 +246,7 @@ info(Pid, Items) ->
 force_event_refresh(Pid, Ref) ->
     gen_server:cast(Pid, {force_event_refresh, Ref}).
 
-conserve_resources(Pid, Source, Conserve) ->
+conserve_resources(Pid, Source, {_, Conserve, _}) ->
     Pid ! {conserve_resources, Source, Conserve},
     ok.
 


### PR DESCRIPTION
Initial draft for discussion.

- Properly handle clearing alarms from dead nodes - #362.
- Unblock publisher only when all alarms throughout the cluster was
  cleared - #379.
- Disable/enable paging in rabbit_memory_monitor only in response
  to disk resource alarms from current node (I'm not totally sure, but I think this is a bug).
- Add some documentation.