### PR TITLE
Recognize help as a valid sub-command for rabbitmqctl and rabbitmq-plugins

### DIFF
--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -86,7 +86,8 @@
          close_connection,
          {trace_on, [?VHOST_DEF]},
          {trace_off, [?VHOST_DEF]},
-         set_vm_memory_high_watermark
+         set_vm_memory_high_watermark,
+         help
         ]).
 
 -define(GLOBAL_QUERIES,
@@ -108,7 +109,7 @@
         [stop, stop_app, start_app, wait, reset, force_reset, rotate_logs,
          join_cluster, change_cluster_node_type, update_cluster_nodes,
          forget_cluster_node, rename_cluster_node, cluster_status, status,
-         environment, eval, force_boot]).
+         environment, eval, force_boot, help]).
 
 -define(COMMANDS_WITH_TIMEOUT,
         [list_user_permissions, list_policies, list_queues, list_exchanges,
@@ -488,6 +489,9 @@ action(eval, Node, [Expr], _Opts, _Inform) ->
         {error, E, _} ->
             {error_string, format_parse_error(E)}
     end;
+
+action(help, _Node, _Args, _Opts, _Inform) ->
+    io:format("~s", [rabbit_ctl_usage:usage()]);
 
 action(Command, Node, Args, Opts, Inform) ->
     %% For backward compatibility, run commands accepting a timeout with

--- a/src/rabbit_plugins_main.erl
+++ b/src/rabbit_plugins_main.erl
@@ -27,7 +27,8 @@
          {enable, [?OFFLINE_DEF, ?ONLINE_DEF]},
          {disable, [?OFFLINE_DEF, ?ONLINE_DEF]},
          {set, [?OFFLINE_DEF, ?ONLINE_DEF]},
-         {sync, []}]).
+         {sync, []},
+         {help, []}]).
 
 %%----------------------------------------------------------------------------
 
@@ -147,7 +148,10 @@ action(disable, Node, ToDisable0, Opts, State = #cli{all      = All,
     action_change(Opts, Node, Implicit, NewImplicit, State);
 
 action(sync, Node, [], _Opts, State) ->
-    sync(Node, true, State).
+    sync(Node, true, State);
+
+action(help, _Node, _Args, _Opts, _State) ->
+    io:format("~s", [rabbit_plugins_usage:usage()]).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
Some people believe that rabbitmqctl and rabbitmq-plugins should provide a valid help subcommand (instead of throwing an error). So here it is.

This is mostly a cosmetic patch so sorry for the noise in advance. Rebased on top of the stable.
