### PR TITLE
Don't update cookie on every run of HA OCF script

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -573,9 +573,22 @@ check_need_join_to() {
 
 # Update erlang cookie, if it has been specified
 update_cookie() {
+    local cookie_file_content
     if [ "${OCF_RESKEY_erlang_cookie}" != 'false' ] ; then
-        echo "${OCF_RESKEY_erlang_cookie}" > "${OCF_RESKEY_erlang_cookie_file}" && \
-        chown ${OCF_RESKEY_username}:${OCF_RESKEY_groupname} "${OCF_RESKEY_erlang_cookie_file}" && \
+        if [ -f "${OCF_RESKEY_erlang_cookie_file}" ]; then
+            # First line of cookie file without newline
+            cookie_file_content=$(head -n1 "${OCF_RESKEY_erlang_cookie_file}" | perl -pe chomp)
+        fi
+        # As there is a brief period of time when the file is empty
+        # (shell redirection has already opened and truncated file,
+        # and echo hasn't finished its job), we are doing this write
+        # only when cookie has changed.
+        if [ "${OCF_RESKEY_erlang_cookie}" != "${cookie_file_content}" ]; then
+            echo "${OCF_RESKEY_erlang_cookie}" > "${OCF_RESKEY_erlang_cookie_file}"
+        fi
+        # And this are idempotent operations, so we don't have to
+        # check any preconditions for running them.
+        chown ${OCF_RESKEY_username}:${OCF_RESKEY_groupname} "${OCF_RESKEY_erlang_cookie_file}"
         chmod 600 "${OCF_RESKEY_erlang_cookie_file}"
     fi
     return $OCF_SUCCESS


### PR DESCRIPTION
Update happens even during no-op commands like 'meta-data' or 'usage'.
During this update there is a short window for a race condition: a shell
redirection truncates the cookie file, and echo writes data there only
after a brief period of time. So erlang may read data from this empty
file and die with the error "Too short cookie string".