### PR TITLE
Rabbitmq server 264

### DIFF
--- a/packaging/windows-exe/rabbitmq_nsi.in
+++ b/packaging/windows-exe/rabbitmq_nsi.in
@@ -61,8 +61,6 @@ FunctionEnd
 
 ;--------------------------------
 
-LoadLanguageFile "${NSISDIR}\Contrib\Language files\English.nlf"
-
 ; The name of the installer
 Name "RabbitMQ Server %%VERSION%%"
 

--- a/packaging/windows-exe/rabbitmq_nsi.in
+++ b/packaging/windows-exe/rabbitmq_nsi.in
@@ -9,6 +9,59 @@
 !define uninstall "Software\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
 
 ;--------------------------------
+; Third-party functions
+; StrContains
+; This function does a case sensitive searches for an occurrence of a substring in a string. 
+; It returns the substring if it is found. 
+; Otherwise it returns null(""). 
+; Written by kenglish_hi
+; Adapted from StrReplace written by dandaman32
+ 
+ 
+Var STR_HAYSTACK
+Var STR_NEEDLE
+Var STR_CONTAINS_VAR_1
+Var STR_CONTAINS_VAR_2
+Var STR_CONTAINS_VAR_3
+Var STR_CONTAINS_VAR_4
+Var STR_RETURN_VAR
+ 
+Function un.StrContains
+  Exch $STR_NEEDLE
+  Exch 1
+  Exch $STR_HAYSTACK
+  ; Uncomment to debug
+  ;MessageBox MB_OK 'STR_NEEDLE = $STR_NEEDLE STR_HAYSTACK = $STR_HAYSTACK '
+    StrCpy $STR_RETURN_VAR ""
+    StrCpy $STR_CONTAINS_VAR_1 -1
+    StrLen $STR_CONTAINS_VAR_2 $STR_NEEDLE
+    StrLen $STR_CONTAINS_VAR_4 $STR_HAYSTACK
+    loop:
+      IntOp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_1 + 1
+      StrCpy $STR_CONTAINS_VAR_3 $STR_HAYSTACK $STR_CONTAINS_VAR_2 $STR_CONTAINS_VAR_1
+      StrCmp $STR_CONTAINS_VAR_3 $STR_NEEDLE found
+      StrCmp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_4 done
+      Goto loop
+    found:
+      StrCpy $STR_RETURN_VAR $STR_NEEDLE
+      Goto done
+    done:
+   Pop $STR_NEEDLE ;Prevent "invalid opcode" errors and keep the
+   Exch $STR_RETURN_VAR  
+FunctionEnd
+ 
+!macro _un.StrContainsConstructor OUT NEEDLE HAYSTACK
+  Push `${HAYSTACK}`
+  Push `${NEEDLE}`
+  Call un.StrContains
+  Pop `${OUT}`
+!macroend
+ 
+!define un.StrContains '!insertmacro "_un.StrContainsConstructor"'
+
+;--------------------------------
+
+LoadLanguageFile "${NSISDIR}\Contrib\Language files\English.nlf"
 
 ; The name of the installer
 Name "RabbitMQ Server %%VERSION%%"
@@ -155,6 +208,12 @@ LangString DESC_RabbitStartMenu ${LANG_ENGLISH} "Add some useful links to the st
 
 Section "Uninstall"
 
+  ; Check if reinstall will occur immediately - don't remove ERLANG_HOME
+  Var /GLOBAL REINSTALLFLAG
+  Var /GLOBAL ISREINSTALL
+  ${GetParameters} $REINSTALLFLAG
+  ${un.StrContains} $ISREINSTALL "reinstall" $REINSTALLFLAG
+
   ; Remove registry keys
   DeleteRegKey HKLM ${uninstall}
   DeleteRegKey HKLM "SOFTWARE\VMware, Inc.\RabbitMQ Server"
@@ -171,9 +230,12 @@ Section "Uninstall"
 
   ; Remove start menu items
   RMDir /r "$SMPROGRAMS\RabbitMQ Server"
-
-  DeleteRegValue ${env_hklm} ERLANG_HOME
-  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  
+  ; If reinstalling immediately (e.g. program update) don't remove ERLANG_HOME environment variable
+  ${If} $ISREINSTALL == ""
+	DeleteRegValue ${env_hklm} ERLANG_HOME
+	SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  ${EndIf}
 
 SectionEnd
 
@@ -186,7 +248,7 @@ Function .onInit
 
   ReadRegStr $0 HKLM ${uninstall} "UninstallString"
   ${If} $0 != ""
-    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "RabbitMQ is already installed. $\n$\nClick 'OK' to remove the previous version or 'Cancel' to cancel this installation." IDOK rununinstall IDCANCEL norun
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "RabbitMQ is already installed. $\n$\nClick 'OK' to remove the previous version or 'Cancel' to cancel this installation." /SD IDOK IDOK rununinstall IDCANCEL norun
 
     norun:
     Abort


### PR DESCRIPTION
Fixes to enable silent install using the NSIS /S command and reinstall without removing ERLANG_HOME, as this prevents successful reinstalls.