### PR TITLE
Make pmon:demonitor/2 respect its contract

### DIFF
--- a/src/pmon.erl
+++ b/src/pmon.erl
@@ -84,7 +84,7 @@ demonitor(Item, S = #state{dict = M, module = Module}) ->
     case dict:find(Item, M) of
         {ok, MRef} -> Module:demonitor(MRef),
                       S#state{dict = dict:erase(Item, M)};
-        error      -> M
+        error      -> S
     end.
 
 is_monitored(Item, #state{dict = M}) -> dict:is_key(Item, M).


### PR DESCRIPTION
Spec states that demonitor/2 should always return #state{}, but it
wasn't the case when pid wasn't found in #state.dict. This made API
unsafe to use, as it could lead to some other process storing incorrect
data as a pmon state.

Same as https://github.com/rabbitmq/rabbitmq-common/pull/18