### PR TITLE
Fix memory reporting for connections

### DIFF
--- a/src/rabbit_vm.erl
+++ b/src/rabbit_vm.erl
@@ -134,11 +134,10 @@ interesting_sups0() ->
     PluginProcs   = plugin_sups(),
     [MsgIndexProcs, MgmtDbProcs, PluginProcs].
 
-%% @todo I have doubts about this ssl_connection_sup and the
-%% amqp_sup. They don't seem to exist anywhere.
-%% @todo We probably need to put the equivalent process here
-%% (the one our Ranch supervisor is under).
-conn_sups()     -> [ssl_connection_sup, amqp_sup].
+conn_sups()     ->
+    Ranches = lists:flatten(ets:match(ranch_server, {{conns_sup, '_'}, '$1'})),
+    [amqp_sup|Ranches].
+
 conn_sups(With) -> [{Sup, With} || Sup <- conn_sups()].
 
 distinguishers() -> [{rabbit_amqqueue_sup_sup, fun queue_type/1} |


### PR DESCRIPTION
Before, there was two parts of the supervision tree: one for the
listener/acceptor, and one for connections. The latter was one
big supervisor handling all connections, regardless of the
listener they were coming from.

With Ranch, each listener has its own branch in the supervision
tree. Inside it are then two more branches, one for the
acceptors and one for the connections.

The fix simply adds all Ranch connection supervisors to the list
by fetching them from the ranch_server ETS table.

Fixes #435.