### PR TITLE
Switch absolute memory watermark values to be in bytes

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -182,9 +182,9 @@
    %%
    %% {vm_memory_high_watermark, 0.4},
 
-   %% Alternatively, we can set a limit (in megabytes) of RAM used by the node.
+   %% Alternatively, we can set a limit (in bytes) of RAM used by the node.
    %%
-   %% {vm_memory_high_watermark, {absolute, 1024}},
+   %% {vm_memory_high_watermark, {absolute, 1073741824}},
 
    %% Fraction of the high watermark limit at which queues start to
    %% page message out to disc in order to free up memory.

--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -1954,14 +1954,14 @@
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><cmdsynopsis><command>set_vm_memory_high_watermark absolute</command> <arg choice="req"><replaceable>memory_limit_mb</replaceable></arg></cmdsynopsis></term>
+          <term><cmdsynopsis><command>set_vm_memory_high_watermark absolute</command> <arg choice="req"><replaceable>memory_limit_in_bytes</replaceable></arg></cmdsynopsis></term>
           <listitem>
             <variablelist>
               <varlistentry>
-                <term>memory_limit_mb</term>
+                <term>memory_limit_in_bytes</term>
                 <listitem><para>
                     The new memory limit at which flow control is
-                    triggered, expressed in MB as an integer number
+                    triggered, expressed in bytes as an integer number
                     greater than or equal to 0.
                 </para></listitem>
               </varlistentry>

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -418,7 +418,7 @@ action(set_vm_memory_high_watermark, Node, [Arg], _Opts, Inform) ->
 
 action(set_vm_memory_high_watermark, Node, ["absolute", Arg], _Opts, Inform) ->
     Limit = list_to_integer(Arg),
-    Inform("Setting memory threshold on ~p to ~pMB", [Node, Limit]),
+    Inform("Setting memory threshold on ~p to ~p bytes", [Node, Limit]),
     rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark,
 	     [{absolute, Limit}]);
 

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -216,8 +216,7 @@ set_mem_limits(State, MemLimit) ->
                                    memory_config_limit = MemLimit}).
 
 interpret_limit({'absolute', MemLim}, UsableMemory) ->
-    %% Absolute memory is provided in MB
-    erlang:min(MemLim * ?ONE_MB, UsableMemory);
+    erlang:min(MemLim, UsableMemory);
 interpret_limit(MemFraction, UsableMemory) ->
     trunc(MemFraction * UsableMemory).
 

--- a/test/src/rabbit_tests.erl
+++ b/test/src/rabbit_tests.erl
@@ -3074,8 +3074,8 @@ nop(_, _) -> ok.
 test_memory_high_watermark() ->
     %% set vm memory high watermark
     HWM = vm_memory_monitor:get_vm_memory_high_watermark(),
-    %% this will trigger an alarm (memory unit is MB)
-    ok = control_action(set_vm_memory_high_watermark, ["absolute", "2"]),
+    %% this will trigger an alarm
+    ok = control_action(set_vm_memory_high_watermark, ["absolute", "200000"]),
     [{{resource_limit,memory,_},[]}] = rabbit_alarm:get_alarms(),
     %% reset
     ok = control_action(set_vm_memory_high_watermark, [float_to_list(HWM)]),


### PR DESCRIPTION
Fixes #407, references #207, #378, #448.