### PR TITLE
Support setting vm_memory_high_watermark and disk_free_limit in units

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -196,15 +196,16 @@
    %%
    %% Or you can set absolute value using memory units.
    %%
-   %% {vm_memory_high_watermark, {absolute, "1024MB"}},
+   %% {vm_memory_high_watermark, {absolute, "1024M"}},
    %%
-   %% Memory units rules:
-   %% k, kiB - kibibytes (2^10)
-   %% M, MiB - mebibytes (2^20)
-   %% G, GiB - gibibytes (2^30)
-   %% kB - kilobytes (10^3)
-   %% MB - megabytes (10^6)
-   %% GB - gigabytes (10^9)
+   %% Supported units suffixes:
+   %%
+   %% k, kiB: kibibytes (2^10 bytes)
+   %% M, MiB: mebibytes (2^20)
+   %% G, GiB: gibibytes (2^30)
+   %% kB: kilobytes (10^3)
+   %% MB: megabytes (10^6)
+   %% GB: gigabytes (10^9)
 
    %% Fraction of the high watermark limit at which queues start to
    %% page message out to disc in order to free up memory.

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -193,6 +193,18 @@
    %% Alternatively, we can set a limit (in bytes) of RAM used by the node.
    %%
    %% {vm_memory_high_watermark, {absolute, 1073741824}},
+   %%
+   %% Or you can set absolute value using memory units.
+   %%
+   %% {vm_memory_high_watermark, {absolute, "1024MB"}},
+   %%
+   %% Memory units rules:
+   %% k, kiB - kibibytes (2^10)
+   %% M, MiB - mebibytes (2^20)
+   %% G, GiB - gibibytes (2^30)
+   %% kB - kilobytes (10^3)
+   %% MB - megabytes (10^6)
+   %% GB - gigabytes (10^9)
 
    %% Fraction of the high watermark limit at which queues start to
    %% page message out to disc in order to free up memory.
@@ -211,6 +223,10 @@
    %% listed above for more details.
    %%
    %% {disk_free_limit, 50000000},
+   %%
+   %% Or you can set it using memory units (same as in vm_memory_high_watermark)
+   %% {disk_free_limit, "50MB"},
+   %% {disk_free_limit, "50000kB"},
 
    %% Alternatively, we can set a limit relative to total available RAM.
    %%

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -227,6 +227,7 @@
    %% Or you can set it using memory units (same as in vm_memory_high_watermark)
    %% {disk_free_limit, "50MB"},
    %% {disk_free_limit, "50000kB"},
+   %% {disk_free_limit, "2GB"},
 
    %% Alternatively, we can set a limit relative to total available RAM.
    %%

--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -1968,12 +1968,12 @@
                     triggered, expressed in bytes as an integer number
                     greater than or equal to 0 or as string with memory unit
                     (e.g. 1024MB). Available units are:
-                    k, kiB - kibibytes (2^10)
-                    M, MiB - mebibytes (2^20)
-                    G, GiB - gibibytes (2^30)
-                    kB - kilobytes (10^3)
-                    MB - megabytes (10^6)
-                    GB - gigabytes (10^9)
+                    k, kiB: kibibytes (2^10 bytes)
+                    M, MiB: mebibytes (2^20)
+                    G, GiB: gibibytes (2^30)
+                    kB: kilobytes (10^3)
+                    MB: megabytes (10^6)
+                    GB: gigabytes (10^9)
                 </para></listitem>
               </varlistentry>
             </variablelist>

--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -1958,15 +1958,22 @@
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><cmdsynopsis><command>set_vm_memory_high_watermark absolute</command> <arg choice="req"><replaceable>memory_limit_in_bytes</replaceable></arg></cmdsynopsis></term>
+          <term><cmdsynopsis><command>set_vm_memory_high_watermark absolute</command> <arg choice="req"><replaceable>memory_limit</replaceable></arg></cmdsynopsis></term>
           <listitem>
             <variablelist>
               <varlistentry>
-                <term>memory_limit_in_bytes</term>
+                <term>memory_limit</term>
                 <listitem><para>
                     The new memory limit at which flow control is
                     triggered, expressed in bytes as an integer number
-                    greater than or equal to 0.
+                    greater than or equal to 0 or as string with memory unit
+                    (e.g. 1024MB). Available units are:
+                    k, kiB - kibibytes (2^10)
+                    M, MiB - mebibytes (2^20)
+                    G, GiB - gibibytes (2^30)
+                    kB - kilobytes (10^3)
+                    MB - megabytes (10^6)
+                    GB - gigabytes (10^9)
                 </para></listitem>
               </varlistentry>
             </variablelist>

--- a/src/rabbit_alarm.erl
+++ b/src/rabbit_alarm.erl
@@ -101,7 +101,7 @@ parse_mem_limit({absolute, Limit}) ->
     case parse_limit(Limit) of
         {ok, ParsedLimit} -> {absolute, ParsedLimit};
         {error, parse_error} ->
-            rabbit_log:error("Unable to parse vm_memory_high_watermark value"),
+            rabbit_log:error("Unable to parse vm_memory_high_watermark value ~p", [Limit]),
             ?DEFAULT_VM_MEMORY_HIGH_WATERMARK
     end;
     {absolute, parse_limit(Limit, ?DEFAULT_VM_MEMORY_HIGH_WATERMARK)};
@@ -117,7 +117,7 @@ parse_disk_limit(Limit) ->
     case parse_limit(Limit) of
         {ok, ParsedLimit} -> ParsedLimit;
         {error, parse_error} ->
-            rabbit_log:error("Unable to parse disk_free_limit value"),
+            rabbit_log:error("Unable to parse disk_free_limit value ~p", [Limit]),
             ?DEFAULT_DISK_FREE_LIMIT
     end;
 parse_disk_limit(_) -> ?DEFAULT_DISK_FREE_LIMIT.

--- a/src/rabbit_alarm.erl
+++ b/src/rabbit_alarm.erl
@@ -104,7 +104,6 @@ parse_mem_limit({absolute, Limit}) ->
             rabbit_log:error("Unable to parse vm_memory_high_watermark value ~p", [Limit]),
             ?DEFAULT_VM_MEMORY_HIGH_WATERMARK
     end;
-    {absolute, parse_limit(Limit, ?DEFAULT_VM_MEMORY_HIGH_WATERMARK)};
 parse_mem_limit(Relative) when is_float(Relative), Relative < 1 ->
     Relative;
 parse_mem_limit(_) ->
@@ -119,17 +118,16 @@ parse_disk_limit(Limit) ->
         {error, parse_error} ->
             rabbit_log:error("Unable to parse disk_free_limit value ~p", [Limit]),
             ?DEFAULT_DISK_FREE_LIMIT
-    end;
-parse_disk_limit(_) -> ?DEFAULT_DISK_FREE_LIMIT.
+    end.
 
 parse_limit(MemLim) when is_integer(MemLim) -> {ok, MemLim};
-parse_limit(MemLim) when is_string(MemLim) ->
+parse_limit(MemLim) when is_list(MemLim) ->
     case re:run(MemLim, 
                 "^(?<VAL>[1-9][0-9]*)(?<UNIT>kB|MB|GB|kiB|MiB|GiB|k|M|G)$", 
                 [{capture, all_names}]) of
         {match, [{NumPos, NumLength}, {UnitPos, UnitLength}]} ->
-            Num = list_to_integer(string:substr(MemLim, NumPos+1, NumLength))
-            Unit = string:substr(MemLim, UnitPos+1, UniqLength),
+            Num = list_to_integer(string:substr(MemLim, NumPos+1, NumLength)),
+            Unit = string:substr(MemLim, UnitPos+1, UnitLength),
             Multiplier = case Unit of
                 KiB when KiB == "k"; KiB == "kiB" -> 1024;
                 MiB when MiB == "M"; MiB == "MiB" -> 1024*1024;

--- a/src/rabbit_alarm.erl
+++ b/src/rabbit_alarm.erl
@@ -39,6 +39,11 @@
 
 -define(SERVER, ?MODULE).
 
+-define(DEFAULT_VM_MEMORY_HIGH_WATERMARK, 0.4).
+-define(DEFAULT_DISK_FREE_LIMIT, 50000000).
+
+-export([parse_limit/1]).
+
 %%----------------------------------------------------------------------------
 
 -ifdef(use_specs).
@@ -61,6 +66,8 @@
 -spec(on_node_up/1 :: (node()) -> 'ok').
 -spec(on_node_down/1 :: (node()) -> 'ok').
 -spec(get_alarms/0 :: () -> [{alarm(), []}]).
+-spec(parse_limit/1 :: (integer() | string()) -> 
+    {ok, integer()} | {error, parse_error}).
 
 -else.
 
@@ -77,8 +84,9 @@ start() ->
     ok = rabbit_sup:start_restartable_child(?MODULE),
     ok = gen_event:add_handler(?SERVER, ?MODULE, []),
     {ok, MemoryWatermark} = application:get_env(vm_memory_high_watermark),
+
     rabbit_sup:start_restartable_child(
-      vm_memory_monitor, [MemoryWatermark,
+      vm_memory_monitor, [parse_mem_limit(MemoryWatermark),
                           fun (Alarm) ->
                                   background_gc:run(),
                                   set_alarm(Alarm)
@@ -86,8 +94,55 @@ start() ->
                           fun clear_alarm/1]),
     {ok, DiskLimit} = application:get_env(disk_free_limit),
     rabbit_sup:start_delayed_restartable_child(
-      rabbit_disk_monitor, [DiskLimit]),
+      rabbit_disk_monitor, [parse_disk_limit(DiskLimit)]),
     ok.
+
+parse_mem_limit({absolute, Limit}) ->
+    case parse_limit(Limit) of
+        {ok, ParsedLimit} -> {absolute, ParsedLimit};
+        {error, parse_error} ->
+            rabbit_log:error("Unable to parse vm_memory_high_watermark value"),
+            ?DEFAULT_VM_MEMORY_HIGH_WATERMARK
+    end;
+    {absolute, parse_limit(Limit, ?DEFAULT_VM_MEMORY_HIGH_WATERMARK)};
+parse_mem_limit(Relative) when is_float(Relative), Relative < 1 ->
+    Relative;
+parse_mem_limit(_) ->
+    ?DEFAULT_VM_MEMORY_HIGH_WATERMARK.
+
+parse_disk_limit({mem_relative, Relative}) 
+    when is_float(Relative), Relative < 1 ->
+    {mem_relative, Relative};
+parse_disk_limit(Limit) -> 
+    case parse_limit(Limit) of
+        {ok, ParsedLimit} -> ParsedLimit;
+        {error, parse_error} ->
+            rabbit_log:error("Unable to parse disk_free_limit value"),
+            ?DEFAULT_DISK_FREE_LIMIT
+    end;
+parse_disk_limit(_) -> ?DEFAULT_DISK_FREE_LIMIT.
+
+parse_limit(MemLim) when is_integer(MemLim) -> {ok, MemLim};
+parse_limit(MemLim) when is_string(MemLim) ->
+    case re:run(MemLim, 
+                "^(?<VAL>[1-9][0-9]*)(?<UNIT>kB|MB|GB|kiB|MiB|GiB|k|M|G)$", 
+                [{capture, all_names}]) of
+        {match, [{NumPos, NumLength}, {UnitPos, UnitLength}]} ->
+            Num = list_to_integer(string:substr(MemLim, NumPos+1, NumLength))
+            Unit = string:substr(MemLim, UnitPos+1, UniqLength),
+            Multiplier = case Unit of
+                KiB when KiB == "k"; KiB == "kiB" -> 1024;
+                MiB when MiB == "M"; MiB == "MiB" -> 1024*1024;
+                GiB when GiB == "G"; GiB == "GiB" -> 1024*1024*1024;
+                "KB" -> 1000;
+                "MB" -> 1000000;
+                "GB" -> 1000000000
+            end,
+            {ok, Num * Multiplier};
+        nomatch ->
+            % log error
+            {error, parse_error}
+    end.
 
 stop() -> ok.
 

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -417,10 +417,14 @@ action(set_vm_memory_high_watermark, Node, [Arg], _Opts, Inform) ->
     rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark, [Frac]);
 
 action(set_vm_memory_high_watermark, Node, ["absolute", Arg], _Opts, Inform) ->
-    Limit = list_to_integer(Arg),
-    Inform("Setting memory threshold on ~p to ~p bytes", [Node, Limit]),
-    rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark,
-	     [{absolute, Limit}]);
+    case rabbit_alarm:parse_limit(Arg) of
+        {ok, Limit} ->
+            Inform("Setting memory threshold on ~p to ~p bytes", [Node, Limit]),
+            rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark,
+                 [{absolute, Limit}]);
+        {error, parse_error} ->
+            {error_string, "Unable to parse absolute memory value"}
+    end;
 
 action(set_permissions, Node, [Username, CPerm, WPerm, RPerm], Opts, Inform) ->
     VHost = proplists:get_value(?VHOST_OPT, Opts),

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -417,7 +417,7 @@ action(set_vm_memory_high_watermark, Node, [Arg], _Opts, Inform) ->
     rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark, [Frac]);
 
 action(set_vm_memory_high_watermark, Node, ["absolute", Arg], _Opts, Inform) ->
-    case rabbit_alarm:parse_limit(Arg) of
+    case rabbit_resource_monitor_misc:parse_information_unit(Arg) of
         {ok, Limit} ->
             Inform("Setting memory threshold on ~p to ~p bytes", [Node, Limit]),
             rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark,

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -423,7 +423,7 @@ action(set_vm_memory_high_watermark, Node, ["absolute", Arg], _Opts, Inform) ->
             rpc_call(Node, vm_memory_monitor, set_vm_memory_high_watermark,
                  [{absolute, Limit}]);
         {error, parse_error} ->
-            {error_string, "Unable to parse absolute memory value"}
+            {error_string, "Unable to parse absolute memory limit value ~p", [Arg]}
     end;
 
 action(set_permissions, Node, [Username, CPerm, WPerm, RPerm], Opts, Inform) ->

--- a/src/rabbit_disk_monitor.erl
+++ b/src/rabbit_disk_monitor.erl
@@ -71,7 +71,7 @@
 
 -ifdef(use_specs).
 
--type(disk_free_limit() :: (integer() | {'mem_relative', float()})).
+-type(disk_free_limit() :: (integer() | string() | {'mem_relative', float()})).
 -spec(start_link/1 :: (disk_free_limit()) -> rabbit_types:ok_pid_or_error()).
 -spec(get_disk_free_limit/0 :: () -> integer()).
 -spec(set_disk_free_limit/1 :: (disk_free_limit()) -> 'ok').

--- a/src/rabbit_resource_monitor_misc.erl
+++ b/src/rabbit_resource_monitor_misc.erl
@@ -1,0 +1,49 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+%%
+
+
+-module(rabbit_resource_monitor_misc).
+
+-export([parse_information_unit/1]).
+
+-ifdef(use_spec).
+
+-spec(parse_information_unit/1 :: (integer() | string()) -> 
+    {ok, integer()} | {error, parse_error}).
+
+-endif.
+
+parse_information_unit(MemLim) when is_integer(MemLim) -> {ok, MemLim};
+parse_information_unit(MemLim) when is_list(MemLim) ->
+    case re:run(MemLim, 
+                "^(?<VAL>[0-9]+)(?<UNIT>kB|MB|GB|kiB|MiB|GiB|k|M|G)?$", 
+                [{capture, all_names, list}]) of
+    	{match, [[], _]} ->
+        	{ok, list_to_integer(MemLim)};    		
+        {match, [Unit, Num]} ->
+            Multiplier = case Unit of
+                KiB when KiB == "k"; KiB == "kiB" -> 1024;
+                MiB when MiB == "M"; MiB == "MiB" -> 1024*1024;
+                GiB when GiB == "G"; GiB == "GiB" -> 1024*1024*1024;
+                "KB" -> 1000;
+                "MB" -> 1000000;
+                "GB" -> 1000000000
+            end,
+            {ok, Num * Multiplier};
+        nomatch ->
+            % log error
+            {error, parse_error}
+    end.

--- a/src/rabbit_resource_monitor_misc.erl
+++ b/src/rabbit_resource_monitor_misc.erl
@@ -21,28 +21,28 @@
 
 -ifdef(use_spec).
 
--spec(parse_information_unit/1 :: (integer() | string()) -> 
+-spec(parse_information_unit/1 :: (integer() | string()) ->
                                        {ok, integer()} | {error, parse_error}).
 
 -endif.
 
-parse_information_unit(MemLim) when is_integer(MemLim) -> {ok, MemLim};
-parse_information_unit(MemLim) when is_list(MemLim) ->
-    case re:run(MemLim, 
-                "^(?<VAL>[0-9]+)(?<UNIT>kB|MB|GB|kiB|MiB|GiB|k|M|G)?$", 
+parse_information_unit(Value) when is_integer(Value) -> {ok, Value};
+parse_information_unit(Value) when is_list(Value) ->
+    case re:run(Value,
+                "^(?<VAL>[0-9]+)(?<UNIT>kB|KB|MB|GB|kb|mb|gb|Kb|Mb|Gb|kiB|KiB|MiB|GiB|kib|mib|gib|KIB|MIB|GIB|k|K|m|M|g|G)?$",
                 [{capture, all_names, list}]) of
     	{match, [[], _]} ->
-            {ok, list_to_integer(MemLim)};    		
+            {ok, list_to_integer(Value)};
         {match, [Unit, Num]} ->
             Multiplier = case Unit of
-                             KiB when KiB == "k"; KiB == "kiB" -> 1024;
-                             MiB when MiB == "M"; MiB == "MiB" -> 1024*1024;
-                             GiB when GiB == "G"; GiB == "GiB" -> 1024*1024*1024;
-                             "KB" -> 1000;
-                             "MB" -> 1000000;
-                             "GB" -> 1000000000
+                             KiB when KiB =:= "k";  KiB =:= "kiB"; KiB =:= "K"; KiB =:= "KIB"; KiB =:= "kib" -> 1024;
+                             MiB when MiB =:= "m";  MiB =:= "MiB"; MiB =:= "M"; MiB =:= "MIB"; MiB =:= "mib" -> 1024*1024;
+                             GiB when GiB =:= "g";  GiB =:= "GiB"; GiB =:= "G"; GiB =:= "GIB"; GiB =:= "gib" -> 1024*1024*1024;
+                             KB  when KB  =:= "KB"; KB  =:= "kB"; KB =:= "kb"; KB =:= "Kb"  -> 1000;
+                             MB  when MB  =:= "MB"; MB  =:= "mB"; MB =:= "mb"; MB =:= "Mb"  -> 1000000;
+                             GB  when GB  =:= "GB"; GB  =:= "gB"; GB =:= "gb"; GB =:= "Gb"  -> 1000000000
                          end,
-            {ok, Num * Multiplier};
+            {ok, list_to_integer(Num) * Multiplier};
         nomatch ->
                                                 % log error
             {error, parse_error}

--- a/src/rabbit_resource_monitor_misc.erl
+++ b/src/rabbit_resource_monitor_misc.erl
@@ -22,7 +22,7 @@
 -ifdef(use_spec).
 
 -spec(parse_information_unit/1 :: (integer() | string()) -> 
-    {ok, integer()} | {error, parse_error}).
+                                       {ok, integer()} | {error, parse_error}).
 
 -endif.
 
@@ -32,18 +32,18 @@ parse_information_unit(MemLim) when is_list(MemLim) ->
                 "^(?<VAL>[0-9]+)(?<UNIT>kB|MB|GB|kiB|MiB|GiB|k|M|G)?$", 
                 [{capture, all_names, list}]) of
     	{match, [[], _]} ->
-        	{ok, list_to_integer(MemLim)};    		
+            {ok, list_to_integer(MemLim)};    		
         {match, [Unit, Num]} ->
             Multiplier = case Unit of
-                KiB when KiB == "k"; KiB == "kiB" -> 1024;
-                MiB when MiB == "M"; MiB == "MiB" -> 1024*1024;
-                GiB when GiB == "G"; GiB == "GiB" -> 1024*1024*1024;
-                "KB" -> 1000;
-                "MB" -> 1000000;
-                "GB" -> 1000000000
-            end,
+                             KiB when KiB == "k"; KiB == "kiB" -> 1024;
+                             MiB when MiB == "M"; MiB == "MiB" -> 1024*1024;
+                             GiB when GiB == "G"; GiB == "GiB" -> 1024*1024*1024;
+                             "KB" -> 1000;
+                             "MB" -> 1000000;
+                             "GB" -> 1000000000
+                         end,
             {ok, Num * Multiplier};
         nomatch ->
-            % log error
+                                                % log error
             {error, parse_error}
     end.

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -63,7 +63,7 @@
 
 -ifdef(use_specs).
 
--type(vm_memory_high_watermark() :: (float() | {'absolute', integer()})).
+-type(vm_memory_high_watermark() :: (float() | {'absolute', integer() | string()})).
 -spec(start_link/1 :: (float()) -> rabbit_types:ok_pid_or_error()).
 -spec(start_link/3 :: (float(), fun ((any()) -> 'ok'),
                        fun ((any()) -> 'ok')) -> rabbit_types:ok_pid_or_error()).


### PR DESCRIPTION
Fixes #448, per https://github.com/rabbitmq/rabbitmq-server/issues/448#issuecomment-161288678.

Not sure where to put parsing function and default values.