### PR TITLE
Log on startup if starting virgin node, or existing database

### DIFF
--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -102,7 +102,7 @@ init() ->
     ensure_mnesia_dir(),
     case is_virgin_node() of
         true  ->
-            rabbit_log:info("Database directory at \"~s\" is empty. Initialising from scratch... ~n",
+            rabbit_log:info("Database directory at ~s is empty. Initialising from scratch... ~n",
                             [dir()]),
             init_from_config();
         false ->

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -106,8 +106,6 @@ init() ->
                             [dir()]),
           init_from_config();
         false ->
-            rabbit_log:info("Database directory \"~s\" is not empty. Init existing database ~n",
-                            [dir()]),
             NodeType = node_type(),
             init_db_and_upgrade(cluster_nodes(all), NodeType,
                                 NodeType =:= ram)

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -102,7 +102,7 @@ init() ->
     ensure_mnesia_dir(),
     case is_virgin_node() of
         true  ->
-            rabbit_log:info("Database directory \"~s\" is empty. Initialising from scratch... ~n",
+            rabbit_log:info("Database directory at \"~s\" is empty. Initialising from scratch... ~n",
                             [dir()]),
             init_from_config();
         false ->

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -102,7 +102,7 @@ init() ->
     ensure_mnesia_dir(),
     case is_virgin_node() of
         true  ->
-            rabbit_log:info("Database directory \"~s\" is empty. Init virgin database ~n",
+            rabbit_log:info("Database directory \"~s\" is empty. Initialising from scratch... ~n",
                             [dir()]),
           init_from_config();
         false ->

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -101,10 +101,16 @@ init() ->
     ensure_mnesia_running(),
     ensure_mnesia_dir(),
     case is_virgin_node() of
-        true  -> init_from_config();
-        false -> NodeType = node_type(),
-                 init_db_and_upgrade(cluster_nodes(all), NodeType,
-                                     NodeType =:= ram)
+        true  ->
+            rabbit_log:info("Database directory \"~s\" is empty. Init virgin database ~n",
+                            [dir()]),
+          init_from_config();
+        false ->
+            rabbit_log:info("Database directory \"~s\" is not empty. Init existing database ~n",
+                            [dir()]),
+            NodeType = node_type(),
+            init_db_and_upgrade(cluster_nodes(all), NodeType,
+                                NodeType =:= ram)
     end,
     %% We intuitively expect the global name server to be synced when
     %% Mnesia is up. In fact that's not guaranteed to be the case -

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -104,7 +104,7 @@ init() ->
         true  ->
             rabbit_log:info("Database directory \"~s\" is empty. Initialising from scratch... ~n",
                             [dir()]),
-          init_from_config();
+            init_from_config();
         false ->
             NodeType = node_type(),
             init_db_and_upgrade(cluster_nodes(all), NodeType,


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/168.