### PR TITLE
Change capture value spec in regex to support older stdlib

### DIFF
--- a/src/rabbit_resource_monitor_misc.erl
+++ b/src/rabbit_resource_monitor_misc.erl
@@ -35,7 +35,7 @@ parse_information_unit(Value) when is_list(Value) ->
             {ok, list_to_integer(Value)};
         {match, [Num]} ->
             {ok, list_to_integer(Value)};
-        {match, [Unit, Num]} ->
+        {match, [Num, Unit]} ->
             Multiplier = case Unit of
                              KiB when KiB =:= "k";  KiB =:= "kiB"; KiB =:= "K"; KiB =:= "KIB"; KiB =:= "kib" -> 1024;
                              MiB when MiB =:= "m";  MiB =:= "MiB"; MiB =:= "M"; MiB =:= "MIB"; MiB =:= "mib" -> 1024*1024;

--- a/src/rabbit_resource_monitor_misc.erl
+++ b/src/rabbit_resource_monitor_misc.erl
@@ -30,8 +30,10 @@ parse_information_unit(Value) when is_integer(Value) -> {ok, Value};
 parse_information_unit(Value) when is_list(Value) ->
     case re:run(Value,
                 "^(?<VAL>[0-9]+)(?<UNIT>kB|KB|MB|GB|kb|mb|gb|Kb|Mb|Gb|kiB|KiB|MiB|GiB|kib|mib|gib|KIB|MIB|GIB|k|K|m|M|g|G)?$",
-                [{capture, all_names, list}]) of
+                [{capture, all_but_first, list}]) of
     	{match, [[], _]} ->
+            {ok, list_to_integer(Value)};
+        {match, [Num]} ->
             {ok, list_to_integer(Value)};
         {match, [Unit, Num]} ->
             Multiplier = case Unit of

--- a/src/rabbit_resource_monitor_misc.erl
+++ b/src/rabbit_resource_monitor_misc.erl
@@ -34,7 +34,7 @@ parse_information_unit(Value) when is_list(Value) ->
     	{match, [[], _]} ->
             {ok, list_to_integer(Value)};
         {match, [Num]} ->
-            {ok, list_to_integer(Value)};
+            {ok, list_to_integer(Num)};
         {match, [Num, Unit]} ->
             Multiplier = case Unit of
                              KiB when KiB =:= "k";  KiB =:= "kiB"; KiB =:= "K"; KiB =:= "KIB"; KiB =:= "kib" -> 1024;


### PR DESCRIPTION
`{capture, all_names}` is badarg in erlang versions older than 18.