### PR TITLE
GM: Ignore 'DOWN' when the ring is going down

### DIFF
--- a/src/gm.erl
+++ b/src/gm.erl
@@ -713,6 +713,10 @@ handle_info(flush, State) ->
 handle_info(timeout, State) ->
     noreply(flush_broadcast_buffer(State));
 
+handle_info({'DOWN', _MRef, process, _Pid, _Reason},
+            State = #state { shutting_down =
+                                 {true, {shutdown, ring_shutdown}} }) ->
+    noreply(State);
 handle_info({'DOWN', MRef, process, _Pid, Reason},
             State = #state { self          = Self,
                              left          = Left,


### PR DESCRIPTION
This is a follow-up commit to ed276656. This fixes the following crash:
```
=ERROR REPORT==== 18-Oct-2015::00:51:30 ===
** Generic server <0.966.0> terminating
** Last message in was {'DOWN',#Ref<0.0.3.4250>,process,<21148.716.0>,
                               shutdown}
** When Server state == {state,
                            ...
                            {true,{shutdown,ring_shutdown}}}
** Reason for termination ==
** {function_clause,[{orddict,fetch,
                              [{1,<0.966.0>},[]],
                              [{file,"orddict.erl"},{line,80}]},
                     {gm,check_neighbours,1,[{file,"src/gm.erl"},{line,1243}]},
```

Submitted by Alvaro Videla (@videlalvaro).
Fixes #368.