### PR TITLE
.gitignore: make absolute paths relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,39 +2,39 @@
 .sw?
 .*.sw?
 *.beam
-/.erlang.mk/
-/cover/
-/deps/
-/doc/
-/ebin/
-/etc/
-/logs/
-/plugins/
+.erlang.mk/
+cover/
+deps/
+doc/
+ebin/
+etc/
+logs/
+plugins/
 
-/rabbit.d
+rabbit.d
 
 # Generated sources files.
-/src/rabbit_ctl_usage.erl
-/src/rabbit_plugins_usage.erl
+src/rabbit_ctl_usage.erl
+src/rabbit_plugins_usage.erl
 
 # Generated documentation.
-/docs/rabbitmq-echopid.man.xml
-/docs/rabbitmq-env.conf.5
-/docs/rabbitmq-env.conf.5.man.xml
-/docs/rabbitmq-plugins.1
-/docs/rabbitmq-plugins.1.man.xml
-/docs/rabbitmq-server.1
-/docs/rabbitmq-server.1.man.xml
-/docs/rabbitmq-service.man.xml
-/docs/rabbitmqctl.1
-/docs/rabbitmqctl.1.man.xml
+docs/rabbitmq-echopid.man.xml
+docs/rabbitmq-env.conf.5
+docs/rabbitmq-env.conf.5.man.xml
+docs/rabbitmq-plugins.1
+docs/rabbitmq-plugins.1.man.xml
+docs/rabbitmq-server.1
+docs/rabbitmq-server.1.man.xml
+docs/rabbitmq-service.man.xml
+docs/rabbitmqctl.1
+docs/rabbitmqctl.1.man.xml
 
 # Source distribution.
-/rabbitmq-server-*/
-/rabbitmq-server-*.tar.gz
-/rabbitmq-server-*.tar.bz2
-/rabbitmq-server-*.tar.xz
-/rabbitmq-server-*.zip
+rabbitmq-server-*/
+rabbitmq-server-*.tar.gz
+rabbitmq-server-*.tar.bz2
+rabbitmq-server-*.tar.xz
+rabbitmq-server-*.zip
 
 # Dialyzer
 *.plt


### PR DESCRIPTION
When this repo is a dependency of another one, and only the other one `.git`'s folder is used, the absolute paths git-ignoring apply to the parent project too; thus possibly ignoring files from the parent project.
And really, there's no need to make these paths absolute.

Note: relative paths in `.gitignore` apply as if this file was located at `/.gitignore`.