### PR TITLE
Improve diagnostics in 'rabbitmq-server' script

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -38,8 +38,21 @@ case "$(uname -s)" in
            if [ $detached ]; then
                echo "Warning: PID file not written; -detached was passed." 1>&2
            else
-               mkdir -p $(dirname ${RABBITMQ_PID_FILE});
-               echo $$ > ${RABBITMQ_PID_FILE}
+               RABBITMQ_PID_DIR="$(dirname ${RABBITMQ_PID_FILE})"
+               EX_CANTCREAT=73 # Standard exit code from sysexits(2)
+               if ! mkdir -p "$RABBITMQ_PID_DIR"; then
+                   # Better diagnostics - 'mkdir -p' reports only the first directory in chain that
+                   # it fails to create
+                   echo "Failed to create directory: $RABBITMQ_PID_DIR"
+                   exit $EX_CANTCREAT
+               fi
+               if ! echo $$ > ${RABBITMQ_PID_FILE}; then
+                   # Bettern diagnostics - otherwise the only report in logs is about failed 'echo'
+                   # command, but without any other details: neither what script has failed nor what
+                   # file output was redirected to.
+                   echo "Failed to write pid file: ${RABBITMQ_PID_FILE}"
+                   exit $EX_CANTCREAT
+               fi
            fi
 esac
 


### PR DESCRIPTION
While errors are detected with '-e' shell option in this script,
diagnostics messages leave a lot to be desired.

E.g. when trying to write pid file to full partition, the only message
in log is:

    sh: echo: I/O error

Which is definitely insufficient