### PR TITLE
Fix 'rabbitmqctl rotate_logs' behaviour

### DIFF
--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -275,10 +275,9 @@
               suffixed files.
             </para>
             <para>
-              When the target files do not exist they are created.
-              When no <option>suffix</option> is specified, the empty
-              log files are simply created at the original location;
-              no rotation takes place.
+              When the target files do not exist they are created. When
+              no <option>suffix</option> is specified, no rotation takes
+              place - log files are just re-opened.
             </para>
             <para role="example-prefix">For example:</para>
             <screen role="example">rabbitmqctl rotate_logs .1</screen>

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -442,9 +442,14 @@ environment(App) ->
     lists:keysort(1, [P || P = {K, _} <- application:get_all_env(App),
                            not lists:member(K, Ignore)]).
 
+rotate_logs_info("") ->
+    rabbit_log:info("Reopening logs", []);
+rotate_logs_info(Suffix) ->
+    rabbit_log:info("Rotating logs with suffix '~s'~n", [Suffix]).
+
 rotate_logs(BinarySuffix) ->
     Suffix = binary_to_list(BinarySuffix),
-    rabbit_log:info("Rotating logs with suffix '~s'~n", [Suffix]),
+    rotate_logs_info(Suffix),
     log_rotation_result(rotate_logs(log_location(kernel),
                                     Suffix,
                                     rabbit_error_logger_file_h),

--- a/src/rabbit_error_logger_file_h.erl
+++ b/src/rabbit_error_logger_file_h.erl
@@ -55,6 +55,9 @@ get_depth() ->
 %% lib/stdlib/src/error_logger_file_h.erl from R14B3 was copied as
 %% init_file/2 and changed so that it opens the file in 'append' mode.
 
+%% Log rotation with empty suffix should result only in file re-opening.
+init({{File, ""}, _}) ->
+    init(File);
 %% Used only when swapping handlers in log rotation, pre OTP 18.1
 init({{File, Suffix}, []}) ->
     rotate_logs(File, Suffix),

--- a/src/rabbit_sasl_report_file_h.erl
+++ b/src/rabbit_sasl_report_file_h.erl
@@ -36,6 +36,8 @@
 
 %% Used only when swapping handlers and performing
 %% log rotation
+init({{File, ""}, _}) ->
+    init(File);
 init({{File, Suffix}, []}) ->
     case rabbit_file:append_file(File, Suffix) of
         ok -> file:delete(File),


### PR DESCRIPTION
When 'rabbitmqctl rotate_logs' is called without any parameters, it
clears logs unconditionally. And given that this form is used in
logrotate config files, this could result in data loss.

This could be reproduced with following scenario:
1) 'max_size' is set globally in lograte config
2) One of two rabbitmq logs is greater than that limit
3) Daily logrotate run was already performed today, and now we
   are calling it manually. In this case logrotate will copy only file
   that is bigger than max_size, but 'rabbitmqctl rotate_logs' will
   clear both of them - leading to data loss. 

I've decided to change behaviour of current command (instead of adding new one) because current behaviour doesn't make sense and is actually dangerous.