### PR TITLE
Reset master score if we decide to restart RabbitMQ on timeout

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1505,6 +1505,7 @@ get_monitor() {
     timeout_alive=$?
 
     if [ $timeout_alive -eq 2 ]; then
+        master_score 0
         return $OCF_ERR_GENERIC
     elif [ $timeout_alive -eq 0 ]; then
         if [ $rc_alive -ne 0 ]; then
@@ -1527,6 +1528,7 @@ get_monitor() {
     timeout_alarms=$?
 
     if [ $timeout_alarms -eq 2 ]; then
+        master_score 0
         return $OCF_ERR_GENERIC
 
     elif [ $timeout_alarms -eq 0 ]; then
@@ -1558,6 +1560,7 @@ get_monitor() {
     timeout_queues=$?
 
     if [ $timeout_queues -eq 2 ]; then
+        master_score 0
         return $OCF_ERR_GENERIC
 
     elif [ $timeout_queues -eq 0 ]; then


### PR DESCRIPTION
Doing otherwise might not trigger the restart while it is clearly
needed.