### PR TITLE
Fix shell quoting issues in HA OCF script

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1361,7 +1361,7 @@ get_monitor() {
     local name
     local node
     local nodelist
-    local rc_check
+    local rc_check=$OCF_SUCCESS
     local max
     local our_uptime
     local node_uptime


### PR DESCRIPTION
Without double quotes it complains about misplaced '-eq' operator.
With quotes but without default value it sometimes complains about bad integer.

@bogdando, WDYT? Is this fix in the spirit of your initial change?