### PR TITLE
Use systemd-notify(1) shell helper as fallback

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -287,7 +287,7 @@ broker_start() ->
     case code:load_file(sd_notify) of
         {module, sd_notify} -> SDNotify = sd_notify,
                                SDNotify:sd_notify(0, "READY=1");
-        {error, _} -> ok
+        {error, _} -> os:cmd("systemd-notify --ready")
     end,
     ok = log_broker_started(rabbit_plugins:active()).
 


### PR DESCRIPTION
As discussed at the end of #52

Currently external erlang library `sd_notify` is used to make systemd
unit with `Type=notify` to work correctly. This library contains some C
code and thus cannot be built into architecture-independent package.

But it is not actually needed, as systemd provides
systemd-notify(1) helper for shell scripts.

The only thing is that you need to add `NotifyAccess=all` to your unit file to
make everything work well.