### PR TITLE
Use -r with sed on Linux

### DIFF
--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -103,10 +103,15 @@ fi
 
 ##--- Set environment vars RABBITMQ_<var_name> to defaults if not set
 
+SED_OPT="-E"
+if [ $(uname -s) = "Linux" ]; then
+    SED_OPT="-r"
+fi
+
 rmq_normalize_path() {
     local path=$1
 
-    echo "$path" | sed -E -e 's,//+,/,g' -e 's,(.)/$,\1,'
+    echo "$path" | sed $SED_OPT -e 's,//+,/,g' -e 's,(.)/$,\1,'
 }
 
 rmq_normalize_path_var() {


### PR DESCRIPTION
Fixes #592.

We previously did the same change in #273 (PR: #275), the file changed there is now at `scripts/rabbitmq-script-wrapper`.

Note that #592 recommends using `-r` unconditionally but that option
is not recognised by sed which ships with OS X.