### PR TITLE
Fix uninitialized status_master

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1403,6 +1403,7 @@ get_monitor() {
             nodelist=$(get_alive_pacemaker_nodes_but)
             for node in $nodelist
             do
+                status_master=1
                 # Do not refetch the master status for *this* node as we know it already
                 if [ $rc -ne $OCF_RUNNING_MASTER ] ; then
                     ocf_log info "${LH} rabbit app is running. looking for master on $node"


### PR DESCRIPTION
Fix multiple nodes may be reported in logs as the running master

Related Fuel bug https://bugs.launchpad.net/bugs/1540936

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>