### PR TITLE
Fix cluster membership check for running master

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1410,6 +1410,11 @@ get_monitor() {
                     is_master $node
                     status_master=$?
                     ocf_log info "${LH} fetched master attribute for $node. attr value is ${status_master}"
+                else
+                    # The master is always running inside of its cluster
+                    ocf_log info "${LH} rabbit app is running and is member of healthy cluster"
+                    rc_check=$OCF_SUCCESS
+                    break
                 fi
                 if [ $status_master -eq 0 ] ; then
                     ocf_log info "${LH} rabbit app is running. master is $node"


### PR DESCRIPTION
The running master is always inside of its own cluster.
Fix the cluster membership check when a node is the master.

Related Fuel bug https://launchpad.net/bugs/1540936