### PR TITLE
Auto deleted queue log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ PACKAGES_DIR ?= $(abspath PACKAGES)
 
 DEPS = ranch lager $(PLUGINS)
 
-dep_lager = git https://github.com/rabbitmq/lager.git master
-
 define usage_xml_to_erl
 $(subst __,_,$(patsubst $(DOCS_DIR)/rabbitmq%.1.xml, src/rabbit_%_usage.erl, $(subst -,_,$(1))))
 endef

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -1361,9 +1361,9 @@ handle_pre_hibernate(State = #q{backing_queue = BQ,
 format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 
 log_auto_delete(Reason, Owner, State = #q{ q = #amqqueue{ name = Name } }) ->
-    rabbit_queue:log("Queue deleted automatically: Queue name: ~p Reason: " 
-                         ++ Reason ++ " ~p",
-                     [Name, Owner]).
+    rabbit_queue:debug("Queue deleted automatically: Queue name: ~p Reason: " 
+                           ++ Reason ++ " ~p",
+                       [Name, Owner]).
 
 
 

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -705,8 +705,7 @@ handle_ch_down(DownPid, State = #q{consumers          = Consumers,
                 true  -> 
                     log_auto_delete(
                         io_lib:format(
-                            "because it's last consumer channel was closed"++
-                            " with ~p consumers",
+                            "because all ~p of its consumers were on a channel that was closed",
                             [length(ChCTags)]),
                         State),
                     {stop, State2};
@@ -1370,8 +1369,8 @@ format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 
 log_delete_exclusive(ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_queue:error("Deleting exclusive queue '~s' for vhost '~s' " ++
-                       " because it's declaring connection ~p was closed",
+    rabbit_queue:error("Deleting exclusive queue '~s' in vhost '~s' " ++
+                       " because its declaring connection ~p was closed",
                        [QName, VHost, ConPid]).
 
 log_auto_delete(Reason, #q{ q = #amqqueue{ name = Resource } }) ->

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -705,7 +705,7 @@ handle_ch_down(DownPid, State = #q{consumers          = Consumers,
                 true  -> 
                     log_auto_delete(
                         io_lib:format(
-                            "because all ~p of its consumers were on a channel that was closed",
+                            "because all of its consumers (~p) were on a channel that was closed",
                             [length(ChCTags)]),
                         State),
                     {stop, State2};
@@ -1074,7 +1074,7 @@ handle_call({basic_cancel, ChPid, ConsumerTag, OkMsg}, _From,
                 true  -> 
                     log_auto_delete(
                         io_lib:format(
-                            "because its last consumer ~s was cancelled", 
+                            "because its last consumer with tag '~s' was cancelled",
                             [ConsumerTag]), 
                         State),
                     stop(ok, State1)
@@ -1375,7 +1375,7 @@ log_delete_exclusive(ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
 
 log_auto_delete(Reason, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_queue:debug("Deleting auto-delete queue '~s' in vhost '~s' " ++ 
+    rabbit_queue:debug("Deleting auto-delete queue '~s' in vhost '~s' " ++
                        Reason,
                        [QName, VHost]).
 

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -1375,7 +1375,7 @@ log_delete_exclusive(ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
 
 log_auto_delete(Reason, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_queue:error("Deleting auto-delete queue '~s' on vhost '~s' " ++ 
+    rabbit_queue:error("Deleting auto-delete queue '~s' in vhost '~s' " ++ 
                        Reason,
                        [QName, VHost]).
 

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -1369,13 +1369,13 @@ format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 
 log_delete_exclusive(ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_queue:error("Deleting exclusive queue '~s' in vhost '~s' " ++
+    rabbit_queue:debug("Deleting exclusive queue '~s' in vhost '~s' " ++
                        " because its declaring connection ~p was closed",
                        [QName, VHost, ConPid]).
 
 log_auto_delete(Reason, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_queue:error("Deleting auto-delete queue '~s' in vhost '~s' " ++ 
+    rabbit_queue:debug("Deleting auto-delete queue '~s' in vhost '~s' " ++ 
                        Reason,
                        [QName, VHost]).
 

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -1367,11 +1367,11 @@ handle_pre_hibernate(State = #q{backing_queue = BQ,
 
 format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 
-log_delete_exclusive(ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
+log_delete_exclusive(_ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
     rabbit_queue:debug("Deleting exclusive queue '~s' in vhost '~s' " ++
-                       " because its declaring connection ~p was closed",
-                       [QName, VHost, ConPid]).
+                       " because its declaring connection was closed",
+                       [QName, VHost]).
 
 log_auto_delete(Reason, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -1367,11 +1367,13 @@ handle_pre_hibernate(State = #q{backing_queue = BQ,
 
 format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 
-log_delete_exclusive(_ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
+log_delete_exclusive({ConPid, ConRef}, State) ->
+    log_delete_exclusive(ConPid, State);
+log_delete_exclusive(ConPid, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,
     rabbit_queue:debug("Deleting exclusive queue '~s' in vhost '~s' " ++
-                       " because its declaring connection was closed",
-                       [QName, VHost]).
+                       " because its declaring connection ~p was closed",
+                       [QName, VHost, ConPid]).
 
 log_auto_delete(Reason, #q{ q = #amqqueue{ name = Resource } }) ->
     #resource{ name = QName, virtual_host = VHost } = Resource,

--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -210,7 +210,8 @@ configure_lager() ->
     %% messages to the default sink. To know the list of expected extra
     %% sinks, we look at the 'lager_extra_sinks' compilation option.
     Sinks0 = application:get_env(lager, extra_sinks, []),
-    Sinks1 = configure_extra_sinks(Sinks0, list_expected_sinks()),
+    Sinks1 = configure_extra_sinks(Sinks0, 
+                                   [error_logger | list_expected_sinks()]),
     %% TODO Waiting for basho/lager#303
     %% Sinks2 = lists:keystore(error_logger_lager_event, 1, Sinks1,
     %%                         {error_logger_lager_event,

--- a/src/rabbit_log.erl
+++ b/src/rabbit_log.erl
@@ -74,9 +74,18 @@ log(Category, Level, Fmt) -> log(Category, Level, Fmt, []).
 log(Category, Level, Fmt, Args) when is_list(Args) ->
     Sink = case Category of
         default -> ?LAGER_SINK;
-        _       -> lager_util:make_internal_sink_name(Category)
+        _       -> make_internal_sink_name(Category)
     end,
     lager:log(Sink, Level, self(), Fmt, Args).
+
+make_internal_sink_name(Category) when Category == channel; 
+                                       Category == connection; 
+                                       Category == mirroring; 
+                                       Category == queue ->
+    lager_util:make_internal_sink_name(list_to_atom("rabbit_" ++ 
+                                                    atom_to_list(Category)));
+make_internal_sink_name(Category) -> 
+    lager_util:make_internal_sink_name(Category).
 
 debug(Format) -> debug(Format, []).
 debug(Format, Args) -> debug(self(), Format, Args).

--- a/src/rabbit_log.erl
+++ b/src/rabbit_log.erl
@@ -81,7 +81,8 @@ log(Category, Level, Fmt, Args) when is_list(Args) ->
 make_internal_sink_name(Category) when Category == channel; 
                                        Category == connection; 
                                        Category == mirroring; 
-                                       Category == queue ->
+                                       Category == queue;
+                                       Category == federation ->
     lager_util:make_internal_sink_name(list_to_atom("rabbit_" ++ 
                                                     atom_to_list(Category)));
 make_internal_sink_name(Category) -> 


### PR DESCRIPTION
Fixes #590

Added some functionality to logging:
- Support for old format log to category. 
- Separate sink for `error_logger` messages. Works same way as `rabbit_` sinks.
- Removed rabbitmq lager fork from dependency