### PR TITLE
Use basic regular expressions for sed portability

### DIFF
--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -103,15 +103,11 @@ fi
 
 ##--- Set environment vars RABBITMQ_<var_name> to defaults if not set
 
-SED_OPT="-E"
-if [ $(uname -s) = "Linux" ]; then
-    SED_OPT="-r"
-fi
-
 rmq_normalize_path() {
     local path=$1
 
-    echo "$path" | sed $SED_OPT -e 's,//+,/,g' -e 's,(.)/$,\1,'
+    # Remove redundant slashes and strip a trailing slash
+    echo "$path" | sed -e 's#/\{2,\}#/#g' -e 's#/$##'
 }
 
 rmq_normalize_path_var() {

--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -15,14 +15,9 @@
 ##  Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 ##
 
-SED_OPT="-E"
-if [ $(uname -s) = "Linux" ]; then
-    SED_OPT="-r"
-fi
-
 for arg in "$@" ; do
     # Wrap each arg in single quotes and wrap single quotes in double quotes, so that they're passed through cleanly.
-    arg=`printf %s "$arg" | sed $SED_OPT -e "s/'/'\"'\"'/g"`
+    arg=`printf %s "$arg" | sed -e "s#'#'\"'\"'#g"`
     CMDLINE="${CMDLINE} '${arg}'"
 done
 


### PR DESCRIPTION
More maintainable (imo) solution to a barrage of issues about `sed -E` vs `sed -r`. See #594.

On El Capitan and Ubuntu Trusty:
```
$ echo 'a//b/c///d/e//' | sed -e 's#/\{2,\}#/#g' -e 's#/$##'
a/b/c/d/e
```