### PR TITLE
Exit waiting loop once node has unjoined

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -932,6 +932,8 @@ unjoin_nodes_from_cluster() {
                     if get_running_nodes | grep -q $(rabbit_node_name $nodename)
                     then
                         ocf_log info "${LH} the ${nodename} is alive and cannot be kicked from the cluster yet"
+                    else
+                        break
                     fi
                     sleep 10
                 done


### PR DESCRIPTION
Without the break we always wait for 50 seconds, even if we don't need
to wait at all.