### PR TITLE
Windows: upper case inferred hostname

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -79,7 +79,7 @@ if "!RABBITMQ_NODENAME!"=="" (
         REM !COMPUTERNAME! and Erlang may return different results.
 	REM Start erl with -sname to make sure epmd is started.
 	call "%ERLANG_HOME%\bin\erl.exe" -A0 -noinput -boot start_clean -sname rabbit-prelaunch-epmd -eval "init:stop()." >nul 2>&1
-        for /f "delims=" %%F in ('call "%ERLANG_HOME%\bin\erl.exe" -A0 -noinput -boot start_clean -eval "net_kernel:start([list_to_atom(""rabbit-gethostname-"" ++ os:getpid()), %NAMETYPE%]), [_, H] = string:tokens(atom_to_list(node()), ""@""), io:format(""~s~n"", [H]), init:stop()."') do @set HOSTNAME=%%F
+        for /f "delims=" %%F in ('call "%ERLANG_HOME%\bin\erl.exe" -A0 -noinput -boot start_clean -eval "net_kernel:start([list_to_atom(""rabbit-gethostname-"" ++ os:getpid()), %NAMETYPE%]), [_, H] = string:tokens(atom_to_list(node()), ""@""), io:format(""~s~n"", [string:to_upper(H)]), init:stop()."') do @set HOSTNAME=%%F
         set RABBITMQ_NODENAME=rabbit@!HOSTNAME!
         set HOSTNAME=
     ) else (


### PR DESCRIPTION
Prior to 3.6.0, hostname was calculated as
%COMPUTERNAME%, which is uppercase. This has changed in https://github.com/rabbitmq/rabbitmq-server/commit/1fb451090a2557f35a2800f9d04c476ff1ad6a22.

See https://github.com/rabbitmq/rabbitmq-server/issues/620
for details.

Using uppercase isn't inherently better than lowercase but this brings things in line with the `3.5.x` behaviour. We will have to mention this in the change log for those upgrading (overriding `RABBITMQ_NODENAME` avoids the problem entirely).

Fixes #620.

@dumbbell @hairyhum WDYT?