### PR TITLE
Update rabbitmqctl manual (-p)

### DIFF
--- a/docs/rabbitmqctl.1.xml
+++ b/docs/rabbitmqctl.1.xml
@@ -535,7 +535,7 @@
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><cmdsynopsis><command>sync_queue</command> <arg choice="req">queue</arg></cmdsynopsis>
+          <term><cmdsynopsis><command>sync_queue</command> <arg choice="opt">-p <replaceable>vhostpath</replaceable></arg> <arg choice="req">queue</arg></cmdsynopsis>
           </term>
           <listitem>
             <variablelist>
@@ -564,7 +564,7 @@
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><cmdsynopsis><command>cancel_sync_queue</command> <arg choice="req">queue</arg></cmdsynopsis>
+          <term><cmdsynopsis><command>cancel_sync_queue</command> <arg choice="opt">-p <replaceable>vhostpath</replaceable></arg> <arg choice="req">queue</arg></cmdsynopsis>
           </term>
           <listitem>
             <variablelist>
@@ -584,7 +584,7 @@
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><cmdsynopsis><command>purge_queue</command> <arg choice="req">queue</arg></cmdsynopsis>
+          <term><cmdsynopsis><command>purge_queue</command> <arg choice="opt">-p <replaceable>vhostpath</replaceable></arg> <arg choice="req">queue</arg></cmdsynopsis>
           </term>
           <listitem>
             <variablelist>


### PR DESCRIPTION
Commands: `sync_queue`, `cancel_sync_queue`, `purge_queue` also accept vhostpath.

Also question about `list_connections` -
looks like it [ignores options ](https://github.com/rabbitmq/rabbitmq-server/blob/023fd3f48a0eb74b9322a7687c2db282350640a3/src/rabbit_control_main.erl#L622) but defined as `{list_connections, [?VHOST_DEF]}`. Am I missing something?

And website probably could be updated too :-). 