### PR TITLE
Bump rabbit.channel_operation_timeout default to 15s

### DIFF
--- a/src/rabbit.app.src
+++ b/src/rabbit.app.src
@@ -97,5 +97,6 @@
          %% see rabbitmq-server#143
          {credit_flow_default_credit, {200, 50}},
          %% see rabbitmq-server#248
-         {channel_operation_timeout, 5000}
+         %% and rabbitmq-server#667
+         {channel_operation_timeout, 15000}
         ]}]}.


### PR DESCRIPTION
Fixes #667.