### PR TITLE
Disable erlang break handler in rabbitmqctl

### DIFF
--- a/scripts/rabbitmqctl
+++ b/scripts/rabbitmqctl
@@ -30,7 +30,7 @@ fi
 RABBITMQ_USE_LONGNAME=${RABBITMQ_USE_LONGNAME} \
 exec ${ERL_DIR}erl \
     -pa "${RABBITMQ_HOME}/ebin" \
-    -noinput \
+    -noinput +B \
     -hidden \
     ${RABBITMQ_CTL_ERL_ARGS} \
     -boot "${CLEAN_BOOT_FILE}" \


### PR DESCRIPTION
So rabbitmq operator will not be baffled by erlang break handler when he
tries to interrupt some long-running `rabbitmqctl` command by `Ctrl-C`.