### PR TITLE
Rabbit ocf ra travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+services:
+  - docker
 language: erlang
 notifications:
   email:
@@ -11,14 +13,20 @@ otp_release:
   - "R16B03-1"
   - "17.5"
   - "18.0"
+env:
+  matrix:
+  - GROUP=1 GROUP=2
 
 # The checkout made by Travis is a "detached HEAD". We switch back
 # to a tag or a branch. This pleases our git_rmq fetch method in
 # rabbitmq-components.mk and the proper tag/branch is selected in
 # dependencies too.
-before_script: (test "$TRAVIS_TAG" && git checkout "$TRAVIS_TAG") || (test "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH")
+before_script:
+  - ([ "${GROUP}" = "1" ] && ((test "$TRAVIS_TAG" && git checkout "$TRAVIS_TAG") || (test "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH")) || /bin/true)
 
-script: travis_wait make tests
+script:
+  - ([ "${GROUP}" = "1" ] && travis_wait make tests)
+  - ([ "${GROUP}" = "2" ] && sh ./scripts/travis_test_ocf_ra.sh)
 
 cache:
   apt: true

--- a/scripts/travis_test_ocf_ra.sh
+++ b/scripts/travis_test_ocf_ra.sh
@@ -1,0 +1,30 @@
+#!/bin/sh -eux
+# Prepare and run a smoke test against the RabbitMQ OCF RA only if
+# the scripts/rabbitmq-server-ha.ocf has changes
+if ! git diff HEAD~ --name-only | grep -q scripts/rabbitmq-server-ha.ocf
+then
+  exit 0
+fi
+
+export VAGRANT_VERSION=1.8.1
+export DOCKER_IMAGE=bogdando/rabbitmq-cluster-ocf-wily
+export UPLOAD_METHOD=none
+export DOCKER_MOUNTS="$(pwd)/scripts/rabbitmq-server-ha.ocf:/tmp/rabbitmq-server-ha"
+
+# Install vagrant and requirements
+sudo apt-get install -qq git wget
+wget --no-verbose https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb
+sudo dpkg -i --force-all ./vagrant_${VAGRANT_VERSION}_x86_64.deb
+vagrant plugin install vagrant-triggers
+
+# Update docker and prepare images
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install --only-upgrade docker-engine
+sudo service docker restart
+docker pull $DOCKER_IMAGE
+
+# Prepare and run a smoke test for a rabbitmq cluster by the OCF RA
+git clone https://github.com/bogdando/rabbitmq-cluster-ocf-vagrant.git
+cd ./rabbitmq-cluster-ocf-vagrant
+vagrant up --provider docker
+docker exec -it n1 /bin/bash /vagrant/vagrant_script/test_rabbitcluster.sh rabbit@n1 rabbit@n2


### PR DESCRIPTION
Add a Travis CI job for the rabbit OCF RA cluster bootstrap and smoke test.
NOTE: it ignores changes to any files but the scripts/rabbitmq-server-ha.ocf
