### PR TITLE
"rabbitmqctl stop" exits with 0 if it fails to contact the node

### DIFF
--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -117,7 +117,10 @@ main(ParseFun, DoFun, UsageMod) ->
                 _ ->
                     print_error("unable to connect to node ~w: ~w", [Node, Reason]),
                     print_badrpc_diagnostics([Node]),
-                    rabbit_misc:quit(?EX_UNAVAILABLE)
+                    case Command of
+                        stop -> rabbit_misc:quit(?EX_OK);
+                        _    -> rabbit_misc:quit(?EX_UNAVAILABLE)
+                    end
             end;
         {badrpc_multi, Reason, Nodes} ->
             print_error("unable to connect to nodes ~p: ~w", [Nodes, Reason]),


### PR DESCRIPTION
If rabbitmqctl fails to contact the node to ask it to stop, it still displays an error message. However, now it exits with 0; it was `EX_UNAVAILABLE` before.

There are two main reasons it can happen:

* The node is stopped, so that's ok to exit with 0 because the end result is the same.
* The Erlang cookie is incorrect. The error message is here to help but this situation is quite rare compared to the other one.

There is no way to distinguish both, so let's assume the common situation.

This helps in the case of systemd in particular: if one stops RabbitMQ using `rabbitmqctl stop` instead of `service rabbitmq-server stop`, systemd tries to call `rabbitmqctl stop` again. Before this change, it
failed and put the service in a "failed" state.

Fixes #693.