### PR TITLE
Fix logrotate / systemd incompatibility

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.logrotate
+++ b/packaging/RPMS/Fedora/rabbitmq-server.logrotate
@@ -7,6 +7,6 @@
         notifempty
         sharedscripts
         postrotate
-            /sbin/service rabbitmq-server rotate-logs > /dev/null
+            /usr/sbin/rabbitmqctl rotate_logs > /dev/null
         endscript
 }


### PR DESCRIPTION
On systemd-enabled hosts `/sbin/service` just proxies commands to
`systemctl`, which doesn't understand funny commands like
`rotate-logs`. So `rabbitmqctl rotate_logs` is a better alternative.