### PR TITLE
Allow memory-relative disk free limits greater than 1.0

### DIFF
--- a/src/rabbit_disk_monitor.erl
+++ b/src/rabbit_disk_monitor.erl
@@ -235,7 +235,7 @@ parse_free_win32(CommandResult) ->
     list_to_integer(lists:reverse(Free)).
 
 interpret_limit({mem_relative, Relative}) 
-    when is_float(Relative), Relative < 1 ->
+    when is_float(Relative) ->
     round(Relative * vm_memory_monitor:get_total_memory());
 interpret_limit(Absolute) -> 
     case rabbit_resource_monitor_misc:parse_information_unit(Absolute) of


### PR DESCRIPTION
Fixes [Issue #717](https://github.com/rabbitmq/rabbitmq-server/issues/717).