### PR TITLE
Fix half-hearted attempt to erase mnesia in OCF RA

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -678,8 +678,8 @@ reset_mnesia() {
     # remove mnesia files, if required
     if $make_amnesia ; then
         kill_rmq_and_remove_pid
-        ocf_run rm -rf "${MNESIA_FILES}/*"
-        ocf_log warn "${LH} Mnesia files appear corrupted and have been removed."
+        ocf_run rm -rf "${MNESIA_FILES}"
+        ocf_log warn "${LH} Mnesia files appear corrupted and have been removed from ${MNESIA_FILES}."
     fi
     # always return OCF SUCCESS
     return $OCF_SUCCESS


### PR DESCRIPTION
ocf_run does `$("$@")`, so "${MNESIA_FILES}/*" wasn't expanded and mnesia
directory wasn't actually cleaned up

Fuel bug: https://bugs.launchpad.net/fuel/+bug/1565868

@dmitrymex @bogdando WDYT?