### PR TITLE
Override CONF_ENV_FILE with RABBITMQ_CONF_ENV_FILE

### DIFF
--- a/scripts/rabbitmq-defaults.bat
+++ b/scripts/rabbitmq-defaults.bat
@@ -46,6 +46,4 @@ REM PLUGINS_DIR="${RABBITMQ_HOME}/plugins"
 for /f "delims=" %%F in ("!TDP0!..\plugins") do set PLUGINS_DIR=%%~dpsF%%~nF%%~xF
 
 REM CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf
-if "!RABBITMQ_CONF_ENV_FILE!"=="" (
-    set RABBITMQ_CONF_ENV_FILE=!RABBITMQ_BASE!\rabbitmq-env-conf.bat
-)
+set CONF_ENV_FILE=!RABBITMQ_BASE!\rabbitmq-env-conf.bat

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -65,20 +65,15 @@ RABBITMQ_HOME="$(rmq_realpath "${RABBITMQ_SCRIPTS_DIR}/..")"
 ## Common defaults
 SERVER_ERL_ARGS="+P 1048576"
 
-# warn about old rabbitmq.conf file, if no new one
-if [ -f /etc/rabbitmq/rabbitmq.conf ] && \
-   [ ! -f ${CONF_ENV_FILE} ] ; then
-    echo -n "WARNING: ignoring /etc/rabbitmq/rabbitmq.conf -- "
-    echo "location has moved to ${CONF_ENV_FILE}"
-fi
-
 # We save the current value of $RABBITMQ_PID_FILE in case it was set by
 # an init script. If $CONF_ENV_FILE overrides it again, we must ignore
 # it and warn the user.
 saved_RABBITMQ_PID_FILE=$RABBITMQ_PID_FILE
 
 ## Get configuration variables from the configure environment file
-[ -f ${CONF_ENV_FILE} ] && . ${CONF_ENV_FILE} || true
+[ "x" = "x$RABBITMQ_CONF_ENV_FILE" ] && RABBITMQ_CONF_ENV_FILE=${CONF_ENV_FILE}
+
+[ -f ${RABBITMQ_CONF_ENV_FILE} ] && . ${RABBITMQ_CONF_ENV_FILE} || true
 
 if [ "$saved_RABBITMQ_PID_FILE" -a \
      "$saved_RABBITMQ_PID_FILE" != "$RABBITMQ_PID_FILE" ]; then

--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -47,6 +47,10 @@ REM set SERVER_ERL_ARGS=+P 1048576
 
 REM ## Get configuration variables from the configure environment file
 REM [ -f ${CONF_ENV_FILE} ] && . ${CONF_ENV_FILE} || true
+if "!RABBITMQ_CONF_ENV_FILE!"=="" (
+    set RABBITMQ_CONF_ENV_FILE=!CONF_ENV_FILE!
+)
+
 if exist "!RABBITMQ_CONF_ENV_FILE!" (
     call "!RABBITMQ_CONF_ENV_FILE!"
 )

--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -187,7 +187,7 @@ check_not_empty() {
     eval value=\$$name
     if [ -z "$value" ]; then
         echo "Error: ENV variable should be defined: $1.
-       Please check rabbitmq-env, rabbitmq-defaults, and $CONF_ENV_FILE script files"
+       Please check rabbitmq-env, rabbitmq-defaults, and ${RABBITMQ_CONF_ENV_FILE} script files"
         exit 78
     fi
 }


### PR DESCRIPTION
Introduce ability to override `CONF_ENV_FILE` for unix environments.
Related to #210