### PR TITLE
Stop a rabbitmq pacemaker resource when monitor fails

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1479,6 +1479,7 @@ get_monitor() {
 
             if [ -n "$master_name" ]; then
                 ocf_log info "${LH} master exists and rabbit app is not running. Exiting to be restarted by pacemaker"
+                stop_server_process
                 rc=$OCF_ERR_GENERIC
             fi
         fi


### PR DESCRIPTION
Related Fuel bug https://bugs.launchpad.net/fuel/+bug/1567355

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>