### PR TITLE
rabbit_policy: Fix several issues with policy updates

### DIFF
--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -242,6 +242,8 @@ update_policies(VHost) ->
                  fun() ->
                          [mnesia:lock({table, T}, write) || T <- Tabs], %% [1]
                          case catch list(VHost) of
+                             {'EXIT', Exit} ->
+                                 exit(Exit);
                              {error, {no_such_vhost, _}} ->
                                  ok; %% [2]
                              Policies ->

--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -242,10 +242,10 @@ update_policies(VHost) ->
                  fun() ->
                          [mnesia:lock({table, T}, write) || T <- Tabs], %% [1]
                          case catch list(VHost) of
+                             {'EXIT', {throw, {error, {no_such_vhost, _}}}} ->
+                                 {[], []}; %% [2]
                              {'EXIT', Exit} ->
                                  exit(Exit);
-                             {error, {no_such_vhost, _}} ->
-                                 {[], []}; %% [2]
                              Policies ->
                                  {[update_exchange(X, Policies) ||
                                       X <- rabbit_exchange:list(VHost)],

--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -245,7 +245,7 @@ update_policies(VHost) ->
                              {'EXIT', Exit} ->
                                  exit(Exit);
                              {error, {no_such_vhost, _}} ->
-                                 ok; %% [2]
+                                 {[], []}; %% [2]
                              Policies ->
                                  {[update_exchange(X, Policies) ||
                                       X <- rabbit_exchange:list(VHost)],


### PR DESCRIPTION
Thus, any transaction abort are properly forwarded. This fixes a `function_clause` because the code called `update_exchange()` or `update_queue()` with the caught exit signal.

References #744.
[#117522069]