### PR TITLE
Stop process when rabbit is running but is not connected to master.

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1463,6 +1463,7 @@ get_monitor() {
                 # Rabbit is running but is not connected to master
                 # Failing to avoid split brain
                 ocf_log err "${LH} rabbit node is running out of the cluster"
+                stop_server_process
                 rc=$OCF_ERR_GENERIC
             fi
         fi


### PR DESCRIPTION
It's should goes down due to avoid split brain.

Related Fuel bug: https://bugs.launchpad.net/fuel/+bug/1541471

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>
Co-authored-by: Maciej Relewicz <mrelewicz@mirantis.com>