### PR TITLE
Do not move rabbitmq.conf to rabbitmq-env.conf during RPM and DEB install

### DIFF
--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -91,11 +91,7 @@ fi
 
 %post
 /sbin/chkconfig --add %{name}
-if [ -f %{_sysconfdir}/rabbitmq/rabbitmq.conf ] && [ ! -f %{_sysconfdir}/rabbitmq/rabbitmq-env.conf ]; then
-    mv %{_sysconfdir}/rabbitmq/rabbitmq.conf %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
-else 
-    touch %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
-fi
+touch %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
 chmod -R o-rwx,g-w %{_localstatedir}/lib/rabbitmq/mnesia
 
 %preun

--- a/packaging/RPMS/Fedora/rabbitmq-server.spec
+++ b/packaging/RPMS/Fedora/rabbitmq-server.spec
@@ -91,7 +91,6 @@ fi
 
 %post
 /sbin/chkconfig --add %{name}
-touch %{_sysconfdir}/rabbitmq/rabbitmq-env.conf
 chmod -R o-rwx,g-w %{_localstatedir}/lib/rabbitmq/mnesia
 
 %preun

--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -37,7 +37,6 @@ chmod -R o-rwx,g-w /var/lib/rabbitmq/mnesia
 
 case "$1" in
     configure)
-        touch /etc/rabbitmq/rabbitmq-env.conf
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/packaging/debs/Debian/debian/postinst
+++ b/packaging/debs/Debian/debian/postinst
@@ -37,12 +37,7 @@ chmod -R o-rwx,g-w /var/lib/rabbitmq/mnesia
 
 case "$1" in
     configure)
-        if [ -f /etc/rabbitmq/rabbitmq.conf ] && \
-           [ ! -f /etc/rabbitmq/rabbitmq-env.conf ]; then
-            mv /etc/rabbitmq/rabbitmq.conf /etc/rabbitmq/rabbitmq-env.conf
-        else
-            touch /etc/rabbitmq/rabbitmq-env.conf
-        fi
+        touch /etc/rabbitmq/rabbitmq-env.conf
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Fixes #763
Since `rabbitmq.conf` name is used in new configuration format, we should not assume it's an old env configuration. 
If someone will upgrade from the old env config (`2.3.0` which is unlikely), rabbitmq will just fail to generate a new `.config` and will crash.
