### PR TITLE
Add log information during the network_partition

### DIFF
--- a/src/rabbit_node_monitor.erl
+++ b/src/rabbit_node_monitor.erl
@@ -415,8 +415,9 @@ handle_cast({check_partial_partition, Node, Rep, NodeGUID, MyGUID, RepGUID},
                            case rpc:call(Node, rabbit, is_running, []) of
                                {badrpc, _} -> ok;
                                _           ->  
-				   rabbit_log:warning("Unexpected running node:"
-						      " ~p is still running ~n",
+				   rabbit_log:warning("Received a 'DOWN' message" 
+						      " from ~p but still can" 
+						      " communicate with it ~n",
 						      [Node]),
 				   cast(Rep, {partial_partition,
                                                          Node, node(), RepGUID})

--- a/src/rabbit_node_monitor.erl
+++ b/src/rabbit_node_monitor.erl
@@ -414,7 +414,11 @@ handle_cast({check_partial_partition, Node, Rep, NodeGUID, MyGUID, RepGUID},
                    fun () ->
                            case rpc:call(Node, rabbit, is_running, []) of
                                {badrpc, _} -> ok;
-                               _           -> cast(Rep, {partial_partition,
+                               _           ->  
+				   rabbit_log:warning("Unexpected running node:"
+						      " ~p is still running ~n",
+						      [Node]),
+				   cast(Rep, {partial_partition,
                                                          Node, node(), RepGUID})
                            end
                    end);


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/772

Output for the new log:

```
=WARNING REPORT==== 27-Apr-2016::11:19:51 ===
Unexpected running node: rabbit1@mac is still running
```