### PR TITLE
Windows, reconfigure ERLANG_HOME during the update

### DIFF
--- a/packaging/windows-exe/rabbitmq_nsi.in
+++ b/packaging/windows-exe/rabbitmq_nsi.in
@@ -14,57 +14,6 @@
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
 
 ;--------------------------------
-; Third-party functions
-; StrContains
-; This function does a case sensitive searches for an occurrence of a substring in a string.
-; It returns the substring if it is found.
-; Otherwise it returns null("").
-; Written by kenglish_hi
-; Adapted from StrReplace written by dandaman32
-
-
-Var STR_HAYSTACK
-Var STR_NEEDLE
-Var STR_CONTAINS_VAR_1
-Var STR_CONTAINS_VAR_2
-Var STR_CONTAINS_VAR_3
-Var STR_CONTAINS_VAR_4
-Var STR_RETURN_VAR
-
-Function un.StrContains
-  Exch $STR_NEEDLE
-  Exch 1
-  Exch $STR_HAYSTACK
-  ; Uncomment to debug
-  ;MessageBox MB_OK 'STR_NEEDLE = $STR_NEEDLE STR_HAYSTACK = $STR_HAYSTACK '
-    StrCpy $STR_RETURN_VAR ""
-    StrCpy $STR_CONTAINS_VAR_1 -1
-    StrLen $STR_CONTAINS_VAR_2 $STR_NEEDLE
-    StrLen $STR_CONTAINS_VAR_4 $STR_HAYSTACK
-    loop:
-      IntOp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_1 + 1
-      StrCpy $STR_CONTAINS_VAR_3 $STR_HAYSTACK $STR_CONTAINS_VAR_2 $STR_CONTAINS_VAR_1
-      StrCmp $STR_CONTAINS_VAR_3 $STR_NEEDLE found
-      StrCmp $STR_CONTAINS_VAR_1 $STR_CONTAINS_VAR_4 done
-      Goto loop
-    found:
-      StrCpy $STR_RETURN_VAR $STR_NEEDLE
-      Goto done
-    done:
-   Pop $STR_NEEDLE ;Prevent "invalid opcode" errors and keep the
-   Exch $STR_RETURN_VAR
-FunctionEnd
-
-!macro _un.StrContainsConstructor OUT NEEDLE HAYSTACK
-  Push `${HAYSTACK}`
-  Push `${NEEDLE}`
-  Call un.StrContains
-  Pop `${OUT}`
-!macroend
-
-!define un.StrContains '!insertmacro "_un.StrContainsConstructor"'
-
-;--------------------------------
 
 ; The name of the installer
 Name "RabbitMQ Server %%VERSION%%"
@@ -214,12 +163,6 @@ LangString DESC_RabbitStartMenu ${LANG_ENGLISH} "Add some useful links to the st
 
 Section "Uninstall"
 
-  ; Check if reinstall will occur immediately - don't remove ERLANG_HOME
-  Var /GLOBAL REINSTALLFLAG
-  Var /GLOBAL ISREINSTALL
-  ${GetParameters} $REINSTALLFLAG
-  ${un.StrContains} $ISREINSTALL "reinstall" $REINSTALLFLAG
-
   ; Remove registry keys
   DeleteRegKey HKLM ${uninstall}
   DeleteRegKey HKLM "SOFTWARE\VMware, Inc.\RabbitMQ Server"
@@ -239,12 +182,9 @@ Section "Uninstall"
   ; Remove start menu items
   RMDir /r "$SMPROGRAMS\RabbitMQ Server"
 
-  ; If reinstalling immediately (e.g. program update) don't remove ERLANG_HOME environment variable
-  ${If} $ISREINSTALL == ""
-    DeleteRegValue ${env_hklm} ERLANG_HOME
-    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
-  ${EndIf}
-
+  DeleteRegValue ${env_hklm} ERLANG_HOME
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+ 
 SectionEnd
 
 ;--------------------------------
@@ -277,6 +217,9 @@ Function .onInit
     ExecWait '"$INSTDIR\uninstall.exe" /S _?=$INSTDIR'
     Delete "$INSTDIR\uninstall.exe"
     RMDir "$INSTDIR"
+    ; the unistaller removes the ERLANG_HOME.
+    ; called again since this is an update
+    Call findErlang
 
   ${EndIf}
 FunctionEnd


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/690

Behaviour:

- Install: `ERLANG_HOME` is configured.
- Update: `ERLANG_HOME` is removed by the uninstall, and then re-configured.
- Uninstall: `ERLANG_HOME` is removed.

Tests:
- New installation  
- Update from `3.6.0`
- Unistall 


 