### PR TITLE
Drop ACKs of messages from lost members of the ring

### DIFF
--- a/src/gm.erl
+++ b/src/gm.erl
@@ -1338,7 +1338,11 @@ find_common(A, B, Common) ->
         {{{value, Val}, A1}, {{value, Val}, B1}} ->
             find_common(A1, B1, queue:in(Val, Common));
         {{empty, _A}, _} ->
-            {Common, B}
+            {Common, B};
+        {_, {_, B1}} ->
+            find_common(A, B1, Common);
+        {{_, A1}, _} ->
+            find_common(A1, B, Common)
     end.
 
 


### PR DESCRIPTION
* when partial partitions happen, inconsistent views can take place
  where both nodes in partial partition see the live node as their left
  (A -> C and B -> C), and override each other view in mnesia. Thus,
  when C tries to compare the ACKs finds missing elements on A or B data.
  We'll drop these as they won't be answered because the origin node
  is going into pause_minority and stops.

Fixes #749 (or at least works around).
