### PR TITLE
Deb repository: Use SIGNING_KEY to select the repository signing key

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -62,9 +62,7 @@ endif
 
 VARS = SOURCE_DIST_FILE="$(abspath $(SOURCE_DIST_FILE))" \
        PACKAGES_DIR="$(abspath $(PACKAGES_DIR))" \
-       SIGNING_KEY="$(SIGNING_KEY)" \
-       SIGNING_USER_ID="$(SIGNING_USER_ID)" \
-       SIGNING_USER_EMAIL="$(SIGNING_USER_EMAIL)"
+       SIGNING_KEY="$(SIGNING_KEY)"
 
 packages: package-deb package-rpm package-windows package-generic-unix
 	@:

--- a/packaging/debs/apt-repository/Makefile
+++ b/packaging/debs/apt-repository/Makefile
@@ -1,7 +1,7 @@
 PACKAGES_DIR ?= ../../../PACKAGES
 REPO_DIR ?= debian
 
-SIGNING_USER_EMAIL ?= info@rabbitmq.com
+SIGNING_KEY ?= default
 
 ifeq "$(UNOFFICIAL_RELEASE)" ""
 HOME_ARG = HOME=$(GNUPG_PATH)
@@ -18,7 +18,7 @@ debian_apt_repository: clean
 	mkdir -p $(REPO_DIR)/conf
 	cp -a distributions $(REPO_DIR)/conf
 ifeq "$(UNOFFICIAL_RELEASE)" ""
-	echo SignWith: $(SIGNING_USER_EMAIL) >> $(REPO_DIR)/conf/distributions
+	echo SignWith: $(SIGNING_KEY) >> $(REPO_DIR)/conf/distributions
 endif
 	for FILE in $(PACKAGES_DIR)/*.changes ; do \
 		$(HOME_ARG) reprepro --ignore=wrongdistribution \


### PR DESCRIPTION
By default, honor the default key; usually it is specified in `gpg.conf`.

References #718.
[#118296861]