### PR TITLE
Bump minimal required version to 18.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ otp_release:
   - "R16B03-1"
   - "17.5"
   - "18.0"
+  - "18.3"
 env:
   matrix:
   - GROUP=1 GROUP=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ addons:
     packages:
       - xsltproc
 otp_release:
-  - "R16B03-1"
-  - "17.5"
-  - "18.0"
   - "18.3"
 env:
   matrix:

--- a/src/file_handle_cache_stats.erl
+++ b/src/file_handle_cache_stats.erl
@@ -59,8 +59,8 @@ get() ->
     lists:sort(ets:tab2list(?TABLE)).
 
 timer_tc(Thunk) ->
-    T1 = time_compat:monotonic_time(),
+    T1 = erlang:monotonic_time(),
     Res = Thunk(),
-    T2 = time_compat:monotonic_time(),
-    Diff = time_compat:convert_time_unit(T2 - T1, native, micro_seconds),
+    T2 = erlang:monotonic_time(),
+    Diff = erlang:convert_time_unit(T2 - T1, native, micro_seconds),
     {Diff, Res}.

--- a/src/gm.erl
+++ b/src/gm.erl
@@ -552,8 +552,8 @@ forget_group(GroupName) ->
 init([GroupName, Module, Args, TxnFun]) ->
     put(process_name, {?MODULE, GroupName}),
     _ = random:seed(erlang:phash2([node()]),
-                    time_compat:monotonic_time(),
-                    time_compat:unique_integer()),
+                    erlang:monotonic_time(),
+                    erlang:unique_integer()),
     Self = make_member(GroupName),
     gen_server2:cast(self(), join),
     {ok, #state { self                = Self,

--- a/src/pg2_fixed.erl
+++ b/src/pg2_fixed.erl
@@ -149,11 +149,11 @@ get_closest_pid(Name) ->
             case get_members(Name) of
                 [] -> {error, {no_process, Name}};
                 Members ->
-                    X = time_compat:erlang_system_time(micro_seconds),
+                    X = erlang:system_time(micro_seconds),
                     lists:nth((X rem length(Members))+1, Members)
             end;
         Members when is_list(Members) ->
-            X = time_compat:erlang_system_time(micro_seconds),
+            X = erlang:system_time(micro_seconds),
             lists:nth((X rem length(Members))+1, Members);
         Else ->
             Else

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -731,7 +731,7 @@ log_broker_started(Plugins) ->
 
 erts_version_check() ->
     ERTSVer = erlang:system_info(version),
-    OTPRel = erlang:system_info(otp_release),
+    OTPRel = rabbit_misc:otp_release(),
     case rabbit_misc:version_compare(?ERTS_MINIMUM, ERTSVer, lte) of
         true when ?ERTS_MINIMUM =/= ERTSVer ->
             ok;

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -431,7 +431,7 @@ ensure_ttl_timer(undefined, State) ->
     State;
 ensure_ttl_timer(Expiry, State = #q{ttl_timer_ref       = undefined,
                                     args_policy_version = Version}) ->
-    After = (case Expiry - time_compat:os_system_time(micro_seconds) of
+    After = (case Expiry - os:system_time(micro_seconds) of
                  V when V > 0 -> V + 999; %% always fire later
                  _            -> 0
              end) div 1000,
@@ -757,7 +757,7 @@ calculate_msg_expiry(#basic_message{content = Content}, TTL) ->
     {ok, MsgTTL} = rabbit_basic:parse_expiration(Props),
     case lists:min([TTL, MsgTTL]) of
         undefined -> undefined;
-        T         -> time_compat:os_system_time(micro_seconds) + T * 1000
+        T         -> os:system_time(micro_seconds) + T * 1000
     end.
 
 %% Logically this function should invoke maybe_send_drained/2.
@@ -768,7 +768,7 @@ calculate_msg_expiry(#basic_message{content = Content}, TTL) ->
 drop_expired_msgs(State) ->
     case is_empty(State) of
         true  -> State;
-        false -> drop_expired_msgs(time_compat:os_system_time(micro_seconds),
+        false -> drop_expired_msgs(os:system_time(micro_seconds),
                                    State)
     end.
 
@@ -1358,7 +1358,7 @@ handle_pre_hibernate(State = #q{backing_queue = BQ,
       State, #q.stats_timer,
       fun () -> emit_stats(State,
                            [{idle_since,
-                             time_compat:os_system_time(milli_seconds)},
+                             os:system_time(milli_seconds)},
                             {consumer_utilisation, ''}])
                 end),
     State1 = rabbit_event:stop_stats_timer(State#q{backing_queue_state = BQS3},

--- a/src/rabbit_dead_letter.erl
+++ b/src/rabbit_dead_letter.erl
@@ -53,7 +53,7 @@ make_msg(Msg = #basic_message{content       = Content,
             _         -> {[RK], fun (H) -> lists:keydelete(<<"CC">>, 1, H) end}
         end,
     ReasonBin = list_to_binary(atom_to_list(Reason)),
-    TimeSec = time_compat:os_system_time(seconds),
+    TimeSec = os:system_time(seconds),
     PerMsgTTL = per_msg_ttl_header(Content#content.properties),
     HeadersFun2 =
         fun (Headers) ->

--- a/src/rabbit_error_logger.erl
+++ b/src/rabbit_error_logger.erl
@@ -100,7 +100,7 @@ publish(_Other, _Format, _Data, _State) ->
 publish1(RoutingKey, Format, Data, LogExch) ->
     %% 0-9-1 says the timestamp is a "64 bit POSIX timestamp". That's
     %% second resolution, not millisecond.
-    Timestamp = time_compat:os_system_time(seconds),
+    Timestamp = os:system_time(seconds),
 
     Args = [truncate:term(A, ?LOG_TRUNC) || A <- Data],
     Headers = [{<<"node">>, longstr, list_to_binary(atom_to_list(node()))}],

--- a/src/rabbit_hipe.erl
+++ b/src/rabbit_hipe.erl
@@ -68,7 +68,7 @@ do_hipe_compile(HipeModules) ->
     Count = length(HipeModules),
     io:format("~nHiPE compiling:  |~s|~n                 |",
               [string:copies("-", Count)]),
-    T1 = time_compat:monotonic_time(),
+    T1 = erlang:monotonic_time(),
     %% We use code:get_object_code/1 below to get the beam binary,
     %% instead of letting hipe get it itself, because hipe:c/{1,2}
     %% expects the given filename to actually exist on disk: it does not
@@ -92,8 +92,8 @@ do_hipe_compile(HipeModules) ->
          {'DOWN', MRef, process, _, normal} -> ok;
          {'DOWN', MRef, process, _, Reason} -> exit(Reason)
      end || {_Pid, MRef} <- PidMRefs],
-    T2 = time_compat:monotonic_time(),
-    Duration = time_compat:convert_time_unit(T2 - T1, native, seconds),
+    T2 = erlang:monotonic_time(),
+    Duration = erlang:convert_time_unit(T2 - T1, native, seconds),
     io:format("|~n~nCompiled ~B modules in ~Bs~n", [Count, Duration]),
     {ok, Count, Duration}.
 

--- a/src/rabbit_mirror_queue_mode_exactly.erl
+++ b/src/rabbit_mirror_queue_mode_exactly.erl
@@ -46,8 +46,8 @@ suggested_queue_nodes(Count, MNode, SNodes, _SSNodes, Poss) ->
 
 shuffle(L) ->
     random:seed(erlang:phash2([node()]),
-                time_compat:monotonic_time(),
-                time_compat:unique_integer()),
+                erlang:monotonic_time(),
+                erlang:unique_integer()),
     {_, L1} = lists:unzip(lists:keysort(1, [{random:uniform(), N} || N <- L])),
     L1.
 

--- a/src/rabbit_mirror_queue_sync.erl
+++ b/src/rabbit_mirror_queue_sync.erl
@@ -108,7 +108,7 @@ master_batch_go0(Args, BatchSize, BQ, BQS) ->
                     false -> {cont, Acc1}
                 end
         end,
-    FoldAcc = {[], 0, {0, BQ:depth(BQS)}, time_compat:monotonic_time()},
+    FoldAcc = {[], 0, {0, BQ:depth(BQS)}, erlang:monotonic_time()},
     bq_fold(FoldFun, FoldAcc, Args, BQ, BQS).
 
 master_batch_send({Syncer, Ref, Log, HandleInfo, EmitStats, Parent},
@@ -168,12 +168,12 @@ stop_syncer(Syncer, Msg) ->
     end.
 
 maybe_emit_stats(Last, I, EmitStats, Log) ->
-    Interval = time_compat:convert_time_unit(
-                 time_compat:monotonic_time() - Last, native, micro_seconds),
+    Interval = erlang:convert_time_unit(
+                 erlang:monotonic_time() - Last, native, micro_seconds),
     case Interval > ?SYNC_PROGRESS_INTERVAL of
         true  -> EmitStats({syncing, I}),
                  Log("~p messages", [I]),
-                 time_compat:monotonic_time();
+                 erlang:monotonic_time();
         false -> Last
     end.
 

--- a/src/rabbit_password.erl
+++ b/src/rabbit_password.erl
@@ -36,8 +36,8 @@ hash(HashingMod, Cleartext) ->
 
 generate_salt() ->
     random:seed(erlang:phash2([node()]),
-        time_compat:monotonic_time(),
-        time_compat:unique_integer()),
+        erlang:monotonic_time(),
+        erlang:unique_integer()),
     Salt = random:uniform(16#ffffffff),
     <<Salt:32>>.
 

--- a/src/rabbit_queue_consumers.erl
+++ b/src/rabbit_queue_consumers.erl
@@ -100,7 +100,7 @@
 
 new() -> #state{consumers = priority_queue:new(),
                 use       = {active,
-                             time_compat:monotonic_time(micro_seconds),
+                             erlang:monotonic_time(micro_seconds),
                              1.0}}.
 
 max_active_priority(#state{consumers = Consumers}) ->
@@ -350,9 +350,9 @@ drain_mode(true)  -> drain;
 drain_mode(false) -> manual.
 
 utilisation(#state{use = {active, Since, Avg}}) ->
-    use_avg(time_compat:monotonic_time(micro_seconds) - Since, 0, Avg);
+    use_avg(erlang:monotonic_time(micro_seconds) - Since, 0, Avg);
 utilisation(#state{use = {inactive, Since, Active, Avg}}) ->
-    use_avg(Active, time_compat:monotonic_time(micro_seconds) - Since, Avg).
+    use_avg(Active, erlang:monotonic_time(micro_seconds) - Since, Avg).
 
 %%----------------------------------------------------------------------------
 
@@ -459,10 +459,10 @@ update_use({inactive, _, _, _}   = CUInfo, inactive) ->
 update_use({active,   _, _}      = CUInfo,   active) ->
     CUInfo;
 update_use({active,   Since,         Avg}, inactive) ->
-    Now = time_compat:monotonic_time(micro_seconds),
+    Now = erlang:monotonic_time(micro_seconds),
     {inactive, Now, Now - Since, Avg};
 update_use({inactive, Since, Active, Avg},   active) ->
-    Now = time_compat:monotonic_time(micro_seconds),
+    Now = erlang:monotonic_time(micro_seconds),
     {active, Now, use_avg(Active, Now - Since, Avg)}.
 
 use_avg(0, 0, Avg) ->

--- a/src/rabbit_queue_location_random.erl
+++ b/src/rabbit_queue_location_random.erl
@@ -39,6 +39,6 @@ description() ->
 
 queue_master_location(#amqqueue{}) ->
     Cluster    = rabbit_queue_master_location_misc:all_nodes(),
-    RandomPos  = erlang:phash2(time_compat:monotonic_time(), length(Cluster)),
+    RandomPos  = erlang:phash2(erlang:monotonic_time(), length(Cluster)),
     MasterNode = lists:nth(RandomPos + 1, Cluster),
     {ok, MasterNode}.

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -774,7 +774,7 @@ update_rates(State = #vqstate{ in_counter      =     InCount,
                                                ack_in    =  AckInRate,
                                                ack_out   = AckOutRate,
                                                timestamp = TS }}) ->
-    Now = time_compat:monotonic_time(),
+    Now = erlang:monotonic_time(),
 
     Rates = #rates { in        = update_rate(Now, TS,     InCount,     InRate),
                      out       = update_rate(Now, TS,    OutCount,    OutRate),
@@ -789,7 +789,7 @@ update_rates(State = #vqstate{ in_counter      =     InCount,
                    rates           = Rates }.
 
 update_rate(Now, TS, Count, Rate) ->
-    Time = time_compat:convert_time_unit(Now - TS, native, micro_seconds) /
+    Time = erlang:convert_time_unit(Now - TS, native, micro_seconds) /
         ?MICROS_PER_SECOND,
     if
         Time == 0 -> Rate;
@@ -1287,7 +1287,7 @@ init(IsDurable, IndexState, DeltaCount, DeltaBytes, Terms,
                                     count        = DeltaCount1,
                                     end_seq_id   = NextSeqId })
             end,
-    Now = time_compat:monotonic_time(),
+    Now = erlang:monotonic_time(),
     IoBatchSize = rabbit_misc:get_env(rabbit, msg_store_io_batch_size,
                                       ?IO_BATCH_SIZE),
 


### PR DESCRIPTION
For #546 
Removed `time_compat` references.
