### PR TITLE
Add explicit epmd dependency in systemd example unit

### DIFF
--- a/docs/rabbitmq-server.service.example
+++ b/docs/rabbitmq-server.service.example
@@ -1,7 +1,8 @@
 # systemd unit example
 [Unit]
 Description=RabbitMQ broker
-After=syslog.target network.target
+After=syslog.target network.target epmd@0.0.0.0.socket
+Wants=network.target epmd@0.0.0.0.socket
 
 [Service]
 Type=notify


### PR DESCRIPTION
Our testing shows that you can't rely on socket activation alone. 