### PR TITLE
Remove systemd dependency on syslog target

### DIFF
--- a/docs/rabbitmq-server.service.example
+++ b/docs/rabbitmq-server.service.example
@@ -1,7 +1,7 @@
 # systemd unit example
 [Unit]
 Description=RabbitMQ broker
-After=syslog.target network.target epmd@0.0.0.0.socket
+After=network.target epmd@0.0.0.0.socket
 Wants=network.target epmd@0.0.0.0.socket
 
 [Service]


### PR DESCRIPTION
Neither rabbitmq nor any dependent services in chain actually relies on
syslog, so why keep it?

This tested in Fedora since 2016-01. See this commit:

http://pkgs.fedoraproject.org/cgit/rpms/rabbitmq-server.git/commit/?id=1477671

Nobody complained so far.

See also PR #801 

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>