### PR TITLE
Enable systemd triggers in deb-package

### DIFF
--- a/packaging/debs/Debian/debian/control
+++ b/packaging/debs/Debian/debian/control
@@ -7,11 +7,12 @@ Uploaders: Alvaro Videla <alvaro@rabbitmq.com>,
  Jean-Sébastien Pédron <jean-sebastien@rabbitmq.com>,
  Giuseppe Privitera <giuseppe@rabbitmq.com>
 Build-Depends: debhelper (>= 9),
+ dh-systemd (>= 1.5),
  erlang-dev,
  python-simplejson,
  xmlto,
  xsltproc,
- erlang-nox (>= 1:16.b.3),
+ erlang-nox (>= 1:16.b.3) | esl-erlang
  zip,
  rsync
 Standards-Version: 3.9.4

--- a/packaging/debs/Debian/debian/rabbitmq-server.service
+++ b/packaging/debs/Debian/debian/rabbitmq-server.service
@@ -1,0 +1,18 @@
+# systemd unit example
+[Unit]
+Description=RabbitMQ broker
+After=network.target epmd@0.0.0.0.socket
+Wants=network.target epmd@0.0.0.0.socket
+
+[Service]
+Type=notify
+User=rabbitmq
+Group=rabbitmq
+NotifyAccess=all
+TimeoutStartSec=3600
+WorkingDirectory=/var/lib/rabbitmq
+ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
+ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/debs/Debian/debian/rules
+++ b/packaging/debs/Debian/debian/rules
@@ -8,7 +8,7 @@ DEB_DESTDIR = debian/rabbitmq-server
 VERSION = $(shell dpkg-parsechangelog | awk '/^Version:/ {version=$$0; sub(/Version: /, "", version); sub(/-.*/, "", version); print version;}')
 
 %:
-	dh $@ --parallel
+	dh $@ --parallel --with systemd
 
 override_dh_auto_clean:
 	$(MAKE) clean distclean-manpages


### PR DESCRIPTION
Fixes #570

With this patch systemd service file will be used on systemd-enabled
hosts, providing more seamless experience.

I've tested it by building it on ubuntu 14.04, which is not managed by
systemd. Still, it has necessary packages to build systemd-aware
debs. And then I tried to install this package:
- On ubuntu 14.04 - regular init script was used
- On debian jessie with systemd and esl-erlang 18.3 - server was
  properly started using systemd service file (and epmd dependency was
  also automatically started by systemd)