### PR TITLE
Fix bashisms in OCF HA script

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1591,7 +1591,7 @@ get_monitor() {
         fi
     fi
 
-    if ! is-cluster-status-ok ; then
+    if ! is_cluster_status_ok ; then
         rc=$OCF_ERR_GENERIC
     fi
 
@@ -1634,13 +1634,13 @@ get_monitor() {
     return $rc
 }
 
-ocf-update-private-attr() {
+ocf_update_private_attr() {
     local attr_name="${1:?}"
     local attr_value="${2:?}"
     ocf_run attrd_updater -p --name "$attr_name" --update "$attr_value"
 }
 
-rabbitmqctl-with-timeout-check() {
+rabbitmqctl_with_timeout_check() {
     local command="${1:?}"
     local timeout_attr_name="${2:?}"
 
@@ -1660,9 +1660,9 @@ rabbitmqctl-with-timeout-check() {
     esac
 }
 
-is-cluster-status-ok() {
-    local LH="${LH}: is-cluster-status-ok:"
-    rabbitmqctl-with-timeout-check cluster_status rabbit_cluster_status_timeouts > /dev/null 2>&1
+is_cluster_status_ok() {
+    local LH="${LH}: is_cluster_status_ok:"
+    rabbitmqctl_with_timeout_check cluster_status rabbit_cluster_status_timeouts > /dev/null 2>&1
 }
 
 action_monitor() {
@@ -1707,7 +1707,7 @@ action_start() {
     local attrs_to_zero="rabbit_list_channels_timeouts rabbit_get_alarms_timeouts rabbit_list_queues_timeouts rabbit_cluster_status_timeouts"
     local attr_name_to_reset
     for attr_name_to_reset in $attrs_to_zero; do
-        ocf-update-private-attr $attr_name_to_reset 0
+        ocf_update_private_attr $attr_name_to_reset 0
     done
 
     ocf_log info "${LH} Deleting start time attribute"


### PR DESCRIPTION
`-` is not allowed in function names by POSIX, and some
shells (e.g. `dash`) will consider this as a syntax error.