### PR TITLE
Significantly bump max restarts intensity for worker_pool_sup

### DIFF
--- a/src/worker_pool_sup.erl
+++ b/src/worker_pool_sup.erl
@@ -52,7 +52,7 @@ init([WCount, PoolName]) ->
     %% e.g. when a large worker pool used for network connections
     %% encounters a network failure. This is the case in the LDAP authentication
     %% backend plugin.
-    {ok, {{one_for_one, 10 * 1000, 10},
+    {ok, {{one_for_one, 1000, 1},
           [{worker_pool, {worker_pool, start_link, [PoolName]}, transient,
             16#ffffffff, worker, [worker_pool]} |
            [{N, {worker_pool_worker, start_link, [PoolName]}, transient,

--- a/src/worker_pool_sup.erl
+++ b/src/worker_pool_sup.erl
@@ -48,7 +48,11 @@ start_link(WCount, PoolName) ->
 %%----------------------------------------------------------------------------
 
 init([WCount, PoolName]) ->
-    {ok, {{one_for_one, 10, 10},
+    %% we want to survive up to 1K of worker restarts per second,
+    %% e.g. when a large worker pool used for network connections
+    %% encounters a network failure. This is the case in the LDAP authentication
+    %% backend plugin.
+    {ok, {{one_for_one, 10 * 1000, 10},
           [{worker_pool, {worker_pool, start_link, [PoolName]}, transient,
             16#ffffffff, worker, [worker_pool]} |
            [{N, {worker_pool_worker, start_link, [PoolName]}, transient,


### PR DESCRIPTION
Fixes #834. The number is picked to tolerate up to 1K worker process failures per second. Per discussion with @dcorbacho.
