### PR TITLE
Removed confusing code from rabbit:stop

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -196,8 +196,6 @@
 
 -define(ASYNC_THREADS_WARNING_THRESHOLD, 8).
 
--define(LEAVE_CLUSTER_TIMEOUT, 15000).
-
 %%----------------------------------------------------------------------------
 
 -ifdef(use_specs).


### PR DESCRIPTION
Fixes #837 
Cleanup moved to `prep_stop`.
Removed `on_node_down`, because other node in cluster should detect node shutdown.
