### PR TITLE
Set bounded timeout for OTP workers

### DIFF
--- a/src/rabbit_amqqueue_sup.erl
+++ b/src/rabbit_amqqueue_sup.erl
@@ -39,7 +39,7 @@ start_link(Q, StartMode) ->
     Marker = spawn_link(fun() -> receive stop -> ok end end),
     ChildSpec = {rabbit_amqqueue,
                  {rabbit_prequeue, start_link, [Q, StartMode, Marker]},
-                 intrinsic, ?MAX_WAIT, worker, [rabbit_amqqueue_process,
+                 intrinsic, ?WORKER_WAIT, worker, [rabbit_amqqueue_process,
                                                 rabbit_mirror_queue_slave]},
     {ok, SupPid} = supervisor2:start_link(?MODULE, []),
     {ok, QPid} = supervisor2:start_child(SupPid, ChildSpec),

--- a/src/rabbit_amqqueue_sup_sup.erl
+++ b/src/rabbit_amqqueue_sup_sup.erl
@@ -49,4 +49,4 @@ start_queue_process(Node, Q, StartMode) ->
 init([]) ->
     {ok, {{simple_one_for_one, 10, 10},
           [{rabbit_amqqueue_sup, {rabbit_amqqueue_sup, start_link, []},
-            temporary, ?MAX_WAIT, supervisor, [rabbit_amqqueue_sup]}]}}.
+            temporary, ?SUPERVISOR_WAIT, supervisor, [rabbit_amqqueue_sup]}]}}.

--- a/src/rabbit_client_sup.erl
+++ b/src/rabbit_client_sup.erl
@@ -53,5 +53,5 @@ init({M,F,A}) ->
           [{client, {M,F,A}, temporary, infinity, supervisor, [M]}]}};
 init({{M,F,A}, worker}) ->
     {ok, {{simple_one_for_one, 0, 1},
-          [{client, {M,F,A}, temporary, ?MAX_WAIT, worker, [M]}]}}.
+          [{client, {M,F,A}, temporary, ?WORKER_WAIT, worker, [M]}]}}.
 

--- a/src/rabbit_connection_helper_sup.erl
+++ b/src/rabbit_connection_helper_sup.erl
@@ -59,7 +59,7 @@ start_queue_collector(SupPid, Identity) ->
     supervisor2:start_child(
       SupPid,
       {collector, {rabbit_queue_collector, start_link, [Identity]},
-       intrinsic, ?MAX_WAIT, worker, [rabbit_queue_collector]}).
+       intrinsic, ?WORKER_WAIT, worker, [rabbit_queue_collector]}).
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_connection_sup.erl
+++ b/src/rabbit_connection_sup.erl
@@ -66,7 +66,7 @@ start_link(Ref, Sock, _Transport, _Opts) ->
         supervisor2:start_child(
           SupPid,
           {reader, {rabbit_reader, start_link, [HelperSup, Ref, Sock]},
-           intrinsic, ?MAX_WAIT, worker, [rabbit_reader]}),
+           intrinsic, ?WORKER_WAIT, worker, [rabbit_reader]}),
     {ok, SupPid, ReaderPid}.
 
 reader(Pid) ->

--- a/src/rabbit_restartable_sup.erl
+++ b/src/rabbit_restartable_sup.erl
@@ -45,4 +45,4 @@ init([{Mod, _F, _A} = Fun, Delay]) ->
           [{Mod, Fun, case Delay of
                           true  -> {transient, 1};
                           false -> transient
-                      end, ?MAX_WAIT, worker, [Mod]}]}}.
+                      end, ?WORKER_WAIT, worker, [Mod]}]}}.

--- a/src/rabbit_sup.erl
+++ b/src/rabbit_sup.erl
@@ -62,7 +62,7 @@ start_child(ChildId, Mod, Args) ->
     child_reply(supervisor:start_child(
                   ?SERVER,
                   {ChildId, {Mod, start_link, Args},
-                   transient, ?MAX_WAIT, worker, [Mod]})).
+                   transient, ?WORKER_WAIT, worker, [Mod]})).
 
 start_supervisor_child(Mod) -> start_supervisor_child(Mod, []).
 


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-server#541
Replace `MAX_WAIT` with `WORKER_WAIT` for workers and with `SUPERVISOR_WAIT` for supervisors.