### PR TITLE
Use rabbit_misc to parse GC stats, supporting maps in R19

### DIFF
--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -925,8 +925,7 @@ i(recoverable_slaves, #q{q = #amqqueue{name    = Name,
 i(state, #q{status = running}) -> credit_flow:state();
 i(state, #q{status = State})   -> State;
 i(garbage_collection, _State) ->
-    {garbage_collection, GC} = erlang:process_info(self(), garbage_collection),
-    GC;
+    rabbit_misc:get_gc_info(self());
 i(reductions, _State) ->
     {reductions, Reductions} = erlang:process_info(self(), reductions),
     Reductions;


### PR DESCRIPTION
Solves https://github.com/rabbitmq/rabbitmq-management/issues/244