### PR TITLE
Handle paths with spaces on disk volumes with 8.3 name creation disabled

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -386,8 +386,8 @@ goto :filter_paths_done
 set paths=%1
 set paths=%paths:"=%
 for /f "tokens=1* delims=;" %%a in ("%paths%") do (
-    if not "%%a" == "" call :filter_path %%a
-    if not "%%b" == "" call :filter_paths %%b
+    if not "%%a" == "" call :filter_path "%%a"
+    if not "%%b" == "" call :filter_paths "%%b"
 )
 set paths=
 exit /b


### PR DESCRIPTION
Fixes #859 