### PR TITLE
Fix longname-mode on hosts without detectable FQDN

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -62,6 +62,17 @@ RABBITMQ_EBIN_ROOT="${RABBITMQ_HOME}/ebin"
 
 set +e
 
+# `net_kernel:start/1` will fail in `longnames` mode when erlang is
+# unable to determine FQDN of a node (with a dot in it). But `erl`
+# itself has some magic that still allow it to start when you
+# explicitly specify host (a.la `erl -name test@localhost`).
+#
+# It's not possible to communicate with this node, unless it's a
+# connection initiator. But as prelaunch IS an initiator, it doesn't
+# matter what we actually put here. But `localhost` sounds good
+# enough.
+RABBITMQ_PRELAUNCH_NODENAME="rabbitmqprelaunch${$}@localhost"
+
 # NOTIFY_SOCKET is needed here to prevent epmd from impersonating the
 # success of our startup sequence to systemd.
 NOTIFY_SOCKET= \
@@ -72,7 +83,7 @@ RABBITMQ_DIST_PORT=$RABBITMQ_DIST_PORT \
     -noinput \
     -hidden \
     -s rabbit_prelaunch \
-    ${RABBITMQ_NAME_TYPE} rabbitmqprelaunch$$ \
+    ${RABBITMQ_NAME_TYPE} ${RABBITMQ_PRELAUNCH_NODENAME} \
     -extra "${RABBITMQ_NODENAME}"
 
 PRELAUNCH_RESULT=$?

--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -147,7 +147,7 @@ main(ParseFun, DoFun, UsageMod) ->
 start_distribution_anon(0, LastError) ->
     {error, LastError};
 start_distribution_anon(TriesLeft, _) ->
-    NameCandidate = list_to_atom(rabbit_misc:format("rabbitmq-cli-~2..0b", [rand_compat:uniform(100)])),
+    NameCandidate = generate_cli_node_name(),
     case net_kernel:start([NameCandidate, name_type()]) of
         {ok, _} = Result ->
             Result;
@@ -155,7 +155,7 @@ start_distribution_anon(TriesLeft, _) ->
             start_distribution_anon(TriesLeft - 1, Reason)
     end.
 
-%% Tries to start distribution with randonm name choosen from limited list of candidates - to
+%% Tries to start distribution with random name choosen from limited list of candidates - to
 %% prevent atom table pollution on target nodes.
 start_distribution() ->
     rabbit_nodes:ensure_epmd(),
@@ -170,6 +170,22 @@ name_type() ->
         "true" -> longnames;
         _      -> shortnames
     end.
+
+generate_cli_node_name() ->
+    Base = rabbit_misc:format("rabbitmq-cli-~2..0b", [rand_compat:uniform(100)]),
+    NameAsList =
+        case {name_type(), inet_db:res_option(domain)} of
+            {longnames, []} ->
+                %% Distribution will fail to start if it's unable to
+                %% determine FQDN of a node (with at least one dot in
+                %% a name).
+                %% CLI is always an initiator of connection, so it
+                %% doesn't matter if the name will not resolve.
+                Base ++ "@" ++ inet_db:gethostname() ++ ".no-domain";
+            _ ->
+                Base
+        end,
+    list_to_atom(NameAsList).
 
 usage(Mod) ->
     usage(Mod, ?EX_USAGE).


### PR DESCRIPTION
Server startup and CLI tools fail in longnames-mode if erlang is not
able to determine host FQDN (with at least one dot in it).

E.g. this can happen when you want to assemble a cluster using only
IP-addresses, and you completely don't care about FQDNs.

And it was not possible to alleviate this situation using any options
from http://erlang.org/doc/apps/erts/inet_cfg.html

Fixes #890