### PR TITLE
Bump default VM atom table limit to 5M

### DIFF
--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -66,7 +66,7 @@ DEFAULT_SCHEDULER_BIND_TYPE="db"
 [ "x" = "x$RABBITMQ_SCHEDULER_BIND_TYPE" ] && RABBITMQ_SCHEDULER_BIND_TYPE=${DEFAULT_SCHEDULER_BIND_TYPE}
 
 ## Common defaults
-SERVER_ERL_ARGS="+P 1048576 +stbt $RABBITMQ_SCHEDULER_BIND_TYPE "
+SERVER_ERL_ARGS="+P 1048576 +t 5000000 +stbt $RABBITMQ_SCHEDULER_BIND_TYPE "
 
 # We save the current value of $RABBITMQ_PID_FILE in case it was set by
 # an init script. If $CONF_ENV_FILE overrides it again, we must ignore

--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -46,7 +46,7 @@ REM     echo "location has moved to ${CONF_ENV_FILE}"
 REM fi
 
 REM Common defaults
-set SERVER_ERL_ARGS=+P 1048576 +stbt !RABBITMQ_SCHEDULER_BIND_TYPE! 
+set SERVER_ERL_ARGS=+P 1048576 +t 5000000 +stbt !RABBITMQ_SCHEDULER_BIND_TYPE! 
 
 REM ## Get configuration variables from the configure environment file
 REM [ -f ${CONF_ENV_FILE} ] && . ${CONF_ENV_FILE} || true


### PR DESCRIPTION
See #895 for background and reasoning.

Fixes #895.