### PR TITLE
Added resume after flow

### DIFF
--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -939,7 +939,7 @@ convert_to_lazy(State) ->
             %% is not in a proper state for a lazy BQ (unless all
             %% messages have been paged to disk already).
             wait_for_msg_store_credit(),
-            convert_to_lazy(State1)
+            convert_to_lazy(State)
     end.
 
 wait_for_msg_store_credit() ->

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -939,7 +939,7 @@ convert_to_lazy(State) ->
             %% is not in a proper state for a lazy BQ (unless all
             %% messages have been paged to disk already).
             wait_for_msg_store_credit(),
-            convert_to_lazy(State)
+            convert_to_lazy(resume(State1))
     end.
 
 wait_for_msg_store_credit() ->


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/850

I added logs when the queue is in `running` status and in `flow` status. 

 1. [Convert](https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq-server-850/src/rabbit_variable_queue.erl#L925): is the status of the record `State` before convert the queue
 2. [Match count](https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq-server-850/src/rabbit_variable_queue.erl#L929): is when the queue is converted.

Convert to lazy when the queue is  `running` status:
```
Convert PID:<0.650.0> Q1:0 Q2:0 Delta:{delta,16384,33616,50000} Q3 16384 Q4:0 Len 50000
 Match count PID:<0.650.0> Q1:0 Q2:0 Delta:{delta,16384,33616,50000} Q3 16384 Q4:0 Len 50000
```
Convert to lazy when the queue is  `flow` status:
```
Convert PID:<0.2692.0> Q1:0 Q2:0 Delta:{delta,undefined,0,undefined} Q3 0 Q4:37879 Len 37879
Convert Flow PID:<0.2692.0> Q1:0 Q2:0 Delta:{delta,undefined,0,undefined} Q3 0 Q4:37879 Len 37879
Convert PID:<0.2692.0> Q1:0 Q2:0 Delta:{delta,16384,21495,37879} Q3 16384 Q4:0 Len 37879
Match count PID:<0.2692.0> Q1:0 Q2:0 Delta:{delta,16384,21495,37879} Q3 16384 Q4:0 Len 37879
```

the different is in the messages position `q3` in `running` status and `q4` in `flow` status.

So, when the queue is in `flow` status it ran in a loop since the `q4` was not empty and this [condition](https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq-server-850/src/rabbit_variable_queue.erl#L927) was never true:

```
case Delta#delta.count + ?QUEUE:len(Q3) == Len of
```

the `lazy` queues expect that the `q4` is [empty](https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq-server-850/src/rabbit_variable_queue.erl#L1076):  
```
 %% q4 must always be empty, since q1 only gets messages during
 %% publish, but for lazy queues messages go straight to delta.
 true = E4,
 ```

By calling the [`resume`](https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq-server-850/src/rabbit_variable_queue.erl#L836) function the messages are dumped and moved on `q3` 

That is basically what is done also in the [tests](https://github.com/rabbitmq/rabbitmq-server/blob/rabbitmq-server-850/test/unit_inbroker_SUITE.erl#L1602):


  

    variable_queue_wait_for_shuffling_end(
    rabbit_variable_queue:resume(VQ))
      

I made several tests by [loading queues](https://github.com/Gsantomaggio/rabbitmqexample/blob/master/stress_test/PerfMessages.java)  and I didn't get in loop. 

