### PR TITLE
Docs: Default AMQP heartbeat delay should be 60 seconds in rabbitmq.config.example

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -161,7 +161,7 @@
 
    %% Set the default AMQP heartbeat delay (in seconds).
    %%
-   %% {heartbeat, 600},
+   %% {heartbeat, 60},
 
    %% Set the max permissible size of an AMQP frame (in bytes).
    %%


### PR DESCRIPTION
It is `600` but should be `60`.

PR made on branch `stable`.

Fixes #935