### PR TITLE
[OCF HA] Do not suggest to run the second monitor action

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -332,7 +332,6 @@ $EXTENDED_OCF_PARAMS
 <action name="status" timeout="20" />
 <action name="monitor" depth="0" timeout="30" interval="5" />
 <action name="monitor" depth="0" timeout="30" interval="3" role="Master"/>
-<action name="monitor" depth="30" timeout="60" interval="103" />
 <action name="promote" timeout="30" />
 <action name="demote"  timeout="30" />
 <action name="notify"   timeout="20" />


### PR DESCRIPTION
Right now we suggest to users to run the second monitor for slaves
with depth=30. It made sense previously, when there was an additional
check at that depth. Right now we don't have any depth-specific
checks and hence it does not make sense to run the second monitor.
Moreover, removing the second monitor fixes an issue with Pacemaker
not reacting on failing monitor if it takes more than a minute. For
details see Fuel bug https://launchpad.net/bugs/1618843