### PR TITLE
Bump default MoreCreditAfter to 100

### DIFF
--- a/src/rabbit.app.src
+++ b/src/rabbit.app.src
@@ -95,7 +95,8 @@
          {msg_store_credit_disc_bound, {2000, 500}},
          {msg_store_io_batch_size, 2048},
          %% see rabbitmq-server#143
-         {credit_flow_default_credit, {200, 50}},
+         %% and rabbitmq-server#949
+         {credit_flow_default_credit, {200, 100}},
          %% see rabbitmq-server#248
          %% and rabbitmq-server#667
          {channel_operation_timeout, 15000}


### PR DESCRIPTION
Local benchmarks with PerfTest demonstrate an insignificant
(ranging from -1% to 2% improvement for 50th percentile and -2% to 4% for the 99th) throughput
change, however, a few large users report this reducing
the amount of time queues spent in flow on their workloads.

The original value is certainly quite conservative.