### PR TITLE
Stop master with reason shutdown on duplicated masters

### DIFF
--- a/src/rabbit_mirror_queue_coordinator.erl
+++ b/src/rabbit_mirror_queue_coordinator.erl
@@ -363,7 +363,7 @@ handle_cast({gm_deaths, DeadGMPids},
             %% NOTE: Reported deaths here, could be inconsistant.
             rabbit_mirror_queue_misc:report_deaths(MPid, false, QueueName,
                                                    DeadPids),
-            {stop, normal, State};
+            {stop, shutdown, State};
         {error, not_found} ->
             {stop, normal, State}
     end;

--- a/test/unit_inbroker_SUITE.erl
+++ b/test/unit_inbroker_SUITE.erl
@@ -1684,15 +1684,15 @@ credit_flow_settings(Config) ->
 
 credit_flow_settings1(_Config) ->
     %% default values
-    passed = test_proc(200, 50),
+    passed = test_proc(200, 100),
 
-    application:set_env(rabbit, credit_flow_default_credit, {100, 20}),
-    passed = test_proc(100, 20),
+    application:set_env(rabbit, credit_flow_default_credit, {100, 300}),
+    passed = test_proc(100, 300),
 
     application:unset_env(rabbit, credit_flow_default_credit),
 
     % back to defaults
-    passed = test_proc(200, 50),
+    passed = test_proc(200, 100),
     passed.
 
 test_proc(InitialCredit, MoreCreditAfter) ->


### PR DESCRIPTION
Avoids removing the queue record when the queue must stay alive.

Part of #953 