### PR TITLE
Add VM GC calls configuration for lazy queues

### DIFF
--- a/src/rabbit.app.src
+++ b/src/rabbit.app.src
@@ -101,5 +101,5 @@
          %% and rabbitmq-server#667
          {channel_operation_timeout, 15000},
          %% rabbitmq-server-973
-         {gc_run_default_threshold, 250}
+         {queue_explicit_gc_run_operation_threshold, 250}
         ]}]}.

--- a/src/rabbit.app.src
+++ b/src/rabbit.app.src
@@ -101,5 +101,5 @@
          %% and rabbitmq-server#667
          {channel_operation_timeout, 15000},
          %% rabbitmq-server-973
-         {gc_default_threshold, 250}
+         {gc_run_default_threshold, 250}
         ]}]}.

--- a/src/rabbit.app.src
+++ b/src/rabbit.app.src
@@ -101,5 +101,5 @@
          %% and rabbitmq-server#667
          {channel_operation_timeout, 15000},
          %% rabbitmq-server-973
-         {queue_explicit_gc_run_operation_threshold, 250}
+         {lazy_queue_explicit_gc_run_operation_threshold, 250}
         ]}]}.

--- a/src/rabbit.app.src
+++ b/src/rabbit.app.src
@@ -99,5 +99,7 @@
          {credit_flow_default_credit, {200, 100}},
          %% see rabbitmq-server#248
          %% and rabbitmq-server#667
-         {channel_operation_timeout, 15000}
+         {channel_operation_timeout, 15000},
+         %% rabbitmq-server-973
+         {gc_default_threshold, 250}
         ]}]}.

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -306,7 +306,9 @@
           io_batch_size,
 
           %% default queue or lazy queue
-          mode
+          mode,
+          % number of executions to reach the GC, see: maybe_execute_gc/1
+          run_count
         }).
 
 -record(rates, { in, out, ack_in, ack_out, timestamp }).
@@ -402,7 +404,8 @@
              disk_write_count      :: non_neg_integer(),
 
              io_batch_size         :: pos_integer(),
-             mode                  :: 'default' | 'lazy' }.
+             mode                  :: 'default' | 'lazy',
+             run_count             :: non_neg_integer()}.
 %% Duplicated from rabbit_backing_queue
 -spec ack([ack()], state()) -> {[rabbit_guid:guid()], state()}.
 
@@ -426,6 +429,21 @@
 %% sooner. We do this since the priority calculations in
 %% rabbit_amqqueue_process need fairly fresh rates.
 -define(MSGS_PER_RATE_CALC, 100).
+
+
+%% we define the garbage collector threshold
+%% it needs to tune the GC calls inside `reduce_memory_use`
+%% see: rabbitmq-server-973 and `maybe_execute_gc` function
+-define(DEFAULT_INITIAL_GC_THRESHOLD, 250).
+-define(GC_THRESHOLD,
+    case get(gc_default_threshold) of
+        undefined ->
+            Val = rabbit_misc:get_env(rabbit, gc_default_threshold,
+                ?DEFAULT_INITIAL_GC_THRESHOLD),
+            put(gc_default_threshold, Val),
+            Val;
+        Val       -> Val
+    end).
 
 %%----------------------------------------------------------------------------
 %% Public API
@@ -2264,6 +2282,14 @@ ifold(Fun, Acc, Its, State) ->
 %% Phase changes
 %%----------------------------------------------------------------------------
 
+maybe_execute_gc(State = #vqstate {run_count = RunCount}) ->
+    case RunCount >= ?GC_THRESHOLD of
+	true ->  garbage_collect(),
+		 State#vqstate{run_count =  0};
+        false ->    State#vqstate{run_count =  RunCount + 1}
+
+    end.
+
 reduce_memory_use(State = #vqstate { target_ram_count = infinity }) ->
     State;
 reduce_memory_use(State = #vqstate {
@@ -2336,8 +2362,7 @@ reduce_memory_use(State = #vqstate {
             S2 ->
                 push_betas_to_deltas(S2, State1)
         end,
-    garbage_collect(),
-    State3.
+    maybe_execute_gc(State3).
 
 limit_ram_acks(0, State) ->
     {0, ui(State)};

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -307,7 +307,8 @@
 
           %% default queue or lazy queue
           mode,
-          % number of executions to reach the GC, see: maybe_execute_gc/1
+          % number of executions to reach the GC_THRESHOLD, 
+	  % see: maybe_execute_gc/1
           run_count
         }).
 
@@ -1348,7 +1349,8 @@ init(IsDurable, IndexState, DeltaCount, DeltaBytes, Terms,
 
       io_batch_size       = IoBatchSize,
 
-      mode                = default },
+      mode                = default,
+      run_count           = 0},
     a(maybe_deltas_to_betas(State)).
 
 blank_rates(Now) ->
@@ -2284,7 +2286,7 @@ ifold(Fun, Acc, Its, State) ->
 
 maybe_execute_gc(State = #vqstate {run_count = RunCount}) ->
     case RunCount >= ?GC_THRESHOLD of
-	true ->  garbage_collect(),
+	true -> garbage_collect(),
 		 State#vqstate{run_count =  0};
         false ->    State#vqstate{run_count =  RunCount + 1}
 

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -440,7 +440,7 @@
 -define(EXPLICIT_GC_RUN_OP_THRESHOLD,
     case get(explicit_gc_run_operation_threshold) of
         undefined ->
-            Val = rabbit_misc:get_env(rabbit, queue_explicit_gc_run_operation_threshold,
+            Val = rabbit_misc:get_env(rabbit, lazy_queue_explicit_gc_run_operation_threshold,
                 ?DEFAULT_EXPLICIT_GC_RUN_OP_THRESHOLD),
             put(explicit_gc_run_operation_threshold, Val),
             Val;


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/973

The improvement reduces the GC calls, that under memory pressure could impact  the performances.

Here an `eprof` profiling that shows the problem:

```
gen_server2:dispatch/3                                                 3577     3.30    5069501  [   1417.25]
erlang:garbage_collect/0                                               1858    84.90  130269831  [  70112.93]
------------------------------------------------------------------  -------  -------  ---------  [----------]
Total:                                                              9941207  100.00%  153436233  [     15.43]
ok
```  

The new parameter is  `lazy_queue_explicit_gc_run_operation_threshold ` (default value is 250):

```
[
 {rabbit,
  [{lazy_queue_explicit_gc_run_operation_threshold, 500}
 ]}
].
```
To have the old versions behavior,  set `lazy_queue_explicit_gc_run_operation_threshold ` to `0` 

