### PR TITLE
DNS peer discovery backend

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -307,6 +307,9 @@
 ## See http://www.rabbitmq.com/clustering.html#auto-config for
 ## further details.
 ##
+
+# autocluster.peer_discovery_backend     = rabbit_peer_discovery_classic_config
+#
 # autocluster.classic_config.nodes.node1 = rabbit1@hostname
 # autocluster.classic_config.nodes.node2 = rabbit2@hostname
 # autocluster.classic_config.nodes.node3 = rabbit3@hostname
@@ -315,7 +318,9 @@
 ## DNS-based peer discovery. This backend will list A records
 ## of the configured hostname and perform reverse lookups for
 ## the addresses returned.
-# autocluster.dns.hostname = "rabbitmq.discovery.mycompany.local"
+
+# autocluster.peer_discovery_backend = rabbit_peer_discovery_dns
+# autocluster.dns.hostname           = rabbitmq.discovery.mycompany.local
 
 ## This node's type can be configured. If you are not sure
 ## what node type to use, always use 'disc'.

--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -312,9 +312,14 @@
 # autocluster.classic_config.nodes.node3 = rabbit3@hostname
 # autocluster.classic_config.nodes.node4 = rabbit4@hostname
 
+## DNS-based peer discovery. This backend will list A records
+## of the configured hostname and perform reverse lookups for
+## the addresses returned.
+# autocluster.dns.hostname = "rabbitmq.discovery.mycompany.local"
+
 ## This node's type can be configured. If you are not sure
 ## what node type to use, always use 'disc'.
-# autocluster.classic_config.node_type = disc
+# autocluster.node_type = disc
 
 ## Interval (in milliseconds) at which we send keepalive messages
 ## to other cluster members. Note that this is not the same thing

--- a/priv/schema/rabbitmq.schema
+++ b/priv/schema/rabbitmq.schema
@@ -757,6 +757,27 @@ end}.
 {mapping, "mirroring_sync_batch_size", "rabbit.mirroring_sync_batch_size",
     [{datatype, bytesize}, {validators, ["size_less_than_2G"]}]}.
 
+%% Own node type used by autoclustering.
+%%
+
+{mapping, "autocluster.node_type", "rabbit.autocluster.node_type", [
+    {datatype, {enum, [disc, disk, ram]}}
+]}.
+
+{translation, "rabbit.autocluster.node_type",
+fun(Conf) ->
+    case cuttlefish:conf_get("autocluster.node_type", Conf) of
+        undefined ->cuttlefish:unset(); 
+        disc      -> disc;
+        %% Always cast to `disc`
+        disk      -> disc;
+        ram       -> ram;
+        _Other    -> disc
+    end
+end}.
+
+%% Classic config-driven autocluster backend.
+%%
 %% Make clustering happen *automatically* at startup - only applied
 %% to nodes that have just been reset or started for the first time.
 %% See http://www.rabbitmq.com/clustering.html#auto-config for
@@ -767,11 +788,6 @@ end}.
 {mapping, "autocluster.classic_config.nodes.$node", "rabbit.cluster_nodes",
     [{datatype, atom}]}.
 
-{mapping, "autocluster.classic_config.node_type", "rabbit.cluster_nodes", [
-    {datatype, {enum, [disc, disk, ram]}},
-    {default,  disc}
-]}.
-
 {translation, "rabbit.cluster_nodes",
 fun(Conf) ->
     Nodes = [V || {_, V} <- cuttlefish_variable:filter_by_prefix("autocluster.classic_config.nodes", Conf)],
@@ -779,12 +795,26 @@ fun(Conf) ->
     case Nodes of
         []    -> cuttlefish:unset();
         Other ->
-            case cuttlefish:conf_get("autocluster.classic_config.node_type", Conf, disc) of
+            case cuttlefish:conf_get("autocluster.node_type", Conf, disc) of
                 disc -> {Other, disc};
-                % Always cast to `disc`
+                %% Always cast to `disc`
                 disk -> {Other, disc};
                 ram  -> {Other, ram}
             end
+    end
+end}.
+
+%% DNS (A records and reverse lookups)-based peer discovery.
+%%
+
+{mapping, "autocluster.dns.hostname", "rabbit.peer_discovery_dns.hostname",
+    [{datatype, string}]}.
+
+{translation, "rabbit.peer_discovery_dns.hostname",
+fun(Conf) ->
+    case cuttlefish:conf_get("autocluster.dns.hostname", Conf) of
+        undefined -> cuttlefish:unset();
+        Value     -> list_to_binary(Value)
     end
 end}.
 
@@ -799,6 +829,8 @@ end}.
 {mapping, "cluster_keepalive_interval", "rabbit.cluster_keepalive_interval",
     [{datatype, integer}]}.
 
+%% Queue master locator
+%%
 
 {mapping, "queue_master_locator", "rabbit.queue_master_locator",
     [{datatype, string}]}.

--- a/priv/schema/rabbitmq.schema
+++ b/priv/schema/rabbitmq.schema
@@ -757,6 +757,13 @@ end}.
 {mapping, "mirroring_sync_batch_size", "rabbit.mirroring_sync_batch_size",
     [{datatype, bytesize}, {validators, ["size_less_than_2G"]}]}.
 
+%% Peer discovery backend used by autoclustering.
+%%
+
+{mapping, "autocluster.peer_discovery_backend", "rabbit.autocluster.peer_discovery_backend", [
+    {datatype, atom}
+]}.
+
 %% Own node type used by autoclustering.
 %%
 
@@ -766,13 +773,18 @@ end}.
 
 {translation, "rabbit.autocluster.node_type",
 fun(Conf) ->
-    case cuttlefish:conf_get("autocluster.node_type", Conf) of
-        undefined ->cuttlefish:unset(); 
-        disc      -> disc;
-        %% Always cast to `disc`
-        disk      -> disc;
-        ram       -> ram;
-        _Other    -> disc
+    %% if peer discovery backend isn't configured, don't generate
+    %% node type
+    case cuttlefish:conf_get("autocluster.peer_discovery_backend", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        _Backend  ->
+            case cuttlefish:conf_get("autocluster.node_type", Conf) of
+                disc      -> disc;
+                %% always cast to `disc`
+                disk      -> disc;
+                ram       -> ram;
+                _Other    -> disc
+            end
     end
 end}.
 
@@ -807,12 +819,12 @@ end}.
 %% DNS (A records and reverse lookups)-based peer discovery.
 %%
 
-{mapping, "autocluster.dns.hostname", "rabbit.peer_discovery_dns.hostname",
+{mapping, "autocluster.dns.hostname", "rabbit.autocluster.peer_discovery_dns.hostname",
     [{datatype, string}]}.
 
-{translation, "rabbit.peer_discovery_dns.hostname",
+{translation, "rabbit.autocluster.peer_discovery_dns.hostname",
 fun(Conf) ->
-    case cuttlefish:conf_get("autocluster.dns.hostname", Conf) of
+    case cuttlefish:conf_get("autocluster.dns.hostname", Conf, undefined) of
         undefined -> cuttlefish:unset();
         Value     -> list_to_binary(Value)
     end

--- a/src/rabbit_peer_discovery.erl
+++ b/src/rabbit_peer_discovery.erl
@@ -16,19 +16,51 @@
 
 -module(rabbit_peer_discovery).
 
+%%
 %% API
--export([discover_cluster_nodes/0, backend/0,
-         normalize/1, format_discovered_nodes/1]).
+%%
+
+-export([discover_cluster_nodes/0, backend/0, node_type/0,
+         normalize/1, format_discovered_nodes/1, log_configured_backend/0]).
 -export([append_node_prefix/1, node_prefix/0]).
+
+-define(DEFAULT_BACKEND,   rabbit_peer_discovery_classic_config).
+%% what node type is used by default for this node when joining
+%% a new cluster as a virgin node
+-define(DEFAULT_NODE_TYPE, disc).
+%% default node prefix to attach to discovered hostnames
+-define(DEFAULT_PREFIX, "rabbit").
+-define(NODENAME_PART_SEPARATOR, "@").
 
 
 -spec backend() -> atom().
 
 backend() ->
-  case application:get_env(rabbit, peer_discovery_backend) of
-    {ok, Backend} when is_atom(Backend) -> Backend;
-    undefined                           -> rabbit_peer_discovery_classic_config
+  case application:get_env(rabbit, autocluster) of
+    {ok, Proplist} ->
+      proplists:get_value(peer_discovery_backend, Proplist, ?DEFAULT_BACKEND);
+    undefined      ->
+      ?DEFAULT_BACKEND
   end.
+
+
+
+-spec node_type() -> rabbit_types:node_type().
+
+node_type() ->
+  case application:get_env(rabbit, autocluster) of
+    {ok, Proplist} ->
+      proplists:get_value(node_type, Proplist, ?DEFAULT_NODE_TYPE);
+    undefined      ->
+      ?DEFAULT_NODE_TYPE
+  end.
+
+
+
+-spec log_configured_backend() -> ok.
+
+log_configured_backend() ->
+  rabbit_log:info("Configured peer discovery backend: ~s~n", [backend()]).
 
 
 -spec discover_cluster_nodes() -> {ok, Nodes :: list()} |
@@ -40,11 +72,17 @@ discover_cluster_nodes() ->
     normalize(Backend:list_nodes()).
 
 
--spec normalize({ok, Nodes :: list()} |
+-spec normalize(Nodes :: list() |
+                {Nodes :: list(), NodeType :: rabbit_types:node_type()} |
+                {ok, Nodes :: list()} |
                 {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} |
                 {error, Reason :: string()}) -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} |
                                                 {error, Reason :: string()}.
 
+normalize(Nodes) when is_list(Nodes) ->
+  {ok, {Nodes, disc}};
+normalize({Nodes, NodeType}) when is_list(Nodes) andalso is_atom(NodeType) ->
+  {ok, {Nodes, NodeType}};
 normalize({ok, Nodes}) when is_list(Nodes) ->
   {ok, {Nodes, disc}};
 normalize({ok, {Nodes, NodeType}}) when is_list(Nodes) andalso is_atom(NodeType) ->
@@ -58,9 +96,6 @@ normalize({error, Reason}) ->
 format_discovered_nodes(Nodes) ->
   string:join(lists:map(fun (Val) -> hd(io_lib:format("~s", [Val])) end, Nodes), ", ").
 
-
--define(DEFAULT_PREFIX, "rabbit").
--define(NODENAME_PART_SEPARATOR, "@").
 
 
 -spec node_prefix() -> string().

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -63,6 +63,7 @@ discover_nodes(SeedHostname, LongNamesUsed) ->
         H <- discover_hostnames(SeedHostname, LongNamesUsed)].
 
 discover_hostnames(SeedHostname, LongNamesUsed) ->
+    %% TODO: IPv6 support
     Hosts = [extract_host(inet_res:gethostbyaddr(A), LongNamesUsed) ||
                 A <- inet_res:lookup(SeedHostname, in, a)],
     lists:filter(fun(E) -> E =/= error end, Hosts).

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -20,6 +20,7 @@
 -include("rabbit.hrl").
 
 -export([list_nodes/0, register/0, unregister/0]).
+%% for tests
 -export([discover_nodes/2]).
 
 %%
@@ -58,7 +59,7 @@ unregister() ->
 %%
 
 discover_nodes(SeedHostname, LongNamesUsed) ->
-    discover_hostnames(SeedHostname, LongNamesUsed).
+    [rabbit_peer_discovery:append_node_prefix(H) || H <- discover_hostnames(SeedHostname, LongNamesUsed)].
 
 discover_hostnames(SeedHostname, LongNamesUsed) ->
     Hosts = [extract_host(inet_res:gethostbyaddr(A), LongNamesUsed) || A <- inet_res:lookup(SeedHostname, in, a)],

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -1,0 +1,75 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_peer_discovery_dns).
+-behaviour(rabbit_peer_discovery_backend).
+
+-include("rabbit.hrl").
+
+-export([list_nodes/0, register/0, unregister/0]).
+-export([discover_nodes/2]).
+
+%%
+%% API
+%%
+
+-spec list_nodes() -> {ok, Nodes :: list()} | {error, Reason :: string()}.
+
+list_nodes() ->
+    case application:get_env(rabbit, autocluster) of
+      undefined         -> io:format("rabbit.autocluster~n", []), {[], disc};
+      {ok, Autocluster} ->
+        case proplists:get_value(peer_discovery_dns, Autocluster) of
+            undefined -> io:format("rabbit.autocluster.peer_discovery_dns~n", []), {[], disc};
+            Proplist  ->
+                Hostname = rabbit_data_coercion:to_list(proplists:get_value(hostname, Proplist)),
+                NodeType = proplists:get_value(node_type, Autocluster, disc),
+
+                {discover_nodes(Hostname, net_kernel:longnames()), NodeType}
+        end
+    end.
+
+-spec register() -> ok.
+
+register() ->
+    ok.
+
+-spec unregister() -> ok.
+
+unregister() ->
+    ok.
+
+
+%%
+%% Implementation
+%%
+
+discover_nodes(SeedHostname, LongNamesUsed) ->
+    discover_hostnames(SeedHostname, LongNamesUsed).
+
+discover_hostnames(SeedHostname, LongNamesUsed) ->
+    Hosts = [extract_host(inet_res:gethostbyaddr(A), LongNamesUsed) || A <- inet_res:lookup(SeedHostname, in, a)],
+    lists:filter(fun(E) -> E =/= error end, Hosts).
+
+%% long node names are used
+extract_host({ok, {hostent, FQDN, _, _, _, _}}, true) ->
+  FQDN;
+%% short node names are used
+extract_host({ok, {hostent, FQDN, _, _, _, _}}, false) ->
+  lists:nth(1, string:tokens(FQDN, "."));
+extract_host(Error, _) ->
+  rabbit_log:error("DNS peer discovery failed: ~p", [Error]),
+  error.

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -31,14 +31,20 @@
 
 list_nodes() ->
     case application:get_env(rabbit, autocluster) of
-      undefined         -> io:format("rabbit.autocluster~n", []), {[], disc};
+      undefined         ->
+        {[], disc};
       {ok, Autocluster} ->
         case proplists:get_value(peer_discovery_dns, Autocluster) of
-            undefined -> io:format("rabbit.autocluster.peer_discovery_dns~n", []), {[], disc};
+            undefined ->
+              rabbit_log:warning("Peer discovery backend is set to ~s "
+                                 "but final config does not contain rabbit.autocluster.peer_discovery_dns. "
+                                 "Cannot discover any nodes because seed hostname is not configured!",
+                                 [?MODULE]),
+              {[], disc};
             Proplist  ->
-                Hostname = rabbit_data_coercion:to_list(proplists:get_value(hostname, Proplist)),
+              Hostname = rabbit_data_coercion:to_list(proplists:get_value(hostname, Proplist)),
 
-                {discover_nodes(Hostname, net_kernel:longnames()), rabbit_peer_discovery:node_type()}
+              {discover_nodes(Hostname, net_kernel:longnames()), rabbit_peer_discovery:node_type()}
         end
     end.
 

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -21,7 +21,7 @@
 
 -export([list_nodes/0, register/0, unregister/0]).
 %% for tests
--export([discover_nodes/2]).
+-export([discover_nodes/2, discover_hostnames/2]).
 
 %%
 %% API
@@ -59,10 +59,12 @@ unregister() ->
 %%
 
 discover_nodes(SeedHostname, LongNamesUsed) ->
-    [rabbit_peer_discovery:append_node_prefix(H) || H <- discover_hostnames(SeedHostname, LongNamesUsed)].
+    [rabbit_peer_discovery:append_node_prefix(H) ||
+        H <- discover_hostnames(SeedHostname, LongNamesUsed)].
 
 discover_hostnames(SeedHostname, LongNamesUsed) ->
-    Hosts = [extract_host(inet_res:gethostbyaddr(A), LongNamesUsed) || A <- inet_res:lookup(SeedHostname, in, a)],
+    Hosts = [extract_host(inet_res:gethostbyaddr(A), LongNamesUsed) ||
+                A <- inet_res:lookup(SeedHostname, in, a)],
     lists:filter(fun(E) -> E =/= error end, Hosts).
 
 %% long node names are used

--- a/test/config_schema_SUITE_data/snippets.config
+++ b/test/config_schema_SUITE_data/snippets.config
@@ -94,28 +94,30 @@ default_permissions.write = .*",
 {default_permissions, [<<".*">>, <<".*">>, <<".*">>]}]}],[]}
 ,
 {13,
-"autocluster.classic_config.nodes.peer1 = rabbit@hostname1
+"autocluster.peer_discovery_backend = rabbit_peer_discovery_classic_config
+autocluster.classic_config.nodes.peer1 = rabbit@hostname1
 autocluster.classic_config.nodes.peer2 = rabbit@hostname2
 autocluster.node_type = disc",
 [{rabbit, [
-    {autocluster,   [{node_type, disc}]},
+    {autocluster,   [{peer_discovery_backend, rabbit_peer_discovery_classic_config},
+                     {node_type, disc}]},
     {cluster_nodes, {[rabbit@hostname2,rabbit@hostname1], disc}}
 ]}],[]}
 ,
 {13.1,
-"autocluster.classic_config.nodes.peer1 = rabbit@hostname1
+"autocluster.peer_discovery_backend = rabbit_peer_discovery_classic_config
+autocluster.classic_config.nodes.peer1 = rabbit@hostname1
 autocluster.classic_config.nodes.peer2 = rabbit@hostname2
 autocluster.node_type = disk",
 [{rabbit, [
-    {autocluster,   [{node_type, disc}]},
+    {autocluster,   [{peer_discovery_backend, rabbit_peer_discovery_classic_config},
+                     {node_type, disc}]},
     {cluster_nodes, {[rabbit@hostname2,rabbit@hostname1], disc}}
 ]}],[]}
 ,
 {13.2,
 "autocluster.node_type = ram",
-[{rabbit, [
-    {autocluster, [{node_type,ram}]}
-]}],[]}
+[],[]}
 ,
 {14,
 "tcp_listen_options.backlog = 128
@@ -746,27 +748,29 @@ tcp_listen_options.linger.timeout = 100",
 "tcp_listen_options.linger.timeout = 100",
 [{rabbit, [{tcp_listen_options, [{linger, {false, 100}}]}]}],
 []},
-
 {75,
-"autocluster.dns.hostname = 192.168.0.2.xip.io
+"
+autocluster.peer_discovery_backend = rabbit_peer_discovery_dns
+autocluster.dns.hostname = 192.168.0.2.xip.io
 autocluster.node_type = disc",
 [{rabbit, [
-    {peer_discovery_dns, [{hostname,  <<"192.168.0.2.xip.io">>}]},
-    {autocluster,        [{node_type, disc}]}
+    {autocluster, [{peer_discovery_dns,     [{hostname,  <<"192.168.0.2.xip.io">>}]},
+                   {peer_discovery_backend, rabbit_peer_discovery_dns},
+                   {node_type,              disc}]}
 ]}],[]}
 ,
-
-{75.1,
-"autocluster.dns.hostname = 192.168.0.2.xip.io
-autocluster.node_type = disk",
+{76,
+"autocluster.peer_discovery_backend = rabbit_peer_discovery_classic_config
+autocluster.node_type = disc",
 [{rabbit, [
-    {peer_discovery_dns, [{hostname,  <<"192.168.0.2.xip.io">>}]},
-    {autocluster,        [{node_type, disc}]}
-]}],[]}
-,
-{75.2,
-"autocluster.node_type = ram",
+    {autocluster,        [{peer_discovery_backend, rabbit_peer_discovery_classic_config},
+                          {node_type, disc}]}
+]}],[]},
+{76.1,
+"autocluster.peer_discovery_backend = rabbit_peer_discovery_classic_config
+autocluster.node_type = ram",
 [{rabbit, [
-    {autocluster,        [{node_type, ram}]}
+    {autocluster, [{peer_discovery_backend, rabbit_peer_discovery_classic_config},
+                   {node_type, ram}]}
 ]}],[]}
 ].

--- a/test/config_schema_SUITE_data/snippets.config
+++ b/test/config_schema_SUITE_data/snippets.config
@@ -96,22 +96,26 @@ default_permissions.write = .*",
 {13,
 "autocluster.classic_config.nodes.peer1 = rabbit@hostname1
 autocluster.classic_config.nodes.peer2 = rabbit@hostname2
-autocluster.classic_config.node_type = disc",
+autocluster.node_type = disc",
 [{rabbit, [
+    {autocluster,   [{node_type, disc}]},
     {cluster_nodes, {[rabbit@hostname2,rabbit@hostname1], disc}}
 ]}],[]}
 ,
 {13.1,
 "autocluster.classic_config.nodes.peer1 = rabbit@hostname1
 autocluster.classic_config.nodes.peer2 = rabbit@hostname2
-autocluster.classic_config.node_type = disk",
+autocluster.node_type = disk",
 [{rabbit, [
+    {autocluster,   [{node_type, disc}]},
     {cluster_nodes, {[rabbit@hostname2,rabbit@hostname1], disc}}
 ]}],[]}
 ,
 {13.2,
-"autocluster.classic_config.node_type = ram",
-[],[]}
+"autocluster.node_type = ram",
+[{rabbit, [
+    {autocluster, [{node_type,ram}]}
+]}],[]}
 ,
 {14,
 "tcp_listen_options.backlog = 128
@@ -713,7 +717,7 @@ web_stomp.ssl.password   = changeme",
 [{rabbitmq_web_stomp,
     [{sockjs_opts, [{sockjs_url, "https://cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js"}]}]}],
 [rabbitmq_web_stomp]},
-{69, 
+{69,
 "auth_backends.1 = http
 rabbitmq_auth_backend_http.user_path     = http://some-server/auth/user
 rabbitmq_auth_backend_http.vhost_path    = http://some-server/auth/vhost
@@ -741,5 +745,28 @@ tcp_listen_options.linger.timeout = 100",
 {74,
 "tcp_listen_options.linger.timeout = 100",
 [{rabbit, [{tcp_listen_options, [{linger, {false, 100}}]}]}],
-[]}
+[]},
+
+{75,
+"autocluster.dns.hostname = 192.168.0.2.xip.io
+autocluster.node_type = disc",
+[{rabbit, [
+    {peer_discovery_dns, [{hostname,  <<"192.168.0.2.xip.io">>}]},
+    {autocluster,        [{node_type, disc}]}
+]}],[]}
+,
+
+{75.1,
+"autocluster.dns.hostname = 192.168.0.2.xip.io
+autocluster.node_type = disk",
+[{rabbit, [
+    {peer_discovery_dns, [{hostname,  <<"192.168.0.2.xip.io">>}]},
+    {autocluster,        [{node_type, disc}]}
+]}],[]}
+,
+{75.2,
+"autocluster.node_type = ram",
+[{rabbit, [
+    {autocluster,        [{node_type, ram}]}
+]}],[]}
 ].

--- a/test/peer_discovery_dns_SUITE.erl
+++ b/test/peer_discovery_dns_SUITE.erl
@@ -95,8 +95,8 @@ hostname_discovery_with_short_node_names(_) ->
 
 node_discovery_with_long_node_names(_) ->
     Result = rabbit_peer_discovery_dns:discover_nodes(?DISCOVERY_ENDPOINT, true),
-    ?assertEqual(["ct_rabbit@www.rabbitmq.com"], Result).
+    ?assertEqual(['ct_rabbit@www.rabbitmq.com'], Result).
 
 node_discovery_with_short_node_names(_) ->
     Result = rabbit_peer_discovery_dns:discover_nodes(?DISCOVERY_ENDPOINT, false),
-    ?assertEqual(["ct_rabbit@www"], Result).
+    ?assertEqual([ct_rabbit@www], Result).

--- a/test/peer_discovery_dns_SUITE.erl
+++ b/test/peer_discovery_dns_SUITE.erl
@@ -1,0 +1,85 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2011-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(peer_discovery_dns_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+     {group, non_parallel}
+    ].
+
+groups() ->
+    [
+      {non_parallel, [], [
+                          hostname_discovery_with_long_node_names,
+                          hostname_discovery_with_short_node_names,
+                          node_discovery_with_long_node_names,
+                          node_discovery_with_short_node_names
+                         ]}
+    ].
+
+suite() ->
+    [
+      %% If a test hangs, no need to wait for 30 minutes.
+      {timetrap, {minutes, 1}}
+    ].
+
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+
+%% -------------------------------------------------------------------
+%% Test cases
+%% -------------------------------------------------------------------
+
+%% peer_discovery.tests.rabbitmq.net used in the tests below
+%% returns three A records two of which fail our resolution process:
+%%
+%% * One does not resolve to a [typically] non-reachable IP
+%% * One does not support reverse lookup queries
+
+-define(DISCOVERY_ENDPOINT, "peer_discovery.tests.rabbitmq.net").
+
+hostname_discovery_with_long_node_names(_) ->
+    Result = rabbit_peer_discovery_dns:discover_hostnames(?DISCOVERY_ENDPOINT, true),
+    ?assertEqual(["www.rabbitmq.com"], Result).
+
+hostname_discovery_with_short_node_names(_) ->
+    Result = rabbit_peer_discovery_dns:discover_hostnames(?DISCOVERY_ENDPOINT, false),
+    ?assertEqual(["www"], Result).
+
+node_discovery_with_long_node_names(_) ->
+    Result = rabbit_peer_discovery_dns:discover_nodes(?DISCOVERY_ENDPOINT, true),
+    ?assertEqual(["ct_rabbit@www.rabbitmq.com"], Result).
+
+node_discovery_with_short_node_names(_) ->
+    Result = rabbit_peer_discovery_dns:discover_nodes(?DISCOVERY_ENDPOINT, false),
+    ?assertEqual(["ct_rabbit@www"], Result).


### PR DESCRIPTION
This ports [the DNS peer discovery backend from rabbitmq-autocluster](https://github.com/aweber/rabbitmq-autocluster/commit/cf71f5759bdabdb67285f94298ac5ab2cf299c67) with a few changes:

 * Node prefix (e.g. `rabbit` in `rabbit@eng.megacorp.com`) is assumed to be the same across all nodes. The node that performs discovery will attach its own prefix to all hostnames discovered via DNS. In `rabbitmq-autocluster` it is configurable.
 * Long vs. short name option is also not configurable and determined from `net_kernel` on the current node (using `net_kernel:longnames/0`, which seems to be undocumented :/)
 * We don't do the [IP address massaging](https://github.com/aweber/rabbitmq-autocluster/blob/master/src/autocluster_util.erl#L210) that `rabbitmq-autocluster` does because I am not sure I understand the intent. We need to clarify that with @gmr :)

While at it, since node type won't vary from backend to backend we should make it backend agnostic.

Documentation for these changes as well as #486 can be found in https://github.com/rabbitmq/rabbitmq-website/pull/298.

Fixes #988.