### PR TITLE
Termination of queue master fails with `{badmatch,{error,not_found}}`

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -22,7 +22,7 @@
          stop_and_halt/0, await_startup/0, status/0, is_running/0,
          is_running/1, environment/0, rotate_logs/1, force_event_refresh/1,
          start_fhc/0]).
--export([start/2, stop/1, prep_stop/1]).
+-export([start/2, stop/1]).
 -export([start_apps/1, stop_apps/1]).
 -export([log_location/1, config_files/0, decrypt_config/2]). %% for testing and mgmt-agent
 
@@ -690,15 +690,13 @@ start(normal, []) ->
             Error
     end.
 
-prep_stop(_State) ->
+stop(_State) ->
     ok = rabbit_alarm:stop(),
     ok = case rabbit_mnesia:is_clustered() of
              true  -> ok;
              false -> rabbit_table:clear_ram_only_tables()
          end,
     ok.
-
-stop(_) -> ok.
 
 -spec boot_error(term(), not_available | [tuple()]) -> no_return().
 


### PR DESCRIPTION
Closes #1035 