### PR TITLE
Properly handle systemd notify errors

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -348,15 +348,16 @@ sd_open_port() ->
        use_stdio, out]).
 
 sd_notify_socat(Unit) ->
-    case sd_open_port() of
-        {'EXIT', Exit} ->
-            io:format(standard_error, "Failed to start socat ~p~n", [Exit]),
-            false;
+    try sd_open_port() of
         Port ->
             Port ! {self(), {command, sd_notify_data()}},
             Result = sd_wait_activation(Port, Unit),
             port_close(Port),
             Result
+    catch
+        Class:Reason ->
+            io:format(standard_error, "Failed to start socat ~p:~p~n", [Class, Reason]),
+            false
     end.
 
 sd_current_unit() ->


### PR DESCRIPTION
Original intention was to call `open_port` protected by `catch`, but I've forgot about it. So instead of nice error message it resulted in a stack-trace like https://groups.google.com/forum/#!topic/rabbitmq-users/JsBTioFtZwI