### PR TITLE
Recursively create `RABBITMQ_SCHEMA_DIR`

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -106,7 +106,7 @@ else
 fi
 
 if [ ! -d ${RABBITMQ_SCHEMA_DIR} ]; then
-    mkdir "${RABBITMQ_SCHEMA_DIR}"
+    mkdir -p "${RABBITMQ_SCHEMA_DIR}"
 fi
 
 if [ ! -f "${RABBITMQ_SCHEMA_DIR}/rabbitmq.schema" ]; then


### PR DESCRIPTION
Just like we do with `RABBITMQ_PID_DIR`. Otherwise there is a warning
emitted at node startup and no directory is created when the enclosing directory doesn't exist.

Per discussion with @acogoluegnes.