### PR TITLE
Configure memory reduction for all queue types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ define PROJECT_ENV
 	                            {passphrase, undefined}
 	                           ]},
 	    %% rabbitmq-server-973
-	    {lazy_queue_explicit_gc_run_operation_threshold, 250},
+	    {queue_explicit_gc_run_operation_threshold, 1000},
+	    {lazy_queue_explicit_gc_run_operation_threshold, 1000},
 	    {background_gc_enabled, true},
 	    {background_gc_target_interval, 60000}
 	  ]

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -432,7 +432,6 @@
 %% rabbit_amqqueue_process need fairly fresh rates.
 -define(MSGS_PER_RATE_CALC, 100).
 
-
 %% we define the garbage collector threshold
 %% it needs to tune the `reduce_memory_use` calls. Thus, the garbage collection.
 %% see: rabbitmq-server-973 and rabbitmq-server-964
@@ -440,18 +439,20 @@
 -define(EXPLICIT_GC_RUN_OP_THRESHOLD(Mode),
     case get(explicit_gc_run_operation_threshold) of
         undefined ->
-            Val = case Mode of
-                      lazy -> rabbit_misc:get_env(rabbit,
-                                                  lazy_queue_explicit_gc_run_operation_threshold,
-                                                  ?DEFAULT_EXPLICIT_GC_RUN_OP_THRESHOLD);
-                      _ -> rabbit_misc:get_env(rabbit,
-                                               queue_explicit_gc_run_operation_threshold,
-                                               ?DEFAULT_EXPLICIT_GC_RUN_OP_THRESHOLD)
-                  end,
+            Val = explicit_gc_run_operation_threshold_for_mode(Mode),
             put(explicit_gc_run_operation_threshold, Val),
             Val;
         Val       -> Val
     end).
+
+explicit_gc_run_operation_threshold_for_mode(Mode) ->
+    {Key, Fallback} = case Mode of
+        lazy -> {lazy_queue_explicit_gc_run_operation_threshold,
+                 ?DEFAULT_EXPLICIT_GC_RUN_OP_THRESHOLD};
+        _    -> {queue_explicit_gc_run_operation_threshold,
+                 ?DEFAULT_EXPLICIT_GC_RUN_OP_THRESHOLD}
+    end,
+    rabbit_misc:get_env(rabbit, Key, Fallback).
 
 %%----------------------------------------------------------------------------
 %% Public API

--- a/test/unit_inbroker_SUITE.erl
+++ b/test/unit_inbroker_SUITE.erl
@@ -250,9 +250,21 @@ orelse Group =:= backing_queue_embed_limit_1024 ->
 end_per_group1(_, Config) ->
     Config.
 
+init_per_testcase(Testcase, Config) when Testcase == variable_queue_requeue;
+                                         Testcase == variable_queue_fold ->
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, set_env,
+           [rabbit, queue_explicit_gc_run_operation_threshold, 0]),
+    rabbit_ct_helpers:testcase_started(Config, Testcase);
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
+end_per_testcase(Testcase, Config) when Testcase == variable_queue_requeue;
+                                        Testcase == variable_queue_fold ->
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config, 0, application, set_env,
+           [rabbit, queue_explicit_gc_run_operation_threshold, 1000]),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 


### PR DESCRIPTION
Might alleviate the problem in #964, as memory reduction is very expensive in CPU usage. If the garbage collection (VM and data) happens less often, the throughput increases and is able to process all queued requests a bit faster.

Could not reproduce the memory increase during the queue's flow control (as connections and channels get into flow first), so it's not fully verified.