### PR TITLE
Fix API for listing vhost limits

### DIFF
--- a/src/rabbit_vhost_limit.erl
+++ b/src/rabbit_vhost_limit.erl
@@ -60,7 +60,7 @@ queue_limit(VirtualHost) ->
     get_limit(VirtualHost, <<"max-queues">>).
 
 
-list0(VHost) ->
+query_limits(VHost) ->
     case rabbit_runtime_parameters:list(VHost, <<"vhost-limits">>) of
         []     -> [];
         Params -> [ {pget(vhost, Param), pget(value, Param)}
@@ -71,14 +71,15 @@ list0(VHost) ->
 
 
 -spec list() -> [{rabbit_types:vhost(), rabbit_types:infos()}].
-
-list() -> list0('_').
-
+list() ->
+    query_limits('_').
 
 -spec list(rabbit_types:vhost()) -> rabbit_types:infos().
-
-list(VHost) -> list0(VHost).
-
+list(VHost) ->
+    case query_limits(VHost) of
+        []               -> [];
+        [{VHost, Value}] -> Value
+    end.
 
 -spec is_over_connection_limit(rabbit_types:vhost()) -> {true, non_neg_integer()} | false.
 


### PR DESCRIPTION
Fix an internal API inconsistency introduced by #1080 

`rabbit_vhost_limit:list` now corresponds to type specs.

Related to rabbitmq/rabbitmq-cli#165