### PR TITLE
Modify new scripts to use /bin/sh

### DIFF
--- a/scripts/rabbitmq-diagnostics
+++ b/scripts/rabbitmq-diagnostics
@@ -1,7 +1,32 @@
-#!/usr/bin/env bash
+#!/bin/sh
+##  The contents of this file are subject to the Mozilla Public License
+##  Version 1.1 (the "License"); you may not use this file except in
+##  compliance with the License. You may obtain a copy of the License
+##  at http://www.mozilla.org/MPL/
+##
+##  Software distributed under the License is distributed on an "AS IS"
+##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+##  the License for the specific language governing rights and
+##  limitations under the License.
+##
+##  The Original Code is RabbitMQ.
+##
+##  The Initial Developer of the Original Code is GoPivotal, Inc.
+##  Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+##
 
+# Exit immediately if a pipeline, which may consist of a single simple command,
+# a list, or a compound command returns a non-zero status
+set -e
+
+# Each variable or function that is created or modified is given the export
+# attribute and marked for export to the environment of subsequent commands.
 set -a
 
-. `dirname $0`/rabbitmq-env
+# shellcheck source=/dev/null
+#
+# TODO: when shellcheck adds support for relative paths, change to
+# shellcheck source=./rabbitmq-env
+. "${0%/*}"/rabbitmq-env
 
-escript $ESCRIPT_DIR/rabbitmq-diagnostics "$@"
+escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-diagnostics "$@"

--- a/scripts/rabbitmq-plugins
+++ b/scripts/rabbitmq-plugins
@@ -1,7 +1,32 @@
-#!/usr/bin/env bash
+#!/bin/sh
+##  The contents of this file are subject to the Mozilla Public License
+##  Version 1.1 (the "License"); you may not use this file except in
+##  compliance with the License. You may obtain a copy of the License
+##  at http://www.mozilla.org/MPL/
+##
+##  Software distributed under the License is distributed on an "AS IS"
+##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+##  the License for the specific language governing rights and
+##  limitations under the License.
+##
+##  The Original Code is RabbitMQ.
+##
+##  The Initial Developer of the Original Code is GoPivotal, Inc.
+##  Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+##
 
+# Exit immediately if a pipeline, which may consist of a single simple command,
+# a list, or a compound command returns a non-zero status
+set -e
+
+# Each variable or function that is created or modified is given the export
+# attribute and marked for export to the environment of subsequent commands.
 set -a
 
-. `dirname $0`/rabbitmq-env
+# shellcheck source=/dev/null
+#
+# TODO: when shellcheck adds support for relative paths, change to
+# shellcheck source=./rabbitmq-env
+. "${0%/*}"/rabbitmq-env
 
-escript $ESCRIPT_DIR/rabbitmq-plugins --formatter=plugins -q "$@"
+escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins --formatter=plugins -q "$@"

--- a/scripts/rabbitmqctl
+++ b/scripts/rabbitmqctl
@@ -1,7 +1,32 @@
-#!/usr/bin/env bash
+#!/bin/sh
+##  The contents of this file are subject to the Mozilla Public License
+##  Version 1.1 (the "License"); you may not use this file except in
+##  compliance with the License. You may obtain a copy of the License
+##  at http://www.mozilla.org/MPL/
+##
+##  Software distributed under the License is distributed on an "AS IS"
+##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+##  the License for the specific language governing rights and
+##  limitations under the License.
+##
+##  The Original Code is RabbitMQ.
+##
+##  The Initial Developer of the Original Code is GoPivotal, Inc.
+##  Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+##
 
+# Exit immediately if a pipeline, which may consist of a single simple command,
+# a list, or a compound command returns a non-zero status
+set -e
+
+# Each variable or function that is created or modified is given the export
+# attribute and marked for export to the environment of subsequent commands.
 set -a
 
-. `dirname $0`/rabbitmq-env
+# shellcheck source=/dev/null
+#
+# TODO: when shellcheck adds support for relative paths, change to
+# shellcheck source=./rabbitmq-env
+. "${0%/*}"/rabbitmq-env
 
-escript $ESCRIPT_DIR/rabbitmqctl "$@"
+escript "${ESCRIPT_DIR:?must be defined}"/rabbitmqctl "$@"


### PR DESCRIPTION
While at it, make them POSIX.1-2008 compliant (a.k.a fix all shellchecks)

Prefer parameter expansion and manipulation over command invocation:

    # OK-ish
    `dirname $0`

    # SPOT ON
    "${0%/*}"

Guard against empty ESCRIPT_DIR var