### PR TITLE
Ignore pre-release version part in plugin version requirement validation

### DIFF
--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -340,7 +340,10 @@ check_plugins_versions(PluginName, AllPlugins, RequiredVersions) ->
 is_version_supported("", _)        -> true;
 is_version_supported("0.0.0", _)   -> true;
 is_version_supported(_Version, []) -> true;
-is_version_supported(Version, ExpectedVersions) ->
+is_version_supported(VersionFull, ExpectedVersions) ->
+    %% Pre-release version should be supported in plugins,
+    %% therefore alpha part should be removed
+    Version = remove_version_alpha_part(VersionFull),
     case lists:any(fun(ExpectedVersion) ->
                        rabbit_misc:version_minor_equivalent(ExpectedVersion, Version)
                        andalso
@@ -350,6 +353,10 @@ is_version_supported(Version, ExpectedVersions) ->
         true  -> true;
         false -> false
     end.
+
+remove_version_alpha_part(Version) ->
+    {Ver, _Alpha} = rabbit_semver:parse(Version),
+    iolist_to_binary(rabbit_semver:format({Ver, {[], []}})).
 
 clean_plugins(Plugins) ->
     {ok, ExpandDir} = application:get_env(rabbit, plugins_expand_dir),

--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -342,8 +342,8 @@ is_version_supported("0.0.0", _)   -> true;
 is_version_supported(_Version, []) -> true;
 is_version_supported(VersionFull, ExpectedVersions) ->
     %% Pre-release version should be supported in plugins,
-    %% therefore alpha part should be removed
-    Version = remove_version_alpha_part(VersionFull),
+    %% therefore preview part should be removed
+    Version = remove_version_preview_part(VersionFull),
     case lists:any(fun(ExpectedVersion) ->
                        rabbit_misc:version_minor_equivalent(ExpectedVersion, Version)
                        andalso
@@ -354,8 +354,8 @@ is_version_supported(VersionFull, ExpectedVersions) ->
         false -> false
     end.
 
-remove_version_alpha_part(Version) ->
-    {Ver, _Alpha} = rabbit_semver:parse(Version),
+remove_version_preview_part(Version) ->
+    {Ver, _Preview} = rabbit_semver:parse(Version),
     iolist_to_binary(rabbit_semver:format({Ver, {[], []}})).
 
 clean_plugins(Plugins) ->

--- a/test/plugin_versioning_SUITE.erl
+++ b/test/plugin_versioning_SUITE.erl
@@ -81,6 +81,8 @@ version_support(_Config) ->
     ,{["3.5.2", "3.6.1"], "3.6.2.999", true}       %% x.y.z.p values are supported
     ,{["3.5.2", "3.6.2.333"], "3.6.2.999", true}   %% x.y.z.p values are supported
     ,{["3.5.2", "3.6.2.333"], "3.6.2.222", false}  %% x.y.z.p values are supported
+    ,{["3.6.0", "3.7.0"], "3.6.3-alpha.1", true}   %% Pre-release versions handled like semver part
+    ,{["3.6.0", "3.7.0"], "3.7.0-alpha.89", true}
     ],
 
     lists:foreach(


### PR DESCRIPTION
Fixes #1090 

Pre-release version is considered to be less then its basic version by semver semantics (e.g. `3.7.0-alpha.68 < 3.7.0`)
But plugins should be valid for pre-release versions if version requirements contain release version.

Alpha version part is removed during plugin version check to avoid this inconsistency.