### PR TITLE
Support error messages returned from `check_X_access` in authz backend

### DIFF
--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -182,13 +182,17 @@ check_access(Fun, Module, ErrStr, ErrArgs, ErrName) ->
                 {error, E}  ->
                     rabbit_log:error(ErrStr ++ " by ~s: ~p~n",
                                      ErrArgs ++ [Module, E]),
-                    false;
+                    {false, ""};
+                {error_message, Message} ->
+                    rabbit_log:error(ErrStr ++ " by ~s: ~p~n",
+                                     ErrArgs ++ [Module, Message]),
+                    {false, Message};
                 Else ->
-                    Else
+                    {Else, ""}
             end,
     case Allow of
-        true ->
+        {true, _} ->
             ok;
-        false ->
-            rabbit_misc:protocol_error(ErrName, ErrStr, ErrArgs)
+        {false, M} ->
+            rabbit_misc:protocol_error(ErrName, ErrStr ++ M, ErrArgs)
     end.


### PR DESCRIPTION
Check functions now can return `{error_message, string()}` to
report a problem to clients in protocol error.

Part of https://github.com/rabbitmq/rabbitmq-auth-backend-uaa/pull/5
https://github.com/rabbitmq/rabbitmq-auth-backend-uaa/issues/3