### PR TITLE
Disable background GC by default; bump credit flow defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ define PROJECT_ENV
 	    %% setting has no effect because credit_flow is not used when
 	    %% writing to the queue index. See the setting
 	    %% queue_index_embed_msgs_below above.
-	    {msg_store_credit_disc_bound, {2000, 500}},
+	    {msg_store_credit_disc_bound, {3000, 800}},
 	    {msg_store_io_batch_size, 2048},
 	    %% see rabbitmq-server#143
 	    %% and rabbitmq-server#949

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ define PROJECT_ENV
 	    {msg_store_io_batch_size, 2048},
 	    %% see rabbitmq-server#143
 	    %% and rabbitmq-server#949
-	    {credit_flow_default_credit, {200, 100}},
+	    {credit_flow_default_credit, {400, 200}},
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667
 	    {channel_operation_timeout, 15000},
@@ -106,7 +106,7 @@ define PROJECT_ENV
 	    %% rabbitmq-server-973
 	    {queue_explicit_gc_run_operation_threshold, 1000},
 	    {lazy_queue_explicit_gc_run_operation_threshold, 1000},
-	    {background_gc_enabled, true},
+	    {background_gc_enabled, false},
 	    {background_gc_target_interval, 60000}
 	  ]
 endef


### PR DESCRIPTION
Quite a bit of evidence from different kinds of workloads suggest
that background GC does not contribute meaningfully to reducing
node RAM usage on most of them. It does, however, on each run
produce a massive spike in VM and CPU context switches,
causing latency spikes.

Some users report that running without background GC cuts
their latency to a half or even down to a third.

Multi-hour stress tests that max out all node CPU cores
suggest that our current credit_flow default can still be bumped
safely, reducing the amount of time publishers are throttled
and making publisher latency and node's observed message throughput
more predictable.