### PR TITLE
Makefile: Use rabbitmq-cli's Makefile `install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,17 +178,12 @@ endif
 
 .PHONY: copy-escripts clean-extra-sources clean-escripts
 
-ESCRIPT_COPIES_DIR = escript
-
-# We want to copy the `escript` directory in rabbitmq_cli locally. We
-# use pax(1) for that. pax(1) is a little weird to use (we need to cd to
-# the source directory) but its behavior is consistent accross systems,
-# unlike cp(1), in particular w.r.t. hardlinks handling.
+CLI_ESCRIPTS_DIR = escript
 
 copy-escripts:
-	$(gen_verbose) mkdir -p $(ESCRIPT_COPIES_DIR)
-	$(verbose) cd $(DEPS_DIR)/rabbitmq_cli/escript && \
-		pax -rw . $(abspath $(ESCRIPT_COPIES_DIR))
+	$(gen_verbose) $(MAKE) -C $(DEPS_DIR)/rabbitmq_cli install \
+		PREFIX="$(abspath $(CLI_ESCRIPTS_DIR))" \
+		DESTDIR=
 
 clean:: clean-extra-sources clean-escripts
 
@@ -196,7 +191,7 @@ clean-extra-sources:
 	$(gen_verbose) rm -f $(EXTRA_SOURCES)
 
 clean-escripts:
-	$(gen_verbose) rm -rf "$(ESCRIPT_COPIES_DIR)"
+	$(gen_verbose) rm -rf "$(CLI_ESCRIPTS_DIR)"
 
 # --------------------------------------------------------------------
 # Documentation.


### PR DESCRIPTION
Before this change, we used cp(1) and its `-r` flag to copy the source directory recursively. Pretty standard.

We are using hardlinks in the source directory because all escripts are the same code: the program uses the filename to determine the behavior. Pretty standard too. We settled on hardlinks, not symlinks, because on Windows, you need elevated privileges to use symlinks apparently.

Unfortunately, `cp -r` treats those hardlinks as separate files. thus the destination directory contains three distinct copies of the same file:

```
$ ls -l escript/
-rwxr-xr-x  1 dumbbell  dumbbell  4545805 Feb  8 17:25 rabbitmq-diagnostics
-rwxr-xr-x  1 dumbbell  dumbbell  4545805 Feb  8 17:25 rabbitmq-plugins
-rwxr-xr-x  1 dumbbell  dumbbell  4545805 Feb  8 17:25 rabbitmqctl
            ^---- Single references to distinct files

$ du -sh escript/
13M    escript/
```

I first tried with `-a` (cp(1) archive mode) instead of `-r`, but the behavior is inconsistent accross platforms. GNU coreutils' cp(1) preserves hardlinks as I would expect, but BSD cp does not. Indeed `-a`
isn't a standard option. BSD cp's manpage documents the behavior and suggests to use tar(1), cpio(1) or pax(1) when hardlinks are meant to be preserved.

tar(1) and cpio(1) are unavailable by default in MSYS2 (used on Windows), but pax(1) is. So now, we use pax(1) to copy the escript source directory and hardlinks are preserved on all platforms, including
Windows.

```
$ ls -l escript/
-rwxr-xr-x  3 dumbbell  dumbbell  4545805 Feb  8 13:53 rabbitmq-diagnostics
-rwxr-xr-x  3 dumbbell  dumbbell  4545805 Feb  8 13:53 rabbitmq-plugins
-rwxr-xr-x  3 dumbbell  dumbbell  4545805 Feb  8 13:53 rabbitmqctl
            ^---- Three references to a single file

$ du -sh escript/
4.4M   escript/
```

**v2**: The comment above is now obsolete. We use the new `install` target in rabbitmq-cli's `Makefile`. See rabbitmq/rabbitmq-cli#175 for more details.

[#138925175]