### PR TITLE
Initialize core stats before any gen_server2 is started

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -89,8 +89,8 @@
                    [{description, "core metrics storage"},
                     {mfa,         {rabbit_sup, start_child,
                                    [rabbit_metrics]}},
-                    {requires,    external_infrastructure},
-                    {enables,     kernel_ready}]}).
+                    {requires,    pre_boot},
+                    {enables,     external_infrastructure}]}).
 
 -rabbit_boot_step({rabbit_event,
                    [{description, "statistics event manager"},


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-top/issues/20