### PR TITLE
Rename msg_store_index:delete_by_file to index_cleanup_undefined_file

### DIFF
--- a/src/rabbit_msg_store.erl
+++ b/src/rabbit_msg_store.erl
@@ -1537,9 +1537,9 @@ index_update_fields(Key, Updates, #msstate { index_module = Index,
 index_delete(Key, #msstate { index_module = Index, index_state = State }) ->
     Index:delete(Key, State).
 
-index_delete_by_file(File, #msstate { index_module = Index,
+index_cleanup_undefined_file(#msstate { index_module = Index,
                                       index_state  = State }) ->
-    Index:delete_by_file(File, State).
+    Index:cleanup_undefined_file(State).
 
 %%----------------------------------------------------------------------------
 %% shutdown and recovery
@@ -1730,7 +1730,7 @@ build_index(Gatherer, Left, [],
         empty ->
             unlink(Gatherer),
             ok = gatherer:stop(Gatherer),
-            ok = index_delete_by_file(undefined, State),
+            ok = index_cleanup_undefined_file(State),
             Offset = case ets:lookup(FileSummaryEts, Left) of
                          []                                       -> 0;
                          [#file_summary { file_size = FileSize }] -> FileSize

--- a/src/rabbit_msg_store.erl
+++ b/src/rabbit_msg_store.erl
@@ -1537,9 +1537,10 @@ index_update_fields(Key, Updates, #msstate { index_module = Index,
 index_delete(Key, #msstate { index_module = Index, index_state = State }) ->
     Index:delete(Key, State).
 
-index_cleanup_undefined_file(#msstate { index_module = Index,
-                                      index_state  = State }) ->
-    Index:cleanup_undefined_file(State).
+index_clean_up_temporary_reference_count_entries(
+        #msstate { index_module = Index,
+                   index_state  = State }) ->
+    Index:clean_up_temporary_reference_count_entries_without_file(State).
 
 %%----------------------------------------------------------------------------
 %% shutdown and recovery
@@ -1730,7 +1731,7 @@ build_index(Gatherer, Left, [],
         empty ->
             unlink(Gatherer),
             ok = gatherer:stop(Gatherer),
-            ok = index_cleanup_undefined_file(State),
+            ok = index_clean_up_temporary_reference_count_entries(State),
             Offset = case ets:lookup(FileSummaryEts, Left) of
                          []                                       -> 0;
                          [#file_summary { file_size = FileSize }] -> FileSize

--- a/src/rabbit_msg_store_ets_index.erl
+++ b/src/rabbit_msg_store_ets_index.erl
@@ -22,7 +22,7 @@
 
 -export([new/1, recover/1,
          lookup/2, insert/2, update/2, update_fields/3, delete/2,
-         delete_object/2, delete_by_file/2, terminate/1]).
+         delete_object/2, cleanup_undefined_file/1, terminate/1]).
 
 -define(MSG_LOC_NAME, rabbit_msg_store_ets_index).
 -define(FILENAME, "msg_store_index.ets").
@@ -68,8 +68,8 @@ delete_object(Obj, State) ->
     true = ets:delete_object(State #state.table, Obj),
     ok.
 
-delete_by_file(File, State) ->
-    MatchHead = #msg_location { file = File, _ = '_' },
+cleanup_undefined_file(State) ->
+    MatchHead = #msg_location { file = undefined, _ = '_' },
     ets:select_delete(State #state.table, [{MatchHead, [], [true]}]),
     ok.
 

--- a/src/rabbit_msg_store_ets_index.erl
+++ b/src/rabbit_msg_store_ets_index.erl
@@ -22,7 +22,7 @@
 
 -export([new/1, recover/1,
          lookup/2, insert/2, update/2, update_fields/3, delete/2,
-         delete_object/2, cleanup_undefined_file/1, terminate/1]).
+         delete_object/2, clean_up_temporary_reference_count_entries_without_file/1, terminate/1]).
 
 -define(MSG_LOC_NAME, rabbit_msg_store_ets_index).
 -define(FILENAME, "msg_store_index.ets").
@@ -68,7 +68,7 @@ delete_object(Obj, State) ->
     true = ets:delete_object(State #state.table, Obj),
     ok.
 
-cleanup_undefined_file(State) ->
+clean_up_temporary_reference_count_entries_without_file(State) ->
     MatchHead = #msg_location { file = undefined, _ = '_' },
     ets:select_delete(State #state.table, [{MatchHead, [], [true]}]),
     ok.


### PR DESCRIPTION
Refactoring related to #838 
The `delete_by_file` function is used only once with `undefined` parameter.
For key-value store implementations (e.g. eleveldb) it's much easier to
implement, than maintaining a filename index. ETS index also can be optimised.