### PR TITLE
Provide some defaults for embedding

### DIFF
--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -840,11 +840,12 @@ with_running_or_clean_mnesia(Fun) ->
     case IsMnesiaRunning of
         true  -> Fun();
         false ->
+            SavedMnesiaDir = dir(),
             application:unset_env(mnesia, dir),
             mnesia:start(),
             Result = Fun(),
             application:stop(mnesia),
-            application:set_env(mnesia, dir, dir()),
+            application:set_env(mnesia, dir, SavedMnesiaDir),
             Result
     end.
 

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -840,12 +840,11 @@ with_running_or_clean_mnesia(Fun) ->
     case IsMnesiaRunning of
         true  -> Fun();
         false ->
-            {ok, MnesiaDir} = application:get_env(mnesia, dir),
             application:unset_env(mnesia, dir),
             mnesia:start(),
             Result = Fun(),
             application:stop(mnesia),
-            application:set_env(mnesia, dir, MnesiaDir),
+            application:set_env(mnesia, dir, dir()),
             Result
     end.
 


### PR DESCRIPTION
Sorry, erroneously submitted to `master` the first time.

This commit provides defaults for some paths (similar to the thing the
mnesia does with its `dir` parameter) that will allow us to start
broker in embedded mode without any additional configuration. The
minimal test-case is to issue the following commands from
`rabbitmq-server` checkout:

    make shell "SHELL_OPTS=-sname embed-friendly@localhost"
    > rabbit:start().