### PR TITLE
DO NOT MERGE Pluggable message stores experiment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ define PROJECT_ENV
 	    {memory_monitor_interval, 2500},
 	    {disk_free_limit, 50000000}, %% 50MB
 	    {msg_store_index_module, rabbit_msg_store_ets_index},
+	    {msg_store_module, rabbit_msg_store},
 	    {backing_queue_module, rabbit_variable_queue},
 	    %% 0 ("no limit") would make a better default, but that
 	    %% breaks the QPid Java client

--- a/src/rabbit_msg_store.erl
+++ b/src/rabbit_msg_store.erl
@@ -16,8 +16,7 @@
 
 -module(rabbit_msg_store).
 
--behaviour(gen_server2).
-
+-behaviour(rabbit_msg_store_behaviour).
 -export([start_link/4, start_global_store_link/4, successfully_recovered_state/1,
          client_init/4, client_terminate/1, client_delete_and_terminate/1,
          client_ref/1, close_all_indicated/1,
@@ -28,6 +27,7 @@
 
 -export([transform_dir/3, force_recovery/2]). %% upgrade
 
+-behaviour(gen_server2).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3, prioritise_call/4, prioritise_cast/3,
          prioritise_info/3, format_message_queue/2]).

--- a/src/rabbit_msg_store_behaviour.erl
+++ b/src/rabbit_msg_store_behaviour.erl
@@ -1,0 +1,65 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+
+-module(rabbit_msg_store_behaviour).
+
+-type msg_ref_delta_gen(A) ::
+        fun ((A) -> 'finished' |
+                    {rabbit_types:msg_id(), non_neg_integer(), A}).
+-type maybe_msg_id_fun() ::
+        'undefined' | fun ((gb_sets:set(), 'written' | 'ignored') -> any()).
+
+-type maybe_close_fds_fun() :: 'undefined' | fun (() -> 'ok').
+
+-type server() :: atom() | pid().
+
+-type client_ref() :: binary().
+
+-type msg() :: any().
+
+-export_type([msg_ref_delta_gen/1,
+              maybe_msg_id_fun/0,
+              maybe_close_fds_fun/0,
+              server/0,
+              client_ref/0,
+              msg/0]).
+
+-callback start_link (atom(), file:filename(),
+                      [binary()] | 'undefined',
+                      {msg_ref_delta_gen(A), A}) -> rabbit_types:ok_pid_or_error().
+
+-callback successfully_recovered_state(server()) -> boolean().
+
+-callback client_init(server(), client_ref(), maybe_msg_id_fun(), maybe_close_fds_fun()) -> term().
+
+-callback client_terminate(term()) -> 'ok'.
+
+-callback client_delete_and_terminate(term()) -> 'ok'.
+
+-callback client_ref(term()) -> client_ref().
+
+-callback close_all_indicated (term()) -> rabbit_types:ok(term()).
+
+-callback write(rabbit_types:msg_id(), msg(), term()) -> 'ok'.
+
+-callback write_flow(rabbit_types:msg_id(), msg(), term()) -> 'ok'.
+
+-callback read(rabbit_types:msg_id(), term()) -> {rabbit_types:ok(msg()) | 'not_found', term()}.
+
+-callback contains(rabbit_types:msg_id(), term()) -> boolean().
+
+-callback remove([rabbit_types:msg_id()], term()) -> 'ok'.

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -516,8 +516,6 @@ start_msg_store(VHost, Refs, StartFunState, IsEmpty) when is_list(Refs); Refs ==
         Other ->
             error(Other)
     end,
-    rabbit_file:read_term_file(msg_store_module_file(),
-                                [MsgStoreModule]),
     rabbit_log:info("Using ~p to provide message store", [MsgStoreModule]),
     do_start_msg_store(VHost, ?TRANSIENT_MSG_STORE, undefined, ?EMPTY_START_FUN_STATE, MsgStoreModule),
     do_start_msg_store(VHost, ?PERSISTENT_MSG_STORE, Refs, StartFunState, MsgStoreModule),

--- a/test/backing_queue_SUITE.erl
+++ b/test/backing_queue_SUITE.erl
@@ -377,7 +377,7 @@ on_disk_stop(Pid) ->
 
 msg_store_client_init_capture(MsgStore, Ref) ->
     Pid = spawn(fun on_disk_capture/0),
-    {rabbit_msg_store, MSCState} = rabbit_msg_store_vhost_sup:client_init(
+    {rabbit_msg_store, MSCState} = rabbit_vhost_msg_store:client_init(
             ?VHOST, MsgStore, Ref,
             fun (MsgIds, _ActionTaken) ->
                 Pid ! {on_disk, MsgIds}
@@ -460,7 +460,7 @@ test_msg_store_confirm_timer() ->
     Ref = rabbit_guid:gen(),
     MsgId  = msg_id_bin(1),
     Self = self(),
-    {rabbit_msg_store, MSCState} = rabbit_msg_store_vhost_sup:client_init(
+    {rabbit_msg_store, MSCState} = rabbit_vhost_msg_store:client_init(
                  ?VHOST,
                  ?PERSISTENT_MSG_STORE, Ref,
                  fun (MsgIds, _ActionTaken) ->
@@ -1342,7 +1342,7 @@ nop(_) -> ok.
 nop(_, _) -> ok.
 
 msg_store_client_init(MsgStore, Ref) ->
-    {rabbit_msg_store, MSCState} = rabbit_msg_store_vhost_sup:client_init(?VHOST, MsgStore, Ref, undefined, undefined),
+    {rabbit_msg_store, MSCState} = rabbit_vhost_msg_store:client_init(?VHOST, MsgStore, Ref, undefined, undefined),
     MSCState.
 
 variable_queue_init(Q, Recover) ->

--- a/test/backing_queue_SUITE.erl
+++ b/test/backing_queue_SUITE.erl
@@ -377,10 +377,13 @@ on_disk_stop(Pid) ->
 
 msg_store_client_init_capture(MsgStore, Ref) ->
     Pid = spawn(fun on_disk_capture/0),
-    {Pid, rabbit_vhost_msg_store:client_init(?VHOST, MsgStore, Ref,
-                                             fun (MsgIds, _ActionTaken) ->
-                                                 Pid ! {on_disk, MsgIds}
-                                             end, undefined)}.
+    {rabbit_msg_store, MSCState} = rabbit_msg_store_vhost_sup:client_init(
+            ?VHOST, MsgStore, Ref,
+            fun (MsgIds, _ActionTaken) ->
+                Pid ! {on_disk, MsgIds}
+            end,
+            undefined),
+    {Pid, MSCState}.
 
 msg_store_contains(Atom, MsgIds, MSCState) ->
     Atom = lists:foldl(
@@ -457,16 +460,15 @@ test_msg_store_confirm_timer() ->
     Ref = rabbit_guid:gen(),
     MsgId  = msg_id_bin(1),
     Self = self(),
-    MSCState = rabbit_vhost_msg_store:client_init(
-        ?VHOST,
-        ?PERSISTENT_MSG_STORE,
-        Ref,
-        fun (MsgIds, _ActionTaken) ->
-            case gb_sets:is_member(MsgId, MsgIds) of
-                true  -> Self ! on_disk;
-                false -> ok
-            end
-        end, undefined),
+    {rabbit_msg_store, MSCState} = rabbit_msg_store_vhost_sup:client_init(
+                 ?VHOST,
+                 ?PERSISTENT_MSG_STORE, Ref,
+                 fun (MsgIds, _ActionTaken) ->
+                         case gb_sets:is_member(MsgId, MsgIds) of
+                             true  -> Self ! on_disk;
+                             false -> ok
+                         end
+                 end, undefined),
     ok = msg_store_write([MsgId], MSCState),
     ok = msg_store_keep_busy_until_confirm([msg_id_bin(2)], MSCState, false),
     ok = msg_store_remove([MsgId], MSCState),
@@ -1340,7 +1342,8 @@ nop(_) -> ok.
 nop(_, _) -> ok.
 
 msg_store_client_init(MsgStore, Ref) ->
-    rabbit_vhost_msg_store:client_init(?VHOST, MsgStore, Ref,  undefined, undefined).
+    {rabbit_msg_store, MSCState} = rabbit_msg_store_vhost_sup:client_init(?VHOST, MsgStore, Ref, undefined, undefined),
+    MSCState.
 
 variable_queue_init(Q, Recover) ->
     rabbit_variable_queue:init(

--- a/test/backing_queue_SUITE.erl
+++ b/test/backing_queue_SUITE.erl
@@ -262,7 +262,7 @@ msg_store1(_Config) ->
                         {MsgId, 1, MsgIdsTail};
                     ([MsgId|MsgIdsTail]) ->
                         {MsgId, 0, MsgIdsTail}
-                end, MsgIds2ndHalf}),
+                end, MsgIds2ndHalf}, true),
     MSCState5 = msg_store_client_init(?PERSISTENT_MSG_STORE, Ref),
     %% check we have the right msgs left
     lists:foldl(
@@ -333,7 +333,7 @@ msg_store1(_Config) ->
 restart_msg_store_empty() ->
     ok = rabbit_variable_queue:stop_msg_store(?VHOST),
     ok = rabbit_variable_queue:start_msg_store(?VHOST,
-           undefined, {fun (ok) -> finished end, ok}).
+           undefined, {fun (ok) -> finished end, ok}, true).
 
 msg_id_bin(X) ->
     erlang:md5(term_to_binary(X)).

--- a/test/channel_operation_timeout_test_queue.erl
+++ b/test/channel_operation_timeout_test_queue.erl
@@ -237,11 +237,13 @@ start_msg_store(VHost, Refs, StartFunState) when is_list(Refs); Refs == undefine
     {ok, _} = rabbit_vhost_msg_store:start(VHost,
                                            ?TRANSIENT_MSG_STORE,
                                            undefined,
-                                           ?EMPTY_START_FUN_STATE),
+                                           ?EMPTY_START_FUN_STATE,
+                                           rabbit_msg_store),
     {ok, _} = rabbit_vhost_msg_store:start(VHost,
                                            ?PERSISTENT_MSG_STORE,
                                            Refs,
-                                           StartFunState),
+                                           StartFunState,
+                                           rabbit_msg_store),
     rabbit_log:info("Message stores for vhost '~s' are started~n", [VHost]).
 
 stop_msg_store(VHost) ->


### PR DESCRIPTION
In order to be able to use different implementation for message store,
the message store module is not called directly from rabbit_variable_queue,
instead it can be configured with application environment and will
be saved in a message store supervisor.

The message store has a bit more complex behaviour when confirming messages to be written on disk synchronously. It still needs to be described in the behaviour module comments.

This is a part of an experiment to replace a message store. 
The replacement module using ElevelDB can be found in [this repo](https://github.com/hairyhum/rabbitmq-msg-store-eleveldb)