### PR TITLE
Do not restart per-vhost message stores.

### DIFF
--- a/src/rabbit_msg_store_vhost_sup.erl
+++ b/src/rabbit_msg_store_vhost_sup.erl
@@ -17,7 +17,7 @@ start_link(Type, VhostsClientRefs, StartupFunState) when is_map(VhostsClientRefs
 
 init([Type, VhostsClientRefs, StartupFunState]) ->
     ets:new(Type, [named_table, public]),
-    {ok, {{simple_one_for_one, 1, 1},
+    {ok, {{simple_one_for_one, 0, 1},
         [{rabbit_msg_store_vhost, {rabbit_msg_store_vhost_sup, start_store_for_vhost,
                                    [Type, VhostsClientRefs, StartupFunState]},
            transient, infinity, supervisor, [rabbit_msg_store]}]}}.

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -507,11 +507,14 @@ stop() ->
     ok = rabbit_queue_index:stop().
 
 start_msg_store(Refs, StartFunState) when is_map(Refs); Refs == undefined ->
-    ok = rabbit_sup:start_child(?TRANSIENT_MSG_STORE_SUP, rabbit_msg_store_vhost_sup,
-                                [?TRANSIENT_MSG_STORE_SUP,
-                                 undefined,  {fun (ok) -> finished end, ok}]),
-    ok = rabbit_sup:start_child(?PERSISTENT_MSG_STORE_SUP, rabbit_msg_store_vhost_sup,
-                                [?PERSISTENT_MSG_STORE_SUP, Refs, StartFunState]),
+    ok = rabbit_sup:start_supervisor_child(
+            ?TRANSIENT_MSG_STORE_SUP,
+            rabbit_msg_store_vhost_sup,
+            [?TRANSIENT_MSG_STORE_SUP,
+             undefined,  {fun (ok) -> finished end, ok}]),
+    ok = rabbit_sup:start_supervisor_child(
+            ?PERSISTENT_MSG_STORE_SUP, rabbit_msg_store_vhost_sup,
+            [?PERSISTENT_MSG_STORE_SUP, Refs, StartFunState]),
     %% Start message store for all known vhosts
     VHosts = rabbit_vhost:list(),
     %% TODO: recovery is limited by queue index recovery
@@ -2925,10 +2928,11 @@ run_old_persistent_store(Refs, StartFunState) ->
 
 start_new_store_sup() ->
     % Start persistent store sup without recovery.
-    ok = rabbit_sup:start_child(?PERSISTENT_MSG_STORE_SUP,
-                                rabbit_msg_store_vhost_sup,
-                                [?PERSISTENT_MSG_STORE_SUP,
-                                 undefined,  {fun (ok) -> finished end, ok}]),
+    ok = rabbit_sup:start_supervisor_child(
+            ?PERSISTENT_MSG_STORE_SUP,
+            rabbit_msg_store_vhost_sup,
+            [?PERSISTENT_MSG_STORE_SUP,
+             undefined,  {fun (ok) -> finished end, ok}]),
     ?PERSISTENT_MSG_STORE_SUP.
 
 delete_old_store(OldStore) ->


### PR DESCRIPTION
Minimal solution to #1146
Set max_restarts to 0 for per-vhost message stores.
Crashed message store will terminate a node.