### PR TITLE
Fix lager initialization code

### DIFF
--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -185,7 +185,7 @@ configure_lager() ->
             %% Setting env var to 'undefined' is different from not
             %% setting it at all, and lager is sensitive to this
             %% difference.
-            case application:get_env(rabbit, lager_log_root, undefined) of
+            case application:get_env(rabbit, lager_log_root) of
                 {ok, FromRabbitConfig} ->
                     application:set_env(lager, log_root, FromRabbitConfig);
                 _ ->

--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -182,9 +182,15 @@ configure_lager() ->
     end,
     case application:get_env(lager, log_root) of
         undefined ->
-            application:set_env(lager, log_root,
-                                application:get_env(rabbit, lager_log_root,
-                                                    undefined));
+            %% Setting env var to 'undefined' is different from not
+            %% setting it at all, and lager is sensitive to this
+            %% difference.
+            case application:get_env(rabbit, lager_log_root, undefined) of
+                {ok, FromRabbitConfig} ->
+                    application:set_env(lager, log_root, FromRabbitConfig);
+                _ ->
+                    ok
+            end;
         _ -> ok
     end,
 


### PR DESCRIPTION
Setting env var to 'undefined' is different from not setting it at
all, and lager is sensitive to this distinction in its 'log_root'
parameter. There will be a crash when rabbit is started without the
help of startup scripts (i.e. from `make shell` or in the embedded
mode).