### PR TITLE
rabbit_epmd_monitor: call register_node on Mod, not its default

### DIFF
--- a/src/rabbit_epmd_monitor.erl
+++ b/src/rabbit_epmd_monitor.erl
@@ -92,6 +92,6 @@ check_epmd(#state{mod  = Mod,
                     "epmd does not know us, re-registering ~s at port ~b~n",
                     [Me, Port]),
                   rabbit_nodes:ensure_epmd(),
-                  erl_epmd:register_node(Me, Port);
+                  Mod:register_node(Me, Port);
         _      -> ok
     end.


### PR DESCRIPTION
The module-to-be-called is stored in `init/1` in case it was overridden, so we should also call that possibly-overridden module, and not the default, to `register_node/2`.

(trivial change)