### PR TITLE
Re-enable disk_monitor in case of parser failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,9 @@ define PROJECT_ENV
 	    {queue_explicit_gc_run_operation_threshold, 1000},
 	    {lazy_queue_explicit_gc_run_operation_threshold, 1000},
 	    {background_gc_enabled, false},
-	    {background_gc_target_interval, 60000}
+	    {background_gc_target_interval, 60000},
+	    {disk_monitor_enable_retries, 10},
+	    {disk_monitor_enable_interval, 120000}
 	  ]
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,8 @@ define PROJECT_ENV
 	    {lazy_queue_explicit_gc_run_operation_threshold, 1000},
 	    {background_gc_enabled, false},
 	    {background_gc_target_interval, 60000},
-	    {disk_monitor_enable_retries, 10},
-	    {disk_monitor_enable_interval, 120000}
+	    {disk_monitor_failure_retries, 10},
+	    {disk_monitor_failure_retry_interval, 120000}
 	  ]
 endef
 

--- a/src/rabbit_disk_monitor.erl
+++ b/src/rabbit_disk_monitor.erl
@@ -119,8 +119,8 @@ start_link(Args) ->
 
 init([Limit]) ->
     Dir = dir(),
-    {ok, Retries} = application:get_env(rabbit, disk_monitor_enable_retries),
-    {ok, Interval} = application:get_env(rabbit, disk_monitor_enable_interval),
+    {ok, Retries} = application:get_env(rabbit, disk_monitor_failure_retries),
+    {ok, Interval} = application:get_env(rabbit, disk_monitor_failure_retry_interval),
     State = #state{dir          = Dir,
                    min_interval = ?DEFAULT_MIN_DISK_CHECK_INTERVAL,
                    max_interval = ?DEFAULT_MAX_DISK_CHECK_INTERVAL,

--- a/src/rabbit_disk_monitor.erl
+++ b/src/rabbit_disk_monitor.erl
@@ -250,7 +250,7 @@ interpret_limit(Absolute) ->
 
 emit_update_info(StateStr, CurrentFree, Limit) ->
     rabbit_log:info(
-      "Disk free space ~s. Free bytes:~p Limit:~p~n",
+      "Free disk space is ~s. Free bytes: ~p. Limit: ~p~n",
       [StateStr, CurrentFree, Limit]).
 
 start_timer(State) ->

--- a/src/rabbit_disk_monitor.erl
+++ b/src/rabbit_disk_monitor.erl
@@ -273,12 +273,12 @@ enable(#state{dir = Dir, interval = Interval, limit = Limit, retries = Retries}
     case {catch get_disk_free(Dir),
           vm_memory_monitor:get_total_memory()} of
         {N1, N2} when is_integer(N1), is_integer(N2) ->
-            rabbit_log:info("Enabling disk free space monitoring~n", []),
+            rabbit_log:info("Enabling free disk space monitoring~n", []),
             start_timer(set_disk_limits(State, Limit));
         Err ->
-            rabbit_log:info("Disabling disk free space monitoring "
-                            "on unsupported platform, ~p retries left:~n~p~n",
-                            [Retries, Err]),
+            rabbit_log:info("Free disk space monitor encountered an error "
+                            "(e.g. failed to parse output from OS tools): ~p, retries left: ~s~n",
+                            [Err, Retries]),
             timer:send_after(Interval, self(), try_enable),
             State#state{enabled = false}
     end.

--- a/test/unit_inbroker_non_parallel_SUITE.erl
+++ b/test/unit_inbroker_non_parallel_SUITE.erl
@@ -761,8 +761,8 @@ disk_monitor_enable1(_Config) ->
 disk_monitor_enable1() ->
     ok = meck:new(rabbit_misc, [passthrough]),
     ok = meck:expect(rabbit_misc, os_cmd, fun(_) -> "\n" end),
-    application:set_env(rabbit, disk_monitor_enable_retries, 20000),
-    application:set_env(rabbit, disk_monitor_enable_interval, 100),
+    application:set_env(rabbit, disk_monitor_failure_retries, 20000),
+    application:set_env(rabbit, disk_monitor_failure_retry_interval, 100),
     ok = rabbit_sup:stop_child(rabbit_disk_monitor_sup),
     ok = rabbit_sup:start_delayed_restartable_child(rabbit_disk_monitor, [1000]),
     undefined = rabbit_disk_monitor:get_disk_free(),
@@ -772,8 +772,8 @@ disk_monitor_enable1() ->
     Bytes = 740758908 * 1024,
     Bytes = rabbit_disk_monitor:get_disk_free(),
     meck:unload(rabbit_misc),
-    application:set_env(rabbit, disk_monitor_enable_retries, 10),
-    application:set_env(rabbit, disk_monitor_enable_interval, 120000),
+    application:set_env(rabbit, disk_monitor_failure_retries, 10),
+    application:set_env(rabbit, disk_monitor_failure_retry_interval, 120000),
     passed.
 
 %% ---------------------------------------------------------------------------


### PR DESCRIPTION
Parser failures could be transient on start-up, so retry a few times
before giving up.

https://github.com/rabbitmq/rabbitmq-server/issues/1178
