### PR TITLE
Add IPv6 support for DNS discovery

### DIFF
--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -68,13 +68,8 @@ discover_nodes(SeedHostname, LongNamesUsed) ->
         H <- discover_hostnames(SeedHostname, LongNamesUsed)].
 
 discover_hostnames(SeedHostname, LongNamesUsed) ->
-    case lookup(SeedHostname, LongNamesUsed, ipv4) of
-	[] ->
-	    rabbit_log:info("Hostnames lookup failed for IPv4, trying IPv6"),
-	    lookup(SeedHostname, LongNamesUsed, ipv6);
-	Hosts4 -> Hosts4
-    end.
-
+    lookup(SeedHostname, LongNamesUsed, ipv4) ++
+    lookup(SeedHostname, LongNamesUsed, ipv6).
 
 decode_record(ipv4) ->
     a;

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -68,13 +68,29 @@ discover_nodes(SeedHostname, LongNamesUsed) ->
         H <- discover_hostnames(SeedHostname, LongNamesUsed)].
 
 discover_hostnames(SeedHostname, LongNamesUsed) ->
-    %% TODO: IPv6 support
-    IPs   = inet_res:lookup(SeedHostname, in, a),
-    rabbit_log:info("Addresses discovered via A records of ~s: ~s",
-      [SeedHostname, string:join([inet_parse:ntoa(IP) || IP <- IPs], ", ")]),
+    case lookup(SeedHostname, LongNamesUsed, ipv4) of
+	[] ->
+	    rabbit_log:info("Hostnames lookup failed for IPv4, trying IPv6"),
+	    lookup(SeedHostname, LongNamesUsed, ipv6);
+	Hosts4 -> Hosts4
+    end.
+
+
+decode_record(ipv4) ->
+    a;
+decode_record(ipv6) ->
+    aaaa.
+
+lookup(SeedHostname, LongNamesUsed, IPv) ->
+    IPs   = inet_res:lookup(SeedHostname, in, decode_record(IPv)),
+    rabbit_log:info("Addresses discovered via ~s records of ~s: ~s",
+		    [string:to_upper(atom_to_list(decode_record(IPv))),
+		     SeedHostname, 
+		     string:join([inet_parse:ntoa(IP) || IP <- IPs], ", ")]),
     Hosts = [extract_host(inet:gethostbyaddr(A), LongNamesUsed, A) ||
-                A <- IPs],
+		A <- IPs],
     lists:filter(fun(E) -> E =/= error end, Hosts).
+
 
 %% long node names are used
 extract_host({ok, {hostent, FQDN, _, _, _, _}}, true, _Address) ->


### PR DESCRIPTION

I have implemented two versions:

1. [First one](https://github.com/rabbitmq/rabbitmq-server/commit/875c327c6b99cdc7d6811d0aa8b6ac0f944493b3),  it checks if there are `IPv4` hosts and then `IPv6`

2. [Second one](https://github.com/rabbitmq/rabbitmq-server/commit/61414f95d26a201c270d8c3dcde77c815ec86acd), it joins both results.

I think the second one it the best one, unless we want to add another parameter to decide the IP version ex:

```
autocluster.peer_discovery_backend = rabbit_peer_discovery_dns
autocluster.dns.hostname = discovery.eng.example.local
autocluster.dns.ipversion = ipv4 #the new one
``` 

To easy test it:

```
(rabbit@mac)1> rabbit_peer_discovery_dns:discover_hostnames("www.v6.facebook.com", true).
["v6-prod6-shv-09-frc3.facebook.com"]
(rabbit@mac)2> 
(rabbit@mac)2> 
(rabbit@mac)2> 
(rabbit@mac)2> rabbit_peer_discovery_dns:discover_hostnames("peer_discovery.tests.rabbitmq.net", true).
["www.rabbitmq.com"]
```

thoughts?

