### PR TITLE
[master] RabbitMQ-server does not quit with Ctrl-C

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 ##  The contents of this file are subject to the Mozilla Public License
 ##  Version 1.1 (the "License"); you may not use this file except in
 ##  compliance with the License. You may obtain a copy of the License
@@ -14,6 +14,10 @@
 ##  The Initial Developer of the Original Code is GoPivotal, Inc.
 ##  Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
 ##
+
+# Exit immediately if a pipeline, which may consist of a single simple command,
+# a list, or a compound command returns a non-zero status
+set -e
 
 # Get default settings with user overrides for (RABBITMQ_)<var_name>
 # Non-empty defaults should be set in rabbitmq-env
@@ -288,11 +292,12 @@ else
     #     They are considered an abnormal process termination, the script
     #     exits with the job exit code.
     trap "stop_rabbitmq_server; exit 0" HUP TERM TSTP
-    trap "stop_rabbitmq_server" INT
+    trap "stop_rabbitmq_server; exit 130" INT
 
     start_rabbitmq_server "$@" &
 
     # Block until RabbitMQ exits or a signal is caught.
     # Waits for last command (which is start_rabbitmq_server)
-    wait $!
+    # This noop fixes dash's trap handling bug.
+    wait $! || true
 fi


### PR DESCRIPTION
The is something in `rabbitmq-server` that prevents `dash` from honoring the `trap` calls in lines 290-291.
In that cases "control-c" will kill the script but leave `epmd` and `beam` still running in the background. 

Changing from `dash` to `bash` fixes this problem.