### PR TITLE
Makefile: Fix malformed manpages with GNU sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,8 @@ clean-extra-sources:
 	    opt='--stringparam man.indent.verbatims=0' ; \
 	xsltproc --novalid $(DOCS_DIR)/examples-to-end.xsl $< > $<.tmp && \
 	xmlto -vv -o $(DOCS_DIR) $$opt man $< 2>&1 | (grep -v '^Note: Writing' || :) && \
+	awk -F"'u " '/^\.HP / { print $$1; print $$2; next; } { print; }' "$@" > "$@.tmp" && \
+	mv "$@.tmp" "$@" && \
 	test -f $@ && \
 	rm $<.tmp
 


### PR DESCRIPTION
The generated manpage contains malformed `.HP` directives:
```
.HP \w'\fBstop\fR\ 'u \fBstop\fR [\fIpid_file\fR]
```

The `.HP` directive takes one argument, the indentation. Thus, the first line (which is not indented) should be on the next line:
```
.HP \w'\fBstop\fR\ 'u
\fBstop\fR [\fIpid_file\fR]
```

We use GNU sed to add that newline. On FreeBSD, BSD sed doesn't interpret the `\n` in the replacement string, that's why we target GNU sed specifically here.

Manpages will be converted to mdoc(7) in master so we are sure of the formatting. The DocBook versions will be dropped. This will also simplify the build process.

References #1180.
[#143563295]