### PR TITLE
[stable] RabbitMQ-server does not quit with Ctrl-C

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -243,11 +243,12 @@ else
     #     They are considered an abnormal process termination, the script
     #     exits with the job exit code.
     trap "stop_rabbitmq_server; exit 0" HUP TERM TSTP
-    trap "stop_rabbitmq_server" INT
+    trap "stop_rabbitmq_server; exit 130" INT
 
     start_rabbitmq_server "$@" &
 
     # Block until RabbitMQ exits or a signal is caught.
     # Waits for last command (which is start_rabbitmq_server)
-    wait $!
+    # This noop fixes dash's trap handling bug.
+    wait $! || true
 fi


### PR DESCRIPTION
This is the same PR as #1192 but against `stable`. 

/bin/sh may point to dash which has a bug with the trap calls in
lines 290-291. In that case "control-c" will kill the wait
command and leave rabbitmq-server still running in the
background.

The fix is to add a noop around the wait command.

Signed-off-by: Patrick Sodré <sodre@sodre.co>