### PR TITLE
Ensure ERL_LIBS starts with a valid path

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -417,7 +417,12 @@ set paths=
 exit /b
 
 :filter_path
-set ERL_LIBS=%ERL_LIBS%;%~dps1%~n1%~x1
+REM Ensure ERL_LIBS begins with valid path
+IF [%ERL_LIBS%] EQU [] (
+    set ERL_LIBS=%~dps1%~n1%~x1
+) else (
+    set ERL_LIBS=%ERL_LIBS%;%~dps1%~n1%~x1
+)
 exit /b
 
 :filter_paths_done


### PR DESCRIPTION
Works around empty value for `ERL_LIBS` on first call to `:filter_path` which was causing erl.exe to crash on any rabbitmq command.

