### PR TITLE
Inject a randomized startup delay

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -328,6 +328,8 @@ broker_start() ->
     start_apps(ToBeLoaded),
     maybe_sd_notify(),
     ok = log_broker_started(rabbit_plugins:strictly_plugins(rabbit_plugins:active())),
+    %% See rabbitmq/rabbitmq-server#1202 for details.
+    rabbit_peer_discovery:maybe_inject_randomized_delay(),
     rabbit_peer_discovery:maybe_register(),
     ok.
 

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -119,6 +119,8 @@ init_from_config() ->
         (Name, BadNames) when is_atom(Name) -> BadNames;
         (Name, BadNames)                    -> [Name | BadNames]
     end,
+    %% See rabbitmq/rabbitmq-server#1202 for details.
+    rabbit_peer_discovery:maybe_inject_randomized_delay(),
     {DiscoveredNodes, NodeType} =
         case rabbit_peer_discovery:discover_cluster_nodes() of
             {ok, {Nodes, Type} = Config}


### PR DESCRIPTION
…for peer discovery backends that support registration.

Fixes #1202.
