### PR TITLE
Check rabbit is running after the boot process finishes

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -19,7 +19,7 @@
 -behaviour(application).
 
 -export([start/0, boot/0, stop/0,
-         stop_and_halt/0, await_startup/0, await_startup2/0, status/0, is_running/0,
+         stop_and_halt/0, await_startup/0, status/0, is_running/0,
          is_running/1, environment/0, rotate_logs/1, force_event_refresh/1,
          start_fhc/0]).
 -export([start/2, stop/1]).
@@ -604,22 +604,6 @@ handle_app_error(Term) ->
     end.
 
 await_startup() ->
-    await_startup(false).
-
-await_startup(HaveSeenRabbitBoot) ->
-    %% We don't take absence of rabbit_boot as evidence we've started,
-    %% since there's a small window before it is registered.
-    case whereis(rabbit_boot) of
-        undefined -> case HaveSeenRabbitBoot orelse is_running() of
-                         true  -> ok;
-                         false -> timer:sleep(100),
-                                  await_startup(false)
-                     end;
-        _         -> timer:sleep(100),
-                     await_startup(true)
-    end.
-
-await_startup2() ->
     case is_booting() of
         true -> wait_to_finish_booting();
         false ->

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -787,7 +787,7 @@ wait_for_application(Node, Pid, Application) ->
 
 wait_for_startup(Node, Pid) ->
     while_process_is_alive(
-      Node, Pid, fun() -> rpc:call(Node, rabbit, await_startup2, []) =:= ok end).
+      Node, Pid, fun() -> rpc:call(Node, rabbit, await_startup, []) =:= ok end).
 
 while_process_is_alive(Node, Pid, Activity) ->
     case rabbit_misc:is_os_process_alive(Pid) of

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -787,7 +787,7 @@ wait_for_application(Node, Pid, Application) ->
 
 wait_for_startup(Node, Pid) ->
     while_process_is_alive(
-      Node, Pid, fun() -> rpc:call(Node, rabbit, await_startup, []) =:= ok end).
+      Node, Pid, fun() -> rpc:call(Node, rabbit, await_startup2, []) =:= ok end).
 
 while_process_is_alive(Node, Pid, Activity) ->
     case rabbit_misc:is_os_process_alive(Pid) of


### PR DESCRIPTION
Boot process can exit if boot fails. It can result in rabbit:await_startup/0 returning ok & rabbitmqctl wait exiting with exit status 0.

WIP, still need to add some tests.

Signed-off-by: Gerhard Lazu <gerhard@rabbitmq.com>

re #1214

[#145043957]