### PR TITLE
Revert "Use new supervisor2:prep_stop to stop rabbit dependencies on shutdown"

### DIFF
--- a/src/rabbit_sup.erl
+++ b/src/rabbit_sup.erl
@@ -16,7 +16,7 @@
 
 -module(rabbit_sup).
 
--behaviour(supervisor2).
+-behaviour(supervisor).
 
 -export([start_link/0, start_child/1, start_child/2, start_child/3, start_child/4,
          start_supervisor_child/1, start_supervisor_child/2,
@@ -25,7 +25,7 @@
          start_delayed_restartable_child/1, start_delayed_restartable_child/2,
          stop_child/1]).
 
--export([init/1, prep_stop/0]).
+-export([init/1]).
 
 -include("rabbit.hrl").
 
@@ -49,20 +49,20 @@
 
 %%----------------------------------------------------------------------------
 
-start_link() -> supervisor2:start_link({local, ?SERVER}, ?MODULE, []).
+start_link() -> supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
 start_child(Mod) -> start_child(Mod, []).
 
 start_child(Mod, Args) -> start_child(Mod, Mod, Args).
 
 start_child(ChildId, Mod, Args) ->
-    child_reply(supervisor2:start_child(
+    child_reply(supervisor:start_child(
                   ?SERVER,
                   {ChildId, {Mod, start_link, Args},
                    transient, ?WORKER_WAIT, worker, [Mod]})).
 
 start_child(ChildId, Mod, Fun, Args) ->
-    child_reply(supervisor2:start_child(
+    child_reply(supervisor:start_child(
                   ?SERVER,
                   {ChildId, {Mod, Fun, Args},
                    transient, ?WORKER_WAIT, worker, [Mod]})).
@@ -73,7 +73,7 @@ start_supervisor_child(Mod) -> start_supervisor_child(Mod, []).
 start_supervisor_child(Mod, Args) -> start_supervisor_child(Mod, Mod, Args).
 
 start_supervisor_child(ChildId, Mod, Args) ->
-    child_reply(supervisor2:start_child(
+    child_reply(supervisor:start_child(
                   ?SERVER,
                   {ChildId, {Mod, start_link, Args},
                    transient, infinity, supervisor, [Mod]})).
@@ -85,25 +85,20 @@ start_delayed_restartable_child(M, A) -> start_restartable_child(M, A,  true).
 
 start_restartable_child(Mod, Args, Delay) ->
     Name = list_to_atom(atom_to_list(Mod) ++ "_sup"),
-    child_reply(supervisor2:start_child(
+    child_reply(supervisor:start_child(
                   ?SERVER,
                   {Name, {rabbit_restartable_sup, start_link,
                           [Name, {Mod, start_link, Args}, Delay]},
                    transient, infinity, supervisor, [rabbit_restartable_sup]})).
 
 stop_child(ChildId) ->
-    case supervisor2:terminate_child(?SERVER, ChildId) of
-        ok -> supervisor2:delete_child(?SERVER, ChildId);
+    case supervisor:terminate_child(?SERVER, ChildId) of
+        ok -> supervisor:delete_child(?SERVER, ChildId);
         E  -> E
     end.
 
 init([]) -> {ok, {{one_for_all, 0, 1}, []}}.
 
-prep_stop() ->
-    rabbit_log:info("Stopping dependencies...~n",[]),
-    Apps = rabbit_plugins:active(),
-    rabbit:stop_apps(app_utils:app_dependency_order(Apps, true)),
-    rabbit_log:info("Dependencies stopped...~n",[]).
 
 %%----------------------------------------------------------------------------
 

--- a/test/clustering_management_SUITE.erl
+++ b/test/clustering_management_SUITE.erl
@@ -180,7 +180,8 @@ join_cluster_bad_operations(Config) ->
     ok = stop_app(Hare),
     assert_failure(fun () -> start_app(Hare) end),
     ok = start_app(Rabbit),
-    ok = start_app(Hare),
+    %% The Erlang VM has stopped after previous rabbit app failure
+    ok = rabbit_ct_broker_helpers:start_node(Config, Hare),
     ok.
 
 %% This tests that the nodes in the cluster are notified immediately of a node
@@ -532,25 +533,34 @@ erlang_config(Config) ->
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, {["Mike's computer"], disc}]),
+    %% Rabbit app stops abnormally, node goes down
     assert_failure(fun () -> start_app(Hare) end),
     assert_not_clustered(Rabbit),
 
     %% If we use an invalid node type, the node fails to start.
+    %% The Erlang VM has stopped after previous rabbit app failure
+    ok = rabbit_ct_broker_helpers:start_node(Config, Hare),
     ok = stop_app(Hare),
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, {[Rabbit], blue}]),
+    %% Rabbit app stops abnormally, node goes down
     assert_failure(fun () -> start_app(Hare) end),
     assert_not_clustered(Rabbit),
 
     %% If we use an invalid cluster_nodes conf, the node fails to start.
+    %% The Erlang VM has stopped after previous rabbit app failure
+    ok = rabbit_ct_broker_helpers:start_node(Config, Hare),
     ok = stop_app(Hare),
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, true]),
+    %% Rabbit app stops abnormally, node goes down
     assert_failure(fun () -> start_app(Hare) end),
     assert_not_clustered(Rabbit),
 
+    %% The Erlang VM has stopped after previous rabbit app failure
+    ok = rabbit_ct_broker_helpers:start_node(Config, Hare),
     ok = stop_app(Hare),
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,


### PR DESCRIPTION
This reverts commit dcf15e7d894e536cc09bc065310d97fcee6c7d12.
Unnecessary when making rabbit application transient

Part of #1216