### PR TITLE
Don't expand plugins that are already unpacked

### DIFF
--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -262,12 +262,12 @@ prepare_plugin(#plugin{type = ez, name = Name, location = Location}, ExpandDir) 
                 [PluginAppDescPath|_] ->
                     prepare_dir_plugin(PluginAppDescPath);
                 _ ->
-                    rabbit_log:error("Plugin archive '~s' doesn't contain .app file~n", [Location]),
-                    throw({no_plugin_app_file_in_archive, Name, Location})
+                    rabbit_log:error("Plugin archive '~s' doesn't contain an .app file~n", [Location]),
+                    throw({app_file_missing, Name, Location})
             end;
         {error, Reason} ->
-            rabbit_log:error("Plugin archive '~s' unpacking failed: ~p~n", [Location, Reason]),
-            throw({plugin_unpack_failed, Name, Location, Reason})
+            rabbit_log:error("Could not unzip plugin archive '~s': ~p~n", [Location, Reason]),
+            throw({failed_to_unzip_plugin, Name, Location, Reason})
     end;
 prepare_plugin(#plugin{type = dir, location = Location, name = Name},
                _ExpandDir) ->
@@ -276,7 +276,7 @@ prepare_plugin(#plugin{type = dir, location = Location, name = Name},
             prepare_dir_plugin(PluginAppDescPath);
         _ ->
             rabbit_log:error("Plugin directory '~s' doesn't contain an .app file~n", [Location]),
-            throw({no_plugin_app_file_in_directory, Name, Location})
+            throw({app_file_missing, Name, Location})
     end.
 
 plugin_info({ez, EZ}) ->

--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -103,7 +103,7 @@ setup() ->
 
 %% @doc Lists the plugins which are currently running.
 active() ->
-    InstalledPlugins = plugin_names(list(plugins_expand_dir())),
+    InstalledPlugins = plugin_names(list(plugins_dist_dir())),
     [App || {App, _, _} <- rabbit_misc:which_applications(),
             lists:member(App, InstalledPlugins)].
 
@@ -200,9 +200,6 @@ prepare_plugins(Enabled) ->
     end,
 
     [prepare_plugin(Plugin, ExpandDir) || Plugin <- WantedPlugins],
-
-    [prepare_dir_plugin(PluginAppDescPath) ||
-        PluginAppDescPath <- filelib:wildcard(ExpandDir ++ "/*/ebin/*.app")],
     Wanted.
 
 clean_plugins(Plugins) ->
@@ -250,11 +247,37 @@ delete_recursively(Fn) ->
         {error, {Path, E}} -> {error, {cannot_delete, Path, E}}
     end.
 
-prepare_plugin(#plugin{type = ez, location = Location}, ExpandDir) ->
-    zip:unzip(Location, [{cwd, ExpandDir}]);
-prepare_plugin(#plugin{type = dir, name = Name, location = Location},
-               ExpandDir) ->
-    rabbit_file:recursive_copy(Location, filename:join([ExpandDir, Name])).
+find_unzipped_app_file(ExpandDir, Files) ->
+    StripComponents = length(filename:split(ExpandDir)),
+    [ X || X <- Files,
+           [_AppName, "ebin", MaybeAppFile] <-
+               [lists:nthtail(StripComponents, filename:split(X))],
+           lists:suffix(".app", MaybeAppFile)
+    ].
+
+prepare_plugin(#plugin{type = ez, name = Name, location = Location}, ExpandDir) ->
+    case zip:unzip(Location, [{cwd, ExpandDir}]) of
+        {ok, Files} ->
+            case find_unzipped_app_file(ExpandDir, Files) of
+                [PluginAppDescPath|_] ->
+                    prepare_dir_plugin(PluginAppDescPath);
+                _ ->
+                    rabbit_log:error("Plugin archive '~s' doesn't contain .app file~n", [Location]),
+                    throw({no_plugin_app_file_in_archive, Name, Location})
+            end;
+        {error, Reason} ->
+            rabbit_log:error("Plugin archive '~s' unpacking failed: ~p~n", [Location, Reason]),
+            throw({plugin_unpack_failed, Name, Location, Reason})
+    end;
+prepare_plugin(#plugin{type = dir, location = Location, name = Name},
+               _ExpandDir) ->
+    case filelib:wildcard(Location ++ "/ebin/*.app") of
+        [PluginAppDescPath|_] ->
+            prepare_dir_plugin(PluginAppDescPath);
+        _ ->
+            rabbit_log:error("Plugin directory '~s' doesn't contain an .app file~n", [Location]),
+            throw({no_plugin_app_file_in_directory, Name, Location})
+    end.
 
 plugin_info({ez, EZ}) ->
     case read_app_file(EZ) of


### PR DESCRIPTION
This prevents creating unnecessary files when running in embedded
mode, and in development mode it keeps code path clean and compatible
with different interactive tools.