### PR TITLE
OTP-20 compatibility workaround for queue directory names. 3.6 only!

### DIFF
--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -653,7 +653,7 @@ recover_message(false,     _, no_del,  RelSeq, {Segment, DirtyCount}) ->
      DirtyCount + 2}.
 
 queue_name_to_dir_name(Name = #resource { kind = queue }) ->
-    <<Num:128>> = erlang:md5(term_to_binary(Name)),
+    <<Num:128>> = erlang:md5(term_to_binary_compat:queue_name_to_binary(Name)),
     rabbit_misc:format("~.36B", [Num]).
 
 queues_dir() ->

--- a/src/term_to_binary_compat.erl
+++ b/src/term_to_binary_compat.erl
@@ -1,0 +1,32 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(term_to_binary_compat).
+
+-include("rabbit.hrl").
+
+-export([queue_name_to_binary/1]).
+
+queue_name_to_binary(#resource{kind = queue} = {resource, VHost, queue, Name}) ->
+    VHostBSize = byte_size(VHost),
+    NameBSize = byte_size(Name),
+    <<131,
+      104, 4,
+      100, 0, 8, "resource",
+      109, VHostBSize:32, VHost/binary,
+      100, 0, 5, "queue",
+      109, NameBSize:32, Name/binary>>.
+

--- a/src/term_to_binary_compat.erl
+++ b/src/term_to_binary_compat.erl
@@ -23,10 +23,10 @@
 queue_name_to_binary(#resource{kind = queue} = {resource, VHost, queue, Name}) ->
     VHostBSize = byte_size(VHost),
     NameBSize = byte_size(Name),
-    <<131,
-      104, 4,
-      100, 0, 8, "resource",
-      109, VHostBSize:32, VHost/binary,
-      100, 0, 5, "queue",
-      109, NameBSize:32, Name/binary>>.
+    <<131,                              %% Binary format "version"
+      104, 4,                           %% 4-element tuple
+      100, 0, 8, "resource",            %% `resource` atom
+      109, VHostBSize:32, VHost/binary, %% Vhost binary
+      100, 0, 5, "queue",               %% `queue` atom
+      109, NameBSize:32, Name/binary>>. %% Name binary
 

--- a/test/backing_queue_SUITE.erl
+++ b/test/backing_queue_SUITE.erl
@@ -1253,7 +1253,7 @@ make_publish_delivered(IsPersistent, PayloadFun, PropFun, N) ->
      PropFun(N, #message_properties{size = 10})}.
 
 queue_name(Config, Name) ->
-    Name1 = rabbit_ct_helpers:config_to_testcase_name(Config, Name),
+    Name1 = iolist_to_binary(rabbit_ct_helpers:config_to_testcase_name(Config, Name)),
     queue_name(Name1).
 
 queue_name(Name) ->

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -354,7 +354,7 @@ test_spawn_remote() ->
     end.
 
 queue_name(Config, Name) ->
-    Name1 = rabbit_ct_helpers:config_to_testcase_name(Config, Name),
+    Name1 = iolist_to_binary(rabbit_ct_helpers:config_to_testcase_name(Config, Name)),
     queue_name(Name1).
 
 queue_name(Name) ->

--- a/test/term_to_binary_compat_prop_SUITE.erl
+++ b/test/term_to_binary_compat_prop_SUITE.erl
@@ -1,0 +1,62 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+
+-module(term_to_binary_compat_prop_SUITE).
+
+-compile(export_all).
+
+-include("rabbit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+
+all() ->
+    %% The test should run on OTP < 20 (erts < 9)
+    case erts_gt_8() of
+        true ->
+            [];
+        false ->
+            [queue_name_to_binary]
+    end.
+
+erts_gt_8() ->
+    Vsn = erlang:system_info(version),
+    [Maj|_] = string:tokens(Vsn, "."),
+    list_to_integer(Maj) > 8.
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+queue_name_to_binary(Config) ->
+    Fun = fun () -> prop_queue_name_to_binary(Config) end,
+    rabbit_ct_proper_helpers:run_proper(Fun, [], 10000).
+
+
+prop_queue_name_to_binary(_Config) ->
+    ?FORALL({Vhost, QName}, {binary(), binary()},
+            begin
+                Resource = rabbit_misc:r(Vhost, queue, QName),
+                Legacy = term_to_binary_compat:queue_name_to_binary(Resource),
+                Current = term_to_binary(Resource),
+                Current =:= Legacy
+            end).

--- a/test/unit_inbroker_parallel_SUITE.erl
+++ b/test/unit_inbroker_parallel_SUITE.erl
@@ -158,7 +158,7 @@ on_disk_stop(Pid) ->
     end.
 
 queue_name(Config, Name) ->
-    Name1 = rabbit_ct_helpers:config_to_testcase_name(Config, Name),
+    Name1 = iolist_to_binary(rabbit_ct_helpers:config_to_testcase_name(Config, Name)),
     queue_name(Name1).
 
 queue_name(Name) ->


### PR DESCRIPTION
Workaround for #1243 for 3.6
OTP-20 has different binary format for atoms (since OTP-14337)
So term_to_binary generates different value.
testm_to_binary_compat now have a function to generate a binary
identical to pre-20 versions.

Does not address management or stomp issues.