### PR TITLE
Improve documentation around new default for background garbage collection

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -386,7 +386,7 @@
 ## Disabling background GC may reduce latency for client operations,
 ## keeping it enabled may reduce median RAM usage.
 ##
-# background_gc_enabled = true
+# background_gc_enabled = false
 
 ## Target (desired) interval (in milliseconds) at which we run background GC.
 ## The actual interval will vary depending on how long it takes to execute

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -276,7 +276,7 @@
    %% See http://www.rabbitmq.com/partitions.html for further details.
    %%
    %% {cluster_partition_handling, ignore},
-   
+
    %% Mirror sync batch size, in messages. Increasing this will speed
    %% up syncing but total batch size in bytes must not exceed 2 GiB.
    %% Available in RabbitMQ 3.6.0 or later.
@@ -343,7 +343,7 @@
    %% Disabling background GC may reduce latency for client operations,
    %% keeping it enabled may reduce median RAM usage.
    %%
-   %% {background_gc_enabled, true},
+   %% {background_gc_enabled, false},
    %%
    %% Target (desired) interval (in milliseconds) at which we run background GC.
    %% The actual interval will vary depending on how long it takes to execute

--- a/src/background_gc.erl
+++ b/src/background_gc.erl
@@ -74,7 +74,7 @@ interval_gc(State = #state{last_interval = LastInterval}) ->
     State#state{last_interval = Interval}.
 
 gc() ->
-    Enabled = rabbit_misc:get_env(rabbit, background_gc_enabled, true),
+    Enabled = rabbit_misc:get_env(rabbit, background_gc_enabled, false),
     case Enabled of
         true ->
             [garbage_collect(P) || P <- processes(),


### PR DESCRIPTION
2f3fb8023ba1f535b13f4deb97106c08b78bc1d9 (v3.6.7) altered the default setting for `background_gc_enabled` to false, however, the default configuration files seem to imply that the default value for this is still set to true. 

This pull request corrects the default configuration and makes a small change to background_gc.erl so that the defaults which are set in the Makefile are clearly communicated to anyone viewing the source code as well.