### PR TITLE
Improve documentation around new default for background garbage collection

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -325,7 +325,7 @@
 
    %% Whether or not to enable background GC.
    %%
-   %% {background_gc_enabled, true},
+   %% {background_gc_enabled, false},
    %%
    %% Interval (in milliseconds) at which we run background GC.
    %%

--- a/src/background_gc.erl
+++ b/src/background_gc.erl
@@ -74,7 +74,7 @@ interval_gc(State = #state{last_interval = LastInterval}) ->
     State#state{last_interval = Interval}.
 
 gc() ->
-    Enabled = rabbit_misc:get_env(rabbit, background_gc_enabled, true),
+    Enabled = rabbit_misc:get_env(rabbit, background_gc_enabled, false),
     case Enabled of
         true ->
             [garbage_collect(P) || P <- processes(),


### PR DESCRIPTION
2f3fb80 (v3.6.7) altered the default setting for background_gc_enabled to false, however, the default configuration files seem to imply that the default value for this is still set to true.

This pull request corrects the default configuration and makes a small change to background_gc.erl so that the defaults which are set in the Makefile are clearly communicated to anyone viewing the source code as well.

(Re-created against stable branch following the discussion in #1252)