### PR TITLE
Remove stale comment

### DIFF
--- a/src/rabbit_config.erl
+++ b/src/rabbit_config.erl
@@ -99,7 +99,6 @@ generate_config_file(ConfFiles, ConfDir, ScriptDir) ->
 
 generate_config_file(ConfFiles, ConfDir, ScriptDir, SchemaDir, Advanced) ->
     prepare_plugin_schemas(SchemaDir),
-    % SchemaFile = filename:join([ScriptDir, "rabbitmq.schema"]),
     Cuttlefish = filename:join([ScriptDir, "cuttlefish"]),
     GeneratedDir = filename:join([ConfDir, "generated"]),
 


### PR DESCRIPTION
While tracing through the code for rabbitmq/rabbitmq-peer-discovery-aws#1 to see how `cuttlefish` is used, I came across this comment, which probably should be removed. Asking for review in case this comment contains historical importance.