### PR TITLE
Locking support in cluster formation

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -327,11 +327,7 @@ broker_start() ->
     ToBeLoaded = Plugins ++ ?APPS,
     start_apps(ToBeLoaded),
     maybe_sd_notify(),
-    ok = log_broker_started(rabbit_plugins:strictly_plugins(rabbit_plugins:active())),
-    %% See rabbitmq/rabbitmq-server#1202 for details.
-    rabbit_peer_discovery:maybe_inject_randomized_delay(),
-    rabbit_peer_discovery:maybe_register(),
-    ok.
+    ok = log_broker_started(rabbit_plugins:strictly_plugins(rabbit_plugins:active())).
 
 %% Try to send systemd ready notification if it makes sense in the
 %% current environment. standard_error is used intentionally in all

--- a/src/rabbit_peer_discovery_classic_config.erl
+++ b/src/rabbit_peer_discovery_classic_config.erl
@@ -20,7 +20,7 @@
 -include("rabbit.hrl").
 
 -export([list_nodes/0, supports_registration/0, register/0, unregister/0,
-         post_registration/0]).
+         post_registration/0, lock/1, unlock/1]).
 
 %%
 %% API
@@ -53,4 +53,14 @@ unregister() ->
 -spec post_registration() -> ok.
 
 post_registration() ->
+    ok.
+
+-spec lock(Node :: atom()) -> not_supported.
+
+lock(_Node) ->
+    not_supported.
+
+-spec unlock(Data :: term()) -> ok.
+
+unlock(_Data) ->
     ok.

--- a/src/rabbit_peer_discovery_dns.erl
+++ b/src/rabbit_peer_discovery_dns.erl
@@ -20,7 +20,7 @@
 -include("rabbit.hrl").
 
 -export([list_nodes/0, supports_registration/0, register/0, unregister/0,
-         post_registration/0]).
+         post_registration/0, lock/1, unlock/1]).
 %% for tests
 -export([discover_nodes/2, discover_hostnames/2]).
 
@@ -71,6 +71,15 @@ unregister() ->
 post_registration() ->
     ok.
 
+-spec lock(Node :: atom()) -> not_supported.
+
+lock(_Node) ->
+    not_supported.
+
+-spec unlock(Data :: term()) -> ok.
+
+unlock(_Data) ->
+    ok.
 
 %%
 %% Implementation

--- a/test/cluster_formation_locking_SUITE.erl
+++ b/test/cluster_formation_locking_SUITE.erl
@@ -13,7 +13,7 @@
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
 %% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 %%
--module(rabbit_mnesia_SUITE).
+-module(cluster_formation_locking_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/test/rabbit_mnesia_SUITE.erl
+++ b/test/rabbit_mnesia_SUITE.erl
@@ -1,0 +1,80 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(rabbit_mnesia_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+      {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+     {non_parallel_tests, [], [
+                               init_with_lock_exits_after_errors,
+                               init_with_lock_ignore_after_errors,
+                               init_with_lock_not_supported,
+                               init_with_lock_supported
+                              ]}
+    ].
+
+init_per_testcase(Testcase, Config) when Testcase == init_with_lock_exits_after_errors;
+                                         Testcase == init_with_lock_not_supported;
+                                         Testcase == init_with_lock_supported ->
+    application:set_env(rabbit, cluster_formation, 
+                        [{peer_discover_backend, peer_discover_classic_config},
+                         {lock_acquisition_failure_mode, fail}]),
+    ok = meck:new(rabbit_peer_discovery_classic_config, [passthrough]),
+    Config;
+init_per_testcase(init_with_lock_ignore_after_errors, Config) ->
+    application:set_env(rabbit, cluster_formation, 
+                        [{peer_discover_backend, peer_discover_classic_config},
+                         {lock_acquisition_failure_mode, ignore}]),
+    ok = meck:new(rabbit_peer_discovery_classic_config, [passthrough]),
+    Config.
+
+end_per_testcase(_, _) ->
+    meck:unload(),
+    application:unset_env(rabbit, cluster_formation).    
+
+init_with_lock_exits_after_errors(_Config) ->
+    meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> {error, "test error"} end),
+    ?assertExit(cannot_acquire_startup_lock, rabbit_mnesia:init_with_lock(2, 10, fun() -> ok end)),
+    ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
+    passed.
+
+init_with_lock_ignore_after_errors(_Config) ->
+    meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> {error, "test error"} end),
+    ?assertEqual(ok, rabbit_mnesia:init_with_lock(2, 10, fun() -> ok end)),
+    ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
+    passed.
+
+init_with_lock_not_supported(_Config) ->
+    meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> not_supported end),
+    ?assertEqual(ok, rabbit_mnesia:init_with_lock(2, 10, fun() -> ok end)),
+    ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
+    passed.
+
+init_with_lock_supported(_Config) ->
+    meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> {ok, data} end),
+    meck:expect(rabbit_peer_discovery_classic_config, unlock, fun(data) -> ok end),
+    ?assertEqual(ok, rabbit_mnesia:init_with_lock(2, 10, fun() -> ok end)),
+    ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
+    passed.


### PR DESCRIPTION
Adapted from `rabbitmq_autocluster` to avoid race conditions on startup

Part of #1257