### PR TITLE
Depend on inets to ensure it is started when peer discovery begins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ define PROJECT_ENV
 	  ]
 endef
 
-LOCAL_DEPS = sasl mnesia os_mon
+LOCAL_DEPS = sasl mnesia os_mon inets
 BUILD_DEPS = rabbitmq_cli
 DEPS = ranch lager rabbit_common
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper


### PR DESCRIPTION
Sometimes the boot sequence of the dependencies changes, and inets is
not started before rabbit. However, it is needed by some of the
peer discovery backends to perform discovery (i.e. etcd).

#1257 