### PR TITLE
Make term_to_binary_compat generate binaries using minor_version 1.

### DIFF
--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -653,7 +653,7 @@ recover_message(false,     _, no_del,  RelSeq, {Segment, DirtyCount}) ->
      DirtyCount + 2}.
 
 queue_name_to_dir_name(Name = #resource { kind = queue }) ->
-    <<Num:128>> = erlang:md5(term_to_binary_compat:queue_name_to_binary(Name)),
+    <<Num:128>> = erlang:md5(term_to_binary_compat:term_to_binary_1(Name)),
     rabbit_misc:format("~.36B", [Num]).
 
 queues_dir() ->

--- a/src/term_to_binary_compat.erl
+++ b/src/term_to_binary_compat.erl
@@ -18,15 +18,8 @@
 
 -include("rabbit.hrl").
 
--export([queue_name_to_binary/1]).
+-export([term_to_binary_1/1]).
 
-queue_name_to_binary(#resource{kind = queue} = {resource, VHost, queue, Name}) ->
-    VHostBSize = byte_size(VHost),
-    NameBSize = byte_size(Name),
-    <<131,                              %% Binary format "version"
-      104, 4,                           %% 4-element tuple
-      100, 0, 8, "resource",            %% `resource` atom
-      109, VHostBSize:32, VHost/binary, %% Vhost binary
-      100, 0, 5, "queue",               %% `queue` atom
-      109, NameBSize:32, Name/binary>>. %% Name binary
+term_to_binary_1(Term) ->
+    term_to_binary(Term, [{minor_version, 1}]).
 

--- a/test/term_to_binary_compat_prop_SUITE.erl
+++ b/test/term_to_binary_compat_prop_SUITE.erl
@@ -24,13 +24,11 @@
 -include_lib("proper/include/proper.hrl").
 
 all() ->
-    %% The test should run on OTP < 20 (erts < 9)
-    case erts_gt_8() of
-        true ->
-            [];
-        false ->
-            [queue_name_to_binary]
-    end.
+    [
+        pre_3_6_11_works,
+        term_to_binary_latin_atom,
+        queue_name_to_binary
+    ].
 
 erts_gt_8() ->
     Vsn = erlang:system_info(version),
@@ -47,16 +45,51 @@ end_per_suite(Config) ->
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
+%% If this test fails - the erlang version is not supported in
+%% RabbitMQ-3.6.10 and earlier.
+pre_3_6_11_works(Config) ->
+    Fun = fun () -> prop_pre_3_6_11_works(Config) end,
+    rabbit_ct_proper_helpers:run_proper(Fun, [], 50000).
+
+prop_pre_3_6_11_works(_Config) ->
+    ?FORALL(Term, any(),
+        begin
+            Current = term_to_binary(Term),
+            Compat = term_to_binary_compat:term_to_binary_1(Term),
+            Current =:= Compat
+        end).
+
+term_to_binary_latin_atom(Config) ->
+    Fun = fun () -> prop_term_to_binary_latin_atom(Config) end,
+    rabbit_ct_proper_helpers:run_proper(Fun, [], 10000).
+
+prop_term_to_binary_latin_atom(_Config) ->
+    ?FORALL(LatinString, list(integer(0, 255)),
+        begin
+            Length = length(LatinString),
+            Atom = list_to_atom(LatinString),
+            Binary = list_to_binary(LatinString),
+            <<131,100, Length:16, Binary/binary>> =:= term_to_binary_compat:term_to_binary_1(Atom)
+        end).
+
 queue_name_to_binary(Config) ->
     Fun = fun () -> prop_queue_name_to_binary(Config) end,
     rabbit_ct_proper_helpers:run_proper(Fun, [], 10000).
 
 
 prop_queue_name_to_binary(_Config) ->
-    ?FORALL({Vhost, QName}, {binary(), binary()},
+    ?FORALL({VHost, QName}, {binary(), binary()},
             begin
-                Resource = rabbit_misc:r(Vhost, queue, QName),
-                Legacy = term_to_binary_compat:queue_name_to_binary(Resource),
-                Current = term_to_binary(Resource),
-                Current =:= Legacy
+                VHostBSize = byte_size(VHost),
+                NameBSize = byte_size(QName),
+                Expected =
+                    <<131,                               %% Binary format "version"
+                      104, 4,                            %% 4-element tuple
+                      100, 0, 8, "resource",             %% `resource` atom
+                      109, VHostBSize:32, VHost/binary,  %% Vhost binary
+                      100, 0, 5, "queue",                %% `queue` atom
+                      109, NameBSize:32, QName/binary>>, %% Name binary
+                Resource = rabbit_misc:r(VHost, queue, QName),
+                Current = term_to_binary_compat:term_to_binary_1(Resource),
+                Current =:= Expected
             end).


### PR DESCRIPTION
Fix for #1243 for 3.6.x

term_to_binary now has `minor_version:2` to always generate utf-8 atoms,
while default is `1`, so binaries generated in OTP-20 should be
the same as in OTP-19 for non-unicode atoms.