### PR TITLE
Using square brackets could cause an error

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -202,7 +202,6 @@ if "!RABBITMQ_SCHEMA_DIR!" == "" (
     )
 )
 
-
 REM [ "x" = "x$RABBITMQ_LOG_BASE" ] && RABBITMQ_LOG_BASE=${LOG_BASE}
 if "!RABBITMQ_LOG_BASE!"=="" (
     if "!LOG_BASE!"=="" (
@@ -418,7 +417,7 @@ exit /b
 
 :filter_path
 REM Ensure ERL_LIBS begins with valid path
-IF [%ERL_LIBS%] EQU [] (
+IF "%ERL_LIBS%"=="" (
     set ERL_LIBS=%~dps1%~n1%~x1
 ) else (
     set ERL_LIBS=%ERL_LIBS%;%~dps1%~n1%~x1


### PR DESCRIPTION
Without this change I received an `C:\Users\lbakken\...\...\...apps] was unexpected at this time` error when running `make run-broker` from `deps/rabbit`.

Master branch, latest msys2, Erlang 19.3 and Windows 10