### PR TITLE
Add OTP version to server properties

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -283,7 +283,7 @@ server_properties(Protocol) ->
                      [{product,      Product},
                       {version,      Version},
                       {cluster_name, rabbit_nodes:cluster_name()},
-                      {platform,     "Erlang/OTP"},
+                      {platform,     rabbit_misc:platform_and_version()},
                       {copyright,    ?COPYRIGHT_MESSAGE},
                       {information,  ?INFORMATION_MESSAGE}]]],
 


### PR DESCRIPTION
I wanted to know which Erlang & RabbitMQ version I am benchmarking
against. Whilst RabbitMQ version was already exposed via server
properties, Erlang version wasn't.

Since otp_release/0 is in rabbit_misc, it felt natural to add this
functionality there, especially since testing it via rabbit_reader felt
awkward.

rabbitmq/rabbitmq-common#209