### PR TITLE
Only preserve stats for local queues

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -25,7 +25,7 @@
          check_exclusive_access/2, with_exclusive_access_or_die/3,
          stat/1, deliver/2, requeue/3, ack/3, reject/4]).
 -export([list/0, list/1, info_keys/0, info/1, info/2, info_all/1, info_all/2,
-         info_all/5, info_local/1, list_names/0]).
+         info_all/5, info_local/1, list_names/0, list_local_names/0]).
 -export([list_down/1]).
 -export([force_event_refresh/1, notify_policy_changed/1]).
 -export([consumers/1, consumers_all/1,  consumers_all/3, consumer_info_keys/0]).
@@ -570,6 +570,11 @@ check_queue_mode({Type,    _}, _Args) ->
 list() -> mnesia:dirty_match_object(rabbit_queue, #amqqueue{_ = '_'}).
 
 list_names() -> mnesia:dirty_all_keys(rabbit_queue).
+
+list_local_names() ->
+    [ Q#amqqueue.name || #amqqueue{state = State, pid = QPid} = Q <- list(),
+           State =/= crashed,
+           node() =:= node(QPid) ].
 
 list(VHostPath) -> list(VHostPath, rabbit_queue).
 

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -258,11 +258,13 @@ init_with_backing_queue_state(Q = #amqqueue{exclusive_owner = Owner}, BQ, BQS,
     State3.
 
 terminate(shutdown = R,      State = #q{backing_queue = BQ}) ->
+    rabbit_core_metrics:queue_deleted(qname(State)),
     terminate_shutdown(fun (BQS) -> BQ:terminate(R, BQS) end, State);
 terminate({shutdown, missing_owner} = Reason, State) ->
     %% if the owner was missing then there will be no queue, so don't emit stats
     terminate_shutdown(terminate_delete(false, Reason, State), State);
 terminate({shutdown, _} = R, State = #q{backing_queue = BQ}) ->
+    rabbit_core_metrics:queue_deleted(qname(State)),
     terminate_shutdown(fun (BQS) -> BQ:terminate(R, BQS) end, State);
 terminate(normal,            State) -> %% delete case
     terminate_shutdown(terminate_delete(true, normal, State), State);

--- a/src/rabbit_core_metrics_gc.erl
+++ b/src/rabbit_core_metrics_gc.erl
@@ -25,8 +25,6 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 
--include_lib("rabbit_common/include/rabbit.hrl").
-
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
@@ -72,10 +70,7 @@ gc_channels() ->
     ok.
 
 gc_queues() ->
-    % Queues will contain pids, we want to filter
-    Queues = lists:filter(fun(#amqqueue{pid = Pid}) ->
-                              node(Pid) =:= node()
-                          end, rabbit_amqqueue:list()),
+    Queues = rabbit_amqqueue:list_local_names(),
     GbSet = gb_sets:from_list(Queues),
     gc_entity(queue_metrics, GbSet),
     gc_entity(queue_coarse_metrics, GbSet),

--- a/src/rabbit_core_metrics_gc.erl
+++ b/src/rabbit_core_metrics_gc.erl
@@ -54,9 +54,13 @@ terminate(_Reason, #state{timer = TRef}) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+start_timer(Interval, #state{timer = TRef0} = St) ->
+    timer:cancel(TRef0),
+    TRef1 = erlang:send_after(Interval, self(), start_gc),
+    St#state{timer = TRef1}.
+
 start_timer(#state{interval = Interval} = St) ->
-    TRef = erlang:send_after(Interval, self(), start_gc),
-    St#state{timer = TRef}.
+    start_timer(Interval, St).
 
 gc_connections() ->
     gc_process(connection_created),

--- a/src/rabbit_core_metrics_gc.erl
+++ b/src/rabbit_core_metrics_gc.erl
@@ -54,13 +54,9 @@ terminate(_Reason, #state{timer = TRef}) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-start_timer(Interval, #state{timer = TRef0} = St) ->
-    timer:cancel(TRef0),
-    TRef1 = erlang:send_after(Interval, self(), start_gc),
-    St#state{timer = TRef1}.
-
 start_timer(#state{interval = Interval} = St) ->
-    start_timer(Interval, St).
+    TRef = erlang:send_after(Interval, self(), start_gc),
+    St#state{timer = TRef}.
 
 gc_connections() ->
     gc_process(connection_created),

--- a/src/rabbit_mirror_queue_sync.erl
+++ b/src/rabbit_mirror_queue_sync.erl
@@ -16,7 +16,7 @@
 
 -module(rabbit_mirror_queue_sync).
 
--include("rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -export([master_prepare/4, master_go/8, slave/7, conserve_resources/3]).
 

--- a/test/rabbit_core_metrics_gc_SUITE.erl
+++ b/test/rabbit_core_metrics_gc_SUITE.erl
@@ -380,26 +380,13 @@ cluster_queue_metrics(Config) ->
     rabbit_ct_broker_helpers:rpc(Config, Node1, erlang, send, [rabbit_core_metrics_gc, start_gc]),
     rabbit_ct_broker_helpers:rpc(Config, Node1, gen_server, call, [rabbit_core_metrics_gc, test]),
 
-    timer:sleep(1000),
-
-    rabbit_ct_broker_helpers:rpc(Config, Node0, erlang, send, [rabbit_core_metrics_gc, start_gc]),
-    rabbit_ct_broker_helpers:rpc(Config, Node0, gen_server, call, [rabbit_core_metrics_gc, test]),
-    rabbit_ct_broker_helpers:rpc(Config, Node1, erlang, send, [rabbit_core_metrics_gc, start_gc]),
-    rabbit_ct_broker_helpers:rpc(Config, Node1, gen_server, call, [rabbit_core_metrics_gc, test]),
-
     % Check ETS table for data
     % rabbit_core_metrics:queue_stats
     % {Name, MessagesReady, MessagesUnacknowledge, Messages, Reductions}
     % [{{resource,<<"/">>,queue,<<"cluster_queue_metrics">>}, 1,0,1,10524}]
-    EtsData0_0 = rabbit_ct_broker_helpers:rpc(Config, Node0, ets, tab2list, [queue_coarse_metrics]),
-    [] = EtsData0_0,
-
-    EtsData0_1 = rabbit_ct_broker_helpers:rpc(Config, Node0, ets, tab2list, [queue_coarse_metrics]),
-    ct:pal("Node 0 ETS: ~p~n", [EtsData0_1]),
-    [{Name, 1, 0, 1, _}] = EtsData0_1,
+    [] = rabbit_ct_broker_helpers:rpc(Config, Node0, ets, tab2list, [queue_coarse_metrics]),
 
     EtsData1_0 = rabbit_ct_broker_helpers:rpc(Config, Node1, ets, tab2list, [queue_coarse_metrics]),
-    ct:pal("Node 1 ETS: ~p~n", [EtsData1_0]),
     [{Name, 1, 0, 1, _}] = EtsData1_0,
 
     amqp_channel:call(Ch, #'queue.delete'{queue=QueueName}),

--- a/test/rabbit_core_metrics_gc_SUITE.erl
+++ b/test/rabbit_core_metrics_gc_SUITE.erl
@@ -392,7 +392,7 @@ cluster_queue_metrics(Config) ->
     % {Name, MessagesReady, MessagesUnacknowledge, Messages, Reductions}
     % [{{resource,<<"/">>,queue,<<"cluster_queue_metrics">>}, 1,0,1,10524}]
     EtsData0_0 = rabbit_ct_broker_helpers:rpc(Config, Node0, ets, tab2list, [queue_coarse_metrics]),
-    [{Name, 1, 0, 1, _}] = EtsData0_0,
+    [] = EtsData0_0,
 
     EtsData0_1 = rabbit_ct_broker_helpers:rpc(Config, Node0, ets, tab2list, [queue_coarse_metrics]),
     ct:pal("Node 0 ETS: ~p~n", [EtsData0_1]),

--- a/test/rabbit_core_metrics_gc_SUITE.erl
+++ b/test/rabbit_core_metrics_gc_SUITE.erl
@@ -368,7 +368,11 @@ cluster_queue_metrics(Config) ->
     rabbit_ct_broker_helpers:rpc(Config, Node0, rabbit_amqqueue, sync_mirrors, [QPid]),
 
     % Check ETS table for data
-    % ets:tab2list(queue_coarse_metrics).
+    % rabbit_core_metrics:queue_stats
+    % {Name, MessagesReady, MessagesUnacknowledge, Messages, Reductions}
+    % [{{resource,<<"/">>,queue,<<"cluster_queue_metrics">>}, 1,0,1,10524}]
+    EtsData = rabbit_ct_broker_helpers:rpc(Config, Node0, ets, tab2list, [queue_coarse_metrics]),
+    [{Name, 1, 0, 1, _Reductions}] = EtsData,
 
     amqp_channel:call(Ch, #'queue.delete'{queue=QueueName}),
     rabbit_ct_client_helpers:close_channel(Ch),


### PR DESCRIPTION
Fixes rabbitmq/rabbitmq-management#427

By using `list_local_names`, metrics entries that are stale are removed.