### PR TITLE
Change the `state` field in vhost info to `cluster_state`.

### DIFF
--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -269,7 +269,7 @@ i(cluster_state, VHost) ->
                                           [VHost]) of
             {badrpc, nodedown} -> nodedown;
             true               -> running;
-            false              -> down
+            false              -> stopped
         end,
         {Node, State}
     end,

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -75,7 +75,7 @@ recover(VHost) ->
 
 %%----------------------------------------------------------------------------
 
--define(INFO_KEYS, [name, tracing, state]).
+-define(INFO_KEYS, [name, tracing, cluster_state]).
 
 add(VHostPath, ActingUser) ->
     rabbit_log:info("Adding vhost '~s'~n", [VHostPath]),
@@ -261,10 +261,19 @@ infos(Items, X) -> [{Item, i(Item, X)} || Item <- Items].
 
 i(name,    VHost) -> VHost;
 i(tracing, VHost) -> rabbit_trace:enabled(VHost);
-i(state,   VHost) -> case rabbit_vhost_sup_sup:is_vhost_alive(VHost) of
-                         true -> running;
-                         false -> down
-                     end;
+i(cluster_state, VHost) ->
+    Nodes = rabbit_nodes:all_running(),
+    lists:map(fun(Node) ->
+        State = case rabbit_misc:rpc_call(Node,
+                                          rabbit_vhost_sup_sup, is_vhost_alive,
+                                          [VHost]) of
+            {badrpc, nodedown} -> nodedown;
+            true               -> running;
+            false              -> down
+        end,
+        {Node, State}
+    end,
+    Nodes);
 i(Item, _)        -> throw({bad_argument, Item}).
 
 info(VHost)        -> infos(?INFO_KEYS, VHost).


### PR DESCRIPTION
Vhost supervisor status can be different on different nodes.
Reporting just the current node state doesn't make much sense for
both management and the CLI.

Required for rabbitmq/rabbitmq-management#460