### PR TITLE
Start/stop windows service using `net` utility instead of `erlsrv`

### DIFF
--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -76,7 +76,8 @@ if not exist "!ERLANG_SERVICE_MANAGER_PATH!\erlsrv.exe" (
 )
 
 if "!P1!" == "install" goto INSTALL_SERVICE
-for %%i in (start stop disable enable list remove) do if "%%i" == "!P1!" goto MODIFY_SERVICE
+for %%i in (start stop) do if "%%i" == "!P1!" goto START_STOP_SERVICE
+for %%i in (disable enable list remove) do if "%%i" == "!P1!" goto MODIFY_SERVICE
 
 echo.
 echo *********************
@@ -226,15 +227,26 @@ set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:"=\"!
 if ERRORLEVEL 1 (
     EXIT /B 1
 )
-
 goto END
 
 
 :MODIFY_SERVICE
 
 "!ERLANG_SERVICE_MANAGER_PATH!\erlsrv" !P1! !RABBITMQ_SERVICENAME!
+if ERRORLEVEL 1 (
+    EXIT /B 1
+)
 goto END
 
+
+:START_STOP_SERVICE
+
+REM start and stop via erlsrv reports no error message. Using net instead
+net !P1! !RABBITMQ_SERVICENAME!
+if ERRORLEVEL 1 (
+    EXIT /B 1
+)
+goto END
 
 :END
 


### PR DESCRIPTION
`erlsrv` doc suggests to use windows system control tools to control
services. It prints weird error when error is occured
(for example access is denied), so using `net` is prefered.

Error reporting for #1324 
[#149953545]