### PR TITLE
Read rabbitmq-env.conf a bit earlier to pick up two variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,24 @@ ERLANG_MK_COMMIT = rabbitmq-tmp
 include rabbitmq-components.mk
 include erlang.mk
 
+ifeq ($(strip $(BATS)),)
+BATS := $(ERLANG_MK_TMP)/bats/bin/bats
+endif
+
+BATS_GIT ?= https://github.com/sstephenson/bats
+BATS_COMMIT ?= v0.4.0
+
+$(BATS):
+	$(verbose) mkdir -p $(ERLANG_MK_TMP)
+	$(gen_verbose) git clone --depth 1 --branch=$(BATS_COMMIT) $(BATS_GIT) $(ERLANG_MK_TMP)/bats
+
+.PHONY: bats
+
+bats: $(BATS)
+	$(verbose) $(BATS) $(TEST_DIR)
+
+tests:: bats
+
 SLOW_CT_SUITES := backing_queue \
 		  cluster_rename \
 		  clustering_management \

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -76,6 +76,10 @@ RABBITMQ_HOME="$(rmq_realpath "${RABBITMQ_SCRIPTS_DIR}/..")"
 ## Set defaults
 . ${RABBITMQ_SCRIPTS_DIR}/rabbitmq-defaults
 
+## Get configuration variables from the configure environment file
+[ "x" = "x$RABBITMQ_CONF_ENV_FILE" ] && RABBITMQ_CONF_ENV_FILE=${CONF_ENV_FILE}
+[ -f ${RABBITMQ_CONF_ENV_FILE} ] && . ${RABBITMQ_CONF_ENV_FILE} || true
+
 DEFAULT_SCHEDULER_BIND_TYPE="db"
 [ "x" = "x$RABBITMQ_SCHEDULER_BIND_TYPE" ] && RABBITMQ_SCHEDULER_BIND_TYPE=${DEFAULT_SCHEDULER_BIND_TYPE}
 
@@ -89,11 +93,6 @@ SERVER_ERL_ARGS="+P 1048576 +t 5000000 +stbt $RABBITMQ_SCHEDULER_BIND_TYPE +zdbb
 # an init script. If $CONF_ENV_FILE overrides it again, we must ignore
 # it and warn the user.
 saved_RABBITMQ_PID_FILE=$RABBITMQ_PID_FILE
-
-## Get configuration variables from the configure environment file
-[ "x" = "x$RABBITMQ_CONF_ENV_FILE" ] && RABBITMQ_CONF_ENV_FILE=${CONF_ENV_FILE}
-
-[ -f ${RABBITMQ_CONF_ENV_FILE} ] && . ${RABBITMQ_CONF_ENV_FILE} || true
 
 if [ "$saved_RABBITMQ_PID_FILE" -a \
      "$saved_RABBITMQ_PID_FILE" != "$RABBITMQ_PID_FILE" ]; then

--- a/test/rabbitmq-env.bats
+++ b/test/rabbitmq-env.bats
@@ -1,0 +1,19 @@
+@test "can set RABBITMQ_SCHEDULER_BIND_TYPE from rabbitmq-env.conf" {
+    declare -r scripts_dir="$BATS_TEST_DIRNAME/../scripts"
+    export RABBITMQ_SCRIPTS_DIR="$scripts_dir"
+    export RABBITMQ_CONF_ENV_FILE="$BATS_TMPDIR/rabbitmq-env.conf"
+    echo 'RABBITMQ_SCHEDULER_BIND_TYPE=u' > "$RABBITMQ_CONF_ENV_FILE"
+    source "$scripts_dir/rabbitmq-env"
+    echo "expect RABBITMQ_SERVER_ERL_ARGS to contain '+stbt u' but got '$SERVER_ERL_ARGS'" 
+    [[ $RABBITMQ_SERVER_ERL_ARGS == *+stbt\ u* ]]
+}
+
+@test "can set RABBITMQ_DISTRIBUTION_BUFFER_SIZE from rabbitmq-env.conf" {
+    declare -r scripts_dir="$BATS_TEST_DIRNAME/../scripts"
+    export RABBITMQ_SCRIPTS_DIR="$scripts_dir"
+    export RABBITMQ_CONF_ENV_FILE="$BATS_TMPDIR/rabbitmq-env.conf"
+    echo 'RABBITMQ_DISTRIBUTION_BUFFER_SIZE=123456' > "$RABBITMQ_CONF_ENV_FILE"
+    source "$scripts_dir/rabbitmq-env"
+    echo "expect RABBITMQ_SERVER_ERL_ARGS to contain '+zdbbl 123456' but got '$SERVER_ERL_ARGS'" 
+    [[ $RABBITMQ_SERVER_ERL_ARGS == *+zdbbl\ 123456* ]]
+}


### PR DESCRIPTION
Prior to this change, setting RABBITMQ_DISTRIBUTION_BUFFER_SIZE
and/or RABBITMQ_SCHEDULER_BIND_TYPE would not be added to
SERVER_ERL_ARGS because the latter variable was built prior to
reading rabbitmq-env.conf

Fixes #1338

Signed-off-by: Luke Bakken <lbakken@pivotal.io>