### PR TITLE
Introduce x-first-death-{queue,reason,exchange}

### DIFF
--- a/src/rabbit_dead_letter.erl
+++ b/src/rabbit_dead_letter.erl
@@ -112,6 +112,8 @@ group_by_queue_and_reason(Tables) ->
           end, {sets:new(), []}, Tables),
     Grouped.
 
+update_x_death_header(Info, undefined) ->
+    update_x_death_header(Info, []);
 update_x_death_header(Info, Headers) ->
     X = x_death_event_key(Info, <<"exchange">>),
     Q = x_death_event_key(Info, <<"queue">>),

--- a/src/rabbit_dead_letter.erl
+++ b/src/rabbit_dead_letter.erl
@@ -113,13 +113,22 @@ group_by_queue_and_reason(Tables) ->
     Grouped.
 
 update_x_death_header(Info, Headers) ->
+    X = x_death_event_key(Info, <<"exchange">>),
     Q = x_death_event_key(Info, <<"queue">>),
     R = x_death_event_key(Info, <<"reason">>),
     case rabbit_basic:header(<<"x-death">>, Headers) of
         undefined ->
+            %% First x-death event gets its own top-level headers.
+            %% See rabbitmq/rabbitmq-server#1332.
+            Headers2 = rabbit_misc:set_table_value(Headers, <<"x-first-death-reason">>,
+                                                   longstr, R),
+            Headers3 = rabbit_misc:set_table_value(Headers2, <<"x-first-death-queue">>,
+                                                   longstr, Q),
+            Headers4 = rabbit_misc:set_table_value(Headers3, <<"x-first-death-exchange">>,
+                                                   longstr, X),
             rabbit_basic:prepend_table_header(
               <<"x-death">>,
-              [{<<"count">>, long, 1} | Info], Headers);
+              [{<<"count">>, long, 1} | Info], Headers4);
         {<<"x-death">>, array, Tables} ->
             %% group existing x-death headers in case we have some from
             %% before rabbitmq-server#78


### PR DESCRIPTION
To manually give it a try, use a script similar to this one (uses Bunny):

``` ruby
#!/usr/bin/env ruby
# encoding: utf-8

require 'bundler'
Bundler.setup(:default)

require 'bunny'
require 'pp'

conn = Bunny.new; conn.start

ch1  = conn.create_channel
ch2  = conn.create_channel
ch3  = conn.create_channel

ch1.queue_delete("server-1332-q1-ttl")
ch2.queue_delete("server-1332-q2")
ch3.queue_delete("server-1332-q3")

q1   = ch1.queue("server-1332-q1-ttl", durable: false, arguments: {
    "x-message-ttl" => 5000,
    "x-dead-letter-exchange" => "",
    "x-dead-letter-routing-key" => "server-1332-q2"
  })
q2   = ch2.queue("server-1332-q2", durable: false, arguments: {
    "x-message-ttl" => 5000,
    "x-dead-letter-exchange" => "",
    "x-dead-letter-routing-key" => "server-1332-q3"
  })
q3   = ch3.queue("server-1332-q3", durable: false)

q3.subscribe(manual_ack: false) do |delivery_info, properties, body|
  pp properties
end

loop do
  sleep 1
end
```

then publish a message so that it is routed to `server-1332-q1-ttl` and wait for more than 10 seconds.

Closes #1332.