### PR TITLE
Sync rabbitmq.config.example with PROJECT_ENV

### DIFF
--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -424,7 +424,7 @@
    %% Whether or not to enable background GC.
    %%
    %% {background_gc_enabled, false},
-   %%
+
    %% Interval (in milliseconds) at which we run background GC.
    %%
    %% {background_gc_target_interval, 60000},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -310,6 +310,12 @@
    %%
    %% {mirroring_sync_batch_size, 4096},
 
+   %% Controls flow control between queue mirrors
+   %% Be careful with this configuration, it's controversial
+   %% https://github.com/rabbitmq/rabbitmq-server/pull/133
+   %%
+   %% {mirroring_flow_control, true},
+
    %% To announce custom properties to clients on connection:
    %%
    %% {server_properties, []},
@@ -406,6 +412,14 @@
    %% Number of lazy queue operations required to trigger an explicit garbage collection
    %%
    %% {lazy_queue_explicit_gc_run_operation_threshold, 1000},
+
+   %% Number of times to retry querying disk space usage
+   %%
+   %% {disk_monitor_failure_retries, 10},
+
+   %% Milliseconds to wait for disk space usage values
+   %%
+   %% {disk_monitor_failure_retry_interval, 120000},
 
    %% Whether or not to enable background GC.
    %%

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -52,7 +52,7 @@
    %% connection. Hostnames will then be shown instead of IP addresses
    %% in rabbitmqctl and the management plugin.
    %%
-   %% {reverse_dns_lookups, true},
+   %% {reverse_dns_lookups, false},
 
    %%
    %% Security / AAA
@@ -124,11 +124,16 @@
    %%
    %% To use the SSL cert's CN instead of its DN as the username
    %%
-   %% {ssl_cert_login_from, common_name},
+   %% {ssl_cert_login_from, distinguished_name},
 
    %% SSL handshake timeout, in milliseconds.
    %%
    %% {ssl_handshake_timeout, 5000},
+
+   %% Whether to allow SSH POODLE attack,
+   %% as is the case of Erlang versions that make it impossible to disable SSLv3
+   %%
+   %% {ssl_allow_poodle_attack, false},
 
    %% Password hashing implementation. Will only affect newly
    %% created users. To recalculate hash for an existing user
@@ -200,7 +205,7 @@
    %% Set the max permissible number of channels per connection.
    %% 0 means "no limit".
    %%
-   %% {channel_max, 128},
+   %% {channel_max, 0},
 
    %% Customising Socket Options.
    %%
@@ -335,9 +340,13 @@
    %%
    %% {collect_statistics_interval, 5000},
 
+   %% Enables vhosts tracing.
+   %%
+   %% {trace_vhosts, []},
+
    %% Explicitly enable/disable HiPE compilation.
    %%
-   %% {hipe_compile, true},
+   %% {hipe_compile, false},
 
    %% Number of delegate processes to use for intra-cluster communication.
    %% On a machine which has a very large number of cores and is also part of a cluster,
@@ -644,8 +653,12 @@
 
    %% TCP/Socket options (as per the broker configuration).
    %%
-   %% {tcp_listen_options, [{backlog,   128},
-   %%                       {nodelay,   true}]}
+   %% {tcp_listen_options, [
+   %%                         {backlog,   128},
+   %%                         {nodelay,       true},
+   %%                         {linger,        {true, 0}},
+   %%                         {exit_on_close, false}
+   %%                      ]},
   ]},
 
  %% ----------------------------------------------------------------------------

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -321,7 +321,7 @@
    %% {server_properties, []},
 
    %% How to respond to cluster partitions.
-   %% See http://www.rabbitmq.com/partitions.html for
+   %% See http://www.rabbitmq.com/partitions.html
    %%
    %% {cluster_partition_handling, ignore},
 

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -130,8 +130,8 @@
    %%
    %% {ssl_handshake_timeout, 5000},
 
-   %% Whether to allow SSL POODLE attack,
-   %% as is the case of Erlang versions that make it impossible to disable SSLv3
+   %% Makes RabbitMQ accept SSLv3 client connections by default.
+   %% DO NOT DO THIS IF YOU CAN HELP IT.
    %%
    %% {ssl_allow_poodle_attack, false},
 
@@ -311,7 +311,10 @@
    %% {mirroring_sync_batch_size, 4096},
 
    %% Controls flow control between queue mirrors
-   %% Be careful with this configuration, it's controversial
+   %% Be careful with this configuration.
+   %% It's dangerous for masters to outpace mirrors and not allow mirrors to catch up.
+   %% Mirrors will end up using more and more RAM,
+   %% until they will eventually trigger the memory alarm and block publishers.
    %% https://github.com/rabbitmq/rabbitmq-server/pull/133
    %%
    %% {mirroring_flow_control, true},
@@ -355,7 +358,7 @@
    %% {hipe_compile, false},
 
    %% Number of delegate processes to use for intra-cluster communication.
-   %% On a machine which has a very large number of cores and is also part of a cluster,
+   %% On a node which is part of cluster, has 16 cores and plenty of network bandwidth,
    %% you may wish to increase this value.
    %%
    %% {delegate_count, 16},
@@ -396,7 +399,9 @@
 
    %% Number of credits that a connection, channel or queue are given
    %% By default, every connection, channel or queue is given 400 credits,
-   %% and then 200 for every 200 messages that it processes
+   %% and then 200 for every 200 messages that it processes.
+   %% Increasing these values may help with throughput, but they can also be dangerous:
+   %% very high credit flow values are no different from not having flow control.
    %% See https://www.rabbitmq.com/blog/2015/10/06/new-credit-flow-settings-on-rabbitmq-3-5-5/
    %%
    %% {credit_flow_default_credit, {400, 200}},
@@ -417,7 +422,7 @@
    %%
    %% {disk_monitor_failure_retries, 10},
 
-   %% Milliseconds to wait for disk space usage values
+   %% Milliseconds to wait before retrying to query disk space usage
    %%
    %% {disk_monitor_failure_retry_interval, 120000},
 
@@ -429,7 +434,10 @@
    %%
    %% {background_gc_target_interval, 60000},
 
-   %% File size in bytes used for persisting messages
+   %% Message store operations are stored in a sequence of files called segments.
+   %% This controls max size of a segment file.
+   %% Increasing this value may speed up (sequential) disk writes but will slow down segment GC process.
+   %% DO NOT CHANGE THIS for existing installations.
    %%
    %% {msg_store_file_size_limit, 16777216},
 
@@ -666,10 +674,10 @@
    %% {num_ssl_acceptors, 1},
 
    %% TCP/Socket options (as per the broker configuration).
+   %% See http://www.rabbitmq.com/networking.html
    %%
    %% {tcp_listen_options, [
    %%                         {backlog,   128},
-   %%                         {nodelay,       true},
    %%                         {linger,        {true, 0}},
    %%                         {exit_on_close, false}
    %%                      ]},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -130,7 +130,7 @@
    %%
    %% {ssl_handshake_timeout, 5000},
 
-   %% Whether to allow SSH POODLE attack,
+   %% Whether to allow SSL POODLE attack,
    %% as is the case of Erlang versions that make it impossible to disable SSLv3
    %%
    %% {ssl_allow_poodle_attack, false},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -38,11 +38,15 @@
    %%
    %% {handshake_timeout, 10000},
 
-   %% Log levels (currently just used for connection logging).
-   %% One of 'debug', 'info', 'warning', 'error' or 'none', in decreasing
-   %% order of verbosity. Defaults to 'info'.
+   %% Log levels in decreasing order of verbosity:
+   %%   * 'debug'
+   %%   * 'info'
+   %%   * 'warning'
+   %%   * 'error'
+   %%   * 'none'
+   %%  Defaults to '{connection, info}'
    %%
-   %% {log_levels, [{connection, info}, {channel, info}]},
+   %% {log_levels, [{channel, info}, {connection, info}, {federation, info}, {mirroring, info}]},
 
    %% Set to 'true' to perform reverse DNS lookups when accepting a
    %% connection. Hostnames will then be shown instead of IP addresses

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -189,7 +189,10 @@
    %% =====================================================
    %%
 
-   %% Set the default AMQP heartbeat delay (in seconds).
+   %% Sets the default AMQP 0-9-1 heartbeat timeout in seconds.
+   %% Values lower than 6 can produce false positives and are not
+   %% recommended.
+   %% See http://www.rabbitmq.com/heartbeats.html.
    %%
    %% {heartbeat, 60},
 
@@ -207,10 +210,9 @@
    %%
    %% {channel_max, 0},
 
-   %% Customising Socket Options.
+   %% TCP socket options.
    %%
-   %% See (http://www.erlang.org/doc/man/inet.html#setopts-2) for
-   %% further documentation.
+   %% See http://www.rabbitmq.com/networking.html.
    %%
    %% {tcp_listen_options, [{backlog,       128},
    %%                       {nodelay,       true},
@@ -305,21 +307,21 @@
    %%
    %% {queue_master_locator, <<"client-local">>},
 
-   %% Batch size of messages to synchronise between queue mirrors
-   %% See https://www.rabbitmq.com/ha.html#batch-sync
+   %% Batch size (number of messages) used during eager queue mirror synchronisation.
+   %% See https://www.rabbitmq.com/ha.html#batch-sync. When average message size is relatively large
+   %% (say, 10s of kilobytes or greater), reducing this value will decrease peak amount
+   %% of RAM used by newly joining nodes that need eager synchronisation.
    %%
    %% {mirroring_sync_batch_size, 4096},
 
-   %% Controls flow control between queue mirrors
-   %% Be careful with this configuration.
-   %% It's dangerous for masters to outpace mirrors and not allow mirrors to catch up.
-   %% Mirrors will end up using more and more RAM,
-   %% until they will eventually trigger the memory alarm and block publishers.
-   %% https://github.com/rabbitmq/rabbitmq-server/pull/133
+   %% Enables flow control between queue mirrors.
+   %% Disabling this can be dangerous and is not recommended.
+   %% When flow control is disablied, queue masters can outpace mirrors and not allow mirrors to catch up.
+   %% Mirrors will end up using increasingly more RAM, eventually triggering a memory alarm.
    %%
    %% {mirroring_flow_control, true},
 
-   %% To announce custom properties to clients on connection:
+   %% Additional server properties to announce to connecting clients.
    %%
    %% {server_properties, []},
 
@@ -358,18 +360,20 @@
    %% {hipe_compile, false},
 
    %% Number of delegate processes to use for intra-cluster communication.
-   %% On a node which is part of cluster, has 16 cores and plenty of network bandwidth,
-   %% you may wish to increase this value.
+   %% On a node which is part of cluster, has more than 16 cores and plenty of network bandwidth,
+   %% it may make sense to increase this value.
    %%
    %% {delegate_count, 16},
 
-   %% Number of times to retry while waiting for Mnesia tables in a cluster to
-   %% become available.
+   %% Number of times to retry while waiting for internal database tables (Mnesia tables) to sync
+   %% from a peer. In deployments where nodes can take a long time to boot, this value
+   %% may need increasing.
    %%
    %% {mnesia_table_loading_retry_limit, 10},
 
-   %% Time to wait per retry for Mnesia tables in a cluster to become
-   %% available.
+   %% Amount of time in milliseconds which this node will wait for internal database tables (Mnesia tables) to sync
+   %% from a peer. In deployments where nodes can take a long time to boot, this value
+   %% may need increasing.
    %%
    %% {mnesia_table_loading_retry_timeout, 30000},
 
@@ -379,7 +383,7 @@
    %% {queue_index_embed_msgs_below, 4096},
 
    %% Maximum number of queue index entries to keep in journal
-   %% See http://www.rabbitmq.com/persistence-conf.html
+   %% See http://www.rabbitmq.com/persistence-conf.html.
    %%
    %% {queue_index_max_journal_entries, 32768},
 
@@ -397,32 +401,38 @@
    %%
    %% {msg_store_io_batch_size, 4096},
 
-   %% Number of credits that a connection, channel or queue are given
+   %% Number of credits that a connection, channel or queue are given.
+   %%
    %% By default, every connection, channel or queue is given 400 credits,
-   %% and then 200 for every 200 messages that it processes.
-   %% Increasing these values may help with throughput, but they can also be dangerous:
-   %% very high credit flow values are no different from not having flow control.
+   %% and then 200 for every 200 messages that it sends to a peer process.
+   %% Increasing these values may help with throughput but also can be dangerous:
+   %% high credit flow values are no different from not having flow control at all.
+   %%
    %% See https://www.rabbitmq.com/blog/2015/10/06/new-credit-flow-settings-on-rabbitmq-3-5-5/
+   %% and http://alvaro-videla.com/2013/09/rabbitmq-internals-credit-flow-for-erlang-processes.html.
    %%
    %% {credit_flow_default_credit, {400, 200}},
 
-   %% Number of milliseconds before a channel operation times out
+   %% Number of milliseconds before a channel operation times out.
    %%
    %% {channel_operation_timeout, 15000},
 
-   %% Number of queue operations required to trigger an explicit garbage collection
+   %% Number of queue operations required to trigger an explicit garbage collection.
+   %% Increasing this value may reduce CPU load and increase peak RAM consumption of queues.
    %%
    %% {queue_explicit_gc_run_operation_threshold, 1000},
 
-   %% Number of lazy queue operations required to trigger an explicit garbage collection
+   %% Number of lazy queue operations required to trigger an explicit garbage collection.
+   %% Increasing this value may reduce CPU load and increase peak RAM consumption of lazy queues.
    %%
    %% {lazy_queue_explicit_gc_run_operation_threshold, 1000},
 
-   %% Number of times to retry querying disk space usage
+   %% Number of times disk monitor will retry free disk space queries before
+   %% giving up.
    %%
    %% {disk_monitor_failure_retries, 10},
 
-   %% Milliseconds to wait before retrying to query disk space usage
+   %% Milliseconds to wait between disk monitor retries on failures.
    %%
    %% {disk_monitor_failure_retry_interval, 120000},
 
@@ -441,11 +451,13 @@
    %%
    %% {msg_store_file_size_limit, 16777216},
 
-   %% Whether or not to enable write file handle cache buffering
+   %% Whether or not to enable file write buffering.
    %%
    %% {fhc_write_buffering, true},
 
-   %% Whether or not to enable read file handle cache buffering
+   %% Whether or not to enable file read buffering. Enabling
+   %% this may slightly speed up reads but will also increase
+   %% node's memory consumption, in particular on boot.
    %%
    %% {fhc_read_buffering, false}
 
@@ -662,18 +674,20 @@
    %%
    %% {prefetch, 10},
 
-   %% TCP/SSL Configuration (as per the broker configuration).
+   %% TLS listeners.
+   %% See http://www.rabbitmq.com/networking.html
    %%
    %% {tcp_listeners, [1883]},
    %% {ssl_listeners, []},
 
    %% Number of Erlang processes that will accept connections for the TCP
-   %% and SSL listeners.
+   %% and TLS listeners.
+   %% See http://www.rabbitmq.com/networking.html
    %%
    %% {num_tcp_acceptors, 10},
    %% {num_ssl_acceptors, 1},
 
-   %% TCP/Socket options (as per the broker configuration).
+   %% TCP socket options.
    %% See http://www.rabbitmq.com/networking.html
    %%
    %% {tcp_listen_options, [

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -299,6 +299,24 @@
    %% See https://www.rabbitmq.com/ha.html#queue-master-location for further details
    %% {queue_master_locator, <<"client-local">>},
 
+   %% Since RabbitMQ 3.6.0, masters perform synchronisation in batches.
+   %% Earlier versions will synchronise 1 message at a time by default.
+   %% By synchronising messages in batches, the synchronisation process can be sped up considerably.
+   %% To choose the right value, you need to consider:
+   %%   * average message size
+   %%   * network throughput between RabbitMQ nodes
+   %%   * net_ticktime value
+   %%
+   %% For example, if you set this value to 50000 (messages),
+   %% and each message in the queue is 1KB,
+   %% then each synchronisation message between nodes will be ~49MB.
+   %%
+   %% You need to make sure that your network between queue mirrors can accomodate this kind of traffic.
+   %%
+   %% If the network takes longer than net_ticktime to send one batch of messages,
+   %% then nodes in the cluster could think they are in the presence of a network partition.
+   %% {mirroring_sync_batch_size, 4096},
+
    %% To announce custom properties to clients on connection:
    %%
    %% {server_properties, []},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -355,12 +355,17 @@
    %%
    %% {mnesia_table_loading_retry_timeout, 30000},
 
-   %% Size in bytes below which to embed messages in the queue index. See
-   %% http://www.rabbitmq.com/persistence-conf.html
+   %% Size in bytes below which to embed messages in the queue index.
+   %% See http://www.rabbitmq.com/persistence-conf.html
    %%
    %% {queue_index_embed_msgs_below, 4096},
 
-   %% The credits that a queue process is given by the message store.
+   %% Maximum number of queue index entries to keep in journal
+   %% See http://www.rabbitmq.com/persistence-conf.html
+   %%
+   %% {queue_index_max_journal_entries, 32768},
+
+   %% Number of credits that a queue process is given by the message store
    %% By default, a queue process is given 4000 message store credits,
    %% and then 800 for every 800 messages that it processes.
    %%
@@ -371,7 +376,27 @@
    %%
    %% This value MUST be higher than the initial msg_store_credit_disc_bound value,
    %% otherwise paging performance may worsen.
+   %%
    %% {msg_store_io_batch_size, 4096},
+
+   %% Number of credits that a connection, channel or queue are given
+   %% By default, every connection, channel or queue is given 400 credits,
+   %% and then 200 for every 200 messages that it processes
+   %% See https://www.rabbitmq.com/blog/2015/10/06/new-credit-flow-settings-on-rabbitmq-3-5-5/
+   %%
+   %% {credit_flow_default_credit, {400, 200}},
+
+   %% Number of milliseconds before a channel operation times out
+   %%
+   %% {channel_operation_timeout, 15000},
+
+   %% Number of queue operations required to trigger an explicit garbage collection
+   %%
+   %% {queue_explicit_gc_run_operation_threshold, 1000},
+
+   %% Number of lazy queue operations required to trigger an explicit garbage collection
+   %%
+   %% {lazy_queue_explicit_gc_run_operation_threshold, 1000},
 
    %% Whether or not to enable background GC.
    %%
@@ -379,7 +404,19 @@
    %%
    %% Interval (in milliseconds) at which we run background GC.
    %%
-   %% {background_gc_target_interval, 60000}
+   %% {background_gc_target_interval, 60000},
+
+   %% File size in bytes used for persisting messages
+   %%
+   %% {msg_store_file_size_limit, 16777216},
+
+   %% Whether or not to enable write file handle cache buffering
+   %%
+   %% {fhc_write_buffering, true},
+
+   %% Whether or not to enable read file handle cache buffering
+   %%
+   %% {fhc_read_buffering, false}
 
   ]},
 

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -372,6 +372,26 @@
    %%
    %% {queue_index_embed_msgs_below, 4096},
 
+   %% The credits that a queue process is given by the message store.
+   %%
+   %% By default, a queue process is given 4000 message store credits,
+   %% and then 800 for every 800 messages that it processes.
+   %%
+   %% A queue process persists AMQP messages by sending them 1 by 1 to the message store process.
+   %% If the queue process sent 4000 AMQP messages and the message store process didn't manage to persist 800,
+   %% the queue process will enter flow state. If the disks are fast and uncontended, as they should,
+   %% the message store process will give the queue process 800 credits for every 800 messages that it processes.
+   %%
+   %% Messages which need to be paged out due to memory pressure will also use this credit.
+   %%
+   %% The Message Store is the last component in the credit flow chain.
+   %% Learn more about credit flow: https://www.rabbitmq.com/blog/2015/10/06/new-credit-flow-settings-on-rabbitmq-3-5-5/
+   %%
+   %% This value only takes effect when messages are persisted to the message store.
+   %% If messages are embedded on the queue index,
+   %% then modifying this setting has no effect because credit_flow is NOT used when writing to the queue index.
+   %% {msg_store_credit_disc_bound, {4000, 800}},
+
    %% Whether or not to enable background GC.
    %%
    %% {background_gc_enabled, false},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -296,25 +296,13 @@
    %%   * <<"min-masters">>
    %%   * <<"client-local">>
    %%   * <<"random">>
-   %% See https://www.rabbitmq.com/ha.html#queue-master-location for further details
+   %% See https://www.rabbitmq.com/ha.html#queue-master-location
+   %%
    %% {queue_master_locator, <<"client-local">>},
 
-   %% Since RabbitMQ 3.6.0, masters perform synchronisation in batches.
-   %% Earlier versions will synchronise 1 message at a time by default.
-   %% By synchronising messages in batches, the synchronisation process can be sped up considerably.
-   %% To choose the right value, you need to consider:
-   %%   * average message size
-   %%   * network throughput between RabbitMQ nodes
-   %%   * net_ticktime value
+   %% Batch size of messages to synchronise between queue mirrors
+   %% See https://www.rabbitmq.com/ha.html#batch-sync
    %%
-   %% For example, if you set this value to 50000 (messages),
-   %% and each message in the queue is 1KB,
-   %% then each synchronisation message between nodes will be ~49MB.
-   %%
-   %% You need to make sure that your network between queue mirrors can accomodate this kind of traffic.
-   %%
-   %% If the network takes longer than net_ticktime to send one batch of messages,
-   %% then nodes in the cluster could think they are in the presence of a network partition.
    %% {mirroring_sync_batch_size, 4096},
 
    %% To announce custom properties to clients on connection:
@@ -322,14 +310,13 @@
    %% {server_properties, []},
 
    %% How to respond to cluster partitions.
-   %% See http://www.rabbitmq.com/partitions.html for further details.
+   %% See http://www.rabbitmq.com/partitions.html for
    %%
    %% {cluster_partition_handling, ignore},
 
    %% Make clustering happen *automatically* at startup - only applied
    %% to nodes that have just been reset or started for the first time.
-   %% See http://www.rabbitmq.com/clustering.html#auto-config for
-   %% further details.
+   %% See http://www.rabbitmq.com/clustering.html#auto-config
    %%
    %% {cluster_nodes, {['rabbit@my.host.com'], disc}},
 
@@ -353,7 +340,8 @@
    %% {hipe_compile, true},
 
    %% Number of delegate processes to use for intra-cluster communication.
-   %% On a machine which has a very large number of cores and is also part of a cluster, you may wish to increase this value.
+   %% On a machine which has a very large number of cores and is also part of a cluster,
+   %% you may wish to increase this value.
    %%
    %% {delegate_count, 16},
 

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -330,9 +330,14 @@
    %%
    %% {collect_statistics_interval, 5000},
 
-   %% Explicitly enable/disable hipe compilation.
+   %% Explicitly enable/disable HiPE compilation.
    %%
    %% {hipe_compile, true},
+
+   %% Number of delegate processes to use for intra-cluster communication.
+   %% On a machine which has a very large number of cores and is also part of a cluster, you may wish to increase this value.
+   %%
+   %% {delegate_count, 16},
 
    %% Number of times to retry while waiting for Mnesia tables in a cluster to
    %% become available.

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -292,6 +292,13 @@
    %% NB: Change these only if you understand what you are doing!
    %%
 
+   %% Queue master location strategy:
+   %%   * <<"min-masters">>
+   %%   * <<"client-local">>
+   %%   * <<"random">>
+   %% See https://www.rabbitmq.com/ha.html#queue-master-location for further details
+   %% {queue_master_locator, <<"client-local">>},
+
    %% To announce custom properties to clients on connection:
    %%
    %% {server_properties, []},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -373,23 +373,9 @@
    %% {queue_index_embed_msgs_below, 4096},
 
    %% The credits that a queue process is given by the message store.
-   %%
    %% By default, a queue process is given 4000 message store credits,
    %% and then 800 for every 800 messages that it processes.
    %%
-   %% A queue process persists AMQP messages by sending them 1 by 1 to the message store process.
-   %% If the queue process sent 4000 AMQP messages and the message store process didn't manage to persist 800,
-   %% the queue process will enter flow state. If the disks are fast and uncontended, as they should,
-   %% the message store process will give the queue process 800 credits for every 800 messages that it processes.
-   %%
-   %% Messages which need to be paged out due to memory pressure will also use this credit.
-   %%
-   %% The Message Store is the last component in the credit flow chain.
-   %% Learn more about credit flow: https://www.rabbitmq.com/blog/2015/10/06/new-credit-flow-settings-on-rabbitmq-3-5-5/
-   %%
-   %% This value only takes effect when messages are persisted to the message store.
-   %% If messages are embedded on the queue index,
-   %% then modifying this setting has no effect because credit_flow is NOT used when writing to the queue index.
    %% {msg_store_credit_disc_bound, {4000, 800}},
 
    %% Whether or not to enable background GC.

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -378,6 +378,13 @@
    %%
    %% {msg_store_credit_disc_bound, {4000, 800}},
 
+   %% Minimum number of messages with their queue position held in RAM required
+   %% to trigger writing their queue position to disk.
+   %%
+   %% This value MUST be higher than the initial msg_store_credit_disc_bound value,
+   %% otherwise paging performance may worsen.
+   %% {msg_store_io_batch_size, 4096},
+
    %% Whether or not to enable background GC.
    %%
    %% {background_gc_enabled, false},

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -2384,6 +2384,9 @@ reduce_memory_use(State = #vqstate {
         end,
 
     State3 =
+        %% If there are more messages with their queue position held in RAM,
+        %% a.k.a. betas, in Q2 & Q3 than IoBatchSize,
+        %% write their queue position to disk, a.k.a. push_betas_to_deltas
         case chunk_size(?QUEUE:len(Q2) + ?QUEUE:len(Q3),
                         permitted_beta_count(State1)) of
             S2 when S2 >= IoBatchSize ->

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -178,12 +178,12 @@
 %% (betas+gammas+delta)/(target_ram_count+betas+gammas+delta). I.e. as
 %% the target_ram_count shrinks to 0, so must betas and gammas.
 %%
-%% The conversion of betas to gammas is done in batches of at least
-%% ?IO_BATCH_SIZE. This value should not be too small, otherwise the
-%% frequent operations on the queues of q2 and q3 will not be
-%% effectively amortised (switching the direction of queue access
-%% defeats amortisation). Note that there is a natural upper bound due
-%% to credit_flow limits on the alpha to beta conversion.
+%% The conversion of betas to deltas is done if there are at least
+%% ?IO_BATCH_SIZE betas in q2 & q3. This value should not be too small,
+%% otherwise the frequent operations on the queues of q2 and q3 will not be
+%% effectively amortised (switching the direction of queue access defeats
+%% amortisation). Note that there is a natural upper bound due to credit_flow
+%% limits on the alpha to beta conversion.
 %%
 %% The conversion from alphas to betas is chunked due to the
 %% credit_flow limits of the msg_store. This further smooths the


### PR DESCRIPTION
I want to reconcile the existing discrepancies between rabbitmq.config.example & [PROJECT_ENV](https://github.com/rabbitmq/rabbitmq-server/blob/stable/Makefile#L10-L115). I want to review all config properties and make sure that they are all present and accurate in this canonical rabbitmq.config

Let's discuss which changes need to happen where so that rabbitmq.config.example is accurate & in sync with PROJECT_ENV