### PR TITLE
Add optional Restart and RestartSec configuration

### DIFF
--- a/docs/rabbitmq-server.service.example
+++ b/docs/rabbitmq-server.service.example
@@ -12,8 +12,8 @@ NotifyAccess=all
 TimeoutStartSec=3600
 # Note:
 # You *may* wish to add the following to automatically restart RabbitMQ
-# in the event of a failure. This is not recommended as a replacement
-# for service monitoring. Please see
+# in the event of a failure. systemd service restarts are not a
+# replacement for service monitoring. Please see
 # http://www.rabbitmq.com/monitoring.html
 #
 # Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=

--- a/docs/rabbitmq-server.service.example
+++ b/docs/rabbitmq-server.service.example
@@ -10,6 +10,14 @@ User=rabbitmq
 Group=rabbitmq
 NotifyAccess=all
 TimeoutStartSec=3600
+# Note:
+# You *may* wish to add the following to automatically restart RabbitMQ
+# in the event of a failure. This is not recommended as a replacement
+# for service monitoring. Please see
+# http://www.rabbitmq.com/monitoring.html
+#
+# Restart=on-failure # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
+# RestartSec=10      # https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=
 WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
 ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop


### PR DESCRIPTION
Fixes #1359

This gives guidances for those users who wish to automatically restart RabbitMQ in the event of a failure. Tested by using the `Restart=on-failure` setting, then running the following to abruptly kill the VM:

```
rabbitmqctl eval 'erlang:halt(abort).'
```

@michaelklishin - question - should these comments also be added to the configuration that ships with RabbitMQ?

https://github.com/rabbitmq/rabbitmq-server-release/blob/stable/packaging/debs/Debian/debian/rabbitmq-server.service
https://github.com/rabbitmq/rabbitmq-server-release/blob/stable/packaging/RPMS/Fedora/rabbitmq-server.service