### PR TITLE
Add additional ExecStop line from rabbitmq-server-release

### DIFF
--- a/docs/rabbitmq-server.service.example
+++ b/docs/rabbitmq-server.service.example
@@ -21,6 +21,7 @@ TimeoutStartSec=3600
 WorkingDirectory=/var/lib/rabbitmq
 ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
 ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop
+ExecStop=/bin/sh -c "while ps -p $MAINPID >/dev/null 2>&1; do sleep 1; done"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This line is part of the release but not included here

https://github.com/rabbitmq/rabbitmq-server-release/blob/stable/packaging/debs/Debian/debian/rabbitmq-server.service#L16