### PR TITLE
Ensure that exit code 0 is used for "stop" command

### DIFF
--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -122,15 +122,12 @@ main(ParseFun, DoFun, UsageMod) ->
                 _ ->
                     print_error("unable to connect to node ~w: ~w", [Node, Reason]),
                     print_badrpc_diagnostics([Node]),
-                    case Command of
-                        stop -> rabbit_misc:quit(?EX_OK);
-                        _    -> rabbit_misc:quit(?EX_UNAVAILABLE)
-                    end
+                    exit_badrpc(Command)
             end;
         {badrpc_multi, Reason, Nodes} ->
             print_error("unable to connect to nodes ~p: ~w", [Nodes, Reason]),
             print_badrpc_diagnostics(Nodes),
-            rabbit_misc:quit(?EX_UNAVAILABLE);
+            exit_badrpc(Command);
         function_clause ->
             print_error("operation ~w used with invalid parameter: ~p",
                         [Command, Args]),
@@ -142,6 +139,11 @@ main(ParseFun, DoFun, UsageMod) ->
             print_error("~p", [Other]),
             rabbit_misc:quit(?EX_SOFTWARE)
     end.
+
+exit_badrpc(stop) ->
+    rabbit_misc:quit(?EX_OK);
+exit_badrpc(_) ->
+    rabbit_misc:quit(?EX_UNAVAILABLE).
 
 start_distribution_anon(0, LastError) ->
     {error, LastError};


### PR DESCRIPTION
Part of the fix to #1362.

I could not reproduce the `badrpc_multi` error but it seems to be the only way exit code `69` could be returned from a `stop` command.