### PR TITLE
Ensure that exit code 0 is used for "stop" command

### DIFF
--- a/src/rabbit_cli.erl
+++ b/src/rabbit_cli.erl
@@ -115,15 +115,12 @@ main(ParseFun, DoFun, UsageMod) ->
                 _ ->
                     print_error("unable to connect to node ~w: ~w", [Node, Reason]),
                     print_badrpc_diagnostics([Node]),
-                    case Command of
-                        stop -> rabbit_misc:quit(?EX_OK);
-                        _    -> rabbit_misc:quit(?EX_UNAVAILABLE)
-                    end
+                    exit_badrpc(Command)
             end;
         {badrpc_multi, Reason, Nodes} ->
             print_error("unable to connect to nodes ~p: ~w", [Nodes, Reason]),
             print_badrpc_diagnostics(Nodes),
-            rabbit_misc:quit(?EX_UNAVAILABLE);
+            exit_badrpc(Command);
         function_clause ->
             print_error("operation ~w used with invalid parameter: ~p",
                         [Command, Args]),
@@ -135,6 +132,11 @@ main(ParseFun, DoFun, UsageMod) ->
             print_error("~p", [Other]),
             rabbit_misc:quit(?EX_SOFTWARE)
     end.
+
+exit_badrpc(stop) ->
+    rabbit_misc:quit(?EX_OK);
+exit_badrpc(_) ->
+    rabbit_misc:quit(?EX_UNAVAILABLE).
 
 start_distribution_anon(0, LastError) ->
     {error, LastError};


### PR DESCRIPTION

See #693 and #151098578 in tracker.

These changes are already in the `stable` branch as they were not reverted there: https://github.com/rabbitmq/rabbitmq-server/blob/stable/src/rabbit_cli.erl#L117-L146

I found issue #693 and it turns out that, yes, `systemd` *does* look at the exit status of the `ExecStop` command to determine if the `rabbitmq-server.service` unit should be put into a failed state. Here is the problematic sequence of events as provided by @dumbbell in #693:

* User runs `rabbitmqctl stop` which causes RabbitMQ server to eventually exit with status `0`
* `systemd` notices that the server process exited, and runs the `ExecStop` command - `rabbitmqctl stop`
* At this point, if `rabbitmqctl stop` returns anything other than `0`, `systemd` puts the unit into a failed state

The other reason `rabbitmqctl stop` could (or should) exit with `0` is due to the change introduced in rabbitmq/rabbitmq-server-release#49. With the change to `Restart=on-failure`, the above sequence of events would cause `systemd` to restart RabbitMQ if `rabbitmqctl stop` returns `69` during the `ExecStop` phase.

## Other Options

* Introduce a `safe_stop` command for `rabbitmqctl` that will always return `0`. This command could also check to see if the `RABBITMQ_PID_FILE` environment variable is set and use it to synchronously wait for the server to exit, which would remove the need for [this code](https://github.com/rabbitmq/rabbitmq-server-release/blob/master/packaging/debs/Debian/debian/rabbitmq-server.service#L22). The code to [wait for RabbitMQ to exit](https://github.com/rabbitmq/rabbitmq-server/blob/stable/src/rabbit_control_main.erl#L302-L303) is already available.

* Use the `systemd` [`SuccessExitStatus=69`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#SuccessExitStatus=) setting. I have tested it and `systemd` does consider the code to be OK from the `ExecStop` command:

```
● rabbitmq-server.service - RabbitMQ broker
   Loaded: loaded (/lib/systemd/system/rabbitmq-server.service; enabled; vendor preset: enabled)
   Active: inactive (dead) since Thu 2017-09-28 19:08:38 UTC; 4s ago
  Process: 9671 ExecStop=/bin/sh -c while ps -p $MAINPID >/dev/null 2>&1; do sleep 1; done (code=exited, status=0/SUCCESS)
  Process: 9518 ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop (code=exited, status=69)
 Main PID: 8819 (code=exited, status=0/SUCCESS)
   Status: "Initialized"

Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]: attempted to contact: ['rabbit@UBUNTU-16']
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]: rabbit@UBUNTU-16:
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]:   * connected to epmd (port 4369) on UBUNTU-16
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]:   * epmd reports: node 'rabbit' not running at all
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]:                   no other nodes on UBUNTU-16
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]:   * suggestion: start the node
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]: current node details:
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]: - node name: 'rabbitmq-cli-46@UBUNTU-16'
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]: - home dir: /var/lib/rabbitmq
Sep 28 19:08:38 UBUNTU-16 rabbitmqctl[9518]: - cookie hash: AsRShfl0Qc4l/Srxe0zd5w==
```