### PR TITLE
Do not limit paging to disk if hibernated or resumed after credit

### DIFF
--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -789,7 +789,7 @@ set_ram_duration_target(
           (TargetRamCount =/= infinity andalso
            TargetRamCount1 >= TargetRamCount) of
           true  -> State1;
-          false -> maybe_reduce_memory_use(State1)
+          false -> reduce_memory_use(State1)
       end).
 
 maybe_update_rates(State = #vqstate{ in_counter  = InCount,
@@ -871,7 +871,7 @@ timeout(State = #vqstate { index_state = IndexState }) ->
 handle_pre_hibernate(State = #vqstate { index_state = IndexState }) ->
     State #vqstate { index_state = rabbit_queue_index:flush(IndexState) }.
 
-resume(State) -> a(maybe_reduce_memory_use(State)).
+resume(State) -> a(reduce_memory_use(State)).
 
 msg_rates(#vqstate { rates = #rates { in  = AvgIngressRate,
                                       out = AvgEgressRate } }) ->


### PR DESCRIPTION
Paging of messages to disk is limited by lazy_queue_explicit_gc_run_operation_threshold
This is required to avoid GC on every publish. But for big messages the
process can get hibernated or blocked by the message store credit-flow,
leaving the process with a lot of memory taken.
When hibernating or unblocking we should try to page messages to disk
regardless of the threshold, because we know that memory reduction is
required at this moment.

Fixes #1379
[#150916864]