### PR TITLE
Flush messages to disk in batches.

### DIFF
--- a/src/rabbit_mirror_queue_slave.erl
+++ b/src/rabbit_mirror_queue_slave.erl
@@ -348,6 +348,9 @@ handle_info({bump_credit, Msg}, State) ->
     credit_flow:handle_bump_msg(Msg),
     noreply(State);
 
+handle_info(bump_reduce_memory_use, State) ->
+    noreply(State);
+
 %% In the event of a short partition during sync we can detect the
 %% master's 'death', drop out of sync, and then receive sync messages
 %% which were still in flight. Ignore them.

--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -2433,7 +2433,7 @@ reduce_memory_use(State = #vqstate {
             case get(waiting_bump) of
                 true -> ok;
                 _    -> self() ! bump_reduce_memory_use,
-                        put(waiting_bump, waiting)
+                        put(waiting_bump, true)
             end
     end,
     State3;


### PR DESCRIPTION
If messages should be embedded to a queue index, there will
be no credit flow limit, so message batches can be too big
and block the queue process.
Limiting the batch size allows consumer to make progress while
publishers are blocked by the paging-out process.

[#151614048]
