### PR TITLE
Update default node memory calculation strategy to match rabbitmq/rabbitmq-common#224

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ define PROJECT_ENV
 	    {ssl_options, []},
 	    {vm_memory_high_watermark, 0.4},
 	    {vm_memory_high_watermark_paging_ratio, 0.5},
-	    {vm_memory_calculation_strategy, rss},
+	    {vm_memory_calculation_strategy, allocated},
 	    {memory_monitor_interval, 2500},
 	    {disk_free_limit, 50000000}, %% 50MB
 	    {msg_store_index_module, rabbit_msg_store_ets_index},

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -262,10 +262,10 @@
    %%
    %% {vm_memory_high_watermark_paging_ratio, 0.5},
 
-   %% Selects Erlang VM memory consumption calculation strategy. Can be `rss` or `erlang`,
-   %% `rss` is the default. Introduced in 3.6.11.
-   %% See https://github.com/rabbitmq/rabbitmq-server/issues/1223 for background.
-   %% {vm_memory_calculation_strategy, rss},
+   %% Selects Erlang VM memory consumption calculation strategy. Can be `allocated`, `rss` or `legacy` (aliased as `erlang`),
+   %% Introduced in 3.6.11. `allocated` is the default as of 3.6.13.
+   %% See https://github.com/rabbitmq/rabbitmq-server/issues/1223 and rabbitmq/rabbitmq-common#224 for background.
+   %% {vm_memory_calculation_strategy, allocated},
    
    %% Interval (in milliseconds) at which we perform the check of the memory
    %% levels against the watermarks.


### PR DESCRIPTION
This changes default node memory calculation strategy to match the state of rabbitmq/rabbitmq-common#224.