### PR TITLE
Shutdown cannot fail

### DIFF
--- a/test/rabbitmqctl_shutdown_SUITE.erl
+++ b/test/rabbitmqctl_shutdown_SUITE.erl
@@ -29,8 +29,7 @@ all() ->
 groups() ->
     [
         {running_node, [], [
-            successful_shutdown,
-            error_during_shutdown
+            successful_shutdown
         ]},
         {non_running_node, [], [
             nothing_to_shutdown
@@ -90,18 +89,6 @@ successful_shutdown(Config) ->
     ok = rabbit_control_main:action(shutdown, Node, [], [], fun ct:pal/2),
     false = erlang_pid_is_running(Pid),
     false = node_is_running(Node).
-
-error_during_shutdown(Config) ->
-    Node = ?config(node, Config),
-    ok = rabbit_control_main:action(stop_app, Node, [], [], fun ct:pal/2),
-    ok = rpc:call(Node, application, unload, [os_mon]),
-
-    {badrpc,
-        {'EXIT', {
-            {error, {badmatch, {error,{edge,{bad_vertex,os_mon},os_mon,rabbit}}}},
-            _}}} =
-        rabbit_control_main:action(shutdown, Node, [], [], fun ct:pal/2).
-
 
 nothing_to_shutdown(Config) ->
     Node = ?config(node, Config),


### PR DESCRIPTION
This is a cherry-pick of commit 79fa87f762c299ec5f023012501843a2821cfb49 from `master`. Removes a test that commit 904744d2c3e039105e2c3aeba4c2bb3ceff27fb2 appears to have broken.