### PR TITLE
Default mem calc strategy should be "rss"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ define PROJECT_ENV
 	    {ssl_options, []},
 	    {vm_memory_high_watermark, 0.4},
 	    {vm_memory_high_watermark_paging_ratio, 0.5},
-	    {vm_memory_calculation_strategy, allocated},
+	    {vm_memory_calculation_strategy, rss},
 	    {memory_monitor_interval, 2500},
 	    {disk_free_limit, 50000000}, %% 50MB
 	    {msg_store_index_module, rabbit_msg_store_ets_index},

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -689,7 +689,7 @@ end}.
 %% Selects Erlang VM memory consumption calculation strategy.
 %% Can be `allocated`, `rss` or `legacy` (aliased as `erlang`).
 %%
-%% {vm_memory_calculation_strategy, allocated},
+%% {vm_memory_calculation_strategy, rss},
 
 {mapping, "vm_memory_calculation_strategy", "rabbit.vm_memory_calculation_strategy",
     [{datatype, {enum, [rss, erlang, allocated, legacy]}}]}.


### PR DESCRIPTION
This is due to a scenario in which the Erlang VM allocator stats report a huge increase in memory consumption which is only reflected in VSS increase, not RSS

PT #152081051