### PR TITLE
Allow configuring max connections through config

### DIFF
--- a/src/tcp_listener_sup.erl
+++ b/src/tcp_listener_sup.erl
@@ -49,7 +49,7 @@ start_link(IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartu
 init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, OnShutdown,
       ConcurrentAcceptorCount, Label}) ->
     {ok, AckTimeout} = application:get_env(rabbit, ssl_handshake_timeout),
-    MaxConnections = application:get_env(rabbit, max_connections, infinity),
+    MaxConnections = rabbit_misc:get_env(rabbit, max_connections, infinity),
     {ok, {{one_for_all, 10, 10}, [
         ranch:child_spec({acceptor, IPAddress, Port}, ConcurrentAcceptorCount,
             Transport, [{port, Port}, {ip, IPAddress},

--- a/src/tcp_listener_sup.erl
+++ b/src/tcp_listener_sup.erl
@@ -49,10 +49,11 @@ start_link(IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartu
 init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, OnShutdown,
       ConcurrentAcceptorCount, Label}) ->
     {ok, AckTimeout} = application:get_env(rabbit, ssl_handshake_timeout),
+    MaxConnections = application:get_env(rabbit, max_connections, infinity),
     {ok, {{one_for_all, 10, 10}, [
         ranch:child_spec({acceptor, IPAddress, Port}, ConcurrentAcceptorCount,
             Transport, [{port, Port}, {ip, IPAddress},
-                {max_connections, infinity},
+                {max_connections, MaxConnections},
                 {ack_timeout, AckTimeout},
                 {connection_type, supervisor}|SocketOpts],
             ProtoSup, ProtoOpts),


### PR DESCRIPTION
## Proposed Changes

Allow configuring max connections through `rabbitmq.config`, using Ranch's max_connections setting:
https://ninenines.eu/docs/en/ranch/1.4/guide/listeners/#_limiting_the_number_of_concurrent_connections

Today the only other way (without a LB) is to limit number of file descriptors, but we often want a higher FD limit than connection limit as queues consumes many FDs. We want to limit connections as misbehaving client might open thousands of connections and consume significant amount of RAM and even OOM the server. 

The change is non-breaking and defaults to `infinity` as today. 

Documentation, tests etc are not added. Wanted to  open up the discussion first. 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [ ] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
