### PR TITLE
Handle errors returned via RPC during shutdown

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -450,7 +450,8 @@ stop() ->
 
 stop_and_halt() ->
     try
-        stop()
+        stop(),
+        exit(whoops_something_went_wrong) %% TODO REMOVE THIS QA ONLY
     catch Type:Reason ->
         rabbit_log:error("Error trying to stop RabbitMQ: ~p:~p", [Type, Reason]),
         erlang:error({Type, Reason})

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -450,8 +450,7 @@ stop() ->
 
 stop_and_halt() ->
     try
-        stop(),
-        exit(whoops_something_went_wrong) %% TODO REMOVE THIS QA ONLY
+        stop()
     catch Type:Reason ->
         rabbit_log:error("Error trying to stop RabbitMQ: ~p:~p", [Type, Reason]),
         erlang:error({Type, Reason})

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -289,14 +289,11 @@ shutdown_node_and_wait_pid_to_stop(Node, Pid, Inform) ->
         % an RPC call to rabbit:stop_and_halt. We return error_during_shutdown
         % so that rabbit_cli:main can differentiate this error from
         % other badrpc errors
-        {badrpc, {'EXIT', RpcErr0}} ->
-            {error, {error_during_shutdown, RpcErr0}};
+        {badrpc, {'EXIT', RpcErr}} ->
+            {error, {error_during_shutdown, RpcErr}};
         % NB: rabbit_cli:main pretty-prints other badrpc errors using
-        % rabbit_nodes:diagnostics, so don't modify the error here
-        {badrpc, _}=RpcErr1 ->
-            RpcErr1;
-        Error ->
-            {error, {error_during_shutdown, Error}}
+        % rabbit_nodes:diagnostics, so don't modify the error here.
+        Error -> Error
     end.
 
 action(shutdown, Node, [], _Opts, Inform) ->
@@ -307,14 +304,11 @@ action(shutdown, Node, [], _Opts, Inform) ->
         % rpc:call. We return error_during_shutdown so that
         % rabbit_cli:main can differentiate this error from other badrpc
         % errors
-        {badrpc, {'EXIT', RpcErr0}} ->
-            {error, {error_during_shutdown, RpcErr0}};
+        {badrpc, {'EXIT', RpcErr}} ->
+            {error, {error_during_shutdown, RpcErr}};
         % NB: rabbit_cli:main pretty-prints other badrpc errors using
-        % rabbit_nodes:diagnostics, so don't modify the error here
-        {badrpc, _}=RpcErr1 ->
-            RpcErr1;
-        Error ->
-            {error, {error_during_shutdown, Error}}
+        % rabbit_nodes:diagnostics, so don't modify the error here.
+        Error -> Error
     end;
 
 action(stop, Node, Args, _Opts, Inform) ->

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -285,8 +285,8 @@ shutdown_node_and_wait_pid_to_stop(Node, Pid, Inform) ->
               "RabbitMQ node ~p running at PID ~s successfully shut down",
               [Node, Pid]),
             Res;
-        {error, Err} ->
-            {error, {error_during_shutdown, Err}};
+        {badrpc, {'EXIT', RpcErr}} ->
+            {error, {error_during_shutdown, RpcErr}};
         _  ->
             Res
     end.
@@ -295,6 +295,8 @@ action(shutdown, Node, [], _Opts, Inform) ->
     case rpc:call(Node, os, getpid, []) of
         Pid when is_list(Pid) ->
             shutdown_node_and_wait_pid_to_stop(Node, Pid, Inform);
+        {badrpc, {'EXIT', RpcErr}} ->
+            {error, {error_during_shutdown, RpcErr}};
         Error -> Error
     end;
 

--- a/src/rabbit_control_main.erl
+++ b/src/rabbit_control_main.erl
@@ -287,8 +287,8 @@ shutdown_node_and_wait_pid_to_stop(Node, Pid, Inform) ->
             Res;
         {badrpc, {'EXIT', RpcErr}} ->
             {error, {error_during_shutdown, RpcErr}};
-        _  ->
-            Res
+        Error ->
+            {error, {error_during_shutdown, Error}}
     end.
 
 action(shutdown, Node, [], _Opts, Inform) ->
@@ -297,7 +297,8 @@ action(shutdown, Node, [], _Opts, Inform) ->
             shutdown_node_and_wait_pid_to_stop(Node, Pid, Inform);
         {badrpc, {'EXIT', RpcErr}} ->
             {error, {error_during_shutdown, RpcErr}};
-        Error -> Error
+        Error ->
+            {error, {error_during_shutdown, Error}}
     end;
 
 action(stop, Node, Args, _Opts, Inform) ->


### PR DESCRIPTION
QA of commit 51aca8851eba66445ad5b164fc92b2ffa0692fc2: I added an `exit()` statement in `rabbit:stop_and_halt`  to trigger an error and then some case statements to handle it.

Any error returned by `call(Node, {rabbit, stop_and_halt, []})` should be a tuple starting with `{badrpc, ...`, so we handle that as well as the general case which is for any other error.