### PR TITLE
Start `rabbit` application as temporary in tests.

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -23,7 +23,7 @@
          is_running/1, environment/0, rotate_logs/1, force_event_refresh/1,
          start_fhc/0]).
 -export([start/2, stop/1]).
--export([start_apps/1, stop_apps/1]).
+-export([start_apps/1, start_apps/2, stop_apps/1]).
 -export([log_location/1, config_files/0, decrypt_config/2]). %% for testing and mgmt-agent
 
 %%---------------------------------------------------------------------------
@@ -217,6 +217,7 @@
 %%----------------------------------------------------------------------------
 
 -type file_suffix() :: binary().
+-type restart_type() :: 'permanent' | 'transient' | 'temporary'.
 %% this really should be an abstract type
 -type log_location() :: 'tty' | 'undefined' | file:filename().
 -type param() :: atom().
@@ -253,6 +254,7 @@
 -spec boot_delegate() -> 'ok'.
 -spec recover() -> 'ok'.
 -spec start_apps([app_name()]) -> 'ok'.
+-spec start_apps([app_name()], [{app_name(), restart_type()}]) -> 'ok'.
 -spec stop_apps([app_name()]) -> 'ok'.
 
 %%----------------------------------------------------------------------------
@@ -474,6 +476,9 @@ stop_and_halt() ->
     ok.
 
 start_apps(Apps) ->
+    start_apps(Apps, []).
+
+start_apps(Apps, RestartTypes) ->
     app_utils:load_applications(Apps),
 
     ConfigEntryDecoder = case application:get_env(rabbit, config_entry_decoder) of
@@ -513,7 +518,8 @@ start_apps(Apps) ->
         true  -> ok                    %% will run during start of rabbit app
     end,
     ok = app_utils:start_applications(OrderedApps,
-                                      handle_app_error(could_not_start)).
+                                      handle_app_error(could_not_start),
+                                      RestartTypes).
 
 %% This function retrieves the correct IoDevice for requesting
 %% input. The problem with using the default IoDevice is that

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -332,10 +332,11 @@ do_decrypt_start_app(Config, Passphrase) ->
     %%
     %% We expect a failure *after* the decrypting has been done.
     try
-        rabbit:start_apps([rabbit_shovel_test])
+        rabbit:start_apps([rabbit_shovel_test], [{rabbit, temporary}])
     catch _:_ ->
         ok
-    end,
+    end
+    ,
     %% Check if the values have been decrypted.
     {ok, Shovels} = application:get_env(rabbit_shovel_test, shovels),
     {_, FirstShovel} = lists:keyfind(my_first_shovel, 1, Shovels),
@@ -359,7 +360,7 @@ decrypt_start_app_undefined(Config) ->
     %%
     %% We expect a failure during decryption because the passphrase is missing.
     try
-        rabbit:start_apps([rabbit_shovel_test])
+        rabbit:start_apps([rabbit_shovel_test], [{rabbit, temporary}])
     catch
         exit:{bad_configuration, config_entry_decoder} -> ok;
         _:_ -> exit(unexpected_exception)
@@ -379,7 +380,7 @@ decrypt_start_app_wrong_passphrase(Config) ->
     %%
     %% We expect a failure during decryption because the passphrase is wrong.
     try
-        rabbit:start_apps([rabbit_shovel_test])
+        rabbit:start_apps([rabbit_shovel_test], [{rabbit, temporary}])
     catch
         exit:{decryption_error,_,_} -> ok;
         _:_ -> exit(unexpected_exception)


### PR DESCRIPTION
Some tests output can break when `rabbit` application failure
stops the node. Make it possible to configure restart type.
This is a part of a backport of https://github.com/rabbitmq/rabbitmq-server/issues/1216