### PR TITLE
Configurable default consumer prefetch for new channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ define PROJECT_ENV
 	    %% by default we choose to not terminate the entire node if one
 	    %% vhost had to shut down, see server#1158 and server#1280
 	    {vhost_restart_strategy, continue},
+	    %% {global, prefetch count}
 	    {default_consumer_prefetch, {false, 0}}
 	  ]
 endef

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ define PROJECT_ENV
 	    %% either "stop_node" or "continue".
 	    %% by default we choose to not terminate the entire node if one
 	    %% vhost had to shut down, see server#1158 and server#1280
-	    {vhost_restart_strategy, continue}
+	    {vhost_restart_strategy, continue},
+	    {default_consumer_prefetch, {false, 0}}
 	  ]
 endef
 

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -390,7 +390,7 @@ init([Channel, ReaderPid, WriterPid, ConnPid, ConnName, Protocol, User, VHost,
     Limiter0 = rabbit_limiter:new(LimiterPid),
     Limiter = case {Global, Prefetch} of
                   {true, 0} ->
-                      Limiter1 = rabbit_limiter:unlimit_prefetch(Limiter0);
+                      rabbit_limiter:unlimit_prefetch(Limiter0);
                   {true, _} ->
                       rabbit_limiter:limit_prefetch(Limiter0, Prefetch, 0);
                   _ ->


### PR DESCRIPTION
Default consumer prefetch can be provided in the config:
```
{rabbit, [{default_consumer_prefetch, {false, 0}}]}
```
or applied in runtime:
```
rabbitmqctl eval 'application:set_env(rabbit, default_consumer_prefetch, {false, 0}).'
```

Closes #1367
