### PR TITLE
Make rabbit_networking:close_connection/2 more benign

### DIFF
--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -305,10 +305,16 @@ connection_info_all(Items, Ref, AggregatorPid) ->
       connections()).
 
 close_connection(Pid, Explanation) ->
-    rabbit_log:info("Closing connection ~p because ~p~n", [Pid, Explanation]),
     case lists:member(Pid, connections()) of
-        true  -> rabbit_reader:shutdown(Pid, Explanation);
-        false -> throw({error, {not_a_connection_pid, Pid}})
+        true  ->
+            Res = rabbit_reader:shutdown(Pid, Explanation),
+            rabbit_log:info("Closing connection ~p because ~p~n", [Pid, Explanation]),
+            Res;
+        false ->
+            rabbit_log:warning("Asked to close connection ~p (reason: ~p) "
+                               "but no running cluster node reported it as an active connection. Was it already closed? ~n",
+                               [Pid, Explanation]),
+            ok
     end.
 
 force_connection_event_refresh(Ref) ->


### PR DESCRIPTION
## Proposed Changes

The function relies on a fanout to all running cluster nodes
which in turn check their local connection process group.
All errors that might arise are ignored.

There are at least two scenarios where the current behavior makes
little sense:

 * A connection process has just terminated (but is still present in the stats DB)
 * A node could not respond (or respond in time) to the fanout

In both cases claiming that connection pid is "not a connection pid"
is misleading and likely will leave the user puzzled. This change
makes connection_close/2 more benign: it simply logs a warning and returns
instead of throwing.

There are only two call sites that use it: rabbitmqctl and an HTTP API
handler, so the chances of non-connection pids passed in are pretty slim.

While at it, only log that a connection was closed when it actually was.

Per discussion with @gerhard.## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
