### PR TITLE
DRAFT Set fullsweep_after to 0 for queue processes.

### DIFF
--- a/src/rabbit_prequeue.erl
+++ b/src/rabbit_prequeue.erl
@@ -43,7 +43,8 @@
 %%----------------------------------------------------------------------------
 
 start_link(Q, StartMode, Marker) ->
-    gen_server2:start_link(?MODULE, {Q, StartMode, Marker}, []).
+    gen_server2:start_link(?MODULE, {Q, StartMode, Marker},
+                           [{spawn_opt, [{fullsweep_after, 10}]}]).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
The setting tends to increase performance of a queue in
publish mode. Although can use more memory if queue contains
more messages when performing GC.

Need to investigate performance impact of this change on other workloads.