### PR TITLE
gm: adapt has_pending_messages/1 for maps

### DIFF
--- a/src/gm.erl
+++ b/src/gm.erl
@@ -1559,9 +1559,10 @@ has_pending_messages(#state{ broadcast_buffer = Buffer })
   when Buffer =/= [] ->
     true;
 has_pending_messages(#state{ members_state = MembersState }) ->
-    [] =/= [M || {_, #member{last_pub = LP, last_ack = LA} = M}
-                 <- MembersState,
-                 LP =/= LA].
+    MembersWithPubAckMismatches = maps:filter(fun(_Id, #member{last_pub = LP, last_ack = LA}) ->
+                                                      LP =/= LA
+                                              end, MembersState),
+    0 =/= maps:size(MembersWithPubAckMismatches).
 
 maybe_confirm(_Self, _Id, Confirms, []) ->
     Confirms;


### PR DESCRIPTION
## Proposed Changes

This updates `gm:has_pending_messages/1` to assume that member stats is a map, which it is as of https://github.com/rabbitmq/rabbitmq-server/commit/3e6d1ad207b5dc5b5ab5fff39d0d82f0d45915c0.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes #1427)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

[#153094258]

