### PR TITLE
Avoid infinite loop when dropping gm queue entries.

### DIFF
--- a/src/gm.erl
+++ b/src/gm.erl
@@ -1354,9 +1354,12 @@ find_common(A, B, Common) ->
             find_common(A1, B1, queue:in(Val, Common));
         {{empty, _A}, _} ->
             {Common, B};
-        {_, {_, B1}} ->
+        %% Drop value from B.
+        %% Match value to avoid infinite loop, since {empty, B} = queue:out(B).
+        {_, {{value, _}, B1}} ->
             find_common(A, B1, Common);
-        {{_, A1}, _} ->
+        %% Drop value from A. Empty A should be matched by second close.
+        {{{value, _}, A1}, _} ->
             find_common(A1, B, Common)
     end.
 


### PR DESCRIPTION
## Proposed Changes

Since `out` operation on empty queue is idempotent `queue:out(B) = {empty, B}`,
there can be a potential infinite loop when dropping messages.
Matching that there is a value to drop.
Empty A queue should be handled by second clause.
Related to #779

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

