### PR TITLE
Check that rabbit application is running when trying to enable plugins.

### DIFF
--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -44,7 +44,13 @@
 
 %%----------------------------------------------------------------------------
 
-ensure(FileJustChanged0) ->
+ensure(FileJustChanged) ->
+    case rabbit:is_running() of
+        true  -> ensure1(FileJustChanged);
+        false -> {error, rabbit_not_running}
+    end.
+
+ensure1(FileJustChanged0) ->
     {ok, OurFile0} = application:get_env(rabbit, enabled_plugins_file),
     FileJustChanged = filename:nativename(FileJustChanged0),
     OurFile = filename:nativename(OurFile0),


### PR DESCRIPTION
If the node is started, but rabbit application is not running,
plugins can fail to start when enabled.

Check for rabbit application and return an error.

Part of rabbitmq/rabbitmq-cli#226
[#153184802]