### PR TITLE
Internal authN backend: make it impossible to successfully log in with a blank password (master)

### DIFF
--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -100,7 +100,7 @@ hashing_module_for_user(#internal_user{
 
 -define(BLANK_PASSWORD_REJECTION_MESSAGE,
         "user '~s' attempted to log in with a blank password, which is prohibited by the internal authN backend. "
-        "To use TLS/x509 certificate-based autentication, set the rabbitmq_auth_mechanism_ssl plugin and configure the client to use the EXTERNAL authentication mechanism. "
+        "To use TLS/x509 certificate-based authentication, see the rabbitmq_auth_mechanism_ssl plugin and configure the client to use the EXTERNAL authentication mechanism. "
         "Alternatively change the password for the user to be non-blank.").
 
 %% For cases when we do not have a set of credentials,

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -98,6 +98,11 @@ hashing_module_for_user(#internal_user{
     hashing_algorithm = ModOrUndefined}) ->
         rabbit_password:hashing_mod(ModOrUndefined).
 
+-define(BLANK_PASSWORD_REJECTION_MESSAGE,
+         "user '~s' attempted to log in with a blank password, which is prohibited by the internal authN backend. "
+        "To use TLS/x509 certificate-based autentication, set the rabbitmq_auth_mechanism_ssl plugin and configure the client to use the EXTERNAL authentication mechanism. "
+         "Alternatively change the password for the user to be non-blank.").
+
 %% For cases when we do not have a set of credentials,
 %% namely when x509 (TLS) certificates are used. This should only be
 %% possible when the EXTERNAL authentication mechanism is used, see
@@ -108,6 +113,12 @@ user_login_authentication(Username, []) ->
 %% performs initial validation.
 user_login_authentication(Username, AuthProps) ->
     case lists:keyfind(password, 1, AuthProps) of
+        {password, <<"">>} ->
+            {refused, ?BLANK_PASSWORD_REJECTION_MESSAGE,
+             [Username]};
+        {password, ""} ->
+            {refused, ?BLANK_PASSWORD_REJECTION_MESSAGE,
+             [Username]};
         {password, Cleartext} ->
             internal_check_user_login(
               Username,

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -99,9 +99,9 @@ hashing_module_for_user(#internal_user{
         rabbit_password:hashing_mod(ModOrUndefined).
 
 -define(BLANK_PASSWORD_REJECTION_MESSAGE,
-         "user '~s' attempted to log in with a blank password, which is prohibited by the internal authN backend. "
+        "user '~s' attempted to log in with a blank password, which is prohibited by the internal authN backend. "
         "To use TLS/x509 certificate-based autentication, set the rabbitmq_auth_mechanism_ssl plugin and configure the client to use the EXTERNAL authentication mechanism. "
-         "Alternatively change the password for the user to be non-blank.").
+        "Alternatively change the password for the user to be non-blank.").
 
 %% For cases when we do not have a set of credentials,
 %% namely when x509 (TLS) certificates are used. This should only be


### PR DESCRIPTION
## Proposed Changes

This disables logins with a blank **provided** password in the internal [authN backend](http://rabbitmq.com/access-control.html). There should be no reason to use passwordless users
and password-based authentication (the PLAIN authentication mechanism). Blank passwords
are only useful when they are, ahem, not used because authentication is handled out of band, e.g. [via x509 certificates](http://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl).

It is still possible to create a user with a blank password or clear a password on an existing user.
When the EXTERNAL authentication mechanism is used, the internal backend is not involved at all.

Note that this change is limited to the internal backend only. External backends such as LDAP
are considered to not be controlled by the broker.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise): https://github.com/rabbitmq/rabbitmq-website/pull/472
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

[#153435857]
  
  