### PR TITLE
Make sure rabbit_misc:pmap callbacks do not throw.

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -361,13 +361,29 @@ emit_info(PidList, InfoItems, Ref, AggregatorPid) ->
 
 refresh_config_local() ->
     rabbit_misc:upmap(
-      fun (C) -> gen_server2:call(C, refresh_config, infinity) end,
+      fun (C) ->
+        try
+          gen_server2:call(C, refresh_config, infinity)
+        catch _:Reason ->
+          rabbit_log:error("Failed to refresh channel config "
+                           "for channel ~p. Reason ~p",
+                           [C, Reason])
+        end
+      end,
       list_local()),
     ok.
 
 refresh_interceptors() ->
     rabbit_misc:upmap(
-      fun (C) -> gen_server2:call(C, refresh_interceptors, ?REFRESH_TIMEOUT) end,
+      fun (C) ->
+        try
+          gen_server2:call(C, refresh_interceptors, ?REFRESH_TIMEOUT)
+        catch _:Reason ->
+          rabbit_log:error("Failed to refresh channel interceptors "
+                           "for channel ~p. Reason ~p",
+                           [C, Reason])
+        end
+      end,
       list_local()),
     ok.
 

--- a/test/channel_interceptor_SUITE.erl
+++ b/test/channel_interceptor_SUITE.erl
@@ -29,7 +29,8 @@ all() ->
 groups() ->
     [
       {non_parallel_tests, [], [
-          register_interceptor
+          register_interceptor,
+          register_failing_interceptors
         ]}
     ].
 
@@ -71,9 +72,9 @@ end_per_testcase(Testcase, Config) ->
 
 register_interceptor(Config) ->
     passed = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, register_interceptor1, [Config]).
+      ?MODULE, register_interceptor1, [Config, dummy_interceptor]).
 
-register_interceptor1(Config) ->
+register_interceptor1(Config, Interceptor) ->
     PredefinedChannels = rabbit_channel:list(),
 
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, 0),
@@ -89,8 +90,8 @@ register_interceptor1(Config) ->
 
     ok = rabbit_registry:register(channel_interceptor,
                                   <<"dummy interceptor">>,
-                                  dummy_interceptor),
-    [{interceptors, [{dummy_interceptor, undefined}]}] =
+                                  Interceptor),
+    [{interceptors, [{Interceptor, undefined}]}] =
       rabbit_channel:info(ChannelProc, [interceptors]),
 
     check_send_receive(Ch1, QName, <<"bar">>, <<"">>),
@@ -102,6 +103,9 @@ register_interceptor1(Config) ->
     check_send_receive(Ch1, QName, <<"bar">>, <<"bar">>),
     passed.
 
+register_failing_interceptors(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, register_interceptor1, [Config, failing_dummy_interceptor]).
 
 check_send_receive(Ch1, QName, Send, Receive) ->
     amqp_channel:call(Ch1,

--- a/test/failing_dummy_interceptor.erl
+++ b/test/failing_dummy_interceptor.erl
@@ -1,0 +1,27 @@
+-module(failing_dummy_interceptor).
+
+-behaviour(rabbit_channel_interceptor).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit_framing.hrl").
+
+
+-compile(export_all).
+
+init(_Ch) ->
+    timer:sleep(15500),
+    undefined.
+
+description() ->
+    [{description,
+      <<"Empties payload on publish">>}].
+
+intercept(#'basic.publish'{} = Method, Content, _IState) ->
+    Content2 = Content#content{payload_fragments_rev = []},
+    {Method, Content2};
+
+intercept(Method, Content, _VHost) ->
+    {Method, Content}.
+
+applies_to() ->
+    ['basic.publish'].


### PR DESCRIPTION
[#153846585]

## Proposed Changes

Catch any errors in callbacks for `rabbit_misc:pmap/2`

`rabbit_misc:pmap/2` can hang if a callback throws an error.
This can cause plugin startup to hang when enabling channel
interceptors.

Made it log errors and continue.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

