### PR TITLE
Declare a quorum queue using the queue.declare method

### DIFF
--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -60,6 +60,7 @@
 -rabbit_upgrade({queue_vhost_field,     mnesia, [operator_policies]}).
 -rabbit_upgrade({topic_permission,      mnesia,  []}).
 -rabbit_upgrade({queue_options,         mnesia, [queue_vhost_field]}).
+-rabbit_upgrade({queue_type,            mnesia, [queue_options]}).
 -rabbit_upgrade({exchange_options,      mnesia, [operator_policies]}).
 
 %% -------------------------------------------------------------------
@@ -98,6 +99,7 @@
 -spec operator_policies() -> 'ok'.
 -spec queue_vhost_field() -> 'ok'.
 -spec queue_options() -> 'ok'.
+-spec queue_type() -> 'ok'.
 -spec exchange_options() -> 'ok'.
 
 
@@ -575,6 +577,26 @@ queue_options(Table) ->
       [name, durable, auto_delete, exclusive_owner, arguments, pid, slave_pids,
        sync_slave_pids, recoverable_slaves, policy, operator_policy,
        gm_pids, decorators, state, policy_version, slave_pids_pending_shutdown, vhost, options]).
+
+queue_type() ->
+    ok = queue_type(rabbit_queue),
+    ok = queue_type(rabbit_durable_queue),
+    ok.
+
+queue_type(Table) ->
+    transform(
+      Table,
+      fun ({amqqueue, Name, Durable, AutoDelete, ExclusiveOwner, Arguments,
+            Pid, SlavePids, SyncSlavePids, DSN, Policy, OperatorPolicy, GmPids, Decorators,
+            State, PolicyVersion, SlavePidsPendingShutdown, VHost, Options}) ->
+              {amqqueue, Name, Durable, AutoDelete, ExclusiveOwner, Arguments,
+               Pid, SlavePids, SyncSlavePids, DSN, Policy, OperatorPolicy, GmPids, Decorators,
+               State, PolicyVersion, SlavePidsPendingShutdown, VHost, Options, classic}
+      end,
+      [name, durable, auto_delete, exclusive_owner, arguments, pid, slave_pids,
+       sync_slave_pids, recoverable_slaves, policy, operator_policy,
+       gm_pids, decorators, state, policy_version, slave_pids_pending_shutdown, vhost, options,
+       type]).
 
 %% Prior to 3.6.0, passwords were hashed using MD5, this populates
 %% existing records with said default.  Users created with 3.6.0+ will


### PR DESCRIPTION
## Proposed Changes

Part of the new high availability implementation using raft as a consensus algorithm

Uses the x-queue-type argument to introduce the type: quorum/classic
Defaults to classic

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
