### PR TITLE
Only call vhost status for fully started nodes

### DIFF
--- a/src/rabbit_nodes.erl
+++ b/src/rabbit_nodes.erl
@@ -85,4 +85,5 @@ set_cluster_name(Name, Username) ->
 ensure_epmd() ->
     rabbit_nodes_common:ensure_epmd().
 
-all_running() -> rabbit_mnesia:cluster_nodes(running).
+all_running() -> [ Node || Node <- rabbit_mnesia:cluster_nodes(running),
+                           is_running(Node, rabbit) ].

--- a/src/rabbit_nodes.erl
+++ b/src/rabbit_nodes.erl
@@ -85,5 +85,4 @@ set_cluster_name(Name, Username) ->
 ensure_epmd() ->
     rabbit_nodes_common:ensure_epmd().
 
-all_running() -> [ Node || Node <- rabbit_mnesia:cluster_nodes(running),
-                           is_running(Node, rabbit) ].
+all_running() -> rabbit_mnesia:cluster_nodes(running).


### PR DESCRIPTION
If a node is restarting, vhost status can throw an error because an ETS table for vhosts is not created yet.
This PR makes sure vhosts status only called for fully started nodes.
