### PR TITLE
Revert "Merge rabbitmq/rabbitmq-server#1486 to master"

### DIFF
--- a/scripts/rabbitmq-diagnostics.bat
+++ b/scripts/rabbitmq-diagnostics.bat
@@ -48,8 +48,6 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
--kernel inet_dist_listen_min 35672 ^
--kernel inet_dist_listen_max 35672 ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -sasl errlog_type error ^
 -mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -343,8 +343,6 @@ run_escript()
     exec "${ERL_DIR}erl" +B \
         -boot "${CLEAN_BOOT_FILE}" \
         -noinput -noshell -hidden -smp enable \
-        -kernel inet_dist_listen_min 35672 \
-        -kernel inet_dist_listen_max 35672 \
         ${RABBITMQ_CTL_ERL_ARGS} \
         -sasl errlog_type error \
         -mnesia dir "\"${RABBITMQ_MNESIA_DIR}\"" \

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -48,8 +48,6 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
--kernel inet_dist_listen_min 35672 ^
--kernel inet_dist_listen_max 35672 ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -sasl errlog_type error ^
 -mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^

--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -48,8 +48,6 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
--kernel inet_dist_listen_min 35672 ^
--kernel inet_dist_listen_max 35672 ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -sasl errlog_type error ^
 -mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-server#1487 because hardcoding a port means more than 1 CLI tool cannot be running at the same time, which is not worth the gain.