### PR TITLE
RABBITMQ_BASE is Windows only

### DIFF
--- a/docs/rabbitmq-service.8
+++ b/docs/rabbitmq-service.8
@@ -89,8 +89,8 @@ using the service control panel.
 .It Ev RABBITMQ_SERVICENAME
 Defaults to RabbitMQ.
 .It Ev RABBITMQ_BASE
-Defaults to the application data directory of the current user.
-This is the location of log and database directories.
+Note: Windows only. Defaults to the application data directory of the
+current user. This is the location of log and database directories.
 .It Ev RABBITMQ_NODENAME
 Defaults to
 .Qq rabbit .

--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -240,6 +240,13 @@
 # tcp_listen_options.backlog = 128
 # tcp_listen_options.nodelay = true
 # tcp_listen_options.exit_on_close = false
+#
+# tcp_listen_options.keepalive = true
+# tcp_listen_options.send_timeout = 15000
+#
+# tcp_listen_options.buffer = 196608
+# tcp_listen_options.sndbuf = 196608
+# tcp_listen_options.recbuf = 196608
 
 ##
 ## Resource Limits & Flow Control


### PR DESCRIPTION
Merges #1506 to `master`

@michaelklishin apparently the changes to `docs/rabbitmq.conf.example` didn't get merged to `master` ... I'm assuming it's OK to bring them in here.