### PR TITLE
RABBITMQ_NAME_TYPE should be correctly set in Windows batch files

### DIFF
--- a/scripts/rabbitmq-diagnostics.bat
+++ b/scripts/rabbitmq-diagnostics.bat
@@ -48,12 +48,12 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
+!RABBITMQ_NAME_TYPE! rabbitmqescript!RANDOM!!TIME:~9!@localhost ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^
 -mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^
--nodename !RABBITMQ_NODENAME! ^
 -run escript start ^
 -escript main rabbitmqctl_escript ^
 -extra "%RABBITMQ_HOME%\escript\rabbitmq-diagnostics" !STAR!

--- a/scripts/rabbitmq-diagnostics.bat
+++ b/scripts/rabbitmq-diagnostics.bat
@@ -48,7 +48,6 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
-!RABBITMQ_NAME_TYPE! rabbitmqescript!RANDOM!!TIME:~9!@localhost ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -350,7 +350,6 @@ run_escript()
     exec "${ERL_DIR}erl" +B \
         -boot "$CLEAN_BOOT_FILE" \
         -noinput -noshell -hidden -smp enable \
-        "$RABBITMQ_NAME_TYPE" "rabbitmqescript$$@localhost" \
         $RABBITMQ_CTL_ERL_ARGS \
         -kernel inet_dist_listen_min "$RABBITMQ_CTL_DIST_PORT_MIN" \
         -kernel inet_dist_listen_max "$RABBITMQ_CTL_DIST_PORT_MAX" \

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -344,16 +344,18 @@ run_escript()
     escript="${1:?escript must be defined}"
     shift
 
+    # Important: do not quote RABBITMQ_CTL_ERL_ARGS as they must be
+    # word-split
     # shellcheck disable=SC2086
     exec "${ERL_DIR}erl" +B \
-        -boot "${CLEAN_BOOT_FILE}" \
+        -boot "$CLEAN_BOOT_FILE" \
         -noinput -noshell -hidden -smp enable \
-        ${RABBITMQ_CTL_ERL_ARGS} \
-        -kernel inet_dist_listen_min $RABBITMQ_CTL_DIST_PORT_MIN \
-        -kernel inet_dist_listen_max $RABBITMQ_CTL_DIST_PORT_MAX \
+        "$RABBITMQ_NAME_TYPE" "rabbitmqescript$$@localhost" \
+        $RABBITMQ_CTL_ERL_ARGS \
+        -kernel inet_dist_listen_min "$RABBITMQ_CTL_DIST_PORT_MIN" \
+        -kernel inet_dist_listen_max "$RABBITMQ_CTL_DIST_PORT_MAX" \
         -sasl errlog_type error \
-        -mnesia dir "\"${RABBITMQ_MNESIA_DIR}\"" \
-        -nodename "$RABBITMQ_NODENAME" \
+        -mnesia dir "\"$RABBITMQ_MNESIA_DIR\"" \
         -run escript start \
         -escript main "$escript_main" \
         -extra "$escript" "$@"

--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -74,14 +74,16 @@ for /f "delims=" %%F in ("!RABBITMQ_BASE!") do set RABBITMQ_BASE=%%~sF
 
 REM Check for the short names here too
 if "!RABBITMQ_USE_LONGNAME!"=="true" (
-    set RABBITMQ_NAME_TYPE="-name"
+    set RABBITMQ_NAME_TYPE=-name
     set NAMETYPE=longnames
 ) else (
     if "!USE_LONGNAME!"=="true" (
-        set RABBITMQ_NAME_TYPE="-name"
+        set RABBITMQ_USE_LONGNAME=true
+        set RABBITMQ_NAME_TYPE=-name
         set NAMETYPE=longnames
     ) else (
-        set RABBITMQ_NAME_TYPE="-sname"
+        set RABBITMQ_USE_LONGNAME=false
+        set RABBITMQ_NAME_TYPE=-sname
         set NAMETYPE=shortnames
     )
 )

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -48,7 +48,6 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
-!RABBITMQ_NAME_TYPE! rabbitmqescript!RANDOM!!TIME:~9!@localhost ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -48,12 +48,12 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
+!RABBITMQ_NAME_TYPE! rabbitmqescript!RANDOM!!TIME:~9!@localhost ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^
 -mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^
--nodename !RABBITMQ_NODENAME! ^
 -run escript start ^
 -escript main rabbitmqctl_escript ^
 -extra "%RABBITMQ_HOME%\escript\rabbitmq-plugins" --formatter=plugins !STAR!

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -55,12 +55,13 @@ if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!.co
 
 "!ERLANG_HOME!\bin\erl.exe" ^
         -pa "!RABBITMQ_EBIN_ROOT!" ^
+        -boot !CLEAN_BOOT_FILE! ^
         -noinput -hidden ^
         -s rabbit_prelaunch ^
+        !RABBITMQ_NAME_TYPE! rabbitmqprelaunch!RANDOM!!TIME:~9!@localhost ^
         -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE!" ^
         -rabbit enabled_plugins_file "!RABBITMQ_ENABLED_PLUGINS_FILE!" ^
         -rabbit plugins_dir "!RABBITMQ_PLUGINS_DIR!" ^
-        !RABBITMQ_NAME_TYPE! rabbitmqprelaunch!RANDOM!!TIME:~9!@localhost ^
         -extra "!RABBITMQ_NODENAME!"
 
 if ERRORLEVEL 2 (

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -144,7 +144,8 @@ if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!.co
         -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE!" ^
         -rabbit enabled_plugins_file "!RABBITMQ_ENABLED_PLUGINS_FILE!" ^
         -rabbit plugins_dir "!RABBITMQ_PLUGINS_DIR!" ^
-        !RABBITMQ_NAME_TYPE! rabbitmqprelaunch!RANDOM!!TIME:~9!@localhost
+        !RABBITMQ_NAME_TYPE! rabbitmqprelaunch!RANDOM!!TIME:~9!@localhost ^
+        -extra "!RABBITMQ_NODENAME!"
 
 if ERRORLEVEL 3 (
     rem ERRORLEVEL means (or greater) so we need to catch all other failure

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -139,12 +139,13 @@ if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!.co
 
 "!ERLANG_HOME!\bin\erl.exe" ^
         -pa "!RABBITMQ_EBIN_ROOT!" ^
+        -boot !CLEAN_BOOT_FILE! ^
         -noinput -hidden ^
         -s rabbit_prelaunch ^
+        !RABBITMQ_NAME_TYPE! rabbitmqprelaunch!RANDOM!!TIME:~9!@localhost ^
         -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE!" ^
         -rabbit enabled_plugins_file "!RABBITMQ_ENABLED_PLUGINS_FILE!" ^
         -rabbit plugins_dir "!RABBITMQ_PLUGINS_DIR!" ^
-        !RABBITMQ_NAME_TYPE! rabbitmqprelaunch!RANDOM!!TIME:~9!@localhost ^
         -extra "!RABBITMQ_NODENAME!"
 
 if ERRORLEVEL 3 (

--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -48,7 +48,6 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
-!RABBITMQ_NAME_TYPE! rabbitmqescript!RANDOM!!TIME:~9!@localhost ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^

--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -48,12 +48,12 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 "!ERLANG_HOME!\bin\erl.exe" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
+!RABBITMQ_NAME_TYPE! rabbitmqescript!RANDOM!!TIME:~9!@localhost ^
 !RABBITMQ_CTL_ERL_ARGS! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^
 -mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^
--nodename !RABBITMQ_NODENAME! ^
 -run escript start ^
 -escript main rabbitmqctl_escript ^
 -extra "%RABBITMQ_HOME%\escript\rabbitmqctl" !STAR!


### PR DESCRIPTION
Remove unused `-nodename` argument to `erl`, ensure that `RABBITMQ_NAME_TYPE` is used correctly in Windows batch files

Fixes #1508 

@michaelklishin - I confirmed that it's OK to remove `-nodename` since the `rabbitmq-cli` commands will get the value from the `RABBITMQ_NODENAME` env variable.