### PR TITLE
Support kernel.net_ticktime in Cuttlefish configuration

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -459,7 +459,7 @@
 # Kernel section
 # ======================================
 
-# kernel.net_ticktime = 60
+# net_ticktime = 60
 
 ## ----------------------------------------------------------------------------
 ## RabbitMQ Management Plugin

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1156,7 +1156,7 @@ end}.
 
 {mapping, "net_ticktime", "kernel.net_ticktime",[
     {datatype, [integer]},
-    {validators, ["non_negative_integer"]}
+    {validators, ["non_zero_positive_integer"]}
 ]}.
 
 % ===============================
@@ -1207,4 +1207,9 @@ end}.
 {validator, "non_negative_integer", "number should be greater or equal to zero",
 fun(Int) when is_integer(Int) ->
     Int >= 0
+end}.
+
+{validator, "non_zero_positive_integer", "number should be greater or equal to one",
+fun(Int) when is_integer(Int) ->
+    Int >= 1
 end}.

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1150,6 +1150,14 @@ end}.
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
 
+% ==========================
+% Kernel section
+% ==========================
+
+{mapping, "net_ticktime", "kernel.net_ticktime",[
+    {datatype, [integer]}
+]}.
+
 % ===============================
 % Validators
 % ===============================

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1155,7 +1155,8 @@ end}.
 % ==========================
 
 {mapping, "net_ticktime", "kernel.net_ticktime",[
-    {datatype, [integer]}
+    {datatype, [integer]},
+    {validators, ["non_negative_integer"]}
 ]}.
 
 % ===============================

--- a/src/rabbit_config.erl
+++ b/src/rabbit_config.erl
@@ -94,14 +94,14 @@ maybe_print_warning_for_running_app(kernel, Config) ->
     ConfigWithoutSupportedEntry = proplists:delete(net_ticktime, Config),
     case length(ConfigWithoutSupportedEntry) > 0 of
         true -> io:format(standard_error,
-            "~nUnable to update config for app ~p from *.conf file."
-            " App is already running. Use advanced.config instead.~n", [kernel]);
+            "~nUnable to update config for app ~p from a .conf file."
+            " The app is already running. Use advanced.config instead.~n", [kernel]);
         false -> ok
     end;
 maybe_print_warning_for_running_app(App, _Config) ->
     io:format(standard_error,
-        "~nUnable to update config for app ~p from *.conf file."
-        " App is already running. Use advanced.config instead.~n",
+        "~nUnable to update config for app ~p from a .conf file: "
+        " The app is already running.~n",
         [App]).
 
 maybe_set_net_ticktime(undefined) ->
@@ -111,7 +111,11 @@ maybe_set_net_ticktime(KernelConfig) ->
         undefined ->
             ok;
         NetTickTime ->
-            case net_kernel:set_net_ticktime(NetTickTime) of
+            case net_kernel:set_net_ticktime(NetTickTime, 0) of
+                unchanged ->
+                    ok;
+                change_initiated ->
+                    ok;
                 {ongoing_change_to, NewNetTicktime} ->
                     io:format(standard_error,
                         "~nCouldn't set net_ticktime to ~p "

--- a/src/rabbit_config.erl
+++ b/src/rabbit_config.erl
@@ -72,13 +72,10 @@ update_app_config(ConfigFile) ->
     %% For application config to be updated, applications should
     %% be unloaded first.
     %% If an application is already running, print an error.
-    lists:foreach(fun({App, _Config}) ->
+    lists:foreach(fun({App, AppConfig}) ->
         case lists:member(App, RunningApps) of
             true ->
-                io:format(standard_error,
-                          "~nUnable to update config for app ~p from *.conf file."
-                          " App is already running. Use advanced.config instead.~n",
-                          [App]);
+                maybe_print_warning_for_running_app(App, AppConfig);
             false ->
                 case lists:member(App, LoadedApps) of
                     true  -> application:unload(App);
@@ -87,10 +84,43 @@ update_app_config(ConfigFile) ->
         end
     end,
     Config),
+    maybe_set_net_ticktime(proplists:get_value(kernel, Config)),
     ok = application_controller:change_application_data([], [ConfigFile]),
     %% Make sure to load all the applications we're unloaded
     lists:foreach(fun(App) -> application:load(App) end, LoadedApps),
     ok.
+
+maybe_print_warning_for_running_app(kernel, Config) ->
+    ConfigWithoutSupportedEntry = proplists:delete(net_ticktime, Config),
+    case length(ConfigWithoutSupportedEntry) > 0 of
+        true -> io:format(standard_error,
+            "~nUnable to update config for app ~p from *.conf file."
+            " App is already running. Use advanced.config instead.~n", [kernel]);
+        false -> ok
+    end;
+maybe_print_warning_for_running_app(App, _Config) ->
+    io:format(standard_error,
+        "~nUnable to update config for app ~p from *.conf file."
+        " App is already running. Use advanced.config instead.~n",
+        [App]).
+
+maybe_set_net_ticktime(undefined) ->
+    ok;
+maybe_set_net_ticktime(KernelConfig) ->
+    case proplists:get_value(net_ticktime, KernelConfig) of
+        undefined ->
+            ok;
+        NetTickTime ->
+            case net_kernel:set_net_ticktime(NetTickTime) of
+                {ongoing_change_to, NewNetTicktime} ->
+                    io:format(standard_error,
+                        "~nCouldn't set net_ticktime to ~p "
+                        "as net_kernel is busy changing net_ticktime to ~p seconds ~n",
+                        [NetTickTime, NewNetTicktime]);
+                _ ->
+                    ok
+            end
+    end.
 
 generate_config_file(ConfFiles, ConfDir, ScriptDir) ->
     generate_config_file(ConfFiles, ConfDir, ScriptDir,

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -528,5 +528,11 @@ credential_validator.regexp = ^abc\\d+",
   [{rabbit, [
       {delegate_count, 64}
     ]}],
-  []}
+  []},
+  {kernel_net_ticktime,
+   "net_ticktime = 20",
+   [{kernel, [
+      {net_ticktime, 20}
+     ]}],
+   []}
 ].


### PR DESCRIPTION
`net_ticktime`, if present in the `.conf` file, is set up with `net_kernel:set_net_ticktime/1` before the configuration of the `.conf` file is applied to the other applications. The `kernel` application is already running when the configuration is applied, so net_ticktime is set in a specific way.

Fixes #1522