### PR TITLE
Correct generated randomized startup delay range key (master)

### DIFF
--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -869,12 +869,12 @@ end}.
 
 %% Cluster formation: Randomized startup delay
 
-{mapping, "cluster_formation.randomized_startup_delay_range.min", "rabbit.cluster_formation.randomized_delay_range",
+{mapping, "cluster_formation.randomized_startup_delay_range.min", "rabbit.cluster_formation.randomized_startup_delay_range",
     [{datatype, integer}]}.
-{mapping, "cluster_formation.randomized_startup_delay_range.max", "rabbit.cluster_formation.randomized_delay_range",
+{mapping, "cluster_formation.randomized_startup_delay_range.max", "rabbit.cluster_formation.randomized_startup_delay_range",
     [{datatype, integer}]}.
 
-{translation, "rabbit.cluster_formation.randomized_delay_range",
+{translation, "rabbit.cluster_formation.randomized_startup_delay_range",
 fun(Conf) ->
     Min = cuttlefish:conf_get("cluster_formation.randomized_startup_delay_range.min", Conf, undefined),
     Max = cuttlefish:conf_get("cluster_formation.randomized_startup_delay_range.max", Conf, undefined),

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -138,6 +138,7 @@ init_with_lock(0, _, InitFromConfig) ->
 init_with_lock(Retries, Timeout, InitFromConfig) ->
     case rabbit_peer_discovery:lock() of
         not_supported ->
+            rabbit_log:info("Peer discovery backend does not support locking, falling back to randomized delay"),
             %% See rabbitmq/rabbitmq-server#1202 for details.
             rabbit_peer_discovery:maybe_inject_randomized_delay(),
             InitFromConfig(),

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -405,21 +405,21 @@ tcp_listen_options.exit_on_close = false",
   "cluster_formation.randomized_startup_delay_range.min = 10
    cluster_formation.randomized_startup_delay_range.max = 30",
   [{rabbit, [{cluster_formation, [
-                                  {randomized_delay_range, {10, 30}}
+                                  {randomized_startup_delay_range, {10, 30}}
                                   ]}]}],
   []},
 
  {cluster_formation_randomized_startup_delay_min_only,
   "cluster_formation.randomized_startup_delay_range.min = 10",
   [{rabbit, [{cluster_formation, [
-                                  {randomized_delay_range, {10, 60}}
+                                  {randomized_startup_delay_range, {10, 60}}
                                   ]}]}],
   []},
 
  {cluster_formation_randomized_startup_delay_max_only,
   "cluster_formation.randomized_startup_delay_range.max = 30",
   [{rabbit, [{cluster_formation, [
-                                  {randomized_delay_range, {5, 30}}
+                                  {randomized_startup_delay_range, {5, 30}}
                                   ]}]}],
   []},
 


### PR DESCRIPTION
## Proposed Changes

This corrects a 🤦‍♂️  typo in the generated randomized startup delay config key.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1531)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #1531.
References rabbitmq/rabbitmq-peer-discovery-aws#17.

[#155538515]