### PR TITLE
Force-delete queues that have no promotable master (or candidates)

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -844,13 +844,13 @@ delete(Q, IfUnused, IfEmpty, ActingUser) ->
             case IfEmpty of
                 true ->
                     rabbit_log:error("Queue ~s on vhost ~s master node is down. "
-                                     "Unable to check if the queue is empty. "
-                                     "Delete failed",
+                                     "The queue may be not empty. "
+                                     "Refusing to force-delete.",
                                      [Name, Vhost]),
                     {error, not_empty};
                 false ->
                     rabbit_log:warning("Queue ~s on vhost ~s master node is down. "
-                                       "Force-deleting the queue",
+                                       "Force-deleting the queue.",
                                        [Name, Vhost]),
                     delete_crashed_internal(Q1, ActingUser),
                     {ok, 0}

--- a/test/dynamic_ha_SUITE.erl
+++ b/test/dynamic_ha_SUITE.erl
@@ -57,6 +57,7 @@ groups() ->
       {clustered, [], [
           {cluster_size_2, [], [
               vhost_deletion,
+              force_delete_if_no_master,
               promote_on_shutdown,
               slave_recovers_after_vhost_failure,
               slave_recovers_after_vhost_down_an_up,
@@ -245,6 +246,45 @@ vhost_deletion(Config) ->
     ACh = rabbit_ct_client_helpers:open_channel(Config, A),
     amqp_channel:call(ACh, #'queue.declare'{queue = <<"vhost_deletion-q">>}),
     ok = rpc:call(A, rabbit_vhost, delete, [<<"/">>, <<"acting-user">>]),
+    ok.
+
+force_delete_if_no_master(Config) ->
+    [A, B] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    rabbit_ct_broker_helpers:set_ha_policy(Config, A, <<"^ha.nopromote">>,
+      <<"all">>),
+    ACh = rabbit_ct_client_helpers:open_channel(Config, A),
+    [begin
+         amqp_channel:call(ACh, #'queue.declare'{queue   = Q,
+                                                 durable = true}),
+         rabbit_ct_client_helpers:publish(ACh, Q, 10)
+     end || Q <- [<<"ha.nopromote.test1">>, <<"ha.nopromote.test2">>]],
+    ok = rabbit_ct_broker_helpers:restart_node(Config, B),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, A),
+
+    BCh = rabbit_ct_client_helpers:open_channel(Config, B),
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 404, _}}, _},
+       amqp_channel:call(
+         BCh, #'queue.declare'{queue   = <<"ha.nopromote.test1">>,
+                               durable = true})),
+
+    BCh1 = rabbit_ct_client_helpers:open_channel(Config, B),
+    ?assertExit(
+        {{shutdown, {server_initiated_close, 404, _}}, _},
+        amqp_channel:call(
+            BCh1, #'queue.declare'{queue   = <<"ha.nopromote.test2">>,
+                                   durable = true})),
+    BCh2 = rabbit_ct_client_helpers:open_channel(Config, B),
+    #'queue.delete_ok'{} =
+        amqp_channel:call(BCh2, #'queue.delete'{queue = <<"ha.nopromote.test1">>}),
+    %% Delete with if_empty will fail, since we don't know if the queue is empty
+    ?assertExit(
+        {{shutdown, {server_initiated_close, 406, _}}, _},
+        amqp_channel:call(BCh2, #'queue.delete'{queue = <<"ha.nopromote.test2">>,
+                                                if_empty = true})),
+    BCh3 = rabbit_ct_client_helpers:open_channel(Config, B),
+    #'queue.delete_ok'{} =
+        amqp_channel:call(BCh3, #'queue.delete'{queue = <<"ha.nopromote.test2">>}),
     ok.
 
 promote_on_shutdown(Config) ->


### PR DESCRIPTION
Fixes #1501
[#155801556]
If a queue is configured to not be promoted (via ha-promote-on-shutdown: when-synced)
queue.delete can hang. Make it check for process existense first and
force-delete if no master of slave processes are running.
Do not force-delete if if_empty is set, since there is no
way to check that the queue is empty.
