### PR TITLE
Add special case in handle_other for normal TCP port exit

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -548,9 +548,14 @@ handle_other({channel_closing, ChPid}, State) ->
     ok = rabbit_channel:ready_for_close(ChPid),
     {_, State1} = channel_cleanup(ChPid, State),
     maybe_close(control_throttle(State1));
+handle_other({'EXIT', Parent, normal}, State = #v1{parent = Parent}) ->
+    %% rabbitmq/rabbitmq-server#544
+    %% The connection port process has exited due to the TCP socket being closed.
+    %% Handle this case in the same manner as receiving {error, closed}
+    stop(closed, State);
 handle_other({'EXIT', Parent, Reason}, State = #v1{parent = Parent}) ->
-    terminate(io_lib:format("broker forced connection closure "
-                            "with reason '~w'", [Reason]), State),
+    Msg = io_lib:format("broker forced connection closure with reason '~w'", [Reason]),
+    terminate(Msg, State),
     %% this is what we are expected to do according to
     %% http://www.erlang.org/doc/man/sys.html
     %%
@@ -735,7 +740,7 @@ wait_for_channel_termination(N, TimerRef,
                     wait_for_channel_termination(N-1, TimerRef, State1)
             end;
         {'EXIT', Sock, _Reason} ->
-            [channel_cleanup(ChPid, State) || ChPid <- all_channels()],
+            clean_up_all_channels(State),
             exit(normal);
         cancel_wait ->
             exit(channel_termination_timeout)
@@ -903,6 +908,12 @@ channel_cleanup(ChPid, State = #v1{channel_count = ChannelCount}) ->
     end.
 
 all_channels() -> [ChPid || {{ch_pid, ChPid}, _ChannelMRef} <- get()].
+
+clean_up_all_channels(State) ->
+    CleanupFun = fun(ChPid) ->
+                    channel_cleanup(ChPid, State)
+                 end,
+    lists:foreach(CleanupFun, all_channels()).
 
 %%--------------------------------------------------------------------------
 


### PR DESCRIPTION
Handle `noport` at epmd monitor startup
Handle `'EXIT'` from TCP port more gracefully

**NOTE**: I can't reproduce the `'EXIT'` case to test this out. However, the new `handle_other` clause should do most of what `terminate` does *except* try to gracefully close channels and the connection (which is already closed).

I tested using a three-node cluster on my local workstation, with each node listening on dedicated loopback interfaces `127.0.0.2` - `127.0.0.4` (`shostakovich2` - `shostakovich4` in `/etc/hosts`). I also limited disterl to use the same interface on which RabbitMQ listened by starting RabbitMQ like this:

```
make RABBITMQ_NODENAME='rabbit2@shostakovich2' \ 
   RABBITMQ_NODE_IP_ADDRESS=127.0.0.2 \
    RABBITMQ_NODE_PORT=5672 \
    RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-kernel inet_dist_use_interface {127,0,0,2} -kernel net_ticktime 5' \
    run-broker
```

Then, to partition a node, I blocked all tcp traffic to an interface using an NFT configuration like this [rabbit2.conf.txt](https://github.com/rabbitmq/rabbitmq-server/files/1812948/rabbit2.conf.txt). During one of these partitions, when the `rabbit2` node restarted, the `rabbit_epmd_monitor` process crashed during `init` due to returning an unexpected `noport`. I suspect this is because usually there is a dedicated, accessible `epmd` process per RabbitMQ node but in my test environment all nodes used the same `epmd`, which happened to be blocked during this test. That's why there are changes to `rabbit_epmd_monitor` to take that case into account.

Fixes #544