### PR TITLE
Do not try to start a vhost supervisors on not fully booted nodes.

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -27,6 +27,7 @@
 -export([start/2, stop/1, prep_stop/1]).
 -export([start_apps/1, start_apps/2, stop_apps/1]).
 -export([log_locations/0, config_files/0, decrypt_config/2]). %% for testing and mgmt-agent
+-export([is_booted/0, is_booted/1, is_booting/0]).
 
 -ifdef(TEST).
 
@@ -652,10 +653,16 @@ await_startup(Node) ->
     end.
 
 is_booting(Node) ->
-    case rpc:call(Node, erlang, whereis, [rabbit_boot]) of
-        {badrpc, _} = Err -> Err;
-        undefined         -> false;
-        P when is_pid(P)  -> true
+    case rpc:call(Node, rabbit, is_booting, []) of
+        true  -> true;
+        false -> false;
+        {badrpc, _} = Err -> Err
+    end.
+
+is_booting() ->
+    case erlang:whereis(rabbit_boot) of
+        undefined        -> false;
+        P when is_pid(P) -> true
     end.
 
 wait_for_boot_to_start(Node) ->
@@ -744,6 +751,16 @@ listeners() ->
 is_running() -> is_running(node()).
 
 is_running(Node) -> rabbit_nodes:is_process_running(Node, rabbit).
+
+is_booted(Node) ->
+    case rpc:call(Node, rabbit, is_booted, []) of
+        true        -> true;
+        false       -> false;
+        {badrpc, _} -> false
+    end.
+
+is_booted() ->
+    is_running() andalso not is_booting().
 
 environment() ->
     %% The timeout value is twice that of gen_server:call/2.

--- a/src/rabbit_vhost_sup_sup.erl
+++ b/src/rabbit_vhost_sup_sup.erl
@@ -60,10 +60,10 @@ init([]) ->
             [rabbit_vhost_sup_wrapper, rabbit_vhost_sup]}]}}.
 
 start_on_all_nodes(VHost) ->
-    NodesStart = [ {Node, start_vhost(VHost, Node)}
-                   || Node <- rabbit_nodes:all_running(),
-                      %% Do not try to start a vhost on booting nodes.
-                      rabbit:is_booted(Node) ],
+    %% Do not try to start a vhost on booting peer nodes
+    AllBooted    = [Node || Node <- rabbit_nodes:all_running(), rabbit:is_booted(Node)],
+    Nodes        = [node() | AllBooted],
+    NodesStarted = [{Node, start_vhost(VHost, Node)} || Node <- Nodes],
     Failures = lists:filter(fun
                                ({_, {ok, _}}) -> false;
                                ({_, {error, {already_started, _}}}) -> false;

--- a/src/rabbit_vhost_sup_sup.erl
+++ b/src/rabbit_vhost_sup_sup.erl
@@ -61,7 +61,9 @@ init([]) ->
 
 start_on_all_nodes(VHost) ->
     NodesStart = [ {Node, start_vhost(VHost, Node)}
-                   || Node <- rabbit_nodes:all_running() ],
+                   || Node <- rabbit_nodes:all_running(),
+                      %% Do not try to start a vhost on booting nodes.
+                      rabbit:is_booted(Node) ],
     Failures = lists:filter(fun
                                ({_, {ok, _}}) -> false;
                                ({_, {error, {already_started, _}}}) -> false;

--- a/src/rabbit_vhost_sup_sup.erl
+++ b/src/rabbit_vhost_sup_sup.erl
@@ -61,15 +61,15 @@ init([]) ->
 
 start_on_all_nodes(VHost) ->
     %% Do not try to start a vhost on booting peer nodes
-    AllBooted    = [Node || Node <- rabbit_nodes:all_running(), rabbit:is_booted(Node)],
-    Nodes        = [node() | AllBooted],
-    NodesStarted = [{Node, start_vhost(VHost, Node)} || Node <- Nodes],
-    Failures = lists:filter(fun
+    AllBooted = [Node || Node <- rabbit_nodes:all_running(), rabbit:is_booted(Node)],
+    Nodes     = [node() | AllBooted],
+    Results   = [{Node, start_vhost(VHost, Node)} || Node <- Nodes],
+    Failures  = lists:filter(fun
                                ({_, {ok, _}}) -> false;
                                ({_, {error, {already_started, _}}}) -> false;
                                (_) -> true
                             end,
-                            NodesStart),
+                            Results),
     case Failures of
         []     -> ok;
         Errors -> {error, {failed_to_start_vhost_on_nodes, Errors}}

--- a/test/clustering_management_SUITE.erl
+++ b/test/clustering_management_SUITE.erl
@@ -640,7 +640,11 @@ wait_fails_when_cluster_fails(Config) ->
 concurrent_default_data_creation(Config) ->
     [Rabbit, Hare] = rabbit_ct_broker_helpers:get_node_configs(Config,
       nodename),
-    %% Run multiple times to detect race.
+    %% Run multiple times to detect a race.
+    %% This test simulates cocurrent database initialisation.
+    %% Since this is node-local state, in practice this can only
+    %% happen when a new cluster is formed and two nodes are booting
+    %% at roughly the same time (say, within a couple of ms from each other).
     [concurrent_default_data_creation1(Rabbit, Hare) || _ <- lists:seq(1, 20)].
 
 concurrent_default_data_creation1(Rabbit, Hare) ->

--- a/test/clustering_management_SUITE.erl
+++ b/test/clustering_management_SUITE.erl
@@ -657,7 +657,8 @@ concurrent_default_data_creation1(Rabbit, Hare) ->
     [spawn(fun() -> rpc:call(Node, rabbit, start, []) end)
      || Node <- [Rabbit, Hare]],
     %% Verify both nodes are started successfully
-    [ok = rpc:call(Node, rabbit, await_startup, [Node]) || Node <- [Rabbit, Hare]].
+    [ok = rpc:call(Node, rabbit, await_startup, [Node]) || Node <- [Rabbit, Hare]],
+    [{ok, _Pid} = rpc:call(Node, rabbit_vhost_sup_sup, get_vhost_sup, [<<"/">>]) || Node <- [Rabbit, Hare]].
 
 %% ----------------------------------------------------------------------------
 %% Internal utils

--- a/test/clustering_management_SUITE.erl
+++ b/test/clustering_management_SUITE.erl
@@ -641,7 +641,7 @@ concurrent_default_data_creation(Config) ->
     [Rabbit, Hare] = rabbit_ct_broker_helpers:get_node_configs(Config,
       nodename),
     %% Run multiple times to detect a race.
-    %% This test simulates cocurrent database initialisation.
+    %% This test simulates concurrent initialisation of several key node DB tables.
     %% Since this is node-local state, in practice this can only
     %% happen when a new cluster is formed and two nodes are booting
     %% at roughly the same time (say, within a couple of ms from each other).


### PR DESCRIPTION
Sometimes when several nodes are started at the same time, add_vhost
can try to start a remote vhost supervisor on a node, which does
not have a rabbit_vhost_sup_sup process yet, resulting in `{error,rabbit_vhost_sup_sup_not_running}`
error.

Filter only fully booted nodes to start remote vhost supervisors.
