### PR TITLE
rabbit_parameter_validation: support maps in proplist validator

### DIFF
--- a/src/rabbit_parameter_validation.erl
+++ b/src/rabbit_parameter_validation.erl
@@ -77,6 +77,10 @@ proplist(Name, Constraints, Term) when is_list(Term) ->
                | Results]
     end;
 
+proplist(Name, Constraints, Term0) when is_map(Term0) ->
+    Term = maps:to_list(Term0),
+    proplist(Name, Constraints, Term);
+
 proplist(Name, _Constraints, Term) ->
     {error, "~s not a list ~p", [Name, Term]}.
 


### PR DESCRIPTION
## Proposed Changes

This makes the proplist validator used by runtime parameters accept maps. Note that the real usage and testing happens in Federation and Shovel plugins.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-federation#73, references rabbitmq/rabbitmq-federation#70,
rabbitmq/rabbitmq-federation#67.
