### PR TITLE
Make it possible for peer discovery backends to provide their own RSD range

### DIFF
--- a/src/rabbit_peer_discovery.erl
+++ b/src/rabbit_peer_discovery.erl
@@ -184,11 +184,16 @@ inject_randomized_delay() ->
 -spec randomized_delay_range_in_ms() -> {integer(), integer()}.
 
 randomized_delay_range_in_ms() ->
+  Backend    = backend(),
+  Default    = case erlang:function_exported(Backend, randomized_startup_delay_range, 0) of
+                   true  -> Backend:randomized_startup_delay_range();
+                   false -> ?DEFAULT_STARTUP_RANDOMIZED_DELAY
+               end,
   {Min, Max} = case application:get_env(rabbit, cluster_formation) of
                    {ok, Proplist} ->
-                       proplists:get_value(randomized_startup_delay_range, Proplist, ?DEFAULT_STARTUP_RANDOMIZED_DELAY);
+                       proplists:get_value(randomized_startup_delay_range, Proplist, Default);
                    undefined      ->
-                       ?DEFAULT_STARTUP_RANDOMIZED_DELAY
+                       Default
                end,
     {Min * 1000, Max * 1000}.
 


### PR DESCRIPTION
## Proposed Changes

This will first check if the peer discovery backend used exported a function that returns
a randomized startup delay (RSD) range. If it doesn't, the same default used as before.

## Types of Changes

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

References rabbitmq/rabbitmq-peer-discovery-k8s#23.
