### PR TITLE
Use rabbit_net:hostname

### DIFF
--- a/src/rabbit_nodes.erl
+++ b/src/rabbit_nodes.erl
@@ -73,8 +73,7 @@ cluster_name() ->
 
 cluster_name_default() ->
     {ID, _} = parts(node()),
-    {ok, Host} = inet:gethostname(),
-    {ok, #hostent{h_name = FQDN}} = inet:gethostbyname(Host),
+    FQDN = rabbit_net:hostname(),
     list_to_binary(atom_to_list(make({ID, FQDN}))).
 
 set_cluster_name(Name, Username) ->


### PR DESCRIPTION
This will take into account error conditions which will default to the value returned by `inet:gethostname/0`

[See this `rabbitmq-users` thread](https://groups.google.com/d/msg/rabbitmq-users/-WhvgwJoGs8/5whdbe3OCAAJ)

[`rabbit_net:hostname/0`](https://github.com/rabbitmq/rabbitmq-common/blob/master/src/rabbit_net.erl#L265-L270)