### PR TITLE
Handle bump_reduce_memory_use non-true case

### DIFF
--- a/src/rabbit_variable_queue.erl
+++ b/src/rabbit_variable_queue.erl
@@ -913,7 +913,9 @@ handle_pre_hibernate(State = #vqstate { index_state = IndexState }) ->
     State #vqstate { index_state = rabbit_queue_index:flush(IndexState) }.
 
 handle_info(bump_reduce_memory_use, State = #vqstate{ waiting_bump = true }) ->
-    State#vqstate{ waiting_bump = false }.
+    State#vqstate{ waiting_bump = false };
+handle_info(bump_reduce_memory_use, State) ->
+    State.
 
 resume(State) -> a(reduce_memory_use(State)).
 


### PR DESCRIPTION
Fixes #1582 

Note that this scenario only happens in rare situations, not all times when the `bump_reduce_memory_use` message is sent to the queue process.