### PR TITLE
One more place where a map definition must be converted to proplist before validation

### DIFF
--- a/src/rabbit_policy.erl
+++ b/src/rabbit_policy.erl
@@ -468,6 +468,9 @@ validation(Name, Terms) ->
 
 validation(_Name, [], _Validator) ->
     {error, "no policy provided", []};
+validation(Name, Terms0, Validator) when is_map(Terms0) ->
+    Terms = maps:to_list(Terms0),
+    validation(Name, Terms, Validator);
 validation(_Name, Terms, Validator) when is_list(Terms) ->
     {Keys, Modules} = lists:unzip(
                         rabbit_registry:lookup_all(Validator)),
@@ -481,8 +484,9 @@ validation(_Name, Terms, Validator) when is_list(Terms) ->
                  end;
         false -> {error, "definition must be a dictionary: ~p", [Terms]}
     end;
-validation(_Name, Term, _Validator) ->
-    {error, "parse error while reading policy: ~p", [Term]}.
+validation(Name, Term, Validator) ->
+    {error, "parse error while reading policy ~s: ~p. Validator: ~p.",
+     [Name, Term, Validator]}.
 
 validation0(Validators, Terms) ->
     case lists:foldl(


### PR DESCRIPTION
## Proposed Changes

This covers one more place where a map definition must be converted to proplist before validation.
Originally reported in rabbitmq/rabbitmq-management#565.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue rabbitmq/rabbitmq-management#565)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Fixes rabbitmq/rabbitmq-management#565.

References rabbitmq/rabbitmq-server#1493, rabbitmq/rabbitmq-federation#70,
rabbitmq/rabbitmq-shovel#38, rabbitmq/rabbitmq-federation#73.

[#157045132]
