### PR TITLE
Change channel_max default to 2047

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ define PROJECT_ENV
 	    %% 0 ("no limit") would make a better default, but that
 	    %% breaks the QPid Java client
 	    {frame_max, 131072},
-	    {channel_max, 0},
+	    %% see rabbitmq-server#1593
+	    {channel_max, 2048},
 	    {connection_max, infinity},
 	    {heartbeat, 60},
 	    {msg_store_file_size_limit, 16777216},
@@ -62,7 +63,7 @@ define PROJECT_ENV
 	                         ]},
 	    {halt_on_upgrade_failure, true},
 	    {hipe_compile, false},
-	    %% see bug 24513 for how this list was created
+	    %% see bug 24513 [in legacy Bugzilla] for how this list was created
 	    {hipe_modules,
 	     [rabbit_reader, rabbit_channel, gen_server2, rabbit_exchange,
 	      rabbit_command_assembler, rabbit_framing_amqp_0_9_1, rabbit_basic,

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ define PROJECT_ENV
 	    %% breaks the QPid Java client
 	    {frame_max, 131072},
 	    %% see rabbitmq-server#1593
-	    {channel_max, 2048},
+	    {channel_max, 2047},
 	    {connection_max, infinity},
 	    {heartbeat, 60},
 	    {msg_store_file_size_limit, 16777216},


### PR DESCRIPTION
## Proposed Changes

This limits how many channels (which consume resources) can be opened on a connection in order
to make excessive channel uysage more visible on the application side and reduce the probability of
cluster resource exhaustion due to apps that leak channels.

This won't be a breaking change for the vast majority of applications since they don't use more than 2K channels per connection. The value can be configured, too:

``` ini
channel_max = 4096
```

Per discussion with @kjnilsson @dcorbacho @lukebakken.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1593)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #1593.
