### PR TITLE
Add client properties to connection.closed events

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -134,7 +134,7 @@
         peer_cert_validity, auth_mechanism, ssl_protocol,
         ssl_key_exchange, ssl_cipher, ssl_hash, protocol, user, vhost,
         timeout, frame_max, channel_max, client_properties, connected_at,
-        node, user_who_performed_action, connection_user_provided_name]).
+        node, user_who_performed_action]).
 
 -define(INFO_KEYS, ?CREATION_EVENT_KEYS ++ ?STATISTICS_KEYS -- [pid]).
 
@@ -394,17 +394,17 @@ start_connection(Parent, HelperSup, Deb, Sock) ->
             Properties ->
                 Properties
         end,
-        ConnectionUserProvidedName = case get(connection_user_provided_name) of
-            undefined ->
-                '';
-            ConnectionName ->
-                ConnectionName
+        EventProperties = [{name, Name},
+                           {pid, self()},
+                           {node, node()},
+                           {client_properties, ClientProperties}],
+        EventProperties1 = case get(connection_user_provided_name) of
+           undefined ->
+               EventProperties;
+           ConnectionUserProvidedName ->
+               [{user_provided_name, ConnectionUserProvidedName} | EventProperties]
         end,
-        rabbit_event:notify(connection_closed, [{name, Name},
-                                                {pid, self()},
-                                                {node, node()},
-                                                {client_properties, ClientProperties},
-                                                {connection_user_provided_name, ConnectionUserProvidedName}])
+        rabbit_event:notify(connection_closed, EventProperties1)
     end,
     done.
 
@@ -621,7 +621,9 @@ handle_other({'$gen_cast', {force_event_refresh, Ref}}, State)
   when ?IS_RUNNING(State) ->
     rabbit_event:notify(
       connection_created,
-      [{type, network} | infos(?CREATION_EVENT_KEYS, State)], Ref),
+      augment_infos_with_user_provided_connection_name(
+          [{type, network} | infos(?CREATION_EVENT_KEYS, State)], State),
+      Ref),
     rabbit_event:init_stats_timer(State, #v1.stats_timer);
 handle_other({'$gen_cast', {force_event_refresh, _Ref}}, State) ->
     %% Ignore, we will emit a created event once we start running.
@@ -1147,7 +1149,12 @@ handle_method0(#'connection.start_ok'{mechanism = Mechanism,
     % adding client properties to process dictionary to send them later
     % in the connection_closed event
     put(client_properties, ClientProperties),
-    put(connection_user_provided_name, user_provided_connection_name(Connection2)),
+    case user_provided_connection_name(Connection2) of
+        undefined ->
+            undefined;
+        UserProvidedConnectionName ->
+            put(connection_user_provided_name, UserProvidedConnectionName)
+    end,
     auth_phase(Response, State);
 
 handle_method0(#'connection.secure_ok'{response = Response},
@@ -1220,7 +1227,10 @@ handle_method0(#'connection.open'{virtual_host = VHost},
                         connection          = NewConnection,
                         channel_sup_sup_pid = ChannelSupSupPid,
                         throttle            = Throttle1}),
-    Infos = [{type, network} | infos(?CREATION_EVENT_KEYS, State1)],
+    Infos = augment_infos_with_user_provided_connection_name(
+        [{type, network} | infos(?CREATION_EVENT_KEYS, State1)],
+        State1
+    ),
     rabbit_core_metrics:connection_created(proplists:get_value(pid, Infos),
                                            Infos),
     rabbit_event:notify(connection_created, Infos),
@@ -1477,13 +1487,6 @@ ic(client_properties, #connection{client_properties = CP}) -> CP;
 ic(auth_mechanism,    #connection{auth_mechanism = none})  -> none;
 ic(auth_mechanism,    #connection{auth_mechanism = {Name, _Mod}}) -> Name;
 ic(connected_at,      #connection{connected_at = T}) -> T;
-ic(connection_user_provided_name, C) ->
-    case user_provided_connection_name(C) of
-        undefined ->
-            '';
-        ConnectionUserProvidedName ->
-            ConnectionUserProvidedName
-    end;
 ic(Item,              #connection{}) -> throw({bad_argument, Item}).
 
 socket_info(Get, Select, #v1{sock = Sock}) ->
@@ -1695,6 +1698,14 @@ augment_connection_log_name(#connection{name = Name} = Connection) ->
             rabbit_log_connection:info("Connection ~p (~s) has a client-provided name: ~s~n", [self(), Name, UserSpecifiedName]),
             ?store_proc_name(LogName),
             Connection#connection{log_name = LogName}
+    end.
+
+augment_infos_with_user_provided_connection_name(Infos, #v1{connection = Connection}) ->
+    case user_provided_connection_name(Connection) of
+     undefined ->
+         Infos;
+     UserProvidedConnectionName ->
+         [{user_provided_name, UserProvidedConnectionName} | Infos]
     end.
 
 user_provided_connection_name(#connection{client_properties = ClientProperties}) ->

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -387,10 +387,17 @@ start_connection(Parent, HelperSup, Deb, Sock) ->
         %% socket w/o delay before termination.
         rabbit_net:fast_close(RealSocket),
         rabbit_networking:unregister_connection(self()),
-	rabbit_core_metrics:connection_closed(self()),
+        rabbit_core_metrics:connection_closed(self()),
+        ClientProperties = case get(client_properties) of
+            undefined ->
+                [];
+            Properties ->
+                Properties
+        end,
         rabbit_event:notify(connection_closed, [{name, Name},
                                                 {pid, self()},
-                                                {node, node()}])
+                                                {node, node()},
+                                                {client_properties, ClientProperties}])
     end,
     done.
 
@@ -1130,6 +1137,9 @@ handle_method0(#'connection.start_ok'{mechanism = Mechanism,
     Connection2 = augment_connection_log_name(Connection1),
     State = State0#v1{connection_state = securing,
                       connection       = Connection2},
+    % adding client properties to process dictionary to send them later
+    % in the connection_closed event
+    put(client_properties, ClientProperties),
     auth_phase(Response, State);
 
 handle_method0(#'connection.secure_ok'{response = Response},

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -134,7 +134,7 @@
         peer_cert_validity, auth_mechanism, ssl_protocol,
         ssl_key_exchange, ssl_cipher, ssl_hash, protocol, user, vhost,
         timeout, frame_max, channel_max, client_properties, connected_at,
-        node, user_who_performed_action]).
+        node, user_who_performed_action, connection_user_provided_name]).
 
 -define(INFO_KEYS, ?CREATION_EVENT_KEYS ++ ?STATISTICS_KEYS -- [pid]).
 
@@ -394,10 +394,17 @@ start_connection(Parent, HelperSup, Deb, Sock) ->
             Properties ->
                 Properties
         end,
+        ConnectionUserProvidedName = case get(connection_user_provided_name) of
+            undefined ->
+                '';
+            ConnectionName ->
+                ConnectionName
+        end,
         rabbit_event:notify(connection_closed, [{name, Name},
                                                 {pid, self()},
                                                 {node, node()},
-                                                {client_properties, ClientProperties}])
+                                                {client_properties, ClientProperties},
+                                                {connection_user_provided_name, ConnectionUserProvidedName}])
     end,
     done.
 
@@ -1140,6 +1147,7 @@ handle_method0(#'connection.start_ok'{mechanism = Mechanism,
     % adding client properties to process dictionary to send them later
     % in the connection_closed event
     put(client_properties, ClientProperties),
+    put(connection_user_provided_name, user_provided_connection_name(Connection2)),
     auth_phase(Response, State);
 
 handle_method0(#'connection.secure_ok'{response = Response},
@@ -1469,6 +1477,13 @@ ic(client_properties, #connection{client_properties = CP}) -> CP;
 ic(auth_mechanism,    #connection{auth_mechanism = none})  -> none;
 ic(auth_mechanism,    #connection{auth_mechanism = {Name, _Mod}}) -> Name;
 ic(connected_at,      #connection{connected_at = T}) -> T;
+ic(connection_user_provided_name, C) ->
+    case user_provided_connection_name(C) of
+        undefined ->
+            '';
+        ConnectionUserProvidedName ->
+            ConnectionUserProvidedName
+    end;
 ic(Item,              #connection{}) -> throw({bad_argument, Item}).
 
 socket_info(Get, Select, #v1{sock = Sock}) ->
@@ -1671,16 +1686,23 @@ control_throttle(State = #v1{connection_state = CS,
         _       -> State1
     end.
 
-augment_connection_log_name(#connection{client_properties = ClientProperties,
-                                        name = Name} = Connection) ->
-    case rabbit_misc:table_lookup(ClientProperties, <<"connection_name">>) of
-        {longstr, UserSpecifiedName} ->
+augment_connection_log_name(#connection{name = Name} = Connection) ->
+    case user_provided_connection_name(Connection) of
+        undefined ->
+            Connection;
+        UserSpecifiedName ->
             LogName = <<Name/binary, " - ", UserSpecifiedName/binary>>,
             rabbit_log_connection:info("Connection ~p (~s) has a client-provided name: ~s~n", [self(), Name, UserSpecifiedName]),
             ?store_proc_name(LogName),
-            Connection#connection{log_name = LogName};
+            Connection#connection{log_name = LogName}
+    end.
+
+user_provided_connection_name(#connection{client_properties = ClientProperties}) ->
+    case rabbit_misc:table_lookup(ClientProperties, <<"connection_name">>) of
+        {longstr, UserSpecifiedName} ->
+            UserSpecifiedName;
         _ ->
-            Connection
+            undefined
     end.
 
 dynamic_connection_name(Default) ->


### PR DESCRIPTION
This commit adds client properties to connection.closed events. The
original need was to have only the optional user-provided connection
name added to correlate connections between created and closed events,
but all the client properties are finally added for the sake of
consistency between the 2 events.

This commit uses the process dictionary to convey the client properties,
as they're not yet available in the connection state when the call to
send the closed event is made (in the after block, just after the
network connection has been established).

Fixes #1596

[#157500358]

![image](https://user-images.githubusercontent.com/514737/40316021-43e683b6-5d1d-11e8-889f-43c56b9f7645.png)

![image](https://user-images.githubusercontent.com/514737/40316080-71d2198e-5d1d-11e8-89c7-c0bdd5dac0ec.png)
