### PR TITLE
Use more optimal default memory allocators where available (Erlang 20.2.3 or later)

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -120,6 +120,25 @@ if [ ! -f "${RABBITMQ_SCHEMA_DIR}/rabbit.schema" ]; then
     cp "${RABBITMQ_HOME}/priv/schema/rabbit.schema" "${RABBITMQ_SCHEMA_DIR}"
 fi
 
+# The default allocation strategy RabbitMQ is using was introduced
+# in Erlang/OTP 20.2.3. Earlier Erlang versions fail to start with
+# this configuration. We therefore need to ensure that erl accepts
+# these values before we can use them.
+#
+# The defaults are meant to reduce RabbitMQ's memory usage and help
+# it reclaim memory at the cost of a slight decrease in performance
+# (due to an increase in memory operations). These defaults can be
+# overriden using the RABBITMQ_SERVER_ERL_ARGS variable.
+RABBITMQ_DEFAULT_ALLOC_ARGS="+MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30"
+
+${ERL_DIR}erl ${RABBITMQ_DEFAULT_ALLOC_ARGS} \
+    -boot "${CLEAN_BOOT_FILE}" \
+    -noinput -eval 'halt(0)' 2>/dev/null
+
+if [ $? != 0 ] ; then
+    RABBITMQ_DEFAULT_ALLOC_ARGS=
+fi
+
 set -e
 
 RABBITMQ_CONFIG_FILE_NOEX="${RABBITMQ_CONFIG_FILE%.*}"
@@ -213,6 +232,7 @@ start_rabbitmq_server() {
         ${RABBITMQ_CONFIG_ARG} \
         +W w \
         +A ${RABBITMQ_IO_THREAD_POOL_SIZE} \
+        ${RABBITMQ_DEFAULT_ALLOC_ARGS} \
         ${RABBITMQ_SERVER_ERL_ARGS} \
         +K true \
         -kernel inet_default_connect_options "[{nodelay,true}]" \

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -72,6 +72,27 @@ if ERRORLEVEL 2 (
     set RABBITMQ_DIST_ARG=-kernel inet_dist_listen_min !RABBITMQ_DIST_PORT! -kernel inet_dist_listen_max !RABBITMQ_DIST_PORT!
 )
 
+rem The default allocation strategy RabbitMQ is using was introduced
+rem in Erlang/OTP 20.2.3. Earlier Erlang versions fail to start with
+rem this configuration. We therefore need to ensure that erl accepts
+rem these values before we can use them.
+rem
+rem The defaults are meant to reduce RabbitMQ's memory usage and help
+rem it reclaim memory at the cost of a slight decrease in performance
+rem (due to an increase in memory operations). These defaults can be
+rem overriden using the RABBITMQ_SERVER_ERL_ARGS variable.
+
+set RABBITMQ_DEFAULT_ALLOC_ARGS=+MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30
+
+"!ERLANG_HOME!\bin\erl.exe" ^
+    !RABBITMQ_DEFAULT_ALLOC_ARGS! ^
+    -boot !CLEAN_BOOT_FILE! ^
+    -noinput -eval "halt(0)"
+
+if ERRORLEVEL 1 (
+    set RABBITMQ_DEFAULT_ALLOC_ARGS=
+)
+
 if not exist "!RABBITMQ_SCHEMA_DIR!" (
     mkdir "!RABBITMQ_SCHEMA_DIR!"
 )
@@ -173,6 +194,7 @@ if "!ENV_OK!"=="false" (
 !RABBITMQ_NAME_TYPE! !RABBITMQ_NODENAME! ^
 +W w ^
 +A "!RABBITMQ_IO_THREAD_POOL_SIZE!" ^
+!RABBITMQ_DEFAULT_ALLOC_ARGS! ^
 !RABBITMQ_SERVER_ERL_ARGS! ^
 !RABBITMQ_LISTEN_ARG! ^
 -kernel inet_default_connect_options "[{nodelay, true}]" ^

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -160,6 +160,27 @@ if ERRORLEVEL 3 (
     set RABBITMQ_DIST_ARG=-kernel inet_dist_listen_min !RABBITMQ_DIST_PORT! -kernel inet_dist_listen_max !RABBITMQ_DIST_PORT!
 )
 
+rem The default allocation strategy RabbitMQ is using was introduced
+rem in Erlang/OTP 20.2.3. Earlier Erlang versions fail to start with
+rem this configuration. We therefore need to ensure that erl accepts
+rem these values before we can use them.
+rem
+rem The defaults are meant to reduce RabbitMQ's memory usage and help
+rem it reclaim memory at the cost of a slight decrease in performance
+rem (due to an increase in memory operations). These defaults can be
+rem overriden using the RABBITMQ_SERVER_ERL_ARGS variable.
+
+set RABBITMQ_DEFAULT_ALLOC_ARGS=+MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30
+
+"!ERLANG_HOME!\bin\erl.exe" ^
+    !RABBITMQ_DEFAULT_ALLOC_ARGS! ^
+    -boot !CLEAN_BOOT_FILE! ^
+    -noinput -eval "halt(0)"
+
+if ERRORLEVEL 1 (
+    set RABBITMQ_DEFAULT_ALLOC_ARGS=
+)
+
 if not exist "!RABBITMQ_SCHEMA_DIR!" (
     mkdir "!RABBITMQ_SCHEMA_DIR!"
 )
@@ -254,6 +275,7 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 !RABBITMQ_CONFIG_ARG! ^
 +W w ^
 +A "!RABBITMQ_IO_THREAD_POOL_SIZE!" ^
+!RABBITMQ_DEFAULT_ALLOC_ARGS! ^
 !RABBITMQ_SERVER_ERL_ARGS! ^
 !RABBITMQ_LISTEN_ARG! ^
 -kernel inet_default_connect_options "[{nodelay,true}]" ^


### PR DESCRIPTION
## Proposed Changes

See [this rabbitmq-users thread](https://groups.google.com/d/msg/rabbitmq-users/LSYaac9frYw/LNZDZUlrBAAJ) for background.

We have settled on the following configuration for memory
allocators after testing many different combinations:

+MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30

They reduce the memory usage and help RabbitMQ reclaim memory,
at the cost of a slight decrease in performance due to an
increased number of memory operations.

We need to start Erlang with these values in order to figure
out whether they are supported. The allocator strategies we
recommend were introduced in Erlang/OTP 20.2.3. The values
can be overriden using RABBITMQ_SERVER_ERL_ARGS.

cc @gerhard

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [x] Optimization (peak and median RAM consumption)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

