### PR TITLE
Use better default memory allocators

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -99,6 +99,25 @@ else
     exit ${PRELAUNCH_RESULT}
 fi
 
+# The default allocation strategy RabbitMQ is using was introduced
+# in Erlang/OTP 20.2.3. Earlier Erlang versions fail to start with
+# this configuration. We therefore need to ensure that erl accepts
+# these values before we can use them.
+#
+# The defaults are meant to reduce RabbitMQ's memory usage and help
+# it reclaim memory at the cost of a slight decrease in performance
+# (due to an increase in memory operations). These defaults can be
+# overriden using the RABBITMQ_SERVER_ERL_ARGS variable.
+RABBITMQ_DEFAULT_ALLOC_ARGS="+MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30"
+
+${ERL_DIR}erl ${RABBITMQ_DEFAULT_ALLOC_ARGS} \
+    -boot "${CLEAN_BOOT_FILE}" \
+    -noinput -eval 'halt(0)' 2>/dev/null
+
+if [ $? != 0 ] ; then
+    RABBITMQ_DEFAULT_ALLOC_ARGS=
+fi
+
 set -e
 
 RABBITMQ_CONFIG_ARG=
@@ -167,6 +186,7 @@ start_rabbitmq_server() {
         ${RABBITMQ_CONFIG_ARG} \
         +W w \
         +A ${RABBITMQ_IO_THREAD_POOL_SIZE} \
+        ${RABBITMQ_DEFAULT_ALLOC_ARGS} \
         ${RABBITMQ_SERVER_ERL_ARGS} \
         +K true \
         -kernel inet_default_connect_options "[{nodelay,true}]" \

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -142,6 +142,27 @@ if ERRORLEVEL 3 (
     set RABBITMQ_DIST_ARG=-kernel inet_dist_listen_min !RABBITMQ_DIST_PORT! -kernel inet_dist_listen_max !RABBITMQ_DIST_PORT!
 )
 
+rem The default allocation strategy RabbitMQ is using was introduced
+rem in Erlang/OTP 20.2.3. Earlier Erlang versions fail to start with
+rem this configuration. We therefore need to ensure that erl accepts
+rem these values before we can use them.
+rem
+rem The defaults are meant to reduce RabbitMQ's memory usage and help
+rem it reclaim memory at the cost of a slight decrease in performance
+rem (due to an increase in memory operations). These defaults can be
+rem overriden using the RABBITMQ_SERVER_ERL_ARGS variable.
+
+set RABBITMQ_DEFAULT_ALLOC_ARGS=+MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30
+
+"!ERLANG_HOME!\bin\erl.exe" ^
+    !RABBITMQ_DEFAULT_ALLOC_ARGS! ^
+    -boot !CLEAN_BOOT_FILE! ^
+    -noinput -eval "halt(0)"
+
+if ERRORLEVEL 1 (
+    set RABBITMQ_DEFAULT_ALLOC_ARGS=
+)
+
     REM Try to create config file, if it doesn't exist
     REM It still can fail to be created, but at least not for default install
 if not exist "!RABBITMQ_CONFIG_FILE!.config" (
@@ -186,6 +207,7 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 !RABBITMQ_CONFIG_ARG! ^
 +W w ^
 +A "!RABBITMQ_IO_THREAD_POOL_SIZE!" ^
+!RABBITMQ_DEFAULT_ALLOC_ARGS! ^
 !RABBITMQ_SERVER_ERL_ARGS! ^
 !RABBITMQ_LISTEN_ARG! ^
 -kernel inet_default_connect_options "[{nodelay,true}]" ^


### PR DESCRIPTION
The v3.6.x equivalent of https://github.com/rabbitmq/rabbitmq-server/pull/1604
