### PR TITLE
Compile on Erlang/OTP 21

### DIFF
--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -292,7 +292,7 @@ if [ "${RABBITMQ_DEV_ENV}" ]; then
                "enabled_plugins_file=\"~s\"~n"
                "mnesia_base=\"~s\"~n"
                "mnesia_dir=\"~s\"~n", [P, E, B, M]).' \
-            2>/dev/null | head -n 4) || :)
+            2>/dev/null | grep -E '^(plugins_dir|enabled_plugins_file|mnesia_base|mnesia_dir)=') || :)
         if [ "${plugins_dir}" -a \
              "$RABBITMQ_PLUGINS_DIR_source" != 'environment' ]; then
             RABBITMQ_PLUGINS_DIR="${plugins_dir}"

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -behaviour(application).
 
 -export([start/0, boot/0, stop/0,

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_channel).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 %% rabbit_channel processes represent an AMQP 0-9-1 channels.
 %%
 %% Connections parse protocol frames coming from clients and

--- a/src/rabbit_node_monitor.erl
+++ b/src/rabbit_node_monitor.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_node_monitor).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -behaviour(gen_server).
 
 -export([start_link/0]).

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_reader).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 %% This is an AMQP 0-9-1 connection implementation. If AMQP 1.0 plugin is enabled,
 %% this module passes control of incoming AMQP 1.0 connections to it.
 %%

--- a/src/rabbit_vhost_process.erl
+++ b/src/rabbit_vhost_process.erl
@@ -30,6 +30,10 @@
 
 -module(rabbit_vhost_process).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -include("rabbit.hrl").
 
 -define(TICKTIME_RATIO, 4).


### PR DESCRIPTION
## Proposed Changes

This is one of the PRs that makes RabbitMQ build successfully on Erlang/OTP 21.

OTP 21 deprecated `erlang:get_stacktrace/0` in favor of a new
try/catch syntax. Unfortunately that's not realistic for projects
that support multiple Erlang versions (like us) until OTP 21 can be
the minimum version requirement. In order to compile we have to ignore
the warning. The broad compiler option seems to be the most common
way to support compilation on multiple OTP versions with `warnings_as_errors`: if we use
a function-specific option it will fail on the releases where the function is not deprecated.

## Types of Changes

- [x] Bug fix (non-breaking change related to https://github.com/rabbitmq/rabbitmq-server/issues/1616)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

[#157964874]
