### PR TITLE
Pass authentication context to Mod:user_login_authorization/2

### DIFF
--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -64,7 +64,7 @@ check_user_login(Username, AuthProps) ->
                   %% passwordless (i.e pre-authenticated) login with authZ.
                   case try_authenticate(ModN, Username, AuthProps) of
                       {ok, ModNUser = #auth_user{username = Username2}} ->
-                          user(ModNUser, try_authorize(ModZs, Username2));
+                          user(ModNUser, try_authorize(ModZs, Username2, AuthProps));
                       Else ->
                           Else
                   end;
@@ -93,10 +93,10 @@ try_authenticate(Module, Username, AuthProps) ->
         {refused, F, A} -> {refused, Username, F, A}
     end.
 
-try_authorize(Modules, Username) ->
+try_authorize(Modules, Username, AuthProps) ->
     lists:foldr(
       fun (Module, {ok, ModsImpls, ModsTags}) ->
-              case Module:user_login_authorization(Username) of
+              case Module:user_login_authorization(Username, AuthProps) of
                   {ok, Impl, Tags}-> {ok, [{Module, Impl} | ModsImpls], ModsTags ++ Tags};
                   {ok, Impl}      -> {ok, [{Module, Impl} | ModsImpls], ModsTags};
                   {error, E}      -> {refused, Username,

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -20,7 +20,7 @@
 -behaviour(rabbit_authn_backend).
 -behaviour(rabbit_authz_backend).
 
--export([user_login_authentication/2, user_login_authorization/1,
+-export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/3, check_topic_access/4]).
 
 -export([add_user/3, delete_user/2, lookup_user/1,
@@ -133,7 +133,7 @@ user_login_authentication(Username, AuthProps) ->
         false -> exit({unknown_auth_props, Username, AuthProps})
     end.
 
-user_login_authorization(Username) ->
+user_login_authorization(Username, _AuthProps) ->
     case user_login_authentication(Username, []) of
         {ok, #auth_user{impl = Impl, tags = Tags}} -> {ok, Impl, Tags};
         Else                                       -> Else


### PR DESCRIPTION
## Proposed Changes

This propagates authentication context (properties) to `user_login_authorization/2`.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #1633)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-server#1633.

[#158805410]
