### PR TITLE
erlang/otp 21 deprecated erlang:get_stacktrace/0 function, use the fu…

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -456,8 +456,8 @@ start_it(StartFun) ->
                         false -> StartFun()
                     end
                 catch
-                    Class:Reason ->
-                        boot_error(Class, Reason)
+                    ?EXCEPTION(Class, Reason, Stacktrace) ->
+                        boot_error(Class, Reason, ?GET_STACK(Stacktrace))
                 after
                     unlink(Marker),
                     Marker ! stop,
@@ -836,9 +836,9 @@ stop(_State) ->
          end,
     ok.
 
--spec boot_error(term(), not_available | [tuple()]) -> no_return().
+-spec boot_error(term(), not_available | [tuple()], term()) -> no_return().
 
-boot_error(_, {could_not_start, rabbit, {{timeout_waiting_for_tables, _}, _}}) ->
+boot_error(_, {could_not_start, rabbit, {{timeout_waiting_for_tables, _}, _}}, _Stacktrace) ->
     AllNodes = rabbit_mnesia:cluster_nodes(all),
     Suffix = "~nBACKGROUND~n==========~n~n"
         "This cluster node was shut down while other nodes were still running.~n"
@@ -858,19 +858,19 @@ boot_error(_, {could_not_start, rabbit, {{timeout_waiting_for_tables, _}, _}}) -
     log_boot_error_and_exit(
       timeout_waiting_for_tables,
       "~n" ++ Err ++ rabbit_nodes:diagnostics(Nodes), []);
-boot_error(Class, {error, {cannot_log_to_file, _, _}} = Reason) ->
+boot_error(Class, {error, {cannot_log_to_file, _, _}} = Reason, Stacktrace) ->
     log_boot_error_and_exit(
       Reason,
       "~nError description:~s",
-      [lager:pr_stacktrace(erlang:get_stacktrace(), {Class, Reason})]);
-boot_error(Class, Reason) ->
+      [lager:pr_stacktrace(Stacktrace, {Class, Reason})]);
+boot_error(Class, Reason, Stacktrace) ->
     LogLocations = log_locations(),
     log_boot_error_and_exit(
       Reason,
       "~nError description:~s"
       "~nLog file(s) (may contain more information):~n" ++
       lists:flatten(["   ~s~n" || _ <- lists:seq(1, length(LogLocations))]),
-      [lager:pr_stacktrace(erlang:get_stacktrace(), {Class, Reason})] ++
+      [lager:pr_stacktrace(Stacktrace, {Class, Reason})] ++
       LogLocations).
 
 log_boot_error_and_exit(Reason, Format, Args) ->

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -539,8 +539,8 @@ handle_cast({method, Method, Content, Flow},
         exit:Reason = #amqp_error{} ->
             MethodName = rabbit_misc:method_record_type(Method),
             handle_exception(Reason#amqp_error{method = MethodName}, State);
-        _:Reason ->
-            {stop, {Reason, erlang:get_stacktrace()}, State}
+        ?EXCEPTION(_, Reason, Stacktrace) ->
+            {stop, {Reason, ?GET_STACK(Stacktrace)}, State}
     end;
 
 handle_cast(ready_for_close, State = #ch{state      = closing,

--- a/src/rabbit_node_monitor.erl
+++ b/src/rabbit_node_monitor.erl
@@ -22,6 +22,8 @@
 
 -behaviour(gen_server).
 
+-include("rabbit.hrl").
+
 -export([start_link/0]).
 -export([running_nodes_filename/0,
          cluster_status_filename/0, prepare_cluster_status_files/0,
@@ -736,10 +738,10 @@ register_outside_app_process(Fun, WaitForExistingProcess) ->
 do_run_outside_app_fun(Fun) ->
     try
         Fun()
-    catch _:E ->
+    catch ?EXCEPTION(_, E, Stacktrace) ->
             rabbit_log:error(
               "rabbit_outside_app_process:~n~p~n~p~n",
-              [E, erlang:get_stacktrace()])
+              [E, ?GET_STACK(Stacktrace)])
     end.
 
 wait_for_cluster_recovery(Condition) ->

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1116,9 +1116,8 @@ handle_method0(MethodName, FieldsBin,
             throw({connection_closed_abruptly, State});
           exit:#amqp_error{method = none} = Reason ->
             handle_exception(State, 0, Reason#amqp_error{method = MethodName});
-          Type:Reason ->
-            Stack = erlang:get_stacktrace(),
-            handle_exception(State, 0, {Type, Reason, MethodName, Stack})
+          ?EXCEPTION(Type, Reason, Stacktrace) ->
+            handle_exception(State, 0, {Type, Reason, MethodName, ?GET_STACK(Stacktrace)})
     end.
 
 handle_method0(#'connection.start_ok'{mechanism = Mechanism,

--- a/src/rabbit_vhost_process.erl
+++ b/src/rabbit_vhost_process.erl
@@ -58,11 +58,11 @@ init([VHost]) ->
         Interval = interval(),
         timer:send_interval(Interval, check_vhost),
         {ok, VHost}
-    catch _:Reason ->
+    catch ?EXCEPTION(_, Reason, Stracktrace) ->
         rabbit_amqqueue:mark_local_durable_queues_stopped(VHost),
         rabbit_log:error("Unable to recover vhost ~p data. Reason ~p~n"
                          " Stacktrace ~p",
-                         [VHost, Reason, erlang:get_stacktrace()]),
+                         [VHost, Reason, ?GET_STACK(Stracktrace)]),
         {stop, Reason}
     end.
 


### PR DESCRIPTION
work with rabbitmq/rabbitmq-common#271
copy from [meck](https://github.com/eproxus/meck/blob/master/src/meck_code_gen.erl#L186-L192)