### PR TITLE
Prepare semi-durable binding table once instead of each time a virtual host is recovered

### DIFF
--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -102,7 +102,7 @@
                     routing_key, arguments,
                     vhost]).
 
-%% Global table recover
+%% Global table recovery
 recover() ->
     rabbit_misc:table_filter(
         fun (Route) ->
@@ -114,7 +114,7 @@ recover() ->
                 ok
         end, rabbit_durable_route).
 
-%% Per-vhost recover
+%% Virtual host-specific recovery
 recover(XNames, QNames) ->
     XNameSet = sets:from_list(XNames),
     QNameSet = sets:from_list(QNames),

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -52,6 +52,10 @@ recover() ->
     rabbit_amqqueue:on_node_down(node()),
 
     rabbit_amqqueue:warn_file_limit(),
+
+    %% Prepare rabbit_semi_durable_route table
+    rabbit_binding:recover(),
+
     %% rabbit_vhost_sup_sup will start the actual recovery.
     %% So recovery will be run every time a vhost supervisor is restarted.
     ok = rabbit_vhost_sup_sup:start(),


### PR DESCRIPTION
Before #567 all binding recover functions were executed once on
node restart.
Executing table_filter can be expensive with high number of vhosts
and bindings and effectively should be called only once.
Moved to a separate function, which should be called from the global
recovery function (`rabbit_vhost:recover/0`).

This problem exacerbated what's described in #1648.

