### PR TITLE
Add support for syslog server hostname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ BUILD_DEPS = rabbitmq_cli
 DEPS = ranch syslog lager rabbit_common
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper
 
-dep_syslog = git https://github.com/schlagert/syslog 3.4.2
+dep_syslog = git https://github.com/schlagert/syslog 3.4.3
 
 define usage_xml_to_erl
 $(subst __,_,$(patsubst $(DOCS_DIR)/rabbitmq%.1.xml, src/rabbit_%_usage.erl, $(subst -,_,$(1))))

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1067,6 +1067,27 @@ end}.
 {mapping, "log.syslog", "rabbit.log.syslog.enabled", [
     {datatype, {enum, [true, false]}}
 ]}.
+
+{translation, "rabbit.log.syslog.enabled",
+fun(Conf) ->
+    case cuttlefish:conf_get("log.syslog", Conf) of
+        true ->
+            case cuttlefish:conf_get("log.syslog.ip", Conf, undefined) of
+                undefined ->
+                    case cuttlefish:conf_get("log.syslog.host", Conf, undefined) of
+                        undefined ->
+                            cuttlefish:invalid("Either log.syslog.ip or log.syslog.host must be set");
+                        _Host ->
+                            true
+                    end;
+                _IpAddr ->
+                    true
+            end;
+        _ ->
+            []
+    end
+end}.
+
 {mapping, "log.syslog.level", "rabbit.log.syslog.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.
@@ -1086,9 +1107,30 @@ end}.
     {datatype, {enum, [true, false]}}
 ]}.
 
+{mapping, "log.syslog.ip", "syslog.dest_host", [
+    {datatype, string},
+    {validators, ["is_ip"]}
+]}.
+
 {mapping, "log.syslog.host", "syslog.dest_host", [
     {datatype, string}
 ]}.
+
+{translation, "syslog.dest_host",
+fun(Conf) ->
+    case cuttlefish:conf_get("log.syslog", Conf) of
+        true ->
+            case cuttlefish:conf_get("log.syslog.ip", Conf, undefined) of
+                undefined ->
+                    % If log.syslog.ip is not set, then this must be set
+                    cuttlefish:conf_get("log.syslog.host", Conf);
+                IpAddr ->
+                    IpAddr
+            end;
+        _ ->
+            cuttlefish:invalid("log.syslog must be set to true to set log.syslog.host or log.syslog.ip")
+    end
+end}.
 
 {mapping, "log.syslog.port", "syslog.dest_port", [
     {datatype, integer}
@@ -1350,6 +1392,12 @@ end}.
 fun(File) ->
     ReadFile = file:read_file_info(File),
     element(1, ReadFile) == ok
+end}.
+
+{validator, "is_ip", "string is a valid IP address",
+fun(IpStr) ->
+    Res = inet:parse_address(IpStr),
+    element(1, Res) == ok
 end}.
 
 {validator, "non_negative_integer", "number should be greater or equal to zero",

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1068,26 +1068,6 @@ end}.
     {datatype, {enum, [true, false]}}
 ]}.
 
-{translation, "rabbit.log.syslog.enabled",
-fun(Conf) ->
-    case cuttlefish:conf_get("log.syslog", Conf) of
-        true ->
-            case cuttlefish:conf_get("log.syslog.ip", Conf, undefined) of
-                undefined ->
-                    case cuttlefish:conf_get("log.syslog.host", Conf, undefined) of
-                        undefined ->
-                            cuttlefish:invalid("Either log.syslog.ip or log.syslog.host must be set");
-                        _Host ->
-                            true
-                    end;
-                _IpAddr ->
-                    true
-            end;
-        _ ->
-            []
-    end
-end}.
-
 {mapping, "log.syslog.level", "rabbit.log.syslog.level", [
     {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
 ]}.

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1086,9 +1086,8 @@ end}.
     {datatype, {enum, [true, false]}}
 ]}.
 
-{mapping, "log.syslog.ip", "syslog.dest_host", [
-    {datatype, string},
-    {validators, ["is_ip"]}
+{mapping, "log.syslog.host", "syslog.dest_host", [
+    {datatype, string}
 ]}.
 
 {mapping, "log.syslog.port", "syslog.dest_port", [
@@ -1351,12 +1350,6 @@ end}.
 fun(File) ->
     ReadFile = file:read_file_info(File),
     element(1, ReadFile) == ok
-end}.
-
-{validator, "is_ip", "string is a valid IP address",
-fun(IpStr) ->
-    Res = inet:parse_address(IpStr),
-    element(1, Res) == ok
 end}.
 
 {validator, "non_negative_integer", "number should be greater or equal to zero",

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -540,7 +540,7 @@ credential_validator.regexp = ^abc\\d+",
     log.syslog.identity = rabbitmq
     log.syslog.facility = user
     log.syslog.multiline_mode = true
-    log.syslog.ip = 10.10.10.10
+    log.syslog.host = 10.10.10.10
     log.syslog.port = 123",
    [
     {rabbit,[{log, [{syslog, [{enabled, true}]}]}]},
@@ -554,10 +554,12 @@ credential_validator.regexp = ^abc\\d+",
   {log_syslog_tcp,
    "log.syslog = true
     log.syslog.transport = tcp
-    log.syslog.protocol = rfc5424",
+    log.syslog.protocol = rfc5424
+    log.syslog.host = syslog.my-network.com",
    [
     {rabbit,[{log, [{syslog, [{enabled, true}]}]}]},
-    {syslog, [{protocol, {rfc5424, tcp}}]}
+    {syslog, [{protocol, {rfc5424, tcp}},
+              {dest_host, "syslog.my-network.com"}]}
    ],
    []},
   {log_syslog_udp_default,

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -540,7 +540,7 @@ credential_validator.regexp = ^abc\\d+",
     log.syslog.identity = rabbitmq
     log.syslog.facility = user
     log.syslog.multiline_mode = true
-    log.syslog.host = 10.10.10.10
+    log.syslog.ip = 10.10.10.10
     log.syslog.port = 123",
    [
     {rabbit,[{log, [{syslog, [{enabled, true}]}]}]},


### PR DESCRIPTION
schlagert/syslog version 3.4.3 adds support for specifying a host name for `dest_host`, this PR supports it as well

See this gist for my test procedure:

https://gist.github.com/lukebakken/20bd05816a8b80839cc3c6645350bfa4