### PR TITLE
Handle generic data structures in priority queue info callback

### DIFF
--- a/src/rabbit_priority_queue.erl
+++ b/src/rabbit_priority_queue.erl
@@ -666,8 +666,8 @@ cse(_, lazy)                -> lazy;
 cse(lazy, _)                -> lazy;
 %% numerical stats
 cse(A, B) when is_number(A) -> A + B;
-cse({delta, _, _, _, _}, _)    -> {delta, todo, todo, todo, todo};
-cse(A, B)                   -> exit({A, B}).
+cse({delta, _, _, _, _}, _) -> {delta, todo, todo, todo, todo};
+cse(_, _)                   -> undefined.
 
 %% When asked about 'head_message_timestamp' fro this priority queue, we
 %% walk all the backing queues, starting by the highest priority. Once a


### PR DESCRIPTION
The priority queue implementation makes assumptions over the
data format returned by the underlying backing queue
`info` callback.

This causes priority queues to crash if used together with other
modules implementing the `rabbit_backing_queue` behaviour and
returning additional data with the `info` callback.

As we cannot predict the format of the data the backing queue
`info` callback could return, we just replace it with the undefined
keyword.

Signed-off-by: Matteo Cafasso <noxdafox@gmail.com>

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Notice this when investigating an [issue](https://github.com/noxdafox/rabbitmq-message-deduplication/issues/14) in my plugin. 

If a module implementing the `rabbit_backing_queue` behaviour wants to enrich the information returned by the `info` callback (more particularly, the `:backing_queue_status` information) will end up crashing the queue if used together with priorities.
