### PR TITLE
Add detail for channel_max 0 value

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1298,9 +1298,10 @@ fail_negotiation(Field, MinOrMax, ServerValue, ClientValue) ->
                    min -> {lower,  minimum};
                    max -> {higher, maximum}
                end,
+    ClientValueDetail = get_client_value_detail(Field, ClientValue),
     rabbit_misc:protocol_error(
-      not_allowed, "negotiated ~w = ~w is ~w than the ~w allowed value (~w)",
-      [Field, ClientValue, S1, S2, ServerValue], 'connection.tune').
+      not_allowed, "negotiated ~w = ~w~s is ~w than the ~w allowed value (~w)",
+      [Field, ClientValue, ClientValueDetail, S1, S2, ServerValue], 'connection.tune').
 
 get_env(Key) ->
     {ok, Value} = application:get_env(rabbit, Key),
@@ -1722,3 +1723,9 @@ dynamic_connection_name(Default) ->
 handle_uncontrolled_channel_close(ChPid) ->
     rabbit_core_metrics:channel_closed(ChPid),
     rabbit_event:notify(channel_closed, [{pid, ChPid}]).
+
+-spec get_client_value_detail(atom(), integer()) -> string().
+get_client_value_detail(channel_max, 0) ->
+    " (no limit)";
+get_client_value_detail(_Field, _ClientValue) ->
+    "".


### PR DESCRIPTION
It is not immediately obvious that a 0 value for channel_max means infinite or "no limit". This change will result in the following message being logged:

"negotiated channel_max = 0 (no limit) is higher than the maximum allowed value (2047)"