### PR TITLE
Don't error when a queue that's being deleted has no bindings to remove

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -178,11 +178,9 @@
 -spec notify_decorators(rabbit_types:amqqueue()) -> 'ok'.
 -spec resume(pid(), pid()) -> 'ok'.
 -spec internal_delete(name(), rabbit_types:username()) ->
-          rabbit_types:ok_or_error('not_found') |
-          rabbit_types:connection_exit() |
+          'ok' | rabbit_types:connection_exit() |
           fun (() ->
-              rabbit_types:ok_or_error('not_found') |
-              rabbit_types:connection_exit()).
+              'ok' | rabbit_types:connection_exit()).
 -spec run_backing_queue
         (pid(), atom(), (fun ((atom(), A) -> {[rabbit_types:msg_id()], A}))) ->
             'ok'.
@@ -995,7 +993,7 @@ internal_delete(QueueName, ActingUser, Reason) ->
               case {mnesia:wread({rabbit_queue, QueueName}),
                     mnesia:wread({rabbit_durable_queue, QueueName})} of
                   {[], []} ->
-                      rabbit_misc:const({error, not_found});
+                      rabbit_misc:const(ok);
                   _ ->
                       Deletions = internal_delete1(QueueName, false, Reason),
                       T = rabbit_binding:process_deletions(Deletions,


### PR DESCRIPTION
## Proposed Changes

It can happen due to retries of (currently not guaranteed to be idempotent,
which is a separate issue in the works) binding removal. Since both
the queue and its bindings are undergoing removal, don't fail when
there's nothing left to be removed for the current transaction [attempt].

This avoids obscure and non-actionable errors in the log ({error, not_found}).
Note that the error is also not handled by the callers and ignoring them
is the only reasonable course of action that I can think of.

## Types of Changes

- [x] Bug fix/usability (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Per discussion with @dumbbell @dcorbacho @hairyhum.
