### PR TITLE
Idempotent binding removal

### DIFF
--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -444,10 +444,7 @@ remove_for_destination(DstName, OnlyDurable, Fun) ->
                         lists:keysort(#binding.source, Bindings), OnlyDurable).
 
 %% Instead of locking entire table on remove operations we can lock the
-%% affected resource only. This will allow us to use dirty_match_object for
-%% do faster search of records to delete.
-%% This works better when there are multiple resources deleted at once, for
-%% example when exclusive queues are deleted.
+%% affected resource only.
 lock_resource(Name) ->
     mnesia:lock({global, Name, mnesia:table_info(rabbit_route, where_to_write)},
                 write).

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -343,9 +343,6 @@ binding_action(Binding = #binding{source      = SrcName,
               Fun(Src, Dst, Binding#binding{args = SortedArgs})
       end, ErrFun).
 
-dirty_delete_object(Table, Record, _LockKind) ->
-    mnesia:dirty_delete_object(Table, Record).
-
 sync_route(Route, true, true, Fun) ->
     ok = Fun(rabbit_durable_route, Route, write),
     sync_route(Route, false, true, Fun);
@@ -415,15 +412,15 @@ remove_routes(Routes) ->
     %% Of course the destination might not really be durable but it's
     %% just as easy to try to delete it from the semi-durable table
     %% than check first
-    [ok = sync_route(R, false, true, fun dirty_delete_object/3) ||
+    [ok = sync_route(R, false, true, fun mnesia:delete_object/3) ||
         R <- RamRoutes],
-    [ok = sync_route(R, true,  true, fun dirty_delete_object/3) ||
+    [ok = sync_route(R, true,  true, fun mnesia:delete_object/3) ||
         R <- DiskRoutes],
     [R#route.binding || R <- Routes].
 
 remove_transient_routes(Routes) ->
     [begin
-         ok = sync_transient_route(R, fun dirty_delete_object/3),
+         ok = sync_transient_route(R, fun mnesia:delete_object/3),
          R#route.binding
      end || R <- Routes].
 


### PR DESCRIPTION
Optimizations introduced in #1589 caused the removal of bindings to
be non-idempotent, as the removal of routing information with dirty
deletes did not allow for full transaction rollback. This commit
reverts that change, losing some of the performance improvements in
favour of data correctness.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
