### PR TITLE
Make rabbit_vhost:add/2 idempotent

### DIFF
--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -83,7 +83,13 @@ recover(VHost) ->
 
 -define(INFO_KEYS, [name, tracing, cluster_state]).
 
-add(VHostPath, ActingUser) ->
+add(VHost, ActingUser) ->
+    case exists(VHost) of
+        true  -> ok;
+        false -> do_add(VHost, ActingUser)
+    end.
+
+do_add(VHostPath, ActingUser) ->
     rabbit_log:info("Adding vhost '~s'~n", [VHostPath]),
     R = rabbit_misc:execute_mnesia_transaction(
           fun () ->
@@ -91,7 +97,8 @@ add(VHostPath, ActingUser) ->
                       []  -> ok = mnesia:write(rabbit_vhost,
                                                #vhost{virtual_host = VHostPath},
                                                write);
-                      [_] -> mnesia:abort({vhost_already_exists, VHostPath})
+                      %% the vhost already exists
+                      [_] -> ok
                   end
           end,
           fun (ok, true) ->

--- a/test/vhost_SUITE.erl
+++ b/test/vhost_SUITE.erl
@@ -34,7 +34,8 @@ groups() ->
     ClusterSize1Tests = [
         single_node_vhost_deletion_forces_connection_closure,
         vhost_failure_forces_connection_closure,
-        dead_vhost_connection_refused
+        dead_vhost_connection_refused,
+        vhost_creation_idempotency
     ],
     ClusterSize2Tests = [
         cluster_vhost_deletion_forces_connection_closure,
@@ -43,7 +44,8 @@ groups() ->
         vhost_failure_forces_connection_closure_on_failure_node,
         dead_vhost_connection_refused_on_failure_node,
         node_starts_with_dead_vhosts,
-        node_starts_with_dead_vhosts_and_ignore_slaves
+        node_starts_with_dead_vhosts_and_ignore_slaves,
+        vhost_creation_idempotency
     ],
     [
       {cluster_size_1_network, [], ClusterSize1Tests},
@@ -372,6 +374,12 @@ node_starts_with_dead_vhosts_and_ignore_slaves(Config) ->
                 rabbit_vhost_sup_sup, is_vhost_alive, [VHost1]),
     true = rabbit_ct_broker_helpers:rpc(Config, 1,
                 rabbit_vhost_sup_sup, is_vhost_alive, [VHost2]).
+
+vhost_creation_idempotency(Config) ->
+    VHost = <<"idempotency-test">>,
+    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)).
 
 %% -------------------------------------------------------------------
 %% Helpers

--- a/test/vhost_SUITE.erl
+++ b/test/vhost_SUITE.erl
@@ -377,9 +377,13 @@ node_starts_with_dead_vhosts_and_ignore_slaves(Config) ->
 
 vhost_creation_idempotency(Config) ->
     VHost = <<"idempotency-test">>,
-    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
-    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
-    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)).
+    try
+        ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+        ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+        ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost))
+    after
+        rabbit_ct_broker_helpers:delete_vhost(Config, VHost)
+    end.
 
 %% -------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
## Proposed Changes

This makes `rabbit_vhost:add/2` idempotent. Returning an error when an existing vhost is [re-]created
is not productive and worsens CLI and automation tool experience.

## Types of Changes

Technically it's a breaking change but we don't expect it to break a system that can handle
both success and error responses in a reasonable way.

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-cli#260.

[#160792770]