### PR TITLE
Bindings optimisation

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -366,8 +366,7 @@ internal_declare(Q = #amqqueue{name = QueueName}, false) ->
                           not_found           -> Q1 = rabbit_policy:set(Q),
                                                  Q2 = Q1#amqqueue{state = live},
                                                  ok = store_queue(Q2),
-                                                 B = add_default_binding(Q1),
-                                                 fun () -> B(), Q1 end;
+                                                 fun () -> Q1 end;
                           {absent, _Q, _} = R -> rabbit_misc:const(R)
                       end;
                   [ExistingQ] ->
@@ -421,15 +420,6 @@ policy_changed(Q1 = #amqqueue{decorators = Decorators1},
     %% Make sure we emit a stats event even if nothing
     %% mirroring-related has changed - the policy may have changed anyway.
     notify_policy_changed(Q1).
-
-add_default_binding(#amqqueue{name = QueueName}) ->
-    ExchangeName = rabbit_misc:r(QueueName, exchange, <<>>),
-    RoutingKey = QueueName#resource.name,
-    rabbit_binding:add(#binding{source      = ExchangeName,
-                                destination = QueueName,
-                                key         = RoutingKey,
-                                args        = []},
-                       ?INTERNAL_USER).
 
 lookup([])     -> [];                             %% optimisation
 lookup([Name]) -> ets:lookup(rabbit_queue, Name); %% optimisation

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -319,8 +319,8 @@ remove_for_source(SrcName) ->
     Match = #route{binding = #binding{source = SrcName, _ = '_'}},
     remove_routes(
       lists:usort(
-        mnesia:match_object(rabbit_route, Match, read) ++
-            mnesia:match_object(rabbit_semi_durable_route, Match, read))).
+        mnesia:dirty_match_object(rabbit_route, Match) ++
+            mnesia:dirty_match_object(rabbit_semi_durable_route, Match))).
 
 remove_for_destination(DstName, OnlyDurable) ->
     remove_for_destination(DstName, OnlyDurable, fun remove_routes/1).
@@ -443,13 +443,13 @@ remove_for_destination(DstName, OnlyDurable, Fun) ->
     Routes = case OnlyDurable of
                  false ->
                         [reverse_route(R) ||
-                              R <- mnesia:match_object(
-                                     rabbit_reverse_route, MatchRev, read)];
+                              R <- mnesia:dirty_match_object(
+                                     rabbit_reverse_route, MatchRev)];
                  true  -> lists:usort(
-                            mnesia:match_object(
-                              rabbit_durable_route, MatchFwd, read) ++
-                                mnesia:match_object(
-                                  rabbit_semi_durable_route, MatchFwd, read))
+                            mnesia:dirty_match_object(
+                              rabbit_durable_route, MatchFwd) ++
+                                mnesia:dirty_match_object(
+                                  rabbit_semi_durable_route, MatchFwd))
              end,
     Bindings = Fun(Routes),
     group_bindings_fold(fun maybe_auto_delete/4, new_deletions(),


### PR DESCRIPTION
A follow-up to #1589
Adresses #1690

A number of optimisations around bindings. Apparently there is not much sense in adding table indexes to binding tables, as index read locks entire table. Indexes could slightly improve performance when there are many bindings and queues, but will require a breaking change in the schema.

The changes in this branch provide performance improvement comparable to introduction of indexes without reworking the schema:

- Replaced `delete_object` with `delete` as bindings are value-objects and there are no bag tables
- In some lookups during cleanup `match_object` is replaced with `dirty_match_object` to not lock the entire bindings table. This change was reverted in d0423f958599cba5148864997aa8446c873dad00 because it was creating inconsistencies with `dirty_delete`. Current branch does not contain dirty deletes. Still requires more testing.
- Default bindings are removed. The default exchange does direct lookup of queues without actually loading the bindings and default bindings are not unbindable and only displayed in `list_bindings`. They are not used, but slow down queue deletion and creation.

Benchmark data will follow.