### PR TITLE
Support changes for `rabbitmq-plugins directories`

### DIFF
--- a/scripts/rabbitmq-plugins
+++ b/scripts/rabbitmq-plugins
@@ -29,4 +29,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins -q "$@"
+run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins "$@"

--- a/scripts/rabbitmq-plugins
+++ b/scripts/rabbitmq-plugins
@@ -29,4 +29,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins --formatter=plugins -q "$@"
+run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins -q "$@"

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -56,7 +56,7 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 -nodename !RABBITMQ_NODENAME! ^
 -run escript start ^
 -escript main rabbitmqctl_escript ^
--extra "%RABBITMQ_HOME%\escript\rabbitmq-plugins" --formatter=plugins !STAR!
+-extra "%RABBITMQ_HOME%\escript\rabbitmq-plugins" !STAR!
 
 endlocal
 endlocal

--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -23,7 +23,7 @@
 -export([extract_schemas/1]).
 -export([validate_plugins/1, format_invalid_plugins/1]).
 -export([is_strictly_plugin/1, strictly_plugins/2, strictly_plugins/1]).
--export([plugins_dist_dir/0, plugins_expand_dir/0, enabled_plugins_file/0]).
+-export([plugins_dir/0, plugins_expand_dir/0, enabled_plugins_file/0]).
 
 % Export for testing purpose.
 -export([is_version_supported/2, validate_plugins/2]).
@@ -98,8 +98,8 @@ plugins_expand_dir() ->
             filename:join([rabbit_mnesia:dir(), "plugins_expand_dir"])
     end.
 
--spec plugins_dist_dir() -> file:filename().
-plugins_dist_dir() ->
+-spec plugins_dir() -> file:filename().
+plugins_dir() ->
     case application:get_env(rabbit, plugins_dir) of
         {ok, PluginsDistDir} ->
             PluginsDistDir;
@@ -184,7 +184,7 @@ extract_schema(#plugin{type = dir, location = Location}, SchemaDir) ->
 
 %% @doc Lists the plugins which are currently running.
 active() ->
-    InstalledPlugins = plugin_names(list(plugins_dist_dir())),
+    InstalledPlugins = plugin_names(list(plugins_dir())),
     [App || {App, _, _} <- rabbit_misc:which_applications(),
             lists:member(App, InstalledPlugins)].
 
@@ -240,7 +240,7 @@ strictly_plugins(Plugins, AllPlugins) ->
       end, Plugins).
 
 strictly_plugins(Plugins) ->
-    AllPlugins = list(plugins_dist_dir()),
+    AllPlugins = list(plugins_dir()),
     lists:filter(
       fun(Name) ->
               is_strictly_plugin(lists:keyfind(Name, #plugin.name, AllPlugins))
@@ -296,7 +296,7 @@ running_plugins() ->
 prepare_plugins(Enabled) ->
     ExpandDir = plugins_expand_dir(),
 
-    AllPlugins = list(plugins_dist_dir()),
+    AllPlugins = list(plugins_dir()),
     Wanted = dependencies(false, Enabled, AllPlugins),
     WantedPlugins = lookup_plugins(Wanted, AllPlugins),
     {ValidPlugins, Problems} = validate_plugins(WantedPlugins),

--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -23,6 +23,7 @@
 -export([extract_schemas/1]).
 -export([validate_plugins/1, format_invalid_plugins/1]).
 -export([is_strictly_plugin/1, strictly_plugins/2, strictly_plugins/1]).
+-export([plugins_dist_dir/0, plugins_expand_dir/0, enabled_plugins_file/0]).
 
 % Export for testing purpose.
 -export([is_version_supported/2, validate_plugins/2]).
@@ -104,6 +105,15 @@ plugins_dist_dir() ->
             PluginsDistDir;
         _ ->
             filename:join([rabbit_mnesia:dir(), "plugins_dir_stub"])
+    end.
+
+-spec enabled_plugins_file() -> file:filename().
+enabled_plugins_file() ->
+     case application:get_env(rabbit, enabled_plugins_file) of
+        {ok, Val} ->
+            Val;
+        _ ->
+            filename:join([rabbit_mnesia:dir(), "enabled_plugins"])
     end.
 
 -spec enabled_plugins() -> [atom()].


### PR DESCRIPTION
## Proposed Changes

These are support changes required by rabbitmq/rabbitmq-cli#261:

 * Export a few functions
 * Give `rabbitmq-plugins` commands a chance to use any formatter they see fit by not forcing `--formatter=plugins` upon them.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue rabbitmq/rabbitmq-cli#261)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-cli#261.
