### PR TITLE
Remove default bindings

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -29,7 +29,7 @@
 -export([list/0, list/1, info_keys/0, info/1, info/2, info_all/1, info_all/2,
          emit_info_all/5, list_local/1, info_local/1,
 	 emit_info_local/4, emit_info_down/4]).
--export([list_down/1, count/1, list_names/0, list_local_names/0]).
+-export([list_down/1, count/1, list_names/0, list_names/1, list_local_names/0]).
 -export([list_by_type/1]).
 -export([notify_policy_changed/1]).
 -export([consumers/1, consumers_all/1,  emit_consumers_all/4, consumer_info_keys/0]).
@@ -746,6 +746,8 @@ check_queue_type({Type,    _}, _Args) ->
 list() -> mnesia:dirty_match_object(rabbit_queue, #amqqueue{_ = '_'}).
 
 list_names() -> mnesia:dirty_all_keys(rabbit_queue).
+
+list_names(VHost) -> [Q#amqqueue.name || Q <- list(VHost)].
 
 list_local_names() ->
     [ Q#amqqueue.name || #amqqueue{state = State, pid = QPid} = Q <- list(),

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -437,8 +437,7 @@ internal_declare(Q = #amqqueue{name = QueueName}, false) ->
                           not_found           -> Q1 = rabbit_policy:set(Q),
                                                  Q2 = Q1#amqqueue{state = live},
                                                  ok = store_queue(Q2),
-                                                 B = add_default_binding(Q2),
-                                                 fun () -> B(), {created, Q2} end;
+                                                 fun () -> {created, Q2} end;
                           {absent, _Q, _} = R -> rabbit_misc:const(R)
                       end;
                   [ExistingQ] ->
@@ -501,15 +500,6 @@ policy_changed(Q1 = #amqqueue{decorators = Decorators1},
     %% Make sure we emit a stats event even if nothing
     %% mirroring-related has changed - the policy may have changed anyway.
     notify_policy_changed(Q1).
-
-add_default_binding(#amqqueue{name = QueueName}) ->
-    ExchangeName = rabbit_misc:r(QueueName, exchange, <<>>),
-    RoutingKey = QueueName#resource.name,
-    rabbit_binding:add(#binding{source      = ExchangeName,
-                                destination = QueueName,
-                                key         = RoutingKey,
-                                args        = []},
-                       ?INTERNAL_USER).
 
 lookup([])     -> [];                             %% optimisation
 lookup([Name]) -> ets:lookup(rabbit_queue, Name); %% optimisation

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -27,6 +27,10 @@
 -export([has_for_source/1, remove_for_source/1,
          remove_for_destination/2, remove_transient_for_destination/1]).
 
+-define(DEFAULT_EXCHANGE(VHostPath), #resource{virtual_host = VHostPath,
+                                              kind = exchange,
+                                              name = <<>>}).
+
 %%----------------------------------------------------------------------------
 
 -export_type([key/0, deletions/0]).
@@ -156,6 +160,14 @@ recover_semi_durable_route_txn(R = #route{binding = B}, X) ->
           (Serial,     false) -> x_callback(Serial,      X, add_binding, B)
       end).
 
+exists(#binding{source = ?DEFAULT_EXCHANGE(_),
+                destination = #resource{kind = queue, name = QName} = Queue,
+                key = QName,
+                args = []}) ->
+    case rabbit_amqqueue:lookup(Queue) of
+        {ok, _} -> true;
+        {error, not_found} -> false
+    end;
 exists(Binding) ->
     binding_action(
       Binding, fun (_Src, _Dst, B) ->
@@ -247,9 +259,7 @@ list(VHostPath) ->
         [B || #route{binding = B} <- mnesia:dirty_match_object(rabbit_route,
                                                                Route)].
 
-list_for_source(#resource{kind = exchange,
-                          virtual_host = VHostPath,
-                          name = <<>>}) ->
+list_for_source(?DEFAULT_EXCHANGE(VHostPath)) ->
     implicit_bindings(VHostPath);
 list_for_source(SrcName) ->
     mnesia:async_dirty(
@@ -273,33 +283,30 @@ list_for_destination(DstName) ->
 
 implicit_bindings(VHostPath) ->
     DstQueues = rabbit_amqqueue:list_names(VHostPath),
-    DefaultExchange = #resource{virtual_host = VHostPath,
-                                kind = exchange,
-                                name = <<>>},
-    [ #binding{source = DefaultExchange,
+    [ #binding{source = ?DEFAULT_EXCHANGE(VHostPath),
                destination = DstQueue,
-               key = QName}
+               key = QName,
+               args = []}
       || DstQueue = #resource{name = QName} <- DstQueues ].
 
 implicit_for_destination(DstQueue = #resource{kind = queue,
                                              virtual_host = VHostPath,
                                              name = QName}) ->
-    DefaultExchange = #resource{virtual_host = VHostPath,
-                                kind = exchange,
-                                name = <<>>},
-    [#binding{source = DefaultExchange,
+    [#binding{source = ?DEFAULT_EXCHANGE(VHostPath),
               destination = DstQueue,
-              key = QName}];
+              key = QName,
+              args = []}];
 implicit_for_destination(_) ->
     [].
 
-list_for_source_and_destination(#resource{kind = exchange,
-                                          virtual_host = VHostPath,
-                                          name = <<>>} = DefaultExchange,
+list_for_source_and_destination(?DEFAULT_EXCHANGE(VHostPath),
                                 #resource{kind = queue,
                                           virtual_host = VHostPath,
                                           name = QName} = DstQueue) ->
-    [#binding{source = DefaultExchange, destination = DstQueue, key = QName}];
+    [#binding{source = ?DEFAULT_EXCHANGE(VHostPath),
+              destination = DstQueue,
+              key = QName,
+              args = []}];
 list_for_source_and_destination(SrcName, DstName) ->
     mnesia:async_dirty(
       fun() ->


### PR DESCRIPTION
Split from #1715

Default bindings slow down queue creation and deletion and are not used in the actual routing logic. They are returned in some HTTP API endpoints though, therefore to merge this PR there should be some changes done in the management plugin.

There is no information in bindings which cannot be extracted from queues, which makes it possible to fake results for HTTP API. The question is should we do that or make the bindings result empty if there are no explicit bindings?

The definitions result does not contain default bindings BTW.