### PR TITLE
Only start syslog application if it is required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ define PROJECT_ENV
 endef
 
 LOCAL_DEPS = sasl mnesia os_mon inets
-BUILD_DEPS = rabbitmq_cli
-DEPS = ranch syslog lager rabbit_common
+BUILD_DEPS = rabbitmq_cli syslog
+DEPS = ranch lager rabbit_common
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper
 
-dep_syslog = git https://github.com/schlagert/syslog 3.4.3
+dep_syslog = git https://github.com/schlagert/syslog 3.4.5
 
 define usage_xml_to_erl
 $(subst __,_,$(patsubst $(DOCS_DIR)/rabbitmq%.1.xml, src/rabbit_%_usage.erl, $(subst -,_,$(1))))

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -517,7 +517,6 @@ start_apps(Apps) ->
 
 start_apps(Apps, RestartTypes) ->
     app_utils:load_applications(Apps),
-
     ConfigEntryDecoder = case application:get_env(rabbit, config_entry_decoder) of
         undefined ->
             [];


### PR DESCRIPTION
Fixes #1718 

Test using the following `rabbitmq.config` file:

```
%% {rfc5424, udp, [{ip, {127,0,0,1}}]}
%% {rfc5424, udp}
[
    {syslog, [
        {dest_port, 5140},
        {dest_host, "127.0.0.1"},
        {protocol,
            {rfc5424, udp, [{ip, {192,168,1,5}}]}
        }
    ]},
    {rabbit, [
        {log, [
            {syslog, [
                {level, info},
                {enabled, true}
            ]},                                                                                                                                                                                                                                                                 
            {console, [                                                                                                                                                                                                                                                         
                {level, info},                                                                                                                                                                                                                                                  
                {enabled, true}                                                                                                                                                                                                                                                 
            ]}                                                                                                                                                                                                                                                                  
        ]},                                                                                                                                                                                                                                                                     
        {loopback_users,[]}                                                                                                                                                                                                                                                     
    ]}                                                                                                                                                                                                                                                                          
].
```

You can experiment by using different values in `protocol`, or by leaving that term out completely. If you leave out `ip`, `127.0.0.1` will be used. Use `netstat` to confirm:

```
netstat -pan | fgrep beam
```

You will see a line beginning with `udp` and it should be bound to the local address you expect.

If you leave out all `syslog` configuration, you will not see `beam.smp` listening on any `udp` ports.