### PR TITLE
Catch one more error when disabling default logger

### DIFF
--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -589,6 +589,9 @@ maybe_remove_logger_handler() ->
         error:undef ->
             % OK since the logger module only exists in OTP 21.1 or later
             ok;
+        error:{badmatch, {error, {not_found, default}}} ->
+            % OK - this error happens when running a CLI command
+            ok;
         Err:Reason ->
             error_logger:error_msg("calling ~p:~p failed: ~p:~p~n",
                                    [M, F, Err, Reason])


### PR DESCRIPTION
Related to #1718 and #1728

Reproduction steps:

* Run two brokers using `master` branch with the idea of creating a two-node cluster.
* Run the following and you should see the following output - note the `badmatch`:

```
$ ./escript/rabbitmqctl -n rabbit2@shostakovich stop_app; ./escript/rabbitmqctl -n rabbit2@shostakovich join_cluster rabbit@shostakovich; ./escript/rabbitmqctl -n rabbit2@shostakovich start_app; ./escript/rabbitmqctl -n rabbit2@shostakovich cluster_statusStopping rabbit application on node rabbit2@shostakovich ...
Clustering node rabbit2@shostakovich with rabbit@shostakovich
The node is already a member of this cluster
Starting node rabbit2@shostakovich ...

10:47:55.004 [error] calling :logger::remove_handler failed: :error:{:badmatch, {:error, {:not_found, :default}}}

 completed with 3 plugins.
Cluster status of node rabbit2@shostakovich ...
[{nodes,[{disc,[rabbit2@shostakovich,rabbit@shostakovich]}]},
 {running_nodes,[rabbit@shostakovich,rabbit2@shostakovich]},
 {cluster_name,<<"rabbit2@localhost.localdomain">>},
 {partitions,[]},
 {alarms,[{rabbit@shostakovich,[]},{rabbit2@shostakovich,[]}]}]
```