### PR TITLE
Expose cipher configuration to new style config format

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -78,6 +78,46 @@
 # ssl_options.cacertfile           = /path/to/cacert.pem
 # ssl_options.certfile             = /path/to/cert.pem
 # ssl_options.keyfile              = /path/to/key.pem
+#
+# ssl_options.honor_cipher_order   = true
+# ssl_options.honor_ecc_order      = true
+
+# ssl_options.ciphers.1  = ECDHE-ECDSA-AES256-GCM-SHA384
+# ssl_options.ciphers.2  = ECDHE-RSA-AES256-GCM-SHA384
+# ssl_options.ciphers.3  = ECDHE-ECDSA-AES256-SHA384
+# ssl_options.ciphers.4  = ECDHE-RSA-AES256-SHA384
+# ssl_options.ciphers.5  = ECDH-ECDSA-AES256-GCM-SHA384
+# ssl_options.ciphers.6  = ECDH-RSA-AES256-GCM-SHA384
+# ssl_options.ciphers.7  = ECDH-ECDSA-AES256-SHA384
+# ssl_options.ciphers.8  = ECDH-RSA-AES256-SHA384
+# ssl_options.ciphers.9  = DHE-RSA-AES256-GCM-SHA384
+# ssl_options.ciphers.10 = DHE-DSS-AES256-GCM-SHA384
+# ssl_options.ciphers.11 = DHE-RSA-AES256-SHA256
+# ssl_options.ciphers.12 = DHE-DSS-AES256-SHA256
+# ssl_options.ciphers.13 = ECDHE-ECDSA-AES128-GCM-SHA256
+# ssl_options.ciphers.14 = ECDHE-RSA-AES128-GCM-SHA256
+# ssl_options.ciphers.15 = ECDHE-ECDSA-AES128-SHA256
+# ssl_options.ciphers.16 = ECDHE-RSA-AES128-SHA256
+# ssl_options.ciphers.17 = ECDH-ECDSA-AES128-GCM-SHA256
+# ssl_options.ciphers.18 = ECDH-RSA-AES128-GCM-SHA256
+# ssl_options.ciphers.19 = ECDH-ECDSA-AES128-SHA256
+# ssl_options.ciphers.20 = ECDH-RSA-AES128-SHA256
+# ssl_options.ciphers.21 = DHE-RSA-AES128-GCM-SHA256
+# ssl_options.ciphers.22 = DHE-DSS-AES128-GCM-SHA256
+# ssl_options.ciphers.23 = DHE-RSA-AES128-SHA256
+# ssl_options.ciphers.24 = DHE-DSS-AES128-SHA256
+# ssl_options.ciphers.25 = ECDHE-ECDSA-AES256-SHA
+# ssl_options.ciphers.26 = ECDHE-RSA-AES256-SHA
+# ssl_options.ciphers.27 = DHE-RSA-AES256-SHA
+# ssl_options.ciphers.28 = DHE-DSS-AES256-SHA
+# ssl_options.ciphers.29 = ECDH-ECDSA-AES256-SHA
+# ssl_options.ciphers.30 = ECDH-RSA-AES256-SHA
+# ssl_options.ciphers.31 = ECDHE-ECDSA-AES128-SHA
+# ssl_options.ciphers.32 = ECDHE-RSA-AES128-SHA
+# ssl_options.ciphers.33 = DHE-RSA-AES128-SHA
+# ssl_options.ciphers.34 = DHE-DSS-AES128-SHA
+# ssl_options.ciphers.35 = ECDH-ECDSA-AES128-SHA
+# ssl_options.ciphers.36 = ECDH-RSA-AES128-SHA
 
 ## Select an authentication/authorisation backend to use.
 ##

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -35,7 +35,7 @@ fun(Conf) ->
     end
 end}.
 
-%% SSL listeners are configured in the same fashion as TCP listeners,
+%% TLS listeners are configured in the same fashion as TCP listeners,
 %% including the option to control the choice of interface.
 %%
 %% {ssl_listeners, [5671]},
@@ -129,7 +129,7 @@ fun(Conf) ->
     end
 end}.
 
-%% Configuring SSL.
+%% TLS options.
 %% See http://www.rabbitmq.com/ssl.html for full documentation.
 %%
 %% {ssl_options, [{cacertfile,           "/path/to/testca/cacert.pem"},
@@ -137,8 +137,6 @@ end}.
 %%                {keyfile,              "/path/to/server/key.pem"},
 %%                {verify,               verify_peer},
 %%                {fail_if_no_peer_cert, false}]},
-
-%% SSL options section ========================================================
 
 {mapping, "ssl_allow_poodle_attack", "rabbit.ssl_allow_poodle_attack",
 [{datatype, {enum, [true, false]}}]}.
@@ -251,7 +249,16 @@ end}.
 {translation, "rabbit.ssl_options.versions",
 fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("ssl_options.versions", Conf),
-    [ V || {_, V} <- Settings ]
+    [V || {_, V} <- Settings]
+end}.
+
+{mapping, "ssl_options.ciphers.$cipher", "rabbit.ssl_options.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbit.ssl_options.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("ssl_options.ciphers", Conf),
+    [V || {_, V} <- Settings]
 end}.
 
 %% ===========================================================================

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -302,6 +302,45 @@ tcp_listen_options.exit_on_close = false",
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {versions,['tlsv1.2','tlsv1.1']}]}]}],
   []},
+
+ {ssl_options_ciphers,
+  "listeners.ssl.1 = 5671
+   ssl_options.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   ssl_options.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   ssl_options.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   ssl_options.versions.1 = tlsv1.2
+   ssl_options.versions.2 = tlsv1.1
+   ssl_options.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   ssl_options.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   ssl_options.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   ssl_options.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   ssl_options.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   ssl_options.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   ssl_options.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   ssl_options.ciphers.8 = ECDH-RSA-AES256-SHA384
+   ssl_options.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [{ssl,[{versions,['tlsv1.2','tlsv1.1']}]}],
+  [{ssl,[{versions,['tlsv1.2','tlsv1.1']}]},
+   {rabbit,
+       [{ssl_listeners,[5671]},
+        {ssl_options,
+            [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {ciphers, [
+               "DHE-RSA-AES256-GCM-SHA384",
+               "ECDH-ECDSA-AES256-GCM-SHA384",
+               "ECDH-ECDSA-AES256-SHA384",
+               "ECDH-RSA-AES256-GCM-SHA384",
+               "ECDH-RSA-AES256-SHA384",
+               "ECDHE-ECDSA-AES256-GCM-SHA384",
+               "ECDHE-ECDSA-AES256-SHA384",
+               "ECDHE-RSA-AES256-GCM-SHA384",
+               "ECDHE-RSA-AES256-SHA384"
+             ]},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {versions,['tlsv1.2','tlsv1.1']}]}]}],
+  []},
+
  {ssl_options_allow_poodle,
   "listeners.ssl.1 = 5671
    ssl_allow_poodle_attack = true


### PR DESCRIPTION
## Proposed Changes

As `ssl_options.ciphers.$cipher`:

``` ini
listeners.ssl.1 = 5671

ssl_options.cacertfile = /path/to/ca_certificate.pem
ssl_options.certfile     = /path/to/server_certificate.pem
ssl_options.keyfile      = /path/to/server_key.pem
ssl_options.versions.1 = tlsv1.2
ssl_options.versions.2 = tlsv1.1

ssl_options.verify = verify_peer
ssl_options.fail_if_no_peer_cert = false

ssl_options.ciphers.1  = ECDHE-ECDSA-AES256-GCM-SHA384
ssl_options.ciphers.2  = ECDHE-RSA-AES256-GCM-SHA384
ssl_options.ciphers.3  = ECDHE-ECDSA-AES256-SHA384
ssl_options.ciphers.4  = ECDHE-RSA-AES256-SHA384
ssl_options.ciphers.5  = ECDH-ECDSA-AES256-GCM-SHA384
# […]
ssl_options.ciphers.34 = DHE-DSS-AES128-SHA
ssl_options.ciphers.35 = ECDH-ECDSA-AES128-SHA
ssl_options.ciphers.36 = ECDH-RSA-AES128-SHA

ssl_options.honor_cipher_order = true
ssl_options.honor_ecc_order    = true
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1712)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #1712.

[#160792113]
