### PR TITLE
Ensure escripts take overridden node name into account

### DIFF
--- a/scripts/rabbitmq-diagnostics.bat
+++ b/scripts/rabbitmq-diagnostics.bat
@@ -49,6 +49,7 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
 !RABBITMQ_CTL_ERL_ARGS! ^
+!RABBITMQ_NAME_TYPE! rabbitmq-diagnostics!RANDOM!!RABBITMQ_NODENAME! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^

--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -407,6 +407,7 @@ run_escript()
         -boot "$CLEAN_BOOT_FILE" \
         -noinput -noshell -hidden -smp enable \
         $RABBITMQ_CTL_ERL_ARGS \
+        "$RABBITMQ_NAME_TYPE" "$escript_main-$$-$RABBITMQ_NODENAME" \
         -kernel inet_dist_listen_min "$RABBITMQ_CTL_DIST_PORT_MIN" \
         -kernel inet_dist_listen_max "$RABBITMQ_CTL_DIST_PORT_MAX" \
         -sasl errlog_type error \

--- a/scripts/rabbitmq-plugins.bat
+++ b/scripts/rabbitmq-plugins.bat
@@ -49,6 +49,7 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
 !RABBITMQ_CTL_ERL_ARGS! ^
+!RABBITMQ_NAME_TYPE! rabbitmq-plugins!RANDOM!!RABBITMQ_NODENAME! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^

--- a/scripts/rabbitmq-queues.bat
+++ b/scripts/rabbitmq-queues.bat
@@ -49,6 +49,7 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
 !RABBITMQ_CTL_ERL_ARGS! ^
+!RABBITMQ_NAME_TYPE! rabbitmq-queues!RANDOM!!RABBITMQ_NODENAME! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^

--- a/scripts/rabbitmqctl.bat
+++ b/scripts/rabbitmqctl.bat
@@ -49,6 +49,7 @@ if not defined ERL_CRASH_DUMP_SECONDS (
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
 !RABBITMQ_CTL_ERL_ARGS! ^
+!RABBITMQ_NAME_TYPE! rabbitmqctl!RANDOM!!RABBITMQ_NODENAME! ^
 -kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
 -kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
 -sasl errlog_type error ^


### PR DESCRIPTION
Without this change, escripts derive their node name from the local host name. In the case of a customized node name, they may not match the host name part and could cause issues

Fixes #1751