### PR TITLE
Call rabbit:stop_apps in reverse order

### DIFF
--- a/src/rabbit_plugins.erl
+++ b/src/rabbit_plugins.erl
@@ -69,7 +69,9 @@ ensure1(FileJustChanged0) ->
             %% that won't work.
             ok = rabbit_event:sync_notify(plugins_changed, [{enabled,  Start},
                                                             {disabled, Stop}]),
-            rabbit:stop_apps(Stop),
+            %% The app_utils module stops the apps in reverse order, so we should
+            %% pass them here in dependency order.
+            rabbit:stop_apps(lists:reverse(Stop)),
             clean_plugins(Stop),
             case {Start, Stop} of
                 {[], []} ->


### PR DESCRIPTION
`rabbit:stop_apps` already reverts the app order

Tested in the management app. Disabling web dispatch has to disable first management, if it doesn't the http listener won't be removed from mnesia and will still be reported in `rabbit:status()`.

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
