### PR TITLE
VHost recovery memory

### DIFF
--- a/src/rabbit_vhost_process.erl
+++ b/src/rabbit_vhost_process.erl
@@ -57,6 +57,7 @@ init([VHost]) ->
         rabbit_vhost_sup_sup:save_vhost_process(VHost, self()),
         Interval = interval(),
         timer:send_interval(Interval, check_vhost),
+        true = erlang:garbage_collect(),
         {ok, VHost}
     catch _:Reason ->
         rabbit_amqqueue:mark_local_durable_queues_stopped(VHost),


### PR DESCRIPTION
After vhost recovery this change triggers an explicit gc to reclaim any memory allocated during recovery as after the init function has completed this process does very little else and may never allocate enough to trigger another gc.

Mailing list link: https://groups.google.com/d/msg/rabbitmq-users/ZbTNp6YqZeo/53JLiy2zAQAJ