### PR TITLE
Make it possible to configure kernel.inet_dist_listen_{min,max} via new style config

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -503,7 +503,16 @@
 # Kernel section
 # ======================================
 
+## Timeout used to detect peer unavailability, including CLI tools.
+## Related doc guide: https://www.rabbitmq.com/nettick.html.
+##
 # net_ticktime = 60
+
+## Inter-node communication port range.
+## Related doc guide: https://www.rabbitmq.com/networking.html#epmd-inet-dist-port-range.
+##
+# inet_dist_listen_min = 25672
+# inet_dist_listen_max = 25692
 
 ## ----------------------------------------------------------------------------
 ## RabbitMQ Management Plugin

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1342,6 +1342,16 @@ end}.
     {validators, ["non_zero_positive_integer"]}
 ]}.
 
+{mapping, "inet_dist_listen_min", "kernel.inet_dist_listen_min",[
+    {datatype, [integer]},
+    {validators, ["non_zero_positive_integer"]}
+]}.
+
+{mapping, "inet_dist_listen_max", "kernel.inet_dist_listen_max",[
+    {datatype, [integer]},
+    {validators, ["non_zero_positive_integer"]}
+]}.
+
 % ===============================
 % Validators
 % ===============================

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -568,12 +568,27 @@ credential_validator.regexp = ^abc\\d+",
       {delegate_count, 64}
     ]}],
   []},
+
   {kernel_net_ticktime,
    "net_ticktime = 20",
    [{kernel, [
       {net_ticktime, 20}
      ]}],
    []},
+
+  {kernel_inet_dist_listen_min,
+   "inet_dist_listen_min = 16000",
+   [{kernel, [
+      {inet_dist_listen_min, 16000}
+     ]}],
+   []},
+  {kernel_inet_dist_listen_max,
+   "inet_dist_listen_max = 16100",
+   [{kernel, [
+      {inet_dist_listen_max, 16100}
+     ]}],
+   []},
+
   {log_syslog_settings,
    "log.syslog = true
     log.syslog.identity = rabbitmq


### PR DESCRIPTION
## Proposed Changes

Make it possible to configure kernel.inet_dist_listen_{min,max} via new style config:


``` ini
inet_dist_listen_min = 25672
inet_dist_listen_max = 25692
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1784)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #1784.