### PR TITLE
Include redelivery counts for quorum queues

### DIFF
--- a/src/rabbit_basic.erl
+++ b/src/rabbit_basic.erl
@@ -23,6 +23,7 @@
          extract_headers/1, extract_timestamp/1, map_headers/2, delivery/4,
          header_routes/1, parse_expiration/1, header/2, header/3]).
 -export([build_content/2, from_content/1, msg_size/1, maybe_gc_large_msg/1]).
+-export([add_header/4]).
 
 %%----------------------------------------------------------------------------
 
@@ -300,3 +301,12 @@ maybe_gc_large_msg(Content) ->
 
 msg_size(Content) ->
     rabbit_writer:msg_size(Content).
+
+add_header(Name, Type, Value, #basic_message{content = Content0} = Msg) ->
+    Content = rabbit_basic:map_headers(
+                fun(undefined) ->
+                        rabbit_misc:set_table_value([], Name, Type, Value);
+                   (Headers) ->
+                        rabbit_misc:set_table_value(Headers, Name, Type, Value)
+                end, Content0),
+    Msg#basic_message{content = Content}.

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -2492,4 +2492,4 @@ maybe_monitor_all(Items,  S) -> lists:foldl(fun maybe_monitor/2, S, Items).
 
 add_delivery_count_header(MsgHeader, Msg) ->
     Count = maps:get(delivery_count, MsgHeader, 0),
-    rabbit_basic:add_header(<<"x-redelivery-count">>, long, Count, Msg).
+    rabbit_basic:add_header(<<"x-delivery-count">>, long, Count, Msg).

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -333,7 +333,7 @@ basic_get(#amqqueue{name = QName, pid = {Name, _} = Id, type = quorum}, NoAck,
         {ok, {MsgId, {MsgHeader, Msg0}}, QState} ->
             Count = maps:get(delivery_count, MsgHeader, 0),
             IsDelivered = Count > 0,
-            Msg = rabbit_basic:add_header(<<"x-redelivery-count">>, long, Count, Msg0),
+            Msg = rabbit_basic:add_header(<<"x-delivery-count">>, long, Count, Msg0),
             {ok, quorum_messages(Name), {QName, Id, MsgId, IsDelivered, Msg}, QState};
         {timeout, _} ->
             {error, timeout}

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -1650,7 +1650,7 @@ subscribe_redelivery_count(Config) ->
     wait_for_messages_pending_ack(Servers, RaName, 0),
     subscribe(Ch, QQ, false),
 
-    DTag = <<"x-redelivery-count">>,
+    DTag = <<"x-delivery-count">>,
     receive
         {#'basic.deliver'{delivery_tag = DeliveryTag,
                           redelivered  = false},
@@ -1695,7 +1695,7 @@ consume_redelivery_count(Config) ->
     wait_for_messages_ready(Servers, RaName, 1),
     wait_for_messages_pending_ack(Servers, RaName, 0),
 
-    DTag = <<"x-redelivery-count">>,
+    DTag = <<"x-delivery-count">>,
 
     {#'basic.get_ok'{delivery_tag = DeliveryTag,
                      redelivered = false},


### PR DESCRIPTION
Added as custom header `x-redelivery-count`

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

