### PR TITLE
Make mandatory based on route data only

### DIFF
--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -15,8 +15,8 @@
 %%
 
 -module(rabbit_amqqueue_process).
--include("rabbit.hrl").
--include("rabbit_framing.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit_framing.hrl").
 
 -behaviour(gen_server2).
 
@@ -604,13 +604,6 @@ send_or_record_confirm(#delivery{confirm    = true,
     rabbit_misc:confirm_to_sender(SenderPid, [MsgSeqNo]),
     {immediately, State}.
 
-send_mandatory(#delivery{mandatory  = false}) ->
-    ok;
-send_mandatory(#delivery{mandatory  = true,
-                         sender     = SenderPid,
-                         msg_seq_no = MsgSeqNo}) ->
-    gen_server2:cast(SenderPid, {mandatory_received, MsgSeqNo}).
-
 discard(#delivery{confirm = Confirm,
                   sender  = SenderPid,
                   flow    = Flow,
@@ -674,7 +667,6 @@ maybe_deliver_or_enqueue(Delivery = #delivery{message = Message},
                          State = #q{overflow            = Overflow,
                                     backing_queue       = BQ,
                                     backing_queue_state = BQS}) ->
-    send_mandatory(Delivery), %% must do this before confirms
     case {will_overflow(Delivery, State), Overflow} of
         {true, 'reject-publish'} ->
             %% Drop publish and nack to publisher


### PR DESCRIPTION
Instead of waiting for a mandatory_received message from the queue the
mandatory result is calculated in the channel based on the routing
result only. This may seem like a weakening of the mandatory semantics but
considering that the mandatory_received message is returned _before_ the
message is enqueued and/or persisted in the queue it doesn't actually
open up any further failure scenarios.

This change is based on internal discussion around the semantics of the mandatory flag and how we would like it to integrate with publisher confirms in the future. It is likely that we will provide some kind of mechanism for more flexible confirms. E.g. confirm after the first queue has persisted the message rather than when all queues have confirmed as is the current behaviour.

