### PR TITLE
Add an upgrade function to remove all default bindings.

### DIFF
--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -256,12 +256,7 @@ remove(Src, Dst, B, ActingUser) ->
 remove_default_exchange_binding_rows_of(Dst = #resource{}) ->
     case rabbit_binding:implicit_for_destination(Dst) of
         [Binding] ->
-            mnesia:dirty_delete(rabbit_route, Binding),
-            mnesia:dirty_delete(rabbit_durable_route, Binding),
-            mnesia:dirty_delete(rabbit_semi_durable_route, Binding),
-
-            RevBinding = rabbit_binding:reverse_binding(Binding),
-            mnesia:dirty_delete(rabbit_reverse_route, RevBinding);
+            mnesia:dirty_delete(rabbit_durable_route, Binding);
         _ ->
             %% no binding to remove or
             %% a competing tx has beaten us to it?

--- a/src/rabbit_binding.erl
+++ b/src/rabbit_binding.erl
@@ -27,6 +27,8 @@
 -export([has_for_source/1, remove_for_source/1,
          remove_for_destination/2, remove_transient_for_destination/1]).
 
+-export([implicit_for_destination/1, reverse_binding/1]).
+
 -define(DEFAULT_EXCHANGE(VHostPath), #resource{virtual_host = VHostPath,
                                               kind = exchange,
                                               name = <<>>}).

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -658,9 +658,10 @@ exchange_options(Table) ->
        operator_policy, decorators, options]).
 
 default_bindings() ->
-    %% The bindings are not used anyway,
-    %% and are replaced by placeholders.
-    %% It should be safe to remove them dirty.
+    %% Default exchange bindings are now implicit
+    %% (not stored in the route tables).
+    %% It should be safe to remove them outside of a
+    %% transaction.
     Queues = mnesia:dirty_all_keys(rabbit_queue),
     [begin
         Binding = rabbit_binding:implicit_for_destination(Q),

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -670,7 +670,8 @@ default_bindings() ->
         mnesia:dirty_delete(rabbit_reverse_route,
                       rabbit_binding:reverse_binding(Binding))
      end
-     || Q <- Queues].
+     || Q <- Queues],
+    ok.
 
 %%--------------------------------------------------------------------
 

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -659,7 +659,7 @@ exchange_options(Table) ->
        operator_policy, decorators, options]).
 
 remove_explicit_default_exchange_bindings() ->
-    Tab = rabbit_queue,
+    Tab = rabbit_durable_queue,
     rabbit_table:wait([Tab]),
     %% Default exchange bindings are now implicit
     %% (not stored in the route tables).


### PR DESCRIPTION
Versions before 3.8 create default bindings for queues in the database.
Since #1721 they are replaced with placeholders only for list operations.
We need to cleanup the bindings to improve binding performance with
older queues.

[#163224049]

