### PR TITLE
Introduce a function that awaits startup with a timeout

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -240,6 +240,7 @@
 -define(BOOT_START_TIMEOUT,     300).
 %% 12 hours
 -define(BOOT_FINISH_TIMEOUT,    43200).
+%% 100ms
 -define(BOOT_STATUS_SAMPLING_INTERVAL, 100).
 
 %%----------------------------------------------------------------------------

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -256,7 +256,7 @@
 -spec stop_and_halt() -> no_return().
 
 -spec await_startup() -> 'ok' | {'error', 'timeout'}.
--spec await_startup(node()) -> 'ok' | {'error', 'timeout'}.
+-spec await_startup(node() | non_neg_integer()) -> 'ok' | {'error', 'timeout'}.
 -spec await_startup(node(), non_neg_integer()) -> 'ok' | {'error', 'timeout'}.
 
 -spec status

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -240,6 +240,7 @@
 -define(BOOT_START_TIMEOUT,     1 * 60 * 1000).
 %% 12 hours
 -define(BOOT_FINISH_TIMEOUT,    12 * 60 * 60 * 1000).
+%% 100ms
 -define(BOOT_STATUS_CHECK_INTERVAL, 100).
 
 %%----------------------------------------------------------------------------

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -23,7 +23,7 @@
 -behaviour(application).
 
 -export([start/0, boot/0, stop/0,
-         stop_and_halt/0, await_startup/0, await_startup/1, await_startup/2,
+         stop_and_halt/0, await_startup/0, await_startup/1, await_startup/3,
          status/0, is_running/0, alarms/0,
          is_running/1, environment/0, rotate_logs/0,
          start_fhc/0]).
@@ -699,35 +699,36 @@ is_booting(Node) ->
 
 
 -spec await_startup() -> 'ok' | {'error', 'timeout'}.
-
 await_startup() ->
-    await_startup(node()).
+    await_startup(node(), false).
 
 -spec await_startup(node() | non_neg_integer()) -> 'ok' | {'error', 'timeout'}.
-
-await_startup(Timeout) when is_integer(Timeout) ->
-    await_startup(node(), Timeout);
 await_startup(Node) when is_atom(Node) ->
+    await_startup(Node, false);
+  await_startup(Timeout) when is_integer(Timeout) ->
+      await_startup(node(), false, Timeout).
+
+-spec await_startup(node(), boolean()) -> 'ok'  | {'error', 'timeout'}.
+await_startup(Node, PrintProgressReports) ->
     case is_booting(Node) of
-        true -> wait_for_boot_to_finish(Node);
+        true  -> wait_for_boot_to_finish(Node, PrintProgressReports);
         false ->
             case is_running(Node) of
-                true -> ok;
+                true  -> ok;
                 false -> wait_for_boot_to_start(Node),
-                         wait_for_boot_to_finish(Node)
+                         wait_for_boot_to_finish(Node, PrintProgressReports)
             end
     end.
 
--spec await_startup(node(), non_neg_integer()) -> 'ok'  | {'error', 'timeout'}.
-
-await_startup(Node, Timeout) ->
+-spec await_startup(node(), boolean(), non_neg_integer()) -> 'ok'  | {'error', 'timeout'}.
+await_startup(Node, PrintProgressReports, Timeout) ->
     case is_booting(Node) of
-        true  -> wait_for_boot_to_finish(Node, Timeout);
+        true  -> wait_for_boot_to_finish(Node, PrintProgressReports, Timeout);
         false ->
             case is_running(Node) of
                 true  -> ok;
                 false -> wait_for_boot_to_start(Node, Timeout),
-                         wait_for_boot_to_finish(Node, Timeout)
+                         wait_for_boot_to_finish(Node, PrintProgressReports, Timeout)
             end
     end.
 
@@ -752,15 +753,18 @@ do_wait_for_boot_to_start(Node, IterationsLeft) ->
     end.
 
 wait_for_boot_to_finish(Node) ->
-    wait_for_boot_to_finish(Node, ?BOOT_FINISH_TIMEOUT).
+    wait_for_boot_to_finish(Node, false, ?BOOT_FINISH_TIMEOUT).
 
-wait_for_boot_to_finish(Node, Timeout) ->
+wait_for_boot_to_finish(Node, PrintProgressReports) ->
+    wait_for_boot_to_finish(Node, PrintProgressReports, ?BOOT_FINISH_TIMEOUT).
+
+wait_for_boot_to_finish(Node, PrintProgressReports, Timeout) ->
     Iterations = Timeout div ?BOOT_STATUS_CHECK_INTERVAL,
-    do_wait_for_boot_to_finish(Node, Iterations).
+    do_wait_for_boot_to_finish(Node, PrintProgressReports, Iterations).
 
-do_wait_for_boot_to_finish(_Node, IterationsLeft) when IterationsLeft =< 0 ->
+do_wait_for_boot_to_finish(_Node, _PrintProgressReports, IterationsLeft) when IterationsLeft =< 0 ->
     {error, timeout};
-do_wait_for_boot_to_finish(Node, IterationsLeft) ->
+do_wait_for_boot_to_finish(Node, PrintProgressReports, IterationsLeft) ->
     case is_booting(Node) of
         false ->
             %% We don't want badrpc error to be interpreted as false,
@@ -773,15 +777,20 @@ do_wait_for_boot_to_finish(Node, IterationsLeft) ->
         {badrpc, _} = Err ->
             Err;
         true  ->
-            case IterationsLeft rem 100 of
-              %% This will be printed on the CLI command end to illustrate some
-              %% progress.
-              0 -> io:format("Still booting, will check again in 10 seconds...~n");
-              _ -> ok
-            end,
+            maybe_print_boot_progress(PrintProgressReports, IterationsLeft),
             timer:sleep(?BOOT_STATUS_CHECK_INTERVAL),
-            do_wait_for_boot_to_finish(Node, IterationsLeft - 1)
+            do_wait_for_boot_to_finish(Node, PrintProgressReports, IterationsLeft - 1)
     end.
+
+maybe_print_boot_progress(false = _PrintProgressReports, _IterationsLeft) ->
+  ok;
+maybe_print_boot_progress(true, IterationsLeft) ->
+  case IterationsLeft rem 100 of
+    %% This will be printed on the CLI command end to illustrate some
+    %% progress.
+    0 -> io:format("Still booting, will check again in 10 seconds...~n");
+    _ -> ok
+  end.
 
 status() ->
     S1 = [{pid,                  list_to_integer(os:getpid())},

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -255,10 +255,6 @@
 -spec stop() -> 'ok'.
 -spec stop_and_halt() -> no_return().
 
--spec await_startup() -> 'ok' | {'error', 'timeout'}.
--spec await_startup(node() | non_neg_integer()) -> 'ok' | {'error', 'timeout'}.
--spec await_startup(node(), non_neg_integer()) -> 'ok' | {'error', 'timeout'}.
-
 -spec status
         () -> [{pid, integer()} |
                {running_applications, [{atom(), string(), string()}]} |
@@ -701,8 +697,13 @@ is_booting(Node) ->
         P when is_pid(P)  -> true
     end.
 
+
+-spec await_startup() -> 'ok' | {'error', 'timeout'}.
+
 await_startup() ->
     await_startup(node()).
+
+-spec await_startup(node() | non_neg_integer()) -> 'ok' | {'error', 'timeout'}.
 
 await_startup(Timeout) when is_integer(Timeout) ->
     await_startup(node(), Timeout);
@@ -716,6 +717,8 @@ await_startup(Node) when is_atom(Node) ->
                          wait_for_boot_to_finish(Node)
             end
     end.
+
+-spec await_startup(node(), non_neg_integer()) -> 'ok'  | {'error', 'timeout'}.
 
 await_startup(Node, Timeout) ->
     case is_booting(Node) of

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -240,7 +240,7 @@
 -define(BOOT_START_TIMEOUT,     1 * 60 * 1000).
 %% 12 hours
 -define(BOOT_FINISH_TIMEOUT,    12 * 60 * 60 * 1000).
-%% 100ms
+%% 100 ms
 -define(BOOT_STATUS_CHECK_INTERVAL, 100).
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
## Proposed Changes

This extends `rabbit:await_startup/{0,1,2}` to be suitable for a new CLI command. It would
be an alternative to `rabbitmqctl wait [pid file]` that doesn't require a pid file path (similarly to
how `rabbitmqctl shutdown` works compared to `rabbitmqctl stop [pid file]`.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

One way to test the timeout path is to temporarily modify `rabbit:broker_start/0`:

``` erlang
broker_start() ->
    Plugins = rabbit_plugins:setup(),
    ToBeLoaded = Plugins ++ ?APPS,
    start_apps(ToBeLoaded),
    maybe_sd_notify(),
    ok = rabbit_lager:broker_is_started(),
    timer:start(90000),
    ok = log_broker_started(rabbit_plugins:strictly_plugins(rabbit_plugins:active())).
```