### PR TITLE
Remove markdown formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,14 +2,20 @@ Thank you for using RabbitMQ.
 
 **STOP NOW AND READ THIS** BEFORE OPENING A NEW ISSUE ON GITHUB
 
-Unless you are CERTAIN you have found a reproducible problem in RabbitMQ
-or have a **specific, actionable** suggestion for our team, you must
-first ask your question or discuss your suspected issue on the [mailing list](https://groups.google.com/forum/#!forum/rabbitmq-users). Team RabbitMQ does not use GitHub issues
-for discussions, investigations, root cause analysis and so on.
+Unless you are CERTAIN you have found a reproducible problem in RabbitMQ or
+have a **specific, actionable** suggestion for our team, you must first ask
+your question or discuss your suspected issue on the mailing list:
 
-Please take the time to read the `CONTRIBUTING.md` document for instructions on [how
-to effectively ask a question or report a suspected issue](https://github.com/rabbitmq/rabbitmq-server/blob/master/CONTRIBUTING.md#github-issues) on the mailing list.
+https://groups.google.com/forum/#!forum/rabbitmq-users
 
-Following these rules **will save time** to both your and the maintainers.
+Team RabbitMQ does not use GitHub issues for discussions, investigations, root
+cause analysis and so on.
+
+Please take the time to read the CONTRIBUTING.md document for instructions on
+how to effectively ask a question or report a suspected issue:
+
+https://github.com/rabbitmq/rabbitmq-server/blob/master/CONTRIBUTING.md#github-issues
+
+Following these rules **will save time** for both you and RabbitMQ's maintainers.
 
 Thank you.


### PR DESCRIPTION
The GitHub issue template is not rendered as markdown but is just plain text filling the input text field. It should be a little easier to read without the markdown links.