### PR TITLE
QQ: Repair amqqrecord leader info on tick

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -660,7 +660,7 @@ tick(_Ts, #state{name = Name,
                EnqueueBytes,
                CheckoutBytes},
     [{mod_call, rabbit_quorum_queue,
-      update_metrics, [QName, Metrics]}, {aux, emit}].
+      handle_tick, [QName, Metrics]}, {aux, emit}].
 
 -spec overview(state()) -> map().
 overview(#state{consumers = Cons,


### PR DESCRIPTION
It is possible that the initial update could fail and then the leader
would never be updated. Here we check periodically if the amqqueue
record pid field is set to the current leader, if not we update it.

Also changes the Ra internal tick frequency to every 5s.

[#163554015]

This PR should work without https://github.com/rabbitmq/ra/pull/55
but there is a fix in that PR that makes it less likely to trigger the repair process shortly after a leader change.