### PR TITLE
Avoid synchronous channel request to connection process 

### DIFF
--- a/src/rabbit_direct.erl
+++ b/src/rabbit_direct.erl
@@ -211,6 +211,7 @@ start_channel(Number, ClientChannelPid, ConnPid, ConnName, Protocol, User,
           rabbit_direct_client_sup,
           [{direct, Number, ClientChannelPid, ConnPid, ConnName, Protocol,
             User, VHost, Capabilities, Collector}]),
+    _ = rabbit_channel:source(ChannelPid, ?MODULE),
     {ok, ChannelPid}.
 
 -spec disconnect(pid(), rabbit_event:event_props()) -> 'ok'.

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -924,6 +924,7 @@ create_channel(Channel,
         rabbit_channel_sup_sup:start_channel(
           ChanSupSup, {tcp, Sock, Channel, FrameMax, self(), Name,
                        Protocol, User, VHost, Capabilities, Collector}),
+    _ = rabbit_channel:source(ChPid, ?MODULE),
     MRef = erlang:monitor(process, ChPid),
     put({ch_pid, ChPid}, {Channel, MRef}),
     put({channel, Channel}, {ChPid, AState}),

--- a/test/channel_source_SUITE.erl
+++ b/test/channel_source_SUITE.erl
@@ -1,0 +1,123 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(channel_source_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+      {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+      {non_parallel_tests, [], [
+          network_channel_source_notifications,
+          direct_channel_source_notifications,
+          undefined_channel_source_notifications
+        ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+network_channel_source_notifications(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, network_channel_source_notifications1, [Config]).
+
+network_channel_source_notifications1(Config) ->
+    ExistingChannels = rabbit_channel:list(),
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config),
+    {ok, _ClientCh} = amqp_connection:open_channel(Conn),
+    [ServerCh] = rabbit_channel:list() -- ExistingChannels,
+    [{channel_source, rabbit_reader}] =
+        rabbit_channel:info(ServerCh, [channel_source]),
+    rabbit_channel:source(ServerCh, ?MODULE),
+    [{channel_source, ?MODULE}] =
+        rabbit_channel:info(ServerCh, [channel_source]),
+    amqp_connection:close(Conn),
+    {error, channel_terminated} = rabbit_channel:source(ServerCh, ?MODULE),
+    passed.
+
+direct_channel_source_notifications(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, direct_channel_source_notifications1, [Config]).
+
+direct_channel_source_notifications1(Config) ->
+    ExistingChannels = rabbit_channel:list(),
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection_direct(Config),
+    {ok, _ClientCh} = amqp_connection:open_channel(Conn),
+    [ServerCh] = rabbit_channel:list() -- ExistingChannels,
+    [{channel_source, rabbit_direct}] =
+        rabbit_channel:info(ServerCh, [channel_source]),
+    rabbit_channel:source(ServerCh, ?MODULE),
+    [{channel_source, ?MODULE}] =
+        rabbit_channel:info(ServerCh, [channel_source]),
+    amqp_connection:close(Conn),
+    {error, channel_terminated} = rabbit_channel:source(ServerCh, ?MODULE),
+    passed.
+
+undefined_channel_source_notifications(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, undefined_channel_source_notifications1, [Config]).
+
+undefined_channel_source_notifications1(_Config) ->
+    ExistingChannels = rabbit_channel:list(),
+    {_Writer, _Limiter, ServerCh} = rabbit_ct_broker_helpers:test_channel(),
+    [ServerCh] = rabbit_channel:list() -- ExistingChannels,
+    [{channel_source, undefined}] =
+        rabbit_channel:info(ServerCh, [channel_source]),
+    rabbit_channel:source(ServerCh, ?MODULE),
+    [{channel_source, ?MODULE}] =
+        rabbit_channel:info(ServerCh, [channel_source]),
+    passed.


### PR DESCRIPTION
## Proposed Changes

Topic Authorization procedures are affecting **BASIC.PUBLISH AMQP** operations as follows: 

Before topic authorization, `'basic.publish'` path was completely asynchronous from the socket reader's perspective.


```
+---------------+      +----------------+       +----------------+       +--------------+     
| rabbit_reader |      | rabbit_channel |       |    delegates   |       |    queues    |      
+---------------+      +----------------+       +----------------+       +--------------+       
        |                      |                        |                        |
        |  #'basic.publish'{}  |                        |                        |
        |--------------------->|                        |                        |
        |                      |        deliver         |                        |
        |                      |----------------------->|                        |
        |                      |                        |      #delivery{}       |
        |                      |                        |----------------------->|
        |                      |                        |                        |
        
```

After topic authorization, `'basic.publish'` now introduces a synchronous info call, which 
throws an [exception within the reader](https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit_reader.erl#L1508), but since it's rightly [caught as expected](https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit_reader.erl#L631-L633), the reader never crashes.

```
+---------------+      +----------------+       +----------------+       +--------------+     
| rabbit_reader |      | rabbit_channel |       |    delegates   |       |    queues    |      
+---------------+      +----------------+       +----------------+       +--------------+       
        |                      |                        |                        |
        |  #'basic.publish'{}  |                        |                        |
        |--------------------->|                        |                        |
        |                      |                        |                        |
        |                      |                        |                        |
        |    gen_server:call   |                        |                        |
        |<---------------------|                        |                        |
        +                      |                        |                        |
   [exception]                 |                        |                        |
        +                      |                        |                        |
        |--------------------->|                        |                        |
        |                      |        deliver         |                        |
        |                      |----------------------->|                        |
        |                      |                        |      #delivery{}       |
        |                      |                        |----------------------->|
        |                      |                        |                        |
        
```

This is happening for each and every AMQP message publish, on a channel sourced/created from the `rabbit_reader`, i.e. meaning all other client applications aside Erlang and Elixir are experiencing this lag. 

As publish rates increase, e.g. this continuous synchronous operation from the channel
and tempering with the reader's message queue (which is bearing more inbound messages),
is affecting performance. Being [more defensive](https://github.com/rabbitmq/rabbitmq-common/commit/b2c707611eb336a98d45ecb3d9432db979b5fbb1) post the synchronous call addresses part of the problem but isn't solving the problem of the performance lag on `'basic.publish'`. From the channel's perspective, when message rates are high, cases are being experienced where channels handling `'basic.publish'`, with **confirmations** enabled (implying more messages and interactions with the queue process) are eventually terminating. On performance drops, publish rates drop significantly, with channels terminating following "normal" failed synchronous call attempts to the connection process (rabbit_reader in this case).  

```
2019-01-12 15:14:14.155 [error] <0.10793.2> Supervisor {<0.10793.2>,rabbit_channel_sup} had child channel started with
rabbit_channel:start_link(1, <0.10787.2>, <0.10794.2>, <0.10787.2>, <<"192.168.127.110:9998 -> 192.168.48.30:5672">>,
rabbit_framing_amqp_0_9_1, {user,<<"xxxxxxxxxx">>,[],[{rabbit_auth_backend_internal,none}]}, <<"xxxxxxxxxx">>,
[{<<"publisher_confirms">>,bool,true},{<<"exchange_exchange_bindings">>,bool,true},{<<"basic.nack">>,...},...], <0.10788.2>,
<0.10795.2>) at <0.10796.2> exit with reason {normal,{gen_server,call,[<0.10787.2>,{info,[amqp_params]},15000]}} in
gen_server:call/3 line 223 in context shutdown_error
```

Quoting a user, on **3.7.7**;

*"We publish 200K to each queue (600K in total within ~2min) and publishers start struggling to publish and get slower while publishing. In this case management UI gets dead, nobody can login, we have to wait either 5-10 minutes to login to management UI or just stop the publishers and all the consumers and UI will work again. When I say publishers struggle to publish; I mean that they can publish but not fast enough, it normally throws an AMQP error and will try again and next time it will publish successfully. This is reasonable situation which we normally face in our live system as well and to handle this we have retry mechanism but not sure why Management UI gets dead slow in new version. We do not have this UI performance issue with old RabbitMQ version."*

Channel terminations illustrated above are observed whenever these performance degradations manifest. To address the main problem of drops in publish rates, we've provided this (similar) patch, which informs the channel of its originating source as part of initialization, and ensures on the publish path, interaction with originating connection/rabbit_reader process is completely avoided unless necessary, i.e. originating from any other connections on plugins like STOMP/MQTT, in which `amqp_params` info is [available](https://github.com/rabbitmq/rabbitmq-erlang-client/blob/master/src/amqp_gen_connection.erl#L251). Hot-code update/upgrade of this patch has been done, and reporting user hasn't experienced this issue to date. Providing patch upstream as well, as promised.

**NOTE:** We could've stored and sourced the channels source in state, but this will imply making changes to channel functions like `handle_method/5` as well (which we don't want to do). Basing this on local process dictionary instead.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behaviour change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
