### PR TITLE
rabbit_lager: Multiply high watermark by 100 when log level is debug

### DIFF
--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -302,7 +302,7 @@ configure_lager() ->
         {ok, Val} when is_integer(Val) andalso Val < 1000 ->
             ok = application:set_env(lager, error_logger_hwm, 1000),
             ok = application:set_env(lager, error_logger_hwm_original, Val);
-        {ok, Val} ->
+        {ok, Val} when is_integer(Val) ->
             ok = application:set_env(lager, error_logger_hwm_original, Val),
             ok
     end,


### PR DESCRIPTION
Otherwise debug messages are quickly dropped by Lager.