### PR TITLE
Move TCP and TLS listener startup to the last boot step "stage"

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -199,12 +199,6 @@
                    [{description, "message delivery logic ready"},
                     {requires,    [core_initialized, recovery]}]}).
 
--rabbit_boot_step({direct_client,
-                   [{description, "direct client"},
-                    {mfa,         {rabbit_direct, boot, []}},
-                    {requires,    routing_ready}
-                    ]}).
-
 -rabbit_boot_step({connection_tracking,
                    [{description, "connection tracking infrastructure"},
                     {mfa,         {rabbit_connection_tracking, boot, []}},
@@ -233,6 +227,12 @@
 -rabbit_boot_step({pre_flight,
                    [{description, "ready to communicate with peers and clients"},
                     {requires,    [core_initialized, recovery, routing_ready]}]}).
+
+-rabbit_boot_step({direct_client,
+                   [{description, "direct client"},
+                    {mfa,         {rabbit_direct, boot, []}},
+                    {requires,    pre_flight}
+                    ]}).
 
 -rabbit_boot_step({notify_cluster,
                    [{description, "notifies cluster peers of our presence"},

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -186,7 +186,7 @@
 -rabbit_boot_step({recovery,
                    [{description, "exchange, queue and binding recovery"},
                     {mfa,         {rabbit, recover, []}},
-                    {requires,    upgrade_queues},
+                    {requires,    [core_initialized]},
                     {enables,     routing_ready}]}).
 
 -rabbit_boot_step({empty_db_check,

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -42,8 +42,7 @@ recover() ->
     %% So recovery will be run every time a vhost supervisor is restarted.
     ok = rabbit_vhost_sup_sup:start(),
 
-    [ ok = rabbit_vhost_sup_sup:init_vhost(VHost)
-      || VHost <- rabbit_vhost:list()],
+    [ok = rabbit_vhost_sup_sup:init_vhost(VHost) || VHost <- rabbit_vhost:list()],
     ok.
 
 recover(VHost) ->


### PR DESCRIPTION
## Proposed Changes

This moves TCP and TLS listener startup to the last boot step "stage". This makes it less likely for clients to connect to and perform operations on a node that's still initialising. See #1869 for background.

## Types of Changes

- [x] Non-breaking change which fixes issue #1869)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

