### PR TITLE
Allow shortstr in AMQPlain authentication method

### DIFF
--- a/src/rabbit_auth_mechanism_amqplain.erl
+++ b/src/rabbit_auth_mechanism_amqplain.erl
@@ -48,6 +48,15 @@ handle_response(Response, _State) ->
         {{value, {_, longstr, User}},
          {value, {_, longstr, Pass}}} ->
             rabbit_access_control:check_user_pass_login(User, Pass);
+        {{value, {_, longstr, User}},
+         {value, {_, shortstr, Pass}}} ->
+            rabbit_access_control:check_user_pass_login(User, Pass);
+        {{value, {_, shortstr, User}},
+         {value, {_, longstr, Pass}}} ->
+            rabbit_access_control:check_user_pass_login(User, Pass);
+        {{value, {_, shortstr, User}},
+         {value, {_, shortstr, Pass}}} ->
+            rabbit_access_control:check_user_pass_login(User, Pass);
         _ ->
             {protocol_error,
              "AMQPLAIN auth info ~w is missing LOGIN or PASSWORD field",


### PR DESCRIPTION
## Proposed Changes

shortstr is supposed to be supported by AMQPlain. There's no reason not to support it.
This PR does just that.

Fixes #1914

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
