### PR TITLE
Mnesia use ram schema on consistency check

### DIFF
--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -945,10 +945,13 @@ with_running_or_clean_mnesia(Fun) ->
         false ->
             SavedMnesiaDir = dir(),
             application:unset_env(mnesia, dir),
+            SchemaLoc = application:get_env(mnesia, schema_location, opt_disc),
+            application:set_env(mnesia, schema_location, ram),
             mnesia:start(),
             Result = Fun(),
             application:stop(mnesia),
             application:set_env(mnesia, dir, SavedMnesiaDir),
+            application:set_env(mnesia, schema_location, SchemaLoc),
             Result
     end.
 


### PR DESCRIPTION
## Proposed Changes

Use ram schema_location for mnesia consistency checks.

By default mnesia uses opt_disk schema location, which will use
a disk schema if there is a directory. This also applies to the
autogenerated directory.
In some cases if the data directory has an autogenerated schema
directory left from previous versions - the node startup will fail.
There is no point in reading a schema on consistency check anyway.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
