### PR TITLE
Fix issues with forward slashes on windows

### DIFF
--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -48,6 +48,8 @@ if not exist "!ERLANG_HOME!\bin\erl.exe" (
 
 set RABBITMQ_EBIN_ROOT=!RABBITMQ_HOME!\ebin
 
+rem convert unix style path seperators into windows style path seperators, needed for comparing with _NOEX variables
+CALL :get_localized !RABBITMQ_ADVANCED_CONFIG_FILE! RABBITMQ_ADVANCED_CONFIG_FILE
 CALL :get_noex !RABBITMQ_ADVANCED_CONFIG_FILE! RABBITMQ_ADVANCED_CONFIG_FILE_NOEX
 
 if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!" (
@@ -59,6 +61,8 @@ if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!" (
     )
 )
 
+rem convert unix style path seperators into windows style path seperators, needed for comparing with _NOEX variables
+CALL :get_localized !RABBITMQ_CONFIG_FILE! RABBITMQ_CONFIG_FILE
 CALL :get_noex !RABBITMQ_CONFIG_FILE! RABBITMQ_CONFIG_FILE_NOEX
 
 if "!RABBITMQ_CONFIG_FILE!" == "!RABBITMQ_CONFIG_FILE_NOEX!" (
@@ -278,6 +282,11 @@ EXIT /B 0
 :get_noex
 set "%~2=%~dpn1"
 EXIT /B 0
+
+:get_localized
+set "%~2=%~dpf1"
+EXIT /B 0
+
 
 endlocal
 endlocal


### PR DESCRIPTION
Fix issues with forward slashes in RABBITMQ_CONFIG_FILE on windows

## Proposed Changes

This small improvements allows using config-files paths containing unix style path separators on windows in RABBITMQ_CONFIG_FILE variable. 

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
See https://groups.google.com/forum/#!topic/rabbitmq-users/pZ1rP3uPXQI