### PR TITLE
Purge stale node state from quorum queues

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -28,7 +28,7 @@
 -export([cluster_state/1, status/2]).
 -export([update_consumer_handler/8, update_consumer/9]).
 -export([cancel_consumer_handler/2, cancel_consumer/3]).
--export([become_leader/2, handle_tick/2]).
+-export([become_leader/2, handle_tick/3]).
 -export([rpc_delete_metrics/1]).
 -export([format/1]).
 -export([open_files/1]).
@@ -243,7 +243,9 @@ rpc_delete_metrics(QName) ->
     ets:delete(queue_metrics, QName),
     ok.
 
-handle_tick(QName, {Name, MR, MU, M, C, MsgBytesReady, MsgBytesUnack}) ->
+handle_tick(QName,
+            {Name, MR, MU, M, C, MsgBytesReady, MsgBytesUnack},
+            Nodes) ->
     %% this makes calls to remote processes so cannot be run inside the
     %% ra server
     Self = self(),
@@ -266,7 +268,21 @@ handle_tick(QName, {Name, MR, MU, M, C, MsgBytesReady, MsgBytesUnack}) ->
                                                     {messages_ready, MR},
                                                     {messages_unacknowledged, MU},
                                                     {reductions, R}]),
-                      ok = repair_leader_record(QName, Self)
+                      ok = repair_leader_record(QName, Self),
+                      ExpectedNodes = rabbit_mnesia:cluster_nodes(all),
+                      case Nodes -- ExpectedNodes of
+                          [] ->
+                              ok;
+                          Stale ->
+                              rabbit_log:info("~s: stale nodes detected. Purging ~w~n",
+                                              [rabbit_misc:rs(QName), Stale]),
+                              %% pipeline purge command
+                              {ok, Q} = rabbit_amqqueue:lookup(QName),
+                              ok = ra:pipeline_command(amqqueue:get_pid(Q),
+                                                       rabbit_fifo:make_purge_nodes(Stale)),
+
+                              ok
+                      end
               end),
     ok.
 

--- a/test/rabbit_fifo_int_SUITE.erl
+++ b/test/rabbit_fifo_int_SUITE.erl
@@ -54,7 +54,7 @@ end_per_group(_, Config) ->
 
 init_per_testcase(TestCase, Config) ->
     meck:new(rabbit_quorum_queue, [passthrough]),
-    meck:expect(rabbit_quorum_queue, handle_tick, fun (_, _) -> ok end),
+    meck:expect(rabbit_quorum_queue, handle_tick, fun (_, _, _) -> ok end),
     meck:expect(rabbit_quorum_queue, cancel_consumer_handler,
                 fun (_, _) -> ok end),
     ra_server_sup_sup:remove_all(),


### PR DESCRIPTION
When a node is disconnected then removed from the RabbitMQ cluster it is
possibly that quorum queues retain some state for this node. This change
purges any enqueuer or consumer state for pids relating to nodes that
are not in the RabbitMQ cluster.

[#164214265]
