### PR TITLE
In memory limits for quorum queues

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -540,6 +540,8 @@ start_loaded_apps(Apps, RestartTypes) ->
     %% make Ra use a custom logger that dispatches to lager instead of the
     %% default OTP logger
     application:set_env(ra, logger_module, rabbit_log_ra_shim),
+    %% use a larger segments size for queues
+    application:set_env(ra, segment_max_entries, 32768),
     ConfigEntryDecoder = case application:get_env(rabbit, config_entry_decoder) of
         undefined ->
             [];

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -685,6 +685,8 @@ declare_args() ->
      {<<"x-dead-letter-routing-key">>, fun check_dlxrk_arg/2},
      {<<"x-max-length">>,              fun check_non_neg_int_arg/2},
      {<<"x-max-length-bytes">>,        fun check_non_neg_int_arg/2},
+     {<<"x-max-in-memory-length">>,    fun check_non_neg_int_arg/2},
+     {<<"x-max-in-memory-bytes">>,     fun check_non_neg_int_arg/2},
      {<<"x-max-priority">>,            fun check_max_priority_arg/2},
      {<<"x-overflow">>,                fun check_overflow/2},
      {<<"x-queue-mode">>,              fun check_queue_mode/2},

--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -1380,8 +1380,8 @@ send_log_effect({CTag, CPid}, IdxMsgs) ->
      end}.
 
 reply_log_effect(RaftIdx, MsgId, Header, Ready, From) ->
-    {log, RaftIdx,
-     fun({enqueue, _, _, Msg}) ->
+    {log, [RaftIdx],
+     fun([{enqueue, _, _, Msg}]) ->
              [{reply, From, {wrap_reply,
                              {dequeue, {MsgId, {Header, Msg}}, Ready}}}]
      end}.

--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -1371,17 +1371,20 @@ send_msg_effect({CTag, CPid}, Msgs) ->
 
 send_log_effect({CTag, CPid}, IdxMsgs) ->
     {RaftIdxs, Data} = lists:unzip(IdxMsgs),
-    {log, RaftIdxs, fun(Log) ->
-                            Msgs = lists:zipwith(fun({enqueue, _, _, Msg}, {MsgId, Header}) ->
-                                                         {MsgId, {Header, Msg}}
-                                                 end, Log, Data),
-                            {send_msg, CPid, {delivery, CTag, Msgs}, ra_event}
-                    end}.
+    {log, RaftIdxs,
+     fun(Log) ->
+             Msgs = lists:zipwith(fun({enqueue, _, _, Msg}, {MsgId, Header}) ->
+                                          {MsgId, {Header, Msg}}
+                                  end, Log, Data),
+             [{send_msg, CPid, {delivery, CTag, Msgs}, ra_event}]
+     end}.
 
 reply_log_effect(RaftIdx, MsgId, Header, Ready, From) ->
-    {log, RaftIdx, fun({enqueue, _, _, Msg}) ->
-                           {reply, From, {wrap_reply, {dequeue, {MsgId, {Header, Msg}}, Ready}}}
-                   end}.
+    {log, RaftIdx,
+     fun({enqueue, _, _, Msg}) ->
+             [{reply, From, {wrap_reply,
+                             {dequeue, {MsgId, {Header, Msg}}, Ready}}}]
+     end}.
 
 checkout_one(#?MODULE{service_queue = SQ0,
                       messages = Messages0,

--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -287,7 +287,7 @@ apply(#{from := From} = Meta, #checkout{spec = {dequeue, Settlement},
             case Msg of
                 {RaftIdx, {Header, 'empty'}} ->
                     %% TODO add here new log effect with reply
-                    {State, '$ra_no_return',
+                    {State, '$ra_no_reply',
                      reply_log_effect(RaftIdx, MsgId, Header, Ready - 1, From)};
                 _ ->
                     {State, {dequeue, {MsgId, Msg}, Ready-1}, Effects}

--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -126,7 +126,7 @@
 init(#{name := Name,
        queue_resource := Resource} = Conf) ->
     update_config(Conf, #?MODULE{cfg = #cfg{name = Name,
-                                          resource = Resource}}).
+                                            resource = Resource}}).
 
 update_config(Conf, State) ->
     DLH = maps:get(dead_letter_handler, Conf, undefined),
@@ -317,7 +317,9 @@ apply(#{index := RaftIdx}, #purge{},
                                                   returns = lqueue:new(),
                                                   msg_bytes_enqueue = 0,
                                                   prefix_msgs = {[], []},
-                                                  low_msg_num = undefined},
+                                                  low_msg_num = undefined,
+                                                  msg_bytes_in_memory = 0,
+                                                  msgs_ready_in_memory = 0},
                                    []),
     %% as we're not checking out after a purge (no point) we have to
     %% reverse the effects ourselves

--- a/src/rabbit_fifo.hrl
+++ b/src/rabbit_fifo.hrl
@@ -108,7 +108,9 @@
          %% whether single active consumer is on or not for this queue
          consumer_strategy = competing :: consumer_strategy(),
          %% the maximum number of unsuccessful delivery attempts permitted
-         delivery_limit :: maybe(non_neg_integer())
+         delivery_limit :: maybe(non_neg_integer()),
+         max_in_memory_length :: maybe(non_neg_integer()),
+         max_in_memory_bytes :: maybe(non_neg_integer())
         }).
 
 -record(rabbit_fifo,
@@ -159,7 +161,9 @@
          msg_bytes_checkout = 0 :: non_neg_integer(),
          %% waiting consumers, one is picked active consumer is cancelled or dies
          %% used only when single active consumer is on
-         waiting_consumers = [] :: [{consumer_id(), consumer()}]
+         waiting_consumers = [] :: [{consumer_id(), consumer()}],
+         msg_bytes_in_memory = 0 :: non_neg_integer(),
+         msgs_ready_in_memory = 0 :: non_neg_integer()
         }).
 
 -type config() :: #{name := atom(),
@@ -169,5 +173,7 @@
                     release_cursor_interval => non_neg_integer(),
                     max_length => non_neg_integer(),
                     max_bytes => non_neg_integer(),
+                    max_in_memory_length => non_neg_integer(),
+                    max_in_memory_bytes => non_neg_integer(),
                     single_active_consumer_on => boolean(),
                     delivery_limit => non_neg_integer()}.

--- a/src/rabbit_fifo.hrl
+++ b/src/rabbit_fifo.hrl
@@ -155,8 +155,8 @@
          %% overflow calculations).
          %% This is done so that consumers are still served in a deterministic
          %% order on recovery.
-         prefix_msgs = {[], []} :: {Return :: [msg_header()],
-                                    PrefixMsgs :: [msg_header()]},
+         prefix_msgs = {[], []} :: {Return :: [msg_header() | {'$empty_msg', msg_header()}],
+                                    PrefixMsgs :: [msg_header() | {msg_header(), 'empty'}]},
          msg_bytes_enqueue = 0 :: non_neg_integer(),
          msg_bytes_checkout = 0 :: non_neg_integer(),
          %% waiting consumers, one is picked active consumer is cancelled or dies

--- a/src/rabbit_policies.erl
+++ b/src/rabbit_policies.erl
@@ -41,6 +41,8 @@ register() ->
                           {policy_validator, <<"expires">>},
                           {policy_validator, <<"max-length">>},
                           {policy_validator, <<"max-length-bytes">>},
+                          {policy_validator, <<"max-in-memory-length">>},
+                          {policy_validator, <<"max-in-memory-bytes">>},
                           {policy_validator, <<"queue-mode">>},
                           {policy_validator, <<"overflow">>},
                           {policy_validator, <<"delivery-limit">>},
@@ -48,11 +50,15 @@ register() ->
                           {operator_policy_validator, <<"message-ttl">>},
                           {operator_policy_validator, <<"max-length">>},
                           {operator_policy_validator, <<"max-length-bytes">>},
+                          {operator_policy_validator, <<"max-in-memory-length">>},
+                          {operator_policy_validator, <<"max-in-memory-bytes">>},
                           {operator_policy_validator, <<"delivery-limit">>},
                           {policy_merge_strategy, <<"expires">>},
                           {policy_merge_strategy, <<"message-ttl">>},
                           {policy_merge_strategy, <<"max-length">>},
                           {policy_merge_strategy, <<"max-length-bytes">>},
+                          {policy_merge_strategy, <<"max-in-memory-length">>},
+                          {policy_merge_strategy, <<"max-in-memory-bytes">>},
                           {policy_merge_strategy, <<"delivery-limit">>}]],
     ok.
 
@@ -103,6 +109,18 @@ validate_policy0(<<"max-length-bytes">>, Value)
 validate_policy0(<<"max-length-bytes">>, Value) ->
     {error, "~p is not a valid maximum length in bytes", [Value]};
 
+validate_policy0(<<"max-in-memory-length">>, Value)
+  when is_integer(Value), Value >= 0 ->
+    ok;
+validate_policy0(<<"max-in-memory-length">>, Value) ->
+    {error, "~p is not a valid maximum memory in bytes", [Value]};
+
+validate_policy0(<<"max-in-memory-bytes">>, Value)
+  when is_integer(Value), Value >= 0 ->
+    ok;
+validate_policy0(<<"max-in-memory-bytes">>, Value) ->
+    {error, "~p is not a valid maximum memory in bytes", [Value]};
+
 validate_policy0(<<"queue-mode">>, <<"default">>) ->
     ok;
 validate_policy0(<<"queue-mode">>, <<"lazy">>) ->
@@ -125,5 +143,7 @@ validate_policy0(<<"delivery-limit">>, Value) ->
 merge_policy_value(<<"message-ttl">>, Val, OpVal)      -> min(Val, OpVal);
 merge_policy_value(<<"max-length">>, Val, OpVal)       -> min(Val, OpVal);
 merge_policy_value(<<"max-length-bytes">>, Val, OpVal) -> min(Val, OpVal);
+merge_policy_value(<<"max-in-memory-length">>, Val, OpVal) -> min(Val, OpVal);
+merge_policy_value(<<"max-in-memory-bytes">>, Val, OpVal) -> min(Val, OpVal);
 merge_policy_value(<<"expires">>, Val, OpVal)          -> min(Val, OpVal);
 merge_policy_value(<<"delivery-limit">>, Val, OpVal)   -> min(Val, OpVal).

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -61,7 +61,9 @@
          members,
          open_files,
          single_active_consumer_pid,
-         single_active_consumer_ctag
+         single_active_consumer_ctag,
+         messages_ram,
+         message_bytes_ram
         ]).
 
 -define(RPC_TIMEOUT, 1000).
@@ -973,6 +975,16 @@ i(single_active_consumer_ctag, Q) when ?is_amqqueue(Q) ->
             ''
     end;
 i(type, _) -> quorum;
+i(messages_ram, Q) when ?is_amqqueue(Q) ->
+    QPid = amqqueue:get_pid(Q),
+    {ok, {_, {Length, _}}, _} = ra:local_query(QPid,
+                                          fun rabbit_fifo:query_in_memory_usage/1),
+    Length;
+i(message_bytes_ram, Q) when ?is_amqqueue(Q) ->
+    QPid = amqqueue:get_pid(Q),
+    {ok, {_, {_, Bytes}}, _} = ra:local_query(QPid,
+                                         fun rabbit_fifo:query_in_memory_usage/1),
+    Bytes;
 i(_K, _Q) -> ''.
 
 open_files(Name) ->

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -164,6 +164,8 @@ ra_machine_config(Q) when ?is_amqqueue(Q) ->
     %% take the minimum value of the policy and the queue arg if present
     MaxLength = args_policy_lookup(<<"max-length">>, fun min/2, Q),
     MaxBytes = args_policy_lookup(<<"max-length-bytes">>, fun min/2, Q),
+    MaxMemoryLength = args_policy_lookup(<<"max-in-memory-length">>, fun min/2, Q),
+    MaxMemoryBytes = args_policy_lookup(<<"max-in-memory-bytes">>, fun min/2, Q),
     DeliveryLimit = args_policy_lookup(<<"delivery-limit">>, fun min/2, Q),
     #{name => Name,
       queue_resource => QName,
@@ -171,6 +173,8 @@ ra_machine_config(Q) when ?is_amqqueue(Q) ->
       become_leader_handler => {?MODULE, become_leader, [QName]},
       max_length => MaxLength,
       max_bytes => MaxBytes,
+      max_in_memory_length => MaxMemoryLength,
+      max_in_memory_bytes => MaxMemoryBytes,
       single_active_consumer_on => single_active_consumer_on(Q),
       delivery_limit => DeliveryLimit
      }.

--- a/test/queue_parallel_SUITE.erl
+++ b/test/queue_parallel_SUITE.erl
@@ -62,7 +62,9 @@ groups() ->
       [
        {classic_queue, [parallel], AllTests ++ [delete_immediately_by_pid_succeeds]},
        {mirrored_queue, [parallel], AllTests ++ [delete_immediately_by_pid_succeeds]},
-       {quorum_queue, [parallel], AllTests ++ [delete_immediately_by_pid_fails]}
+       {quorum_queue, [parallel], AllTests ++ [delete_immediately_by_pid_fails]},
+       {quorum_queue_in_memory_limit, [parallel], AllTests ++ [delete_immediately_by_pid_fails]},
+       {quorum_queue_in_memory_bytes, [parallel], AllTests ++ [delete_immediately_by_pid_fails]}
       ]}
     ].
 
@@ -93,6 +95,28 @@ init_per_group(quorum_queue, Config) ->
             rabbit_ct_helpers:set_config(
               Config,
               [{queue_args, [{<<"x-queue-type">>, longstr, <<"quorum">>}]},
+               {queue_durable, true}]);
+        Skip ->
+            Skip
+    end;
+init_per_group(quorum_queue_in_memory_limit, Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
+        ok ->
+            rabbit_ct_helpers:set_config(
+              Config,
+              [{queue_args, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                             {<<"x-max-in-memory-length">>, long, 1}]},
+               {queue_durable, true}]);
+        Skip ->
+            Skip
+    end;
+init_per_group(quorum_queue_in_memory_bytes, Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
+        ok ->
+            rabbit_ct_helpers:set_config(
+              Config,
+              [{queue_args, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                             {<<"x-max-in-memory-bytes">>, long, 1}]},
                {queue_durable, true}]);
         Skip ->
             Skip

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -120,7 +120,8 @@ all_tests() ->
      queue_length_in_memory_limit,
      queue_length_in_memory_bytes_limit_basic_get,
      queue_length_in_memory_bytes_limit_subscribe,
-     queue_length_in_memory_bytes_limit
+     queue_length_in_memory_bytes_limit,
+     in_memory
     ].
 
 memory_tests() ->
@@ -1819,7 +1820,7 @@ queue_length_limit_drop_head(Config) ->
                                                     no_ack = true})).
 
 queue_length_in_memory_limit_basic_get(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -1841,7 +1842,7 @@ queue_length_in_memory_limit_basic_get(Config) ->
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
 
     ?assertEqual([{1, byte_size(Msg1)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
 
     ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = Msg1}},
                  amqp_channel:call(Ch, #'basic.get'{queue = QQ,
@@ -1851,7 +1852,7 @@ queue_length_in_memory_limit_basic_get(Config) ->
                                                     no_ack = true})).
 
 queue_length_in_memory_limit_subscribe(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -1867,7 +1868,7 @@ queue_length_in_memory_limit_subscribe(Config) ->
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
 
     ?assertEqual([{1, byte_size(Msg1)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
 
     subscribe(Ch, QQ, false),
     receive
@@ -1878,7 +1879,7 @@ queue_length_in_memory_limit_subscribe(Config) ->
                                                multiple     = false})
     end, 
     ?assertEqual([{0, 0}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
     receive
         {#'basic.deliver'{delivery_tag = DeliveryTag2,
                           redelivered  = false},
@@ -1888,7 +1889,7 @@ queue_length_in_memory_limit_subscribe(Config) ->
     end.
 
 queue_length_in_memory_limit(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -1908,8 +1909,8 @@ queue_length_in_memory_limit(Config) ->
     wait_for_messages(Config, [[QQ, <<"3">>, <<"3">>, <<"0">>]]),
 
     ?assertEqual([{2, byte_size(Msg1) + byte_size(Msg2)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
-
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+    
     ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = Msg1}},
                  amqp_channel:call(Ch, #'basic.get'{queue = QQ,
                                                     no_ack = true})),
@@ -1919,10 +1920,10 @@ queue_length_in_memory_limit(Config) ->
     wait_for_messages(Config, [[QQ, <<"3">>, <<"3">>, <<"0">>]]),
 
     ?assertEqual([{2, byte_size(Msg2) + byte_size(Msg4)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)).
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)).
 
 queue_length_in_memory_bytes_limit_basic_get(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -1944,7 +1945,7 @@ queue_length_in_memory_bytes_limit_basic_get(Config) ->
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
 
     ?assertEqual([{1, byte_size(Msg1)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
 
     ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = Msg1}},
                  amqp_channel:call(Ch, #'basic.get'{queue = QQ,
@@ -1954,7 +1955,7 @@ queue_length_in_memory_bytes_limit_basic_get(Config) ->
                                                     no_ack = true})).
 
 queue_length_in_memory_bytes_limit_subscribe(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -1970,7 +1971,7 @@ queue_length_in_memory_bytes_limit_subscribe(Config) ->
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
 
     ?assertEqual([{1, byte_size(Msg1)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
 
     subscribe(Ch, QQ, false),
     receive
@@ -1981,7 +1982,7 @@ queue_length_in_memory_bytes_limit_subscribe(Config) ->
                                                multiple     = false})
     end, 
     ?assertEqual([{0, 0}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
     receive
         {#'basic.deliver'{delivery_tag = DeliveryTag2,
                           redelivered  = false},
@@ -1991,7 +1992,7 @@ queue_length_in_memory_bytes_limit_subscribe(Config) ->
     end.
 
 queue_length_in_memory_bytes_limit(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -2011,7 +2012,7 @@ queue_length_in_memory_bytes_limit(Config) ->
     wait_for_messages(Config, [[QQ, <<"3">>, <<"3">>, <<"0">>]]),
 
     ?assertEqual([{2, byte_size(Msg1) + byte_size(Msg2)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
 
     ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = Msg1}},
                  amqp_channel:call(Ch, #'basic.get'{queue = QQ,
@@ -2022,7 +2023,47 @@ queue_length_in_memory_bytes_limit(Config) ->
     wait_for_messages(Config, [[QQ, <<"3">>, <<"3">>, <<"0">>]]),
 
     ?assertEqual([{2, byte_size(Msg2) + byte_size(Msg4)}],
-                 dirty_query(Servers, RaName, fun rabbit_fifo:query_in_memory_usage/1)).
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)).
+
+in_memory(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    RaName = ra_name(QQ),
+    Msg1 = <<"msg1">>,
+    Msg2 = <<"msg11">>,
+
+    publish(Ch, QQ, Msg1),
+
+    wait_for_messages(Config, [[QQ, <<"1">>, <<"1">>, <<"0">>]]),
+    ?assertEqual([{1, byte_size(Msg1)}],
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+
+    subscribe(Ch, QQ, false),
+    
+    wait_for_messages(Config, [[QQ, <<"1">>, <<"0">>, <<"1">>]]),
+    ?assertEqual([{0, 0}],
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+
+    publish(Ch, QQ, Msg2),
+
+    wait_for_messages(Config, [[QQ, <<"2">>, <<"0">>, <<"2">>]]),
+    ?assertEqual([{0, 0}],
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)),
+
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag}, #amqp_msg{}} ->
+            amqp_channel:cast(Ch, #'basic.ack'{delivery_tag = DeliveryTag,
+                                               multiple     = false})
+    end,
+
+    wait_for_messages(Config, [[QQ, <<"1">>, <<"0">>, <<"1">>]]),
+    ?assertEqual([{0, 0}],
+                 dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
Similar to queue length limits, but controls the message data held in memory. Once the limit is reached for messages in `ready` state (messages delivered to consumers are not taken into account) any new messages are not stored in memory. These messages go only to disk - the `ra` log. 

Depends on https://github.com/rabbitmq/ra/pull/87 and https://github.com/rabbitmq/rabbitmq-management/pull/685

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
