### PR TITLE
Handle connection tracking events in a separate process.

### DIFF
--- a/src/rabbit_connection_tracking_handler.erl
+++ b/src/rabbit_connection_tracking_handler.erl
@@ -27,8 +27,6 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2,
          terminate/2, code_change/3]).
 
--export([close_connections/3]).
-
 -include_lib("rabbit.hrl").
 -import(rabbit_misc, [pget/2]).
 
@@ -38,9 +36,15 @@
                                    [rabbit_event, ?MODULE, []]}},
                     {cleanup,     {gen_event, delete_handler,
                                    [rabbit_event, ?MODULE, []]}},
-                    {requires,    [rabbit_event, rabbit_node_monitor]},
+                    {requires,    [rabbit_connection_tracking]},
                     {enables,     recovery}]}).
 
+-rabbit_boot_step({rabbit_connection_tracking,
+                   [{description, "statistics event manager"},
+                    {mfa,         {rabbit_sup, start_restartable_child,
+                                   [rabbit_connection_tracking]}},
+                    {requires,    [rabbit_event, rabbit_node_monitor]},
+                    {enables,     ?MODULE}]}).
 
 %%
 %% API
@@ -50,74 +54,26 @@ init([]) ->
     {ok, []}.
 
 handle_event(#event{type = connection_created, props = Details}, State) ->
-    ThisNode = node(),
-    case pget(node, Details) of
-        ThisNode ->
-            TConn = rabbit_connection_tracking:tracked_connection_from_connection_created(Details),
-            ConnId = TConn#tracked_connection.id,
-            try
-                rabbit_connection_tracking:register_connection(TConn)
-            catch
-                error:{no_exists, _} ->
-                    Msg = "Could not register connection ~p for tracking, "
-                          "its table is not ready yet or the connection terminated prematurely",
-                    rabbit_log_connection:warning(Msg, [ConnId]),
-                    ok;
-                error:Err ->
-                    Msg = "Could not register connection ~p for tracking: ~p",
-                    rabbit_log_connection:warning(Msg, [ConnId, Err]),
-                    ok
-            end;
-        _OtherNode ->
-            %% ignore
-            ok
-    end,
+    gen_server:cast(rabbit_connection_tracking, {connection_created, Details}),
     {ok, State};
 handle_event(#event{type = connection_closed, props = Details}, State) ->
-    ThisNode = node(),
-    case pget(node, Details) of
-      ThisNode ->
-          %% [{name,<<"127.0.0.1:64078 -> 127.0.0.1:5672">>},
-          %%  {pid,<0.1774.0>},
-          %%  {node, rabbit@hostname}]
-          rabbit_connection_tracking:unregister_connection(
-            {pget(node, Details),
-             pget(name, Details)});
-      _OtherNode ->
-        %% ignore
-        ok
-    end,
+    gen_server:cast(rabbit_connection_tracking, {connection_closed, Details}),
     {ok, State};
 handle_event(#event{type = vhost_deleted, props = Details}, State) ->
-    VHost = pget(name, Details),
-    rabbit_log_connection:info("Closing all connections in vhost '~s' because it's being deleted", [VHost]),
-    close_connections(rabbit_connection_tracking:list(VHost),
-                      rabbit_misc:format("vhost '~s' is deleted", [VHost])),
+    gen_server:cast(rabbit_connection_tracking, {vhost_deleted, Details}),
     {ok, State};
 %% Note: under normal circumstances this will be called immediately
 %% after the vhost_deleted above. Therefore we should be careful about
 %% what we log and be more defensive.
 handle_event(#event{type = vhost_down, props = Details}, State) ->
-    VHost = pget(name, Details),
-    Node = pget(node, Details),
-    rabbit_log_connection:info("Closing all connections in vhost '~s' on node '~s'"
-                               " because the vhost is stopping",
-                               [VHost, Node]),
-    close_connections(rabbit_connection_tracking:list_on_node(Node, VHost),
-                      rabbit_misc:format("vhost '~s' is down", [VHost])),
+    gen_server:cast(rabbit_connection_tracking, {vhost_down, Details}),
     {ok, State};
 handle_event(#event{type = user_deleted, props = Details}, State) ->
-    Username = pget(name, Details),
-    rabbit_log_connection:info("Closing all connections from user '~s' because it's being deleted", [Username]),
-    close_connections(rabbit_connection_tracking:list_of_user(Username),
-                      rabbit_misc:format("user '~s' is deleted", [Username])),
+    gen_server:cast(rabbit_connection_tracking, {user_deleted, Details}),
     {ok, State};
 %% A node had been deleted from the cluster.
 handle_event(#event{type = node_deleted, props = Details}, State) ->
-    Node = pget(node, Details),
-    rabbit_log_connection:info("Node '~s' was removed from the cluster, deleting its connection tracking tables...", [Node]),
-    rabbit_connection_tracking:delete_tracked_connections_table_for_node(Node),
-    rabbit_connection_tracking:delete_per_vhost_tracked_connections_table_for_node(Node),
+    gen_server:cast(rabbit_connection_tracking, {node_deleted, Details}),
     {ok, State};
 handle_event(_Event, State) ->
     {ok, State}.
@@ -133,31 +89,3 @@ terminate(_Arg, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-
-close_connections(Tracked, Message) ->
-    close_connections(Tracked, Message, 0).
-
-close_connections(Tracked, Message, Delay) ->
-    [begin
-         close_connection(Conn, Message),
-         timer:sleep(Delay)
-     end || Conn <- Tracked],
-    ok.
-
-close_connection(#tracked_connection{pid = Pid, type = network}, Message) ->
-    try
-        rabbit_networking:close_connection(Pid, Message)
-    catch error:{not_a_connection, _} ->
-            %% could has been closed concurrently, or the input
-            %% is bogus. In any case, we should not terminate
-            ok;
-          _:Err ->
-            %% ignore, don't terminate
-            rabbit_log:warning("Could not close connection ~p: ~p", [Pid, Err]),
-            ok
-    end;
-close_connection(#tracked_connection{pid = Pid, type = direct}, Message) ->
-    %% Do an RPC call to the node running the direct client.
-    Node = node(Pid),
-    rpc:call(Node, amqp_direct_connection, server_close, [Pid, 320, Message]).


### PR DESCRIPTION
## Proposed Changes

Connection tracking event handling may involve DB operations and closing of
connections (e.g. for vhost deletion).
Because gen_event handles all events in the same process - this may
cause message accumulation in the rabbit_event process and memory
accumulation.
Connection tracking process will only receive connection tracking
events and all other events will be dropped, freeing the memory.

Follow-up to #1722
[#164353033]

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
