### PR TITLE
Make sure amq.rabbitmq.log is accessible to client connections

### DIFF
--- a/src/lager_exchange_backend.erl
+++ b/src/lager_exchange_backend.erl
@@ -191,7 +191,7 @@ init_exchange(true) ->
     try
         %% durable
         #exchange{} = rabbit_exchange:declare(Exchange, topic, true, false, false, [], ?INTERNAL_USER),
-        {ok, #resource{virtual_host = DefaultVHost, kind = exchange, name = ?LOG_EXCH_NAME}}
+        {ok, Exchange}
     catch
         ErrType:Err ->
             rabbit_log:error("Could not declare exchange '~s' in vhost '~s', reason: ~p:~p",

--- a/src/lager_exchange_backend.erl
+++ b/src/lager_exchange_backend.erl
@@ -187,10 +187,11 @@ maybe_init_exchange(State) ->
 %% @private
 init_exchange(true) ->
     {ok, DefaultVHost} = application:get_env(rabbit, default_vhost),
-    VHost = rabbit_misc:r(DefaultVHost, exchange, ?LOG_EXCH_NAME),
+    Exchange = rabbit_misc:r(DefaultVHost, exchange, ?LOG_EXCH_NAME),
     try
-        #exchange{} = rabbit_exchange:declare(VHost, topic, true, false, true, [], ?INTERNAL_USER),
-        {ok, #resource{virtual_host=DefaultVHost, kind=exchange, name=?LOG_EXCH_NAME}}
+        %% durable
+        #exchange{} = rabbit_exchange:declare(Exchange, topic, true, false, false, [], ?INTERNAL_USER),
+        {ok, #resource{virtual_host = DefaultVHost, kind = exchange, name = ?LOG_EXCH_NAME}}
     catch
         ErrType:Err ->
             rabbit_log:debug("Could not initialize exchange '~s' in vhost '~s', reason: ~p:~p",

--- a/src/lager_exchange_backend.erl
+++ b/src/lager_exchange_backend.erl
@@ -194,7 +194,7 @@ init_exchange(true) ->
         {ok, #resource{virtual_host = DefaultVHost, kind = exchange, name = ?LOG_EXCH_NAME}}
     catch
         ErrType:Err ->
-            rabbit_log:debug("Could not initialize exchange '~s' in vhost '~s', reason: ~p:~p",
+            rabbit_log:error("Could not declare exchange '~s' in vhost '~s', reason: ~p:~p",
                              [?LOG_EXCH_NAME, DefaultVHost, ErrType, Err]),
             {ok, undefined}
     end;


### PR DESCRIPTION
## Proposed Changes

`amq.rabbitmq.log` must not be declared as internal since internal exchanges cannot be used by client connections.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1973)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments


Closes #1973, references #1456.

[#165243321]
