### PR TITLE
Follow up to #1973 - ensure amq.rabbitmq.log exchange is declared early

### DIFF
--- a/src/lager_exchange_backend.erl
+++ b/src/lager_exchange_backend.erl
@@ -190,7 +190,7 @@ init_exchange(true) ->
     Exchange = rabbit_misc:r(DefaultVHost, exchange, ?LOG_EXCH_NAME),
     try
         %% durable
-        #exchange{} = rabbit_exchange:declare(Exchange, topic, true, false, false, [], ?INTERNAL_USER),
+        #exchange{} = rabbit_exchange:declare(Exchange, topic, true, false, true, [], ?INTERNAL_USER),
         {ok, Exchange}
     catch
         ErrType:Err ->

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -1031,8 +1031,9 @@ boot_delegate() ->
 -spec recover() -> 'ok'.
 
 recover() ->
-    rabbit_policy:recover(),
-    rabbit_vhost:recover().
+    ok = rabbit_policy:recover(),
+    ok = rabbit_vhost:recover(),
+    ok = lager_exchange_backend:maybe_init_exchange().
 
 -spec maybe_insert_default_data() -> 'ok'.
 
@@ -1058,6 +1059,7 @@ insert_default_data() ->
     DefaultReadPermBin = rabbit_data_coercion:to_binary(DefaultReadPerm),
 
     ok = rabbit_vhost:add(DefaultVHostBin, ?INTERNAL_USER),
+    ok = lager_exchange_backend:maybe_init_exchange(),
     ok = rabbit_auth_backend_internal:add_user(
         DefaultUserBin,
         DefaultPassBin,


### PR DESCRIPTION
These changes make the `amq.rabbitmq.log` exchange internal again, and adds code to create this exchange immediately after adding or recovering the default `/` vhost.

Fixes #1973 