### PR TITLE
Workaround for IPv6 EPMD

### DIFF
--- a/scripts/rabbitmq-server
+++ b/scripts/rabbitmq-server
@@ -194,6 +194,7 @@ RABBITMQ_DIST_PORT=$RABBITMQ_DIST_PORT \
     -noinput \
     -hidden \
     -s rabbit_prelaunch \
+    ${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS} \
     ${RABBITMQ_NAME_TYPE} ${RABBITMQ_PRELAUNCH_NODENAME} \
     -conf_advanced "${RABBITMQ_ADVANCED_CONFIG_FILE}" \
     -rabbit feature_flags_file "\"$RABBITMQ_FEATURE_FLAGS_FILE\"" \


### PR DESCRIPTION
Add workaround for EPMD IPV6.

## Proposed Changes

Possible workaround / fix for [ipv6 epmd issue](https://groups.google.com/forum/#!searchin/rabbitmq-users/ipv6%7Csort:date/rabbitmq-users/mbsT8PSJTHQ/tjAgsRULBgAJ)
(Until Erlang won't fix the [issue](https://github.com/erlang/otp/pull/602)) 

Had to add:
```
 ${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS} \
 ``` 
 In `rabbit_prelaunch` since it wans't not possible to [pass parameters](https://github.com/rabbitmq/rabbitmq-server/blob/v3.7.x/scripts/rabbitmq-server#L191)
 
 in this case:
 
 ```
 RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS = " -proto_dist inet6_tcp "
 RABBITMQ_CTL_ERL_ARGS = " -proto_dist inet6_tcp "
 ```
 
The enviroment where i tested it is the same I described [here](https://groups.google.com/forum/#!searchin/rabbitmq-users/ipv6%7Csort:date/rabbitmq-users/mbsT8PSJTHQ/tjAgsRULBgAJ)
 And with this patch I can start the rabbitmq-server.
 
 
 
if you want to test it without rabbitmq it is enough to:
```
erl -proto_dist inet6_tcp  -sname hello
net_adm:names(localhost).
{error,address}
```

Try again using:

```
erl -proto_dist inet6_tcp  -sname hello
net_adm:names({0,0,0,0,0,0,0,1}).
{ok,[{"hello",36371}]}
```

_In short this fix tries to use the local IPV6 address when for some reason the `net_adm:names(..)` fails with the default value_
 
## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

**NOTE** this is just an idea, the code should be organised differnetly as for example the variable:
 ```
 -define(LOCAL_IPV6_ADDRESS, {0,0,0,0,0,0,0,1}).
``` 
should be inside some common file.

Let me know what you think.

Thank you
