### PR TITLE
Clarify unit symbols

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -307,11 +307,14 @@
 ##
 # vm_memory_high_watermark.absolute = 2GB
 ##
-## Supported units suffixes:
+## Supported unit symbols:
 ##
-## kb, KB: kibibytes (2^10 bytes)
-## mb, MB: mebibytes (2^20)
-## gb, GB: gibibytes (2^30)
+## k, kiB: kibibytes (2^10 - 1,024 bytes)
+## M, MiB: mebibytes (2^20 - 1,048,576 bytes)
+## G, GiB: gibibytes (2^30 - 1,073,741,824 bytes)
+## kB: kilobytes (10^3 - 1,000 bytes)
+## MB: megabytes (10^6 - 1,000,000 bytes)
+## GB: gigabytes (10^9 - 1,000,000,000 bytes)
 
 
 

--- a/docs/rabbitmq.config.example
+++ b/docs/rabbitmq.config.example
@@ -259,14 +259,14 @@
    %%
    %% {vm_memory_high_watermark, {absolute, "1024M"}},
    %%
-   %% Supported units suffixes:
+   %% Supported unit symbols:
    %%
-   %% k, kiB: kibibytes (2^10 bytes)
-   %% M, MiB: mebibytes (2^20)
-   %% G, GiB: gibibytes (2^30)
-   %% kB: kilobytes (10^3)
-   %% MB: megabytes (10^6)
-   %% GB: gigabytes (10^9)
+   %% k, kiB: kibibytes (2^10 - 1,024 bytes)
+   %% M, MiB: mebibytes (2^20 - 1,048,576 bytes)
+   %% G, GiB: gibibytes (2^30 - 1,073,741,824 bytes)
+   %% kB: kilobytes (10^3 - 1,000 bytes)
+   %% MB: megabytes (10^6 - 1,000,000 bytes)
+   %% GB: gigabytes (10^9 - 1,000,000,000 bytes)
 
    %% Fraction of the high watermark limit at which queues start to
    %% page message out to disc in order to free up memory.

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -1836,8 +1836,8 @@ a floating point number greater than or equal to 0.
 .It Ar memory_limit
 The new memory limit at which flow control is triggered, expressed in
 bytes as an integer number greater than or equal to 0 or as a string
-with memory units (e.g. 512M or 1G).
-Available units are:
+with memory unit symbol(e.g. 512M or 1G).
+Available unit symbols are:
 .Bl -tag -width Ds
 .It Cm k , Cm kiB
 kibibytes (2^10 bytes)
@@ -1857,7 +1857,7 @@ gigabytes (10^9 bytes)
 .It Cm set_disk_free_limit Ar disk_limit
 .Bl -tag -width Ds
 .It Ar disk_limit
-Lower bound limit as an integer in bytes or a string with memory units
+Lower bound limit as an integer in bytes or a string with memory unit symbols
 (see vm_memory_high_watermark), e.g. 512M or 1G.
 Once free disk space reaches the limit, a disk alarm will be set.
 .El

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -668,15 +668,18 @@ end}.
 %%
 %% {vm_memory_high_watermark, {absolute, 1073741824}},
 %%
-%% Or you can set absolute value using memory units (with RabbitMQ 3.6.0+).
+%% Or you can set absolute value using memory unit symbols (with RabbitMQ 3.6.0+).
 %%
 %% {vm_memory_high_watermark, {absolute, "1024M"}},
 %%
-%% Supported units suffixes:
+%% Supported unit symbols:
 %%
-%% kb, KB: kibibytes (2^10 bytes)
-%% mb, MB: mebibytes (2^20)
-%% gb, GB: gibibytes (2^30)
+%% k, kiB: kibibytes (2^10 - 1,024 bytes)
+%% M, MiB: mebibytes (2^20 - 1,048,576 bytes)
+%% G, GiB: gibibytes (2^30 - 1,073,741,824 bytes)
+%% kB: kilobytes (10^3 - 1,000 bytes)
+%% MB: megabytes (10^6 - 1,000,000 bytes)
+%% GB: gigabytes (10^9 - 1,000,000,000 bytes)
 
 {mapping, "vm_memory_high_watermark.relative", "rabbit.vm_memory_high_watermark", [
     {datatype, float}]}.


### PR DESCRIPTION
RabbitMQ supports both power of 2 & power of 10 unit symbols. Giving clear examples of the difference - it's a mistake easy to make.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Pushed this commit into master first, by mistake, had to revert.
