### PR TITLE
Track messages that were not routed anywhere and also not published as mandatory

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -2115,8 +2115,15 @@ deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{
     end,
     State2#ch{queue_states = QueueStates}.
 
-process_routing_mandatory(true, [], Msg, State) ->
+process_routing_mandatory(_Mandatory = true,
+                          _RoutedToQs = [],
+                          Msg, State) ->
     ok = basic_return(Msg, State, no_route),
+    ok;
+process_routing_mandatory(_Mandatory = false,
+                          _RoutedToQs = [],
+                          #basic_message{exchange_name = ExchangeName}, State) ->
+    ?INCR_STATS(exchange_stats, ExchangeName, 1, drop_unroutable, State),
     ok;
 process_routing_mandatory(_, _, _, _) ->
     ok.

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -2061,8 +2061,9 @@ notify_limiter(Limiter, Acked) ->
 deliver_to_queues({#delivery{message   = #basic_message{exchange_name = XName},
                              confirm   = false,
                              mandatory = false},
-                   []}, State) -> %% optimisation
+                   _RoutedToQs = []}, State) -> %% optimisation
     ?INCR_STATS(exchange_stats, XName, 1, publish, State),
+    ?INCR_STATS(exchange_stats, XName, 1, drop_unroutable, State),
     State;
 deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{
                                                        exchange_name = XName},

--- a/src/rabbit_core_metrics_gc.erl
+++ b/src/rabbit_core_metrics_gc.erl
@@ -157,7 +157,7 @@ gc_process_and_entity(Table, GbSet) ->
     ets:foldl(fun({{Pid, Id} = Key, _, _, _, _, _, _, _, _}, none)
                   when Table == channel_queue_metrics ->
                       gc_process_and_entity(Id, Pid, Table, Key, GbSet);
-                 ({{Pid, Id} = Key, _, _, _, _}, none)
+                 ({{Pid, Id} = Key, _, _, _, _, _}, none)
                     when Table == channel_exchange_metrics ->
                       gc_process_and_entity(Id, Pid, Table, Key, GbSet);
                  ({{Id, Pid, _} = Key, _, _, _, _, _, _}, none)

--- a/test/rabbit_core_metrics_gc_SUITE.erl
+++ b/test/rabbit_core_metrics_gc_SUITE.erl
@@ -177,6 +177,8 @@ channel_metrics(Config) ->
     amqp_channel:call(Ch, #'queue.declare'{queue = <<"queue_metrics">>}),
     amqp_channel:cast(Ch, #'basic.publish'{routing_key = <<"queue_metrics">>},
                       #amqp_msg{payload = <<"hello">>}),
+    amqp_channel:cast(Ch, #'basic.publish'{routing_key = <<"won't route $¢% anywhere">>},
+                      #amqp_msg{payload = <<"hello">>}),
     {#'basic.get_ok'{}, _} = amqp_channel:call(Ch, #'basic.get'{queue = <<"queue_metrics">>,
                                                                 no_ack=true}),
     timer:sleep(150),

--- a/test/unit_inbroker_non_parallel_SUITE.erl
+++ b/test/unit_inbroker_non_parallel_SUITE.erl
@@ -494,7 +494,7 @@ channel_statistics1(_Config) ->
                      [{{Ch, QRes}, 1, 0, 0, 0, 0, 0, 0, 0}] = ets:lookup(
                                                                 channel_queue_metrics,
                                                                 {Ch, QRes}),
-                     [{{Ch, X}, 1, 0, 0, 0}] = ets:lookup(
+                     [{{Ch, X}, 1, 0, 0, 0, 0}] = ets:lookup(
                                                  channel_exchange_metrics,
                                                  {Ch, X}),
                      [{{Ch, {QRes, X}}, 1, 0}] = ets:lookup(
@@ -509,7 +509,7 @@ channel_statistics1(_Config) ->
                      [{{Ch, QRes}, 1, 0, 0, 0, 0, 0, 0, 1}] = ets:lookup(
                                                                 channel_queue_metrics,
                                                                 {Ch, QRes}),
-                 [{{Ch, X}, 1, 0, 0, 0}] = ets:lookup(
+                 [{{Ch, X}, 1, 0, 0, 0, 0}] = ets:lookup(
                                              channel_exchange_metrics,
                                              {Ch, X}),
                  [{{Ch, {QRes, X}}, 1, 1}] = ets:lookup(
@@ -522,7 +522,7 @@ channel_statistics1(_Config) ->
     force_metric_gc(),
     Check4 = fun() ->
                  [] = ets:lookup(channel_queue_metrics, {Ch, QRes}),
-                 [{{Ch, X}, 1, 0, 0, 0}] = ets:lookup(
+                 [{{Ch, X}, 1, 0, 0, 0, 0}] = ets:lookup(
                                              channel_exchange_metrics,
                                              {Ch, X}),
                  [] = ets:lookup(channel_queue_exchange_metrics,


### PR DESCRIPTION
## Proposed Changes

This introduces a metric for messages that were not routed anywhere but also weren't published as
mandatory, so they have to be dropped. See #1904 for background.

This metric won't be reported by older nodes so we will hide it behind a [feature flag](https://www.rabbitmq.com/blog/2019/04/23/simplifying-rolling-upgrades-between-minor-versions-with-feature-flags/).

Depends on

 * https://github.com/rabbitmq/rabbitmq-common/pull/324
 * https://github.com/rabbitmq/rabbitmq-management-agent/pull/79
 * https://github.com/rabbitmq/rabbitmq-management/pull/695

Pair: @dcorbacho.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist


- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of #1904.

[#165548314]

