### PR TITLE
Add functions to get erlang or openssl formatted ciphers.

### DIFF
--- a/src/rabbit_ssl.erl
+++ b/src/rabbit_ssl.erl
@@ -70,23 +70,11 @@ cipher_suites_openssl(Mode, Version) ->
     ssl:cipher_suites(Mode, Version)).
 
 
-%% OTP-20.3 and OTP-21 have different modules containing cipher format functions
-%% This is not a hot codepath and `function_exported` should not slow things down much.
 format_cipher_erlang(Cipher) ->
-    case erlang:function_exported(ssl_cipher_format, suite, 1) of
-        true ->
-            ssl_cipher_format:erl_suite_definition(ssl_cipher_format:suite(Cipher));
-        false ->
-            ssl_cipher:erl_suite_definition(ssl_cipher:suite(Cipher))
-    end.
+    ssl_cipher_format:erl_suite_definition(ssl_cipher_format:suite(Cipher)).
 
 format_cipher_openssl(Cipher) ->
-    case erlang:function_exported(ssl_cipher_format, suite, 1) of
-        true ->
-            ssl_cipher_format:openssl_suite_name(ssl_cipher_format:suite(Cipher));
-        false ->
-            ssl_cipher:openssl_suite_name(ssl_cipher:suite(Cipher))
-    end.
+    ssl_cipher_format:openssl_suite_name(ssl_cipher_format:suite(Cipher)).
 
 -spec get_highest_protocol_version() -> tls_record:tls_version().
 get_highest_protocol_version() ->

--- a/src/rabbit_ssl.erl
+++ b/src/rabbit_ssl.erl
@@ -20,12 +20,77 @@
 
 -export([peer_cert_issuer/1, peer_cert_subject/1, peer_cert_validity/1]).
 -export([peer_cert_subject_items/2, peer_cert_auth_name/1]).
+-export([cipher_suites_erlang/2, cipher_suites_erlang/1,
+         cipher_suites_openssl/2, cipher_suites_openssl/1,
+         cipher_suites/1]).
 
 %%--------------------------------------------------------------------------
 
 -export_type([certificate/0]).
 
 -type certificate() :: rabbit_cert_info:certificate().
+
+-type cipher_suites_mode() :: default | all | anonymous.
+
+-spec cipher_suites(cipher_suites_mode()) -> ssl:ciphers().
+cipher_suites(Mode) ->
+    Version = get_highest_protocol_version(),
+    ssl:cipher_suites(Mode, Version).
+
+-spec cipher_suites_erlang(cipher_suites_mode()) ->
+    [ssl:old_cipher_suite()].
+cipher_suites_erlang(Mode) ->
+    Version = get_highest_protocol_version(),
+    cipher_suites_erlang(Mode, Version).
+
+-spec cipher_suites_erlang(cipher_suites_mode(),
+                           ssl:protocol_version() | tls_record:tls_version()) ->
+    [ssl:old_cipher_suite()].
+cipher_suites_erlang(Mode, Version) ->
+    [ format_cipher_erlang(C)
+      || C <- ssl:cipher_suites(Mode, Version) ].
+
+-spec cipher_suites_openssl(cipher_suites_mode()) ->
+    [ssl:old_cipher_suite()].
+cipher_suites_openssl(Mode) ->
+    Version = get_highest_protocol_version(),
+    cipher_suites_openssl(Mode, Version).
+
+-spec cipher_suites_openssl(cipher_suites_mode(),
+                           ssl:protocol_version() | tls_record:tls_version()) ->
+    [ssl:old_cipher_suite()].
+cipher_suites_openssl(Mode, Version) ->
+    lists:filtermap(fun(C) ->
+        OpenSSL = format_cipher_openssl(C),
+        case is_list(OpenSSL) of
+            true  -> {true, OpenSSL};
+            false -> false
+        end
+    end,
+    ssl:cipher_suites(Mode, Version)).
+
+
+%% OTP-20.3 and OTP-21 have different modules containing cipher format functions
+%% This is not a hot codepath and `function_exported` should not slow things down much.
+format_cipher_erlang(Cipher) ->
+    case erlang:function_exported(ssl_cipher_format, suite, 1) of
+        true ->
+            ssl_cipher_format:erl_suite_definition(ssl_cipher_format:suite(Cipher));
+        false ->
+            ssl_cipher:erl_suite_definition(ssl_cipher:suite(Cipher))
+    end.
+
+format_cipher_openssl(Cipher) ->
+    case erlang:function_exported(ssl_cipher_format, suite, 1) of
+        true ->
+            ssl_cipher_format:openssl_suite_name(ssl_cipher_format:suite(Cipher));
+        false ->
+            ssl_cipher:openssl_suite_name(ssl_cipher:suite(Cipher))
+    end.
+
+-spec get_highest_protocol_version() -> tls_record:tls_version().
+get_highest_protocol_version() ->
+    tls_record:highest_protocol_version([]).
 
 %%--------------------------------------------------------------------------
 %% High-level functions used by reader


### PR DESCRIPTION
## Proposed Changes

Add functions got get cipher suites with more options.
SSL application provides API to get ciphers by format or by default/all/anonymous,
but not both, so it's not possible to get all openssl-formatted ciphers.

OTP-20 and OTP-21 have different modules containing cipher formatting
functions - using function_exported to support both.

Addresses rabbitmq/rabbitmq-cli#342

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

