### PR TITLE
print cuttlefish validation error on a new line

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -1030,7 +1030,7 @@ boot_error(_, {error, {cannot_log_to_file, LogFile, Reason}}) ->
                             [LogFile, Reason]);
 boot_error(_, {error, {generate_config_file, Error}}) ->
     log_boot_error_and_exit(generate_config_file,
-                            "~nConfig file generation failed ~s~n",
+                            "~nConfig file generation failed:~n~s~n",
                             [Error]);
 boot_error(Class, Reason) ->
     LogLocations = log_locations(),


### PR DESCRIPTION
## Proposed Changes

Print cuttlefish validation output starting with a new line:

before:
```
BOOT FAILED
===========

Config file generation failed 18:44:22.549 [error] You've tried to set management.inactivity_timeout, but there is no setting with that name.
18:44:22.549 [error]   Did you mean one of these?
18:44:22.549 [error]     handshake_timeout
18:44:22.549 [error]     ssl_handshake_timeout
18:44:22.549 [error]     mnesia_table_loading_retry_timeout
18:44:22.549 [error] Error generating configuration in phase transform_datatypes
18:44:22.549 [error] Conf file attempted to set unknown variable: management.inactivity_timeout

{"init terminating in do_boot",generate_config_file}
init terminating in do_boot (generate_config_file)
```

after:
```
BOOT FAILED
===========

Config file generation failed:
18:44:22.549 [error] You've tried to set management.inactivity_timeout, but there is no setting with that name.
18:44:22.549 [error]   Did you mean one of these?
18:44:22.549 [error]     handshake_timeout
18:44:22.549 [error]     ssl_handshake_timeout
18:44:22.549 [error]     mnesia_table_loading_retry_timeout
18:44:22.549 [error] Error generating configuration in phase transform_datatypes
18:44:22.549 [error] Conf file attempted to set unknown variable: management.inactivity_timeout

{"init terminating in do_boot",generate_config_file}
init terminating in do_boot (generate_config_file)
```

Change:
``` diff
--- error-before.txt	2019-04-25 09:09:02.000000000 +0100
+++ error-after.txt	2019-04-25 09:09:19.000000000 +0100
@@ -1,7 +1,8 @@
 BOOT FAILED
 ===========
 
-Config file generation failed 18:44:22.549 [error] You've tried to set management.inactivity_timeout, but there is no setting with that name.
+Config file generation failed:
+18:44:22.549 [error] You've tried to set management.inactivity_timeout, but there is no setting with that name.
 18:44:22.549 [error]   Did you mean one of these?
 18:44:22.549 [error]     handshake_timeout
 18:44:22.549 [error]     ssl_handshake_timeout
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories