### PR TITLE
Policy validation must return 'ok' or an error

### DIFF
--- a/src/rabbit_queue_location_validator.erl
+++ b/src/rabbit_queue_location_validator.erl
@@ -33,7 +33,10 @@
 
 validate_policy(KeyList) ->
     case proplists:lookup(<<"queue-master-locator">> , KeyList) of
-        {_, Strategy} -> validate_strategy(Strategy);
+        {_, Strategy} -> case validate_strategy(Strategy) of
+                             {error, _} = Er -> Er;
+                             _ -> ok
+                         end;
         _             -> {error, "queue-master-locator undefined"}
     end.
 

--- a/test/queue_master_location_SUITE.erl
+++ b/test/queue_master_location_SUITE.erl
@@ -132,12 +132,12 @@ declare_policy(Config) ->
 
 declare_invalid_policy(Config) ->
     %% Tests that queue masters location returns 'ok', otherwise the validation of
-    %% any other parameter might be skipped - and policy accepted which will crash
-    %% in application
+    %% any other parameter might be skipped and invalid policy accepted.
     setup_test_environment(Config),
     unset_location_config(Config),
     Policy = [{<<"queue-master-locator">>, <<"min-masters">>},
               {<<"ha-mode">>, <<"exactly">>},
+              %% this field is expected to be an integer
               {<<"ha-params">>, <<"2">>}],
     {error_string, _} = rabbit_ct_broker_helpers:rpc(
                           Config, 0, rabbit_policy, set,

--- a/test/queue_master_location_SUITE.erl
+++ b/test/queue_master_location_SUITE.erl
@@ -51,6 +51,7 @@ groups() ->
       {cluster_size_3, [], [
           declare_args,
           declare_policy,
+          declare_invalid_policy,
           declare_policy_nodes,
           declare_policy_all,
           declare_policy_exactly,
@@ -128,6 +129,19 @@ declare_policy(Config) ->
     QueueName = rabbit_misc:r(<<"/">>, queue, Q = <<"qm.test">>),
     declare(Config, QueueName, false, false, _Args=[], none),
     verify_min_master(Config, Q).
+
+declare_invalid_policy(Config) ->
+    %% Tests that queue masters location returns 'ok', otherwise the validation of
+    %% any other parameter might be skipped - and policy accepted which will crash
+    %% in application
+    setup_test_environment(Config),
+    unset_location_config(Config),
+    Policy = [{<<"queue-master-locator">>, <<"min-masters">>},
+              {<<"ha-mode">>, <<"exactly">>},
+              {<<"ha-params">>, <<"2">>}],
+    {error_string, _} = rabbit_ct_broker_helpers:rpc(
+                          Config, 0, rabbit_policy, set,
+                          [<<"/">>, ?POLICY, <<".*">>, Policy, 0, <<"queues">>, <<"acting-user">>]).
 
 declare_policy_nodes(Config) ->
     setup_test_environment(Config),


### PR DESCRIPTION
Any other value will break the validation cycle and leave the rest of the arguments without validate

Reported in the mailing list: https://groups.google.com/forum/#!topic/rabbitmq-users/7mwL2AWwUyI

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
