### PR TITLE
Move check for active readers to message store GC action function

### DIFF
--- a/src/rabbit_msg_store.erl
+++ b/src/rabbit_msg_store.erl
@@ -2068,6 +2068,8 @@ do_combine_files(SourceSummary, DestinationSummary,
               {#file_summary.file_size,        TotalValidData}]),
 
     Reclaimed = SourceFileSize + DestinationFileSize - TotalValidData,
+    rabbit_log:debug("Combined segment files number ~p (source) and ~p (destination), reclaimed ~p bytes",
+                     [Source, Destination, Reclaimed]),
     gen_server2:cast(Server, {combine_files, Source, Destination, Reclaimed}),
     safe_file_delete_fun(Source, Dir, FileHandlesEts).
 

--- a/src/rabbit_msg_store.erl
+++ b/src/rabbit_msg_store.erl
@@ -2086,7 +2086,7 @@ delete_file(File, State = #gc_state { file_summary_ets = FileSummaryEts,
             gen_server2:cast(Server, {delete_file, File, FileSize}),
             {ok, safe_file_delete_fun(File, Dir, FileHandlesEts)};
         [#file_summary{readers = Readers}] when Readers > 0 ->
-            rabbit_log:error("Asked to delete file ~p, but it has readers. Deferring.",
+            rabbit_log:debug("Asked to delete file ~p but it has active readers. Deferring.",
                              [File]),
             {defer, [File]}
     end.

--- a/src/rabbit_msg_store.erl
+++ b/src/rabbit_msg_store.erl
@@ -1986,7 +1986,7 @@ combine_files(Source, Destination,
             {ok, do_combine_files(SourceSummary, DestinationSummary,
                                   Source, Destination, State)};
         _ ->
-            rabbit_log:error("Asked to combine files ~p and ~p, but they have readers. Deferring.",
+            rabbit_log:debug("Asked to combine files ~p and ~p but they have active readers. Deferring.",
                              [Source, Destination]),
             DeferredFiles = [FileSummary#file_summary.file
                              || FileSummary <- [SourceSummary, DestinationSummary],

--- a/src/rabbit_msg_store_gc.erl
+++ b/src/rabbit_msg_store_gc.erl
@@ -119,15 +119,13 @@ attempt_action(Action, Files,
                State = #state { pending_no_readers = Pending,
                                 on_action          = Thunks,
                                 msg_store_state    = MsgStoreState }) ->
-    case [File || File <- Files,
-                  rabbit_msg_store:has_readers(File, MsgStoreState)] of
-        []         -> State #state {
-                        on_action = lists:filter(
-                                      fun (Thunk) -> not Thunk() end,
-                                      [do_action(Action, Files, MsgStoreState) |
-                                       Thunks]) };
-        [File | _] -> Pending1 = maps:put(File, {Action, Files}, Pending),
-                      State #state { pending_no_readers = Pending1 }
+    case do_action(Action, Files, MsgStoreState) of
+        {ok, OkThunk} ->
+            State#state{on_action = lists:filter(fun (Thunk) -> not Thunk() end,
+                                                 [OkThunk | Thunks])};
+        {defer, [File | _]} ->
+            Pending1 = maps:put(File, {Action, Files}, Pending),
+            State #state { pending_no_readers = Pending1 }
     end.
 
 do_action(combine, [Source, Destination], MsgStoreState) ->


### PR DESCRIPTION
## Proposed Changes

Message store GC postpones processing of file, which have readers.
When performing an action, it asserts that there are no readers.

Check for readers may race with readers update by a queue, crashing
the message store.

Make check and assert work with the same lookup to reduce failure rate.

In case of races the queue process should handle exception instead.

It's quite hard to reproduce the race without adding sleeps in the code, unfortunately.
I was not able to produce a test case.

Addresses #2000
[#165755203]

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #2000)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

