### PR TITLE
Fix type issues with send_drained message

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -236,7 +236,7 @@ apply(Meta, #credit{credit = NewCredit, delivery_count = RemoteDelCnt,
                     {State1#?MODULE{consumers = Consumers},
                      %% returning a multi response with two client actions
                      %% for the channel to execute
-                     {multi, [Response, {send_drained, [{CTag, Drained}]}]},
+                     {multi, [Response, {send_drained, {CTag, Drained}}]},
                      Effects}
             end;
         _ when Waiting0 /= [] ->

--- a/test/rabbit_fifo_SUITE.erl
+++ b/test/rabbit_fifo_SUITE.erl
@@ -138,7 +138,7 @@ credit_with_drained_test(_) ->
                                                        delivery_count = 5}}},
                  State),
     ?assertEqual({multi, [{send_credit_reply, 0},
-                          {send_drained, [{?FUNCTION_NAME, 5}]}]},
+                          {send_drained, {?FUNCTION_NAME, 5}}]},
                            Result),
     ok.
 
@@ -153,7 +153,7 @@ credit_and_drain_test(_) ->
 
     ?ASSERT_NO_EFF({send_msg, _, {delivery, _, _}}, CheckEffs),
     {State4, {multi, [{send_credit_reply, 0},
-                      {send_drained, [{?FUNCTION_NAME, 2}]}]},
+                      {send_drained, {?FUNCTION_NAME, 2}}]},
     Effects} = apply(meta(4), rabbit_fifo:make_credit(Cid, 4, 0, true), State3),
     ?assertMatch(#rabbit_fifo{consumers = #{Cid := #consumer{credit = 0,
                                                        delivery_count = 4}}},


### PR DESCRIPTION
For quorum queues.

[#165796741]