### PR TITLE
New dependency: observer_cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ BUILD_DEPS = rabbitmq_cli syslog
 DEPS = ranch lager rabbit_common ra sysmon_handler stdout_formatter observer_cli
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper
 
-dep_observer_cli = hex observer_cli 1.4.4
+dep_observer_cli = git https://github.com/zhongwencool/observer_cli 1.4.4
 dep_syslog = git https://github.com/schlagert/syslog 3.4.5
 
 define usage_xml_to_erl

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ BUILD_DEPS = rabbitmq_cli syslog
 DEPS = ranch lager rabbit_common ra sysmon_handler stdout_formatter observer_cli
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper
 
-dep_observer_cli = hex observer_cli 1.4.3
+dep_observer_cli = hex observer_cli 1.4.4
 dep_syslog = git https://github.com/schlagert/syslog 3.4.5
 
 define usage_xml_to_erl

--- a/Makefile
+++ b/Makefile
@@ -135,9 +135,10 @@ endef
 
 LOCAL_DEPS = sasl mnesia os_mon inets compiler public_key crypto ssl syntax_tools
 BUILD_DEPS = rabbitmq_cli syslog
-DEPS = ranch lager rabbit_common ra sysmon_handler stdout_formatter
+DEPS = ranch lager rabbit_common ra sysmon_handler stdout_formatter observer_cli
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper
 
+dep_observer_cli = hex observer_cli 1.4.3
 dep_syslog = git https://github.com/schlagert/syslog 3.4.5
 
 define usage_xml_to_erl


### PR DESCRIPTION
## Proposed Changes

The new dependency will only be [used by rabbitmq-cli](https://github.com/rabbitmq/rabbitmq-cli/pull/353) and must be available on broker
nodes. It makes most sense to have it in these two reports only
and not expose it in `rabbitmq-components.mk`.

Per discussion with @dumbbell.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-cli#353.
