### PR TITLE
Add an option to dead-letter rejected publishes

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -761,7 +761,9 @@ check_dlxrk_arg({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}}.
 
 check_overflow({longstr, Val}, _Args) ->
-    case lists:member(Val, [<<"drop-head">>, <<"reject-publish">>]) of
+    case lists:member(Val, [<<"drop-head">>,
+                            <<"reject-publish">>,
+                            <<"reject-publish-dlx">>]) of
         true  -> ok;
         false -> {error, invalid_overflow}
     end;

--- a/src/rabbit_policies.erl
+++ b/src/rabbit_policies.erl
@@ -131,6 +131,8 @@ validate_policy0(<<"overflow">>, <<"drop-head">>) ->
     ok;
 validate_policy0(<<"overflow">>, <<"reject-publish">>) ->
     ok;
+validate_policy0(<<"overflow">>, <<"reject-publish-dlx">>) ->
+    ok;
 validate_policy0(<<"overflow">>, Value) ->
     {error, "~p is not a valid overflow value", [Value]};
 

--- a/test/confirms_rejects_SUITE.erl
+++ b/test/confirms_rejects_SUITE.erl
@@ -11,13 +11,17 @@ all() ->
     ].
 
 groups() ->
+    OverflowTests = [
+      confirms_rejects_conflict,
+      policy_resets_to_default
+    ],
     [
       {parallel_tests, [parallel], [
-          confirms_rejects_conflict,
-          policy_resets_to_default,
-          dead_queue_rejects,
-          mixed_dead_alive_queues_reject
-        ]}
+        {overflow_reject_publish_dlx, [parallel], OverflowTests},
+        {overflow_reject_publish, [parallel], OverflowTests},
+        dead_queue_rejects,
+        mixed_dead_alive_queues_reject
+      ]}
     ].
 
 init_per_suite(Config) ->
@@ -28,6 +32,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 
+init_per_group(overflow_reject_publish, Config) ->
+    rabbit_ct_helpers:set_config(Config, [
+        {overflow, <<"reject-publish">>}
+      ]);
+init_per_group(overflow_reject_publish_dlx, Config) ->
+    rabbit_ct_helpers:set_config(Config, [
+        {overflow, <<"reject-publish-dlx">>}
+      ]);
 init_per_group(Group, Config) ->
     ClusterSize = 2,
     Config1 = rabbit_ct_helpers:set_config(Config, [
@@ -38,6 +50,10 @@ init_per_group(Group, Config) ->
       rabbit_ct_broker_helpers:setup_steps() ++
       rabbit_ct_client_helpers:setup_steps()).
 
+end_per_group(overflow_reject_publish, _Config) ->
+    ok;
+end_per_group(overflow_reject_publish_dlx, _Config) ->
+    ok;
 end_per_group(_Group, Config) ->
     rabbit_ct_helpers:run_steps(Config,
       rabbit_ct_client_helpers:teardown_steps() ++
@@ -60,7 +76,9 @@ init_per_testcase(Testcase, Config)
 
 end_per_testcase(policy_resets_to_default = Testcase, Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
-    amqp_channel:call(Ch, #'queue.delete'{queue = <<"policy_resets_to_default">>}),
+    XOverflow = ?config(overflow, Config),
+    QueueName = <<"policy_resets_to_default", "_", XOverflow/binary>>,
+    amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
     rabbit_ct_client_helpers:close_channels_and_connection(Config, 0),
 
     Conn = ?config(conn, Config),
@@ -70,7 +88,9 @@ end_per_testcase(policy_resets_to_default = Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(confirms_rejects_conflict = Testcase, Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
-    amqp_channel:call(Ch, #'queue.delete'{queue = <<"confirms_rejects_conflict">>}),
+    XOverflow = ?config(overflow, Config),
+    QueueName = <<"confirms_rejects_conflict", "_", XOverflow/binary>>,
+    amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
     end_per_testcase0(Testcase, Config);
 end_per_testcase(dead_queue_rejects = Testcase, Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
@@ -187,15 +207,15 @@ confirms_rejects_conflict(Config) ->
     false = Conn =:= Conn1,
     false = Ch =:= Ch1,
 
-    QueueName = <<"confirms_rejects_conflict">>,
-
     amqp_channel:call(Ch, #'confirm.select'{}),
     amqp_channel:register_confirm_handler(Ch, self()),
 
+    XOverflow = ?config(overflow, Config),
+    QueueName = <<"confirms_rejects_conflict", "_", XOverflow/binary>>,
     amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
                                            durable = true,
-                                           arguments = [{<<"x-max-length">>,long,12},
-                                                        {<<"x-overflow">>,longstr,<<"reject-publish">>}]
+                                           arguments = [{<<"x-max-length">>, long, 12},
+                                                        {<<"x-overflow">>, longstr, XOverflow}]
                                            }),
     %% Consume 3 messages at once. Do that often.
     Consume = fun Consume() ->
@@ -238,12 +258,14 @@ confirms_rejects_conflict(Config) ->
 
 policy_resets_to_default(Config) ->
     Conn = ?config(conn, Config),
+
     {ok, Ch} = amqp_connection:open_channel(Conn),
-    QueueName = <<"policy_resets_to_default">>,
 
     amqp_channel:call(Ch, #'confirm.select'{}),
     amqp_channel:register_confirm_handler(Ch, self()),
 
+    XOverflow = ?config(overflow, Config),
+    QueueName = <<"policy_resets_to_default", "_", XOverflow/binary>>,
     amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
                                            durable = true
                                            }),
@@ -251,7 +273,7 @@ policy_resets_to_default(Config) ->
     rabbit_ct_broker_helpers:set_policy(
         Config, 0,
         QueueName, QueueName, <<"queues">>,
-        [{<<"max-length">>, MaxLength}, {<<"overflow">>, <<"reject-publish">>}]),
+        [{<<"max-length">>, MaxLength}, {<<"overflow">>, XOverflow}]),
 
     timer:sleep(1000),
 

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -323,11 +323,12 @@ declare_invalid_args(Config) ->
                LQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
                     {<<"x-max-priority">>, long, 2000}])),
 
-    ?assertExit(
-       {{shutdown, {server_initiated_close, 406, _}}, _},
-       declare(rabbit_ct_client_helpers:open_channel(Config, Server),
-               LQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
-                    {<<"x-overflow">>, longstr, <<"reject-publish">>}])),
+    [?assertExit(
+        {{shutdown, {server_initiated_close, 406, _}}, _},
+        declare(rabbit_ct_client_helpers:open_channel(Config, Server),
+                LQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                     {<<"x-overflow">>, longstr, XOverflow}]))
+     || XOverflow <- [<<"reject-publish">>, <<"reject-publish-dlx">>]],
 
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},


### PR DESCRIPTION
## Proposed Changes

Add `reject-publish-dlx` overflow strategy, which is similar to `reject-publish` strategy, but also dead-letters rejected messages.

Closes #1443

## Types of Changes

- Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- Documentation improvements (corrections, new content, etc)
- Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CLA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

TODOs:

- [x] Add tests that cover the same behaviour covered by existing tests for `reject-publish`.
- [x] Documentation should also be updated accordingly, i.e. https://github.com/rabbitmq/rabbitmq-website/blob/master/site/maxlength.xml. I'm ready to propose a corresponding pull request, if this is going to be approved.