### PR TITLE
New setting to confirm messages on ack.

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -693,7 +693,8 @@ declare_args() ->
      {<<"x-queue-mode">>,              fun check_queue_mode/2},
      {<<"x-single-active-consumer">>,  fun check_single_active_consumer_arg/2},
      {<<"x-queue-type">>,              fun check_queue_type/2},
-     {<<"x-quorum-initial-group-size">>,     fun check_default_quorum_initial_group_size_arg/2}].
+     {<<"x-quorum-initial-group-size">>,     fun check_default_quorum_initial_group_size_arg/2},
+     {<<"x-confirm-on">>,              fun check_confirm_on/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
                    {<<"x-cancel-on-ha-failover">>, fun check_bool_arg/2}].
@@ -782,6 +783,14 @@ check_queue_type({longstr, Val}, _Args) ->
         false -> {error, invalid_queue_type}
     end;
 check_queue_type({Type,    _}, _Args) ->
+    {error, {unacceptable_type, Type}}.
+
+check_confirm_on({longstr, Val}, _Args) ->
+    case lists:member(Val, [<<"enqueue">>, <<"ack">>]) of
+        true  -> ok;
+        false -> {error, invalid_confirm_on}
+    end;
+check_confirm_on({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}}.
 
 -spec list() -> [amqqueue:amqqueue()].

--- a/src/rabbit_policies.erl
+++ b/src/rabbit_policies.erl
@@ -46,6 +46,7 @@ register() ->
                           {policy_validator, <<"queue-mode">>},
                           {policy_validator, <<"overflow">>},
                           {policy_validator, <<"delivery-limit">>},
+                          {policy_validator, <<"confirm-on">>},
                           {operator_policy_validator, <<"expires">>},
                           {operator_policy_validator, <<"message-ttl">>},
                           {operator_policy_validator, <<"max-length">>},
@@ -138,7 +139,14 @@ validate_policy0(<<"delivery-limit">>, Value)
   when is_integer(Value), Value >= 0 ->
     ok;
 validate_policy0(<<"delivery-limit">>, Value) ->
-    {error, "~p is not a valid delivery limit", [Value]}.
+    {error, "~p is not a valid delivery limit", [Value]};
+
+validate_policy0(<<"confirm-on">>, <<"enqueue">>) ->
+    ok;
+validate_policy0(<<"confirm-on">>, <<"ack">>) ->
+    ok;
+validate_policy0(<<"confirm-on">>, Value) ->
+    {error, "~p is not a valid confirm-on setting", [Value]}.
 
 merge_policy_value(<<"message-ttl">>, Val, OpVal)      -> min(Val, OpVal);
 merge_policy_value(<<"max-length">>, Val, OpVal)       -> min(Val, OpVal);


### PR DESCRIPTION
Make it possible to configure queues to confirm messages either
on enqueue (default) or on ack.
This will make it possible to communicate to the publisher that the
message was processed by consumer.
For example in federation this will mean that the message is successfully
published on the downstream (1 level).

Configurations:
queue argument `x-confirm-on`
policy `confirm-on`

Values:
`enqueue` - old behaviour, confirm on enqueue (default)
`ack` - new behaviour, confirm when message is acked or dropped

TODO:
- There may still be some ways for a message to leave the queue
without acking. Need to find them all.

- Dead lettering and dropping of the message should probably not
confirm, but reject the message.

- When changing the configuration using policies to `enqueue`,
all messages will be confirmed. Need to implement some sort of
enqueued messages tracker to only confirm enqueued messages.

- Quorum queues