### PR TITLE
Confirm messages on ack.

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -693,7 +693,8 @@ declare_args() ->
      {<<"x-queue-mode">>,              fun check_queue_mode/2},
      {<<"x-single-active-consumer">>,  fun check_single_active_consumer_arg/2},
      {<<"x-queue-type">>,              fun check_queue_type/2},
-     {<<"x-quorum-initial-group-size">>,     fun check_default_quorum_initial_group_size_arg/2}].
+     {<<"x-quorum-initial-group-size">>,     fun check_default_quorum_initial_group_size_arg/2},
+     {<<"x-confirm-on">>,              fun check_confirm_on/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
                    {<<"x-cancel-on-ha-failover">>, fun check_bool_arg/2}].
@@ -784,6 +785,14 @@ check_queue_type({longstr, Val}, _Args) ->
         false -> {error, invalid_queue_type}
     end;
 check_queue_type({Type,    _}, _Args) ->
+    {error, {unacceptable_type, Type}}.
+
+check_confirm_on({longstr, Val}, _Args) ->
+    case lists:member(Val, [<<"enqueue">>, <<"ack">>]) of
+        true  -> ok;
+        false -> {error, invalid_confirm_on}
+    end;
+check_confirm_on({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}}.
 
 -spec list() -> [amqqueue:amqqueue()].

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -694,7 +694,7 @@ declare_args() ->
      {<<"x-single-active-consumer">>,  fun check_single_active_consumer_arg/2},
      {<<"x-queue-type">>,              fun check_queue_type/2},
      {<<"x-quorum-initial-group-size">>,     fun check_default_quorum_initial_group_size_arg/2},
-     {<<"x-confirm-on">>,              fun check_confirm_on/2}].
+     {<<"x-confirm-on">>,              fun confirm_on_not_supported/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
                    {<<"x-cancel-on-ha-failover">>, fun check_bool_arg/2}].
@@ -787,13 +787,8 @@ check_queue_type({longstr, Val}, _Args) ->
 check_queue_type({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}}.
 
-check_confirm_on({longstr, Val}, _Args) ->
-    case lists:member(Val, [<<"enqueue">>, <<"ack">>]) of
-        true  -> ok;
-        false -> {error, invalid_confirm_on}
-    end;
-check_confirm_on({Type,    _}, _Args) ->
-    {error, {unacceptable_type, Type}}.
+confirm_on_not_supported(_, _Args) ->
+    {error, can_only_be_set_as_policy}.
 
 -spec list() -> [amqqueue:amqqueue()].
 

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -62,8 +62,10 @@
             expiry_timer_ref,
             %% stats emission timer
             stats_timer,
-            %% maps message IDs to {channel pid, MsgSeqNo}
-            %% pairs
+            %% a tuple of two maps, which map message IDs to {channel pid, MsgSeqNo} pairs
+            %% first element contains messages not confirmed by the backing queue
+            %% second element contains messages confirmed by the backing queue
+            %% second element is empty if confirm_on is set to enqueue
             msg_id_to_channel,
             %% message TTL value
             ttl,
@@ -97,7 +99,9 @@
             %% running | flow | idle
             status,
             %% true | false
-            single_active_consumer_on
+            single_active_consumer_on,
+            %% enqueue | ack
+            confirm_on
            }).
 
 %%----------------------------------------------------------------------------
@@ -163,11 +167,12 @@ init_state(Q) ->
                has_had_consumers         = false,
                consumers                 = rabbit_queue_consumers:new(),
                senders                   = pmon:new(delegate),
-               msg_id_to_channel         = #{},
+               msg_id_to_channel         = {#{}, #{}},
                status                    = running,
                args_policy_version       = 0,
                overflow                  = 'drop-head',
-               single_active_consumer_on = SingleActiveConsumerOn},
+               single_active_consumer_on = SingleActiveConsumerOn,
+               confirm_on                = enqueue},
     rabbit_event:init_stats_timer(State, #q.stats_timer).
 
 init_it(Recover, From, State = #q{q = Q})
@@ -276,7 +281,7 @@ init_with_backing_queue_state(Q, BQ, BQS,
                      backing_queue_state = BQS,
                      rate_timer_ref      = RateTRef,
                      senders             = Senders,
-                     msg_id_to_channel   = MTC},
+                     msg_id_to_channel   = {MTC, #{}}},
     State2 = process_args_policy(State1),
     State3 = lists:foldl(fun (Delivery, StateN) ->
                                  maybe_deliver_or_enqueue(Delivery, true, StateN)
@@ -429,7 +434,8 @@ process_args_policy(State = #q{q                   = Q,
          {<<"max-length">>,              fun res_min/2, fun init_max_length/2},
          {<<"max-length-bytes">>,        fun res_min/2, fun init_max_bytes/2},
          {<<"overflow">>,                fun res_arg/2, fun init_overflow/2},
-         {<<"queue-mode">>,              fun res_arg/2, fun init_queue_mode/2}],
+         {<<"queue-mode">>,              fun res_arg/2, fun init_queue_mode/2},
+         {<<"confirm-on">>,              fun res_arg/2, fun init_confirm_on/2}],
       drop_expired_msgs(
          lists:foldl(fun({Name, Resolve, Fun}, StateN) ->
                              Fun(args_policy_lookup(Name, Resolve, Q), StateN)
@@ -497,6 +503,18 @@ init_queue_mode(Mode, State = #q {backing_queue = BQ,
     BQS1 = BQ:set_queue_mode(binary_to_existing_atom(Mode, utf8), BQS),
     State#q{backing_queue_state = BQS1}.
 
+init_confirm_on(<<"ack">>, State = #q{confirm_on = enqueue}) ->
+    State#q{confirm_on = ack};
+init_confirm_on(<<"enqueue">>, State = #q{confirm_on = ack,
+                                          msg_id_to_channel = MTC = {_, MTCC}}) ->
+    %% TODO: only confirm enqueued messages.
+    MsgIds = maps:keys(MTCC),
+    MTC1 = confirm_messages(MsgIds, MTC),
+    State#q{msg_id_to_channel = MTC1,
+            confirm_on = enqueue};
+init_confirm_on(_, State) ->
+    State.
+
 reply(Reply, NewState) ->
     {NewState1, Timeout} = next_state(NewState),
     {reply, Reply, ensure_stats_timer(ensure_rate_timer(NewState1)), Timeout}.
@@ -507,16 +525,34 @@ noreply(NewState) ->
 
 next_state(State = #q{backing_queue       = BQ,
                       backing_queue_state = BQS,
-                      msg_id_to_channel   = MTC}) ->
+                      msg_id_to_channel   = MTC0,
+                      confirm_on          = ConfirmOn}) ->
     assert_invariant(State),
     {MsgIds, BQS1} = BQ:drain_confirmed(BQS),
-    MTC1 = confirm_messages(MsgIds, MTC),
-    State1 = State#q{backing_queue_state = BQS1, msg_id_to_channel = MTC1},
+    MTC1 = case ConfirmOn of
+        enqueue -> confirm_messages(MsgIds, MTC0);
+        ack -> mark_messages_confirmed(MsgIds, MTC0)
+    end,
+    State1 = State#q{backing_queue_state = BQS1,
+                     msg_id_to_channel = MTC1},
     case BQ:needs_timeout(BQS1) of
         false -> {stop_sync_timer(State1),   hibernate     };
         idle  -> {stop_sync_timer(State1),   ?SYNC_INTERVAL};
         timed -> {ensure_sync_timer(State1), 0             }
     end.
+
+mark_messages_confirmed(MsgIds, {MTCU0, MTCC0}) ->
+    lists:foldl(
+        fun(MsgId, {MTCU, MTCC}) ->
+            case maps:get(MsgId, MTCU, none) of
+                none -> {MTCU, MTCC};
+                Val ->
+                    {maps:remove(MsgId, MTCU),
+                     maps:put(MsgId, Val, MTCC)}
+            end
+        end,
+        {MTCU0, MTCC0},
+        MsgIds).
 
 backing_queue_module(Q) ->
     case rabbit_mirror_queue_misc:is_mirrored(Q) of
@@ -593,36 +629,90 @@ maybe_send_drained(WasEmpty, State) ->
     end,
     State.
 
+reject_all_messages({MTCU, MTCC} = MTC) ->
+    MsgIds = maps:keys(MTCU) ++ maps:keys(MTCC),
+    reject_messages(MsgIds, MTC).
+
+reject_messages([], MTC) ->
+    MTC;
+reject_messages(MsgIds, {MTCU, MTCC}) ->
+    {CMUs, MTCU1} = select_cms(MsgIds, MTCU),
+    {CMCs, MTCC1} = select_cms(MsgIds, MTCC),
+    maps:fold(
+        fun(Pid, MsgSeqNos, _) ->
+            %% TODO: batch reject
+            [gen_server2:cast(Pid, {reject_publish, MsgSeqNo, self()}) ||
+             MsgSeqNo <- MsgSeqNos],
+            ok
+        end,
+        ok,
+        CMUs),
+    maps:fold(
+        fun(Pid, MsgSeqNos, _) ->
+            %% TODO: batch reject
+            [gen_server2:cast(Pid, {reject_publish, MsgSeqNo, self()}) ||
+             MsgSeqNo <- MsgSeqNos],
+            ok
+        end,
+        ok,
+        CMCs),
+    {MTCU1, MTCC1}.
+
 confirm_messages([], MTC) ->
     MTC;
-confirm_messages(MsgIds, MTC) ->
-    {CMs, MTC1} =
-        lists:foldl(
-          fun(MsgId, {CMs, MTC0}) ->
-                  case maps:get(MsgId, MTC0, none) of
-                      none ->
-                          {CMs, MTC0};
-                      {SenderPid, MsgSeqNo} ->
-                          {maps:update_with(SenderPid,
-                                            fun(MsgSeqNos) ->
-                                                [MsgSeqNo | MsgSeqNos]
-                                            end,
-                                            [MsgSeqNo],
-                                            CMs),
-                           maps:remove(MsgId, MTC0)}
-
-                  end
-          end, {#{}, MTC}, MsgIds),
+confirm_messages(MsgIds, {MTCU, MTCC}) ->
+    {CMUs, MTCU1} = select_cms(MsgIds, MTCU),
+    {CMCs, MTCC1} = select_cms(MsgIds, MTCC),
     maps:fold(
         fun(Pid, MsgSeqNos, _) ->
             rabbit_misc:confirm_to_sender(Pid, MsgSeqNos)
         end,
         ok,
-        CMs),
-    MTC1.
+        CMUs),
+    maps:fold(
+        fun(Pid, MsgSeqNos, _) ->
+            rabbit_misc:confirm_to_sender(Pid, MsgSeqNos)
+        end,
+        ok,
+        CMCs),
+    {MTCU1, MTCC1}.
+
+select_cms(MsgIds, MTCMap0) ->
+    lists:foldl(
+        fun(MsgId, {CMs, MTCMap}) ->
+            case maps:get(MsgId, MTCMap, none) of
+                none ->
+                    {CMs, MTCMap};
+                {SenderPid, MsgSeqNo} ->
+                    {maps:update_with(SenderPid,
+                                      fun(MsgSeqNos) ->
+                                          [MsgSeqNo | MsgSeqNos]
+                                      end,
+                                      [MsgSeqNo],
+                                      CMs),
+                     maps:remove(MsgId, MTCMap)}
+            end
+        end,
+        {#{}, MTCMap0},
+        MsgIds).
 
 send_or_record_confirm(#delivery{confirm    = false}, State) ->
     {never, State};
+send_or_record_confirm(#delivery{confirm    = true,
+                                 sender     = SenderPid,
+                                 msg_seq_no = MsgSeqNo,
+                                 message    = #basic_message{id = MsgId,
+                                                             is_persistent = IsPersistent}},
+                       State = #q{q = Q,
+                                  confirm_on = ack,
+                                  msg_id_to_channel = {MTCU, MTCC}}) ->
+    MTC1 = case ?amqqueue_is_durable(Q) andalso IsPersistent of
+        true ->
+            {maps:put(MsgId, {SenderPid, MsgSeqNo}, MTCU), MTCC};
+        false ->
+            {MTCU, maps:put(MsgId, {SenderPid, MsgSeqNo}, MTCC)}
+    end,
+    {eventually, State#q{msg_id_to_channel = MTC1}};
 send_or_record_confirm(#delivery{confirm    = true,
                                  sender     = SenderPid,
                                  msg_seq_no = MsgSeqNo,
@@ -630,13 +720,15 @@ send_or_record_confirm(#delivery{confirm    = true,
                                    is_persistent = true,
                                    id            = MsgId}},
                        State = #q{q                 = Q,
-                                  msg_id_to_channel = MTC})
+                                  confirm_on        = enqueue,
+                                  msg_id_to_channel = {MTCU, MTCC}})
   when ?amqqueue_is_durable(Q) ->
-    MTC1 = maps:put(MsgId, {SenderPid, MsgSeqNo}, MTC),
-    {eventually, State#q{msg_id_to_channel = MTC1}};
+    MTCU1 = maps:put(MsgId, {SenderPid, MsgSeqNo}, MTCU),
+    {eventually, State#q{msg_id_to_channel = {MTCU1, MTCC}}};
 send_or_record_confirm(#delivery{confirm    = true,
                                  sender     = SenderPid,
-                                 msg_seq_no = MsgSeqNo}, State) ->
+                                 msg_seq_no = MsgSeqNo},
+                       State = #q{confirm_on = enqueue}) ->
     rabbit_misc:confirm_to_sender(SenderPid, [MsgSeqNo]),
     {immediately, State}.
 
@@ -652,13 +744,32 @@ send_mandatory(#delivery{mandatory  = true,
                          msg_seq_no = MsgSeqNo}) ->
     gen_server2:cast(SenderPid, {mandatory_received, MsgSeqNo}).
 
-discard(#delivery{confirm = Confirm,
-                  sender  = SenderPid,
-                  flow    = Flow,
-                  message = #basic_message{id = MsgId}}, BQ, BQS, MTC) ->
+discard_and_confirm(#delivery{confirm = Confirm,
+                              sender  = SenderPid,
+                              flow    = Flow,
+                              message = #basic_message{id = MsgId}},
+                    BQ, BQS, MTC) ->
+    %% TODO: why does discard confirm a message?
     MTC1 = case Confirm of
                true  -> confirm_messages([MsgId], MTC);
                false -> MTC
+           end,
+    BQS1 = BQ:discard(MsgId, SenderPid, Flow, BQS),
+    {BQS1, MTC1}.
+
+discard_and_reject_delivery(#delivery{confirm    = Confirm,
+                                      sender     = SenderPid,
+                                      flow       = Flow,
+                                      msg_seq_no = MsgSeqNo,
+                                      message    = #basic_message{id = MsgId}},
+                            BQ, BQS, {MTCU, MTCC}) ->
+    MTC1 = case Confirm of
+               true  ->
+                   gen_server2:cast(SenderPid, {reject_publish, MsgSeqNo, self()}),
+                   {maps:remove(MsgId, MTCU),
+                    maps:remove(MsgId, MTCC)};
+               false ->
+                   {MTCU, MTCC}
            end,
     BQS1 = BQ:discard(MsgId, SenderPid, Flow, BQS),
     {BQS1, MTC1}.
@@ -696,7 +807,7 @@ attempt_delivery(Delivery = #delivery{sender  = SenderPid,
                                 Message, Props, SenderPid, Flow, BQS),
                           {{Message, Delivered, AckTag}, {BQS1, MTC}};
                (false) -> {{Message, Delivered, undefined},
-                           discard(Delivery, BQ, BQS, MTC)}
+                           discard_and_confirm(Delivery, BQ, BQS, MTC)}
            end, qname(State), State#q.consumers, State#q.single_active_consumer_on, State#q.active_consumer) of
         {delivered, ActiveConsumersChanged, {BQS1, MTC1}, Consumers} ->
             {delivered,   maybe_notify_decorators(
@@ -760,9 +871,17 @@ deliver_or_enqueue(Delivery = #delivery{message = Message,
             State2;
         %% The next one is an optimisation
         {undelivered, State2 = #q{ttl = 0, dlx = undefined,
+                                  backing_queue       = BQ,
                                   backing_queue_state = BQS,
-                                  msg_id_to_channel   = MTC}} ->
-            {BQS1, MTC1} = discard(Delivery, BQ, BQS, MTC),
+                                  msg_id_to_channel   = MTC,
+                                  confirm_on          = ConfirmOn}} ->
+            {BQS1, MTC1} = case ConfirmOn of
+                enqueue ->
+                    discard_and_confirm(Delivery, BQ, BQS, MTC);
+                ack ->
+                    discard_and_reject_delivery(Delivery, BQ, BQS, MTC)
+            end,
+
             State2#q{backing_queue_state = BQS1, msg_id_to_channel = MTC1};
         {undelivered, State2 = #q{backing_queue_state = BQS}} ->
 
@@ -795,7 +914,9 @@ maybe_drop_head(State = #q{overflow = 'drop-head'}) ->
     maybe_drop_head(false, State).
 
 maybe_drop_head(AlreadyDropped, State = #q{backing_queue       = BQ,
-                                           backing_queue_state = BQS}) ->
+                                           backing_queue_state = BQS,
+                                           confirm_on          = ConfirmOn,
+                                           msg_id_to_channel   = MTC}) ->
     case over_max_length(State) of
         true ->
             maybe_drop_head(true,
@@ -803,27 +924,27 @@ maybe_drop_head(AlreadyDropped, State = #q{backing_queue       = BQ,
                               State#q.dlx,
                               fun (X) -> dead_letter_maxlen_msg(X, State) end,
                               fun () ->
-                                      {_, BQS1} = BQ:drop(false, BQS),
-                                      State#q{backing_queue_state = BQS1}
+                                    {DropResult, BQS1} = BQ:drop(false, BQS),
+                                    case {DropResult, ConfirmOn} of
+                                        {{MsgId, _}, ack} ->
+                                            MTC1 = reject_messages([MsgId], MTC),
+                                            State#q{backing_queue_state = BQS1,
+                                                    msg_id_to_channel = MTC1};
+                                        _ ->
+                                            State#q{backing_queue_state = BQS1}
+                                    end
                               end));
         false ->
             {AlreadyDropped, State}
     end.
 
-send_reject_publish(#delivery{confirm = true,
-                              sender = SenderPid,
-                              flow = Flow,
-                              msg_seq_no = MsgSeqNo,
-                              message = #basic_message{id = MsgId}},
-                      _Delivered,
-                      State = #q{ backing_queue = BQ,
-                                  backing_queue_state = BQS,
-                                  msg_id_to_channel   = MTC}) ->
-    gen_server2:cast(SenderPid, {reject_publish, MsgSeqNo, self()}),
-
-    MTC1 = maps:remove(MsgId, MTC),
-    BQS1 = BQ:discard(MsgId, SenderPid, Flow, BQS),
-    State#q{ backing_queue_state = BQS1, msg_id_to_channel = MTC1 };
+send_reject_publish(#delivery{confirm = true} = Delivery,
+                    _Delivered,
+                    State = #q{backing_queue = BQ,
+                               backing_queue_state = BQS,
+                               msg_id_to_channel   = MTC}) ->
+    {BQS1, MTC1} = discard_and_reject_delivery(Delivery, BQ, BQS, MTC),
+    State#q{backing_queue_state = BQS1, msg_id_to_channel = MTC1};
 send_reject_publish(#delivery{confirm = false},
                       _Delivered, State) ->
     State.
@@ -857,17 +978,34 @@ requeue_and_run(AckTags, State = #q{backing_queue       = BQ,
     run_message_queue(maybe_send_drained(WasEmpty, drop_expired_msgs(State1))).
 
 fetch(AckRequired, State = #q{backing_queue       = BQ,
-                              backing_queue_state = BQS}) ->
+                              backing_queue_state = BQS,
+                              confirm_on          = ConfirmOn,
+                              msg_id_to_channel   = MTC}) ->
     {Result, BQS1} = BQ:fetch(AckRequired, BQS),
-    State1 = drop_expired_msgs(State#q{backing_queue_state = BQS1}),
+    MTC1 = case {ConfirmOn, Result, AckRequired} of
+        {ack, {#basic_message{id = MsgId}, _, _}, false} ->
+            confirm_messages([MsgId], MTC);
+        _ -> MTC
+    end,
+    State1 = drop_expired_msgs(State#q{backing_queue_state = BQS1,
+                                       msg_id_to_channel   = MTC1}),
     {Result, maybe_send_drained(Result =:= empty, State1)}.
 
 ack(AckTags, ChPid, State) ->
     subtract_acks(ChPid, AckTags, State,
                   fun (State1 = #q{backing_queue       = BQ,
-                                   backing_queue_state = BQS}) ->
-                          {_Guids, BQS1} = BQ:ack(AckTags, BQS),
-                          State1#q{backing_queue_state = BQS1}
+                                   backing_queue_state = BQS,
+                                   confirm_on          = ConfirmOn,
+                                   msg_id_to_channel   = MTC}) ->
+                        {MsgIds, BQS1} = BQ:ack(AckTags, BQS),
+                        case ConfirmOn of
+                            ack ->
+                                MTC1 = confirm_messages(MsgIds, MTC),
+                                State1#q{backing_queue_state = BQS1,
+                                         msg_id_to_channel = MTC1};
+                            enqueue ->
+                                State1#q{backing_queue_state = BQS1}
+                        end
                   end).
 
 requeue(AckTags, ChPid, State) ->
@@ -1006,19 +1144,37 @@ drop_expired_msgs(State) ->
                                    State)
     end.
 
-drop_expired_msgs(Now, State = #q{backing_queue_state = BQS,
-                                  backing_queue       = BQ }) ->
+drop_expired_msgs(Now, State) ->
     ExpirePred = fun (#message_properties{expiry = Exp}) -> Now >= Exp end,
     {Props, State1} =
         with_dlx(
           State#q.dlx,
           fun (X) -> dead_letter_expired_msgs(ExpirePred, X, State) end,
-          fun () -> {Next, BQS1} = BQ:dropwhile(ExpirePred, BQS),
-                    {Next, State#q{backing_queue_state = BQS1}} end),
+          fun ()  -> delete_expired_msgs(ExpirePred, State) end),
     ensure_ttl_timer(case Props of
                          undefined                         -> undefined;
                          #message_properties{expiry = Exp} -> Exp
                      end, State1).
+
+
+delete_expired_msgs(ExpirePred, State = #q{backing_queue_state = BQS,
+                                           backing_queue       = BQ,
+                                           confirm_on          = ack,
+                                           msg_id_to_channel   = MTC}) ->
+    {Res, Acks, BQS1} =
+        BQ:fetchwhile(ExpirePred,
+                      fun(_, AckTag, AckTags) ->
+                          [AckTag | AckTags]
+                      end,
+                      [], BQS),
+    {MsgIds, BQS2} = BQ:ack(Acks, BQS1),
+    MTC1 = reject_messages(MsgIds, MTC),
+    {Res, State#q{backing_queue_state = BQS2,
+                  msg_id_to_channel = MTC1}};
+delete_expired_msgs(ExpirePred, State = #q{backing_queue_state = BQS,
+                                           backing_queue       = BQ}) ->
+    {Next, BQS1} = BQ:dropwhile(ExpirePred, BQS),
+    {Next, State#q{backing_queue_state = BQS1}}.
 
 with_dlx(undefined, _With,  Without) -> Without();
 with_dlx(DLX,        With,  Without) -> case rabbit_exchange:lookup(DLX) of
@@ -1051,15 +1207,25 @@ dead_letter_maxlen_msg(X, State = #q{backing_queue = BQ}) ->
 
 dead_letter_msgs(Fun, Reason, X, State = #q{dlx_routing_key     = RK,
                                             backing_queue_state = BQS,
-                                            backing_queue       = BQ}) ->
+                                            backing_queue       = BQ,
+                                            confirm_on          = ConfirmOn,
+                                            msg_id_to_channel   = MTC}) ->
     QName = qname(State),
-    {Res, Acks1, BQS1} =
+    {Res, Acks, BQS1} =
         Fun(fun (Msg, AckTag, Acks) ->
                     rabbit_dead_letter:publish(Msg, Reason, X, RK, QName),
                     [AckTag | Acks]
             end, [], BQS),
-    {_Guids, BQS2} = BQ:ack(Acks1, BQS1),
-    {Res, State#q{backing_queue_state = BQS2}}.
+    %% TODO: should the message be rejected if it's dead-lettered
+    {MsgIds, BQS2} = BQ:ack(Acks, BQS1),
+    case ConfirmOn of
+        ack ->
+            MTC1 = reject_messages(MsgIds, MTC),
+            {Res, State#q{backing_queue_state = BQS2,
+                          msg_id_to_channel = MTC1}};
+        enqueue ->
+            {Res, State#q{backing_queue_state = BQS2}}
+    end.
 
 stop(State) -> stop(noreply, State).
 
@@ -1296,7 +1462,7 @@ handle_call({notify_down, ChPid}, _From, State) ->
     end;
 
 handle_call({basic_get, ChPid, NoAck, LimiterPid}, _From,
-            State = #q{q = Q}) ->
+            State = #q{q = Q, confirm_on = ConfirmOn, msg_id_to_channel = MTC}) ->
     QName = amqqueue:get_name(Q),
     AckRequired = not NoAck,
     State1 = ensure_expiry_timer(State),
@@ -1305,13 +1471,23 @@ handle_call({basic_get, ChPid, NoAck, LimiterPid}, _From,
             reply(empty, State2);
         {{Message, IsDelivered, AckTag},
          #q{backing_queue = BQ, backing_queue_state = BQS} = State2} ->
-            case AckRequired of
-                true  -> ok = rabbit_queue_consumers:record_ack(
-                                ChPid, LimiterPid, AckTag);
-                false -> ok
+            State3 = case AckRequired of
+                true  ->
+                    ok = rabbit_queue_consumers:record_ack(
+                                ChPid, LimiterPid, AckTag),
+                    State2;
+                false ->
+                    case ConfirmOn of
+                        ack ->
+                            MsgId = Message#basic_message.id,
+                            MTC1 = confirm_messages([MsgId], MTC),
+                            State2#q{msg_id_to_channel = MTC1};
+                        enqueue ->
+                            State2
+                    end
             end,
             Msg = {QName, self(), AckTag, IsDelivered, Message},
-            reply({ok, BQ:len(BQS), Msg}, State2)
+            reply({ok, BQ:len(BQS), Msg}, State3)
     end;
 
 handle_call({basic_consume, NoAck, ChPid, LimiterPid, LimiterActive,
@@ -1433,9 +1609,19 @@ handle_call({delete, IfUnused, IfEmpty, ActingUser}, _From,
     end;
 
 handle_call(purge, _From, State = #q{backing_queue       = BQ,
-                                     backing_queue_state = BQS}) ->
+                                     backing_queue_state = BQS,
+                                     confirm_on          = ConfirmOn,
+                                     msg_id_to_channel   = MTC}) ->
     {Count, BQS1} = BQ:purge(BQS),
-    State1 = State#q{backing_queue_state = BQS1},
+    %% TODO: test race between purge and confirm in enqueue mode
+    State1 = case ConfirmOn of
+        ack ->
+            MTC1 = reject_all_messages(MTC),
+            State#q{backing_queue_state = BQS1,
+                    msg_id_to_channel = MTC1};
+        _ ->
+            State#q{backing_queue_state = BQS1}
+    end,
     reply({ok, Count}, maybe_send_drained(Count =:= 0, State1));
 
 handle_call({requeue, AckTags, ChPid}, From, State) ->

--- a/src/rabbit_policies.erl
+++ b/src/rabbit_policies.erl
@@ -46,6 +46,7 @@ register() ->
                           {policy_validator, <<"queue-mode">>},
                           {policy_validator, <<"overflow">>},
                           {policy_validator, <<"delivery-limit">>},
+                          {policy_validator, <<"confirm-on">>},
                           {operator_policy_validator, <<"expires">>},
                           {operator_policy_validator, <<"message-ttl">>},
                           {operator_policy_validator, <<"max-length">>},
@@ -140,7 +141,14 @@ validate_policy0(<<"delivery-limit">>, Value)
   when is_integer(Value), Value >= 0 ->
     ok;
 validate_policy0(<<"delivery-limit">>, Value) ->
-    {error, "~p is not a valid delivery limit", [Value]}.
+    {error, "~p is not a valid delivery limit", [Value]};
+
+validate_policy0(<<"confirm-on">>, <<"enqueue">>) ->
+    ok;
+validate_policy0(<<"confirm-on">>, <<"ack">>) ->
+    ok;
+validate_policy0(<<"confirm-on">>, Value) ->
+    {error, "~p is not a valid confirm-on setting", [Value]}.
 
 merge_policy_value(<<"message-ttl">>, Val, OpVal)      -> min(Val, OpVal);
 merge_policy_value(<<"max-length">>, Val, OpVal)       -> min(Val, OpVal);

--- a/test/confirms_rejects_SUITE.erl
+++ b/test/confirms_rejects_SUITE.erl
@@ -20,7 +20,18 @@ groups() ->
         {overflow_reject_publish_dlx, [parallel], OverflowTests},
         {overflow_reject_publish, [parallel], OverflowTests},
         dead_queue_rejects,
-        mixed_dead_alive_queues_reject
+        mixed_dead_alive_queues_reject,
+        {confirm_on_ack, [],
+         [coa_policy_resets_to_enqueue,
+          coa_confirms_on_ack,
+          coa_rejects_on_nack_without_requeue,
+          coa_confirms_on_no_ack,
+          coa_rejects_on_ttl,
+          coa_rejects_on_drop_head,
+          coa_rejects_on_purge,
+          coa_rejects_on_dead_letter
+         ]
+        }
       ]}
     ].
 
@@ -59,7 +70,16 @@ end_per_group(_Group, Config) ->
       rabbit_ct_client_helpers:teardown_steps() ++
       rabbit_ct_broker_helpers:teardown_steps()).
 
-init_per_testcase(policy_resets_to_default = Testcase, Config) ->
+init_per_testcase(Testcase, Config)
+        when Testcase == policy_resets_to_default;
+             Testcase == coa_policy_resets_to_enqueue;
+             Testcase == coa_confirms_on_no_ack;
+             Testcase == coa_confirms_on_ack;
+             Testcase == coa_rejects_on_nack_without_requeue;
+             Testcase == coa_rejects_on_dead_letter;
+             Testcase == coa_rejects_on_drop_head;
+             Testcase == coa_rejects_on_ttl;
+             Testcase == coa_rejects_on_purge  ->
     Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config),
     rabbit_ct_helpers:testcase_started(
         rabbit_ct_helpers:set_config(Config, [{conn, Conn}]), Testcase);
@@ -74,17 +94,48 @@ init_per_testcase(Testcase, Config)
         rabbit_ct_helpers:set_config(Config, [{conn, Conn}, {conn1, Conn1}]),
         Testcase).
 
+end_per_testcase(coa_rejects_on_dead_letter = Testcase, Config) ->
+    {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
+    QueueName = atom_to_binary(Testcase, utf8),
+    amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
+    amqp_channel:call(Ch, #'exchange.delete'{exchange = QueueName}),
+    amqp_channel:call(Ch, #'queue.delete'{queue = <<QueueName/binary, "_dlq">>}),
+    rabbit_ct_broker_helpers:clear_policy(Config, 0, QueueName),
+    rabbit_ct_client_helpers:close_channels_and_connection(Config, 0),
+    Conn = ?config(conn, Config),
+    rabbit_ct_client_helpers:close_connection(Conn),
+    clean_consume_mailbox(),
+    clean_acks_mailbox(),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
+end_per_testcase(Testcase, Config)
+        when Testcase == coa_confirms_on_ack;
+             Testcase == coa_confirms_on_no_ack;
+             Testcase == coa_policy_resets_to_enqueue;
+             Testcase == coa_rejects_on_nack_without_requeue;
+             Testcase == coa_rejects_on_dead_letter;
+             Testcase == coa_rejects_on_drop_head;
+             Testcase == coa_rejects_on_ttl;
+             Testcase == coa_rejects_on_purge ->
+    {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
+    QueueName = atom_to_binary(Testcase, utf8),
+    amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
+    rabbit_ct_broker_helpers:clear_policy(Config, 0, QueueName),
+    rabbit_ct_client_helpers:close_channels_and_connection(Config, 0),
+    Conn = ?config(conn, Config),
+    rabbit_ct_client_helpers:close_connection(Conn),
+    clean_consume_mailbox(),
+    clean_acks_mailbox(),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(policy_resets_to_default = Testcase, Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
     XOverflow = ?config(overflow, Config),
     QueueName = <<"policy_resets_to_default", "_", XOverflow/binary>>,
     amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
     rabbit_ct_client_helpers:close_channels_and_connection(Config, 0),
-
     Conn = ?config(conn, Config),
-
     rabbit_ct_client_helpers:close_connection(Conn),
-
+    clean_consume_mailbox(),
+    clean_acks_mailbox(),
     rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(confirms_rejects_conflict = Testcase, Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
@@ -113,6 +164,7 @@ end_per_testcase0(Testcase, Config) ->
     rabbit_ct_client_helpers:close_connection(Conn1),
 
     clean_acks_mailbox(),
+    clean_consume_mailbox(),
 
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
@@ -315,6 +367,386 @@ policy_resets_to_default(Config) ->
         _ -> ok
     end.
 
+coa_policy_resets_to_enqueue(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_policy_resets_to_enqueue">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<>>}),
+
+    assert_ack(1),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>}]),
+
+    %% Wait for the policy to apply
+    wait_for_confirm_on(Config, QueueName, ack, 10000),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    receive {'basic.ack', _, _} -> error(unexpected_ack)
+    after 1000 -> ok
+    end,
+
+    rabbit_ct_broker_helpers:clear_policy(Config, 0, QueueName),
+
+    wait_for_confirm_on(Config, QueueName, enqueue, 10000),
+
+    assert_ack(2).
+
+coa_confirms_on_ack(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_confirms_on_ack">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<>>}),
+
+    receive {'basic.ack', 1, _} -> ok
+    after 10000 -> error({timeout_waiting_for_ack, process_info(self(), messages)})
+    end,
+    clean_acks_mailbox(),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>}]),
+
+    %% Wait for the policy to apply
+    wait_for_confirm_on(Config, QueueName, ack, 10000),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    receive {'basic.ack', _, _} -> error(unexpected_ack)
+    after 1000 -> ok
+    end,
+
+    consume_all(Ch, QueueName, false,
+        fun(Tag) ->
+            amqp_channel:call(Ch, #'basic.ack'{delivery_tag = Tag})
+        end),
+
+    receive {'basic.ack', 2, _} -> ok
+    after 10000 -> error({timeout_waiting_for_ack, process_info(self(), messages)})
+    end,
+    clean_acks_mailbox().
+
+coa_rejects_on_nack_without_requeue(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_rejects_on_nack_without_requeue">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>}]),
+
+    %% Wait for the policy to apply
+    wait_for_confirm_on(Config, QueueName, ack, 10000),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    receive {'basic.ack', _, _} -> error(unexpected_ack)
+    after 1000 -> ok
+    end,
+
+    #'basic.consume_ok'{consumer_tag = CTag} =
+        amqp_channel:subscribe(Ch, #'basic.consume'{queue = QueueName}, self()),
+
+    %% Requeue should not ack or nack the message.
+    receive
+        {#'basic.deliver'{delivery_tag = Tag}, #amqp_msg{payload = <<"message">>}} ->
+            amqp_channel:call(Ch, #'basic.nack'{delivery_tag = Tag, requeue = true})
+    after 10000 ->
+        error(expecting_delivery)
+    end,
+
+    receive
+        {'basic.ack', _, _} -> error(unexpected_ack);
+        {'basic.nack', _, _, _} -> error(unexpected_nack)
+    after 1000 -> ok
+    end,
+
+    %% If requeue is false - the message should be nacked
+    receive
+        {#'basic.deliver'{delivery_tag = Tag1}, #amqp_msg{payload = <<"message">>}} ->
+            amqp_channel:call(Ch, #'basic.nack'{delivery_tag = Tag1, requeue = false})
+    after 10000 ->
+        error(expecting_delivery)
+    end,
+
+    receive
+        {'basic.ack', _, _} -> error(expecting_nack_got_ack);
+        {'basic.nack', _, _, _} -> ok
+    after 10000 -> error(timeout_waiting_for_nack)
+    end,
+    amqp_channel:call(Ch, #'basic.cancel'{consumer_tag = CTag}),
+    clean_consume_mailbox(),
+    clean_acks_mailbox().
+
+coa_confirms_on_no_ack(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_confirms_on_no_ack">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>}]),
+
+    %% Wait for the policy to apply
+    wait_for_confirm_on(Config, QueueName, ack, 10000),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    receive {'basic.ack', _, _} -> error(unexpected_ack)
+    after 1000 -> ok
+    end,
+
+    consume_all(Ch, QueueName, true,
+        fun(Tag) ->
+            ok
+        end),
+
+    receive {'basic.ack', _, _} -> ok
+    after 10000 -> error({timeout_waiting_for_ack, process_info(self(), messages)})
+    end,
+    clean_acks_mailbox().
+
+coa_rejects_on_ttl(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_rejects_on_ttl">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>}, {<<"message-ttl">>, 200}]),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    ct:sleep(200),
+
+    receive
+        {'basic.ack', _, _} -> error(expecting_nack_got_ack);
+        {'basic.nack', _, _, _} -> ok
+    after 10000 -> error(timeout_waiting_for_nack)
+    end,
+    clean_acks_mailbox().
+
+coa_rejects_on_drop_head(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_rejects_on_drop_head">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>},
+         {<<"max-length">>, 1}]),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    receive
+        {'basic.ack', _, _} -> error(expecting_nack_got_ack);
+        %% First message is dropped from the head
+        {'basic.nack', 1, _, _} -> ok
+    after 10000 -> error(timeout_waiting_for_nack)
+    end,
+    clean_acks_mailbox().
+
+coa_rejects_on_purge(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_rejects_on_purge">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>}]),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message">>}),
+
+    receive
+        {'basic.ack', _, _} -> error(unexpected_ack);
+        {'basic.nack', _, _, _} -> error(unexpected_nack)
+    after 1000 -> ok
+    end,
+
+    amqp_channel:call(Ch, #'queue.purge'{queue = QueueName}),
+
+    receive
+        {'basic.ack', _, _} ->
+            error(expecting_nack_got_ack);
+        {'basic.nack', 1, _, _} ->
+            receive {'basic.nack', 2, _, _} -> ok
+            after 10000 -> error(timeout_waiting_for_nack)
+            end;
+        {'basic.nack', 2, true, _} ->
+            ok
+    after 10000 ->
+        error(timeout_waiting_for_nack)
+    end,
+
+    clean_acks_mailbox().
+
+coa_rejects_on_dead_letter(Config) ->
+    Conn = ?config(conn, Config),
+
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    QueueName = <<"coa_rejects_on_dead_letter">>,
+    %% The queue is declared as default
+    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
+                                           durable = true}),
+
+    DLX = QueueName,
+    DLQ = <<QueueName/binary, "_dlq">>,
+
+    amqp_channel:call(Ch, #'exchange.declare'{exchange = DLX, type = <<"fanout">>}),
+    amqp_channel:call(Ch, #'queue.declare'{queue = DLQ}),
+    amqp_channel:call(Ch, #'queue.bind'{exchange = DLX, queue = DLQ}),
+
+    rabbit_ct_broker_helpers:set_policy(
+        Config, 0,
+        QueueName, QueueName, <<"queues">>,
+        [{<<"confirm-on">>, <<"ack">>},
+         {<<"max-length">>, 1},
+         {<<"dead-letter-exchange">>, DLX}]),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message1">>}),
+
+    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
+                          #amqp_msg{payload = <<"message2">>}),
+
+    timer:sleep(10000),
+    receive
+        {'basic.ack', _, _} -> error(expecting_nack_got_ack);
+        %% First message is dropped from the head
+        {'basic.nack', 1, _, _} -> ok
+    after 10000 -> error(timeout_waiting_for_nack)
+    end,
+    clean_acks_mailbox(),
+
+    %% The message is dead-lettered
+    {#'basic.get_ok'{}, #amqp_msg{payload = <<"message1">>}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = DLQ}).
+
+
+consume_all(Ch, QueueName, NoAck, Fun) ->
+    #'basic.consume_ok'{consumer_tag = CTag} =
+        amqp_channel:subscribe(Ch,
+                               #'basic.consume'{queue = QueueName,
+                                                no_ack = NoAck},
+                               self()),
+    loop_consume_and_ack(Ch, Fun),
+    amqp_channel:call(Ch, #'basic.cancel'{consumer_tag = CTag}),
+    clean_consume_mailbox().
+
+loop_consume_and_ack(Ch, Fun) ->
+    receive
+        {#'basic.deliver'{delivery_tag = Tag}, #amqp_msg{}} ->
+            Fun(Tag),
+            loop_consume_and_ack(Ch, Fun)
+    after 10000 ->
+        ok
+    end.
+
+wait_for_confirm_on(_Config, QueueName, ConfirmOn, Time) when Time =< 0 ->
+    error({timeout_waiting_for_confirm_on_setting, ConfirmOn, QueueName});
+wait_for_confirm_on(Config, QueueName, ConfirmOn, Time) ->
+    {ok, Q} = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                           rabbit_amqqueue, lookup,
+                                           [{resource, <<"/">>, queue, QueueName}]),
+    [{confirm_on, ConfirmOnInfo}] =
+        rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, info, [Q, [confirm_on]]),
+    case ConfirmOnInfo of
+        ConfirmOn -> ok;
+        _ ->
+            SleepTime = 100,
+            ct:sleep(SleepTime),
+            wait_for_confirm_on(Config, QueueName, ConfirmOn, Time - SleepTime)
+    end.
+
+
+%% Helpers
+
 consume_all_messages(Ch, QueueName) ->
     consume_all_messages(Ch, QueueName, []).
 
@@ -324,6 +756,12 @@ consume_all_messages(Ch, QueueName, Msgs) ->
             consume_all_messages(Ch, QueueName, [Msg | Msgs]);
         #'basic.get_empty'{} -> Msgs
     end.
+
+assert_ack(N) ->
+    receive {'basic.ack', N, _} -> ok
+    after 10000 -> error({timeout_waiting_for_ack, process_info(self(), messages)})
+    end,
+    clean_acks_mailbox().
 
 assert_ack() ->
     receive {'basic.ack', _, _} -> ok
@@ -374,6 +812,15 @@ clean_acks_mailbox() ->
     receive
         {'basic.ack', _, _} -> clean_acks_mailbox();
         {'basic.nack', _, _, _} -> clean_acks_mailbox()
+    after
+        1000 -> done
+    end.
+
+clean_consume_mailbox() ->
+    receive
+        #'basic.consume_ok'{} -> clean_consume_mailbox();
+        #'basic.cancel_ok'{} -> clean_consume_mailbox();
+        {#'basic.deliver'{}, _} -> clean_consume_mailbox()
     after
         1000 -> done
     end.


### PR DESCRIPTION
Make it possible to configure queues to confirm messages either on enqueue (default) or on ack.
This will make it possible to communicate to the publisher that the message was processed by consumer.
For example in federation this will mean that the message is successfully published on the downstream (1 level).

Configurations:
queue argument `x-confirm-on`
policy `confirm-on`

Values:
`enqueue` - old behaviour, confirm on enqueue (default)
`ack` - new behaviour, confirm when message is acked or dropped

TODO:
- [x] There may still be some ways for a message to leave the queue
without acking. Need to find them all.

- [x] Dead lettering and dropping of the message should probably not
confirm, but reject the message.

- [x] When changing the configuration using policies to `enqueue`,
all messages will be confirmed. Need to implement some sort of
enqueued messages tracker to only confirm enqueued messages.

- [ ] Quorum queues

- [ ] Mirrored queues

- [x] rabbitmqctl info item