### PR TITLE
fix missing quote in argument to handle directories with spaces properly

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -318,7 +318,7 @@ if "!RABBITMQ_ENABLED_PLUGINS_FILE!"=="" (
     set RABBITMQ_ENABLED_PLUGINS_FILE_source=environment
 )
 if not exist "!RABBITMQ_ENABLED_PLUGINS_FILE!" (
-    for /f "delims=" %%F in ("!RABBITMQ_ENABLED_PLUGINS_FILE!") do mkdir %%~dpF 2>NUL
+    for /f "delims=" %%F in ("!RABBITMQ_ENABLED_PLUGINS_FILE!") do mkdir "%%~dpF" 2>NUL
     copy /y NUL "!RABBITMQ_ENABLED_PLUGINS_FILE!" >NUL
 )
 for /f "delims=" %%F in ("!RABBITMQ_ENABLED_PLUGINS_FILE!") do set RABBITMQ_ENABLED_PLUGINS_FILE=%%~sF
@@ -350,7 +350,7 @@ if "!RABBITMQ_LOGS!"=="" (
 )
 if not "!RABBITMQ_LOGS!" == "-" (
     if not exist "!RABBITMQ_LOGS!" (
-        for /f "delims=" %%F in ("!RABBITMQ_LOGS!") do mkdir %%~dpF 2>NUL
+        for /f "delims=" %%F in ("!RABBITMQ_LOGS!") do mkdir "%%~dpF" 2>NUL
         copy /y NUL "!RABBITMQ_LOGS!" >NUL
     )
     for /f "delims=" %%F in ("!RABBITMQ_LOGS!") do set RABBITMQ_LOGS=%%~sF


### PR DESCRIPTION
## Proposed Changes

Put the argument to mkdir in quotes in rabbitmq-env.bat in quotes to handle cases where RABBITMQ_BASE contains whitespaces.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2025)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
