### PR TITLE
Backport the `amqqueue` API to RabbitMQ 3.7.x

### DIFF
--- a/include/amqqueue.hrl
+++ b/include/amqqueue.hrl
@@ -1,0 +1,93 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2018-2019 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-include("amqqueue_v1.hrl").
+
+-define(is_amqqueue(Q),
+        (?is_amqqueue_v1(Q))).
+
+-define(amqqueue_is_auto_delete(Q),
+        ((?is_amqqueue_v1(Q) andalso
+          ?amqqueue_v1_field_auto_delete(Q) =:= true))).
+
+-define(amqqueue_is_durable(Q),
+        ((?is_amqqueue_v1(Q) andalso
+          ?amqqueue_v1_field_durable(Q) =:= true))).
+
+-define(amqqueue_exclusive_owner_is(Q, Owner),
+        ((?is_amqqueue_v1(Q) andalso
+          ?amqqueue_v1_field_exclusive_owner(Q) =:= Owner))).
+
+-define(amqqueue_exclusive_owner_is_pid(Q),
+        ((?is_amqqueue_v1(Q) andalso
+          is_pid(?amqqueue_v1_field_exclusive_owner(Q))))).
+
+-define(amqqueue_state_is(Q, State),
+        ((?is_amqqueue_v1(Q) andalso
+          ?amqqueue_v1_field_state(Q) =:= State))).
+
+-define(amqqueue_v1_type, classic).
+
+-define(amqqueue_is_classic(Q),
+        (?is_amqqueue_v1(Q))).
+
+-define(amqqueue_is_quorum(Q),
+        false).
+
+-define(amqqueue_has_valid_pid(Q),
+        (?is_amqqueue_v1(Q) andalso
+         is_pid(?amqqueue_v1_field_pid(Q)))).
+
+-define(amqqueue_pid_runs_on_local_node(Q),
+        (?is_amqqueue_v1(Q) andalso
+         node(?amqqueue_v1_field_pid(Q)) =:= node())).
+
+-define(amqqueue_pid_equals(Q, Pid),
+        ((?is_amqqueue_v1(Q) andalso
+          ?amqqueue_v1_field_pid(Q) =:= Pid))).
+
+-define(amqqueue_pids_are_equal(Q0, Q1),
+        ((?is_amqqueue_v1(Q0) andalso ?is_amqqueue_v1(Q1) andalso
+          ?amqqueue_v1_field_pid(Q0) =:= ?amqqueue_v1_field_pid(Q1)))).
+
+-define(amqqueue_field_name(Q),
+        case ?is_amqqueue_v1(Q) of
+            true -> ?amqqueue_v1_field_name(Q)
+        end).
+
+-define(amqqueue_field_pid(Q),
+        case ?is_amqqueue_v1(Q) of
+            true -> ?amqqueue_v1_field_pid(Q)
+        end).
+
+-define(amqqueue_v1_vhost(Q), element(2, ?amqqueue_v1_field_name(Q))).
+
+-define(amqqueue_vhost_equals(Q, VHost),
+        ((?is_amqqueue_v1(Q) andalso
+          ?amqqueue_v1_vhost(Q) =:= VHost))).
+
+-define(enable_quorum_queue_if_debug, noop).
+
+-define(try_mnesia_tx_or_upgrade_amqqueue_and_retry(Expr1, Expr2),
+        try
+            ?enable_quorum_queue_if_debug,
+            Expr1
+        catch
+            throw:{error, {bad_type, T}} when ?is_amqqueue(T) ->
+                Expr2;
+            throw:{aborted, {bad_type, T}} when ?is_amqqueue(T) ->
+                Expr2
+        end).

--- a/include/amqqueue_v1.hrl
+++ b/include/amqqueue_v1.hrl
@@ -1,0 +1,20 @@
+-define(is_amqqueue_v1(Q), is_record(Q, amqqueue, 19)).
+
+-define(amqqueue_v1_field_name(Q), element(2, Q)).
+-define(amqqueue_v1_field_durable(Q), element(3, Q)).
+-define(amqqueue_v1_field_auto_delete(Q), element(4, Q)).
+-define(amqqueue_v1_field_exclusive_owner(Q), element(5, Q)).
+-define(amqqueue_v1_field_arguments(Q), element(6, Q)).
+-define(amqqueue_v1_field_pid(Q), element(7, Q)).
+-define(amqqueue_v1_field_slave_pids(Q), element(8, Q)).
+-define(amqqueue_v1_field_sync_slave_pids(Q), element(9, Q)).
+-define(amqqueue_v1_field_recoverable_slaves(Q), element(10, Q)).
+-define(amqqueue_v1_field_policy(Q), element(11, Q)).
+-define(amqqueue_v1_field_operator_policy(Q), element(12, Q)).
+-define(amqqueue_v1_field_gm_pids(Q), element(13, Q)).
+-define(amqqueue_v1_field_decorators(Q), element(14, Q)).
+-define(amqqueue_v1_field_state(Q), element(15, Q)).
+-define(amqqueue_v1_field_policy_version(Q), element(16, Q)).
+-define(amqqueue_v1_field_slave_pids_pending_shutdown(Q), element(17, Q)).
+-define(amqqueue_v1_field_vhost(Q), element(18, Q)).
+-define(amqqueue_v1_field_options(Q), element(19, Q)).

--- a/src/amqqueue.erl
+++ b/src/amqqueue.erl
@@ -1,0 +1,561 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2018-2019 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(amqqueue).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include("amqqueue.hrl").
+
+-export([new/8,
+         new/9,
+         new_with_version/9,
+         new_with_version/10,
+         fields/0,
+         fields/1,
+         field_vhost/0,
+         record_version_to_use/0,
+         upgrade/1,
+         upgrade_to/2,
+         % arguments
+         get_arguments/1,
+         set_arguments/2,
+         % decorators
+         get_decorators/1,
+         set_decorators/2,
+         % exclusive_owner
+         get_exclusive_owner/1,
+         % gm_pids
+         get_gm_pids/1,
+         set_gm_pids/2,
+         get_leader/1,
+         % name (#resource)
+         get_name/1,
+         set_name/2,
+         % operator_policy
+         get_operator_policy/1,
+         set_operator_policy/2,
+         get_options/1,
+         % pid
+         get_pid/1,
+         set_pid/2,
+         % policy
+         get_policy/1,
+         set_policy/2,
+         % policy_version
+         get_policy_version/1,
+         set_policy_version/2,
+         % quorum_nodes
+         get_quorum_nodes/1,
+         set_quorum_nodes/2,
+         % recoverable_slaves
+         get_recoverable_slaves/1,
+         set_recoverable_slaves/2,
+         % slave_pids
+         get_slave_pids/1,
+         set_slave_pids/2,
+         % slave_pids_pending_shutdown
+         get_slave_pids_pending_shutdown/1,
+         set_slave_pids_pending_shutdown/2,
+         % state
+         get_state/1,
+         set_state/2,
+         % sync_slave_pids
+         get_sync_slave_pids/1,
+         set_sync_slave_pids/2,
+         get_type/1,
+         get_vhost/1,
+         is_amqqueue/1,
+         is_auto_delete/1,
+         is_durable/1,
+         is_classic/1,
+         is_quorum/1,
+         pattern_match_all/0,
+         pattern_match_on_name/1,
+         pattern_match_on_type/1,
+         reset_mirroring_and_decorators/1,
+         set_immutable/1,
+         qnode/1,
+         macros/0]).
+
+-define(record_version, amqqueue_v1).
+
+-type amqqueue() :: amqqueue_v1().
+-type amqqueue_v1() :: #amqqueue{
+                          name :: rabbit_amqqueue:name(),
+                          durable :: boolean(),
+                          auto_delete :: boolean(),
+                          exclusive_owner :: pid() | none,
+                          arguments :: rabbit_framing:amqp_table(),
+                          pid :: pid() | none,
+                          slave_pids :: [pid()] | none,
+                          sync_slave_pids :: [pid()] | none,
+                          recoverable_slaves :: [atom()] | none,
+                          policy :: binary() | none | undefined,
+                          operator_policy :: binary() | none | undefined,
+                          gm_pids :: [pid()] | none,
+                          decorators :: [atom()] | none | undefined,
+                          state :: atom() | none,
+                          policy_version :: non_neg_integer(),
+                          slave_pids_pending_shutdown :: [pid()],
+                          vhost :: rabbit_types:vhost() | undefined,
+                          options :: map()
+                         }.
+
+-type amqqueue_pattern() :: amqqueue_v1_pattern().
+-type amqqueue_v1_pattern() :: #amqqueue{
+                                  name :: rabbit_amqqueue:name() | '_',
+                                  durable :: '_',
+                                  auto_delete :: '_',
+                                  exclusive_owner :: '_',
+                                  arguments :: '_',
+                                  pid :: '_',
+                                  slave_pids :: '_',
+                                  sync_slave_pids :: '_',
+                                  recoverable_slaves :: '_',
+                                  policy :: '_',
+                                  operator_policy :: '_',
+                                  gm_pids :: '_',
+                                  decorators :: '_',
+                                  state :: '_',
+                                  policy_version :: '_',
+                                  slave_pids_pending_shutdown :: '_',
+                                  vhost :: '_',
+                                  options :: '_'
+                                 }.
+
+-export_type([amqqueue/0,
+              amqqueue_v1/0,
+              amqqueue_pattern/0,
+              amqqueue_v1_pattern/0]).
+
+-spec new(rabbit_amqqueue:name(),
+          pid() | none,
+          boolean(),
+          boolean(),
+          pid() | none,
+          rabbit_framing:amqp_table(),
+          rabbit_types:vhost() | undefined,
+          map()) -> amqqueue().
+
+new(#resource{kind = queue} = Name,
+    Pid,
+    Durable,
+    AutoDelete,
+    Owner,
+    Args,
+    VHost,
+    Options)
+  when (is_pid(Pid) orelse Pid =:= none) andalso
+       is_boolean(Durable) andalso
+       is_boolean(AutoDelete) andalso
+       (is_pid(Owner) orelse Owner =:= none) andalso
+       is_list(Args) andalso
+       (is_binary(VHost) orelse VHost =:= undefined) andalso
+       is_map(Options) ->
+    new_with_version(
+      ?record_version,
+      Name,
+      Pid,
+      Durable,
+      AutoDelete,
+      Owner,
+      Args,
+      VHost,
+      Options).
+
+-spec new(rabbit_amqqueue:name(),
+          pid() | none,
+          boolean(),
+          boolean(),
+          pid() | none,
+          rabbit_framing:amqp_table(),
+          rabbit_types:vhost() | undefined,
+          map(),
+          ?amqqueue_v1_type) -> amqqueue().
+
+new(#resource{kind = queue} = Name,
+    Pid,
+    Durable,
+    AutoDelete,
+    Owner,
+    Args,
+    VHost,
+    Options,
+    ?amqqueue_v1_type)
+  when (is_pid(Pid) orelse Pid =:= none) andalso
+       is_boolean(Durable) andalso
+       is_boolean(AutoDelete) andalso
+       (is_pid(Owner) orelse Owner =:= none) andalso
+       is_list(Args) andalso
+       (is_binary(VHost) orelse VHost =:= undefined) andalso
+       is_map(Options) ->
+    new(
+      Name,
+      Pid,
+      Durable,
+      AutoDelete,
+      Owner,
+      Args,
+      VHost,
+      Options).
+
+-spec new_with_version(amqqueue_v1,
+                       rabbit_amqqueue:name(),
+                       pid() | none,
+                       boolean(),
+                       boolean(),
+                       pid() | none,
+                       rabbit_framing:amqp_table(),
+                       rabbit_types:vhost() | undefined,
+                       map()) -> amqqueue().
+
+new_with_version(?record_version,
+                 #resource{kind = queue} = Name,
+                 Pid,
+                 Durable,
+                 AutoDelete,
+                 Owner,
+                 Args,
+                 VHost,
+                 Options)
+  when (is_pid(Pid) orelse Pid =:= none) andalso
+       is_boolean(Durable) andalso
+       is_boolean(AutoDelete) andalso
+       (is_pid(Owner) orelse Owner =:= none) andalso
+       is_list(Args) andalso
+       (is_binary(VHost) orelse VHost =:= undefined) andalso
+       is_map(Options) ->
+    #amqqueue{name            = Name,
+              durable         = Durable,
+              auto_delete     = AutoDelete,
+              arguments       = Args,
+              exclusive_owner = Owner,
+              pid             = Pid,
+              vhost           = VHost,
+              options         = Options}.
+
+-spec new_with_version(amqqueue_v1,
+                       rabbit_amqqueue:name(),
+                       pid() | none,
+                       boolean(),
+                       boolean(),
+                       pid() | none,
+                       rabbit_framing:amqp_table(),
+                       rabbit_types:vhost() | undefined,
+                       map(),
+                       ?amqqueue_v1_type) -> amqqueue().
+
+new_with_version(?record_version,
+                 #resource{kind = queue} = Name,
+                 Pid,
+                 Durable,
+                 AutoDelete,
+                 Owner,
+                 Args,
+                 VHost,
+                 Options,
+                 ?amqqueue_v1_type)
+  when (is_pid(Pid) orelse Pid =:= none) andalso
+       is_boolean(Durable) andalso
+       is_boolean(AutoDelete) andalso
+       (is_pid(Owner) orelse Owner =:= none) andalso
+       is_list(Args) andalso
+       (is_binary(VHost) orelse VHost =:= undefined) andalso
+       is_map(Options) ->
+    new_with_version(
+      ?record_version,
+      Name,
+      Pid,
+      Durable,
+      AutoDelete,
+      Owner,
+      Args,
+      VHost,
+      Options).
+
+-spec is_amqqueue(any()) -> boolean().
+
+is_amqqueue(#amqqueue{}) -> true;
+is_amqqueue(_)           -> false.
+
+-spec record_version_to_use() -> amqqueue_v1.
+
+record_version_to_use() ->
+    ?record_version.
+
+-spec upgrade(amqqueue()) -> amqqueue().
+
+upgrade(#amqqueue{} = Queue) -> Queue.
+
+-spec upgrade_to(amqqueue_v1, amqqueue()) -> amqqueue().
+
+upgrade_to(?record_version, #amqqueue{} = Queue) ->
+    Queue.
+
+% arguments
+
+-spec get_arguments(amqqueue()) -> rabbit_framing:amqp_table().
+
+get_arguments(#amqqueue{arguments = Args}) -> Args.
+
+-spec set_arguments(amqqueue(), rabbit_framing:amqp_table()) -> amqqueue().
+
+set_arguments(#amqqueue{} = Queue, Args) ->
+    Queue#amqqueue{arguments = Args}.
+
+% decorators
+
+-spec get_decorators(amqqueue()) -> [atom()] | none | undefined.
+
+get_decorators(#amqqueue{decorators = Decorators}) -> Decorators.
+
+-spec set_decorators(amqqueue(), [atom()] | none | undefined) -> amqqueue().
+
+set_decorators(#amqqueue{} = Queue, Decorators) ->
+    Queue#amqqueue{decorators = Decorators}.
+
+-spec get_exclusive_owner(amqqueue()) -> pid() | none.
+
+get_exclusive_owner(#amqqueue{exclusive_owner = Owner}) -> Owner.
+
+% gm_pids
+
+-spec get_gm_pids(amqqueue()) -> [{pid(), pid()} | pid()] | none.
+
+get_gm_pids(#amqqueue{gm_pids = GMPids}) -> GMPids.
+
+-spec set_gm_pids(amqqueue(), [{pid(), pid()} | pid()] | none) -> amqqueue().
+
+set_gm_pids(#amqqueue{} = Queue, GMPids) ->
+    Queue#amqqueue{gm_pids = GMPids}.
+
+-spec get_leader(amqqueue_v1()) -> no_return().
+
+get_leader(_) -> throw({unsupported, ?record_version, get_leader}).
+
+% operator_policy
+
+-spec get_operator_policy(amqqueue()) -> binary() | none | undefined.
+
+get_operator_policy(#amqqueue{operator_policy = OpPolicy}) -> OpPolicy.
+
+-spec set_operator_policy(amqqueue(), binary() | none | undefined) ->
+    amqqueue().
+
+set_operator_policy(#amqqueue{} = Queue, OpPolicy) ->
+    Queue#amqqueue{operator_policy = OpPolicy}.
+
+% name
+
+-spec get_name(amqqueue()) -> rabbit_amqqueue:name().
+
+get_name(#amqqueue{name = Name}) -> Name.
+
+-spec set_name(amqqueue(), rabbit_amqqueue:name()) -> amqqueue().
+
+set_name(#amqqueue{} = Queue, Name) ->
+    Queue#amqqueue{name = Name}.
+
+-spec get_options(amqqueue()) -> map().
+
+get_options(#amqqueue{options = Options}) -> Options.
+
+% pid
+
+-spec get_pid
+(amqqueue_v1:amqqueue_v1()) -> pid() | none.
+
+get_pid(#amqqueue{pid = Pid}) -> Pid.
+
+-spec set_pid
+(amqqueue_v1:amqqueue_v1(), pid() | none) -> amqqueue_v1:amqqueue_v1().
+
+set_pid(#amqqueue{} = Queue, Pid) ->
+    Queue#amqqueue{pid = Pid}.
+
+% policy
+
+-spec get_policy(amqqueue()) -> proplists:proplist() | none | undefined.
+
+get_policy(#amqqueue{policy = Policy}) -> Policy.
+
+-spec set_policy(amqqueue(), binary() | none | undefined) -> amqqueue().
+
+set_policy(#amqqueue{} = Queue, Policy) ->
+    Queue#amqqueue{policy = Policy}.
+
+% policy_version
+
+-spec get_policy_version(amqqueue()) -> non_neg_integer().
+
+get_policy_version(#amqqueue{policy_version = PV}) ->
+    PV.
+
+-spec set_policy_version(amqqueue(), non_neg_integer()) -> amqqueue().
+
+set_policy_version(#amqqueue{} = Queue, PV) ->
+    Queue#amqqueue{policy_version = PV}.
+
+% recoverable_slaves
+
+-spec get_recoverable_slaves(amqqueue()) -> [atom()] | none.
+
+get_recoverable_slaves(#amqqueue{recoverable_slaves = Slaves}) ->
+    Slaves.
+
+-spec set_recoverable_slaves(amqqueue(), [atom()] | none) -> amqqueue().
+
+set_recoverable_slaves(#amqqueue{} = Queue, Slaves) ->
+    Queue#amqqueue{recoverable_slaves = Slaves}.
+
+% quorum_nodes (new in v2)
+
+-spec get_quorum_nodes(amqqueue()) -> no_return().
+
+get_quorum_nodes(_) -> throw({unsupported, ?record_version, get_quorum_nodes}).
+
+-spec set_quorum_nodes(amqqueue(), [node()]) -> no_return().
+
+set_quorum_nodes(_, _) ->
+    throw({unsupported, ?record_version, set_quorum_nodes}).
+
+% slave_pids
+
+get_slave_pids(#amqqueue{slave_pids = Slaves}) ->
+    Slaves.
+
+set_slave_pids(#amqqueue{} = Queue, SlavePids) ->
+    Queue#amqqueue{slave_pids = SlavePids}.
+
+% slave_pids_pending_shutdown
+
+get_slave_pids_pending_shutdown(
+  #amqqueue{slave_pids_pending_shutdown = Slaves}) ->
+    Slaves.
+
+set_slave_pids_pending_shutdown(#amqqueue{} = Queue, SlavePids) ->
+    Queue#amqqueue{slave_pids_pending_shutdown = SlavePids}.
+
+% state
+
+-spec get_state(amqqueue()) -> atom() | none.
+
+get_state(#amqqueue{state = State}) -> State.
+
+-spec set_state(amqqueue(), atom() | none) -> amqqueue().
+
+set_state(#amqqueue{} = Queue, State) ->
+    Queue#amqqueue{state = State}.
+
+% sync_slave_pids
+
+-spec get_sync_slave_pids(amqqueue()) -> [pid()] | none.
+
+get_sync_slave_pids(#amqqueue{sync_slave_pids = Pids}) ->
+    Pids.
+
+-spec set_sync_slave_pids(amqqueue(), [pid()] | none) -> amqqueue().
+
+set_sync_slave_pids(#amqqueue{} = Queue, Pids) ->
+    Queue#amqqueue{sync_slave_pids = Pids}.
+
+%% New in v2.
+
+-spec get_type(amqqueue()) -> atom().
+
+get_type(Queue) when ?is_amqqueue(Queue) -> ?amqqueue_v1_type.
+
+-spec get_vhost(amqqueue()) -> rabbit_types:vhost() | undefined.
+
+get_vhost(#amqqueue{vhost = VHost}) -> VHost.
+
+-spec is_auto_delete(amqqueue()) -> boolean().
+
+is_auto_delete(#amqqueue{auto_delete = AutoDelete}) -> AutoDelete.
+
+-spec is_durable(amqqueue()) -> boolean().
+
+is_durable(#amqqueue{durable = Durable}) -> Durable.
+
+-spec is_classic(amqqueue()) -> boolean().
+
+is_classic(Queue) ->
+    get_type(Queue) =:= ?amqqueue_v1_type.
+
+-spec is_quorum(amqqueue()) -> boolean().
+
+is_quorum(Queue) ->
+    get_type(Queue) =:= quorum.
+
+fields() -> fields(?record_version).
+
+fields(?record_version) -> record_info(fields, amqqueue).
+
+field_vhost() -> #amqqueue.vhost.
+
+-spec pattern_match_all() -> amqqueue_pattern().
+
+pattern_match_all() -> #amqqueue{_ = '_'}.
+
+-spec pattern_match_on_name(rabbit_amqqueue:name()) ->
+    amqqueue_pattern().
+
+pattern_match_on_name(Name) -> #amqqueue{name = Name, _ = '_'}.
+
+-spec pattern_match_on_type(atom()) -> no_return().
+
+pattern_match_on_type(_) ->
+    throw({unsupported, ?record_version, pattern_match_on_type}).
+
+reset_mirroring_and_decorators(#amqqueue{} = Queue) ->
+    Queue#amqqueue{slave_pids      = [],
+                   sync_slave_pids = [],
+                   gm_pids         = [],
+                   decorators      = undefined}.
+
+set_immutable(#amqqueue{} = Queue) ->
+    Queue#amqqueue{pid                = none,
+                   slave_pids         = none,
+                   sync_slave_pids    = none,
+                   recoverable_slaves = none,
+                   gm_pids            = none,
+                   policy             = none,
+                   decorators         = none,
+                   state              = none}.
+
+-spec qnode(amqqueue() | pid()) -> node().
+
+qnode(Queue) when ?is_amqqueue(Queue) ->
+    QPid = get_pid(Queue),
+    qnode(QPid);
+qnode(QPid) when is_pid(QPid) ->
+    node(QPid).
+
+macros() ->
+    io:format(
+      "-define(is_~s(Q), is_record(Q, amqqueue, ~b)).~n~n",
+      [?record_version, record_info(size, amqqueue)]),
+    %% The field number starts at 2 because the first element is the
+    %% record name.
+    macros(record_info(fields, amqqueue), 2).
+
+macros([Field | Rest], I) ->
+    io:format(
+      "-define(~s_field_~s(Q), element(~b, Q)).~n",
+      [?record_version, Field, I]),
+    macros(Rest, I + 1);
+macros([], _) ->
+    ok.

--- a/test/amqqueue_backward_compatibility_SUITE.erl
+++ b/test/amqqueue_backward_compatibility_SUITE.erl
@@ -1,0 +1,168 @@
+-module(amqqueue_backward_compatibility_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include("amqqueue.hrl").
+
+-export([all/0,
+         groups/0,
+         init_per_suite/2,
+         end_per_suite/2,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2,
+
+         new_amqqueue_v1_is_amqqueue/1,
+         random_term_is_not_amqqueue/1,
+
+         amqqueue_v1_is_durable/1,
+         random_term_is_not_durable/1,
+
+         amqqueue_v1_state_matching/1,
+         random_term_state_matching/1,
+
+         amqqueue_v1_type_matching/1,
+         random_term_type_matching/1
+        ]).
+
+-define(long_tuple, {random_tuple, a, b, c, d, e, f, g, h, i, j, k, l, m,
+                     n, o, p, q, r, s, t, u, v, w, x, y, z}).
+
+all() ->
+    [
+     {group, parallel_tests}
+    ].
+
+groups() ->
+    [
+     {parallel_tests, [parallel], [new_amqqueue_v1_is_amqqueue,
+                                   random_term_is_not_amqqueue,
+                                   amqqueue_v1_is_durable,
+                                   random_term_is_not_durable,
+                                   amqqueue_v1_state_matching,
+                                   random_term_state_matching,
+                                   amqqueue_v1_type_matching,
+                                   random_term_type_matching]}
+    ].
+
+init_per_suite(_, Config) -> Config.
+end_per_suite(_, Config) -> Config.
+
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+
+init_per_testcase(_, Config) -> Config.
+end_per_testcase(_, Config) -> Config.
+
+new_amqqueue_v1_is_amqqueue(_) ->
+    VHost = <<"/">>,
+    Name = rabbit_misc:r(VHost, queue, my_amqqueue_v1),
+    Queue = amqqueue:new_with_version(amqqueue_v1,
+                                      Name,
+                                      self(),
+                                      false,
+                                      false,
+                                      none,
+                                      [],
+                                      VHost,
+                                      #{},
+                                      ?amqqueue_v1_type),
+    ?assert(?is_amqqueue(Queue)),
+    ?assert(?is_amqqueue_v1(Queue)),
+    ?assert(?amqqueue_is_classic(Queue)),
+    ?assert(amqqueue:is_classic(Queue)),
+    ?assert(not ?amqqueue_is_quorum(Queue)),
+    ?assert(not ?amqqueue_vhost_equals(Queue, <<"frazzle">>)),
+    ?assert(?amqqueue_has_valid_pid(Queue)),
+    ?assert(?amqqueue_pid_equals(Queue, self())),
+    ?assert(?amqqueue_pids_are_equal(Queue, Queue)),
+    ?assert(?amqqueue_pid_runs_on_local_node(Queue)),
+    ?assert(amqqueue:qnode(Queue) == node()).
+
+random_term_is_not_amqqueue(_) ->
+    Term = ?long_tuple,
+    ?assert(not ?is_amqqueue(Term)),
+    ?assert(not ?is_amqqueue_v1(Term)).
+
+%% -------------------------------------------------------------------
+
+amqqueue_v1_is_durable(_) ->
+    VHost = <<"/">>,
+    Name = rabbit_misc:r(VHost, queue, my_amqqueue_v1),
+    TransientQueue = amqqueue:new_with_version(amqqueue_v1,
+                                               Name,
+                                               self(),
+                                               false,
+                                               false,
+                                               none,
+                                               [],
+                                               VHost,
+                                               #{},
+                                               ?amqqueue_v1_type),
+    DurableQueue = amqqueue:new_with_version(amqqueue_v1,
+                                             Name,
+                                             self(),
+                                             true,
+                                             false,
+                                             none,
+                                             [],
+                                             VHost,
+                                             #{},
+                                             ?amqqueue_v1_type),
+    ?assert(not ?amqqueue_is_durable(TransientQueue)),
+    ?assert(?amqqueue_is_durable(DurableQueue)).
+
+random_term_is_not_durable(_) ->
+    Term = ?long_tuple,
+    ?assert(not ?amqqueue_is_durable(Term)).
+
+%% -------------------------------------------------------------------
+
+amqqueue_v1_state_matching(_) ->
+    VHost = <<"/">>,
+    Name = rabbit_misc:r(VHost, queue, my_amqqueue_v1),
+    Queue1 = amqqueue:new_with_version(amqqueue_v1,
+                                       Name,
+                                       self(),
+                                       true,
+                                       false,
+                                       none,
+                                       [],
+                                       VHost,
+                                       #{},
+                                       ?amqqueue_v1_type),
+    ?assert(?amqqueue_state_is(Queue1, undefined)),
+    Queue2 = amqqueue:set_state(Queue1, stopped),
+    ?assert(?amqqueue_state_is(Queue2, stopped)).
+
+random_term_state_matching(_) ->
+    Term = ?long_tuple,
+    ?assert(not ?amqqueue_state_is(Term, live)).
+
+%% -------------------------------------------------------------------
+
+amqqueue_v1_type_matching(_) ->
+    VHost = <<"/">>,
+    Name = rabbit_misc:r(VHost, queue, my_amqqueue_v1),
+    Queue = amqqueue:new_with_version(amqqueue_v1,
+                                      Name,
+                                      self(),
+                                      true,
+                                      false,
+                                      none,
+                                      [],
+                                      VHost,
+                                      #{},
+                                      ?amqqueue_v1_type),
+    ?assert(?amqqueue_is_classic(Queue)),
+    ?assert(amqqueue:is_classic(Queue)),
+    ?assert(not ?amqqueue_is_quorum(Queue)).
+
+random_term_type_matching(_) ->
+    Term = ?long_tuple,
+    ?assert(not ?amqqueue_is_classic(Term)),
+    ?assert(not ?amqqueue_is_quorum(Term)),
+    ?assertException(error, function_clause, amqqueue:is_classic(Term)),
+    ?assertException(error, function_clause, amqqueue:is_quorum(Term)).


### PR DESCRIPTION
In v3.7.x, the `#amqqueue{}` remains public, unlike in v3.8.x. However, to ease the transition to v3.8.x for plugin developers, the new `amqqueue` module and its associated header are backported to v3.7.x.

Obviously, only the "amqqueue v1" part was backported because v3.7.x does not know about the new "amqqueue v2" record introduced for quorum queues. Therefore, the content of the `amqqueue` module corresponds to `amqqueue_v1` in v3.8.x (i.e. the fallback module).

Plugin developers shouldn't really care about this: if they want to support both v3.7.x and later, they just have to stop using the `#amqqueue{}` record directly and start using the new `amqqueue` module and the various macros offered by `amqqueue.hrl`. This way, plugins will be compatible with v3.7.x and later, both API- (a single source code will compile fine with all versions) and ABI-wise (a pre-compiled plugin will work fine with all versions).

Of course, if they want to use new features introduced later (e.g. the `quorum` queue type in v3.8.x), they also need to use the macros and the feature flags subsystem to determine if the plugin can expect them.

[#164026804]