### PR TITLE
Make default worker pool size configurable

### DIFF
--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -391,6 +391,13 @@ end}.
     {datatype, integer}
 ]}.
 
+%% Default worker process pool size. Used to limit maximum concurrency rate
+%% of certain operations, e.g. queue initialisation and recovery on node boot.
+
+{mapping, "default_worker_pool_size", "rabbit.default_worker_pool_size", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.
+
 %% Password hashing implementation. Will only affect newly
 %% created users. To recalculate hash for an existing user
 %% it's necessary to update her password.

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -566,6 +566,14 @@ credential_validator.regexp = ^abc\\d+",
   [{rabbit,[{log, [{categories, [{connection, [{file, "file_name_connection"}]},
                                  {channel, [{file, "file_name_channel"}]}]}]}]}],
   []},
+
+ {default_worker_pool_size,
+  "default_worker_pool_size = 512",
+  [{rabbit, [
+      {default_worker_pool_size, 512}
+    ]}],
+  []},
+
  {delegate_count,
   "delegate_count = 64",
   [{rabbit, [


### PR DESCRIPTION
## Proposed Changes

This makes default worker pool size configurable. See #2030 for background.
Depends on https://github.com/rabbitmq/rabbitmq-common/pull/329.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-server#2030.
