### PR TITLE
Qq metrics tweak

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -539,6 +539,12 @@ start_loaded_apps(Apps, RestartTypes) ->
     application:set_env(ra, logger_module, rabbit_log_ra_shim),
     %% use a larger segments size for queues
     application:set_env(ra, segment_max_entries, 32768),
+    case application:get_env(ra, wal_max_size_bytes) of
+        undefined ->
+            application:set_env(ra, wal_max_size_bytes, 536870912); %% 5 * 2 ^ 20
+        _ ->
+            ok
+    end,
     ConfigEntryDecoder = case application:get_env(rabbit, config_entry_decoder) of
         undefined ->
             [];

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -130,6 +130,7 @@ declare(Q) when ?amqqueue_is_quorum(Q) ->
                              id => ServerId,
                              uid => UId,
                              friendly_name => FName,
+                             metrics_key => QName,
                              initial_members => ServerIds,
                              log_init_args => #{uid => UId},
                              tick_timeout => TickTimeout,


### PR DESCRIPTION
Set wal_max_size_bytes` default.

Add custom `ra_metrics` key that uses the queue resource instead of the registered process name default.