### PR TITLE
Support client-driven refresh of expiring credentials

### DIFF
--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -21,7 +21,7 @@
 -export([check_user_pass_login/2, check_user_login/2, check_user_loopback/2,
          check_vhost_access/4, check_resource_access/4, check_topic_access/4]).
 
--export([can_use_permission_cache/1, update_state/2]).
+-export([permission_cache_can_expire/1, update_state/2]).
 
 %%----------------------------------------------------------------------------
 
@@ -248,9 +248,9 @@ update_state(User = #user{authz_backends = Backends0}, NewState) ->
       Else        -> Else
     end.
 
--spec can_use_permission_cache(User :: rabbit_types:user()) -> boolean().
+-spec permission_cache_can_expire(User :: rabbit_types:user()) -> boolean().
 
-%% Returns false if any of the backends support credential expiration,
-%% otherwise returns true.
-can_use_permission_cache(#user{authz_backends = Backends}) ->
-    not lists:any(fun ({Module, _State}) -> Module:state_can_expire() end, Backends).
+%% Returns true if any of the backends support credential expiration,
+%% otherwise returns false.
+permission_cache_can_expire(#user{authz_backends = Backends}) ->
+    lists:any(fun ({Module, _State}) -> Module:state_can_expire() end, Backends).

--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -21,6 +21,8 @@
 -export([check_user_pass_login/2, check_user_login/2, check_user_loopback/2,
          check_vhost_access/4, check_resource_access/4, check_topic_access/4]).
 
+-export([update_state/2]).
+
 %%----------------------------------------------------------------------------
 
 -export_type([permission_atom/0]).
@@ -216,4 +218,32 @@ check_access(Fun, Module, ErrStr, ErrArgs, ErrName) ->
             FullErrArgs = ErrArgs ++ [Module, E],
             rabbit_log:error(FullErrStr, FullErrArgs),
             rabbit_misc:protocol_error(ErrName, FullErrStr, FullErrArgs)
+    end.
+
+-spec update_state(User :: rabbit_types:user(), NewState :: term()) ->
+    {'ok', rabbit_types:auth_user()} |
+    {'refused', string(), [any()]} |
+    {'error', any()}.
+
+update_state(User = #user{authz_backends = Backends0}, NewState) ->
+    %% N.B.: we use foldl/3 and prepending, so the final list of
+    %% backends
+    Backends = lists:foldl(
+                fun({Module, Impl}, {ok, Acc}) ->
+                        case Module:state_can_expire() of
+                          true  ->
+                            case Module:update_state(auth_user(User, Impl), NewState) of
+                              {ok, #auth_user{impl = Impl1}} ->
+                                {ok, [{Module, Impl1} | Acc]};
+                              Else -> Else
+                            end;
+                          false ->
+                            {ok, [{Module, Impl} | Acc]}
+                        end;
+                   (_, {error, _} = Err)      -> Err;
+                   (_, {refused, _, _} = Err) -> Err
+                end, {ok, []}, Backends0),
+    case Backends of
+      {ok, Pairs} -> {ok, User#user{authz_backends = lists:reverse(Pairs)}};
+      Else        -> Else
     end.

--- a/src/rabbit_access_control.erl
+++ b/src/rabbit_access_control.erl
@@ -227,7 +227,7 @@ check_access(Fun, Module, ErrStr, ErrArgs, ErrName) ->
 
 update_state(User = #user{authz_backends = Backends0}, NewState) ->
     %% N.B.: we use foldl/3 and prepending, so the final list of
-    %% backends
+    %% backends is in reverse order from the original list.
     Backends = lists:foldl(
                 fun({Module, Impl}, {ok, Acc}) ->
                         case Module:state_can_expire() of

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -40,6 +40,8 @@
          list_user_vhost_permissions/2,
          list_user_topic_permissions/1, list_vhost_topic_permissions/1, list_user_vhost_topic_permissions/2]).
 
+-export([state_can_expire/0]).
+
 %% for testing
 -export([hashing_module_for_user/1, expand_topic_permission/2]).
 
@@ -93,6 +95,8 @@ user_login_authentication(Username, AuthProps) ->
         false -> exit({unknown_auth_props, Username, AuthProps})
     end.
 
+state_can_expire() -> false.
+
 user_login_authorization(Username, _AuthProps) ->
     case user_login_authentication(Username, []) of
         {ok, #auth_user{impl = Impl, tags = Tags}} -> {ok, Impl, Tags};
@@ -123,7 +127,7 @@ check_vhost_access(#auth_user{username = Username}, VHostPath, _AuthzData) ->
 
 check_resource_access(#auth_user{username = Username},
                       #resource{virtual_host = VHostPath, name = Name},
-                      Permission, 
+                      Permission,
                       _AuthContext) ->
     case mnesia:dirty_read({rabbit_user_permission,
                             #user_vhost{username     = Username,

--- a/src/rabbit_auth_mechanism_plain.erl
+++ b/src/rabbit_auth_mechanism_plain.erl
@@ -31,9 +31,6 @@
 %% SASL PLAIN, as used by the Qpid Java client and our clients. Also,
 %% apparently, by OpenAMQ.
 
-%% TODO: reimplement this using the binary module? - that makes use of
-%% BIFs to do binary matching and will thus be much faster.
-
 description() ->
     [{description, <<"SASL PLAIN authentication mechanism">>}].
 

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -500,7 +500,7 @@ init([Channel, ReaderPid, WriterPid, ConnPid, ConnName, Protocol, User, VHost,
                       Limiter0
               end,
     %% Process dictionary is used here because permission cache already uses it. MK.
-    put(permission_cache_enabled, rabbit_access_control:can_use_permission_cache(User)),
+    put(permission_cache_can_expire, rabbit_access_control:permission_cache_can_expire(User)),
     MaxMessageSize = get_max_message_size(),
     ConsumerTimeout = get_consumer_timeout(),
     State = #ch{cfg = #conf{state = starting,
@@ -850,6 +850,10 @@ handle_info({{Ref, Node}, LateAnswer},
     noreply(State);
 
 handle_info(tick, State0 = #ch{queue_states = QueueStates0}) ->
+    case get(permission_cache_can_expire) of
+      true  -> ok = clear_permission_cache();
+      _     -> ok
+    end,
     QueueStates1 =
         maps:filter(fun(_, QS) ->
                             QName = rabbit_quorum_queue:queue_name(QS),
@@ -986,14 +990,7 @@ return_queue_declare_ok(#resource{name = ActualName},
                                           message_count  = MessageCount,
                                           consumer_count = ConsumerCount}).
 
-%% permission cache must not be used (one of the authz
-%% backends supports credential expiration)
-check_resource_access(User, Resource, Perm, Context, false = _Enabled) ->
-  ok = rabbit_access_control:check_resource_access(
-                  User, Resource, Perm, Context);
-
-%% permission cache enabled
-check_resource_access(User, Resource, Perm, Context, _Enabled) ->
+check_resource_access(User, Resource, Perm, Context) ->
     V = {Resource, Context, Perm},
 
     Cache = case get(permission_cache) of
@@ -1013,19 +1010,19 @@ clear_permission_cache() -> erase(permission_cache),
                             ok.
 
 check_configure_permitted(Resource, User, Context) ->
-    check_resource_access(User, Resource, configure, Context, get(permission_cache_enabled)).
+    check_resource_access(User, Resource, configure, Context).
 
 check_write_permitted(Resource, User, Context) ->
-    check_resource_access(User, Resource, write, Context, get(permission_cache_enabled)).
+    check_resource_access(User, Resource, write, Context).
 
 check_read_permitted(Resource, User, Context) ->
-    check_resource_access(User, Resource, read, Context, get(permission_cache_enabled)).
+    check_resource_access(User, Resource, read, Context).
 
 check_write_permitted_on_topic(Resource, User, ConnPid, RoutingKey, ChSrc) ->
-    check_topic_authorisation(Resource, User, ConnPid, RoutingKey, ChSrc, write, get(permission_cache_enabled)).
+    check_topic_authorisation(Resource, User, ConnPid, RoutingKey, ChSrc, write).
 
 check_read_permitted_on_topic(Resource, User, ConnPid, RoutingKey, ChSrc) ->
-    check_topic_authorisation(Resource, User, ConnPid, RoutingKey, ChSrc, read, get(permission_cache_enabled)).
+    check_topic_authorisation(Resource, User, ConnPid, RoutingKey, ChSrc, read).
 
 check_user_id_header(#'P_basic'{user_id = undefined}, _) ->
     ok;
@@ -1061,29 +1058,20 @@ check_internal_exchange(_) ->
     ok.
 
 check_topic_authorisation(Resource = #exchange{type = topic},
-                          User, none, RoutingKey, _ChSrc, Permission, PermCacheEnabled) ->
+                          User, none, RoutingKey, _ChSrc, Permission) ->
     %% Called from outside the channel by mgmt API
     AmqpParams = [],
-    do_check_topic_authorisation(Resource, User, AmqpParams, RoutingKey, Permission, PermCacheEnabled);
+    check_topic_authorisation(Resource, User, AmqpParams, RoutingKey, Permission);
 check_topic_authorisation(Resource = #exchange{type = topic},
-                          User, ConnPid, RoutingKey, ChSrc, Permission, PermCacheEnabled) when is_pid(ConnPid) ->
+                          User, ConnPid, RoutingKey, ChSrc, Permission) when is_pid(ConnPid) ->
     AmqpParams = get_amqp_params(ConnPid, ChSrc),
-    do_check_topic_authorisation(Resource, User, AmqpParams, RoutingKey, Permission, PermCacheEnabled);
-check_topic_authorisation(_, _, _, _, _, _, _) ->
+    check_topic_authorisation(Resource, User, AmqpParams, RoutingKey, Permission);
+check_topic_authorisation(_, _, _, _, _, _) ->
     ok.
 
-do_check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost}, type = topic},
+check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost}, type = topic},
                              User = #user{username = Username},
-                             AmqpParams, RoutingKey, Permission, false = _PermCacheEnabled) ->
-    Resource = Name#resource{kind = topic},
-    VariableMap = build_topic_variable_map(AmqpParams, VHost, Username),
-    Context = #{routing_key  => RoutingKey,
-                variable_map => VariableMap},
-    ok = rabbit_access_control:check_topic_access(
-        User, Resource, Permission, Context);
-do_check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost}, type = topic},
-                             User = #user{username = Username},
-                             AmqpParams, RoutingKey, Permission, _PermCacheEnabled) ->
+                             AmqpParams, RoutingKey, Permission) ->
     Resource = Name#resource{kind = topic},
     VariableMap = build_topic_variable_map(AmqpParams, VHost, Username),
     Context = #{routing_key  => RoutingKey,

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1277,7 +1277,7 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
                State = #v1{connection =
                                #connection{protocol   = Protocol,
                                            user       = User = #user{username = Username},
-                                           log_name   = ConnName},
+                                           log_name   = ConnName} = Conn,
                            sock       = Sock}) when ?IS_RUNNING(State) ->
     rabbit_log_connection:debug(
         "connection ~p (~s) of user '~s': "
@@ -1300,7 +1300,7 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
             "connection ~p (~s): "
             "user '~s' updated secret, reason: ~s~n",
             [self(), dynamic_connection_name(ConnName), Username, Reason]),
-        State#v1{connection = #connection{user = User1}};
+        State#v1{connection = Conn#connection{user = User1}};
       {refused, Reason} ->
         rabbit_log_connection:error("Secret update was refused for user '~p': ~p",
                                     [Username, Reason]),

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1293,7 +1293,7 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
         %% Therefore we optimistically do no error handling here. MK.
         lists:foreach(fun(Ch) ->
           rabbit_log:debug("Updating user/auth backend state for channel ~p", [Ch]),
-          rabbit_channel:update_user_state(Ch, User1)
+          _ = rabbit_channel:update_user_state(Ch, User1)
         end, all_channels()),
         ok = send_on_channel0(Sock, #'connection.update_secret_ok'{}, Protocol),
         rabbit_log_connection:info(

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1301,13 +1301,13 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
             "user '~s' updated secret, reason: ~s~n",
             [self(), dynamic_connection_name(ConnName), Username, Reason]),
         State#v1{connection = Conn#connection{user = User1}};
-      {refused, Reason} ->
+      {refused, Message} ->
         rabbit_log_connection:error("Secret update was refused for user '~p': ~p",
-                                    [Username, Reason]),
+                                    [Username, Message]),
         rabbit_misc:protocol_error(not_allowed, "New secret was refused by one of the backends", []);
-      {error, Reason} ->
+      {error, Message} ->
         rabbit_log_connection:error("Secret update for user '~p' failed: ~p",
-                                    [Username, Reason]),
+                                    [Username, Message]),
         rabbit_misc:protocol_error(not_allowed,
                                   "Secret update failed", [])
     end;

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1301,7 +1301,7 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
             "connection ~p (~s): "
             "user '~s' updated secret, reason: ~s~n",
             [self(), dynamic_connection_name(ConnName), Username, Reason]),
-        State;
+        State#v1{connection = #connection{user = User1}};
       {refused, Reason} ->
         rabbit_log_connection:error("Secret update was refused for user '~p': ~p",
                                     [Username, Reason]),

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1285,7 +1285,6 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
         [self(), dynamic_connection_name(ConnName), Username, Reason]),
     case rabbit_access_control:update_state(User, NewSecret) of
       {ok, User1} ->
-        rabbit_log_connection:debug("Updated user/auth state from ~p to ~p", [User, User1]),
         %% User/auth backend state has been updated. Now we can propagate it to channels
         %% asynchronously and return. All the channels have to do is to update their
         %% own state.

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -32,7 +32,9 @@ all() ->
 groups() ->
     [
       {parallel_tests, [parallel], [
-          auth_backend_internal_expand_topic_permission,
+          {access_control, [parallel], [
+            auth_backend_internal_expand_topic_permission
+          ]},
           {basic_header_handling, [parallel], [
               write_table_with_invalid_existing_type,
               invalid_existing_headers,
@@ -892,6 +894,10 @@ listing_plugins_from_multiple_directories(Config) ->
             exit({wrong_plugins_list, Got})
     end,
     ok.
+
+%%
+%% Access Control
+%%
 
 auth_backend_internal_expand_topic_permission(_Config) ->
     ExpandMap = #{<<"username">> => <<"guest">>, <<"vhost">> => <<"default">>},

--- a/test/unit_inbroker_parallel_SUITE.erl
+++ b/test/unit_inbroker_parallel_SUITE.erl
@@ -61,9 +61,6 @@ groups() ->
               login_of_passwordless_user,
               set_tags_for_passwordless_user
             ]},
-          {access_control, [parallel], [
-              state_update
-          ]},
           set_disk_free_limit_command,
           set_vm_memory_high_watermark_command,
           topic_matching,

--- a/test/unit_inbroker_parallel_SUITE.erl
+++ b/test/unit_inbroker_parallel_SUITE.erl
@@ -61,6 +61,9 @@ groups() ->
               login_of_passwordless_user,
               set_tags_for_passwordless_user
             ]},
+          {access_control, [parallel], [
+              state_update
+          ]},
           set_disk_free_limit_command,
           set_vm_memory_high_watermark_command,
           topic_matching,


### PR DESCRIPTION
## Proposed Changes

This introduces support for a new AMQP 0-9-1 extension, `connection.update-secret`, which is used to update authZ backend state when it can expire. Specifically we want to support client-driven JWT/OAuth 2 access token "renewal" without reconnection.

See https://github.com/rabbitmq/rabbitmq-auth-backend-oauth2/issues/28 for background.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (in `rabbitmq-auth-backend-oauth2`)
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of https://github.com/rabbitmq/rabbitmq-auth-backend-oauth2/issues/28.