### PR TITLE
Publish persistent stats for quorum queues

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -252,7 +252,9 @@ handle_tick(QName,
                       Infos = [{consumers, C}, {consumer_utilisation, Util},
                                {message_bytes_ready, MsgBytesReady},
                                {message_bytes_unacknowledged, MsgBytesUnack},
-                               {message_bytes, MsgBytesReady + MsgBytesUnack}
+                               {message_bytes, MsgBytesReady + MsgBytesUnack},
+                               {message_bytes_persistent, MsgBytesReady + MsgBytesUnack}
+
                                | infos(QName)],
                       rabbit_core_metrics:queue_stats(QName, Infos),
                       rabbit_event:notify(queue_stats,
@@ -260,6 +262,7 @@ handle_tick(QName,
                                                     {messages, M},
                                                     {messages_ready, MR},
                                                     {messages_unacknowledged, MU},
+                                                    {messages_persistent, M},
                                                     {reductions, R}]),
                       ok = repair_leader_record(QName, Self),
                       ExpectedNodes = rabbit_mnesia:cluster_nodes(all),


### PR DESCRIPTION
The persistent columns in the `/queues` page of the management UI where missing the values for quorum queues. See `NaN` and `?` in the screenshot below.

These are equivalent to the total number of messages/bytes in the queue.

<img width="1343" alt="Screen Shot 2019-08-01 at 4 27 39 PM" src="https://user-images.githubusercontent.com/646577/62308103-bbba3d80-b47c-11e9-9800-740f57d26cc2.png">


## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

