### PR TITLE
Publish messages_persistent

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -253,7 +253,8 @@ handle_tick(QName,
                                {message_bytes_ready, MsgBytesReady},
                                {message_bytes_unacknowledged, MsgBytesUnack},
                                {message_bytes, MsgBytesReady + MsgBytesUnack},
-                               {message_bytes_persistent, MsgBytesReady + MsgBytesUnack}
+                               {message_bytes_persistent, MsgBytesReady + MsgBytesUnack},
+                               {messages_persistent, M}
 
                                | infos(QName)],
                       rabbit_core_metrics:queue_stats(QName, Infos),
@@ -262,7 +263,6 @@ handle_tick(QName,
                                                     {messages, M},
                                                     {messages_ready, MR},
                                                     {messages_unacknowledged, MU},
-                                                    {messages_persistent, M},
                                                     {reductions, R}]),
                       ok = repair_leader_record(QName, Self),
                       ExpectedNodes = rabbit_mnesia:cluster_nodes(all),


### PR DESCRIPTION
On the previous PR the `messages_persistent` stat was only sent in the event, but not published in the core metrics. 

[#167649915]

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
