### PR TITLE
Fix log rotation on Windows

### DIFF
--- a/scripts/rabbitmq-defaults.bat
+++ b/scripts/rabbitmq-defaults.bat
@@ -21,15 +21,13 @@ REM ## Set default values
 
 if "!RABBITMQ_BASE!"=="" (
     set RABBITMQ_BASE=!APPDATA!\RabbitMQ
+) else (
+    set RABBITMQ_BASE=!RABBITMQ_BASE:"=!
 )
 
-REM Make sure $RABBITMQ_BASE contains no non-ASCII characters. We create
-REM the directory first so we don't end up creating it later in its "short
-REM filename" version.
 if not exist "!RABBITMQ_BASE!" (
     mkdir "!RABBITMQ_BASE!"
 )
-for /f "delims=" %%F in ("!RABBITMQ_BASE!") do set RABBITMQ_BASE=%%~sF
 
 REM BOOT_MODULE="rabbit"
 REM CONFIG_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq
@@ -46,7 +44,7 @@ set ADVANCED_CONFIG_FILE=!RABBITMQ_BASE!\advanced.config
 set SCHEMA_DIR=!RABBITMQ_BASE!\schema
 
 REM PLUGINS_DIR="${RABBITMQ_HOME}/plugins"
-for /f "delims=" %%F in ("!TDP0!..\plugins") do set PLUGINS_DIR=%%~dpsF%%~nF%%~xF
+for /f "delims=" %%F in ("!TDP0!..\plugins") do set PLUGINS_DIR=%%~dpF%%~nF%%~xF
 
 REM CONF_ENV_FILE=${SYS_PREFIX}/etc/rabbitmq/rabbitmq-env.conf
 set CONF_ENV_FILE=!RABBITMQ_BASE!\rabbitmq-env-conf.bat

--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -12,7 +12,7 @@ REM SCRIPT_DIR=`dirname $SCRIPT_PATH`
 REM RABBITMQ_HOME="${SCRIPT_DIR}/.."
 set SCRIPT_DIR=%TDP0%
 set SCRIPT_NAME=%1
-for /f "delims=" %%F in ("%SCRIPT_DIR%..") do set RABBITMQ_HOME=%%~dpsF%%~nF%%~xF
+for /f "delims=" %%F in ("%SCRIPT_DIR%..") do set RABBITMQ_HOME=%%~dpF%%~nF%%~xF
 
 REM If ERLANG_HOME is not defined, check if "erl.exe" is available in
 REM the path and use that.
@@ -20,7 +20,7 @@ if not defined ERLANG_HOME (
     for /f "delims=" %%F in ('where.exe erl.exe') do @set ERL_PATH=%%F
     if exist "!ERL_PATH!" (
         for /f "delims=" %%F in ("!ERL_PATH!") do set ERL_DIRNAME=%%~dpF
-        for /f "delims=" %%F in ("!ERL_DIRNAME!\..") do @set ERLANG_HOME=%%~dpsF%%~nF%%~xF
+        for /f "delims=" %%F in ("!ERL_DIRNAME!\..") do @set ERLANG_HOME=%%~dpF%%~nF%%~xF
     )
     set ERL_PATH=
     set ERL_DIRNAME=
@@ -30,7 +30,9 @@ REM ## Set defaults
 call "%SCRIPT_DIR%\rabbitmq-defaults.bat"
 
 if "!RABBITMQ_CONF_ENV_FILE!"=="" (
-    set RABBITMQ_CONF_ENV_FILE=!CONF_ENV_FILE!
+    set RABBITMQ_CONF_ENV_FILE=!CONF_ENV_FILE:"=!
+) else (
+    set RABBITMQ_CONF_ENV_FILE=!RABBITMQ_CONF_ENV_FILE:"=!
 )
 
 if exist "!RABBITMQ_CONF_ENV_FILE!" (
@@ -71,12 +73,6 @@ if "!RABBITMQ_MAX_NUMBER_OF_ATOMS!"=="" (
 
 REM Common defaults
 set SERVER_ERL_ARGS=+P !RABBITMQ_MAX_NUMBER_OF_PROCESSES! +t !RABBITMQ_MAX_NUMBER_OF_ATOMS! +stbt !RABBITMQ_SCHEDULER_BIND_TYPE! +zdbbl !RABBITMQ_DISTRIBUTION_BUFFER_SIZE!
-
-REM Make sure $RABBITMQ_BASE contains no non-ASCII characters.
-if not exist "!RABBITMQ_BASE!" (
-    mkdir "!RABBITMQ_BASE!"
-)
-for /f "delims=" %%F in ("!RABBITMQ_BASE!") do set RABBITMQ_BASE=%%~sF
 
 REM Check for the short names here too
 if "!RABBITMQ_USE_LONGNAME!"=="true" (
@@ -119,16 +115,6 @@ REM [ "x" = "x$RABBITMQ_NODE_IP_ADDRESS" ] && RABBITMQ_NODE_IP_ADDRESS=${NODE_IP
 REM [ "x" = "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_NODE_PORT=${NODE_PORT}
 REM [ "x" = "x$RABBITMQ_NODE_IP_ADDRESS" ] && [ "x" != "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_NODE_IP_ADDRESS=${DEFAULT_NODE_IP_ADDRESS}
 REM [ "x" != "x$RABBITMQ_NODE_IP_ADDRESS" ] && [ "x" = "x$RABBITMQ_NODE_PORT" ] && RABBITMQ_NODE_PORT=${DEFAULT_NODE_PORT}
-
-REM if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
-REM    if not "!RABBITMQ_NODE_PORT!"=="" (
-REM       set RABBITMQ_NODE_IP_ADDRESS=auto
-REM    )
-REM ) else (
-REM    if "!RABBITMQ_NODE_PORT!"=="" (
-REM       set RABBITMQ_NODE_PORT=5672
-REM    )
-REM )
 
 if "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
     if not "!NODE_IP_ADDRESS!"=="" (
@@ -174,38 +160,44 @@ if "!RABBITMQ_SERVER_ERL_ARGS!"=="" (
 )
 
 REM [ "x" = "x$RABBITMQ_CONFIG_FILE" ] && RABBITMQ_CONFIG_FILE=${CONFIG_FILE}
-CALL :unquote RABBITMQ_CONFIG_FILE %RABBITMQ_CONFIG_FILE%
 if "!RABBITMQ_CONFIG_FILE!"=="" (
     if "!CONFIG_FILE!"=="" (
         set RABBITMQ_CONFIG_FILE=!RABBITMQ_BASE!\rabbitmq
     ) else (
-        set RABBITMQ_CONFIG_FILE=!CONFIG_FILE!
+        set RABBITMQ_CONFIG_FILE=!CONFIG_FILE:"=!
     )
+) else (
+    set RABBITMQ_CONFIG_FILE=!RABBITMQ_CONFIG_FILE:"=!
 )
 
 if "!RABBITMQ_GENERATED_CONFIG_DIR!"=="" (
     if "!GENERATED_CONFIG_DIR!"=="" (
         set RABBITMQ_GENERATED_CONFIG_DIR=!RABBITMQ_BASE!\config
     ) else (
-        set RABBITMQ_GENERATED_CONFIG_DIR=!GENERATED_CONFIG_DIR!
+        set RABBITMQ_GENERATED_CONFIG_DIR=!GENERATED_CONFIG_DIR:"=!
     )
+) else (
+    set RABBITMQ_GENERATED_CONFIG_DIR=!RABBITMQ_GENERATED_CONFIG_DIR:"=!
 )
 
-CALL :unquote RABBITMQ_ADVANCED_CONFIG_FILE %RABBITMQ_ADVANCED_CONFIG_FILE%
 if "!RABBITMQ_ADVANCED_CONFIG_FILE!"=="" (
     if "!ADVANCED_CONFIG_FILE!"=="" (
         set RABBITMQ_ADVANCED_CONFIG_FILE=!RABBITMQ_BASE!\advanced.config
     ) else (
-        set RABBITMQ_ADVANCED_CONFIG_FILE=!ADVANCED_CONFIG_FILE!
+        set RABBITMQ_ADVANCED_CONFIG_FILE=!ADVANCED_CONFIG_FILE:"=!
     )
+) else (
+    set RABBITMQ_ADVANCED_CONFIG_FILE=!RABBITMQ_ADVANCED_CONFIG_FILE:"=!
 )
 
 if "!RABBITMQ_SCHEMA_DIR!" == "" (
     if "!SCHEMA_DIR!"=="" (
         set RABBITMQ_SCHEMA_DIR=!RABBITMQ_HOME!\priv\schema
     ) else (
-        set RABBITMQ_SCHEMA_DIR=!SCHEMA_DIR!
+        set RABBITMQ_SCHEMA_DIR=!SCHEMA_DIR:"=!
     )
+) else (
+    set RABBITMQ_SCHEMA_DIR=!RABBITMQ_SCHEMA_DIR:"=!
 )
 
 REM [ "x" = "x$RABBITMQ_LOG_BASE" ] && RABBITMQ_LOG_BASE=${LOG_BASE}
@@ -213,26 +205,28 @@ if "!RABBITMQ_LOG_BASE!"=="" (
     if "!LOG_BASE!"=="" (
         set RABBITMQ_LOG_BASE=!RABBITMQ_BASE!\log
     ) else (
-        set RABBITMQ_LOG_BASE=!LOG_BASE!
+        set RABBITMQ_LOG_BASE=!LOG_BASE:"=!
     )
+) else (
+    set RABBITMQ_LOG_BASE=!RABBITMQ_LOG_BASE:"=!
 )
 if not exist "!RABBITMQ_LOG_BASE!" (
     mkdir "!RABBITMQ_LOG_BASE!"
 )
-for /f "delims=" %%F in ("!RABBITMQ_LOG_BASE!") do set RABBITMQ_LOG_BASE=%%~sF
 
 REM [ "x" = "x$RABBITMQ_MNESIA_BASE" ] && RABBITMQ_MNESIA_BASE=${MNESIA_BASE}
 if "!RABBITMQ_MNESIA_BASE!"=="" (
     if "!MNESIA_BASE!"=="" (
         set RABBITMQ_MNESIA_BASE=!RABBITMQ_BASE!\db
     ) else (
-        set RABBITMQ_MNESIA_BASE=!MNESIA_BASE!
+        set RABBITMQ_MNESIA_BASE=!MNESIA_BASE:"=!
     )
+) else (
+    set RABBITMQ_MNESIA_BASE=!RABBITMQ_MNESIA_BASE:"=!
 )
 if not exist "!RABBITMQ_MNESIA_BASE!" (
     mkdir "!RABBITMQ_MNESIA_BASE!"
 )
-for /f "delims=" %%F in ("!RABBITMQ_MNESIA_BASE!") do set RABBITMQ_MNESIA_BASE=%%~sF
 
 REM [ "x" = "x$RABBITMQ_SERVER_START_ARGS" ] && RABBITMQ_SERVER_START_ARGS=${SERVER_START_ARGS}
 if "!RABBITMQ_SERVER_START_ARGS!"=="" (
@@ -254,13 +248,14 @@ if "!RABBITMQ_MNESIA_DIR!"=="" (
     if "!MNESIA_DIR!"=="" (
         set RABBITMQ_MNESIA_DIR=!RABBITMQ_MNESIA_BASE!\!RABBITMQ_NODENAME!-mnesia
     ) else (
-        set RABBITMQ_MNESIA_DIR=!MNESIA_DIR!
+        set RABBITMQ_MNESIA_DIR=!MNESIA_DIR:"=!
     )
+) else (
+    set RABBITMQ_MNESIA_DIR=!RABBITMQ_MNESIA_DIR:"=!
 )
 if not exist "!RABBITMQ_MNESIA_DIR!" (
     mkdir "!RABBITMQ_MNESIA_DIR!"
 )
-for /f "delims=" %%F in ("!RABBITMQ_MNESIA_DIR!") do set RABBITMQ_MNESIA_DIR=%%~sF
 
 REM [ "x" = "x$RABBITMQ_PID_FILE" ] && RABBITMQ_PID_FILE=${PID_FILE}
 REM [ "x" = "x$RABBITMQ_PID_FILE" ] && RABBITMQ_PID_FILE=${RABBITMQ_MNESIA_DIR}.pid
@@ -280,8 +275,10 @@ if "!RABBITMQ_FEATURE_FLAGS_FILE!"=="" (
     if "!FEATURE_FLAGS_FILE!"=="" (
         set RABBITMQ_FEATURE_FLAGS_FILE=!RABBITMQ_MNESIA_BASE!\!RABBITMQ_NODENAME!-feature_flags
     ) else (
-        set RABBITMQ_FEATURE_FLAGS_FILE=!FEATURE_FLAGS_FILE!
+        set RABBITMQ_FEATURE_FLAGS_FILE=!FEATURE_FLAGS_FILE:"=!
     )
+) else (
+    set RABBITMQ_FEATURE_FLAGS_FILE=!RABBITMQ_FEATURE_FLAGS_FILE:"=!
 )
 
 REM [ "x" = "x$RABBITMQ_PLUGINS_EXPAND_DIR" ] && RABBITMQ_PLUGINS_EXPAND_DIR=${PLUGINS_EXPAND_DIR}
@@ -290,44 +287,42 @@ if "!RABBITMQ_PLUGINS_EXPAND_DIR!"=="" (
     if "!PLUGINS_EXPAND_DIR!"=="" (
         set RABBITMQ_PLUGINS_EXPAND_DIR=!RABBITMQ_MNESIA_BASE!\!RABBITMQ_NODENAME!-plugins-expand
     ) else (
-        set RABBITMQ_PLUGINS_EXPAND_DIR=!PLUGINS_EXPAND_DIR!
+        set RABBITMQ_PLUGINS_EXPAND_DIR=!PLUGINS_EXPAND_DIR:"=!
     )
+) else (
+    set RABBITMQ_PLUGINS_EXPAND_DIR=!RABBITMQ_PLUGINS_EXPAND_DIR:"=!
 )
-REM FIXME: RabbitMQ removes and recreates RABBITMQ_PLUGINS_EXPAND_DIR
-REM itself. Therefore we can't create it here in advance and escape the
-REM directory name, and RABBITMQ_PLUGINS_EXPAND_DIR must not contain
-REM non-US-ASCII characters.
 
 REM [ "x" = "x$RABBITMQ_ENABLED_PLUGINS_FILE" ] && RABBITMQ_ENABLED_PLUGINS_FILE=${ENABLED_PLUGINS_FILE}
 if "!RABBITMQ_ENABLED_PLUGINS_FILE!"=="" (
     if "!ENABLED_PLUGINS_FILE!"=="" (
         set RABBITMQ_ENABLED_PLUGINS_FILE=!RABBITMQ_BASE!\enabled_plugins
     ) else (
-        set RABBITMQ_ENABLED_PLUGINS_FILE=!ENABLED_PLUGINS_FILE!
+        set RABBITMQ_ENABLED_PLUGINS_FILE=!ENABLED_PLUGINS_FILE:"=!
     )
 ) else (
+    set RABBITMQ_ENABLED_PLUGINS_FILE=!RABBITMQ_ENABLED_PLUGINS_FILE:"=!
     set RABBITMQ_ENABLED_PLUGINS_FILE_source=environment
 )
 if not exist "!RABBITMQ_ENABLED_PLUGINS_FILE!" (
-    for /f "delims=" %%F in ("!RABBITMQ_ENABLED_PLUGINS_FILE!") do mkdir %%~dpF 2>NUL
+    for /f "delims=" %%F in ("!RABBITMQ_ENABLED_PLUGINS_FILE!") do mkdir "%%~dpF" 2>NUL
     copy /y NUL "!RABBITMQ_ENABLED_PLUGINS_FILE!" >NUL
 )
-for /f "delims=" %%F in ("!RABBITMQ_ENABLED_PLUGINS_FILE!") do set RABBITMQ_ENABLED_PLUGINS_FILE=%%~sF
 
 REM [ "x" = "x$RABBITMQ_PLUGINS_DIR" ] && RABBITMQ_PLUGINS_DIR=${PLUGINS_DIR}
 if "!RABBITMQ_PLUGINS_DIR!"=="" (
     if "!PLUGINS_DIR!"=="" (
         set RABBITMQ_PLUGINS_DIR=!RABBITMQ_HOME!\plugins
     ) else (
-        set RABBITMQ_PLUGINS_DIR=!PLUGINS_DIR!
+        set RABBITMQ_PLUGINS_DIR=!PLUGINS_DIR:"=!
     )
 ) else (
+    set RABBITMQ_PLUGINS_DIR=!RABBITMQ_PLUGINS_DIR:"=!
     set RABBITMQ_PLUGINS_DIR_source=environment
 )
 if not exist "!RABBITMQ_PLUGINS_DIR!" (
     mkdir "!RABBITMQ_PLUGINS_DIR!"
 )
-for /f "delims=" %%F in ("!RABBITMQ_PLUGINS_DIR!") do set RABBITMQ_PLUGINS_DIR=%%~sF
 
 REM ## Log rotation
 REM [ "x" = "x$RABBITMQ_LOGS" ] && RABBITMQ_LOGS=${LOGS}
@@ -336,23 +331,28 @@ if "!RABBITMQ_LOGS!"=="" (
     if "!LOGS!"=="" (
         set RABBITMQ_LOGS=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!.log
     ) else (
-        set RABBITMQ_LOGS=!LOGS!
+        set RABBITMQ_LOGS=!LOGS:"=!
     )
+) else (
+    set RABBITMQ_LOGS=!RABBITMQ_LOGS:"=!
 )
 if not "!RABBITMQ_LOGS!" == "-" (
     if not exist "!RABBITMQ_LOGS!" (
-        for /f "delims=" %%F in ("!RABBITMQ_LOGS!") do mkdir %%~dpF 2>NUL
+        for /f "delims=" %%F in ("!RABBITMQ_LOGS!") do mkdir "%%~dpF" 2>NUL
         copy /y NUL "!RABBITMQ_LOGS!" >NUL
     )
-    for /f "delims=" %%F in ("!RABBITMQ_LOGS!") do set RABBITMQ_LOGS=%%~sF
 )
 rem [ "x" = "x$RABBITMQ_UPGRADE_LOG" ] && RABBITMQ_UPGRADE_LOG="${RABBITMQ_LOG_BASE}/${RABBITMQ_NODENAME}_upgrade.log"
 if "!RABBITMQ_UPGRADE_LOG!" == "" (
     set RABBITMQ_UPGRADE_LOG=!RABBITMQ_LOG_BASE!\!RABBITMQ_NODENAME!_upgrade.log
+) else (
+    set RABBITMQ_UPGRADE_LOG=!RABBITMQ_UPGRADE_LOG:"=!
 )
 REM [ "x" = "x$ERL_CRASH_DUMP"] && ERL_CRASH_DUMP="${RABBITMQ_LOG_BASE}/erl_crash.dump"
 if "!ERL_CRASH_DUMP!"=="" (
     set ERL_CRASH_DUMP=!RABBITMQ_LOG_BASE!\erl_crash.dump
+) else (
+    set ERL_CRASH_DUMP=!ERL_CRASH_DUMP:"=!
 )
 
 REM [ "x" = "x$RABBITMQ_CTL_ERL_ARGS" ] && RABBITMQ_CTL_ERL_ARGS=${CTL_ERL_ARGS}
@@ -379,10 +379,6 @@ if "!RABBITMQ_CTL_DIST_PORT_MAX!"=="" (
 )
 
 REM ADDITIONAL WINDOWS ONLY CONFIG ITEMS
-REM rabbitmq-plugins.bat
-REM if "!RABBITMQ_SERVICENAME!"=="" (
-REM     set RABBITMQ_SERVICENAME=RabbitMQ
-REM )
 
 if "!RABBITMQ_SERVICENAME!"=="" (
     if "!SERVICENAME!"=="" (
@@ -400,21 +396,21 @@ if defined RABBITMQ_DEV_ENV (
         if not "%RABBITMQ_FEATURE_FLAGS_FILE_source%" == "environment" (
             for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl eval "{ok, P} = application:get_env(rabbit, feature_flags_file), io:format(""~s~n"", [P])."') do @set feature_flags_file=%%F
             if exist "!feature_flags_file!" (
-                set RABBITMQ_FEATURE_FLAGS_FILE=!feature_flags_file!
+                set RABBITMQ_FEATURE_FLAGS_FILE=!feature_flags_file:"=!
             )
             REM set feature_flags_file=
         )
         if not "%RABBITMQ_PLUGINS_DIR_source%" == "environment" (
             for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl eval "{ok, P} = application:get_env(rabbit, plugins_dir), io:format(""~s~n"", [P])."') do @set plugins_dir=%%F
             if exist "!plugins_dir!" (
-                set RABBITMQ_PLUGINS_DIR=!plugins_dir!
+                set RABBITMQ_PLUGINS_DIR=!plugins_dir:"=!
             )
             REM set plugins_dir=
         )
         if not "%RABBITMQ_ENABLED_PLUGINS_FILE_source%" == "environment" (
             for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl eval "{ok, P} = application:get_env(rabbit, enabled_plugins_file), io:format(""~s~n"", [P])."') do @set enabled_plugins_file=%%F
             if exist "!enabled_plugins_file!" (
-                set RABBITMQ_ENABLED_PLUGINS_FILE=!enabled_plugins_file!
+                set RABBITMQ_ENABLED_PLUGINS_FILE=!enabled_plugins_file:"=!
             )
             REM set enabled_plugins_file=
         )
@@ -432,15 +428,15 @@ if defined RABBITMQ_DEV_ENV (
         if "!DEPS_DIR!" == "" (
             if exist "!RABBITMQ_HOME!\..\..\deps\rabbit_common\erlang.mk" (
                 REM Dependencies in the Umbrella or a plugin.
-                set DEPS_DIR_norm="!RABBITMQ_HOME!\..\..\deps"
+                set DEPS_DIR_norm=!RABBITMQ_HOME!\..\..\deps
             ) else (
                 if exist "!RABBITMQ_HOME!\deps\rabbit_common\erlang.mk" (
                     REM Dependencies in the broker.
-                    set DEPS_DIR_norm="!RABBITMQ_HOME!\deps"
+                    set DEPS_DIR_norm=!RABBITMQ_HOME!\deps
                 )
             )
         ) else (
-            for /f "delims=" %%F in ("!DEPS_DIR!") do @set DEPS_DIR_norm=%%~dpsF%%~nF%%~xF
+            for /f "delims=" %%F in ("!DEPS_DIR!") do @set DEPS_DIR_norm=%%~dpF%%~nF%%~xF
         )
 
         set ERL_LIBS=!DEPS_DIR_norm!;!ERL_LIBS!
@@ -449,12 +445,12 @@ if defined RABBITMQ_DEV_ENV (
     if exist "!RABBITMQ_PLUGINS_DIR!" (
         REM RabbitMQ was started from its install directory. Take
         REM rabbit_common from the plugins directory.
-        set ERL_LIBS=!RABBITMQ_PLUGINS_DIR!;!ERL_LIBS!
+        set ERL_LIBS=!RABBITMQ_PLUGINS_DIR:"=!;!ERL_LIBS:"=!
     )
 )
 
-REM Ensure all paths in ERL_LIBS do not contains non-ASCII characters.
-set ERL_LIBS_orig=%ERL_LIBS%
+REM Ensure ERL_LIBS begins with valid path
+set ERL_LIBS_orig=%ERL_LIBS:"=%
 set ERL_LIBS=
 call :filter_paths "%ERL_LIBS_orig%"
 goto :filter_paths_done
@@ -467,16 +463,15 @@ for /f "tokens=1* delims=;" %%a in ("%paths%") do (
     if not "%%b" == "" call :filter_paths "%%b"
 )
 set paths=
-exit /b
+goto :eof
 
 :filter_path
-REM Ensure ERL_LIBS begins with valid path
 IF "%ERL_LIBS%"=="" (
-    set ERL_LIBS=%~dps1%~n1%~x1
+    set ERL_LIBS=%~dp1%~n1%~x1
 ) else (
-    set ERL_LIBS=%ERL_LIBS%;%~dps1%~n1%~x1
+    set ERL_LIBS=%ERL_LIBS%;%~dp1%~n1%~x1
 )
-exit /b
+goto :eof
 
 :filter_paths_done
 
@@ -496,7 +491,3 @@ REM ##--- End of overridden <var_name> variables
 REM
 REM # Since we source this elsewhere, don't accidentally stop execution
 REM true
-
-:unquote
-set %1=%~2
-EXIT /B 0

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -21,7 +21,7 @@ rem Preserve values that might contain exclamation marks before
 rem enabling delayed expansion
 set TDP0=%~dp0
 set STAR=%*
-set CONF_SCRIPT_DIR="%~dp0"
+set CONF_SCRIPT_DIR=%~dp0
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
@@ -48,8 +48,8 @@ if not exist "!ERLANG_HOME!\bin\erl.exe" (
 
 set RABBITMQ_EBIN_ROOT=!RABBITMQ_HOME!\ebin
 
-CALL :convert_forward_slashes !RABBITMQ_ADVANCED_CONFIG_FILE! RABBITMQ_ADVANCED_CONFIG_FILE
-CALL :get_noex !RABBITMQ_ADVANCED_CONFIG_FILE! RABBITMQ_ADVANCED_CONFIG_FILE_NOEX
+CALL :convert_forward_slashes "!RABBITMQ_ADVANCED_CONFIG_FILE!" RABBITMQ_ADVANCED_CONFIG_FILE
+CALL :get_noex "!RABBITMQ_ADVANCED_CONFIG_FILE!" RABBITMQ_ADVANCED_CONFIG_FILE_NOEX
 
 if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!" (
     set RABBITMQ_ADVANCED_CONFIG_FILE=!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!.config
@@ -60,8 +60,8 @@ if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!" (
     )
 )
 
-CALL :convert_forward_slashes !RABBITMQ_CONFIG_FILE! RABBITMQ_CONFIG_FILE
-CALL :get_noex !RABBITMQ_CONFIG_FILE! RABBITMQ_CONFIG_FILE_NOEX
+CALL :convert_forward_slashes "!RABBITMQ_CONFIG_FILE!" RABBITMQ_CONFIG_FILE
+CALL :get_noex "!RABBITMQ_CONFIG_FILE!" RABBITMQ_CONFIG_FILE_NOEX
 
 if "!RABBITMQ_CONFIG_FILE!" == "!RABBITMQ_CONFIG_FILE_NOEX!" (
     if exist "!RABBITMQ_CONFIG_FILE_NOEX!.config" (
@@ -102,8 +102,8 @@ if "!RABBITMQ_CONFIG_FILE_NOEX!.config" == "!RABBITMQ_CONFIG_FILE!" (
     )
 )
 
-CALL :convert_forward_slashes !RABBITMQ_CONFIG_ARG_FILE! RABBITMQ_CONFIG_ARG_FILE
-CALL :get_noex !RABBITMQ_CONFIG_ARG_FILE! RABBITMQ_CONFIG_ARG_FILE_NOEX
+CALL :convert_forward_slashes "!RABBITMQ_CONFIG_ARG_FILE!" RABBITMQ_CONFIG_ARG_FILE
+CALL :get_noex "!RABBITMQ_CONFIG_ARG_FILE!" RABBITMQ_CONFIG_ARG_FILE_NOEX
 
 if not "!RABBITMQ_CONFIG_ARG_FILE_NOEX!.config" == "!RABBITMQ_CONFIG_ARG_FILE!" (
     if "!RABBITMQ_CONFIG_ARG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE!" (
@@ -135,15 +135,15 @@ if "!RABBITMQ_CONFIG_FILE_NOEX!.conf" == "!RABBITMQ_CONFIG_FILE!" (
 
     copy /Y "!RABBITMQ_HOME!\priv\schema\rabbit.schema" "!RABBITMQ_SCHEMA_DIR!\rabbit.schema"
 
-    set RABBITMQ_GENERATED_CONFIG_ARG=-conf "!RABBITMQ_CONFIG_FILE!" ^
-                                      -conf_dir "!RABBITMQ_GENERATED_CONFIG_DIR!" ^
-                                      -conf_script_dir !CONF_SCRIPT_DIR:\=/! ^
-                                      -conf_schema_dir "!RABBITMQ_SCHEMA_DIR!" ^
-                                      -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE!"
+    set RABBITMQ_GENERATED_CONFIG_ARG=-conf "!RABBITMQ_CONFIG_FILE:\=/!" ^
+                                      -conf_dir "!RABBITMQ_GENERATED_CONFIG_DIR:\=/!" ^
+                                      -conf_script_dir "!CONF_SCRIPT_DIR:\=/!" ^
+                                      -conf_schema_dir "!RABBITMQ_SCHEMA_DIR:\=/!" ^
+                                      -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE:\=/!"
 )
 
 "!ERLANG_HOME!\bin\erl.exe" ^
-        -pa "!RABBITMQ_EBIN_ROOT!" ^
+        -pa "!RABBITMQ_EBIN_ROOT:\=/!" ^
         -boot !CLEAN_BOOT_FILE! ^
         -noinput -hidden ^
         -s rabbit_prelaunch ^
@@ -183,12 +183,10 @@ if ERRORLEVEL 1 (
     set RABBITMQ_DEFAULT_ALLOC_ARGS=
 )
 
-set RABBITMQ_EBIN_PATH="-pa !RABBITMQ_EBIN_ROOT!"
-
 set RABBITMQ_LISTEN_ARG=
 if not "!RABBITMQ_NODE_IP_ADDRESS!"=="" (
    if not "!RABBITMQ_NODE_PORT!"=="" (
-      set RABBITMQ_LISTEN_ARG=-rabbit tcp_listeners [{\""!RABBITMQ_NODE_IP_ADDRESS!"\","!RABBITMQ_NODE_PORT!"}]
+      set RABBITMQ_LISTEN_ARG=-rabbit tcp_listeners [{"\"!RABBITMQ_NODE_IP_ADDRESS!\"","!RABBITMQ_NODE_PORT!"}]
    )
 )
 
@@ -201,8 +199,8 @@ if "!RABBITMQ_LOGS!" == "-" (
     set RABBITMQ_LAGER_HANDLER_UPGRADE=tty
 ) else (
     set SASL_ERROR_LOGGER=false
-    set RABBIT_LAGER_HANDLER=\""!RABBITMQ_LOGS:\=/!"\"
-    set RABBITMQ_LAGER_HANDLER_UPGRADE=\""!RABBITMQ_UPGRADE_LOG:\=/!"\"
+    set RABBIT_LAGER_HANDLER="\"!RABBITMQ_LOGS:\=/!\""
+    set RABBITMQ_LAGER_HANDLER_UPGRADE="\"!RABBITMQ_UPGRADE_LOG:\=/!\""
 )
 
 set RABBITMQ_START_RABBIT=
@@ -233,7 +231,7 @@ if "!ENV_OK!"=="false" (
 )
 
 "!ERLANG_HOME!\bin\erl.exe" ^
--pa "!RABBITMQ_EBIN_ROOT!" ^
+-pa "!RABBITMQ_EBIN_ROOT:\=/!" ^
 -boot start_sasl ^
 !RABBITMQ_START_RABBIT! ^
 !RABBITMQ_CONFIG_ARG! ^
@@ -248,17 +246,17 @@ if "!ENV_OK!"=="false" (
 !RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS! ^
 -sasl errlog_type error ^
 -sasl sasl_error_logger !SASL_ERROR_LOGGER! ^
--rabbit lager_log_root \""!RABBITMQ_LOG_BASE:\=/!"\" ^
+-rabbit lager_log_root "\"!RABBITMQ_LOG_BASE:\=/!\"" ^
 -rabbit lager_default_file !RABBIT_LAGER_HANDLER! ^
 -rabbit lager_upgrade_file !RABBITMQ_LAGER_HANDLER_UPGRADE! ^
--rabbit feature_flags_file \""!RABBITMQ_FEATURE_FLAGS_FILE:\=/!"\" ^
--rabbit enabled_plugins_file \""!RABBITMQ_ENABLED_PLUGINS_FILE:\=/!"\" ^
--rabbit plugins_dir \""!RABBITMQ_PLUGINS_DIR:\=/!"\" ^
--rabbit plugins_expand_dir \""!RABBITMQ_PLUGINS_EXPAND_DIR:\=/!"\" ^
+-rabbit feature_flags_file "\"!RABBITMQ_FEATURE_FLAGS_FILE:\=/!\"" ^
+-rabbit enabled_plugins_file "\"!RABBITMQ_ENABLED_PLUGINS_FILE:\=/!\"" ^
+-rabbit plugins_dir "\"!RABBITMQ_PLUGINS_DIR:\=/!\"" ^
+-rabbit plugins_expand_dir "\"!RABBITMQ_PLUGINS_EXPAND_DIR:\=/!\"" ^
+-mnesia dir "\"!RABBITMQ_MNESIA_DIR:\=/!\"" ^
 -os_mon start_cpu_sup false ^
 -os_mon start_disksup false ^
 -os_mon start_memsup false ^
--mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^
 !RABBITMQ_SERVER_START_ARGS! ^
 !RABBITMQ_DIST_ARG! ^
 !STAR!

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -21,7 +21,7 @@ rem Preserve values that might contain exclamation marks before
 rem enabling delayed expansion
 set TN0=%~n0
 set TDP0=%~dp0
-set CONF_SCRIPT_DIR="%~dp0"
+set CONF_SCRIPT_DIR=%~dp0
 set P1=%1
 setlocal enabledelayedexpansion
 setlocal enableextensions
@@ -109,7 +109,7 @@ exit /B
 :INSTALL_SERVICE
 
 if not exist "!RABBITMQ_BASE!" (
-    echo Creating base directory !RABBITMQ_BASE! & md "!RABBITMQ_BASE!"
+    echo Creating base directory !RABBITMQ_BASE! & mkdir "!RABBITMQ_BASE!"
 )
 
 set ENV_OK=true
@@ -131,8 +131,8 @@ if errorlevel 1 (
 
 set RABBITMQ_EBIN_ROOT=!RABBITMQ_HOME!\ebin
 
-CALL :convert_forward_slashes !RABBITMQ_ADVANCED_CONFIG_FILE! RABBITMQ_ADVANCED_CONFIG_FILE
-CALL :get_noex !RABBITMQ_ADVANCED_CONFIG_FILE! RABBITMQ_ADVANCED_CONFIG_FILE_NOEX
+CALL :convert_forward_slashes "!RABBITMQ_ADVANCED_CONFIG_FILE!" RABBITMQ_ADVANCED_CONFIG_FILE
+CALL :get_noex "!RABBITMQ_ADVANCED_CONFIG_FILE!" RABBITMQ_ADVANCED_CONFIG_FILE_NOEX
 
 if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!" (
     set RABBITMQ_ADVANCED_CONFIG_FILE=!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!.config
@@ -143,8 +143,8 @@ if "!RABBITMQ_ADVANCED_CONFIG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE_NOEX!" (
     )
 )
 
-CALL :convert_forward_slashes !RABBITMQ_CONFIG_FILE! RABBITMQ_CONFIG_FILE
-CALL :get_noex !RABBITMQ_CONFIG_FILE! RABBITMQ_CONFIG_FILE_NOEX
+CALL :convert_forward_slashes "!RABBITMQ_CONFIG_FILE!" RABBITMQ_CONFIG_FILE
+CALL :get_noex "!RABBITMQ_CONFIG_FILE!" RABBITMQ_CONFIG_FILE_NOEX
 
 if "!RABBITMQ_CONFIG_FILE!" == "!RABBITMQ_CONFIG_FILE_NOEX!" (
     if exist "!RABBITMQ_CONFIG_FILE_NOEX!.config" (
@@ -185,8 +185,8 @@ if "!RABBITMQ_CONFIG_FILE_NOEX!.config" == "!RABBITMQ_CONFIG_FILE!" (
     )
 )
 
-CALL :convert_forward_slashes !RABBITMQ_CONFIG_ARG_FILE! RABBITMQ_CONFIG_ARG_FILE
-CALL :get_noex !RABBITMQ_CONFIG_ARG_FILE! RABBITMQ_CONFIG_ARG_FILE_NOEX
+CALL :convert_forward_slashes "!RABBITMQ_CONFIG_ARG_FILE!" RABBITMQ_CONFIG_ARG_FILE
+CALL :get_noex "!RABBITMQ_CONFIG_ARG_FILE!" RABBITMQ_CONFIG_ARG_FILE_NOEX
 
 if not "!RABBITMQ_CONFIG_ARG_FILE_NOEX!.config" == "!RABBITMQ_CONFIG_ARG_FILE!" (
     if "!RABBITMQ_CONFIG_ARG_FILE!" == "!RABBITMQ_ADVANCED_CONFIG_FILE!" (
@@ -218,15 +218,15 @@ if "!RABBITMQ_CONFIG_FILE_NOEX!.conf" == "!RABBITMQ_CONFIG_FILE!" (
 
     copy /Y "!RABBITMQ_HOME!\priv\schema\rabbit.schema" "!RABBITMQ_SCHEMA_DIR!\rabbit.schema"
 
-    set RABBITMQ_GENERATED_CONFIG_ARG=-conf "!RABBITMQ_CONFIG_FILE!" ^
-                                      -conf_dir "!RABBITMQ_GENERATED_CONFIG_DIR!" ^
-                                      -conf_script_dir !CONF_SCRIPT_DIR:\=/! ^
-                                      -conf_schema_dir "!RABBITMQ_SCHEMA_DIR!" ^
-                                      -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE!"
+    set RABBITMQ_GENERATED_CONFIG_ARG=-conf "!RABBITMQ_CONFIG_FILE:\=/!" ^
+                                      -conf_dir "!RABBITMQ_GENERATED_CONFIG_DIR:\=/!" ^
+                                      -conf_script_dir "!CONF_SCRIPT_DIR:\=/!" ^
+                                      -conf_schema_dir "!RABBITMQ_SCHEMA_DIR:\=/!" ^
+                                      -conf_advanced "!RABBITMQ_ADVANCED_CONFIG_FILE:\=/!"
 )
 
 "!ERLANG_HOME!\bin\erl.exe" ^
-        -pa "!RABBITMQ_EBIN_ROOT!" ^
+        -pa "!RABBITMQ_EBIN_ROOT:\=/!" ^
         -boot !CLEAN_BOOT_FILE! ^
         -noinput -hidden ^
         -s rabbit_prelaunch ^
@@ -284,8 +284,8 @@ if "!RABBITMQ_LOGS!" == "-" (
     set RABBITMQ_LAGER_HANDLER_UPGRADE=tty
 ) else (
     set SASL_ERROR_LOGGER=false
-    set RABBIT_LAGER_HANDLER=\""!RABBITMQ_LOGS:\=/!"\"
-    set RABBITMQ_LAGER_HANDLER_UPGRADE=\""!RABBITMQ_UPGRADE_LOG:\=/!"\"
+    set RABBIT_LAGER_HANDLER="\"!RABBITMQ_LOGS:\=/!\""
+    set RABBITMQ_LAGER_HANDLER_UPGRADE="\"!RABBITMQ_UPGRADE_LOG:\=/!\""
 )
 
 set RABBITMQ_START_RABBIT=
@@ -307,7 +307,7 @@ if "!ERL_MAX_ETS_TABLES!"=="" (
 )
 
 set ERLANG_SERVICE_ARGUMENTS= ^
--pa "!RABBITMQ_EBIN_ROOT!" ^
+-pa "!RABBITMQ_EBIN_ROOT:\=/!" ^
 -boot start_sasl ^
 !RABBITMQ_START_RABBIT! ^
 !RABBITMQ_CONFIG_ARG! ^
@@ -321,26 +321,24 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 !RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS! ^
 -sasl errlog_type error ^
 -sasl sasl_error_logger false ^
--rabbit lager_log_root \""!RABBITMQ_LOG_BASE:\=/!"\" ^
+-rabbit lager_log_root "\"!RABBITMQ_LOG_BASE:\=/!\"" ^
 -rabbit lager_default_file !RABBIT_LAGER_HANDLER! ^
 -rabbit lager_upgrade_file !RABBITMQ_LAGER_HANDLER_UPGRADE! ^
--rabbit feature_flags_file \""!RABBITMQ_FEATURE_FLAGS_FILE:\=/!"\" ^
--rabbit enabled_plugins_file \""!RABBITMQ_ENABLED_PLUGINS_FILE:\=/!"\" ^
--rabbit plugins_dir \""!RABBITMQ_PLUGINS_DIR:\=/!"\" ^
--rabbit plugins_expand_dir \""!RABBITMQ_PLUGINS_EXPAND_DIR:\=/!"\" ^
--rabbit windows_service_config \""!RABBITMQ_CONFIG_FILE:\=/!"\" ^
+-rabbit feature_flags_file "\"!RABBITMQ_FEATURE_FLAGS_FILE:\=/!\"" ^
+-rabbit enabled_plugins_file "\"!RABBITMQ_ENABLED_PLUGINS_FILE:\=/!\"" ^
+-rabbit plugins_dir "\"!RABBITMQ_PLUGINS_DIR:\=/!\"" ^
+-rabbit plugins_expand_dir "\"!RABBITMQ_PLUGINS_EXPAND_DIR:\=/!\"" ^
+-rabbit windows_service_config "\"!RABBITMQ_CONFIG_FILE:\=/!\"" ^
+-mnesia dir "\"!RABBITMQ_MNESIA_DIR:\=/!\"" ^
 -os_mon start_cpu_sup false ^
 -os_mon start_disksup false ^
 -os_mon start_memsup false ^
--mnesia dir \""!RABBITMQ_MNESIA_DIR:\=/!"\" ^
 !RABBITMQ_SERVER_START_ARGS! ^
 !RABBITMQ_DIST_ARG! ^
 !STARVAR!
 
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:\=\\!
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:"=\"!
-
-
 
 "!ERLANG_SERVICE_MANAGER_PATH!\erlsrv" set !RABBITMQ_SERVICENAME! ^
 -onfail !RABBITMQ_SERVICE_RESTART! ^

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -1120,7 +1120,7 @@ print_banner() ->
     {ok, Version} = application:get_key(vsn),
     {LogFmt, LogLocations} = case log_locations() of
         [_ | Tail] = LL ->
-            LF = lists:flatten(["~n                    ~s"
+            LF = lists:flatten(["~n                    ~ts"
                                 || _ <- lists:seq(1, length(Tail))]),
             {LF, LL};
         [] ->
@@ -1130,7 +1130,7 @@ print_banner() ->
               "~n  ##  ##      ~s ~s. ~s"
               "~n  ##########  ~s"
               "~n  ######  ##"
-              "~n  ##########  Logs: ~s" ++
+              "~n  ##########  Logs: ~ts" ++
               LogFmt ++
               "~n~n              Starting broker..."
               "~n",
@@ -1154,7 +1154,7 @@ log_banner() ->
     DescrLen = 1 + lists:max([length(K) || {K, _V} <- Settings]),
     Format = fun (K, V) ->
                      rabbit_misc:format(
-                       " ~-" ++ integer_to_list(DescrLen) ++ "s: ~s~n", [K, V])
+                       " ~-" ++ integer_to_list(DescrLen) ++ "s: ~ts~n", [K, V])
              end,
     Banner = string:strip(lists:flatten(
                [case S of
@@ -1165,7 +1165,7 @@ log_banner() ->
                     {K, V} ->
                         Format(K, V)
                 end || S <- Settings]), right, $\n),
-    rabbit_log:info("~n~s", [Banner]).
+    rabbit_log:info("~n~ts", [Banner]).
 
 warn_if_kernel_config_dubious() ->
     case os:type() of

--- a/src/rabbit_config.erl
+++ b/src/rabbit_config.erl
@@ -143,7 +143,7 @@ generate_config_file(ConfFiles, ConfDir, ScriptDir, SchemaDir, Advanced) ->
     Command = lists:concat(["escript ", "\"", Cuttlefish, "\"",
                             "  -f rabbitmq -s ", "\"", SchemaDir, "\"",
                             " -e ", "\"",  ConfDir, "\"",
-                            [[" -c ", ConfFile] || ConfFile <- ConfFiles],
+                            [[" -c \"", ConfFile, "\""] || ConfFile <- ConfFiles],
                             AdvancedConfigArg]),
     rabbit_log:debug("Generating config file using '~s'", [Command]),
     Result = rabbit_misc:os_cmd(Command),

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -106,7 +106,7 @@ init() ->
     ensure_mnesia_dir(),
     case is_virgin_node() of
         true  ->
-            rabbit_log:info("Node database directory at ~s is empty. "
+            rabbit_log:info("Node database directory at ~ts is empty. "
                             "Assuming we need to join an existing cluster or initialise from scratch...~n",
                             [dir()]),
             rabbit_peer_discovery:log_configured_backend(),

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -64,7 +64,7 @@ recover() ->
 
 recover(VHost) ->
     VHostDir = rabbit_vhost:msg_store_dir_path(VHost),
-    rabbit_log:info("Making sure data directory '~s' for vhost '~s' exists~n",
+    rabbit_log:info("Making sure data directory '~ts' for vhost '~s' exists~n",
                     [VHostDir, VHost]),
     VHostStubFile = filename:join(VHostDir, ".vhost"),
     ok = rabbit_file:ensure_dir(VHostStubFile),
@@ -295,7 +295,7 @@ dir(Vhost) ->
     rabbit_misc:format("~.36B", [Num]).
 
 msg_store_dir_path(VHost) ->
-    EncodedName = list_to_binary(dir(VHost)),
+    EncodedName = dir(VHost),
     rabbit_data_coercion:to_list(filename:join([msg_store_dir_base(),
                                                 EncodedName])).
 


### PR DESCRIPTION
Fixes #2059 

Requires erlang-lager/lager#509

* Removes "short name" formatting of paths.
* Correctly quotes paths when passed as arguments to commands and functions to address spaces

Testing instructions:

https://gist.github.com/lukebakken/5b26ecee1ff9eb6e582bcdf1452cfc78

[167411855]