### PR TITLE
Make it possible to pre-configure cluster name via config

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -200,6 +200,10 @@
 # ssl_handshake_timeout = 5000
 
 
+## Cluster name
+##
+# cluster_name = dev3.eng.megacorp.local
+
 ## Password hashing implementation. Will only affect newly
 ## created users. To recalculate hash for an existing user
 ## it's necessary to update her password.
@@ -512,7 +516,7 @@
 # net_ticktime = 60
 
 ## Inter-node communication port range.
-## The parameters inet_dist_listen_min and inet_dist_listen_max  
+## The parameters inet_dist_listen_min and inet_dist_listen_max
 ## can be configured in the classic config format only.
 ## Related doc guide: https://www.rabbitmq.com/networking.html#epmd-inet-dist-port-range.
 

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -383,12 +383,18 @@ end}.
     {datatype, {enum, [distinguished_name, common_name]}}
 ]}.
 
-%% SSL handshake timeout, in milliseconds.
+%% TLS handshake timeout, in milliseconds.
 %%
 %% {ssl_handshake_timeout, 5000},
 
 {mapping, "ssl_handshake_timeout", "rabbit.ssl_handshake_timeout", [
     {datatype, integer}
+]}.
+
+%% Cluster name
+
+{mapping, "cluster_name", "rabbit.cluster_name", [
+    {datatype, string}
 ]}.
 
 %% Default worker process pool size. Used to limit maximum concurrency rate

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -226,6 +226,12 @@
                    [{description, "ready to communicate with peers and clients"},
                     {requires,    [core_initialized, recovery, routing_ready]}]}).
 
+-rabbit_boot_step({cluster_name,
+                   [{description, "sets cluster name if configured"},
+                    {mfa,         {rabbit_nodes, boot, []}},
+                    {requires,    pre_flight}
+                    ]}).
+
 -rabbit_boot_step({direct_client,
                    [{description, "direct client"},
                     {mfa,         {rabbit_direct, boot, []}},


### PR DESCRIPTION
## Proposed Changes

This introduces a new boot step that [pre-]configures cluster name so that it is available to plugins that might use it, such as `rabbitmq_prometheus`.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Per discussion with @gerhard.
