### PR TITLE
rabbit_amqqueue: Return empty list in consumers/1 when the queue is gone

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -1074,9 +1074,10 @@ consumers(Q) when ?amqqueue_is_classic(Q) ->
     delegate:invoke(QPid, {gen_server2, call, [consumers, infinity]});
 consumers(Q) when ?amqqueue_is_quorum(Q) ->
     QPid = amqqueue:get_pid(Q),
-    {ok, {_, Result}, _} = ra:local_query(QPid,
-                                          fun rabbit_fifo:query_consumers/1),
-    maps:values(Result).
+    case ra:local_query(QPid, fun rabbit_fifo:query_consumers/1) of
+        {ok, {_, Result}, _} -> maps:values(Result);
+        _                    -> []
+    end.
 
 -spec consumer_info_keys() -> rabbit_types:info_keys().
 


### PR DESCRIPTION
This seems to happen in our CI quite frequently with `queue_parallel_SUITE`. In this testsuite, testcases are executed in parallel. At least the `basic_cancel` testcase queries all consumers of all queues: if an unrelated testcase finishes in parallel and thus deletes its queue(s), the call to `consumers_all/1` crashes.