### PR TITLE
On Windows, ensure RABBITMQ_FEATURE_FLAGS_FILE_source is set to "environment" correctly

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -404,21 +404,21 @@ if defined RABBITMQ_DEV_ENV (
         REM We may need to query the running node for the plugins directory
         REM and the "enabled plugins" file.
         if not "%RABBITMQ_FEATURE_FLAGS_FILE_source%" == "environment" (
-            for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl eval "{ok, P} = application:get_env(rabbit, feature_flags_file), io:format(""~s~n"", [P])."') do @set feature_flags_file=%%F
+            for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl.bat eval "{ok, P} = application:get_env(rabbit, feature_flags_file), io:format(""~s~n"", [P])."') do @set feature_flags_file=%%F
             if exist "!feature_flags_file!" (
                 set RABBITMQ_FEATURE_FLAGS_FILE=!feature_flags_file:"=!
             )
             REM set feature_flags_file=
         )
         if not "%RABBITMQ_PLUGINS_DIR_source%" == "environment" (
-            for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl eval "{ok, P} = application:get_env(rabbit, plugins_dir), io:format(""~s~n"", [P])."') do @set plugins_dir=%%F
+            for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl.bat eval "{ok, P} = application:get_env(rabbit, plugins_dir), io:format(""~s~n"", [P])."') do @set plugins_dir=%%F
             if exist "!plugins_dir!" (
                 set RABBITMQ_PLUGINS_DIR=!plugins_dir:"=!
             )
             REM set plugins_dir=
         )
         if not "%RABBITMQ_ENABLED_PLUGINS_FILE_source%" == "environment" (
-            for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl eval "{ok, P} = application:get_env(rabbit, enabled_plugins_file), io:format(""~s~n"", [P])."') do @set enabled_plugins_file=%%F
+            for /f "delims=" %%F in ('!SCRIPT_DIR!\rabbitmqctl.bat eval "{ok, P} = application:get_env(rabbit, enabled_plugins_file), io:format(""~s~n"", [P])."') do @set enabled_plugins_file=%%F
             if exist "!enabled_plugins_file!" (
                 set RABBITMQ_ENABLED_PLUGINS_FILE=!enabled_plugins_file:"=!
             )


### PR DESCRIPTION
Prior to this patch, `make run-broker` on Windows would attempt to contact a running node when rabbitmq-env.bat is sourced, even when it shouldn't. You would see the typical "Can't contact node..." error output, but the make target would proceed as normal.

This patch brings `rabbitmq-env.bat` in-line with `rabbitmq-env`

[168153903]