### PR TITLE
rabbitmq-env.bat: Quote the expansion of %1 in `filter_path`

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -477,9 +477,9 @@ goto :eof
 
 :filter_path
 IF "%ERL_LIBS%"=="" (
-    set ERL_LIBS=%~dp1%~n1%~x1
+    set "ERL_LIBS=%~dp1%~n1%~x1"
 ) else (
-    set ERL_LIBS=%ERL_LIBS%;%~dp1%~n1%~x1
+    set "ERL_LIBS=!ERL_LIBS!;%~dp1%~n1%~x1"
 )
 goto :eof
 


### PR DESCRIPTION
Otherwise, paths containing parenthesis such as `C:/Program Files (x86)/...` get mis-interpreted and the function fails.

In my testing, the error was:
```
\Elixir\lib\elixir was unexpected
```

... based on the fact that Elixir is installed in `C:\Program Files (x86)\Elixir`.

While here, explicitely calls `rabbitmqctl.bat`, not `rabbitmqctl`. The latter might be available and picked in a Git clone.