### PR TITLE
rabbit_disk_monitor: Tell Win32 API to not enforce path limits to dir's argument

### DIFF
--- a/src/rabbit_disk_monitor.erl
+++ b/src/rabbit_disk_monitor.erl
@@ -240,7 +240,28 @@ get_disk_free(Dir, {unix, _}) ->
     Df = os:find_executable("df"),
     parse_free_unix(rabbit_misc:os_cmd(Df ++ " -kP " ++ Dir));
 get_disk_free(Dir, {win32, _}) ->
-    parse_free_win32(rabbit_misc:os_cmd("dir /-C /W \"" ++ Dir ++ "\"")).
+    %% On Windows, the Win32 API enforces a limit of 260 characters
+    %% (MAX_PATH). If we call `dir` with a path longer than that, it
+    %% fails with "File not found". Starting with Windows 10 version
+    %% 1607, this limit was removed, but the administrator has to
+    %% configure that.
+    %%
+    %% NTFS supports paths up to 32767 characters. Therefore, paths
+    %% longer than 260 characters exist but they are "inaccessible" to
+    %% `dir`.
+    %%
+    %% A workaround is to tell the Win32 API to not parse a path and
+    %% just pass it raw to the underlying filesystem. To do this, the
+    %% path must be prepended with "\\?\". That's what we do here.
+    %%
+    %% However, the underlying filesystem may not support forward
+    %% slashes transparently, as the Win32 API does. Therefore, we
+    %% convert all forward slashes to backslashes.
+    %%
+    %% See the following page to learn more about this:
+    %% https://ss64.com/nt/syntax-filenames.html
+    RawDir = "\\\\?\\" ++ string:replace(Dir, "/", "\\", all),
+    parse_free_win32(rabbit_misc:os_cmd("dir /-C /W \"" ++ RawDir ++ "\"")).
 
 parse_free_unix(Str) ->
     case string:tokens(Str, "\n") of


### PR DESCRIPTION
On Windows, the Win32 API enforces a limit of 260 characters (MAX_PATH). If we call `dir` with a path longer than that, it fails with "File not found". Starting with Windows 10 version 1607, this limit was removed, but the administrator has to configure that.

NTFS supports paths up to 32767 characters. Therefore, paths longer than 260 characters exist but they are "inaccessible" to `dir`.

A workaround is to tell the Win32 API to not parse a path and just pass it raw to the underlying filesystem. To do this, the path must be prepended with "\\?\". That's what we do here.

However, the underlying filesystem may not support forward slashes transparently, as the Win32 API does. Therefore, we convert all forward slashes to backslashes.

See the following page to learn more about this:
https://ss64.com/nt/syntax-filenames.html

This was discovered while working on the common_test testsuites on Windows: we store RabbitMQ data files under common_test's `log_private` directory and we can quickly reach the 260-character limit.