### PR TITLE
call "add_to_journal" before "maybe_flush_pre_publish_cache" in pre_publish

### DIFF
--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -349,11 +349,11 @@ pre_publish(MsgOrId, SeqId, MsgProps, IsPersistent, IsDelivered, JournalSizeHint
                 DC
         end,
 
-    add_to_journal(SeqId, {IsPersistent, Bin, MsgBin},
-                   maybe_flush_pre_publish_cache(
+    State2 = add_to_journal(SeqId, {IsPersistent, Bin, MsgBin}, State1),
+    maybe_flush_pre_publish_cache(
                      JournalSizeHint,
-                     State1#qistate{pre_publish_cache = PPC1,
-                                    delivered_cache   = DC1})).
+                     State2#qistate{pre_publish_cache = PPC1,
+                                    delivered_cache   = DC1}).
 
 %% pre_publish_cache is the entry with most elements when compared to
 %% delivered_cache so we only check the former in the guard.


### PR DESCRIPTION
To reproduce the issue:
1. pre_publish a delivered message.
2. Put its SeqId into delivered_cache, and might call "flush_pre_publish_cache" and "flush_delivered_cache", 
   then put its "del" data into the journal_entries of the corresponding segment.
3. Call add_to_journal and action_to_entry with a "?PUB" Action. 
4. in action_to_entry, "array:get(RelSeq, JEntries)" will return {no_pub,    del, no_ack}, but has none case for a "?PUB" Action, so an error will occur like "{{case_clause,{no_pub,del,no_ack}},[{rabbit_queue_index,action_to_entry,3..."

