### PR TITLE
force to flush segments when recovering a message with last non-CleanShutdown.

### DIFF
--- a/src/rabbit_queue_index.erl
+++ b/src/rabbit_queue_index.erl
@@ -640,7 +640,8 @@ init_dirty(CleanShutdown, ContainsCheckFun, State) ->
                   {{Segment = #segment { unacked = UnackedCount }, Dirty},
                    UnackedBytes} =
                       recover_segment(ContainsCheckFun, CleanShutdown,
-                                      segment_find_or_new(Seg, Dir, Segments2)),
+                                      segment_find_or_new(Seg, Dir, Segments2),
+                                      State1#qistate.max_journal_entries),
                   {segment_store(Segment, Segments2),
                    CountAcc + UnackedCount,
                    BytesAcc + UnackedBytes, DirtyCount + Dirty}
@@ -664,7 +665,7 @@ terminate(State = #qistate { journal_handle = JournalHdl,
                                      segments = undefined }}.
 
 recover_segment(ContainsCheckFun, CleanShutdown,
-                Segment = #segment { journal_entries = JEntries }) ->
+                Segment = #segment { journal_entries = JEntries }, MaxJournal) ->
     {SegEntries, UnackedCount} = load_segment(false, Segment),
     {SegEntries1, UnackedCountDelta} =
         segment_plus_journal(SegEntries, JEntries),
@@ -673,7 +674,7 @@ recover_segment(ContainsCheckFun, CleanShutdown,
            {SegmentAndDirtyCount, Bytes}) ->
               {MsgOrId, MsgProps} = parse_pub_record_body(Bin, MsgBin),
               {recover_message(ContainsCheckFun(MsgOrId), CleanShutdown,
-                               Del, RelSeq, SegmentAndDirtyCount),
+                               Del, RelSeq, SegmentAndDirtyCount, MaxJournal),
                Bytes + case IsPersistent of
                            true  -> MsgProps#message_properties.size;
                            false -> 0
@@ -682,15 +683,16 @@ recover_segment(ContainsCheckFun, CleanShutdown,
       {{Segment #segment { unacked = UnackedCount + UnackedCountDelta }, 0}, 0},
       SegEntries1).
 
-recover_message( true,  true,   _Del, _RelSeq, SegmentAndDirtyCount) ->
+recover_message( true,  true,   _Del, _RelSeq, SegmentAndDirtyCount, _MaxJournal) ->
     SegmentAndDirtyCount;
-recover_message( true, false,    del, _RelSeq, SegmentAndDirtyCount) ->
+recover_message( true, false,    del, _RelSeq, SegmentAndDirtyCount, _MaxJournal) ->
     SegmentAndDirtyCount;
-recover_message( true, false, no_del,  RelSeq, {Segment, DirtyCount}) ->
-    {add_to_journal(RelSeq, del, Segment), DirtyCount + 1};
-recover_message(false,     _,    del,  RelSeq, {Segment, DirtyCount}) ->
+recover_message( true, false, no_del,  RelSeq, {Segment, _DirtyCount}, MaxJournal) ->
+    %% force to flush the segment
+    {add_to_journal(RelSeq, del, Segment), MaxJournal + 1}; 
+recover_message(false,     _,    del,  RelSeq, {Segment, DirtyCount}, _MaxJournal) ->
     {add_to_journal(RelSeq, ack, Segment), DirtyCount + 1};
-recover_message(false,     _, no_del,  RelSeq, {Segment, DirtyCount}) ->
+recover_message(false,     _, no_del,  RelSeq, {Segment, DirtyCount}, _MaxJournal) ->
     {add_to_journal(RelSeq, ack,
                     add_to_journal(RelSeq, del, Segment)),
      DirtyCount + 2}.


### PR DESCRIPTION
If the broker shutdown before queue process call "rabbit_queue_index:flush", 
there might be only ?PUB and ack of a message in the queue's journal file.
restart the broker, a crash would happen when recover_journal.

to reproduce the issue by the following steps:
1. Disable flush in rabbit_queue_index, Just for reproducing the problem much more easily.

2. delcare a durable queue and an exchange. 
[root@controller2 erlang]# date;python msg_test.py create_queue 192.168.1.66 'queue=q11;durable=true'
Sat Sep  7 15:53:20 CST 2019
connent to 192.168.1.66 ok
2019-09-07 15:53:20.264 create_queue q11
2019-09-07 15:53:20.293 to close connection
[root@controller2 erlang]# date;python msg_test.py create_exchange 192.168.1.66 'exchange=ex11;exchange_type=topic'
Sat Sep  7 15:53:20 CST 2019
connent to 192.168.1.66 ok
2019-09-07 15:53:20.461 create_exchange ex11 topic
2019-09-07 15:53:20.463 to close connection
[root@controller2 erlang]# date;python msg_test.py bind 192.168.1.66 'exchange=ex11;queue=q11;routing_key=exq11'
Sat Sep  7 15:53:21 CST 2019
connent to 192.168.1.66 ok
2019-09-07 15:53:21.263 bind ex11 q11 r_key:exq11
2019-09-07 15:53:21.266 to close connection

3. publish a persistent message.
[root@controller2 erlang]# date;python msg_test.py publish 192.168.1.66 'exchange=ex11;routing_key=exq11;msg="_unique_id:123";persistent=true;count=1'
Sat Sep  7 15:53:34 CST 2019
connent to 192.168.1.66 ok
2019-09-07 15:53:34.642 publish ex11 r_key:exq11, 0
2019-09-07 15:53:35.643 to close connection

4. kill the broker. the system auto-restart the broker which will call recover_message with non-CleanShutdown.
[root@controller2 erlang]# date;pkill -9 beam
Sat Sep  7 15:54:15 CST 2019

5. create a consumer, attach it to the queue. It will receive and ack the last recovered message.
[root@controller2 erlang]# date;python msg_test.py consume 192.168.1.66 'queue=q11;auto_ack=false'
Sat Sep  7 15:55:47 CST 2019
connent to 192.168.1.66 ok
2019-09-07 15:55:47.529  [*] Waiting for messages from q11. To exit press CTRL+C
2019-09-07 15:55:47.529  [x] Received '_unique_id:0 aaaaaaa' ack:True delivery_tag:1 sleep:0
^C2019-09-07 15:56:12.692 BaseException
2019-09-07 15:56:12.693 to close connection

6. now in the queue's journal file, there are only ?PUB and ack of the message. 
restart the broker, a crash should occur when calling recover_journal.
[root@controller2 erlang]# date;systemctl restart rabbitmq-server
Sat Sep  7 15:56:24 CST 2019

7. the crash information in the /var/log/rabbitmq/rabbit@controller2.log:
** Reason for termination ==
** {{case_clause,{{true,<<10,5,11,69,10,165,64,237,79,106,53,20,96,22,129,137,0,0,0,0,0,0,0,0,0,0,0,113>>,<<131,104,6,100,0,13,98,97,115,105,99,95,109,101,115,115,97,103,101,104,4,100,0,8,114,101,115,111,117,114,99,101,109,0,0,0,1,47,100,0,8,101,120,99,104,97,110,103,101,109,0,0,0,4,101,120,49,49,108,0,0,0,1,109,0,0,0,5,101,120,113,49,49,106,104,7,100,0,7,99,111,110,116,101,110,116,97,60,100,0,4,110,111,110,101,109,0,0,0,3,16,0,2,100,0,25,114,97,98,98,105,116,95,102,114,97,109,105,110,103,95,97,109,113,112,95,48,95,57,95,49,108,0,0,0,1,109,0,0,0,113,95,117,110,105,113,117,101,95,105,100,58,48,32,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,97,106,104,4,100,0,14,99,111,110,116,101,110,116,95,116,114,97,99,101,100,100,0,5,102,97,108,115,101,104,3,100,0,9,117,110,100,101,102,105,110,101,100,100,0,9,117,110,100,101,102,105,110,101,100,100,0,9,117,110,100,101,102,105,110,101,100,110,6,0,178,202,182,10,109,1,109,0,0,0,16,10,5,11,69,10,165,64,237,79,106,53,20,96,22,129,137,100,0,4,116,114,117,101>>},no_del,no_ack}},[{rabbit_queue_index,action_to_entry,3,[{file,"src/rabbit_queue_index.erl"},{line,838}]},{rabbit_queue_index,add_to_journal,3,[{file,"src/rabbit_queue_index.erl"},{line,814}]},{rabbit_queue_index,add_to_journal,3,[{file,"src/rabbit_queue_index.erl"},{line,805}]},{rabbit_queue_index,parse_journal_entries,2,[{file,"src/rabbit_queue_index.erl"},{line,958}]},{rabbit_queue_index,recover_journal,1,[{file,"src/rabbit_queue_index.erl"},{line,932}]},{rabbit_queue_index,init_dirty,3,[{file,"src/rabbit_queue_index.erl"},{line,622}]},{rabbit_variable_queue,init,6,[{file,"src/rabbit_variable_queue.erl"},{line,570}]},{rabbit_priority_queue,init,3,[{file,"src/rabbit_priority_queue.erl"},{line,151}]}]}

