### PR TITLE
Rebalance all queues

### DIFF
--- a/src/rabbit_mirror_queue_misc.erl
+++ b/src/rabbit_mirror_queue_misc.erl
@@ -28,7 +28,7 @@
 
 -export([sync_queue/1, cancel_sync_queue/1]).
 
--export([rebalance/2]).
+-export([transfer_leadership/2, queue_length/1, get_replicas/1]).
 
 %% for testing only
 -export([module/1]).
@@ -537,110 +537,14 @@ update_mirrors(Q) when ?is_amqqueue(Q) ->
     maybe_auto_sync(Q),
     ok.
 
--spec rebalance(binary(), binary()) -> {ok, [{node(), pos_integer()}]}.
-rebalance(VhostSpec, QueueSpec) ->
-    Running = rabbit_mnesia:cluster_nodes(running),
-    NumRunning = length(Running),
-    ToRebalance = [Q || Q <- rabbit_amqqueue:list(),
-                        ?amqqueue_is_classic(Q),
-                        is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
-                            is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)],
-    NumToRebalance = length(ToRebalance),
-    ByNode = group_by_node(ToRebalance),
-    rabbit_log:warning("######## BYNODE ~p", [ByNode]),
-    Rem = case (NumToRebalance rem NumRunning) of
-              0 -> 0;
-              _ -> 1
-          end,
-    MaxQueuesDesired = (NumToRebalance div NumRunning) + Rem,
-    iterative_rebalance(ByNode, MaxQueuesDesired).
-
-get_resource_name(#resource{name  = Name}) ->
-    Name.
-
-is_match(Subj, E) ->
-   nomatch /= re:run(Subj, E).
-
-iterative_rebalance(ByNode, MaxQueuesDesired) ->
-    case maybe_migrate(ByNode, MaxQueuesDesired) of
-        {ok, Summary} ->
-            rabbit_log:warning("Nothing to do, all balanced"),
-            {ok, Summary};
-        {migrated, Other} ->
-            iterative_rebalance(Other, MaxQueuesDesired);
-        {not_migrated, Other} ->
-            iterative_rebalance(Other, MaxQueuesDesired)
-    end.
-
-maybe_migrate(ByNode, MaxQueuesDesired) ->
-    maybe_migrate(ByNode, MaxQueuesDesired, maps:keys(ByNode)).
-
-maybe_migrate(ByNode, _, []) ->
-    {ok, maps:fold(fun(K, V, Acc) ->
-                           [{K, length(V)} | Acc]
-                   end, [], ByNode)};
-maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
-    case maps:get(N, ByNode, []) of
-        [{_, Q, false} = Queue | Queues] = All when length(All) > MaxQueuesDesired ->
-            Name = amqqueue:get_name(Q),
-            OtherNodes = rabbit_mnesia:cluster_nodes(running) -- [N],
-            case OtherNodes of
-                [] ->
-                    {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};
-                _ ->
-                    [{Length, Destination} | _] = sort_by_number_of_queues(OtherNodes, ByNode),
-                    rabbit_log:warning("Migrating mirrored queue ~p from node ~p with ~p queues to node ~p with ~p queues",
-                               [Name, N, length(All), Destination, Length]),
-                    case transfer_master(Q, Destination) of
-                        migrated ->
-                            rabbit_log:warning("Mirrored queue ~p migrated to ~p", [Name, Destination]),
-                            {migrated, update_migrated_queue(Destination, N, Queue, Queues, ByNode)};
-                        not_migrated ->
-                            rabbit_log:warning("Error migrating mirrored queue ~p", [Name]),
-                            {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)}
-                    end
-            end;
-        [{_, _, true} | _] = All when length(All) > MaxQueuesDesired ->
-            rabbit_log:warning("Node ~p contains ~p queues, but all have already migrated. "
-                               "Do nothing", [N, length(All)]),
-            maybe_migrate(ByNode, MaxQueuesDesired, Nodes);
-        All ->
-            rabbit_log:warning("Node ~p only contains ~p queues, do nothing",
-                               [N, length(All)]),
-            maybe_migrate(ByNode, MaxQueuesDesired, Nodes)
-    end.
-
-update_not_migrated_queue(N, {Entries, Q, _}, Queues, ByNode) ->
-    maps:update(N, Queues ++ [{Entries, Q, true}], ByNode).
-
-update_migrated_queue(NewNode, OldNode, {Entries, Q, _}, Queues, ByNode) ->
-    maps:update_with(NewNode,
-                     fun(L) -> L ++ [{Entries, Q, true}] end,
-                     [{Entries, Q, true}], maps:update(OldNode, Queues, ByNode)).
-
-sort_by_number_of_queues(Nodes, ByNode) ->
-    lists:keysort(1,
-                  lists:map(fun(Node) ->
-                                    {num_queues(Node, ByNode), Node}
-                            end, Nodes)).
-
-num_queues(Node, ByNode) ->
-    length(maps:get(Node, ByNode, [])).
-
-group_by_node(Queues) ->
-    ByNode = lists:foldl(fun(Q, Acc) ->
-                                 Messages = total_messages(Q),
-                                 maps:update_with(amqqueue:qnode(Q),
-                                                   fun(L) -> [{Messages, Q, false} | L] end,
-                                                  [{Messages, Q, false}], Acc)
-                         end, #{}, Queues),
-    maps:map(fun(_K, V) -> lists:keysort(1, V) end, ByNode).
-
-total_messages(Q) ->
+queue_length(Q) ->
     [{messages, M}] = rabbit_amqqueue:info(Q, [messages]),
     M.
 
-transfer_master(Q, Destination) ->
+get_replicas(Q) ->
+    rabbit_mnesia:cluster_nodes(running).
+
+transfer_leadership(Q, Destination) ->
     QName = amqqueue:get_name(Q),
     {OldMNode, OldSNodes, _} = actual_queue_nodes(Q),
     OldNodes = [OldMNode | OldSNodes],
@@ -655,7 +559,7 @@ wait_for_new_master(QName, Destination) ->
 
 wait_for_new_master(QName, _, 0) ->
     {ok, Q} = rabbit_amqqueue:lookup(QName),
-    {not_migrated, Q};
+    {{not_migrated, ""}, Q};
 wait_for_new_master(QName, Destination, N) ->
     {ok, Q} = rabbit_amqqueue:lookup(QName),
     case amqqueue:get_pid(Q) of
@@ -665,7 +569,7 @@ wait_for_new_master(QName, Destination, N) ->
         Pid ->
             case node(Pid) of
                 Destination ->
-                    {migrated, Q};
+                    {{migrated, Destination}, Q};
                 _ ->
                     timer:sleep(100),
                     wait_for_new_master(QName, Destination, N - 1)

--- a/src/rabbit_mirror_queue_misc.erl
+++ b/src/rabbit_mirror_queue_misc.erl
@@ -542,7 +542,8 @@ queue_length(Q) ->
     M.
 
 get_replicas(Q) ->
-    rabbit_mnesia:cluster_nodes(running).
+    {MNode, SNodes} = suggested_queue_nodes(Q),
+    [MNode] ++ SNodes.
 
 transfer_leadership(Q, Destination) ->
     QName = amqqueue:get_name(Q),

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -39,6 +39,7 @@
 -export([cleanup_data_dir/0]).
 -export([shrink_all/1,
          grow/4]).
+-export([rebalance/2]).
 
 %%-include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit.hrl").
@@ -846,6 +847,114 @@ grow(Node, VhostSpec, QueueSpec, Strategy) ->
         matches_strategy(Strategy, get_nodes(Q)),
         is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
         is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec) ].
+
+-spec rebalance(binary(), binary()) -> {ok, [{node(), pos_integer()}]}.
+rebalance(VhostSpec, QueueSpec) ->
+    Running = rabbit_mnesia:cluster_nodes(running),
+    NumRunning = length(Running),
+    ToRebalance = [Q || Q <- rabbit_amqqueue:list(),
+                        amqqueue:get_type(Q) == ?MODULE,
+                        is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
+                            is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)],
+    NumToRebalance = length(ToRebalance),
+    ByNode = group_by_node(ToRebalance),
+    Rem = case (NumToRebalance rem NumRunning) of
+              0 -> 0;
+              _ -> 1
+          end,
+    MaxQueuesDesired = (NumToRebalance div NumRunning) + Rem,
+    iterative_rebalance(ByNode, MaxQueuesDesired).
+
+iterative_rebalance(ByNode, MaxQueuesDesired) ->
+    case maybe_migrate(ByNode, MaxQueuesDesired) of
+        {ok, Summary} ->
+            rabbit_log:warning("Nothing to do, all balanced"),
+            {ok, Summary};
+        {migrated, Other} ->
+            iterative_rebalance(Other, MaxQueuesDesired);
+        {not_migrated, Other} ->
+            iterative_rebalance(Other, MaxQueuesDesired)
+    end.
+
+maybe_migrate(ByNode, MaxQueuesDesired) ->
+    maybe_migrate(ByNode, MaxQueuesDesired, maps:keys(ByNode)).
+
+maybe_migrate(ByNode, _, []) ->
+    {ok, maps:fold(fun(K, V, Acc) ->
+                           [{K, length(V)} | Acc]
+                   end, [], ByNode)};
+maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
+    case maps:get(N, ByNode, []) of
+        [{_, Q, false} = Queue | Queues] = All when length(All) > MaxQueuesDesired ->
+            {RaName, _} = Pid = amqqueue:get_pid(Q),
+            Name = amqqueue:get_name(Q),
+            Members = get_nodes(Q) -- [N],
+            case Members of
+                [] ->
+                    {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};
+                _ ->
+                    [{Length, Destination} | _] = sort_by_number_of_queues(Members, ByNode),
+                    rabbit_log:warning("Migrating quorum queue ~p from node ~p with ~p queues to node ~p with ~p queues",
+                               [Name, N, length(All), Destination, Length]),
+                    case ra:transfer_leadership(Pid, {RaName, Destination}) of
+                        ok ->
+                            {_, _, {_, NewNode}} = ra:members(Pid),
+                            rabbit_log:warning("Quorum queue ~p migrated to ~p", [Name, NewNode]),
+                            {migrated, update_migrated_queue(NewNode, N, Queue, Queues, ByNode)};
+                        already_leader ->
+                            rabbit_log:warning("Quorum queue ~p in ~p is already a leader",
+                                               [Name, Destination]),
+                            {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};
+                        {error, Reason} ->
+                            rabbit_log:warning("Error migrating quorum queue ~p: ~p", [Name, Reason]),
+                            {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};
+                        {timeout, _} ->
+                            %% TODO should we retry once?
+                            rabbit_log:warning("Timeout migrating quorum queue ~p: ~p", [Name]),
+                            {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)}
+                    end
+            end;
+        [{_, _, true} | _] = All when length(All) > MaxQueuesDesired ->
+            rabbit_log:warning("Node ~p contains ~p queues, but all have already migrated. "
+                               "Do nothing", [N, length(All)]),
+            maybe_migrate(ByNode, MaxQueuesDesired, Nodes);
+        All ->
+            rabbit_log:warning("Node ~p only contains ~p queues, do nothing",
+                               [N, length(All)]),
+            maybe_migrate(ByNode, MaxQueuesDesired, Nodes)
+    end.
+
+update_not_migrated_queue(N, {Entries, Q, _}, Queues, ByNode) ->
+    maps:update(N, Queues ++ [{Entries, Q, true}], ByNode).
+
+update_migrated_queue(NewNode, OldNode, {Entries, Q, _}, Queues, ByNode) ->
+    maps:update_with(NewNode,
+                     fun(L) -> L ++ [{Entries, Q, true}] end,
+                     [{Entries, Q, true}], maps:update(OldNode, Queues, ByNode)).
+
+sort_by_number_of_queues(Nodes, ByNode) ->
+    lists:keysort(1,
+                  lists:map(fun(Node) ->
+                                    {num_queues(Node, ByNode), Node}
+                            end, Nodes)).
+
+num_queues(Node, ByNode) ->
+    length(maps:get(Node, ByNode, [])).
+
+group_by_node(Queues) ->
+    ByNode = lists:foldl(fun(Q, Acc) ->
+                                 maps:update_with(amqqueue:qnode(Q),
+                                                  fun(L) -> [{log_entries(Q), Q, false} | L] end,
+                                                  [{log_entries(Q), Q, false}], Acc)
+                         end, #{}, Queues),
+    maps:map(fun(_K, V) -> lists:keysort(1, V) end, ByNode).
+
+log_entries(Q) ->
+    Name = amqqueue:get_name(Q),
+    case ets:lookup(ra_metrics, Name) of
+        [] -> 0;
+        [{_, _, SnapIdx, _, _, LastIdx, _}] -> LastIdx - SnapIdx
+    end.
 
 get_resource_name(#resource{name  = Name}) ->
     Name.

--- a/test/dynamic_ha_SUITE.erl
+++ b/test/dynamic_ha_SUITE.erl
@@ -71,7 +71,10 @@ groups() ->
               rapid_change,
               nodes_policy_should_pick_master_from_its_params,
               promote_slave_after_standalone_restart,
-              queue_survive_adding_dead_vhost_mirror
+              queue_survive_adding_dead_vhost_mirror,
+              rebalance_all,
+              rebalance_exactly,
+              rebalance_nodes
               % FIXME: Re-enable those tests when the know issues are
               % fixed.
               % failing_random_policies,
@@ -536,6 +539,118 @@ promote_slave_after_standalone_restart(Config) ->
     ok = rabbit_ct_broker_helpers:start_node(Config, C),
     15 = proplists:get_value(messages, find_queue(?QNAME, C)),
     ok = rabbit_ct_broker_helpers:stop_node(Config, C),
+
+    ok.
+
+rebalance_all(Config) ->
+    [A, B, C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ACh = rabbit_ct_client_helpers:open_channel(Config, A),
+
+    Q1 = <<"q1">>,
+    Q2 = <<"q2">>,
+    Q3 = <<"q3">>,
+    Q4 = <<"q4">>,
+    Q5 = <<"q5">>,
+
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q1}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q2}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q3}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q4}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q5}),
+    rabbit_ct_broker_helpers:set_ha_policy(Config, A, <<"q.*">>, <<"all">>),
+    timer:sleep(1000),
+
+    rabbit_ct_client_helpers:publish(ACh, Q1, 5),
+    rabbit_ct_client_helpers:publish(ACh, Q2, 3),
+    assert_slaves(A, Q1, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+    assert_slaves(A, Q2, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+    assert_slaves(A, Q3, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+    assert_slaves(A, Q4, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+    assert_slaves(A, Q5, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+
+    {ok, Summary} = rpc:call(A, rabbit_amqqueue, rebalance, [classic, ".*", ".*"]),
+
+    %% Check that we have at most 2 queues per node
+    ?assert(lists:all(fun({_, V}) -> V =< 2 end, Summary)),
+    %% Check that Q1 and Q2 haven't moved
+    assert_slaves(A, Q1, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+    assert_slaves(A, Q2, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
+
+    ok.
+
+rebalance_exactly(Config) ->
+    [A, _, _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ACh = rabbit_ct_client_helpers:open_channel(Config, A),
+
+    Q1 = <<"q1">>,
+    Q2 = <<"q2">>,
+    Q3 = <<"q3">>,
+    Q4 = <<"q4">>,
+    Q5 = <<"q5">>,
+
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q1}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q2}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q3}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q4}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q5}),
+    rabbit_ct_broker_helpers:set_ha_policy(Config, A, <<"q.*">>, {<<"exactly">>, 2}),
+    timer:sleep(1000),
+
+    rabbit_ct_client_helpers:publish(ACh, Q1, 5),
+    rabbit_ct_client_helpers:publish(ACh, Q2, 3),
+
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q1, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q2, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q3, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q4, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q5, A)))),
+
+    {ok, Summary} = rpc:call(A, rabbit_amqqueue, rebalance, [classic, ".*", ".*"]),
+
+    %% Check that we have at most 2 queues per node
+    ?assert(lists:all(fun({_, V}) -> V =< 2 end, Summary)),
+    %% Check that Q1 and Q2 haven't moved
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q1, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q2, A)))),
+
+    ok.
+
+rebalance_nodes(Config) ->
+    [A, B, _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ACh = rabbit_ct_client_helpers:open_channel(Config, A),
+
+    Q1 = <<"q1">>,
+    Q2 = <<"q2">>,
+    Q3 = <<"q3">>,
+    Q4 = <<"q4">>,
+    Q5 = <<"q5">>,
+
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q1}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q2}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q3}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q4}),
+    amqp_channel:call(ACh, #'queue.declare'{queue = Q5}),
+    rabbit_ct_broker_helpers:set_ha_policy(
+      Config, A, <<"q.*">>,
+      {<<"nodes">>, [rabbit_misc:atom_to_binary(A), rabbit_misc:atom_to_binary(B)]}),
+    timer:sleep(1000),
+
+    rabbit_ct_client_helpers:publish(ACh, Q1, 5),
+    rabbit_ct_client_helpers:publish(ACh, Q2, 3),
+
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q1, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q2, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q3, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q4, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q5, A)))),
+
+    {ok, Summary} = rpc:call(A, rabbit_amqqueue, rebalance, [classic, ".*", ".*"]),
+
+    %% Check that we have at most 3 queues per node
+    ?assert(lists:all(fun({_, V}) -> V =< 3 end, Summary)),
+    %% Check that Q1 and Q2 haven't moved
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q1, A)))),
+    ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q2, A)))),
 
     ok.
 

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -688,10 +688,8 @@ rebalance(Config) ->
 
     {ok, _, {_, Leader1}} = ra:members({ra_name(Q1), Server0}),
     {ok, _, {_, Leader2}} = ra:members({ra_name(Q2), Server0}),
-    publish(Ch, Q1),
-    publish(Ch, Q1),
-    publish(Ch, Q2),
-    publish(Ch, Q2),
+    rabbit_ct_client_helpers:publish(Ch, Q1, 3),
+    rabbit_ct_client_helpers:publish(Ch, Q2, 2),
 
     ?assertEqual({'queue.declare_ok', Q3, 0, 0},
                  declare(Ch, Q3, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),


### PR DESCRIPTION
Rebalance all replicated queues (quorum and HA) to evenly distribute the leaders/masters across the cluster. It's a best effort implementation.

* Queues with lowest number of log entries (quorum) or total messages (ha) are moved first, to the node with the smallest number of leaders/masters.
* If a queue fails to transfer its leader it will not retry.

Depends on rabbitmq/ra#116

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
