### PR TITLE
Return number of queues per type

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -539,7 +539,11 @@ maybe_migrate(ByNode, MaxQueuesDesired) ->
 
 maybe_migrate(ByNode, _, []) ->
     {ok, maps:fold(fun(K, V, Acc) ->
-                           [{K, length(V)} | Acc]
+                           {CQs, QQs} = lists:splitwith(fun({_, Q, _}) ->
+                                                                ?amqqueue_is_classic(Q)
+                                                        end, V),
+                           [[{<<"Node name">>, K}, {<<"Number of quorum queues">>, length(QQs)},
+                             {<<"Number of classic queues">>, length(CQs)}] | Acc]
                    end, [], ByNode)};
 maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
     case maps:get(N, ByNode, []) of

--- a/test/dynamic_ha_SUITE.erl
+++ b/test/dynamic_ha_SUITE.erl
@@ -571,7 +571,11 @@ rebalance_all(Config) ->
     {ok, Summary} = rpc:call(A, rabbit_amqqueue, rebalance, [classic, ".*", ".*"]),
 
     %% Check that we have at most 2 queues per node
-    ?assert(lists:all(fun({_, V}) -> V =< 2 end, Summary)),
+    ?assert(lists:all(fun(NodeData) ->
+                              lists:all(fun({_, V}) when is_integer(V) -> V =< 2;
+                                           (_) -> true end,
+                                        NodeData)
+                      end, Summary)),
     %% Check that Q1 and Q2 haven't moved
     assert_slaves(A, Q1, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
     assert_slaves(A, Q2, {A, [B, C]}, [{A, []}, {A, [B]}, {A, [C]}]),
@@ -608,7 +612,11 @@ rebalance_exactly(Config) ->
     {ok, Summary} = rpc:call(A, rabbit_amqqueue, rebalance, [classic, ".*", ".*"]),
 
     %% Check that we have at most 2 queues per node
-    ?assert(lists:all(fun({_, V}) -> V =< 2 end, Summary)),
+    ?assert(lists:all(fun(NodeData) ->
+                              lists:all(fun({_, V}) when is_integer(V) -> V =< 2;
+                                           (_) -> true end,
+                                        NodeData)
+                      end, Summary)),
     %% Check that Q1 and Q2 haven't moved
     ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q1, A)))),
     ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q2, A)))),
@@ -647,7 +655,11 @@ rebalance_nodes(Config) ->
     {ok, Summary} = rpc:call(A, rabbit_amqqueue, rebalance, [classic, ".*", ".*"]),
 
     %% Check that we have at most 3 queues per node
-    ?assert(lists:all(fun({_, V}) -> V =< 3 end, Summary)),
+    ?assert(lists:all(fun(NodeData) ->
+                              lists:all(fun({_, V}) when is_integer(V) -> V =< 3;
+                                           (_) -> true end,
+                                        NodeData)
+                      end, Summary)),
     %% Check that Q1 and Q2 haven't moved
     ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q1, A)))),
     ?assertEqual(A, node(proplists:get_value(pid, find_queue(Q2, A)))),

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -706,7 +706,11 @@ rebalance(Config) ->
     ?assertMatch({ok, _, {_, Leader2}}, ra:members({ra_name(Q2), Server0})),
 
     %% Check that we have at most 2 queues per node
-    ?assert(lists:all(fun({_, V}) -> V =< 2 end, Summary)),
+    ?assert(lists:all(fun(NodeData) ->
+                              lists:all(fun({_, V}) when is_integer(V) -> V =< 2;
+                                           (_) -> true end,
+                                        NodeData)
+                      end, Summary)),
     ok.
 
 subscribe_should_fail_when_global_qos_true(Config) ->


### PR DESCRIPTION
On queue rebalance. Pretty-formatter ready for the CLI `rebalance` command

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

