### PR TITLE
Added more helpful message in case the config file failed to generate

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -1040,8 +1040,9 @@ boot_error(_, {error, {cannot_log_to_file, LogFile, Reason}}) ->
                             [LogFile, Reason]);
 boot_error(_, {error, {generate_config_file, Error}}) ->
     log_boot_error_and_exit(generate_config_file,
-                            "~nConfig file generation failed:~n~s~n",
-                            [Error]);
+      "~nConfig file generation failed:~n~s"
+      "In case a setting of a plugin is unknown, verify the plugin is enabled or remove the setting from the config.~n",
+      [Error]);
 boot_error(Class, Reason) ->
     LogLocations = log_locations(),
     log_boot_error_and_exit(


### PR DESCRIPTION
## Proposed Changes

Based on the comments in https://github.com/rabbitmq/rabbitmq-server/issues/2085 a hint is added in regards to the possible reason of failure - a plugin that is not enabled. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [X] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in related repositories

## Further Comments

A possible improvement on this might be having this "hint" be based on the contents of the error provided by cuttlefish. For example only showing this error message when the error message contains the string "but there is no setting with that name". For now I did not do this, because I am not aware of other errors that could be produced from the cuttlefish library.