### PR TITLE
Allow setting ERL_MAX_PORTS in rabbitmq-env-conf.bat

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -39,6 +39,17 @@ if exist "!RABBITMQ_CONF_ENV_FILE!" (
     call "!RABBITMQ_CONF_ENV_FILE!"
 )
 
+rem Bump ETS table limit to 50000
+if "!ERL_MAX_ETS_TABLES!"=="" (
+    set ERL_MAX_ETS_TABLES=50000
+)
+
+rem Default is defined here:
+rem https://github.com/erlang/otp/blob/master/erts/emulator/beam/erl_port.h
+if "!ERL_MAX_PORTS!"=="" (
+    set ERL_MAX_PORTS=65536
+)
+
 set DEFAULT_SCHEDULER_BIND_TYPE=db
 if "!RABBITMQ_SCHEDULER_BIND_TYPE!"=="" (
     set RABBITMQ_SCHEDULER_BIND_TYPE=!SCHEDULER_BIND_TYPE!

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -220,6 +220,12 @@ if "!ERL_MAX_ETS_TABLES!"=="" (
     set ERL_MAX_ETS_TABLES=50000
 )
 
+rem Default is defined here:
+rem https://github.com/erlang/otp/blob/master/erts/emulator/beam/erl_port.h
+if "!ERL_MAX_PORTS!"=="" (
+    set ERL_MAX_PORTS=8192
+)
+
 set ENV_OK=true
 CALL :check_not_empty "RABBITMQ_BOOT_MODULE" !RABBITMQ_BOOT_MODULE!
 CALL :check_not_empty "RABBITMQ_NAME_TYPE" !RABBITMQ_NAME_TYPE!

--- a/scripts/rabbitmq-server.bat
+++ b/scripts/rabbitmq-server.bat
@@ -215,17 +215,6 @@ if "!RABBITMQ_IO_THREAD_POOL_SIZE!"=="" (
     set RABBITMQ_IO_THREAD_POOL_SIZE=64
 )
 
-rem Bump ETS table limit to 50000
-if "!ERL_MAX_ETS_TABLES!"=="" (
-    set ERL_MAX_ETS_TABLES=50000
-)
-
-rem Default is defined here:
-rem https://github.com/erlang/otp/blob/master/erts/emulator/beam/erl_port.h
-if "!ERL_MAX_PORTS!"=="" (
-    set ERL_MAX_PORTS=8192
-)
-
 set ENV_OK=true
 CALL :check_not_empty "RABBITMQ_BOOT_MODULE" !RABBITMQ_BOOT_MODULE!
 CALL :check_not_empty "RABBITMQ_NAME_TYPE" !RABBITMQ_NAME_TYPE!

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -301,11 +301,6 @@ if "!RABBITMQ_SERVICE_RESTART!"=="" (
     set RABBITMQ_SERVICE_RESTART=restart
 )
 
-rem Bump ETS table limit to 50000
-if "!ERL_MAX_ETS_TABLES!"=="" (
-    set ERL_MAX_ETS_TABLES=50000
-)
-
 set ERLANG_SERVICE_ARGUMENTS= ^
 -pa "!RABBITMQ_EBIN_ROOT:\=/!" ^
 -boot start_sasl ^

--- a/scripts/rabbitmq-service.bat
+++ b/scripts/rabbitmq-service.bat
@@ -347,6 +347,7 @@ set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:"=\"!
 -env ERL_CRASH_DUMP="!RABBITMQ_BASE:\=/!/erl_crash.dump" ^
 -env ERL_LIBS="!ERL_LIBS!" ^
 -env ERL_MAX_ETS_TABLES="!ERL_MAX_ETS_TABLES!" ^
+-env ERL_MAX_PORTS="!ERL_MAX_PORTS!" ^
 -workdir "!RABBITMQ_BASE!" ^
 -stopaction "rabbit:stop_and_halt()." ^
 !RABBITMQ_NAME_TYPE! !RABBITMQ_NODENAME! ^


### PR DESCRIPTION
Fixes #2084

Since env vars must be passed with `-env` to `erlsrv.exe`, this is the only way to pass the value after being set by `rabbitmq-env-conf.bat`. The only alternative is to set a system-wide env variable that is picked up any time `erl.exe` starts