### PR TITLE
rabbit_diagnostics: handle race in binary_refs

### DIFF
--- a/src/rabbit_diagnostics.erl
+++ b/src/rabbit_diagnostics.erl
@@ -94,9 +94,12 @@ top_binary_refs(Count) ->
     io:format("~s ~p~n", [get_time(), Sorted]).
 
 binary_refs(Pid) ->
-    {binary, Refs} = info(Pid, binary, []),
-    lists:sum([Sz || {_Ptr, Sz} <- lists:usort([{Ptr, Sz} ||
-                                                   {Ptr, Sz, _Cnt} <- Refs])]).
+    case info(Pid, binary, []) of
+        {binary, Refs} ->
+            lists:sum([Sz || {_Ptr, Sz} <- lists:usort([{Ptr, Sz} ||
+                                                           {Ptr, Sz, _Cnt} <- Refs])]);
+        _ -> 0
+    end.
 
 info(Pid) ->
     [{pid, Pid} | info(Pid, ?PROCESS_INFO, [])].


### PR DESCRIPTION
It is possible for a process to terminate between the call to
processes() and subsequent call to process_info(), and the latter
returns undefined instead of a tuple.  This results in the crash:

Error: {{badmatch,undefined},
        [{rabbit_diagnostics,binary_refs,1,
                             [{file,"src/rabbit_diagnostics.erl"},{line,98}]},
         {rabbit_diagnostics,'-top_binary_refs/1-lc$^0/1-0-',1,
                             [{file,"src/rabbit_diagnostics.erl"},{line,93}]},
         {rabbit_diagnostics,'-top_binary_refs/1-lc$^0/1-0-',1,
                             [{file,"src/rabbit_diagnostics.erl"},{line,93}]},
         {rabbit_diagnostics,top_binary_refs,1,
                             [{file,"src/rabbit_diagnostics.erl"},{line,93}]},
         {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,670}]}]}