### PR TITLE
Fix regression where queue exchange rates were too high

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -2231,9 +2231,9 @@ deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{
     case rabbit_event:stats_level(State, #ch.stats_timer) of
         fine ->
             ?INCR_STATS(exchange_stats, XName, 1, publish),
-            [?INCR_STATS(queue_exchange_stats, {QName, XName}, 1, publish) ||
-                QRef        <- AllDeliveredQRefs,
-                {ok, QName} <- [maps:find(QRef, QNames1)]];
+            [?INCR_STATS(queue_exchange_stats,
+                         {amqqueue:get_name(Q), XName}, 1, publish) ||
+                Q        <- Qs];
         _ ->
             ok
     end,


### PR DESCRIPTION
Prior to 3.8 only the queue masters were tracked in the queue_names map
inside the channel and these were used to filter the increments of this
metric. Here we instead use the list of routed amqqueue records to
update which should be correct for all queue types.

[#168729890]
Fixes #2115 