### PR TITLE
Man pages: add missing diagnostics and ctl commands

### DIFF
--- a/docs/rabbitmq-diagnostics.8
+++ b/docs/rabbitmq-diagnostics.8
@@ -130,18 +130,368 @@ results.
 The default value is
 .Qq / .
 .Bl -tag -width Ds
+.El
+.El
+.Ss Help
+.Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm help
 .Pp
 Displays general help and commands supported by
 .Nm .
 .\" ------------------------------------
-.It Cm ping
+.It Cm version
 .Pp
-Most basic health check. Succeeds if target node (runtime) is running
-and
-.Nm
-can authenticate with it successfully.
+Displays CLI tools version
+.El
+.El
+.Ss Nodes
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm wait
+See
+.Cm wait
+in
+.Xr rabbitmqctl 8
+.El
+.El
+.Ss Cluster
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm cluster_status
+See
+.Cm cluster_status
+in
+.Xr rabbitmqctl 8
+.El
+.El
+.Ss Users
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm list_users
+See
+.Cm list_users
+in
+.Xr rabbitmqctl 8
+.El
+.El
+.Ss Access Control
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm list_permissions Op Fl p Ar vhost
+See
+.Cm list_permissions
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_topic_permissions Op Fl p Ar vhost
+See
+.Cm list_topic_permissions
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_user_permissions Ar username
+See
+.Cm list_user_permissions
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_user_topic_permissions Ar username
+See
+.Cm list_user_topic_permissions
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_vhosts Op Ar vhostinfoitem ...
+See
+.Cm list_vhosts
+in
+.Xr rabbitmqctl 8
+.El
+.El
+.Ss Monitoring, observability and health checks
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm alarms
+.Pp
+Lists resource alarms, if any, in the cluster.
+.Pp
+See
+.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics alarms
+.\" ------------------------------------
+.It Cm check_alarms
+.Pp
+Health check that fails (returns with a non-zero code) if there are alarms
+in effect on any of the cluster nodes.
+.Pp
+See
+.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_alarms
+.\" ------------------------------------
+.It Cm check_local_alarms
+.Pp
+Health check that fails (returns with a non-zero code) if there are alarms
+in effect on the target node.
+.Pp
+See
+.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_local_alarms
+.\" ------------------------------------
+.It Cm check_port_connectivity
+.Pp
+Health check that fails (returns with a non-zero code) if any listener ports
+on the target node cannot accept a new TCP connection opened by
+.Nm.
+The check only validates if a new TCP connection is accepted. It does not
+perform messaging protocol handshake or authenticate.
+.Pp
+See
+.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_port_connectivity
+.\" ------------------------------------
+.It Cm check_port_listener
+.Pp
+Health check that fails (returns with a non-zero code) if the target node
+is not listening on the specified port (there is no listener that
+uses that port).
+.Pp
+See
+.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_port_listener 5672
+.\" ------------------------------------
+.It Cm check_protocol_listener
+.Pp
+Health check that fails (returns with a non-zero code) if the target node
+does not have a listener for the specified protocol.
+.Pp
+See
+.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_protocol_listener mqtt
+.\" ------------------------------------
+.It Cm check_running
+.Pp
+Health check that fails (returns with a non-zero code) if the RabbitMQ
+application is not running on the target node.
+.Pp
+If
+.Cm rabbitmqctl(8)
+was used to stop the application, this check will fail.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_running
+.\" ------------------------------------
+.It Cm check_virtual_hosts
+.Pp
+Health check that checks if all vhosts are running in the target node
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics check_virtual_hosts --timeout 60
+.\" ------------------------------------
+.It Cm cipher_suites
+.Pp
+Lists cipher suites enabled by default. To list all available cipher suites, add the --all argument.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics cipher_suites --format openssl --all
+.\" ------------------------------------
+.It Cm command_line_arguments
+.Pp
+Displays target node's command-line arguments and flags as reported by the runtime.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics command_line_arguments -n rabbit@hostname
+.\" ------------------------------------
+.It Cm consume_event_stream
+.Pp
+Streams internal events from a running node. Output is jq-compatible.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics consume_event_stream -n rabbit@hostname --duration 20 --pattern "queue_.*"
+.\" ------------------------------------
+.It Cm discover_peers
+.Pp
+Runs a peer discovery on the target node and prints the discovered nodes, if any.
+.Pp
+See
+.Lk https://www.rabbitmq.com/cluster-formation.html "RabbitMQ Cluster Formation guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics discover_peers --timeout 60
+.\" ------------------------------------
+.It Cm environment
+See
+.Cm environment
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm erlang_cookie_hash
+.Pp
+Outputs a hashed value of the shared secret used by the target node
+to authenticate CLI tools and peers. The value can be compared with the hash
+found in error messages of CLI tools.
+.Pp
+See
+.Lk https://www.rabbitmq.com/clustering.html#erlang-cookie "RabbitMQ Clustering guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics erlang_cookie_hash -q
+.\" ------------------------------------
+.It Cm erlang_version
+.Pp
+Reports target node's Erlang/OTP version.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics erlang_version -q
+.\" ------------------------------------
+.It Cm is_booting
+.Pp
+Reports if RabbitMQ application is currently booting (not booted/running or stopped) on
+the target node.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics is_booting
+.\" ------------------------------------
+.It Cm is_running
+.Pp
+Reports if RabbitMQ application is fully booted and running (that is, not stopped) on
+the target node.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics is_running
+.\" ------------------------------------
+.It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
+See
+.Cm list_bindings
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.ll.It Cm list_channels Op Ar channelinfoitem ...
+See
+.Cm list_channels
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_ciphers
+See
+.Cm list_ciphers
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_connections Op Ar connectioninfoitem ...
+See
+.Cm list_connections
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_consumers Op Fl p Ar vhost
+See
+.Cm list_consumers
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
+See
+.Cm list_exchanges
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_hashes
+See
+.Cm list_hashes
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
+See
+.Cm list_queues
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm list_unresponsive_queues Oc Oo Fl -local Oc Oo Fl -queue_timeout Ar milliseconds Oc Oo Ar column ... Oc Op Fl -no-table-headers
+See
+.Cm list_unresponsive_queues
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm listeners
+.Pp
+Lists listeners (bound sockets) on this node. Use this to inspect
+what protocols and ports the node is listening on for client, CLI tool
+and peer connections.
+.Pp
+See
+.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+to learn more.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics listeners
+.\" ------------------------------------
+.It Cm log_tail Oc Oo Fl -number Ar number | Fl N Ar number Oc Op Fl -timeout Ar milliseconds
+.Pp
+Prints the last N lines of the log on the node
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics log_tail -number 100
+.\" ------------------------------------
+.It Cm log_tail_stream Oc Oo Fl -duration Ar seconds | Fl d Ar seconds Oc Op Fl -timeout Ar milliseconds
+.Pp
+Streams logs from a running node for a period of time
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics log_tail_stream --duration 60
+.\" ------------------------------------
+.It Cm maybe_stuck
+.Pp
+Periodically samples stack traces of all Erlang processes
+("lightweight threads") on the node. Reports the processes for which
+stack trace samples are identical.
+.Pp
+Identical samples may indicate that the process is not making any progress
+but is not necessarily an indication of a problem.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics maybe_stuck -q
 .\" ------------------------------------
 .It Cm memory_breakdown Op Fl -unit Ar memory_unit
 .Pp
@@ -166,34 +516,26 @@ Example:
 .sp
 .Dl rabbitmq-diagnostics memory_breakdown --unit gigabytes
 .\" ------------------------------------
-.It Cm server_version
+.It Cm observer Op Fl -interval Ar seconds
 .Pp
-Reports target node's version.
+Starts a CLI observer interface on the target node
 .Pp
 Example:
 .Sp
-.Dl rabbitmq-diagnostics server_version -q
+.Dl rabbitmq-diagnostics observer --interval 10
 .\" ------------------------------------
-.It Cm erlang_version
+.It Cm ping
 .Pp
-Reports target node's Erlang/OTP version.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics erlang_version -q
+Most basic health check. Succeeds if target node (runtime) is running
+and
+.Nm
+can authenticate with it successfully.
 .\" ------------------------------------
-.It Cm maybe_stuck
-.Pp
-Periodically samples stack traces of all Erlang processes
-("lightweight threads") on the node. Reports the processes for which
-stack trace samples are identical.
-.Pp
-Identical samples may indicate that the process is not making any progress
-but is not necessarily an indication of a problem.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics maybe_stuck -q
+.It Cm report
+See
+.Cm report
+in
+.Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm runtime_thread_stats Op Fl -sample-interval Ar interval
 .Pp
@@ -208,6 +550,27 @@ Example:
 .Sp
 .Dl rabbitmq-diagnostics runtime_thread_stats --sample-interval 15
 .\" ------------------------------------
+.It Cm schema_info Oc Oo Fl -no_table_headers Oc Oo Ar column ... Oc Op Fl -timeout Ar milliseconds
+.Pp
+See
+.Cm schema_info
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.It Cm server_version
+.Pp
+Reports target node's version.
+.Pp
+Example:
+.Sp
+.Dl rabbitmq-diagnostics server_version -q
+.\" ------------------------------------
+.It Cm status
+See
+.Cm status
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
 .It Cm tls_versions
 .Pp
 Lists all TLS versions supported by the runtime on the target node.
@@ -221,253 +584,14 @@ to learn more.
 Example:
 .Sp
 .Dl rabbitmq-diagnostics tls_versions -q
-.\" ------------------------------------
-.It Cm erlang_cookie_hash
-.Pp
-Outputs a hashed value of the shared secret used by the target node
-to authenticate CLI tools and peers. The value can be compared with the hash
-found in error messages of CLI tools.
-.Pp
-See
-.Lk https://www.rabbitmq.com/clustering.html#erlang-cookie "RabbitMQ Clustering guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics erlang_cookie_hash -q
-.\" ------------------------------------
-.It Cm discover_peers
-.Pp
-Runs a peer discovery on the target node and prints the discovered nodes, if any.
-.Pp
-See
-.Lk https://www.rabbitmq.com/cluster-formation.html "RabbitMQ Cluster Formation guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics discover_peers --timeout 60
-.\" ------------------------------------
-.It Cm list_channels Op Ar channelinfoitem ...
-See
-.Cm list_channels
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
-See
-.Cm list_queues
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
-See
-.Cm list_exchanges
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
-See
-.Cm list_bindings
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_connections Op Ar connectioninfoitem ...
-See
-.Cm list_connections
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_channels Op Ar channelinfoitem ...
-See
-.Cm list_channels
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_consumers Op Fl p Ar vhost
-See
-.Cm list_consumers
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm alarms
-.Pp
-Lists resource alarms, if any, in the cluster.
-.Pp
-See
-.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics alarms
-.\" ------------------------------------
-.It Cm listeners
-.Pp
-Lists listeners (bound sockets) on this node. Use this to inspect
-what protocols and ports the node is listening on for client, CLI tool
-and peer connections.
-.Pp
-See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics listeners
-.\" ------------------------------------
-.It Cm is_running
-.Pp
-Reports if RabbitMQ application is fully booted and running (that is, not stopped) on
-the target node.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics is_running
-.\" ------------------------------------
-.It Cm is_booting
-.Pp
-Reports if RabbitMQ application is currently booting (not booted/running or stopped) on
-the target node.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics is_booting
-.\" ------------------------------------
-
-check_port_connectivity [-t <timeout>]
-.\" ------------------------------------
-.It Cm check_running
-.Pp
-Health check that fails (returns with a non-zero code) if the RabbitMQ
-application is not running on the target node.
-.Pp
-If
-.Cm rabbitmqctl(8)
-was used to stop the application, this check will fail.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics check_running
-.\" ------------------------------------
-.It Cm check_local_alarms
-.Pp
-Health check that fails (returns with a non-zero code) if there are alarms
-in effect on the target node.
-.Pp
-See
-.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics check_local_alarms
-.\" ------------------------------------
-.It Cm check_alarms
-.Pp
-Health check that fails (returns with a non-zero code) if there are alarms
-in effect on any of the cluster nodes.
-.Pp
-See
-.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics check_alarms
-.\" ------------------------------------
-.It Cm check_port_connectivity
-.Pp
-Health check that fails (returns with a non-zero code) if any listener ports
-on the target node cannot accept a new TCP connection opened by
-.Nm.
-The check only validates if a new TCP connection is accepted. It does not
-perform messaging protocol handshake or authenticate.
-.Pp
-See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics check_port_connectivity
-.\" ------------------------------------
-.It Cm check_protocol_listener
-.Pp
-Health check that fails (returns with a non-zero code) if the target node
-does not have a listener for the specified protocol.
-.Pp
-See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics check_protocol_listener mqtt
-.\" ------------------------------------
-.It Cm check_port_listener
-.Pp
-Health check that fails (returns with a non-zero code) if the target node
-is not listening on the specified port (there is no listener that
-uses that port).
-.Pp
-See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
-to learn more.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics check_port_listener 5672
-.\" ------------------------------------
-.It Cm consume_event_stream
-.Pp
-Streams internal events from a running node. Output is jq-compatible.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics consume_event_stream -n rabbit@hostname --duration 20 --pattern "queue_.*"
-.\" ------------------------------------
-.It Cm command_line_arguments
-.Pp
-Displays target node's command-line arguments and flags as reported by the runtime.
-.Pp
-Example:
-.Sp
-.Dl rabbitmq-diagnostics command_line_arguments -n rabbit@hostname
-.\" ------------------------------------
-.It Cm status
-See
-.Cm status
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm cluster_status
-See
-.Cm cluster_status
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm environment
-See
-.Cm environment
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm report
-See
-.Cm report
-in
-.Xr rabbitmqctl 8
+.El
+.El
+.Ss Parameters
+.Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_global_parameters
 See
 .Cm list_global_parameters
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_operator_policies Op Fl p Ar vhost
-See
-.Cm list_operator_policies
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
@@ -476,10 +600,14 @@ See
 .Cm list_parameters
 in
 .Xr rabbitmqctl 8
-.\" ------------------------------------------------------------------
-.It Cm list_permissions Op Fl p Ar vhost
+.El
+.El
+.Ss Policies
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm list_operator_policies Op Fl p Ar vhost
 See
-.Cm list_permissions
+.Cm list_operator_policies
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
@@ -489,45 +617,49 @@ See
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
-.It Cm list_topic_permissions Op Fl p Ar vhost
-See
-.Cm list_topic_permissions
-in
-.Xr rabbitmqctl 8
+.El
+.El
+.Ss Virtual hosts
+.Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm list_user_permissions Ar username
-See
-.Cm list_user_permissions
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_user_topic_permissions Ar username
-See
-.Cm list_user_topic_permissions
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_users
-See
-.Cm list_users
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm list_vhosts Op Ar vhostinfoitem ...
-See
-.Cm list_vhosts
-in
-.Xr rabbitmqctl 8
-.\" ------------------------------------
-.It Cm node_health_check
-Performs several health checks of the target node.
+.It Cm list_vhost_limits Oc Oo Fl -vhost Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
 .Pp
-Verifies the rabbit application is running and alarms are not set,
-then checks that every queue and channel on the node can emit basic stats.
+See
+.Cm list_vhost_limits
+in
+.Xr rabbitmqctl 8
+.El
+.El
+.Ss Node configuration
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm log_location Oc Oo Fl -all | Fl a Oc Op Fl -timeout Ar milliseconds
+.Pp
+Shows log file location(s) on target node
 .Pp
 Example:
 .Sp
-.Dl rabbitmq-diagnostics node_health_check -n rabbit@hostname
+.Dl rabbitmq-diagnostics log_location -a
+.El
+.El
+.Ss Feature flags
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm list_feature_flags Oc Oo Ar column ... Oc Op Fl -timeout Ar milliseconds
+See
+.Cm list_feature_flags
+in
+.Xr rabbitmqctl 8
+.\" ------------------------------------
+.El
+.El
+.Ss Queues
+.Bl -tag -width Ds
+.It Cm quorum_status Ar queue Oc Op Fl -vhost Ar vhost
+See
+.Cm quorum_status
+in
+.Xr rabbitmqctl 8
 .\" ------------------------------------------------------------------
 .Sh SEE ALSO
 .\" ------------------------------------------------------------------

--- a/docs/rabbitmq-diagnostics.8
+++ b/docs/rabbitmq-diagnostics.8
@@ -129,8 +129,6 @@ commands accept an optional virtual host parameter for which to display
 results.
 The default value is
 .Qq / .
-.Bl -tag -width Ds
-.El
 .El
 .Ss Help
 .Bl -tag -width Ds
@@ -144,7 +142,6 @@ Displays general help and commands supported by
 .Pp
 Displays CLI tools version
 .El
-.El
 .Ss Nodes
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -153,7 +150,6 @@ See
 .Cm wait
 in
 .Xr rabbitmqctl 8
-.El
 .El
 .Ss Cluster
 .Bl -tag -width Ds
@@ -164,7 +160,6 @@ See
 in
 .Xr rabbitmqctl 8
 .El
-.El
 .Ss Users
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -173,7 +168,6 @@ See
 .Cm list_users
 in
 .Xr rabbitmqctl 8
-.El
 .El
 .Ss Access Control
 .Bl -tag -width Ds

--- a/docs/rabbitmq-diagnostics.8
+++ b/docs/rabbitmq-diagnostics.8
@@ -133,10 +133,16 @@ The default value is
 .Ss Help
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm help
+.Bl -tag -width Ds
+.It Cm help Oo Fl l Oc Op Ar command_name
 .Pp
-Displays general help and commands supported by
-.Nm .
+Prints usage for all available commands.
+.Bl -tag -width Ds
+.It Fl l , Fl -list-commands
+List command usages only, without parameter explanation.
+.It Ar command_name
+Prints usage for the specified command.
+.El
 .\" ------------------------------------
 .It Cm version
 .Pp
@@ -146,6 +152,7 @@ Displays CLI tools version
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm wait
+.Pp
 See
 .Cm wait
 in
@@ -155,6 +162,7 @@ in
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm cluster_status
+.Pp
 See
 .Cm cluster_status
 in
@@ -164,6 +172,7 @@ in
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_users
+.Pp
 See
 .Cm list_users
 in
@@ -173,35 +182,39 @@ in
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_permissions Op Fl p Ar vhost
+.Pp
 See
 .Cm list_permissions
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_topic_permissions Op Fl p Ar vhost
+.Pp
 See
 .Cm list_topic_permissions
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_user_permissions Ar username
+.Pp
 See
 .Cm list_user_permissions
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_user_topic_permissions Ar username
+.Pp
 See
 .Cm list_user_topic_permissions
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_vhosts Op Ar vhostinfoitem ...
+.Pp
 See
 .Cm list_vhosts
 in
 .Xr rabbitmqctl 8
-.El
 .El
 .Ss Monitoring, observability and health checks
 .Bl -tag -width Ds
@@ -391,54 +404,63 @@ Example:
 .Dl rabbitmq-diagnostics is_running
 .\" ------------------------------------
 .It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
+.Pp
 See
 .Cm list_bindings
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
-.ll.It Cm list_channels Op Ar channelinfoitem ...
+.It Cm list_channels Op Ar channelinfoitem ...
+.Pp
 See
 .Cm list_channels
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_ciphers
+.Pp
 See
 .Cm list_ciphers
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_connections Op Ar connectioninfoitem ...
+.Pp
 See
 .Cm list_connections
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_consumers Op Fl p Ar vhost
+.Pp
 See
 .Cm list_consumers
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
+.Pp
 See
 .Cm list_exchanges
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_hashes
+.Pp
 See
 .Cm list_hashes
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
+.Pp
 See
 .Cm list_queues
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_unresponsive_queues Oc Oo Fl -local Oc Oo Fl -queue_timeout Ar milliseconds Oc Oo Ar column ... Oc Op Fl -no-table-headers
+.Pp
 See
 .Cm list_unresponsive_queues
 in
@@ -526,6 +548,7 @@ and
 can authenticate with it successfully.
 .\" ------------------------------------
 .It Cm report
+.Pp
 See
 .Cm report
 in
@@ -560,6 +583,7 @@ Example:
 .Dl rabbitmq-diagnostics server_version -q
 .\" ------------------------------------
 .It Cm status
+.Pp
 See
 .Cm status
 in
@@ -579,39 +603,40 @@ Example:
 .Sp
 .Dl rabbitmq-diagnostics tls_versions -q
 .El
-.El
 .Ss Parameters
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_global_parameters
+.Pp
 See
 .Cm list_global_parameters
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_parameters Op Fl p Ar vhost
+.Pp
 See
 .Cm list_parameters
 in
 .Xr rabbitmqctl 8
 .El
-.El
 .Ss Policies
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_operator_policies Op Fl p Ar vhost
+.Pp
 See
 .Cm list_operator_policies
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
 .It Cm list_policies Op Fl p Ar vhost
+.Pp
 See
 .Cm list_policies
 in
 .Xr rabbitmqctl 8
 .\" ------------------------------------
-.El
 .El
 .Ss Virtual hosts
 .Bl -tag -width Ds
@@ -622,7 +647,6 @@ See
 .Cm list_vhost_limits
 in
 .Xr rabbitmqctl 8
-.El
 .El
 .Ss Node configuration
 .Bl -tag -width Ds
@@ -635,21 +659,21 @@ Example:
 .Sp
 .Dl rabbitmq-diagnostics log_location -a
 .El
-.El
 .Ss Feature flags
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_feature_flags Oc Oo Ar column ... Oc Op Fl -timeout Ar milliseconds
+.Pp
 See
 .Cm list_feature_flags
 in
 .Xr rabbitmqctl 8
-.\" ------------------------------------
-.El
 .El
 .Ss Queues
 .Bl -tag -width Ds
+.\" ------------------------------------
 .It Cm quorum_status Ar queue Oc Op Fl -vhost Ar vhost
+.Pp
 See
 .Cm quorum_status
 in

--- a/docs/rabbitmq-diagnostics.8
+++ b/docs/rabbitmq-diagnostics.8
@@ -38,7 +38,7 @@
 is a command line tool that provides commands used for diagnostics, monitoring
 and health checks of RabbitMQ nodes.
 See the
-.Lk https://www.rabbitmq.com/documentation.html "RabbitMQ documentation guides"
+.Lk https://rabbitmq.com/documentation.html "RabbitMQ documentation guides"
 to learn more about RabbitMQ diagnostics, monitoring and health checks.
 
 .Nm
@@ -49,7 +49,7 @@ health checks are available to be used interactively and by monitoring tools.
 By default if it is not possible to connect to and authenticate with the target node
 (for example if it is stopped), the operation will fail.
 To learn more, see the
-.Lk https://www.rabbitmq.com/monitoring.html "RabbitMQ Monitoring guide"
+.Lk https://rabbitmq.com/monitoring.html "RabbitMQ Monitoring guide"
 .
 .\" ------------------------------------------------------------------
 .Sh OPTIONS
@@ -90,14 +90,14 @@ Default is
 .It Fl l , Fl -longnames
 Must be specified when the cluster is configured to use long (FQDN) node names.
 To learn more, see the
-.Lk https://www.rabbitmq.com/clustering.html "RabbitMQ Clustering guide"
+.Lk https://rabbitmq.com/clustering.html "RabbitMQ Clustering guide"
 .It Fl -erlang-cookie Ar cookie
 Shared secret to use to authenticate to the target node.
 Prefer using a local file or the
 .Ev RABBITMQ_ERLANG_COOKIE
 environment variable instead of specifying this option on the command line.
 To learn more, see the
-.Lk https://www.rabbitmq.com/cli.html "RabbitMQ CLI Tools guide"
+.Lk https://rabbitmq.com/cli.html "RabbitMQ CLI Tools guide"
 .El
 .\" ------------------------------------------------------------------
 .Sh COMMANDS
@@ -224,7 +224,7 @@ in
 Lists resource alarms, if any, in the cluster.
 .Pp
 See
-.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
+.Lk https://rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
 to learn more.
 .Pp
 Example:
@@ -237,7 +237,7 @@ Health check that fails (returns with a non-zero code) if there are alarms
 in effect on any of the cluster nodes.
 .Pp
 See
-.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
+.Lk https://rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
 to learn more.
 .Pp
 Example:
@@ -250,7 +250,7 @@ Health check that fails (returns with a non-zero code) if there are alarms
 in effect on the target node.
 .Pp
 See
-.Lk https://www.rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
+.Lk https://rabbitmq.com/alarms.html "RabbitMQ Resource Alarms guide"
 to learn more.
 .Pp
 Example:
@@ -261,12 +261,13 @@ Example:
 .Pp
 Health check that fails (returns with a non-zero code) if any listener ports
 on the target node cannot accept a new TCP connection opened by
-.Nm.
+.Nm
+.Pp
 The check only validates if a new TCP connection is accepted. It does not
 perform messaging protocol handshake or authenticate.
 .Pp
 See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+.Lk https://rabbitmq.com/networking.html "RabbitMQ Networking guide"
 to learn more.
 .Pp
 Example:
@@ -280,7 +281,7 @@ is not listening on the specified port (there is no listener that
 uses that port).
 .Pp
 See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+.Lk https://rabbitmq.com/networking.html "RabbitMQ Networking guide"
 to learn more.
 .Pp
 Example:
@@ -293,7 +294,7 @@ Health check that fails (returns with a non-zero code) if the target node
 does not have a listener for the specified protocol.
 .Pp
 See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+.Lk https://rabbitmq.com/networking.html "RabbitMQ Networking guide"
 to learn more.
 .Pp
 Example:
@@ -350,7 +351,7 @@ Example:
 Runs a peer discovery on the target node and prints the discovered nodes, if any.
 .Pp
 See
-.Lk https://www.rabbitmq.com/cluster-formation.html "RabbitMQ Cluster Formation guide"
+.Lk https://rabbitmq.com/cluster-formation.html "RabbitMQ Cluster Formation guide"
 to learn more.
 .Pp
 Example:
@@ -370,7 +371,7 @@ to authenticate CLI tools and peers. The value can be compared with the hash
 found in error messages of CLI tools.
 .Pp
 See
-.Lk https://www.rabbitmq.com/clustering.html#erlang-cookie "RabbitMQ Clustering guide"
+.Lk https://rabbitmq.com/clustering.html#erlang-cookie "RabbitMQ Clustering guide"
 to learn more.
 .Pp
 Example:
@@ -473,14 +474,14 @@ what protocols and ports the node is listening on for client, CLI tool
 and peer connections.
 .Pp
 See
-.Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
+.Lk https://rabbitmq.com/networking.html "RabbitMQ Networking guide"
 to learn more.
 .Pp
 Example:
 .Sp
 .Dl rabbitmq-diagnostics listeners
 .\" ------------------------------------
-.It Cm log_tail Oc Oo Fl -number Ar number | Fl N Ar number Oc Op Fl -timeout Ar milliseconds
+.It Cm log_tail Fl -number Ar number | Fl N Ar number  Op Fl -timeout Ar milliseconds
 .Pp
 Prints the last N lines of the log on the node
 .Pp
@@ -488,7 +489,7 @@ Example:
 .Sp
 .Dl rabbitmq-diagnostics log_tail -number 100
 .\" ------------------------------------
-.It Cm log_tail_stream Oc Oo Fl -duration Ar seconds | Fl d Ar seconds Oc Op Fl -timeout Ar milliseconds
+.It Cm log_tail_stream Oo Fl -duration Ar seconds | Fl d Ar seconds Oc Op Fl -timeout Ar milliseconds
 .Pp
 Streams logs from a running node for a period of time
 .Pp
@@ -525,7 +526,7 @@ terabytes
 .El
 .Pp
 See
-.Lk https://www.rabbitmq.com/memory-use.html "RabbitMQ Memory Use guide"
+.Lk https://rabbitmq.com/memory-use.html "RabbitMQ Memory Use guide"
 to learn more.
 .Pp
 Example:
@@ -596,7 +597,7 @@ Note that RabbitMQ can be configured to only accept a subset of those
 versions, for example, SSLv3 is disabled by default.
 .Pp
 See
-.Lk https://www.rabbitmq.com/ssl.html "RabbitMQ TLS guide"
+.Lk https://rabbitmq.com/ssl.html "RabbitMQ TLS guide"
 to learn more.
 .Pp
 Example:
@@ -641,7 +642,7 @@ in
 .Ss Virtual hosts
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm list_vhost_limits Oc Oo Fl -vhost Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
+.It Cm list_vhost_limits Oo Fl -vhost Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
 .Pp
 See
 .Cm list_vhost_limits
@@ -651,7 +652,7 @@ in
 .Ss Node configuration
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm log_location Oc Oo Fl -all | Fl a Oc Op Fl -timeout Ar milliseconds
+.It Cm log_location Oo Fl -all | Fl a Oc Op Fl -timeout Ar milliseconds
 .Pp
 Shows log file location(s) on target node
 .Pp
@@ -662,7 +663,7 @@ Example:
 .Ss Feature flags
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm list_feature_flags Oc Oo Ar column ... Oc Op Fl -timeout Ar milliseconds
+.It Cm list_feature_flags Oo Ar column ... Oc Op Fl -timeout Ar milliseconds
 .Pp
 See
 .Cm list_feature_flags
@@ -672,7 +673,7 @@ in
 .Ss Queues
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm quorum_status Ar queue Oc Op Fl -vhost Ar vhost
+.It Cm quorum_status Ar queue Op Fl -vhost Ar vhost
 .Pp
 See
 .Cm quorum_status

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -278,7 +278,7 @@ up:
 .Dl rabbitmqctl wait /var/run/rabbitmq/pid
 .El
 .\" ------------------------------------------------------------------
-.\" ## Cluster management
+.\" ## Cluster Operations
 .\" ------------------------------------------------------------------
 .Ss Cluster management
 .Bl -tag -width Ds
@@ -323,9 +323,6 @@ with the currently running nodes.
 For example, this command displays the nodes in the cluster:
 .sp
 .Dl rabbitmqctl cluster_status
-.El
-.Ss Application Management
-.Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm force_boot
 .Pp
@@ -417,12 +414,14 @@ from the node
 .sp
 .Dl rabbitmqctl -n hare@mcnulty forget_cluster_node rabbit@stringer
 .\" ------------------------------------------------------------------
-.It Cm join_cluster Ar clusternode Op Fl -ram
+.It Cm join_cluster Ar seed-node Op Fl -ram
 .Bl -tag -width Ds
-.It Ar clusternode
-Node to cluster with.
+.It Ar seed-node
+Existing cluster member (seed node) to cluster with.
 .It Fl -ram
 If provided, the node will join the cluster as a RAM node.
+RAM node use is discouraged. Use only if you understand why
+exactly you need to use them.
 .El
 .Pp
 Instructs the node to become a member of the cluster that the specified
@@ -463,14 +462,14 @@ You can also remove nodes remotely with the
 .Cm forget_cluster_node
 command.
 .Pp
-For more details see the
-.Lk https://www.rabbitmq.com/clustering.html Clustering guide .
-.Pp
 For example, this command instructs the RabbitMQ node to join the cluster that
 .Qq hare@elena
 is part of, as a ram node:
 .sp
 .Dl rabbitmqctl join_cluster hare@elena --ram
+.Pp
+To learn more, see the
+.Lk https://www.rabbitmq.com/clustering.html "RabbitMQ Clustering guide".
 .\" ------------------------------------------------------------------
 .It Cm rename_cluster_node Ar oldnode1 Ar newnode1 Op Ar oldnode2 Ar newnode2 ...
 .Pp
@@ -532,14 +531,13 @@ mv \\
 .Ed
 .sp
 .It
-If you have
+If node name is configured e.g. using
 .Ar /etc/rabbitmq/rabbitmq-env.conf
-and configured the node name there, update this configuration.
+it has also be updated there.
 .sp
 .It
 Start the node when ready
 .El
-.Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm update_cluster_nodes Ar clusternode
 .Bl -tag -width Ds
@@ -549,7 +547,7 @@ The node to consult for up-to-date information.
 .Pp
 Instructs an already clustered node to contact
 .Ar clusternode
-to cluster when waking up.
+to cluster when booting up.
 This is different from
 .Cm join_cluster
 since it does not join any cluster - it checks that the node is already
@@ -558,32 +556,40 @@ in a cluster with
 .Pp
 The need for this command is motivated by the fact that clusters can
 change while a node is offline.
-Consider the situation in which node
-.Va A
+Consider a situation where node
+.Va rabbit@A
 and
-.Va B
+.Va rabbit@B
 are clustered.
-.Va A
+.Va rabbit@A
 goes down,
-.Va C
+.Va rabbit@C
 clusters with
-.Va B ,
+.Va rabbit@B ,
 and then
-.Va B
+.Va rabbit@B
 leaves the cluster.
 When
-.Va A
-wakes up, it'll try to contact
-.Va B ,
+.Va rabbit@A
+starts back up, it'll try to contact
+.Va rabbit@B ,
 but this will fail since
-.Va B
+.Va rabbit@B
 is not in the cluster anymore.
-The following command will solve this situation:
+The following command will rename node
+.Va rabbit@B
+to
+.Va rabbit@C
+on node
+.Va rabbitA
 .sp
-.Dl update_cluster_nodes -n Va A Va C
+.Dl update_cluster_nodes -n Va rabbit@A Va rabbit@B Va rabbit@C
+.Pp
+To learn more, see the
+.Lk https://www.rabbitmq.com/clustering.html "RabbitMQ Clustering guide"
 .El
 .\" ------------------------------------------------------------------
-.\" ## Replication
+.\" ## Classic Mirrored Queues
 .\" ------------------------------------------------------------------
 .Ss Replication
 .Bl -tag -width Ds
@@ -1677,20 +1683,6 @@ For example, this command sets the policy
 in the default virtual host so that built-in exchanges are federated:
 .sp
 .Dl rabbitmqctl set_policy federate-me "^amq." '{"federation-upstream-set":"all"}'
-.El
-.\" ------------------------------------------------------------------
-.\" ## Operator Policies
-.\" ------------------------------------------------------------------
-.Ss Operator Policies
-Operator policies are merged with user-defined policies and allow for
-operator override of a limited set of optional queue arguments (such as max length limit).
-.Bl -tag -width Ds
-.\" ------------------------------------------------------------------
-.It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
-.Pp
-Clears an operator policy.
-Arguments are identical to those of
-.Cm clear_policy .
 .\" ------------------------------------------------------------------
 .It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
 .Pp
@@ -1705,6 +1697,12 @@ For example, this command clears the
 policy in the default virtual host:
 .sp
 .Dl rabbitmqctl clear_policy federate-me
+.\" ------------------------------------------------------------------
+.It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
+.Pp
+Clears an operator policy.
+Arguments are identical to those of
+.Cm clear_policy .
 .\" ------------------------------------------------------------------
 .It Cm list_operator_policies Op Fl p Ar vhost
 .Pp

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -123,7 +123,7 @@ Prints usage for the specified command.
 Displays CLI tools version
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Nodes
+.\" ## Nodes
 .\" ------------------------------------------------------------------
 .Ss Nodes
 .Bl -tag -width Ds
@@ -278,7 +278,7 @@ up:
 .Dl rabbitmqctl wait /var/run/rabbitmq/pid
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Cluster management
+.\" ## Cluster management
 .\" ------------------------------------------------------------------
 .Ss Cluster management
 .Bl -tag -width Ds
@@ -583,7 +583,7 @@ The following command will solve this situation:
 .Dl update_cluster_nodes -n Va A Va C
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Replication
+.\" ## Replication
 .\" ------------------------------------------------------------------
 .Ss Replication
 .Bl -tag -width Ds
@@ -615,7 +615,7 @@ The name of the queue to cancel synchronisation for.
 Instructs a synchronising mirrored queue to stop synchronising itself.
 .El
 .\" ------------------------------------------------------------------
-.\" ##  User management
+.\" ## User management
 .\" ------------------------------------------------------------------
 .Ss User Management
 Note that all user management commands
@@ -734,7 +734,7 @@ This command instructs the RabbitMQ broker to remove any tags from the user name
 .Dl rabbitmqctl set_user_tags janeway
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Access Control
+.\" ## Access Control
 .\" ------------------------------------------------------------------
 .Ss Access control
 .Bl -tag -width Ds
@@ -852,7 +852,7 @@ has been granted access, and the topic permissions the user has in these virtual
 .Dl rabbitmqctl list_topic_user_permissions janeway
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Parameter management
+.\" ## Parameter management
 .\" ------------------------------------------------------------------
 .Ss Parameter Management
 Certain features of RabbitMQ (such as the Federation plugin) are
@@ -967,7 +967,7 @@ The previous example could be made more generic by using
 .Dl rabbitmqctl set_topic_permissions -p my-vhost janeway amq.topic Qo ^{username}-.* Qc Qo ^{username}-.* Qc
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Monitoring and Observability
+.\" ## Monitoring and Observability
 .\" ------------------------------------------------------------------
 .Ss Monitoring, observability and health checks
 .Bl -tag -width Ds
@@ -1503,9 +1503,18 @@ broker:
 .Dl rabbitmqctl status
 .El
 .\" ------------------------------------------------------------------
-.\" ##  Runtime Parameters
+.\" ## Runtime Parameters and Policies
 .\" ------------------------------------------------------------------
-.Ss Parameters
+.Ss Runtime Parameters and Policies
+Some settings must be identical on all cluster nodes and are likely
+to change at runtime. They are controlled via a mechanism
+called runtime parameters.
+Policies is a feature built on top of runtime parameters.
+Policies are used to control and modify the behaviour of queues and
+exchanges on a cluster-wide basis.
+Policies apply within a given vhost, and consist of a name, pattern,
+definition and an optional priority.
+Policies can be set, cleared and listed.
 .Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm clear_global_parameter Ar name
@@ -1552,17 +1561,6 @@ but the global runtime parameters are not tied to any virtual host.
 For example, this command lists all global parameters:
 .sp
 .Dl rabbitmqctl list_global_parameters
-.El
-.\" ------------------------------------------------------------------
-.\" ##  Policies
-.\" ------------------------------------------------------------------
-.Ss Policy Management
-Policies are used to control and modify the behaviour of queues and
-exchanges on a cluster-wide basis.
-Policies apply within a given vhost, and consist of a name, pattern,
-definition and an optional priority.
-Policies can be set, cleared and listed.
-.Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm list_parameters Op Fl p Ar vhost
 .Pp
@@ -1614,39 +1612,6 @@ component in the default virtual host to the following JSON
 .Qq guest :
 .sp
 .Dl rabbitmqctl set_parameter federation-upstream node01 '{"uri":"amqp://user:password@server/%2F","ack-mode":"on-publish"}'
-.El
-.Ss Policies
-.Bl -tag -width Ds
-.\" ------------------------------------------------------------------
-.It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
-.Pp
-Clears an operator policy.
-Arguments are identical to those of
-.Cm clear_policy .
-.\" ------------------------------------------------------------------
-.It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
-.Pp
-Clears a policy.
-.Bl -tag -width Ds
-.It Ar name
-The name of the policy being cleared.
-.El
-.Pp
-For example, this command clears the
-.Qq federate-me
-policy in the default virtual host:
-.sp
-.Dl rabbitmqctl clear_policy federate-me
-.\" ------------------------------------------------------------------
-.It Cm list_operator_policies Op Fl p Ar vhost
-.Pp
-Lists operator policy overrides for a virtual host.
-Arguments are identical to those of
-.Cm list_policies .
-.El
-.Ss Virtual Host Limits
-It is possible to enforce certain limits on virtual hosts.
-.Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm list_policies Op Fl p Ar vhost
 .Pp
@@ -1713,6 +1678,43 @@ in the default virtual host so that built-in exchanges are federated:
 .sp
 .Dl rabbitmqctl set_policy federate-me "^amq." '{"federation-upstream-set":"all"}'
 .El
+.\" ------------------------------------------------------------------
+.\" ## Operator Policies
+.\" ------------------------------------------------------------------
+.Ss Operator Policies
+Operator policies are merged with user-defined policies and allow for
+operator override of a limited set of optional queue arguments (such as max length limit).
+.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
+.It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
+.Pp
+Clears an operator policy.
+Arguments are identical to those of
+.Cm clear_policy .
+.\" ------------------------------------------------------------------
+.It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
+.Pp
+Clears a policy.
+.Bl -tag -width Ds
+.It Ar name
+The name of the policy being cleared.
+.El
+.Pp
+For example, this command clears the
+.Qq federate-me
+policy in the default virtual host:
+.sp
+.Dl rabbitmqctl clear_policy federate-me
+.\" ------------------------------------------------------------------
+.It Cm list_operator_policies Op Fl p Ar vhost
+.Pp
+Lists operator policy overrides for a virtual host.
+Arguments are identical to those of
+.Cm list_policies .
+.El
+.\" ------------------------------------------------------------------
+.\" ## Virtual Host Management
+.\" ------------------------------------------------------------------
 .Ss Virtual hosts
 Note that
 .Nm
@@ -1726,6 +1728,7 @@ not be visible to
 .Bl -tag -width Ds
 .It Ar vhost
 The name of the virtual host entry to create.
+.El
 .Pp
 Creates a virtual host.
 .Pp
@@ -1759,7 +1762,7 @@ For example, this command instructs the RabbitMQ broker to delete the
 virtual host called
 .Qq test :
 .sp
-.Dl rabbitmqctl delete_vhost test
+.Dl rabbitmqctl delete_vhost a-vhost
 .\" ------------------------------------------------------------------
 .It Cm list_vhost_limits Oo Fl p Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
 .Pp
@@ -1771,37 +1774,12 @@ Suppresses the
 .Fl p
 parameter.
 .El
-.El
-.\" ------------------------------------------------------------------
-.\" ## Topology Introspection
-.\" ------------------------------------------------------------------
-.Ss Topology Introspection
-The topology introspection commands list topology entities (e.g. queues) with tab-delimited columns.
-Some commands (
-.Cm list_queues ,
-.Cm list_exchanges ,
-.Cm list_bindings
-and
-.Cm list_consumers )
-accept an optional
-.Ar vhost
-parameter.
-.Pp
-The
-.Cm list_queues ,
-.Cm list_exchanges
-and
-.Cm list_bindings
-commands accept an optional virtual host parameter for which to display
-results.
-The default value is
-.Qq / .
-.Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm restart_vhost Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
 The name of the virtual host entry to restart.
+.El
 .Pp
 Restarts a failed vhost data stores and queues.
 .Pp
@@ -1869,9 +1847,12 @@ The name of the virtual host for which to start tracing.
 .Pp
 Starts tracing.
 Note that the trace state is not persistent; it will revert to being off
-if the server is restarted.
+if the node is restarted.
 .El
-.Ss Node configuration
+.\" ------------------------------------------------------------------
+.\" ## Configuration
+.\" ------------------------------------------------------------------
+.Ss Configuration
 .Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm decode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
@@ -1990,18 +1971,23 @@ megabytes (10^6 bytes)
 .It Cm GB
 gigabytes (10^9 bytes)
 .El
+.El
+.El
+.\" ------------------------------------------------------------------
+.\" ## Feature Flags
+.\" ------------------------------------------------------------------
 .Ss Feature flags
 .Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm enable_feature_flag Ar feature_flag
 .Pp
-Enables a feature flag on target node
+Enables a feature flag on the target node.
+.Pp
 Example:
 .Sp
 .Dl rabbitmqctl enable_feature_flag quorum_queue
-.El
 .\" ------------------------------------------------------------------
-.It Cm list_feature_flags Oc Op Ar column ...
+.It Cm list_feature_flags Op Ar column ...
 .Pp
 Lists feature flags
 .Pp
@@ -2022,11 +2008,15 @@ desc
 .It
 doc_url
 .El
+.Pp
 Example:
 .Sp
 .Dl rabbitmqctl list_feature_flags name state
 .El
-.Ss Operations
+.\" ------------------------------------------------------------------
+.\" ## Misc Operations
+.\" ------------------------------------------------------------------
+.Ss Connection Operations
 .Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm close_all_connections Oo Fl p Ar vhost Oc Oo Fl -global Oc Oo Fl -per-connection-delay Ar delay Oc Oo Fl -limit Ar limit Oc Ar explanation
@@ -2091,8 +2081,18 @@ passing the explanation
 to the connected client:
 .sp
 .Dl rabbitmqctl close_connection Qo <rabbit@tanto.4262.0> Qc Qq go away
+.El
 .\" ------------------------------------------------------------------
-.It Cm eval Ar expr
+.\" ## Misc
+.\" ------------------------------------------------------------------
+.Ss Misc
+.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
+.It Cm eval Ar expression
+.Pp
+Evaluates an Erlang expression on the target node
+.\" ------------------------------------------------------------------
+.It Cm hipe_compile Ar directory
 .Pp
 Performs HiPE-compilation and caches resulting
 .Pa .beam Ns -files in the given directory.
@@ -2114,7 +2114,10 @@ directory:
 .sp
 .Dl rabbitmqctl hipe_compile /tmp/rabbit-hipe/ebin
 .El
-.Ss Queues
+.\" ------------------------------------------------------------------
+.\" ## Queue Operations
+.\" ------------------------------------------------------------------
+.Ss Queue Operations
 .Bl -tag -width Ds
 .\" ------------------------------------------------------------------
 .It Cm delete_queue Ar queue_name Oo Fl -if-empty | Fl e Oc Op Fl -if-unused | Fl u
@@ -2136,14 +2139,7 @@ The name of the queue to purge.
 .El
 .Pp
 Purges a queue (removes all messages in it).
-.\" ------------------------------------------------------------------
-.It Cm quorum_status Ar queue_name
-.Bl -tag -width Ds
-.It Ar queue_name
-The name of the queue.
 .El
-.Pp
-Displays quorum status of a quorum queue.
 .\" ------------------------------------------------------------------------------------------------
 .Sh PLUGIN COMMANDS
 .\" ------------------------------------------------------------------------------------------------
@@ -2159,7 +2155,7 @@ distribution:
 .Ss Shovel plugin
 .Bl -tag -width Ds
 .It Cm shovel_status
-Prints a list of configured shovels
+Prints a list of configured Shovels
 .It Cm delete_shovel Oo Fl p Ar vhost Oc Ar name
 Instructs the RabbitMQ node to delete the configured shovel by
 .Ar name .
@@ -2260,6 +2256,7 @@ The period for which the peer's SSL certificate is valid.
 .It Cm node
 The node name of the RabbitMQ node to which connection is established.
 .El
+.El
 .\" ------------------------------------------------------------------
 .\" ## MQTT
 .\" ------------------------------------------------------------------
@@ -2354,6 +2351,7 @@ Username associated with the connection.
 .It Cm vhost
 Virtual host name with non-ASCII characters escaped as in C.
 .El
+.El
 .\" ------------------------------------------------------------------
 .\" ## STOMP
 .\" ------------------------------------------------------------------
@@ -2436,17 +2434,18 @@ Informational properties transmitted by the client during connection
 .It Cm ssl
 Boolean indicating whether the connection is secured with SSL.
 .It Cm ssl_protocol
-SSL protocol (e.g.\&
+TLS protocol (e.g.\&
 .Qq tlsv1 ) .
 .It Cm ssl_key_exchange
-SSL key exchange algorithm (e.g.\&
+TLS key exchange algorithm (e.g.\&
 .Qq rsa ) .
 .It Cm ssl_cipher
-SSL cipher algorithm (e.g.\&
+TLS cipher algorithm (e.g.\&
 .Qq aes_256_cbc ) .
 .It Cm ssl_hash
 SSL hash function (e.g.\&
 .Qq sha ) .
+.El
 .El
 .\" ------------------------------------------------------------------
 .\" ## Management Agent
@@ -2458,6 +2457,7 @@ Reset management stats database for the RabbitMQ node.
 .Bl -tag -width Ds
 .It Fl -all
 Reset stats database for all nodes in the cluster.
+.El
 .El
 .\" ------------------------------------------------------------------------------------------------
 .Sh SEE ALSO

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -1930,7 +1930,7 @@ Lower bound limit as an integer in bytes or a string with memory unit symbols
 Once free disk space reaches the limit, a disk alarm will be set.
 .El
 .\" ------------------------------------------------------------------
-.It Cm set_disk_free_limit Oc mem_relative Ar fraction
+.It Cm set_disk_free_limit mem_relative Ar fraction
 .Bl -tag -width Ds
 .It Ar fraction
 Limit relative to the total amount available RAM as a non-negative
@@ -1938,7 +1938,7 @@ floating point number.
 Values lower than 1.0 can be dangerous and should be used carefully.
 .El
 .\" ------------------------------------------------------------------
-.It Cm set_log_level Oc Op Ar log_level
+.It Cm set_log_level Op Ar log_level
 .Pp
 Sets log level in the running node
 .Pp
@@ -1969,7 +1969,7 @@ The new memory threshold fraction at which flow control is triggered, as
 a floating point number greater than or equal to 0.
 .El
 .\" ------------------------------------------------------------------
-.It Cm set_vm_memory_high_watermark Oc absolute Ar memory_limit
+.It Cm set_vm_memory_high_watermark Oo absolute Oc Ar memory_limit
 .Bl -tag -width Ds
 .It Ar memory_limit
 The new memory limit at which flow control is triggered, expressed in
@@ -2117,7 +2117,7 @@ directory:
 .Ss Queues
 .Bl -tag -width Ds
 .\" ------------------------------------------------------------------
-.It Cm delete_queue Oc Ar queue_name Oc Oo Fl -if-empty | Fl e Oc Op Fl -if-unused | Fl u
+.It Cm delete_queue Ar queue_name Oo Fl -if-empty | Fl e Oc Op Fl -if-unused | Fl u
 .Bl -tag -width Ds
 .It Ar queue_name
 The name of the queue to delete.
@@ -2137,7 +2137,7 @@ The name of the queue to purge.
 .Pp
 Purges a queue (removes all messages in it).
 .\" ------------------------------------------------------------------
-.It Cm quorum_status Oc Ar queue_name
+.It Cm quorum_status Ar queue_name
 .Bl -tag -width Ds
 .It Ar queue_name
 The name of the queue.
@@ -2153,6 +2153,9 @@ Currently available commands can be found in
 output.
 Following commands are added by RabbitMQ plugins, available in default
 distribution:
+.\" ------------------------------------------------------------------
+.\" ## Shovel
+.\" ------------------------------------------------------------------
 .Ss Shovel plugin
 .Bl -tag -width Ds
 .It Cm shovel_status
@@ -2161,6 +2164,9 @@ Prints a list of configured shovels
 Instructs the RabbitMQ node to delete the configured shovel by
 .Ar name .
 .El
+.\" ------------------------------------------------------------------
+.\" ## Federation
+.\" ------------------------------------------------------------------
 .Ss Federation plugin
 .Bl -tag -width Ds
 .It Cm federation_status Op Fl -only-down
@@ -2173,7 +2179,10 @@ Only list federation links which are not running.
 Instructs the RabbitMQ node to restart the federation link with specified
 .Ar link_id .
 .El
-.Ss AMQP-1.0 plugin
+.\" ------------------------------------------------------------------
+.\" ## AMQP 1.0
+.\" ------------------------------------------------------------------
+.Ss AMQP 1.0 plugin
 .Bl -tag -width Ds
 .It Cm list_amqp10_connections Op Ar amqp10_connectioninfoitem ...
 Similar to the
@@ -2251,6 +2260,9 @@ The period for which the peer's SSL certificate is valid.
 .It Cm node
 The node name of the RabbitMQ node to which connection is established.
 .El
+.\" ------------------------------------------------------------------
+.\" ## MQTT
+.\" ------------------------------------------------------------------
 .Ss MQTT plugin
 .Bl -tag -width Ds
 .It Cm list_mqtt_connections Op Ar mqtt_connectioninfoitem
@@ -2342,6 +2354,9 @@ Username associated with the connection.
 .It Cm vhost
 Virtual host name with non-ASCII characters escaped as in C.
 .El
+.\" ------------------------------------------------------------------
+.\" ## STOMP
+.\" ------------------------------------------------------------------
 .Ss STOMP plugin
 .Bl -tag -width Ds
 .It Cm list_stomp_connections Op Ar stomp_connectioninfoitem
@@ -2433,6 +2448,9 @@ SSL cipher algorithm (e.g.\&
 SSL hash function (e.g.\&
 .Qq sha ) .
 .El
+.\" ------------------------------------------------------------------
+.\" ## Management Agent
+.\" ------------------------------------------------------------------
 .Ss Management agent plugin
 .Bl -tag -width Ds
 .It Cm reset_stats_db Op Fl -all

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -1075,6 +1075,7 @@ cipher suites supported by encoding commands:
 .Dl rabbitmqctl list_ciphers
 .El
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm list_connections Op Ar connectioninfoitem ...
 .Pp
 Returns TCP/IP connection statistics.
@@ -1196,6 +1197,7 @@ for each connection:
 .sp
 .Dl rabbitmqctl list_connections send_pend port
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm list_consumers Op Fl p Ar vhost
 .Pp
 Lists consumers, i.e. subscriptions to a queue\'s message stream.
@@ -1208,6 +1210,7 @@ consumer, an integer indicating the prefetch limit (with 0 meaning
 .Qq none ) ,
 and any arguments for this consumer.
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
 .Pp
 Returns exchange details.
@@ -1265,6 +1268,7 @@ of the virtual host named
 .sp
 .Dl rabbitmqctl list_exchanges -p my-vhost name type
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm list_hashes
 .Pp
 Lists hash functions supported by encoding commands.
@@ -1274,6 +1278,7 @@ functions supported by encoding commands:
 .sp
 .Dl rabbitmqctl list_hashes
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
 .Pp
 Returns queue details.
@@ -1422,6 +1427,7 @@ each queue of the virtual host named
 .sp
 .Dl rabbitmqctl list_queues -p my-vhost messages consumers
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm list_unresponsive_queues Oc Oo Fl -local Oc Oo Fl -queue_timeout Ar milliseconds Oc Oo Ar column ... Oc Op Fl -no-table-headers
 .Pp
 Tests queues to respond within timeout. Lists those which did not respond
@@ -1431,6 +1437,7 @@ is located on the current node.
 .Sp
 .Dl rabbitmqctl list_unresponsive_queues --local name
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm node_health_check
 .Pp
 Performs several health checks of the target node.
@@ -1441,6 +1448,7 @@ then checks that every queue and channel on the node can emit basic stats.
 Example:
 .Dl rabbitmqctl node_health_check -n rabbit@hostname
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm ping
 .Pp
 Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it
@@ -1448,6 +1456,7 @@ Checks that the node OS process is up, registered with EPMD and CLI tools can au
 Example:
 .Dl rabbitmqctl ping -n rabbit@hostname
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm report
 .Pp
 Generate a server status report containing a concatenation of all server
@@ -1460,6 +1469,7 @@ to a support request email:
 .sp
 .Dl rabbitmqctl report > server_report.txt
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm schema_info Oc Oo Fl -no-table-headers Oc Op Ar column ...
 .Pp
 Lists schema database tables and their properties
@@ -1468,6 +1478,7 @@ For example, this command lists the table names and their active replicas:
 .sp
 .Dl rabbitmqctl schema_info name active_replicas
 .\" ------------------------------------
+.Bl -tag -width Ds
 .It Cm status
 .Pp
 Displays broker status information such as the running applications on

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -20,9 +20,9 @@
 .Sh NAME
 .Nm rabbitmqctl
 .Nd tool for managing RabbitMQ nodes
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh SYNOPSIS
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Nm
 .Op Fl q
 .Op Fl s
@@ -31,9 +31,9 @@
 .Op Fl t Ar timeout
 .Ar command
 .Op Ar command_options
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh DESCRIPTION
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 RabbitMQ is an open source multi-protocol messaging broker.
 .Pp
 .Nm
@@ -51,9 +51,9 @@ To learn more, see the
 .Lk https://www.rabbitmq.com/cli.html "RabbitMQ CLI Tools guide"
 and
 .Lk https://www.rabbitmq.com/networking.html "RabbitMQ Networking guide"
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh OPTIONS
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Bl -tag -width Ds
 .It Fl n Ar node
 Default node is
@@ -104,9 +104,9 @@ environment variable instead of specifying this option on the command line.
 To learn more, see the
 .Lk https://www.rabbitmq.com/cli.html "RabbitMQ CLI Tools guide"
 .El
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh COMMANDS
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Bl -tag -width Ds
 .It Cm help Oo Fl l Oc Op Ar command_name
 .Pp
@@ -117,14 +117,17 @@ List command usages only, without parameter explanation.
 .It Ar command_name
 Prints usage for the specified command.
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm version
 .Pp
 Displays CLI tools version
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Nodes
+.\" ------------------------------------------------------------------
 .Ss Nodes
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm await_startup
 .Pp
 Waits for the RabbitMQ application to start on the target node
@@ -132,7 +135,7 @@ Waits for the RabbitMQ application to start on the target node
 For example, to wait for the RabbitMQ application to start:
 .sp
 .Dl rabbitmqctl await_startup
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm reset
 .Pp
 Returns a RabbitMQ node to its virgin state.
@@ -151,7 +154,7 @@ to succeed the RabbitMQ application must have been stopped, e.g. with
 For example, to resets the RabbitMQ node:
 .sp
 .Dl rabbitmqctl reset
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm rotate_logs
 .Pp
 Instructs the RabbitMQ node to perform internal log rotation.
@@ -170,7 +173,7 @@ process:
 .Pp
 Rotation is performed asynchronously, so there is no guarantee that it
 will be completed when this command returns.
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm shutdown
 .Pp
 Shuts down the node, both RabbitMQ and its runtime.
@@ -195,7 +198,7 @@ For example, this will shut down a locally running RabbitMQ node
 with default node name:
 .sp
 .Dl rabbitmqctl shutdown
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm start_app
 .Pp
 Starts the RabbitMQ application.
@@ -208,14 +211,14 @@ For example, to instruct the RabbitMQ node to start the RabbitMQ
 application:
 .sp
 .Dl rabbitmqctl start_app
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm stop Op Ar pid_file
 .Pp
 Stops the Erlang node on which RabbitMQ is running.
 To restart the node follow the instructions for
 .Qq Running the Server
 in the
-.Lk https://www.rabbitmq.com/download.html installation guide .
+.Lk https://rabbitmq.com/download.html installation guide .
 .Pp
 If a
 .Ar pid_file
@@ -227,7 +230,7 @@ command for details on this file.
 For example, to instruct the RabbitMQ node to terminate:
 .sp
 .Dl rabbitmqctl stop
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm stop_app
 .Pp
 Stops the RabbitMQ application, leaving the runtime (Erlang VM) running.
@@ -240,7 +243,7 @@ For example, to instruct the RabbitMQ node to stop the RabbitMQ
 application:
 .sp
 .Dl rabbitmqctl stop_app
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm wait Ar pid_file , Cm wait Fl -pid Ar pid
 .Pp
 Waits for the RabbitMQ application to start.
@@ -274,9 +277,12 @@ up:
 .sp
 .Dl rabbitmqctl wait /var/run/rabbitmq/pid
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Cluster management
+.\" ------------------------------------------------------------------
 .Ss Cluster management
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm await_online_nodes Ar count
 .Pp
 Waits for
@@ -286,7 +292,7 @@ nodes to join the cluster
 For example, to wait for two RabbitMQ nodes to start:
 .sp
 .Dl rabbitmqctl await_online_nodes 2
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm change_cluster_node_type Ar type
 .Pp
 Changes the type of the cluster node.
@@ -308,7 +314,7 @@ cluster.
 For example, this command will turn a RAM node into a disc node:
 .sp
 .Dl rabbitmqctl change_cluster_node_type disc
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm cluster_status
 .Pp
 Displays all the nodes in the cluster grouped by node type, together
@@ -320,7 +326,7 @@ For example, this command displays the nodes in the cluster:
 .El
 .Ss Application Management
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm force_boot
 .Pp
 Ensures that the node will start next time, even if it was not the last
@@ -350,7 +356,7 @@ For example, this will force the node not to wait for other nodes next
 time it is started:
 .sp
 .Dl rabbitmqctl force_boot
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm force_reset
 .Pp
 Forcefully returns a RabbitMQ node to its virgin state.
@@ -374,7 +380,7 @@ to succeed the RabbitMQ application must have been stopped, e.g. with
 For example, to reset the RabbitMQ node:
 .sp
 .Dl rabbitmqctl force_reset
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm forget_cluster_node Op Fl -offline
 .Bl -tag -width Ds
 .It Fl -offline
@@ -410,7 +416,7 @@ from the node
 .Qq hare@mcnulty :
 .sp
 .Dl rabbitmqctl -n hare@mcnulty forget_cluster_node rabbit@stringer
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm join_cluster Ar clusternode Op Fl -ram
 .Bl -tag -width Ds
 .It Ar clusternode
@@ -465,7 +471,7 @@ For example, this command instructs the RabbitMQ node to join the cluster that
 is part of, as a ram node:
 .sp
 .Dl rabbitmqctl join_cluster hare@elena --ram
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm rename_cluster_node Ar oldnode1 Ar newnode1 Op Ar oldnode2 Ar newnode2 ...
 .Pp
 Supports renaming of cluster nodes in the local database.
@@ -534,7 +540,7 @@ and configured the node name there, update this configuration.
 Start the node when ready
 .El
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm update_cluster_nodes Ar clusternode
 .Bl -tag -width Ds
 .It Ar clusternode
@@ -576,9 +582,12 @@ The following command will solve this situation:
 .sp
 .Dl update_cluster_nodes -n Va A Va C
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Replication
+.\" ------------------------------------------------------------------
 .Ss Replication
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm sync_queue Oo Fl p Ar vhost Oc Ar queue
 .Bl -tag -width Ds
 .It Ar queue
@@ -596,7 +605,7 @@ To learn more, see the
 Note that queues with unsynchronised replicas and active consumers
 will become synchronised eventually (assuming that consumers make progress).
 This command is primarily useful for queues which do not have active consumers.
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm cancel_sync_queue Oo Fl p Ar vhost Oc Ar queue
 .Bl -tag -width Ds
 .It Ar queue
@@ -605,6 +614,9 @@ The name of the queue to cancel synchronisation for.
 .Pp
 Instructs a synchronising mirrored queue to stop synchronising itself.
 .El
+.\" ------------------------------------------------------------------
+.\" ##  User management
+.\" ------------------------------------------------------------------
 .Ss User Management
 Note that all user management commands
 .Nm
@@ -613,7 +625,7 @@ Users from any alternative authentication backends such as LDAP cannot be inspec
 or managed with those commands.
 .Nm .
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm add_user Ar username Ar password
 .Bl -tag -width Ds
 .It Ar username
@@ -628,7 +640,7 @@ with (initial) password
 .Qq changeit :
 .sp
 .Dl rabbitmqctl add_user janeway changeit
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm authenticate_user Ar username Ar password
 .Bl -tag -width Ds
 .It Ar username
@@ -643,7 +655,7 @@ with password
 .Qq verifyit :
 .sp
 .Dl rabbitmqctl authenticate_user janeway verifyit
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm change_password Ar username Ar newpassword
 .Bl -tag -width Ds
 .It Ar username
@@ -659,7 +671,7 @@ to
 .Qq newpass :
 .sp
 .Dl rabbitmqctl change_password janeway newpass
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_password Ar username
 .Bl -tag -width Ds
 .It Ar username
@@ -674,7 +686,7 @@ password for the user named
 .Pp
 This user now cannot log in with a password (but may be able to through
 e.g. SASL EXTERNAL if configured).
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm delete_user Ar username
 .Bl -tag -width Ds
 .It Ar username
@@ -685,7 +697,7 @@ For example, this command instructs the RabbitMQ broker to delete the user named
 .Qq janeway :
 .sp
 .Dl rabbitmqctl delete_user janeway
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_users
 .Pp
 Lists users.
@@ -695,7 +707,7 @@ tags set for that user.
 For example, this command instructs the RabbitMQ broker to list all users:
 .sp
 .Dl rabbitmqctl list_users
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_user_tags Ar username Op Ar tag ...
 .Bl -tag -width Ds
 .It Ar username
@@ -721,9 +733,12 @@ This command instructs the RabbitMQ broker to remove any tags from the user name
 .sp
 .Dl rabbitmqctl set_user_tags janeway
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Access Control
+.\" ------------------------------------------------------------------
 .Ss Access control
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_permissions Oo Fl p Ar vhost Oc Ar username
 .Bl -tag -width Ds
 .It Ar vhost
@@ -743,7 +758,7 @@ access to the virtual host called
 .Qq my-vhost :
 .sp
 .Dl rabbitmqctl clear_permissions -p my-vhost janeway
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_topic_permissions Oo Fl p Ar vhost Oc Ar username Oo Ar exchange Oc
 .Bl -tag -width Ds
 .It Ar vhost
@@ -768,7 +783,7 @@ in the virtual host called
 .Qq my-vhost :
 .sp
 .Dl rabbitmqctl clear_topic_permissions -p my-vhost janeway amq.topic
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_permissions Op Fl p Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -788,7 +803,7 @@ virtual host.
 Note that an empty string means no permissions granted:
 .sp
 .Dl rabbitmqctl list_permissions -p my-vhost
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_topic_permissions Op Fl p Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -804,7 +819,7 @@ users which have been granted topic permissions in the virtual host called
 .Qq my-vhost:
 .sp
 .Dl rabbitmqctl list_topic_permissions -p my-vhost
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_user_permissions Ar username
 .Bl -tag -width Ds
 .It Ar username
@@ -820,7 +835,7 @@ has been granted access, and the permissions the user has for operations
 on resources in these virtual hosts:
 .sp
 .Dl rabbitmqctl list_user_permissions janeway
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_user_topic_permissions Ar username
 .Bl -tag -width Ds
 .It Ar username
@@ -836,6 +851,9 @@ has been granted access, and the topic permissions the user has in these virtual
 .sp
 .Dl rabbitmqctl list_topic_user_permissions janeway
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Parameter management
+.\" ------------------------------------------------------------------
 .Ss Parameter Management
 Certain features of RabbitMQ (such as the Federation plugin) are
 controlled by dynamic, cluster-wide
@@ -851,7 +869,7 @@ Parameters can be set, cleared and listed.
 In general you should refer to the documentation for the feature in
 question to see how to set parameters.
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_vhosts Op Ar vhostinfoitem ...
 .Pp
 Lists virtual hosts.
@@ -878,7 +896,7 @@ For example, this command instructs the RabbitMQ broker to list all
 virtual hosts:
 .sp
 .Dl rabbitmqctl list_vhosts name tracing
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_permissions Oo Fl p Ar vhost Oc Ar user Ar conf Ar write Ar read
 .Bl -tag -width Ds
 .It Ar vhost
@@ -910,7 +928,7 @@ with configure permissions on all resources whose names starts with
 and write and read permissions on all resources:
 .sp
 .Dl rabbitmqctl set_permissions -p my-vhost janeway Qo ^janeway-.* Qc Qo .* Qc Qq .*
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_topic_permissions Oo Fl p Ar vhost Oc Ar user Ar exchange Ar write Ar read
 .Bl -tag -width Ds
 .It Ar vhost
@@ -948,14 +966,17 @@ The previous example could be made more generic by using
 .sp
 .Dl rabbitmqctl set_topic_permissions -p my-vhost janeway amq.topic Qo ^{username}-.* Qc Qo ^{username}-.* Qc
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Monitoring and Observability
+.\" ------------------------------------------------------------------
 .Ss Monitoring, observability and health checks
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm environment
 .Pp
 Displays the name and value of each variable in the application
 environment for each running application.
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
 .Pp
 Returns binding details.
@@ -1004,7 +1025,7 @@ the bindings in the virtual host named
 .Qq my-vhost
 .sp
 .Dl rabbitmqctl list_bindings -p my-vhost exchange_name queue_name
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_channels Op Ar channelinfoitem ...
 .Pp
 Returns information on all current channels, the logical containers
@@ -1064,7 +1085,7 @@ For example, this command displays the connection process and count of
 unacknowledged messages for each channel:
 .sp
 .Dl rabbitmqctl list_channels connection messages_unacknowledged
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_ciphers
 .Pp
 Lists cipher suites supported by encoding commands.
@@ -1073,9 +1094,7 @@ For example, this command instructs the RabbitMQ broker to list all
 cipher suites supported by encoding commands:
 .sp
 .Dl rabbitmqctl list_ciphers
-.El
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm list_connections Op Ar connectioninfoitem ...
 .Pp
 Returns TCP/IP connection statistics.
@@ -1196,8 +1215,7 @@ For example, this command displays the send queue size and server port
 for each connection:
 .sp
 .Dl rabbitmqctl list_connections send_pend port
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm list_consumers Op Fl p Ar vhost
 .Pp
 Lists consumers, i.e. subscriptions to a queue\'s message stream.
@@ -1209,8 +1227,7 @@ whether acknowledgements are expected for messages delivered to this
 consumer, an integer indicating the prefetch limit (with 0 meaning
 .Qq none ) ,
 and any arguments for this consumer.
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
 .Pp
 Returns exchange details.
@@ -1267,8 +1284,7 @@ of the virtual host named
 .Qq my-vhost :
 .sp
 .Dl rabbitmqctl list_exchanges -p my-vhost name type
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm list_hashes
 .Pp
 Lists hash functions supported by encoding commands.
@@ -1277,8 +1293,7 @@ For example, this command instructs the RabbitMQ broker to list all hash
 functions supported by encoding commands:
 .sp
 .Dl rabbitmqctl list_hashes
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
 .Pp
 Returns queue details.
@@ -1426,9 +1441,8 @@ each queue of the virtual host named
 .Qq my-vhost
 .sp
 .Dl rabbitmqctl list_queues -p my-vhost messages consumers
-.\" ------------------------------------
-.Bl -tag -width Ds
-.It Cm list_unresponsive_queues Oc Oo Fl -local Oc Oo Fl -queue_timeout Ar milliseconds Oc Oo Ar column ... Oc Op Fl -no-table-headers
+.\" ------------------------------------------------------------------
+.It Cm list_unresponsive_queues Oo Fl -local Oc Oo Fl -queue_timeout Ar milliseconds Oc Oo Ar column ... Oc Op Fl -no-table-headers
 .Pp
 Tests queues to respond within timeout. Lists those which did not respond
 .Pp
@@ -1436,8 +1450,7 @@ For example, this command lists only those unresponsive queues whose master proc
 is located on the current node.
 .Sp
 .Dl rabbitmqctl list_unresponsive_queues --local name
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm node_health_check
 .Pp
 Performs several health checks of the target node.
@@ -1447,16 +1460,14 @@ then checks that every queue and channel on the node can emit basic stats.
 .sp
 Example:
 .Dl rabbitmqctl node_health_check -n rabbit@hostname
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm ping
 .Pp
 Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it
 .Pp
 Example:
 .Dl rabbitmqctl ping -n rabbit@hostname
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm report
 .Pp
 Generate a server status report containing a concatenation of all server
@@ -1468,17 +1479,15 @@ For example, this command creates a server report which may be attached
 to a support request email:
 .sp
 .Dl rabbitmqctl report > server_report.txt
-.\" ------------------------------------
-.Bl -tag -width Ds
-.It Cm schema_info Oc Oo Fl -no-table-headers Oc Op Ar column ...
+.\" ------------------------------------------------------------------
+.It Cm schema_info Oo Fl -no-table-headers Oc Op Ar column ...
 .Pp
 Lists schema database tables and their properties
 .Pp
 For example, this command lists the table names and their active replicas:
 .sp
 .Dl rabbitmqctl schema_info name active_replicas
-.\" ------------------------------------
-.Bl -tag -width Ds
+.\" ------------------------------------------------------------------
 .It Cm status
 .Pp
 Displays broker status information such as the running applications on
@@ -1493,9 +1502,12 @@ broker:
 .sp
 .Dl rabbitmqctl status
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Runtime Parameters
+.\" ------------------------------------------------------------------
 .Ss Parameters
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_global_parameter Ar name
 .Pp
 Clears a global runtime parameter.
@@ -1511,7 +1523,7 @@ For example, this command clears the global runtime parameter
 .Qq mqtt_default_vhosts :
 .sp
 .Dl rabbitmqctl clear_global_parameter mqtt_default_vhosts
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_parameter Oo Fl p Ar vhost Oc Ar component_name Ar key
 .Pp
 Clears a parameter.
@@ -1529,7 +1541,7 @@ for the
 component in the default virtual host:
 .sp
 .Dl rabbitmqctl clear_parameter federation-upstream node01
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_global_parameters
 .Pp
 Lists all global runtime parameters.
@@ -1541,6 +1553,9 @@ For example, this command lists all global parameters:
 .sp
 .Dl rabbitmqctl list_global_parameters
 .El
+.\" ------------------------------------------------------------------
+.\" ##  Policies
+.\" ------------------------------------------------------------------
 .Ss Policy Management
 Policies are used to control and modify the behaviour of queues and
 exchanges on a cluster-wide basis.
@@ -1548,7 +1563,7 @@ Policies apply within a given vhost, and consist of a name, pattern,
 definition and an optional priority.
 Policies can be set, cleared and listed.
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_parameters Op Fl p Ar vhost
 .Pp
 Lists all parameters for a virtual host.
@@ -1557,7 +1572,7 @@ For example, this command lists all parameters in the default virtual
 host:
 .sp
 .Dl rabbitmqctl list_parameters
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_global_parameter Ar name Ar value
 .Pp
 Sets a global runtime parameter.
@@ -1577,7 +1592,7 @@ For example, this command sets the global runtime parameter
 to the JSON term {"O=client,CN=guest":"/"}:
 .sp
 .Dl rabbitmqctl set_global_parameter mqtt_default_vhosts '{"O=client,CN=guest":"/"}'
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_parameter Oo Fl p Ar vhost Oc Ar component_name Ar name Ar value
 .Pp
 Sets a parameter.
@@ -1602,13 +1617,13 @@ component in the default virtual host to the following JSON
 .El
 .Ss Policies
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
 .Pp
 Clears an operator policy.
 Arguments are identical to those of
 .Cm clear_policy .
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
 .Pp
 Clears a policy.
@@ -1622,7 +1637,7 @@ For example, this command clears the
 policy in the default virtual host:
 .sp
 .Dl rabbitmqctl clear_policy federate-me
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_operator_policies Op Fl p Ar vhost
 .Pp
 Lists operator policy overrides for a virtual host.
@@ -1632,7 +1647,7 @@ Arguments are identical to those of
 .Ss Virtual Host Limits
 It is possible to enforce certain limits on virtual hosts.
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_policies Op Fl p Ar vhost
 .Pp
 Lists all policies for a virtual host.
@@ -1641,7 +1656,7 @@ For example, this command lists all policies in the default virtual
 host:
 .sp
 .Dl rabbitmqctl list_policies
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_operator_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
 .Pp
 Sets an operator policy that overrides a subset of arguments in user
@@ -1660,7 +1675,7 @@ max-length
 .It
 max-length-bytes
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
 .Pp
 Sets a policy.
@@ -1706,7 +1721,7 @@ Permissions for users from any alternative authorisation backend will
 not be visible to
 .Nm .
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm add_vhost Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -1719,7 +1734,7 @@ virtual host called
 .Qq test :
 .Pp
 .Dl rabbitmqctl add_vhost test
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm clear_vhost_limits Op Fl p Ar vhost
 .Pp
 Clears virtual host limits.
@@ -1728,7 +1743,7 @@ For example, this command clears vhost limits in vhost
 .Qq qa_env :
 .sp
 .Dl rabbitmqctl clear_vhost_limits -p qa_env
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm delete_vhost Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -1745,7 +1760,7 @@ virtual host called
 .Qq test :
 .sp
 .Dl rabbitmqctl delete_vhost test
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_vhost_limits Oo Fl p Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
 .Pp
 Displays configured virtual host limits.
@@ -1756,6 +1771,10 @@ Suppresses the
 .Fl p
 parameter.
 .El
+.El
+.\" ------------------------------------------------------------------
+.\" ## Topology Introspection
+.\" ------------------------------------------------------------------
 .Ss Topology Introspection
 The topology introspection commands list topology entities (e.g. queues) with tab-delimited columns.
 Some commands (
@@ -1778,7 +1797,7 @@ results.
 The default value is
 .Qq / .
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm restart_vhost Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -1791,7 +1810,7 @@ virtual host called
 .Qq test :
 .Pp
 .Dl rabbitmqctl restart_vhost test
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_vhost_limits Oo Fl p Ar vhost Oc Ar definition
 .Pp
 Sets virtual host limits.
@@ -1833,7 +1852,7 @@ This command disables client connections in vhost
 .Qq qa_env :
 .sp
 .Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-connections": 0}'
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm trace_off Op Fl p Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -1841,7 +1860,7 @@ The name of the virtual host for which to stop tracing.
 .El
 .Pp
 Stops tracing.
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm trace_on Op Fl p Ar vhost
 .Bl -tag -width Ds
 .It Ar vhost
@@ -1854,7 +1873,7 @@ if the server is restarted.
 .El
 .Ss Node configuration
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm decode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
 .Bl -tag -width Ds
 .It Ar value Ar passphrase
@@ -1871,7 +1890,7 @@ For example:
 .sp
 .Dl rabbitmqctl decode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 '{encrypted,<<"...">>} mypassphrase
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm encode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
 .Bl -tag -width Ds
 .It Ar value Ar passphrase
@@ -1888,7 +1907,7 @@ For example:
 .sp
 .Dl rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 '<<"guest">>' mypassphrase
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_cluster_name Ar name
 .Pp
 Sets the cluster name to
@@ -1902,7 +1921,7 @@ For example, this sets the cluster name to
 .Qq london :
 .sp
 .Dl rabbitmqctl set_cluster_name london
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_disk_free_limit Ar disk_limit
 .Bl -tag -width Ds
 .It Ar disk_limit
@@ -1910,7 +1929,7 @@ Lower bound limit as an integer in bytes or a string with memory unit symbols
 (see vm_memory_high_watermark), e.g. 512M or 1G.
 Once free disk space reaches the limit, a disk alarm will be set.
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_disk_free_limit Oc mem_relative Ar fraction
 .Bl -tag -width Ds
 .It Ar fraction
@@ -1918,7 +1937,7 @@ Limit relative to the total amount available RAM as a non-negative
 floating point number.
 Values lower than 1.0 can be dangerous and should be used carefully.
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_log_level Oc Op Ar log_level
 .Pp
 Sets log level in the running node
@@ -1942,14 +1961,14 @@ none
 Example:
 .Sp
 .Dl rabbitmqctl log_level debug
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_vm_memory_high_watermark Ar fraction
 .Bl -tag -width Ds
 .It Ar fraction
 The new memory threshold fraction at which flow control is triggered, as
 a floating point number greater than or equal to 0.
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm set_vm_memory_high_watermark Oc absolute Ar memory_limit
 .Bl -tag -width Ds
 .It Ar memory_limit
@@ -1973,7 +1992,7 @@ gigabytes (10^9 bytes)
 .El
 .Ss Feature flags
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm enable_feature_flag Ar feature_flag
 .Pp
 Enables a feature flag on target node
@@ -1981,7 +2000,7 @@ Example:
 .Sp
 .Dl rabbitmqctl enable_feature_flag quorum_queue
 .El
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm list_feature_flags Oc Op Ar column ...
 .Pp
 Lists feature flags
@@ -2009,7 +2028,7 @@ Example:
 .El
 .Ss Operations
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm close_all_connections Oo Fl p Ar vhost Oc Oo Fl -global Oc Oo Fl -per-connection-delay Ar delay Oc Oo Fl -limit Ar limit Oc Ar explanation
 .Bl -tag -width Ds
 .It Fl p Ar vhost
@@ -2046,7 +2065,7 @@ This command instructs broker to close all connections to the node:
 .sp
 .Dl rabbitmqctl close_all_connections --global
 .sp
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm close_connection Ar connectionpid Ar explanation
 .Bl -tag -width Ds
 .It Ar connectionpid
@@ -2072,7 +2091,7 @@ passing the explanation
 to the connected client:
 .sp
 .Dl rabbitmqctl close_connection Qo <rabbit@tanto.4262.0> Qc Qq go away
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm eval Ar expr
 .Pp
 Performs HiPE-compilation and caches resulting
@@ -2097,7 +2116,7 @@ directory:
 .El
 .Ss Queues
 .Bl -tag -width Ds
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm delete_queue Oc Ar queue_name Oc Oo Fl -if-empty | Fl e Oc Op Fl -if-unused | Fl u
 .Bl -tag -width Ds
 .It Ar queue_name
@@ -2109,7 +2128,7 @@ Delete the queue only if it has no consumers
 .El
 .Pp
 Deletes a queue.
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm purge_queue Oo Fl p Ar vhost Oc Ar queue
 .Bl -tag -width Ds
 .It Ar queue
@@ -2117,7 +2136,7 @@ The name of the queue to purge.
 .El
 .Pp
 Purges a queue (removes all messages in it).
-.\" ------------------------------------
+.\" ------------------------------------------------------------------
 .It Cm quorum_status Oc Ar queue_name
 .Bl -tag -width Ds
 .It Ar queue_name
@@ -2125,9 +2144,9 @@ The name of the queue.
 .El
 .Pp
 Displays quorum status of a quorum queue.
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh PLUGIN COMMANDS
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 RabbitMQ plugins can extend rabbitmqctl tool to add new commands when enabled.
 Currently available commands can be found in
 .Cm rabbitmqctl help
@@ -2422,9 +2441,9 @@ Reset management stats database for the RabbitMQ node.
 .It Fl -all
 Reset stats database for all nodes in the cluster.
 .El
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh SEE ALSO
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Xr rabbitmq-diagnostics 8 ,
 .Xr rabbitmq-plugins 8 ,
 .Xr rabbitmq-server 8 ,
@@ -2433,7 +2452,7 @@ Reset stats database for all nodes in the cluster.
 .Xr rabbitmq-service 8 ,
 .Xr rabbitmq-env.conf 5 ,
 .Xr rabbitmq-echopid 8
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .Sh AUTHOR
-.\" ------------------------------------------------------------------
+.\" ------------------------------------------------------------------------------------------------
 .An The RabbitMQ Team Aq Mt info@rabbitmq.com

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -115,54 +115,20 @@ Prints usage for all available commands.
 List command usages only, without parameter explanation.
 .It Ar command_name
 Prints usage for the specified command.
+.\" ------------------------------------
+.It Cm version
+Displays CLI tools version
 .El
 .El
-.Ss Application Management
+.Ss Nodes
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm force_reset
-Forcefully returns a RabbitMQ node to its virgin state.
+.It Cm await_startup
+Waits for the RabbitMQ application to start on the target node
 .Pp
-The
-.Cm force_reset
-command differs from
-.Cm reset
-in that it resets the node unconditionally, regardless of the current
-management database state and cluster configuration.
-It should only be used as a last resort if the database or cluster
-configuration has been corrupted.
-.Pp
-For
-.Cm reset
-and
-.Cm force_reset
-to succeed the RabbitMQ application must have been stopped, e.g. with
-.Cm stop_app .
-.Pp
-For example, to reset the RabbitMQ node:
+For example, to wait for the RabbitMQ application to start:
 .sp
-.Dl rabbitmqctl force_reset
-.\" ------------------------------------
-.It Cm hipe_compile Ar directory
-Performs HiPE-compilation and caches resulting
-.Pa .beam Ns -files in the given directory.
-.Pp
-Parent directories are created if necessary.
-Any existing
-.Pa .beam
-files from the directory are automatically deleted prior to compilation.
-.Pp
-To use this precompiled files, you should set
-.Ev RABBITMQ_SERVER_CODE_PATH
-environment variable to directory specified in
-.Cm hipe_compile
-invocation.
-.Pp
-For example, to HiPE-compile modules and store them to
-.Pa /tmp/rabbit-hipe/ebin
-directory:
-.sp
-.Dl rabbitmqctl hipe_compile /tmp/rabbit-hipe/ebin
+.Dl rabbitmqctl await_startup
 .\" ------------------------------------
 .It Cm reset
 Returns a RabbitMQ node to its virgin state.
@@ -297,10 +263,138 @@ For example, this command will return when the RabbitMQ node has started
 up:
 .sp
 .Dl rabbitmqctl wait /var/run/rabbitmq/pid
-.\" ------------------------------------
 .El
-.Ss Cluster Management
+.El
+.Ss Cluster management
 .Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm await_online_nodes
+Waits for <count> nodes to join the cluster
+.Pp
+For example, to wait for two RabbitMQ nodes to start:
+.sp
+.Dl rabbitmqctl await_online_nodes 2
+.\" ------------------------------------
+.It Cm change_cluster_node_type Ar type
+Changes the type of the cluster node.
+.Pp
+The
+.Ar type
+must be one of the following:
+.Bl -bullet -compact
+.It
+.Cm disc
+.It
+.Cm ram
+.El
+.Pp
+The node must be stopped for this operation to succeed, and when turning
+a node into a RAM node the node must not be the only disc node in the
+cluster.
+.Pp
+For example, this command will turn a RAM node into a disc node:
+.sp
+.Dl rabbitmqctl change_cluster_node_type disc
+.\" ------------------------------------
+.It Cm cluster_status
+Displays all the nodes in the cluster grouped by node type, together
+with the currently running nodes.
+.Pp
+For example, this command displays the nodes in the cluster:
+.sp
+.Dl rabbitmqctl cluster_status
+.El
+.El
+.Ss Application Management
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm force_boot
+Ensures that the node will start next time, even if it was not the last
+to shut down.
+.Pp
+Normally when you shut down a RabbitMQ cluster altogether, the first
+node you restart should be the last one to go down, since it may have
+seen things happen that other nodes did not.
+But sometimes that's not possible: for instance if the entire cluster
+loses power then all nodes may think they were not the last to shut
+down.
+.Pp
+In such a case you can invoke
+.Cm force_boot
+while the node is down.
+This will tell the node to unconditionally start next time you ask it
+to.
+If any changes happened to the cluster after this node shut down, they
+will be lost.
+.Pp
+If the last node to go down is permanently lost then you should use
+.Cm forget_cluster_node Fl -offline
+in preference to this command, as it will ensure that mirrored queues
+which were mastered on the lost node get promoted.
+.Pp
+For example, this will force the node not to wait for other nodes next
+time it is started:
+.sp
+.Dl rabbitmqctl force_boot
+.\" ------------------------------------
+.It Cm force_reset
+Forcefully returns a RabbitMQ node to its virgin state.
+.Pp
+The
+.Cm force_reset
+command differs from
+.Cm reset
+in that it resets the node unconditionally, regardless of the current
+management database state and cluster configuration.
+It should only be used as a last resort if the database or cluster
+configuration has been corrupted.
+.Pp
+For
+.Cm reset
+and
+.Cm force_reset
+to succeed the RabbitMQ application must have been stopped, e.g. with
+.Cm stop_app .
+.Pp
+For example, to reset the RabbitMQ node:
+.sp
+.Dl rabbitmqctl force_reset
+.\" ------------------------------------
+.It Cm forget_cluster_node Op Fl -offline
+.Bl -tag -width Ds
+.It Fl -offline
+Enables node removal from an offline node.
+This is only useful in the situation where all the nodes are offline and
+the last node to go down cannot be brought online, thus preventing the
+whole cluster from starting.
+It should not be used in any other circumstances since it can lead to
+inconsistencies.
+.El
+.Pp
+Removes a cluster node remotely.
+The node that is being removed must be offline, while the node we are
+removing from must be online, except when using the
+.Fl -offline
+flag.
+.Pp
+When using the
+.Fl -offline
+flag ,
+.Nm
+will not attempt to connect to a node as normal; instead it will
+temporarily become the node in order to make the change.
+This is useful if the node cannot be started normally.
+In this case the node will become the canonical source for cluster
+metadata (e.g. which queues exist), even if it was not before.
+Therefore you should use this command on the latest node to shut down if
+at all possible.
+.Pp
+For example, this command will remove the node
+.Qq rabbit@stringer
+from the node
+.Qq hare@mcnulty :
+.sp
+.Dl rabbitmqctl -n hare@mcnulty forget_cluster_node rabbit@stringer
 .\" ------------------------------------
 .It Cm join_cluster Ar clusternode Op Fl -ram
 .Bl -tag -width Ds
@@ -356,71 +450,6 @@ For example, this command instructs the RabbitMQ node to join the cluster that
 is part of, as a ram node:
 .sp
 .Dl rabbitmqctl join_cluster hare@elena --ram
-.\" ------------------------------------
-.It Cm cluster_status
-Displays all the nodes in the cluster grouped by node type, together
-with the currently running nodes.
-.Pp
-For example, this command displays the nodes in the cluster:
-.sp
-.Dl rabbitmqctl cluster_status
-.\" ------------------------------------
-.It Cm change_cluster_node_type Ar type
-Changes the type of the cluster node.
-.Pp
-The
-.Ar type
-must be one of the following:
-.Bl -bullet -compact
-.It
-.Cm disc
-.It
-.Cm ram
-.El
-.Pp
-The node must be stopped for this operation to succeed, and when turning
-a node into a RAM node the node must not be the only disc node in the
-cluster.
-.Pp
-For example, this command will turn a RAM node into a disc node:
-.sp
-.Dl rabbitmqctl change_cluster_node_type disc
-.\" ------------------------------------
-.It Cm forget_cluster_node Op Fl -offline
-.Bl -tag -width Ds
-.It Fl -offline
-Enables node removal from an offline node.
-This is only useful in the situation where all the nodes are offline and
-the last node to go down cannot be brought online, thus preventing the
-whole cluster from starting.
-It should not be used in any other circumstances since it can lead to
-inconsistencies.
-.El
-.Pp
-Removes a cluster node remotely.
-The node that is being removed must be offline, while the node we are
-removing from must be online, except when using the
-.Fl -offline
-flag.
-.Pp
-When using the
-.Fl -offline
-flag ,
-.Nm
-will not attempt to connect to a node as normal; instead it will
-temporarily become the node in order to make the change.
-This is useful if the node cannot be started normally.
-In this case the node will become the canonical source for cluster
-metadata (e.g. which queues exist), even if it was not before.
-Therefore you should use this command on the latest node to shut down if
-at all possible.
-.Pp
-For example, this command will remove the node
-.Qq rabbit@stringer
-from the node
-.Qq hare@mcnulty :
-.sp
-.Dl rabbitmqctl -n hare@mcnulty forget_cluster_node rabbit@stringer
 .\" ------------------------------------
 .It Cm rename_cluster_node Ar oldnode1 Ar newnode1 Op Ar oldnode2 Ar newnode2 ...
 Supports renaming of cluster nodes in the local database.
@@ -529,35 +558,10 @@ is not in the cluster anymore.
 The following command will solve this situation:
 .sp
 .Dl update_cluster_nodes -n Va A Va C
-.\" ------------------------------------
-.It Cm force_boot
-Ensures that the node will start next time, even if it was not the last
-to shut down.
-.Pp
-Normally when you shut down a RabbitMQ cluster altogether, the first
-node you restart should be the last one to go down, since it may have
-seen things happen that other nodes did not.
-But sometimes that's not possible: for instance if the entire cluster
-loses power then all nodes may think they were not the last to shut
-down.
-.Pp
-In such a case you can invoke
-.Cm force_boot
-while the node is down.
-This will tell the node to unconditionally start next time you ask it
-to.
-If any changes happened to the cluster after this node shut down, they
-will be lost.
-.Pp
-If the last node to go down is permanently lost then you should use
-.Cm forget_cluster_node Fl -offline
-in preference to this command, as it will ensure that mirrored queues
-which were mastered on the lost node get promoted.
-.Pp
-For example, this will force the node not to wait for other nodes next
-time it is started:
-.sp
-.Dl rabbitmqctl force_boot
+.El
+.El
+.Ss Replication
+.Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm sync_queue Oo Fl p Ar vhost Oc Ar queue
 .Bl -tag -width Ds
@@ -584,27 +588,6 @@ The name of the queue to cancel synchronisation for.
 .El
 .Pp
 Instructs a synchronising mirrored queue to stop synchronising itself.
-.\" ------------------------------------
-.It Cm purge_queue Oo Fl p Ar vhost Oc Ar queue
-.Bl -tag -width Ds
-.It Ar queue
-The name of the queue to purge.
-.El
-.Pp
-Purges a queue (removes all messages in it).
-.\" ------------------------------------
-.It Cm set_cluster_name Ar name
-Sets the cluster name to
-.Ar name .
-The cluster name is announced to clients on connection, and used by the
-federation and shovel plugins to record where a message has been.
-The cluster name is by default derived from the hostname of the first
-node in the cluster, but can be changed.
-.Pp
-For example, this sets the cluster name to
-.Qq london :
-.sp
-.Dl rabbitmqctl set_cluster_name london
 .El
 .Ss User Management
 Note that all user management commands
@@ -630,16 +613,20 @@ with (initial) password
 .sp
 .Dl rabbitmqctl add_user janeway changeit
 .\" ------------------------------------
-.It Cm delete_user Ar username
+.It Cm authenticate_user Ar username Ar password
 .Bl -tag -width Ds
 .It Ar username
-The name of the user to delete.
+The name of the user.
+.It Ar password
+The password of the user.
 .El
 .Pp
-For example, this command instructs the RabbitMQ broker to delete the user named
-.Qq janeway :
+For example, this command instructs the RabbitMQ broker to authenticate the user named
+.Qq janeway
+with password
+.Qq verifyit :
 .sp
-.Dl rabbitmqctl delete_user janeway
+.Dl rabbitmqctl authenticate_user janeway verifyit
 .\" ------------------------------------
 .It Cm change_password Ar username Ar newpassword
 .Bl -tag -width Ds
@@ -672,20 +659,25 @@ password for the user named
 This user now cannot log in with a password (but may be able to through
 e.g. SASL EXTERNAL if configured).
 .\" ------------------------------------
-.It Cm authenticate_user Ar username Ar password
+.It Cm delete_user Ar username
 .Bl -tag -width Ds
 .It Ar username
-The name of the user.
-.It Ar password
-The password of the user.
+The name of the user to delete.
 .El
 .Pp
-For example, this command instructs the RabbitMQ broker to authenticate the user named
-.Qq janeway
-with password
-.Qq verifyit :
+For example, this command instructs the RabbitMQ broker to delete the user named
+.Qq janeway :
 .sp
-.Dl rabbitmqctl authenticate_user janeway verifyit
+.Dl rabbitmqctl delete_user janeway
+.\" ------------------------------------
+.It Cm list_users
+Lists users.
+Each result row will contain the user name followed by a list of the
+tags set for that user.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all users:
+.sp
+.Dl rabbitmqctl list_users
 .\" ------------------------------------
 .It Cm set_user_tags Ar username Op Ar tag ...
 .Bl -tag -width Ds
@@ -711,55 +703,138 @@ This command instructs the RabbitMQ broker to remove any tags from the user name
 .Qq janeway :
 .sp
 .Dl rabbitmqctl set_user_tags janeway
-.\" ------------------------------------
-.It Cm list_users
-Lists users.
-Each result row will contain the user name followed by a list of the
-tags set for that user.
-.Pp
-For example, this command instructs the RabbitMQ broker to list all users:
-.sp
-.Dl rabbitmqctl list_users
 .El
-.Ss Access Control
-Note that
-.Nm
-manages the RabbitMQ internal user database.
-Permissions for users from any alternative authorisation backend will
-not be visible to
-.Nm .
+.El
+.Ss Access control
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm add_vhost Ar vhost
+.It Cm clear_permissions Oo Fl p Ar vhost Oc Ar username
 .Bl -tag -width Ds
 .It Ar vhost
-The name of the virtual host entry to create.
+The name of the virtual host to which to deny the user access,
+defaulting to
+.Qq / .
+.It Ar username
+The name of the user to deny access to the specified virtual host.
 .El
 .Pp
-Creates a virtual host.
+Sets user permissions.
 .Pp
-For example, this command instructs the RabbitMQ broker to create a new
-virtual host called
-.Qq test :
-.Pp
-.Dl rabbitmqctl add_vhost test
+For example, this command instructs the RabbitMQ broker to deny the user
+named
+.Qq janeway
+access to the virtual host called
+.Qq my-vhost :
+.sp
+.Dl rabbitmqctl clear_permissions -p my-vhost janeway
 .\" ------------------------------------
-.It Cm delete_vhost Ar vhost
+.It Cm clear_topic_permissions Oo Fl p Ar vhost Oc Ar username Oo Ar exchange Oc
 .Bl -tag -width Ds
 .It Ar vhost
-The name of the virtual host entry to delete.
+The name of the virtual host to which to clear the topic permissions,
+defaulting to
+.Qq / .
+.It Ar username
+The name of the user to clear topic permissions to the specified virtual host.
+.It Ar exchange
+The name of the topic exchange to clear topic permissions, defaulting to all the
+topic exchanges the given user has topic permissions for.
 .El
 .Pp
-Deletes a virtual host.
+Clear user topic permissions.
 .Pp
-Deleting a virtual host deletes all its exchanges, queues, bindings,
-user permissions, parameters and policies.
-.Pp
-For example, this command instructs the RabbitMQ broker to delete the
-virtual host called
-.Qq test :
+For example, this command instructs the RabbitMQ broker to remove topic permissions for user
+named
+.Qq janeway
+for the topic exchange
+.Qq amq.topic
+in the virtual host called
+.Qq my-vhost :
 .sp
-.Dl rabbitmqctl delete_vhost test
+.Dl rabbitmqctl clear_topic_permissions -p my-vhost janeway amq.topic
+.\" ------------------------------------
+.It Cm list_permissions Op Fl p Ar vhost
+.Bl -tag -width Ds
+.It Ar vhost
+The name of the virtual host for which to list the users that have been
+granted access to it, and their permissions.
+Defaults to
+.Qq / .
+.El
+.Pp
+Lists permissions in a virtual host.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all the
+users which have been granted access to the virtual host called
+.Qq my-vhost ,
+and the permissions they have for operations on resources in that
+virtual host.
+Note that an empty string means no permissions granted:
+.sp
+.Dl rabbitmqctl list_permissions -p my-vhost
+.\" ------------------------------------
+.It Cm list_topic_permissions Op Fl p Ar vhost
+.Bl -tag -width Ds
+.It Ar vhost
+The name of the virtual host for which to list the users topic permissions.
+Defaults to
+.Qq / .
+.El
+.Pp
+Lists topic permissions in a virtual host.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all the
+users which have been granted topic permissions in the virtual host called
+.Qq my-vhost:
+.sp
+.Dl rabbitmqctl list_topic_permissions -p my-vhost
+.\" ------------------------------------
+.It Cm list_user_permissions Ar username
+.Bl -tag -width Ds
+.It Ar username
+The name of the user for which to list the permissions.
+.El
+.Pp
+Lists user permissions.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all the
+virtual hosts to which the user named
+.Qq janeway
+has been granted access, and the permissions the user has for operations
+on resources in these virtual hosts:
+.sp
+.Dl rabbitmqctl list_user_permissions janeway
+.\" ------------------------------------
+.It Cm list_user_topic_permissions Ar username
+.Bl -tag -width Ds
+.It Ar username
+The name of the user for which to list the topic permissions.
+.El
+.Pp
+Lists user topic permissions.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all the
+virtual hosts to which the user named
+.Qq janeway
+has been granted access, and the topic permissions the user has in these virtual hosts:
+.sp
+.Dl rabbitmqctl list_topic_user_permissions janeway
+.El
+.Ss Parameter Management
+Certain features of RabbitMQ (such as the Federation plugin) are
+controlled by dynamic, cluster-wide
+.Em parameters.
+There are 2 kinds of parameters: parameters scoped to a virtual host and
+global parameters.
+Each vhost-scoped parameter consists of a component name, a name and a
+value.
+The component name and name are strings, and the value is a valid JSON document.
+A global parameter consists of a name and value.
+The name is a string and the value is an arbitrary Erlang data structure.
+Parameters can be set, cleared and listed.
+In general you should refer to the documentation for the feature in
+question to see how to set parameters.
+.Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_vhosts Op Ar vhostinfoitem ...
 Lists virtual hosts.
@@ -819,62 +894,6 @@ and write and read permissions on all resources:
 .sp
 .Dl rabbitmqctl set_permissions -p my-vhost janeway Qo ^janeway-.* Qc Qo .* Qc Qq .*
 .\" ------------------------------------
-.It Cm clear_permissions Oo Fl p Ar vhost Oc Ar username
-.Bl -tag -width Ds
-.It Ar vhost
-The name of the virtual host to which to deny the user access,
-defaulting to
-.Qq / .
-.It Ar username
-The name of the user to deny access to the specified virtual host.
-.El
-.Pp
-Sets user permissions.
-.Pp
-For example, this command instructs the RabbitMQ broker to deny the user
-named
-.Qq janeway
-access to the virtual host called
-.Qq my-vhost :
-.sp
-.Dl rabbitmqctl clear_permissions -p my-vhost janeway
-.\" ------------------------------------
-.It Cm list_permissions Op Fl p Ar vhost
-.Bl -tag -width Ds
-.It Ar vhost
-The name of the virtual host for which to list the users that have been
-granted access to it, and their permissions.
-Defaults to
-.Qq / .
-.El
-.Pp
-Lists permissions in a virtual host.
-.Pp
-For example, this command instructs the RabbitMQ broker to list all the
-users which have been granted access to the virtual host called
-.Qq my-vhost ,
-and the permissions they have for operations on resources in that
-virtual host.
-Note that an empty string means no permissions granted:
-.sp
-.Dl rabbitmqctl list_permissions -p my-vhost
-.\" ------------------------------------
-.It Cm list_user_permissions Ar username
-.Bl -tag -width Ds
-.It Ar username
-The name of the user for which to list the permissions.
-.El
-.Pp
-Lists user permissions.
-.Pp
-For example, this command instructs the RabbitMQ broker to list all the
-virtual hosts to which the user named
-.Qq janeway
-has been granted access, and the permissions the user has for operations
-on resources in these virtual hosts:
-.sp
-.Dl rabbitmqctl list_user_permissions janeway
-.\" ------------------------------------
 .It Cm set_topic_permissions Oo Fl p Ar vhost Oc Ar user Ar exchange Ar write Ar read
 .Bl -tag -width Ds
 .It Ar vhost
@@ -911,347 +930,325 @@ The previous example could be made more generic by using
 .Qq ^{username}-.* :
 .sp
 .Dl rabbitmqctl set_topic_permissions -p my-vhost janeway amq.topic Qo ^{username}-.* Qc Qo ^{username}-.* Qc
-.\" ------------------------------------
-.It Cm clear_topic_permissions Oo Fl p Ar vhost Oc Ar username Oo Ar exchange Oc
-.Bl -tag -width Ds
-.It Ar vhost
-The name of the virtual host to which to clear the topic permissions,
-defaulting to
-.Qq / .
-.It Ar username
-The name of the user to clear topic permissions to the specified virtual host.
-.It Ar exchange
-The name of the topic exchange to clear topic permissions, defaulting to all the
-topic exchanges the given user has topic permissions for.
 .El
-.Pp
-Clear user topic permissions.
-.Pp
-For example, this command instructs the RabbitMQ broker to remove topic permissions for user
-named
-.Qq janeway
-for the topic exchange
-.Qq amq.topic
-in the virtual host called
-.Qq my-vhost :
-.sp
-.Dl rabbitmqctl clear_topic_permissions -p my-vhost janeway amq.topic
-.\" ------------------------------------
-.It Cm list_topic_permissions Op Fl p Ar vhost
-.Bl -tag -width Ds
-.It Ar vhost
-The name of the virtual host for which to list the users topic permissions.
-Defaults to
-.Qq / .
 .El
-.Pp
-Lists topic permissions in a virtual host.
-.Pp
-For example, this command instructs the RabbitMQ broker to list all the
-users which have been granted topic permissions in the virtual host called
-.Qq my-vhost:
-.sp
-.Dl rabbitmqctl list_topic_permissions -p my-vhost
-.\" ------------------------------------
-.It Cm list_user_topic_permissions Ar username
-.Bl -tag -width Ds
-.It Ar username
-The name of the user for which to list the topic permissions.
-.El
-.Pp
-Lists user topic permissions.
-.Pp
-For example, this command instructs the RabbitMQ broker to list all the
-virtual hosts to which the user named
-.Qq janeway
-has been granted access, and the topic permissions the user has in these virtual hosts:
-.sp
-.Dl rabbitmqctl list_topic_user_permissions janeway
-.El
-.Ss Parameter Management
-Certain features of RabbitMQ (such as the Federation plugin) are
-controlled by dynamic, cluster-wide
-.Em parameters.
-There are 2 kinds of parameters: parameters scoped to a virtual host and
-global parameters.
-Each vhost-scoped parameter consists of a component name, a name and a
-value.
-The component name and name are strings, and the value is a valid JSON document.
-A global parameter consists of a name and value.
-The name is a string and the value is an arbitrary Erlang data structure.
-Parameters can be set, cleared and listed.
-In general you should refer to the documentation for the feature in
-question to see how to set parameters.
+.Ss Monitoring, observability and health checks
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm set_parameter Oo Fl p Ar vhost Oc Ar component_name Ar name Ar value
-Sets a parameter.
-.Bl -tag -width Ds
-.It Ar component_name
-The name of the component for which the parameter is being set.
-.It Ar name
-The name of the parameter being set.
-.It Ar value
-The value for the parameter, as a JSON term.
-In most shells you are very likely to need to quote this.
-.El
-.Pp
-For example, this command sets the parameter
-.Qq node01
-for the
-.Qq federation-upstream
-component in the default virtual host to the following JSON
-.Qq guest :
-.sp
-.Dl rabbitmqctl set_parameter federation-upstream node01 '{"uri":"amqp://user:password@server/%2F","ack-mode":"on-publish"}'
+.It Cm environment
+Displays the name and value of each variable in the application
+environment for each running application.
 .\" ------------------------------------
-.It Cm clear_parameter Oo Fl p Ar vhost Oc Ar component_name Ar key
-Clears a parameter.
-.Bl -tag -width Ds
-.It Ar component_name
-The name of the component for which the parameter is being cleared.
-.It Ar name
-The name of the parameter being cleared.
-.El
-.Pp
-For example, this command clears the parameter
-.Qq node01
-for the
-.Qq federation-upstream
-component in the default virtual host:
-.sp
-.Dl rabbitmqctl clear_parameter federation-upstream node01
-.\" ------------------------------------
-.It Cm list_parameters Op Fl p Ar vhost
-Lists all parameters for a virtual host.
-.Pp
-For example, this command lists all parameters in the default virtual
-host:
-.sp
-.Dl rabbitmqctl list_parameters
-.\" ------------------------------------
-.It Cm set_global_parameter Ar name Ar value
-Sets a global runtime parameter.
-This is similar to
-.Cm set_parameter
-but the key-value pair isn't tied to a virtual host.
-.Bl -tag -width Ds
-.It Ar name
-The name of the global runtime parameter being set.
-.It Ar value
-The value for the global runtime parameter, as a JSON term.
-In most shells you are very likely to need to quote this.
-.El
-.Pp
-For example, this command sets the global runtime parameter
-.Qq mqtt_default_vhosts
-to the JSON term {"O=client,CN=guest":"/"}:
-.sp
-.Dl rabbitmqctl set_global_parameter mqtt_default_vhosts '{"O=client,CN=guest":"/"}'
-.\" ------------------------------------
-.It Cm clear_global_parameter Ar name
-Clears a global runtime parameter.
-This is similar to
-.Cm clear_parameter
-but the key-value pair isn't tied to a virtual host.
-.Bl -tag -width Ds
-.It Ar name
-The name of the global runtime parameter being cleared.
-.El
-.Pp
-For example, this command clears the global runtime parameter
-.Qq mqtt_default_vhosts :
-.sp
-.Dl rabbitmqctl clear_global_parameter mqtt_default_vhosts
-.\" ------------------------------------
-.It Cm list_global_parameters
-Lists all global runtime parameters.
-This is similar to
-.Cm list_parameters
-but the global runtime parameters are not tied to any virtual host.
-.Pp
-For example, this command lists all global parameters:
-.sp
-.Dl rabbitmqctl list_global_parameters
-.El
-.Ss Policy Management
-Policies are used to control and modify the behaviour of queues and
-exchanges on a cluster-wide basis.
-Policies apply within a given vhost, and consist of a name, pattern,
-definition and an optional priority.
-Policies can be set, cleared and listed.
-.Bl -tag -width Ds
-.\" ------------------------------------
-.It Cm set_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
-Sets a policy.
-.Bl -tag -width Ds
-.It Ar name
-The name of the policy.
-.It Ar pattern
-The regular expression, which when matches on a given resources causes
-the policy to apply.
-.It Ar definition
-The definition of the policy, as a JSON term.
-In most shells you are very likely to need to quote this.
-.It Ar priority
-The priority of the policy as an integer.
-Higher numbers indicate greater precedence.
-The default is 0.
-.It Ar apply-to
-Which types of object this policy should apply to.
-Possible values are:
-.Bl -bullet -compact
-.It
-.Cm queues
-.It
-.Cm exchanges
-.It
-.Cm all
-.El
-The default is
-.Cm all ..
-.El
-.Pp
-For example, this command sets the policy
-.Qq federate-me
-in the default virtual host so that built-in exchanges are federated:
-.sp
-.Dl rabbitmqctl set_policy federate-me "^amq." '{"federation-upstream-set":"all"}'
-.\" ------------------------------------
-.It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
-Clears a policy.
-.Bl -tag -width Ds
-.It Ar name
-The name of the policy being cleared.
-.El
-.Pp
-For example, this command clears the
-.Qq federate-me
-policy in the default virtual host:
-.sp
-.Dl rabbitmqctl clear_policy federate-me
-.\" ------------------------------------
-.It Cm list_policies Op Fl p Ar vhost
-Lists all policies for a virtual host.
-.Pp
-For example, this command lists all policies in the default virtual
-host:
-.sp
-.Dl rabbitmqctl list_policies
-.\" ------------------------------------
-.It Cm set_operator_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
-Sets an operator policy that overrides a subset of arguments in user
-policies.
-Arguments are identical to those of
-.Cm set_policy .
-.Pp
-Supported arguments are:
-.Bl -bullet -compact
-.It
-expires
-.It
-message-ttl
-.It
-max-length
-.It
-max-length-bytes
-.El
-.\" ------------------------------------
-.It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
-Clears an operator policy.
-Arguments are identical to those of
-.Cm clear_policy .
-.\" ------------------------------------
-.It Cm list_operator_policies Op Fl p Ar vhost
-Lists operator policy overrides for a virtual host.
-Arguments are identical to those of
-.Cm list_policies .
-.El
-.Ss Virtual Host Limits
-It is possible to enforce certain limits on virtual hosts.
-.Bl -tag -width Ds
-.\" ------------------------------------
-.It Cm set_vhost_limits Oo Fl p Ar vhost Oc Ar definition
-Sets virtual host limits.
-.Bl -tag -width Ds
-.It Ar definition
-The definition of the limits, as a JSON term.
-In most shells you are very likely to need to quote this.
-.Pp
-Recognised limits are:
-.Bl -bullet -compact
-.It
-max-connections
-.It
-max-queues
-.El
-.Pp
-Use a negative value to specify "no limit".
-.El
-.Pp
-For example, this command limits the max number of concurrent
-connections in vhost
-.Qq qa_env
-to 64:
-.sp
-.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-connections": 64}'
-.Pp
-This command limits the max number of queues in vhost
-.Qq qa_env
-to 256:
-.sp
-.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-queues": 256}'
-.Pp
-This command clears the max number of connections limit in vhost
-.Qq qa_env :
-.sp
-.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max\-connections": \-1}'
-.Pp
-This command disables client connections in vhost
-.Qq qa_env :
-.sp
-.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-connections": 0}'
-.\" ------------------------------------
-.It Cm clear_vhost_limits Op Fl p Ar vhost
-Clears virtual host limits.
-.Pp
-For example, this command clears vhost limits in vhost
-.Qq qa_env :
-.sp
-.Dl rabbitmqctl clear_vhost_limits -p qa_env
-.\" ------------------------------------
-.It Cm list_vhost_limits Oo Fl p Ar vhost Oc Op Fl -global
-Displays configured virtual host limits.
-.Bl -tag -width Ds
-.It Fl -global
-Show limits for all vhosts.
-Suppresses the
+.It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
+Returns binding details.
+By default the bindings for the
+.Qq /
+virtual host are returned.
+The
 .Fl p
-parameter.
-.El
-.El
-.Ss Topology Introspection
-The topology introspection commands list topology entities (e.g. queues) with tab-delimited columns.
-Some commands (
-.Cm list_queues ,
-.Cm list_exchanges ,
-.Cm list_bindings
-and
-.Cm list_consumers )
-accept an optional
-.Ar vhost
-parameter.
+flag can be used to override this default.
 .Pp
 The
-.Cm list_queues ,
-.Cm list_exchanges
-and
-.Cm list_bindings
-commands accept an optional virtual host parameter for which to display
-results.
-The default value is
-.Qq / .
+.Ar bindinginfoitem
+parameter is used to indicate which binding information items to include
+in the results.
+The column order in the results will match the order of the parameters.
+.Ar bindinginfoitem
+can take any value from the list that follows:
 .Bl -tag -width Ds
+.It Cm source_name
+The name of the source of messages to which the binding is attached.
+With non-ASCII characters escaped as in C.
+.It Cm source_kind
+The kind of the source of messages to which the binding is attached.
+Currently always exchange.
+With non-ASCII characters escaped as in C.
+.It Cm destination_name
+The name of the destination of messages to which the binding is
+attached.
+With non-ASCII characters escaped as in C.
+.It Cm destination_kind
+The kind of the destination of messages to which the binding is
+attached.
+With non-ASCII characters escaped as in C.
+.It Cm routing_key
+The binding's routing key, with non-ASCII characters escaped as in C.
+.It Cm arguments
+The binding's arguments.
+.El
+.Pp
+If no
+.Ar bindinginfoitem
+are specified then all above items are displayed.
+.Pp
+For example, this command displays the exchange name and queue name of
+the bindings in the virtual host named
+.Qq my-vhost
+.sp
+.Dl rabbitmqctl list_bindings -p my-vhost exchange_name queue_name
+.\" ------------------------------------
+.It Cm list_channels Op Ar channelinfoitem ...
+Returns information on all current channels, the logical containers
+executing most AMQP commands.
+This includes channels that are part of ordinary AMQP connections, and
+channels created by various plug-ins and other extensions.
+.Pp
+The
+.Ar channelinfoitem
+parameter is used to indicate which channel information items to include
+in the results.
+The column order in the results will match the order of the parameters.
+.Ar channelinfoitem
+can take any value from the list that follows:
+.Bl -tag -width Ds
+.It Cm pid
+Id of the Erlang process associated with the connection.
+.It Cm connection
+Id of the Erlang process associated with the connection to which the
+channel belongs.
+.It Cm name
+Readable name for the channel.
+.It Cm number
+The number of the channel, which uniquely identifies it within a
+connection.
+.It Cm user
+Username associated with the channel.
+.It Cm vhost
+Virtual host in which the channel operates.
+.It Cm transactional
+True if the channel is in transactional mode, false otherwise.
+.It Cm confirm
+True if the channel is in confirm mode, false otherwise.
+.It Cm consumer_count
+Number of logical AMQP consumers retrieving messages via the channel.
+.It Cm messages_unacknowledged
+Number of messages delivered via this channel but not yet acknowledged.
+.It Cm messages_uncommitted
+Number of messages received in an as yet uncommitted transaction.
+.It Cm acks_uncommitted
+Number of acknowledgements received in an as yet uncommitted transaction.
+.It Cm messages_unconfirmed
+Number of published messages not yet confirmed.
+On channels not in confirm mode, this remains 0.
+.It Cm prefetch_count
+QoS prefetch limit for new consumers, 0 if unlimited.
+.It Cm global_prefetch_count
+QoS prefetch limit for the entire channel, 0 if unlimited.
+.El
+.Pp
+If no
+.Ar channelinfoitem
+are specified then pid, user, consumer_count, and
+messages_unacknowledged are assumed.
+.Pp
+For example, this command displays the connection process and count of
+unacknowledged messages for each channel:
+.sp
+.Dl rabbitmqctl list_channels connection messages_unacknowledged
+.\" ------------------------------------
+.It Cm list_ciphers
+Lists cipher suites supported by encoding commands.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all
+cipher suites supported by encoding commands:
+.sp
+.Dl rabbitmqctl list_ciphers
+.El
+.\" ------------------------------------
+.It Cm list_connections Op Ar connectioninfoitem ...
+Returns TCP/IP connection statistics.
+.Pp
+The
+.Ar connectioninfoitem
+parameter is used to indicate which connection information items to
+include in the results.
+The column order in the results will match the order of the parameters.
+.Ar connectioninfoitem
+can take any value from the list that follows:
+.Bl -tag -width Ds
+.It Cm pid
+Id of the Erlang process associated with the connection.
+.It Cm name
+Readable name for the connection.
+.It Cm port
+Server port.
+.It Cm host
+Server hostname obtained via reverse DNS, or its IP address if reverse
+DNS failed or was disabled.
+.It Cm peer_port
+Peer port.
+.It Cm peer_host
+Peer hostname obtained via reverse DNS, or its IP address if reverse DNS
+failed or was not enabled.
+.It Cm ssl
+Boolean indicating whether the connection is secured with SSL.
+.It Cm ssl_protocol
+SSL protocol (e.g.\&
+.Qq tlsv1 ) .
+.It Cm ssl_key_exchange
+SSL key exchange algorithm (e.g.\&
+.Qq rsa ) .
+.It Cm ssl_cipher
+SSL cipher algorithm (e.g.\&
+.Qq aes_256_cbc ) .
+.It Cm ssl_hash
+SSL hash function (e.g.\&
+.Qq sha ) .
+.It Cm peer_cert_subject
+The subject of the peer's SSL certificate, in RFC4514 form.
+.It Cm peer_cert_issuer
+The issuer of the peer's SSL certificate, in RFC4514 form.
+.It Cm peer_cert_validity
+The period for which the peer's SSL certificate is valid.
+.It Cm state
+Connection state; one of:
+.Bl -bullet -compact
+.It
+starting
+.It
+tuning
+.It
+opening
+.It
+running
+.It
+flow
+.It
+blocking
+.It
+blocked
+.It
+closing
+.It
+closed
+.El
+.It Cm channels
+Number of channels using the connection.
+.It Cm protocol
+Version of the AMQP protocol in use; currently one of:
+.Bl -bullet -compact
+.It
+{0,9,1}
+.It
+{0,8,0}
+.El
+.Pp
+Note that if a client requests an AMQP 0-9 connection, we treat it as
+AMQP 0-9-1.
+.It Cm auth_mechanism
+SASL authentication mechanism used, such as
+.Qq PLAIN .
+.It Cm user
+Username associated with the connection.
+.It Cm vhost
+Virtual host name with non-ASCII characters escaped as in C.
+.It Cm timeout
+Connection timeout / negotiated heartbeat interval, in seconds.
+.It Cm frame_max
+Maximum frame size (bytes).
+.It Cm channel_max
+Maximum number of channels on this connection.
+.It Cm client_properties
+Informational properties transmitted by the client during connection
+establishment.
+.It Cm recv_oct
+Octets received.
+.It Cm recv_cnt
+Packets received.
+.It Cm send_oct
+Octets send.
+.It Cm send_cnt
+Packets sent.
+.It Cm send_pend
+Send queue size.
+.It Cm connected_at
+Date and time this connection was established, as timestamp.
+.El
+.Pp
+If no
+.Ar connectioninfoitem
+are specified then user, peer host, peer port, time since flow control
+and memory block state are displayed.
+.Pp
+For example, this command displays the send queue size and server port
+for each connection:
+.sp
+.Dl rabbitmqctl list_connections send_pend port
+.\" ------------------------------------
+.It Cm list_consumers Op Fl p Ar vhost
+Lists consumers, i.e. subscriptions to a queue\'s message stream.
+Each line printed shows, separated by tab characters, the name of
+the queue subscribed to, the id of the channel process via which the
+subscription was created and is managed, the consumer tag which uniquely
+identifies the subscription within a channel, a boolean indicating
+whether acknowledgements are expected for messages delivered to this
+consumer, an integer indicating the prefetch limit (with 0 meaning
+.Qq none ) ,
+and any arguments for this consumer.
+.\" ------------------------------------
+.It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
+Returns exchange details.
+Exchange details of the
+.Qq /
+virtual host are returned if the
+.Fl p
+flag is absent.
+The
+.Fl p
+flag can be used to override this default.
+.Pp
+The
+.Ar exchangeinfoitem
+parameter is used to indicate which exchange information items to
+include in the results.
+The column order in the results will match the order of the parameters.
+.Ar exchangeinfoitem
+can take any value from the list that follows:
+.Bl -tag -width Ds
+.It Cm name
+The name of the exchange with non-ASCII characters escaped as in C.
+.It Cm type
+The exchange type, such as:
+.Bl -bullet -compact
+.It
+direct
+.It
+topic
+.It
+headers
+.It
+fanout
+.El
+.It Cm durable
+Whether or not the exchange survives server restarts.
+.It Cm auto_delete
+Whether the exchange will be deleted automatically when no longer used.
+.It Cm internal
+Whether the exchange is internal, i.e. cannot be directly published to
+by a client.
+.It Cm arguments
+Exchange arguments.
+.It Cm policy
+Policy name for applying to the exchange.
+.El
+.Pp
+If no
+.Ar exchangeinfoitem
+are specified then exchange name and type are displayed.
+.Pp
+For example, this command displays the name and type for each exchange
+of the virtual host named
+.Qq my-vhost :
+.sp
+.Dl rabbitmqctl list_exchanges -p my-vhost name type
+.\" ------------------------------------
+.It Cm list_hashes
+Lists hash functions supported by encoding commands.
+.Pp
+For example, this command instructs the RabbitMQ broker to list all hash
+functions supported by encoding commands:
+.sp
+.Dl rabbitmqctl list_hashes
 .\" ------------------------------------
 .It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
 Returns queue details.
@@ -1400,299 +1397,47 @@ each queue of the virtual host named
 .sp
 .Dl rabbitmqctl list_queues -p my-vhost messages consumers
 .\" ------------------------------------
-.It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
-Returns exchange details.
-Exchange details of the
-.Qq /
-virtual host are returned if the
-.Fl p
-flag is absent.
-The
-.Fl p
-flag can be used to override this default.
+.It Cm list_unresponsive_queues Oc Oo Fl -local Oc Oo Fl -queue_timeout Ar milliseconds Oc Oo Ar column ... Oc Op Fl -no-table-headers
 .Pp
-The
-.Ar exchangeinfoitem
-parameter is used to indicate which exchange information items to
-include in the results.
-The column order in the results will match the order of the parameters.
-.Ar exchangeinfoitem
-can take any value from the list that follows:
-.Bl -tag -width Ds
-.It Cm name
-The name of the exchange with non-ASCII characters escaped as in C.
-.It Cm type
-The exchange type, such as:
-.Bl -bullet -compact
-.It
-direct
-.It
-topic
-.It
-headers
-.It
-fanout
-.El
-.It Cm durable
-Whether or not the exchange survives server restarts.
-.It Cm auto_delete
-Whether the exchange will be deleted automatically when no longer used.
-.It Cm internal
-Whether the exchange is internal, i.e. cannot be directly published to
-by a client.
-.It Cm arguments
-Exchange arguments.
-.It Cm policy
-Policy name for applying to the exchange.
-.El
+Tests queues to respond within timeout. Lists those which did not respond
 .Pp
-If no
-.Ar exchangeinfoitem
-are specified then exchange name and type are displayed.
-.Pp
-For example, this command displays the name and type for each exchange
-of the virtual host named
-.Qq my-vhost :
-.sp
-.Dl rabbitmqctl list_exchanges -p my-vhost name type
+For example, this command lists only those unresponsive queues whose master process
+is located on the current node.
+.Sp
+.Dl rabbitmqctl list_unresponsive_queues --local name
 .\" ------------------------------------
-.It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
-Returns binding details.
-By default the bindings for the
-.Qq /
-virtual host are returned.
-The
-.Fl p
-flag can be used to override this default.
+.It Cm node_health_check
+Performs several health checks of the target node.
 .Pp
-The
-.Ar bindinginfoitem
-parameter is used to indicate which binding information items to include
-in the results.
-The column order in the results will match the order of the parameters.
-.Ar bindinginfoitem
-can take any value from the list that follows:
-.Bl -tag -width Ds
-.It Cm source_name
-The name of the source of messages to which the binding is attached.
-With non-ASCII characters escaped as in C.
-.It Cm source_kind
-The kind of the source of messages to which the binding is attached.
-Currently always exchange.
-With non-ASCII characters escaped as in C.
-.It Cm destination_name
-The name of the destination of messages to which the binding is
-attached.
-With non-ASCII characters escaped as in C.
-.It Cm destination_kind
-The kind of the destination of messages to which the binding is
-attached.
-With non-ASCII characters escaped as in C.
-.It Cm routing_key
-The binding's routing key, with non-ASCII characters escaped as in C.
-.It Cm arguments
-The binding's arguments.
-.El
-.Pp
-If no
-.Ar bindinginfoitem
-are specified then all above items are displayed.
-.Pp
-For example, this command displays the exchange name and queue name of
-the bindings in the virtual host named
-.Qq my-vhost
+Verifies the rabbit application is running and alarms are not set,
+then checks that every queue and channel on the node can emit basic stats.
 .sp
-.Dl rabbitmqctl list_bindings -p my-vhost exchange_name queue_name
+Example:
+.Dl rabbitmqctl node_health_check -n rabbit@hostname
 .\" ------------------------------------
-.It Cm list_connections Op Ar connectioninfoitem ...
-Returns TCP/IP connection statistics.
+.It Cm ping
+Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it
 .Pp
-The
-.Ar connectioninfoitem
-parameter is used to indicate which connection information items to
-include in the results.
-The column order in the results will match the order of the parameters.
-.Ar connectioninfoitem
-can take any value from the list that follows:
-.Bl -tag -width Ds
-.It Cm pid
-Id of the Erlang process associated with the connection.
-.It Cm name
-Readable name for the connection.
-.It Cm port
-Server port.
-.It Cm host
-Server hostname obtained via reverse DNS, or its IP address if reverse
-DNS failed or was disabled.
-.It Cm peer_port
-Peer port.
-.It Cm peer_host
-Peer hostname obtained via reverse DNS, or its IP address if reverse DNS
-failed or was not enabled.
-.It Cm ssl
-Boolean indicating whether the connection is secured with SSL.
-.It Cm ssl_protocol
-SSL protocol (e.g.\&
-.Qq tlsv1 ) .
-.It Cm ssl_key_exchange
-SSL key exchange algorithm (e.g.\&
-.Qq rsa ) .
-.It Cm ssl_cipher
-SSL cipher algorithm (e.g.\&
-.Qq aes_256_cbc ) .
-.It Cm ssl_hash
-SSL hash function (e.g.\&
-.Qq sha ) .
-.It Cm peer_cert_subject
-The subject of the peer's SSL certificate, in RFC4514 form.
-.It Cm peer_cert_issuer
-The issuer of the peer's SSL certificate, in RFC4514 form.
-.It Cm peer_cert_validity
-The period for which the peer's SSL certificate is valid.
-.It Cm state
-Connection state; one of:
-.Bl -bullet -compact
-.It
-starting
-.It
-tuning
-.It
-opening
-.It
-running
-.It
-flow
-.It
-blocking
-.It
-blocked
-.It
-closing
-.It
-closed
-.El
-.It Cm channels
-Number of channels using the connection.
-.It Cm protocol
-Version of the AMQP protocol in use; currently one of:
-.Bl -bullet -compact
-.It
-{0,9,1}
-.It
-{0,8,0}
-.El
+Example:
+.Dl rabbitmqctl ping -n rabbit@hostname
+.\" ------------------------------------
+.It Cm report
+Generate a server status report containing a concatenation of all server
+status information for support purposes.
+The output should be redirected to a file when accompanying a support
+request.
 .Pp
-Note that if a client requests an AMQP 0-9 connection, we treat it as
-AMQP 0-9-1.
-.It Cm auth_mechanism
-SASL authentication mechanism used, such as
-.Qq PLAIN .
-.It Cm user
-Username associated with the connection.
-.It Cm vhost
-Virtual host name with non-ASCII characters escaped as in C.
-.It Cm timeout
-Connection timeout / negotiated heartbeat interval, in seconds.
-.It Cm frame_max
-Maximum frame size (bytes).
-.It Cm channel_max
-Maximum number of channels on this connection.
-.It Cm client_properties
-Informational properties transmitted by the client during connection
-establishment.
-.It Cm recv_oct
-Octets received.
-.It Cm recv_cnt
-Packets received.
-.It Cm send_oct
-Octets send.
-.It Cm send_cnt
-Packets sent.
-.It Cm send_pend
-Send queue size.
-.It Cm connected_at
-Date and time this connection was established, as timestamp.
-.El
-.Pp
-If no
-.Ar connectioninfoitem
-are specified then user, peer host, peer port, time since flow control
-and memory block state are displayed.
-.Pp
-For example, this command displays the send queue size and server port
-for each connection:
+For example, this command creates a server report which may be attached
+to a support request email:
 .sp
-.Dl rabbitmqctl list_connections send_pend port
+.Dl rabbitmqctl report > server_report.txt
 .\" ------------------------------------
-.It Cm list_channels Op Ar channelinfoitem ...
-Returns information on all current channels, the logical containers
-executing most AMQP commands.
-This includes channels that are part of ordinary AMQP connections, and
-channels created by various plug-ins and other extensions.
+.It Cm schema_info Oc Oo Fl -no-table-headers Oc Op Ar column ...
+Lists schema database tables and their properties
 .Pp
-The
-.Ar channelinfoitem
-parameter is used to indicate which channel information items to include
-in the results.
-The column order in the results will match the order of the parameters.
-.Ar channelinfoitem
-can take any value from the list that follows:
-.Bl -tag -width Ds
-.It Cm pid
-Id of the Erlang process associated with the connection.
-.It Cm connection
-Id of the Erlang process associated with the connection to which the
-channel belongs.
-.It Cm name
-Readable name for the channel.
-.It Cm number
-The number of the channel, which uniquely identifies it within a
-connection.
-.It Cm user
-Username associated with the channel.
-.It Cm vhost
-Virtual host in which the channel operates.
-.It Cm transactional
-True if the channel is in transactional mode, false otherwise.
-.It Cm confirm
-True if the channel is in confirm mode, false otherwise.
-.It Cm consumer_count
-Number of logical AMQP consumers retrieving messages via the channel.
-.It Cm messages_unacknowledged
-Number of messages delivered via this channel but not yet acknowledged.
-.It Cm messages_uncommitted
-Number of messages received in an as yet uncommitted transaction.
-.It Cm acks_uncommitted
-Number of acknowledgements received in an as yet uncommitted transaction.
-.It Cm messages_unconfirmed
-Number of published messages not yet confirmed.
-On channels not in confirm mode, this remains 0.
-.It Cm prefetch_count
-QoS prefetch limit for new consumers, 0 if unlimited.
-.It Cm global_prefetch_count
-QoS prefetch limit for the entire channel, 0 if unlimited.
-.El
-.Pp
-If no
-.Ar channelinfoitem
-are specified then pid, user, consumer_count, and
-messages_unacknowledged are assumed.
-.Pp
-For example, this command displays the connection process and count of
-unacknowledged messages for each channel:
+For example, this command lists the table names and their active replicas:
 .sp
-.Dl rabbitmqctl list_channels connection messages_unacknowledged
-.\" ------------------------------------
-.It Cm list_consumers Op Fl p Ar vhost
-Lists consumers, i.e. subscriptions to a queue\'s message stream.
-Each line printed shows, separated by tab characters, the name of
-the queue subscribed to, the id of the channel process via which the
-subscription was created and is managed, the consumer tag which uniquely
-identifies the subscription within a channel, a boolean indicating
-whether acknowledgements are expected for messages delivered to this
-consumer, an integer indicating the prefetch limit (with 0 meaning
-.Qq none ) ,
-and any arguments for this consumer.
+.Dl rabbitmqctl schema_info name active_replicas
 .\" ------------------------------------
 .It Cm status
 Displays broker status information such as the running applications on
@@ -1706,68 +1451,500 @@ For example, this command displays information about the RabbitMQ
 broker:
 .sp
 .Dl rabbitmqctl status
+.El
+.El
+.Ss Parameters
+.Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm node_health_check
-Performs several health checks of the target node.
+.It Cm clear_global_parameter Ar name
+Clears a global runtime parameter.
+This is similar to
+.Cm clear_parameter
+but the key-value pair isn't tied to a virtual host.
+.Bl -tag -width Ds
+.It Ar name
+The name of the global runtime parameter being cleared.
+.El
 .Pp
-Verifies the rabbit application is running and alarms are not set,
-then checks that every queue and channel on the node can emit basic stats.
+For example, this command clears the global runtime parameter
+.Qq mqtt_default_vhosts :
 .sp
-Example:
-.Dl rabbitmqctl node_health_check -n rabbit@hostname
+.Dl rabbitmqctl clear_global_parameter mqtt_default_vhosts
 .\" ------------------------------------
-.It Cm environment
-Displays the name and value of each variable in the application
-environment for each running application.
-.\" ------------------------------------
-.It Cm report
-Generate a server status report containing a concatenation of all server
-status information for support purposes.
-The output should be redirected to a file when accompanying a support
-request.
+.It Cm clear_parameter Oo Fl p Ar vhost Oc Ar component_name Ar key
+Clears a parameter.
+.Bl -tag -width Ds
+.It Ar component_name
+The name of the component for which the parameter is being cleared.
+.It Ar name
+The name of the parameter being cleared.
+.El
 .Pp
-For example, this command creates a server report which may be attached
-to a support request email:
+For example, this command clears the parameter
+.Qq node01
+for the
+.Qq federation-upstream
+component in the default virtual host:
 .sp
-.Dl rabbitmqctl report > server_report.txt
+.Dl rabbitmqctl clear_parameter federation-upstream node01
 .\" ------------------------------------
-.It Cm eval Ar expr
-Evaluate an arbitrary Erlang expression.
+.It Cm list_global_parameters
+Lists all global runtime parameters.
+This is similar to
+.Cm list_parameters
+but the global runtime parameters are not tied to any virtual host.
 .Pp
-For example, this command returns the name of the node to which
+For example, this command lists all global parameters:
+.sp
+.Dl rabbitmqctl list_global_parameters
+.El
+.Ss Policy Management
+Policies are used to control and modify the behaviour of queues and
+exchanges on a cluster-wide basis.
+Policies apply within a given vhost, and consist of a name, pattern,
+definition and an optional priority.
+Policies can be set, cleared and listed.
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm list_parameters Op Fl p Ar vhost
+Lists all parameters for a virtual host.
+.Pp
+For example, this command lists all parameters in the default virtual
+host:
+.sp
+.Dl rabbitmqctl list_parameters
+.\" ------------------------------------
+.It Cm set_global_parameter Ar name Ar value
+Sets a global runtime parameter.
+This is similar to
+.Cm set_parameter
+but the key-value pair isn't tied to a virtual host.
+.Bl -tag -width Ds
+.It Ar name
+The name of the global runtime parameter being set.
+.It Ar value
+The value for the global runtime parameter, as a JSON term.
+In most shells you are very likely to need to quote this.
+.El
+.Pp
+For example, this command sets the global runtime parameter
+.Qq mqtt_default_vhosts
+to the JSON term {"O=client,CN=guest":"/"}:
+.sp
+.Dl rabbitmqctl set_global_parameter mqtt_default_vhosts '{"O=client,CN=guest":"/"}'
+.\" ------------------------------------
+.It Cm set_parameter Oo Fl p Ar vhost Oc Ar component_name Ar name Ar value
+Sets a parameter.
+.Bl -tag -width Ds
+.It Ar component_name
+The name of the component for which the parameter is being set.
+.It Ar name
+The name of the parameter being set.
+.It Ar value
+The value for the parameter, as a JSON term.
+In most shells you are very likely to need to quote this.
+.El
+.Pp
+For example, this command sets the parameter
+.Qq node01
+for the
+.Qq federation-upstream
+component in the default virtual host to the following JSON
+.Qq guest :
+.sp
+.Dl rabbitmqctl set_parameter federation-upstream node01 '{"uri":"amqp://user:password@server/%2F","ack-mode":"on-publish"}'
+.El
+.El
+.Ss Policies
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
+Clears an operator policy.
+Arguments are identical to those of
+.Cm clear_policy .
+.\" ------------------------------------
+.It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
+Clears a policy.
+.Bl -tag -width Ds
+.It Ar name
+The name of the policy being cleared.
+.El
+.Pp
+For example, this command clears the
+.Qq federate-me
+policy in the default virtual host:
+.sp
+.Dl rabbitmqctl clear_policy federate-me
+.\" ------------------------------------
+.It Cm list_operator_policies Op Fl p Ar vhost
+Lists operator policy overrides for a virtual host.
+Arguments are identical to those of
+.Cm list_policies .
+.El
+.Ss Virtual Host Limits
+It is possible to enforce certain limits on virtual hosts.
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm list_policies Op Fl p Ar vhost
+Lists all policies for a virtual host.
+.Pp
+For example, this command lists all policies in the default virtual
+host:
+.sp
+.Dl rabbitmqctl list_policies
+.\" ------------------------------------
+.It Cm set_operator_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
+Sets an operator policy that overrides a subset of arguments in user
+policies.
+Arguments are identical to those of
+.Cm set_policy .
+.Pp
+Supported arguments are:
+.Bl -bullet -compact
+.It
+expires
+.It
+message-ttl
+.It
+max-length
+.It
+max-length-bytes
+.El
+.\" ------------------------------------
+.It Cm set_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
+Sets a policy.
+.Bl -tag -width Ds
+.It Ar name
+The name of the policy.
+.It Ar pattern
+The regular expression, which when matches on a given resources causes
+the policy to apply.
+.It Ar definition
+The definition of the policy, as a JSON term.
+In most shells you are very likely to need to quote this.
+.It Ar priority
+The priority of the policy as an integer.
+Higher numbers indicate greater precedence.
+The default is 0.
+.It Ar apply-to
+Which types of object this policy should apply to.
+Possible values are:
+.Bl -bullet -compact
+.It
+.Cm queues
+.It
+.Cm exchanges
+.It
+.Cm all
+.El
+The default is
+.Cm all ..
+.El
+.Pp
+For example, this command sets the policy
+.Qq federate-me
+in the default virtual host so that built-in exchanges are federated:
+.sp
+.Dl rabbitmqctl set_policy federate-me "^amq." '{"federation-upstream-set":"all"}'
+.El
+.Ss Virtual hosts
+Note that
 .Nm
-has connected:
-.sp
-.Dl rabbitmqctl eval Qq node().
-.El
-.Ss Miscellaneous
+manages the RabbitMQ internal user database.
+Permissions for users from any alternative authorisation backend will
+not be visible to
+.Nm .
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm close_connection Ar connectionpid Ar explanation
+.It Cm add_vhost Ar vhost
 .Bl -tag -width Ds
-.It Ar connectionpid
-Id of the Erlang process associated with the connection to close.
-.It Ar explanation
-Explanation string.
+.It Ar vhost
+The name of the virtual host entry to create.
+.Pp
+Creates a virtual host.
+.Pp
+For example, this command instructs the RabbitMQ broker to create a new
+virtual host called
+.Qq test :
+.Pp
+.Dl rabbitmqctl add_vhost test
+.\" ------------------------------------
+.It Cm clear_vhost_limits Op Fl p Ar vhost
+Clears virtual host limits.
+.Pp
+For example, this command clears vhost limits in vhost
+.Qq qa_env :
+.sp
+.Dl rabbitmqctl clear_vhost_limits -p qa_env
+.\" ------------------------------------
+.It Cm delete_vhost Ar vhost
+.Bl -tag -width Ds
+.It Ar vhost
+The name of the virtual host entry to delete.
 .El
 .Pp
-Instructs the broker to close the connection associated with the Erlang
-process id
-.Ar connectionpid
-(see also the
-.Cm list_connections
-command), passing the
-.Ar explanation
-string to the connected client as part of the AMQP connection shutdown
-protocol.
+Deletes a virtual host.
 .Pp
-For example, this command instructs the RabbitMQ broker to close the connection associated with the Erlang process id
-.Qq <rabbit@tanto.4262.0> ,
-passing the explanation
-.Qq go away
-to the connected client:
+Deleting a virtual host deletes all its exchanges, queues, bindings,
+user permissions, parameters and policies.
+.Pp
+For example, this command instructs the RabbitMQ broker to delete the
+virtual host called
+.Qq test :
 .sp
-.Dl rabbitmqctl close_connection Qo <rabbit@tanto.4262.0> Qc Qq go away
+.Dl rabbitmqctl delete_vhost test
+.\" ------------------------------------
+.It Cm list_vhost_limits Oo Fl p Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
+Displays configured virtual host limits.
+.Bl -tag -width Ds
+.It Fl -global
+Show limits for all vhosts.
+Suppresses the
+.Fl p
+parameter.
+.El
+.El
+.Ss Topology Introspection
+The topology introspection commands list topology entities (e.g. queues) with tab-delimited columns.
+Some commands (
+.Cm list_queues ,
+.Cm list_exchanges ,
+.Cm list_bindings
+and
+.Cm list_consumers )
+accept an optional
+.Ar vhost
+parameter.
+.Pp
+The
+.Cm list_queues ,
+.Cm list_exchanges
+and
+.Cm list_bindings
+commands accept an optional virtual host parameter for which to display
+results.
+The default value is
+.Qq / .
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm restart_vhost Ar vhost
+.Bl -tag -width Ds
+.It Ar vhost
+The name of the virtual host entry to restart.
+.Pp
+Restarts a failed vhost data stores and queues.
+.Pp
+For example, this command instructs the RabbitMQ broker to restart a
+virtual host called
+.Qq test :
+.Pp
+.Dl rabbitmqctl restart_vhost test
+.\" ------------------------------------
+.It Cm set_vhost_limits Oo Fl p Ar vhost Oc Ar definition
+Sets virtual host limits.
+.Bl -tag -width Ds
+.It Ar definition
+The definition of the limits, as a JSON term.
+In most shells you are very likely to need to quote this.
+.Pp
+Recognised limits are:
+.Bl -bullet -compact
+.It
+max-connections
+.It
+max-queues
+.El
+.Pp
+Use a negative value to specify "no limit".
+.El
+.Pp
+For example, this command limits the max number of concurrent
+connections in vhost
+.Qq qa_env
+to 64:
+.sp
+.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-connections": 64}'
+.Pp
+This command limits the max number of queues in vhost
+.Qq qa_env
+to 256:
+.sp
+.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-queues": 256}'
+.Pp
+This command clears the max number of connections limit in vhost
+.Qq qa_env :
+.sp
+.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max\-connections": \-1}'
+.Pp
+This command disables client connections in vhost
+.Qq qa_env :
+.sp
+.Dl rabbitmqctl set_vhost_limits -p qa_env '{"max-connections": 0}'
+.\" ------------------------------------
+.It Cm trace_off Op Fl p Ar vhost
+.Bl -tag -width Ds
+.It Ar vhost
+The name of the virtual host for which to stop tracing.
+.El
+.Pp
+Stops tracing.
+.\" ------------------------------------
+.It Cm trace_on Op Fl p Ar vhost
+.Bl -tag -width Ds
+.It Ar vhost
+The name of the virtual host for which to start tracing.
+.El
+.Pp
+Starts tracing.
+Note that the trace state is not persistent; it will revert to being off
+if the server is restarted.
+.El
+.El
+.Ss Node configuration
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm decode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
+.Bl -tag -width Ds
+.It Ar value Ar passphrase
+Value to decrypt (as produced by the encode command) and passphrase.
+.Pp
+For example:
+.sp
+.Dl rabbitmqctl decode '{encrypted, <<"...">>}' mypassphrase
+.It Fl -cipher Ar cipher Fl -hash Ar hash Fl -iterations Ar iterations
+Options to specify the decryption settings.
+They can be used independently.
+.Pp
+For example:
+.sp
+.Dl rabbitmqctl decode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 '{encrypted,<<"...">>} mypassphrase
+.El
+.\" ------------------------------------
+.It Cm encode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
+.Bl -tag -width Ds
+.It Ar value Ar passphrase
+Value to encrypt and passphrase.
+.Pp
+For example:
+.sp
+.Dl rabbitmqctl encode '<<"guest">>' mypassphrase
+.It Fl -cipher Ar cipher Fl -hash Ar hash Fl -iterations Ar iterations
+Options to specify the encryption settings.
+They can be used independently.
+.Pp
+For example:
+.sp
+.Dl rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 '<<"guest">>' mypassphrase
+.El
+.\" ------------------------------------
+.It Cm set_cluster_name Ar name
+Sets the cluster name to
+.Ar name .
+The cluster name is announced to clients on connection, and used by the
+federation and shovel plugins to record where a message has been.
+The cluster name is by default derived from the hostname of the first
+node in the cluster, but can be changed.
+.Pp
+For example, this sets the cluster name to
+.Qq london :
+.sp
+.Dl rabbitmqctl set_cluster_name london
+.\" ------------------------------------
+.It Cm set_disk_free_limit Ar disk_limit
+.Bl -tag -width Ds
+.It Ar disk_limit
+Lower bound limit as an integer in bytes or a string with memory unit symbols
+(see vm_memory_high_watermark), e.g. 512M or 1G.
+Once free disk space reaches the limit, a disk alarm will be set.
+.El
+.\" ------------------------------------
+.It Cm set_disk_free_limit mem_relative Ar fraction
+.Bl -tag -width Ds
+.It Ar fraction
+Limit relative to the total amount available RAM as a non-negative
+floating point number.
+Values lower than 1.0 can be dangerous and should be used carefully.
+.El
+.\" ------------------------------------
+.It Cm set_log_level Oc Op Ar log_level
+.Pp
+Sets log level in the running node
+.Pp
+Supported
+.Ar type
+values are:
+.Bl -tag -width Ds
+.It Dv Sy debug
+.It Dv Sy info
+.It Dv Sy warning
+.It Dv Sy error
+.It Dv Sy none
+.El
+.Pp
+Example:
+.Sp
+.Dl rabbitmqctl log_level debug
+.\" ------------------------------------
+.It Cm set_vm_memory_high_watermark Ar fraction
+.Bl -tag -width Ds
+.It Ar fraction
+The new memory threshold fraction at which flow control is triggered, as
+a floating point number greater than or equal to 0.
+.El
+.\" ------------------------------------
+.It Cm set_vm_memory_high_watermark absolute Ar memory_limit
+.Bl -tag -width Ds
+.It Ar memory_limit
+The new memory limit at which flow control is triggered, expressed in
+bytes as an integer number greater than or equal to 0 or as a string
+with memory unit symbol(e.g. 512M or 1G).
+Available unit symbols are:
+.Bl -tag -width Ds
+.It Cm k , Cm kiB
+kibibytes (2^10 bytes)
+.It Cm M , Cm MiB
+mebibytes (2^20 bytes)
+.It Cm G , Cm GiB
+gibibytes (2^30 bytes)
+.It Cm kB
+kilobytes (10^3 bytes)
+.It Cm MB
+megabytes (10^6 bytes)
+.It Cm GB
+gigabytes (10^9 bytes)
+.El
+.El
+.Ss Feature flags
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm enable_feature_flag Ar feature_flag
+Enables a feature flag on target node
+Example:
+.Sp
+.Dl rabbitmqctl enable_feature_flag quorum_queue
+.El
+.\" ------------------------------------
+.It Cm list_feature_flags Oc Op Ar column ...
+Lists feature flags
+.Pp
+Supported
+.Ar column
+values are:
+.Bl -tag -width Ds
+.It Dv Sy name
+.It Dv Sy state
+.It Dv Sy stability
+.It Dv Sy provided_by
+.It Dv Sy desc
+.It Dv Sy doc_url
+.El
+Example:
+.Sp
+.Dl rabbitmqctl list_feature_flags name state
+.El
+.El
+.Ss Operations
+.Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm close_all_connections Oo Fl p Ar vhost Oc Oo Fl -global Oc Oo Fl -per-connection-delay Ar delay Oc Oo Fl -limit Ar limit Oc Ar explanation
 .Bl -tag -width Ds
@@ -1806,120 +1983,105 @@ This command instructs broker to close all connections to the node:
 .Dl rabbitmqctl close_all_connections --global
 .sp
 .\" ------------------------------------
-.It Cm trace_on Op Fl p Ar vhost
+.It Cm close_connection Ar connectionpid Ar explanation
 .Bl -tag -width Ds
-.It Ar vhost
-The name of the virtual host for which to start tracing.
+.It Ar connectionpid
+Id of the Erlang process associated with the connection to close.
+.It Ar explanation
+Explanation string.
 .El
 .Pp
-Starts tracing.
-Note that the trace state is not persistent; it will revert to being off
-if the server is restarted.
-.\" ------------------------------------
-.It Cm trace_off Op Fl p Ar vhost
-.Bl -tag -width Ds
-.It Ar vhost
-The name of the virtual host for which to stop tracing.
-.El
+Instructs the broker to close the connection associated with the Erlang
+process id
+.Ar connectionpid
+(see also the
+.Cm list_connections
+command), passing the
+.Ar explanation
+string to the connected client as part of the AMQP connection shutdown
+protocol.
 .Pp
-Stops tracing.
-.\" ------------------------------------
-.It Cm set_vm_memory_high_watermark Ar fraction
-.Bl -tag -width Ds
-.It Ar fraction
-The new memory threshold fraction at which flow control is triggered, as
-a floating point number greater than or equal to 0.
-.El
-.\" ------------------------------------
-.It Cm set_vm_memory_high_watermark absolute Ar memory_limit
-.Bl -tag -width Ds
-.It Ar memory_limit
-The new memory limit at which flow control is triggered, expressed in
-bytes as an integer number greater than or equal to 0 or as a string
-with memory unit symbol(e.g. 512M or 1G).
-Available unit symbols are:
-.Bl -tag -width Ds
-.It Cm k , Cm kiB
-kibibytes (2^10 bytes)
-.It Cm M , Cm MiB
-mebibytes (2^20 bytes)
-.It Cm G , Cm GiB
-gibibytes (2^30 bytes)
-.It Cm kB
-kilobytes (10^3 bytes)
-.It Cm MB
-megabytes (10^6 bytes)
-.It Cm GB
-gigabytes (10^9 bytes)
-.El
-.El
-.\" ------------------------------------
-.It Cm set_disk_free_limit Ar disk_limit
-.Bl -tag -width Ds
-.It Ar disk_limit
-Lower bound limit as an integer in bytes or a string with memory unit symbols
-(see vm_memory_high_watermark), e.g. 512M or 1G.
-Once free disk space reaches the limit, a disk alarm will be set.
-.El
-.\" ------------------------------------
-.It Cm set_disk_free_limit mem_relative Ar fraction
-.Bl -tag -width Ds
-.It Ar fraction
-Limit relative to the total amount available RAM as a non-negative
-floating point number.
-Values lower than 1.0 can be dangerous and should be used carefully.
-.El
-.\" ------------------------------------
-.It Cm encode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
-.Bl -tag -width Ds
-.It Ar value Ar passphrase
-Value to encrypt and passphrase.
-.Pp
-For example:
+For example, this command instructs the RabbitMQ broker to close the connection associated with the Erlang process id
+.Qq <rabbit@tanto.4262.0> ,
+passing the explanation
+.Qq go away
+to the connected client:
 .sp
-.Dl rabbitmqctl encode '<<"guest">>' mypassphrase
-.It Fl -cipher Ar cipher Fl -hash Ar hash Fl -iterations Ar iterations
-Options to specify the encryption settings.
-They can be used independently.
-.Pp
-For example:
-.sp
-.Dl rabbitmqctl encode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 '<<"guest">>' mypassphrase
-.El
+.Dl rabbitmqctl close_connection Qo <rabbit@tanto.4262.0> Qc Qq go away
 .\" ------------------------------------
-.It Cm decode Ar value Ar passphrase Oo Fl -cipher Ar cipher Oc Oo Fl -hash Ar hash Oc Op Fl -iterations Ar iterations
+.It Cm eval Ar expr
+Evaluate an arbitrary Erlang expression.
+.Pp
+For example, this command returns the name of the node to which
+.Nm
+has connected:
+.sp
+.Dl rabbitmqctl eval Qq node().
+.El
+.Ss Miscellaneous
 .Bl -tag -width Ds
-.It Ar value Ar passphrase
-Value to decrypt (as produced by the encode command) and passphrase.
-.Pp
-For example:
-.sp
-.Dl rabbitmqctl decode '{encrypted, <<"...">>}' mypassphrase
-.It Fl -cipher Ar cipher Fl -hash Ar hash Fl -iterations Ar iterations
-Options to specify the decryption settings.
-They can be used independently.
-.Pp
-For example:
-.sp
-.Dl rabbitmqctl decode --cipher blowfish_cfb64 --hash sha256 --iterations 10000 '{encrypted,<<"...">>} mypassphrase
-.El
 .\" ------------------------------------
-.It Cm list_hashes
-Lists hash functions supported by encoding commands.
-.Pp
-For example, this command instructs the RabbitMQ broker to list all hash
-functions supported by encoding commands:
-.sp
-.Dl rabbitmqctl list_hashes
+.It Cm exec Ar expr Oc Op Fl -offline
+Evaluates a snippet of Elixir code on the CLI node
 .\" ------------------------------------
-.It Cm list_ciphers
-Lists cipher suites supported by encoding commands.
+.It Cm force_gc
+Makes all Erlang processes on the target node perform/schedule a full sweep garbage collection
+Example:
+.Sp
+.Dl rabbitmqctl force_gc
+.\" ------------------------------------
+.It Cm hipe_compile Ar directory
+Performs HiPE-compilation and caches resulting
+.Pa .beam Ns -files in the given directory.
 .Pp
-For example, this command instructs the RabbitMQ broker to list all
-cipher suites supported by encoding commands:
+Parent directories are created if necessary.
+Any existing
+.Pa .beam
+files from the directory are automatically deleted prior to compilation.
+.Pp
+To use this precompiled files, you should set
+.Ev RABBITMQ_SERVER_CODE_PATH
+environment variable to directory specified in
+.Cm hipe_compile
+invocation.
+.Pp
+For example, to HiPE-compile modules and store them to
+.Pa /tmp/rabbit-hipe/ebin
+directory:
 .sp
-.Dl rabbitmqctl list_ciphers
+.Dl rabbitmqctl hipe_compile /tmp/rabbit-hipe/ebin
 .El
+.El
+.Ss Queues
+.Bl -tag -width Ds
+.\" ------------------------------------
+.It Cm delete_queue Oc Ar queue_name Oc Oo Fl -if-empty | Fl e Oc Op Fl -if-unused | Fl u
+.Bl -tag -width Ds
+.It Ar queue_name
+The name of the queue to delete.
+.It Ar --if-empty
+Delete the queue if it is empty (has no messages ready for delivery)
+.It Ar --if-unused
+Delete the queue only if it has no consumers
+.El
+.Pp
+Deletes a queue.
+.\" ------------------------------------
+.It Cm purge_queue Oo Fl p Ar vhost Oc Ar queue
+.Bl -tag -width Ds
+.It Ar queue
+The name of the queue to purge.
+.El
+.Pp
+Purges a queue (removes all messages in it).
+.\" ------------------------------------
+.It Cm quorum_status Oc Ar queue_name
+.Bl -tag -width Ds
+.It Ar queue_name
+The name of the queue.
+.El
+.Pp
+Displays quorum status of a quorum queue.
 .\" ------------------------------------------------------------------
 .Sh PLUGIN COMMANDS
 .\" ------------------------------------------------------------------

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -122,7 +122,6 @@ Prints usage for the specified command.
 .Pp
 Displays CLI tools version
 .El
-.El
 .Ss Nodes
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -275,7 +274,6 @@ up:
 .sp
 .Dl rabbitmqctl wait /var/run/rabbitmq/pid
 .El
-.El
 .Ss Cluster management
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -319,7 +317,6 @@ with the currently running nodes.
 For example, this command displays the nodes in the cluster:
 .sp
 .Dl rabbitmqctl cluster_status
-.El
 .El
 .Ss Application Management
 .Bl -tag -width Ds
@@ -579,7 +576,6 @@ The following command will solve this situation:
 .sp
 .Dl update_cluster_nodes -n Va A Va C
 .El
-.El
 .Ss Replication
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -724,7 +720,6 @@ This command instructs the RabbitMQ broker to remove any tags from the user name
 .Qq janeway :
 .sp
 .Dl rabbitmqctl set_user_tags janeway
-.El
 .El
 .Ss Access control
 .Bl -tag -width Ds
@@ -952,7 +947,6 @@ The previous example could be made more generic by using
 .Qq ^{username}-.* :
 .sp
 .Dl rabbitmqctl set_topic_permissions -p my-vhost janeway amq.topic Qo ^{username}-.* Qc Qo ^{username}-.* Qc
-.El
 .El
 .Ss Monitoring, observability and health checks
 .Bl -tag -width Ds
@@ -1488,7 +1482,6 @@ broker:
 .sp
 .Dl rabbitmqctl status
 .El
-.El
 .Ss Parameters
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -1751,7 +1744,6 @@ Show limits for all vhosts.
 Suppresses the
 .Fl p
 parameter.
-.El
 .El
 .Ss Topology Introspection
 The topology introspection commands list topology entities (e.g. queues) with tab-delimited columns.
@@ -2229,7 +2221,6 @@ The period for which the peer's SSL certificate is valid.
 .It Cm node
 The node name of the RabbitMQ node to which connection is established.
 .El
-.El
 .Ss MQTT plugin
 .Bl -tag -width Ds
 .It Cm list_mqtt_connections Op Ar mqtt_connectioninfoitem
@@ -2320,7 +2311,6 @@ Id of the Erlang process associated with retain storage for the connection.
 Username associated with the connection.
 .It Cm vhost
 Virtual host name with non-ASCII characters escaped as in C.
-.El
 .El
 .Ss STOMP plugin
 .Bl -tag -width Ds
@@ -2413,7 +2403,6 @@ SSL cipher algorithm (e.g.\&
 SSL hash function (e.g.\&
 .Qq sha ) .
 .El
-.El
 .Ss Management agent plugin
 .Bl -tag -width Ds
 .It Cm reset_stats_db Op Fl -all
@@ -2421,7 +2410,6 @@ Reset management stats database for the RabbitMQ node.
 .Bl -tag -width Ds
 .It Fl -all
 Reset stats database for all nodes in the cluster.
-.El
 .El
 .\" ------------------------------------------------------------------
 .Sh SEE ALSO

--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -109,14 +109,17 @@ To learn more, see the
 .\" ------------------------------------------------------------------
 .Bl -tag -width Ds
 .It Cm help Oo Fl l Oc Op Ar command_name
+.Pp
 Prints usage for all available commands.
 .Bl -tag -width Ds
 .It Fl l , Fl -list-commands
 List command usages only, without parameter explanation.
 .It Ar command_name
 Prints usage for the specified command.
+.El
 .\" ------------------------------------
 .It Cm version
+.Pp
 Displays CLI tools version
 .El
 .El
@@ -124,6 +127,7 @@ Displays CLI tools version
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm await_startup
+.Pp
 Waits for the RabbitMQ application to start on the target node
 .Pp
 For example, to wait for the RabbitMQ application to start:
@@ -131,6 +135,7 @@ For example, to wait for the RabbitMQ application to start:
 .Dl rabbitmqctl await_startup
 .\" ------------------------------------
 .It Cm reset
+.Pp
 Returns a RabbitMQ node to its virgin state.
 .Pp
 Removes the node from any cluster it belongs to, removes all data from
@@ -149,6 +154,7 @@ For example, to resets the RabbitMQ node:
 .Dl rabbitmqctl reset
 .\" ------------------------------------
 .It Cm rotate_logs
+.Pp
 Instructs the RabbitMQ node to perform internal log rotation.
 .Pp
 Log rotation is performed according to lager settings specified in
@@ -167,6 +173,7 @@ Rotation is performed asynchronously, so there is no guarantee that it
 will be completed when this command returns.
 .\" ------------------------------------
 .It Cm shutdown
+.Pp
 Shuts down the node, both RabbitMQ and its runtime.
 The command is blocking and will return after the runtime process exits.
 If RabbitMQ fails to stop, it will return a non-zero exit code.
@@ -191,6 +198,7 @@ with default node name:
 .Dl rabbitmqctl shutdown
 .\" ------------------------------------
 .It Cm start_app
+.Pp
 Starts the RabbitMQ application.
 .Pp
 This command is typically run after performing other management actions
@@ -203,6 +211,7 @@ application:
 .Dl rabbitmqctl start_app
 .\" ------------------------------------
 .It Cm stop Op Ar pid_file
+.Pp
 Stops the Erlang node on which RabbitMQ is running.
 To restart the node follow the instructions for
 .Qq Running the Server
@@ -221,6 +230,7 @@ For example, to instruct the RabbitMQ node to terminate:
 .Dl rabbitmqctl stop
 .\" ------------------------------------
 .It Cm stop_app
+.Pp
 Stops the RabbitMQ application, leaving the runtime (Erlang VM) running.
 .Pp
 This command is typically run prior to performing other management
@@ -233,6 +243,7 @@ application:
 .Dl rabbitmqctl stop_app
 .\" ------------------------------------
 .It Cm wait Ar pid_file , Cm wait Fl -pid Ar pid
+.Pp
 Waits for the RabbitMQ application to start.
 .Pp
 This command will wait for the RabbitMQ application to start at the
@@ -268,14 +279,18 @@ up:
 .Ss Cluster management
 .Bl -tag -width Ds
 .\" ------------------------------------
-.It Cm await_online_nodes
-Waits for <count> nodes to join the cluster
+.It Cm await_online_nodes Ar count
+.Pp
+Waits for
+.Ar count
+nodes to join the cluster
 .Pp
 For example, to wait for two RabbitMQ nodes to start:
 .sp
 .Dl rabbitmqctl await_online_nodes 2
 .\" ------------------------------------
 .It Cm change_cluster_node_type Ar type
+.Pp
 Changes the type of the cluster node.
 .Pp
 The
@@ -297,6 +312,7 @@ For example, this command will turn a RAM node into a disc node:
 .Dl rabbitmqctl change_cluster_node_type disc
 .\" ------------------------------------
 .It Cm cluster_status
+.Pp
 Displays all the nodes in the cluster grouped by node type, together
 with the currently running nodes.
 .Pp
@@ -309,6 +325,7 @@ For example, this command displays the nodes in the cluster:
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm force_boot
+.Pp
 Ensures that the node will start next time, even if it was not the last
 to shut down.
 .Pp
@@ -338,6 +355,7 @@ time it is started:
 .Dl rabbitmqctl force_boot
 .\" ------------------------------------
 .It Cm force_reset
+.Pp
 Forcefully returns a RabbitMQ node to its virgin state.
 .Pp
 The
@@ -452,6 +470,7 @@ is part of, as a ram node:
 .Dl rabbitmqctl join_cluster hare@elena --ram
 .\" ------------------------------------
 .It Cm rename_cluster_node Ar oldnode1 Ar newnode1 Op Ar oldnode2 Ar newnode2 ...
+.Pp
 Supports renaming of cluster nodes in the local database.
 .Pp
 This subcommand causes
@@ -517,6 +536,7 @@ and configured the node name there, update this configuration.
 .It
 Start the node when ready
 .El
+.Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm update_cluster_nodes Ar clusternode
 .Bl -tag -width Ds
@@ -671,6 +691,7 @@ For example, this command instructs the RabbitMQ broker to delete the user named
 .Dl rabbitmqctl delete_user janeway
 .\" ------------------------------------
 .It Cm list_users
+.Pp
 Lists users.
 Each result row will contain the user name followed by a list of the
 tags set for that user.
@@ -837,6 +858,7 @@ question to see how to set parameters.
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_vhosts Op Ar vhostinfoitem ...
+.Pp
 Lists virtual hosts.
 .Pp
 The
@@ -936,10 +958,12 @@ The previous example could be made more generic by using
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm environment
+.Pp
 Displays the name and value of each variable in the application
 environment for each running application.
 .\" ------------------------------------
 .It Cm list_bindings Oo Fl p Ar vhost Oc Op Ar bindinginfoitem ...
+.Pp
 Returns binding details.
 By default the bindings for the
 .Qq /
@@ -988,6 +1012,7 @@ the bindings in the virtual host named
 .Dl rabbitmqctl list_bindings -p my-vhost exchange_name queue_name
 .\" ------------------------------------
 .It Cm list_channels Op Ar channelinfoitem ...
+.Pp
 Returns information on all current channels, the logical containers
 executing most AMQP commands.
 This includes channels that are part of ordinary AMQP connections, and
@@ -1047,6 +1072,7 @@ unacknowledged messages for each channel:
 .Dl rabbitmqctl list_channels connection messages_unacknowledged
 .\" ------------------------------------
 .It Cm list_ciphers
+.Pp
 Lists cipher suites supported by encoding commands.
 .Pp
 For example, this command instructs the RabbitMQ broker to list all
@@ -1056,6 +1082,7 @@ cipher suites supported by encoding commands:
 .El
 .\" ------------------------------------
 .It Cm list_connections Op Ar connectioninfoitem ...
+.Pp
 Returns TCP/IP connection statistics.
 .Pp
 The
@@ -1176,6 +1203,7 @@ for each connection:
 .Dl rabbitmqctl list_connections send_pend port
 .\" ------------------------------------
 .It Cm list_consumers Op Fl p Ar vhost
+.Pp
 Lists consumers, i.e. subscriptions to a queue\'s message stream.
 Each line printed shows, separated by tab characters, the name of
 the queue subscribed to, the id of the channel process via which the
@@ -1187,6 +1215,7 @@ consumer, an integer indicating the prefetch limit (with 0 meaning
 and any arguments for this consumer.
 .\" ------------------------------------
 .It Cm list_exchanges Oo Fl p Ar vhost Oc Op Ar exchangeinfoitem ...
+.Pp
 Returns exchange details.
 Exchange details of the
 .Qq /
@@ -1243,6 +1272,7 @@ of the virtual host named
 .Dl rabbitmqctl list_exchanges -p my-vhost name type
 .\" ------------------------------------
 .It Cm list_hashes
+.Pp
 Lists hash functions supported by encoding commands.
 .Pp
 For example, this command instructs the RabbitMQ broker to list all hash
@@ -1251,6 +1281,7 @@ functions supported by encoding commands:
 .Dl rabbitmqctl list_hashes
 .\" ------------------------------------
 .It Cm list_queues Oo Fl p Ar vhost Oc Oo Fl -offline | Fl -online | Fl -local Oc Op Ar queueinfoitem ...
+.Pp
 Returns queue details.
 Queue details of the
 .Qq /
@@ -1407,6 +1438,7 @@ is located on the current node.
 .Dl rabbitmqctl list_unresponsive_queues --local name
 .\" ------------------------------------
 .It Cm node_health_check
+.Pp
 Performs several health checks of the target node.
 .Pp
 Verifies the rabbit application is running and alarms are not set,
@@ -1416,12 +1448,14 @@ Example:
 .Dl rabbitmqctl node_health_check -n rabbit@hostname
 .\" ------------------------------------
 .It Cm ping
+.Pp
 Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it
 .Pp
 Example:
 .Dl rabbitmqctl ping -n rabbit@hostname
 .\" ------------------------------------
 .It Cm report
+.Pp
 Generate a server status report containing a concatenation of all server
 status information for support purposes.
 The output should be redirected to a file when accompanying a support
@@ -1433,6 +1467,7 @@ to a support request email:
 .Dl rabbitmqctl report > server_report.txt
 .\" ------------------------------------
 .It Cm schema_info Oc Oo Fl -no-table-headers Oc Op Ar column ...
+.Pp
 Lists schema database tables and their properties
 .Pp
 For example, this command lists the table names and their active replicas:
@@ -1440,6 +1475,7 @@ For example, this command lists the table names and their active replicas:
 .Dl rabbitmqctl schema_info name active_replicas
 .\" ------------------------------------
 .It Cm status
+.Pp
 Displays broker status information such as the running applications on
 the current Erlang node, RabbitMQ and Erlang versions, OS name, memory
 and file descriptor statistics.
@@ -1457,6 +1493,7 @@ broker:
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm clear_global_parameter Ar name
+.Pp
 Clears a global runtime parameter.
 This is similar to
 .Cm clear_parameter
@@ -1472,6 +1509,7 @@ For example, this command clears the global runtime parameter
 .Dl rabbitmqctl clear_global_parameter mqtt_default_vhosts
 .\" ------------------------------------
 .It Cm clear_parameter Oo Fl p Ar vhost Oc Ar component_name Ar key
+.Pp
 Clears a parameter.
 .Bl -tag -width Ds
 .It Ar component_name
@@ -1489,6 +1527,7 @@ component in the default virtual host:
 .Dl rabbitmqctl clear_parameter federation-upstream node01
 .\" ------------------------------------
 .It Cm list_global_parameters
+.Pp
 Lists all global runtime parameters.
 This is similar to
 .Cm list_parameters
@@ -1507,6 +1546,7 @@ Policies can be set, cleared and listed.
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_parameters Op Fl p Ar vhost
+.Pp
 Lists all parameters for a virtual host.
 .Pp
 For example, this command lists all parameters in the default virtual
@@ -1515,6 +1555,7 @@ host:
 .Dl rabbitmqctl list_parameters
 .\" ------------------------------------
 .It Cm set_global_parameter Ar name Ar value
+.Pp
 Sets a global runtime parameter.
 This is similar to
 .Cm set_parameter
@@ -1534,6 +1575,7 @@ to the JSON term {"O=client,CN=guest":"/"}:
 .Dl rabbitmqctl set_global_parameter mqtt_default_vhosts '{"O=client,CN=guest":"/"}'
 .\" ------------------------------------
 .It Cm set_parameter Oo Fl p Ar vhost Oc Ar component_name Ar name Ar value
+.Pp
 Sets a parameter.
 .Bl -tag -width Ds
 .It Ar component_name
@@ -1554,16 +1596,17 @@ component in the default virtual host to the following JSON
 .sp
 .Dl rabbitmqctl set_parameter federation-upstream node01 '{"uri":"amqp://user:password@server/%2F","ack-mode":"on-publish"}'
 .El
-.El
 .Ss Policies
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm clear_operator_policy Oo Fl p Ar vhost Oc Ar name
+.Pp
 Clears an operator policy.
 Arguments are identical to those of
 .Cm clear_policy .
 .\" ------------------------------------
 .It Cm clear_policy Oo Fl p Ar vhost Oc Ar name
+.Pp
 Clears a policy.
 .Bl -tag -width Ds
 .It Ar name
@@ -1577,6 +1620,7 @@ policy in the default virtual host:
 .Dl rabbitmqctl clear_policy federate-me
 .\" ------------------------------------
 .It Cm list_operator_policies Op Fl p Ar vhost
+.Pp
 Lists operator policy overrides for a virtual host.
 Arguments are identical to those of
 .Cm list_policies .
@@ -1586,6 +1630,7 @@ It is possible to enforce certain limits on virtual hosts.
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm list_policies Op Fl p Ar vhost
+.Pp
 Lists all policies for a virtual host.
 .Pp
 For example, this command lists all policies in the default virtual
@@ -1594,6 +1639,7 @@ host:
 .Dl rabbitmqctl list_policies
 .\" ------------------------------------
 .It Cm set_operator_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
+.Pp
 Sets an operator policy that overrides a subset of arguments in user
 policies.
 Arguments are identical to those of
@@ -1612,6 +1658,7 @@ max-length-bytes
 .El
 .\" ------------------------------------
 .It Cm set_policy Oo Fl p Ar vhost Oc Oo Fl -priority Ar priority Oc Oo Fl -apply-to Ar apply-to Oc Ar name Ar pattern Ar definition
+.Pp
 Sets a policy.
 .Bl -tag -width Ds
 .It Ar name
@@ -1631,11 +1678,11 @@ Which types of object this policy should apply to.
 Possible values are:
 .Bl -bullet -compact
 .It
-.Cm queues
+queues
 .It
-.Cm exchanges
+exchanges
 .It
-.Cm all
+all
 .El
 The default is
 .Cm all ..
@@ -1670,6 +1717,7 @@ virtual host called
 .Dl rabbitmqctl add_vhost test
 .\" ------------------------------------
 .It Cm clear_vhost_limits Op Fl p Ar vhost
+.Pp
 Clears virtual host limits.
 .Pp
 For example, this command clears vhost limits in vhost
@@ -1695,6 +1743,7 @@ virtual host called
 .Dl rabbitmqctl delete_vhost test
 .\" ------------------------------------
 .It Cm list_vhost_limits Oo Fl p Ar vhost Oc Oo Fl -global Oc Op Fl -no-table-headers
+.Pp
 Displays configured virtual host limits.
 .Bl -tag -width Ds
 .It Fl -global
@@ -1741,6 +1790,7 @@ virtual host called
 .Dl rabbitmqctl restart_vhost test
 .\" ------------------------------------
 .It Cm set_vhost_limits Oo Fl p Ar vhost Oc Ar definition
+.Pp
 Sets virtual host limits.
 .Bl -tag -width Ds
 .It Ar definition
@@ -1799,7 +1849,6 @@ Starts tracing.
 Note that the trace state is not persistent; it will revert to being off
 if the server is restarted.
 .El
-.El
 .Ss Node configuration
 .Bl -tag -width Ds
 .\" ------------------------------------
@@ -1838,6 +1887,7 @@ For example:
 .El
 .\" ------------------------------------
 .It Cm set_cluster_name Ar name
+.Pp
 Sets the cluster name to
 .Ar name .
 The cluster name is announced to clients on connection, and used by the
@@ -1858,7 +1908,7 @@ Lower bound limit as an integer in bytes or a string with memory unit symbols
 Once free disk space reaches the limit, a disk alarm will be set.
 .El
 .\" ------------------------------------
-.It Cm set_disk_free_limit mem_relative Ar fraction
+.It Cm set_disk_free_limit Oc mem_relative Ar fraction
 .Bl -tag -width Ds
 .It Ar fraction
 Limit relative to the total amount available RAM as a non-negative
@@ -1873,12 +1923,17 @@ Sets log level in the running node
 Supported
 .Ar type
 values are:
-.Bl -tag -width Ds
-.It Dv Sy debug
-.It Dv Sy info
-.It Dv Sy warning
-.It Dv Sy error
-.It Dv Sy none
+.Bl -bullet -compact
+.It
+debug
+.It
+info
+.It
+warning
+.It
+error
+.It
+none
 .El
 .Pp
 Example:
@@ -1892,7 +1947,7 @@ The new memory threshold fraction at which flow control is triggered, as
 a floating point number greater than or equal to 0.
 .El
 .\" ------------------------------------
-.It Cm set_vm_memory_high_watermark absolute Ar memory_limit
+.It Cm set_vm_memory_high_watermark Oc absolute Ar memory_limit
 .Bl -tag -width Ds
 .It Ar memory_limit
 The new memory limit at which flow control is triggered, expressed in
@@ -1913,11 +1968,11 @@ megabytes (10^6 bytes)
 .It Cm GB
 gigabytes (10^9 bytes)
 .El
-.El
 .Ss Feature flags
 .Bl -tag -width Ds
 .\" ------------------------------------
 .It Cm enable_feature_flag Ar feature_flag
+.Pp
 Enables a feature flag on target node
 Example:
 .Sp
@@ -1925,23 +1980,29 @@ Example:
 .El
 .\" ------------------------------------
 .It Cm list_feature_flags Oc Op Ar column ...
+.Pp
 Lists feature flags
 .Pp
 Supported
 .Ar column
 values are:
-.Bl -tag -width Ds
-.It Dv Sy name
-.It Dv Sy state
-.It Dv Sy stability
-.It Dv Sy provided_by
-.It Dv Sy desc
-.It Dv Sy doc_url
+.Bl -bullet -compact
+.It
+name
+.It
+state
+.It
+stability
+.It
+provided_by
+.It
+desc
+.It
+doc_url
 .El
 Example:
 .Sp
 .Dl rabbitmqctl list_feature_flags name state
-.El
 .El
 .Ss Operations
 .Bl -tag -width Ds
@@ -2010,27 +2071,7 @@ to the connected client:
 .Dl rabbitmqctl close_connection Qo <rabbit@tanto.4262.0> Qc Qq go away
 .\" ------------------------------------
 .It Cm eval Ar expr
-Evaluate an arbitrary Erlang expression.
 .Pp
-For example, this command returns the name of the node to which
-.Nm
-has connected:
-.sp
-.Dl rabbitmqctl eval Qq node().
-.El
-.Ss Miscellaneous
-.Bl -tag -width Ds
-.\" ------------------------------------
-.It Cm exec Ar expr Oc Op Fl -offline
-Evaluates a snippet of Elixir code on the CLI node
-.\" ------------------------------------
-.It Cm force_gc
-Makes all Erlang processes on the target node perform/schedule a full sweep garbage collection
-Example:
-.Sp
-.Dl rabbitmqctl force_gc
-.\" ------------------------------------
-.It Cm hipe_compile Ar directory
 Performs HiPE-compilation and caches resulting
 .Pa .beam Ns -files in the given directory.
 .Pp
@@ -2050,7 +2091,6 @@ For example, to HiPE-compile modules and store them to
 directory:
 .sp
 .Dl rabbitmqctl hipe_compile /tmp/rabbit-hipe/ebin
-.El
 .El
 .Ss Queues
 .Bl -tag -width Ds


### PR DESCRIPTION
Adds over 20 commands missing in the man pages. 
The formatting order and titles is now similar to `rabbitmqctl` help output.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
