### PR TITLE
fix health check returning ok in case of partition

### DIFF
--- a/src/rabbit_health_check.erl
+++ b/src/rabbit_health_check.erl
@@ -62,8 +62,11 @@ node_health_check(list_queues) ->
 
 node_health_check(rabbit_node_monitor) ->
     case rabbit_node_monitor:partitions() of
-        L when is_list(L) ->
-            ok
+        [] ->
+            ok;
+        L when is_list(L), length(L) > 0 ->
+            ErrorMsg = io_lib:format("cluster partition in effect: ~p", [L]),
+            {error_string, ErrorMsg}
     end;
 
 node_health_check(alarms) ->


### PR DESCRIPTION
Health check assumed if the result of partitions() is a list then everything
is ok, this is not the case the result is always a list.
rabbit_node_monitor:partitions() returns a non empty list in case there
is an mnesia_partition.

## Proposed Changes

The check is incorrect, I added a fix to check if the list is non-empty. 

I could not write a test case as in normal operation it's quite hard to introduce a partition, however for example the known suspend vm issue can cause it (or if it's left on ignore), for this reason this check is a must have.
If you have some pointers I'd gladly implement a test

Let me know what you think.

It returns errors like: 
```
{"status":"failed","reason":"cluster partition in effect: ['rabbit@rmq1.source.host',\n                             'rabbit@rmq3.source.host']"}
```

```
{"status":"failed","reason":"cluster partition in effect: ['rabbit@rmq2.source.host']"}
```

```
root@rmq1:/# rabbitmqctl --node rabbit@rmq2.source.host node_health_check
Timeout: 70 seconds ...
Checking health of node rabbit@rmq2.source.host ...
Error: healthcheck failed. Message: cluster partition in effect: ['rabbit@rmq1.source.host',
                             'rabbit@rmq3.source.host']
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

