### PR TITLE
Adjust quorum queue flow control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ define PROJECT_ENV
 	    %% see rabbitmq-server#143,
 	    %% rabbitmq-server#949, rabbitmq-server#1098
 	    {credit_flow_default_credit, {400, 200}},
-	    {quorum_commands_soft_limit, 256},
+	    {quorum_commands_soft_limit, 400},
 	    {quorum_cluster_size, 5},
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667


### PR DESCRIPTION
Such that enqueuing channels will be put into flow slightly earlier
whilst aligning the quorum_commands_soft_limit with the credit flow
default will allow consuming channels to send acks slightly earlier.

Also slight state refactoring to separate the mutable from static parts of the rabbit_fifo_state.