### PR TITLE
Make it possible to bypass queue master locator when declaring a queue

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -309,9 +309,14 @@ do_declare(Q, _Node) when ?amqqueue_is_quorum(Q) ->
 declare_classic_queue(Q, Node) ->
     QName = amqqueue:get_name(Q),
     VHost = amqqueue:get_vhost(Q),
-    Node1 = case rabbit_queue_master_location_misc:get_location(Q)  of
-              {ok, Node0}  -> Node0;
-              {error, _}   -> Node
+    Node1 = case Node of
+                {ignore_location, Node0} ->
+                    Node0;
+                _ ->
+                    case rabbit_queue_master_location_misc:get_location(Q)  of
+                        {ok, Node0}  -> Node0;
+                        {error, _}   -> Node
+                    end
             end,
     Node1 = rabbit_mirror_queue_misc:initial_queue_node(Q, Node1),
     case rabbit_vhost_sup_sup:get_vhost_sup(VHost, Node1) of


### PR DESCRIPTION
Needed by the sharding plugin so the shards are created in the
requested node, not wherever a non-related policy might try to enforce.

Part of https://github.com/rabbitmq/rabbitmq-sharding/issues/30

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
