### PR TITLE
Reserve file handles for quorum queues

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -574,8 +574,9 @@ state_enter(eol, #?MODULE{enqueuers = Enqs,
     [{send_msg, P, eol, ra_event}
      || P <- maps:keys(maps:merge(Enqs, AllConsumers))] ++
         [{mod_call, rabbit_quorum_queue, file_handle_release_reservation, []}];
-state_enter(_, #?MODULE{cfg = #cfg{resource = _Resource} }) ->
-    [{mod_call, rabbit_quorum_queue, file_handle_other_reservation, []}];
+state_enter(State, #?MODULE{cfg = #cfg{resource = _Resource}}) when State =/= leader ->
+    FHReservation = {mod_call, rabbit_quorum_queue, file_handle_other_reservation, []},
+    [FHReservation];
  state_enter(_, _) ->
     %% catch all as not handling all states
     [].

--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -574,9 +574,11 @@ state_enter(eol, #?MODULE{enqueuers = Enqs,
     [{send_msg, P, eol, ra_event}
      || P <- maps:keys(maps:merge(Enqs, AllConsumers))] ++
         [{mod_call, rabbit_quorum_queue, file_handle_release_reservation, []}];
-state_enter(_, #?MODULE{cfg = #cfg{resource = Resource} }) ->
+state_enter(_, #?MODULE{cfg = #cfg{resource = _Resource} }) ->
+    [{mod_call, rabbit_quorum_queue, file_handle_other_reservation, []}];
+ state_enter(_, _) ->
     %% catch all as not handling all states
-    [{mod_call, rabbit_quorum_queue, file_handle_other_reservation, []}].
+    [].
 
 
 -spec tick(non_neg_integer(), state()) -> ra_machine:effects().

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -894,7 +894,7 @@ file_handle_other_reservation() ->
     file_handle_cache:set_reservation(2).
 
 file_handle_release_reservation() ->
-    file_handle_cache:release_reserve().
+    file_handle_cache:release_reservation().
 
 %%----------------------------------------------------------------------------
 dlx_mfa(Q) ->

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -40,6 +40,8 @@
 -export([shrink_all/1,
          grow/4]).
 -export([transfer_leadership/2, get_replicas/1, queue_length/1]).
+-export([file_handle_leader_reservation/1, file_handle_other_reservation/0]).
+-export([file_handle_release_reservation/0]).
 
 %%-include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit.hrl").
@@ -883,6 +885,16 @@ matches_strategy(even, Members) ->
 is_match(Subj, E) ->
    nomatch /= re:run(Subj, E).
 
+file_handle_leader_reservation(QName) ->
+    {ok, Q} = rabbit_amqqueue:lookup(QName),
+    ClusterSize = length(get_nodes(Q)),
+    file_handle_cache:set_reservation(2 + ClusterSize).
+
+file_handle_other_reservation() ->
+    file_handle_cache:set_reservation(2).
+
+file_handle_release_reservation() ->
+    file_handle_cache:release_reserve().
 
 %%----------------------------------------------------------------------------
 dlx_mfa(Q) ->

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -72,7 +72,9 @@ groups() ->
                                             metrics_cleanup_on_leader_crash,
                                             consume_in_minority,
                                             shrink_all,
-                                            rebalance
+                                            rebalance,
+                                            file_handle_reservations,
+                                            file_handle_reservations_above_limit
                                             ]},
                       {cluster_size_5, [], [start_queue,
                                             start_queue_concurrent,
@@ -1368,6 +1370,53 @@ delete_member_not_a_member(Config) ->
     ?assertEqual(ok,
                  rpc:call(Server, rabbit_quorum_queue, delete_member,
                           [<<"/">>, QQ, Server])).
+
+file_handle_reservations(Config) ->
+    Servers = [Server1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    RaName = ra_name(QQ),
+    {ok, _, {_, Leader}} = ra:members({RaName, Server1}),
+    [Follower1, Follower2] = Servers -- [Leader],
+    ?assertEqual([{files_reserved, 5}],
+                 rpc:call(Leader, file_handle_cache, info, [[files_reserved]])),
+    ?assertEqual([{files_reserved, 2}],
+                 rpc:call(Follower1, file_handle_cache, info, [[files_reserved]])),
+    ?assertEqual([{files_reserved, 2}],
+                 rpc:call(Follower2, file_handle_cache, info, [[files_reserved]])),
+    force_leader_change(Servers, QQ),
+    {ok, _, {_, Leader0}} = ra:members({RaName, Server1}),
+    [Follower01, Follower02] = Servers -- [Leader0],
+    ?assertEqual([{files_reserved, 5}],
+                 rpc:call(Leader0, file_handle_cache, info, [[files_reserved]])),
+    ?assertEqual([{files_reserved, 2}],
+                 rpc:call(Follower01, file_handle_cache, info, [[files_reserved]])),
+    ?assertEqual([{files_reserved, 2}],
+                 rpc:call(Follower02, file_handle_cache, info, [[files_reserved]])).
+
+file_handle_reservations_above_limit(Config) ->
+    [S1, S2, S3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
+    QQ = ?config(queue_name, Config),
+    QQ2 = ?config(alt_queue_name, Config),
+
+    Limit = rpc:call(S1, file_handle_cache, get_limit, []),
+
+    ok = rpc:call(S1, file_handle_cache, set_limit, [3]),
+    ok = rpc:call(S2, file_handle_cache, set_limit, [3]),
+    ok = rpc:call(S3, file_handle_cache, set_limit, [3]),
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    ?assertEqual({'queue.declare_ok', QQ2, 0, 0},
+                 declare(Ch, QQ2, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    ok = rpc:call(S1, file_handle_cache, set_limit, [Limit]),
+    ok = rpc:call(S2, file_handle_cache, set_limit, [Limit]),
+    ok = rpc:call(S3, file_handle_cache, set_limit, [Limit]).
 
 cleanup_data_dir(Config) ->
     %% This test is slow, but also checks that we handle properly errors when

--- a/test/rabbit_fifo_int_SUITE.erl
+++ b/test/rabbit_fifo_int_SUITE.erl
@@ -55,6 +55,8 @@ end_per_group(_, Config) ->
 init_per_testcase(TestCase, Config) ->
     meck:new(rabbit_quorum_queue, [passthrough]),
     meck:expect(rabbit_quorum_queue, handle_tick, fun (_, _, _) -> ok end),
+    meck:expect(rabbit_quorum_queue, file_handle_leader_reservation, fun (_) -> ok end),
+    meck:expect(rabbit_quorum_queue, file_handle_other_reservation, fun () -> ok end),
     meck:expect(rabbit_quorum_queue, cancel_consumer_handler,
                 fun (_, _) -> ok end),
     ra_server_sup_sup:remove_all(),

--- a/test/unit_inbroker_non_parallel_SUITE.erl
+++ b/test/unit_inbroker_non_parallel_SUITE.erl
@@ -251,7 +251,7 @@ file_handle_cache_reserve_release1(_Config) ->
     ?assertEqual([{files_reserved, 7}], file_handle_cache:info([files_reserved])),
     ok = file_handle_cache:set_reservation(3),
     ?assertEqual([{files_reserved, 3}], file_handle_cache:info([files_reserved])),
-    ok = file_handle_cache:release_reserve(),
+    ok = file_handle_cache:release_reservation(),
     ?assertEqual([{files_reserved, 0}], file_handle_cache:info([files_reserved])),
     passed.
 


### PR DESCRIPTION
These should be taken into account into the limits, but always be granted.
Three file handles are reserved on startup for the wal, segment writer and a DETS table,
the rest must be reserved by the queues themselves using `set_reservation/0` or
`set_reservation/1`.

Depends on https://github.com/rabbitmq/rabbitmq-common/pull/336

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

