### PR TITLE
Handle infinity timeout when awaiting boot finish

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -783,6 +783,10 @@ wait_for_boot_to_finish(Node) ->
 wait_for_boot_to_finish(Node, PrintProgressReports) ->
     wait_for_boot_to_finish(Node, PrintProgressReports, ?BOOT_FINISH_TIMEOUT).
 
+wait_for_boot_to_finish(Node, PrintProgressReports, infinity) ->
+    %% This assumes that 100K iterations is close enough to "infinity".
+    %% Now that's deep.
+    do_wait_for_boot_to_finish(Node, PrintProgressReports, 100000);
 wait_for_boot_to_finish(Node, PrintProgressReports, Timeout) ->
     Iterations = Timeout div ?BOOT_STATUS_CHECK_INTERVAL,
     do_wait_for_boot_to_finish(Node, PrintProgressReports, Iterations).


### PR DESCRIPTION
## Proposed Changes

`rabbitmqctl await_startup` can fail with an exception that looks like this:


when timeout ends up being  `infinity` in the function that awaits boot completion by periodically checking every N milliseconds.

Spotted by @lukebakken.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
