### PR TITLE
Quorum queue local delivery

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -1431,8 +1431,9 @@ send_log_effect({CTag, CPid}, IdxMsgs) ->
              Msgs = lists:zipwith(fun({enqueue, _, _, Msg}, {MsgId, Header}) ->
                                           {MsgId, {Header, Msg}}
                                   end, Log, Data),
-             [{send_msg, CPid, {delivery, CTag, Msgs}, ra_event}]
-     end}.
+             [{send_msg, CPid, {delivery, CTag, Msgs}, [local, ra_event]}]
+     end,
+     {local, node(CPid)}}.
 
 reply_log_effect(RaftIdx, MsgId, Header, Ready, From) ->
     {log, [RaftIdx],

--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -1422,7 +1422,7 @@ take_next_msg(#?MODULE{returns = Returns,
     end.
 
 send_msg_effect({CTag, CPid}, Msgs) ->
-    {send_msg, CPid, {delivery, CTag, Msgs}, ra_event}.
+    {send_msg, CPid, {delivery, CTag, Msgs}, [local, ra_event]}.
 
 send_log_effect({CTag, CPid}, IdxMsgs) ->
     {RaftIdxs, Data} = lists:unzip(IdxMsgs),

--- a/test/rabbit_fifo_SUITE.erl
+++ b/test/rabbit_fifo_SUITE.erl
@@ -306,10 +306,10 @@ return_checked_out_test(_) ->
     Cid = {<<"cid">>, self()},
     {State0, [_, _]} = enq(1, 1, first, test_init(test)),
     {State1, [_Monitor,
-              {send_msg, _, {delivery, _, [{MsgId, _}]}, ra_event},
+              {send_msg, _, {delivery, _, [{MsgId, _}]}, _},
               {aux, active} | _ ]} = check_auto(Cid, 2, State0),
     % returning immediately checks out the same message again
-    {_, ok, [{send_msg, _, {delivery, _, [{_, _}]}, ra_event},
+    {_, ok, [{send_msg, _, {delivery, _, [{_, _}]}, _},
              {aux, active}]} =
         apply(meta(3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
     ok.
@@ -323,10 +323,10 @@ return_checked_out_limit_test(_) ->
                   delivery_limit => 1}),
     {State0, [_, _]} = enq(1, 1, first, Init),
     {State1, [_Monitor,
-              {send_msg, _, {delivery, _, [{MsgId, _}]}, ra_event},
+              {send_msg, _, {delivery, _, [{MsgId, _}]}, _},
               {aux, active} | _ ]} = check_auto(Cid, 2, State0),
     % returning immediately checks out the same message again
-    {State2, ok, [{send_msg, _, {delivery, _, [{MsgId2, _}]}, ra_event},
+    {State2, ok, [{send_msg, _, {delivery, _, [{MsgId2, _}]}, _},
                   {aux, active}]} =
         apply(meta(3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
     {#rabbit_fifo{ra_indexes = RaIdxs}, ok, []} =


### PR DESCRIPTION
This allows consumer deliveries to be sent from followers that are local to the consuming channels (when available). When there isn't a local follower the leader will deliver the message as before.

This saves unnecessary network hops.

Needs latest Ra master.

