### PR TITLE
Makes sure `rabbitmq-diagnostics list_unresponsive_queues` does not trip up on quorum queues

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -1073,13 +1073,24 @@ map(Qs, F) -> rabbit_misc:filter_exit_map(F, Qs).
 
 is_unresponsive(Q, _Timeout) when ?amqqueue_state_is(Q, crashed) ->
     false;
-is_unresponsive(Q, Timeout) ->
+is_unresponsive(Q, Timeout) when ?amqqueue_is_classic(Q) ->
     QPid = amqqueue:get_pid(Q),
     try
         delegate:invoke(QPid, {gen_server2, call, [{info, [name]}, Timeout]}),
         false
     catch
         %% TODO catch any exit??
+        exit:{timeout, _} ->
+            true
+    end;
+is_unresponsive(Q, Timeout) when ?amqqueue_is_quorum(Q) ->
+    try
+        case rabbit_fifo_client:stat(Q, Timeout) of
+          {ok, _, _}   -> false;
+          {timeout, _} -> true;
+          {error, _}   -> true
+        end
+    catch
         exit:{timeout, _} ->
             true
     end.

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -1085,7 +1085,8 @@ is_unresponsive(Q, Timeout) when ?amqqueue_is_classic(Q) ->
     end;
 is_unresponsive(Q, Timeout) when ?amqqueue_is_quorum(Q) ->
     try
-        case rabbit_fifo_client:stat(Q, Timeout) of
+        Leader = amqqueue:get_pid(Q),
+        case rabbit_fifo_client:stat(Leader, Timeout) of
           {ok, _, _}   -> false;
           {timeout, _} -> true;
           {error, _}   -> true


### PR DESCRIPTION
## Proposed Changes

This makes `rabbitmq-diagnostics list_unresponsive_queues` aware of quorum queues.
For classic queues, we request their `name` field as a state. For quorum queues I found no
easy way to do this with a timeout without moderate in scope internal API changes, so we
request a basic message stat breakdown (what a `queue.declare-ok` would return).

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes rabbitmq/rabbitmq-cli-#386.