### PR TITLE
Make a bunch of Ra settings configurable rabbitmq.conf

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -442,6 +442,18 @@
 # collect_statistics_interval = 5000
 
 ##
+## Ra Settings
+## =====================
+##
+## NB: changing these on a node with existing data directory
+##     can lead to DATA LOSS.
+##
+# raft.segment_max_entries = 65535
+# raft.wal_max_size_bytes = 1048576
+# raft.wal_max_batch_size = 32768
+# raft.snapshot_chunk_size = 1000000
+
+##
 ## Misc/Advanced Options
 ## =====================
 ##

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1522,6 +1522,67 @@ end}.
     end
 }.
 
+%%
+%% Ra
+%%
+
+{mapping, "raft.segment_max_entries", "ra.segment_max_entries", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
+{translation, "ra.segment_max_entries",
+    fun(Conf) ->
+        case cuttlefish:conf_get("raft.segment_max_entries", Conf, undefined) of
+            undefined -> cuttlefish:unset();
+            Val       -> Val
+        end
+    end
+}.
+
+{mapping, "raft.wal_max_size_bytes", "ra.wal_max_size_bytes", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
+{translation, "ra.wal_max_size_bytes",
+    fun(Conf) ->
+        case cuttlefish:conf_get("raft.wal_max_size_bytes", Conf, undefined) of
+            undefined -> cuttlefish:unset();
+            Val       -> Val
+        end
+    end
+}.
+
+{mapping, "raft.wal_max_batch_size", "ra.wal_max_batch_size", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
+{translation, "ra.wal_max_batch_size",
+    fun(Conf) ->
+        case cuttlefish:conf_get("raft.wal_max_batch_size", Conf, undefined) of
+            undefined -> cuttlefish:unset();
+            Val       -> Val
+        end
+    end
+}.
+
+{mapping, "raft.snapshot_chunk_size", "ra.snapshot_chunk_size", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
+{translation, "ra.snapshot_chunk_size",
+    fun(Conf) ->
+        case cuttlefish:conf_get("raft.snapshot_chunk_size", Conf, undefined) of
+            undefined -> cuttlefish:unset();
+            Val       -> Val
+        end
+    end
+}.
+
+
 % ===============================
 % Validators
 % ===============================

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -541,7 +541,12 @@ start_loaded_apps(Apps, RestartTypes) ->
     %% default OTP logger
     application:set_env(ra, logger_module, rabbit_log_ra_shim),
     %% use a larger segments size for queues
-    application:set_env(ra, segment_max_entries, 32768),
+    case application:get_env(ra, segment_max_entries) of
+      undefined ->
+        application:set_env(ra, segment_max_entries, 32768);
+      _ ->
+        ok
+    end,
     case application:get_env(ra, wal_max_size_bytes) of
         undefined ->
             application:set_env(ra, wal_max_size_bytes, 536870912); %% 5 * 2 ^ 20

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -638,5 +638,38 @@ credential_validator.regexp = ^abc\\d+",
                {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
                {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
                {keyfile,"test/config_schema_SUITE_data/certs/key.pem"}]}}]}],
-  []}
+  []},
+
+  %%
+  %% Raft
+  %%
+
+  {raft_segment_max_entries,
+   "raft.segment_max_entries = 65535",
+   [{ra, [
+      {segment_max_entries, 65535}
+     ]}],
+   []},
+
+  {raft_wal_max_size_bytes,
+   "raft.wal_max_size_bytes = 1048576",
+   [{ra, [
+      {wal_max_size_bytes, 1048576}
+     ]}],
+   []},
+
+   {raft_wal_max_batch_size,
+    "raft.wal_max_batch_size = 32768",
+    [{ra, [
+       {wal_max_batch_size, 32768}
+      ]}],
+    []},
+
+    {raft_snapshot_chunk_size,
+     "raft.snapshot_chunk_size = 1000000",
+     [{ra, [
+        {snapshot_chunk_size, 1000000}
+       ]}],
+     []}
+
 ].


### PR DESCRIPTION
## Proposed Changes

This makes a few Ra settings configurable via `rabbitmq.conf`:

``` ini
raft.segment_max_entries = 65535
raft.wal_max_size_bytes = 1048576
raft.wal_max_batch_size = 32768
raft.snapshot_chunk_size = 1000000
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue _)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #2140.
