### PR TITLE
rabbit_fifo: remove assertion

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -567,10 +567,6 @@ state_enter(leader, #?MODULE{consumers = Cons,
         {Mod, Fun, Args} ->
             [{mod_call, Mod, Fun, Args ++ [Name]} | Effects]
     end;
-state_enter(recovered, #?MODULE{prefix_msgs = PrefixMsgCounts})
-  when PrefixMsgCounts =/= {[], []} ->
-    %% TODO: remove assertion?
-    exit({rabbit_fifo, unexpected_prefix_msgs, PrefixMsgCounts});
 state_enter(eol, #?MODULE{enqueuers = Enqs,
                           consumers = Custs0,
                           waiting_consumers = WaitingConsumers0}) ->


### PR DESCRIPTION
Removing assertion that the machine state contains no prefix messages
after recovery as this can happen when the WAL is running slowly on a
server and the leader commits entries by receining responses from
followers before it has a confirmation of it being locally written.
