### PR TITLE
rabbit_reader: Format `Explanation` before passing it

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -663,7 +663,7 @@ switch_callback(State, Callback, Length) ->
 terminate(Explanation, State) when ?IS_RUNNING(State) ->
     {normal, handle_exception(State, 0,
                               rabbit_misc:amqp_error(
-                                connection_forced, Explanation, [], none))};
+                                connection_forced, "~s", [Explanation], none))};
 terminate(_Explanation, State) ->
     {force, State}.
 


### PR DESCRIPTION
... to `rabbit_misc:amqp_error()`.

`Explanation` can be a user input. Therefore, we don't want to pass it as a format string to `rabbit_misc:amqp_error()`, as we can't trust its content.

Now, we pass our own format string (`"~s"`) and `Explanation` becomes the argument to that format string. This ensures we don't interpret untrusted user input.

Discussed with: @dcorbacho, @essen and @michaelklishin.