### PR TITLE
Skip importing queues and exchanges with invalid names

### DIFF
--- a/test/definition_import_SUITE.erl
+++ b/test/definition_import_SUITE.erl
@@ -44,7 +44,8 @@ groups() ->
                                import_case7,
                                import_case8,
                                import_case9,
-                               import_case10
+                               import_case10,
+                               import_case11
                               ]}
     ].
 
@@ -102,6 +103,8 @@ import_case5(Config) ->
                  %% expect a proplist, see rabbitmq/rabbitmq-management#528
                  [{<<"1883">>,<<"/">>},
                   {<<"1884">>,<<"vhost2">>}]).
+
+import_case11(Config) -> import_file_case(Config, "case11").
 
 import_file_case(Config, CaseName) ->
     CasePath = filename:join(?config(data_dir, Config), CaseName ++ ".json"),

--- a/test/definition_import_SUITE_data/case11.json
+++ b/test/definition_import_SUITE_data/case11.json
@@ -1,0 +1,24 @@
+{
+  "rabbit_version": "3.8.0+rc.1.5.g9148053",
+  "rabbitmq_version": "3.8.0+rc.1.5.g9148053",
+  "queues": [
+    {
+      "name": "amq.queuebar",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    }
+  ],
+  "exchanges": [
+    {
+      "name": "amq.foobar",
+      "vhost": "/",
+      "type": "direct",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #2170

To verify, try to import this file:

[defs.json.txt](https://github.com/rabbitmq/rabbitmq-server/files/3876598/defs.json.txt)

You will see two warnings emitted.