### PR TITLE
Remove duplicated consumers metric in quorum queues

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -252,7 +252,7 @@ handle_tick(QName,
                                  0 -> 0;
                                  _ -> rabbit_fifo:usage(Name)
                              end,
-                      Infos = [{consumers, C}, {consumer_utilisation, Util},
+                      Infos = [{consumer_utilisation, Util},
                                {message_bytes_ready, MsgBytesReady},
                                {message_bytes_unacknowledged, MsgBytesUnack},
                                {message_bytes, MsgBytesReady + MsgBytesUnack},

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -252,14 +252,15 @@ handle_tick(QName,
                                  0 -> 0;
                                  _ -> rabbit_fifo:usage(Name)
                              end,
-                      Infos = [{consumer_utilisation, Util},
+                      Infos = [{consumers, C},
+                               {consumer_utilisation, Util},
                                {message_bytes_ready, MsgBytesReady},
                                {message_bytes_unacknowledged, MsgBytesUnack},
                                {message_bytes, MsgBytesReady + MsgBytesUnack},
                                {message_bytes_persistent, MsgBytesReady + MsgBytesUnack},
                                {messages_persistent, M}
 
-                               | infos(QName)],
+                               | infos(QName, ?STATISTICS_KEYS -- [consumers])],
                       rabbit_core_metrics:queue_stats(QName, Infos),
                       rabbit_event:notify(queue_stats,
                                           Infos ++ [{name, QName},
@@ -582,9 +583,12 @@ info(Q) ->
 -spec infos(rabbit_types:r('queue')) -> rabbit_types:infos().
 
 infos(QName) ->
+    infos(QName, ?STATISTICS_KEYS).
+
+infos(QName, Keys) ->
     case rabbit_amqqueue:lookup(QName) of
         {ok, Q} ->
-            info(Q, ?STATISTICS_KEYS);
+            info(Q, Keys);
         {error, not_found} ->
             []
     end.

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -2246,7 +2246,7 @@ in_memory(Config) ->
                  dirty_query([Server], RaName, fun rabbit_fifo:query_in_memory_usage/1)).
 
 consumer_metrics(Config) ->
-    [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
@@ -2259,9 +2259,9 @@ consumer_metrics(Config) ->
     timer:sleep(5000),
     QNameRes = rabbit_misc:r(<<"/">>, queue, QQ),
     [{_, PropList, _}] = rpc:call(Leader, ets, lookup, [queue_metrics, QNameRes]),
-    ?assertMatch([_], lists:filter(fun({Key, _}) ->
-                                           Key == consumers
-                                   end, PropList)).
+    ?assertMatch([{consumers, 1}], lists:filter(fun({Key, _}) ->
+                                                        Key == consumers
+                                                end, PropList)).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
This metric is already provided by `infos/1`

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
