### PR TITLE
rabbit_{amqueue,quorum_queue}: add several listing and sampling functions for new CLI commands

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -1006,15 +1006,13 @@ list_by_type(Type) ->
 list_local_quorum_queue_names() ->
     [ amqqueue:get_name(Q) || Q <- list_by_type(quorum),
            amqqueue:get_state(Q) =/= crashed,
-           lists:member(node(), get_quorum_nodes(Q)),
-           is_local_to_node(amqqueue:get_pid(Q), node())].
+           lists:member(node(), get_quorum_nodes(Q))].
 
 -spec list_local_quorum_queues() -> [amqqueue:amqqueue()].
 list_local_quorum_queues() ->
     [ Q || Q <- list_by_type(quorum),
       amqqueue:get_state(Q) =/= crashed,
-      lists:member(node(), get_quorum_nodes(Q)),
-      is_local_to_node(amqqueue:get_pid(Q), node())].
+      lists:member(node(), get_quorum_nodes(Q))].
 
 -spec list_local_leaders() -> [amqqueue:amqqueue()].
 list_local_leaders() ->

--- a/src/rabbit_core_metrics_gc.erl
+++ b/src/rabbit_core_metrics_gc.erl
@@ -80,7 +80,7 @@ gc_local_queues() ->
     GbSetDown = gb_sets:from_list(QueuesDown),
     gc_queue_metrics(GbSet, GbSetDown),
     gc_entity(queue_coarse_metrics, GbSet),
-    Followers = gb_sets:from_list(rabbit_amqqueue:list_local_followers()),
+    Followers = gb_sets:from_list([amqqueue:get_name(Q) || Q <- rabbit_amqqueue:list_local_followers() ]),
     gc_leader_data(Followers).
 
 gc_leader_data(Followers) ->

--- a/src/rabbit_feature_flags.erl
+++ b/src/rabbit_feature_flags.erl
@@ -2293,7 +2293,7 @@ on_load() ->
         true ->
             %% RabbitMQ is running.
             %%
-            %% Now we want to differenciate a pre-feature-flags node
+            %% Now we want to differentiate a pre-feature-flags node
             %% from one having the subsystem.
             %%
             %% To do that, we verify if the `feature_flags_file`

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -43,6 +43,7 @@ groups() ->
     [
      {single_node, [], all_tests()},
      {single_node, [], memory_tests()},
+     {single_node, [], [node_removal_is_quorum_critical]},
      {unclustered, [], [
                         {cluster_size_2, [], [add_member]}
                        ]},
@@ -56,7 +57,8 @@ groups() ->
                                             delete_member_classic,
                                             delete_member_queue_not_found,
                                             delete_member,
-                                            delete_member_not_a_member]
+                                            delete_member_not_a_member,
+                                            node_removal_is_quorum_critical]
                        ++ all_tests()},
                       {cluster_size_2, [], memory_tests()},
                       {cluster_size_3, [], [
@@ -74,12 +76,14 @@ groups() ->
                                             shrink_all,
                                             rebalance,
                                             file_handle_reservations,
-                                            file_handle_reservations_above_limit
+                                            file_handle_reservations_above_limit,
+                                            node_removal_is_not_quorum_critical
                                             ]},
                       {cluster_size_5, [], [start_queue,
                                             start_queue_concurrent,
                                             quorum_cluster_size_3,
-                                            quorum_cluster_size_7
+                                            quorum_cluster_size_7,
+                                            node_removal_is_not_quorum_critical
                                            ]},
                       {clustered_with_partitions, [], [
                                             reconnect_consumer_and_publish,
@@ -1387,6 +1391,29 @@ delete_member_not_a_member(Config) ->
                  rpc:call(Server, rabbit_quorum_queue, delete_member,
                           [<<"/">>, QQ, Server])).
 
+%% These tests check if node removal would cause any queues to lose (or not lose)
+%% their quorum. See rabbitmq/rabbitmq-cli#389 for background.
+
+node_removal_is_quorum_critical(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QName = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QName, 0, 0},
+                 declare(Ch, QName, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    timer:sleep(100),
+    Qs = rpc:call(Server, rabbit_quorum_queue, list_with_minimum_quorum, []),
+    ?assertEqual([QName], queue_names(Qs)).
+
+node_removal_is_not_quorum_critical(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QName = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QName, 0, 0},
+                 declare(Ch, QName, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    timer:sleep(100),
+    Qs = rpc:call(Server, rabbit_quorum_queue, list_with_minimum_quorum, []),
+    ?assertEqual([], Qs).
+
 file_handle_reservations(Config) ->
     Servers = [Server1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
@@ -2407,3 +2434,9 @@ wait_for_consensus(Name, Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     RaName = ra_name(Name),
     {ok, _, _} = ra:members({RaName, Server}).
+
+queue_names(Records) ->
+    [begin
+         #resource{name = Name} = amqqueue:get_name(Q),
+         Name
+     end || Q <- Records].


### PR DESCRIPTION
So that node-local queues that satisfy certain criteria
can be listed easily.

Mob: @kjnilsson and several other Pivots.

Part of rabbitmq/rabbitmq-cli#389.
