### PR TITLE
Update rabbit_fifo with Ra aux changes

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -601,7 +601,7 @@ tick(_Ts, #?MODULE{cfg = #cfg{name = Name,
                EnqueueBytes,
                CheckoutBytes},
     [{mod_call, rabbit_quorum_queue,
-      handle_tick, [QName, Metrics, all_nodes(State)]}, {aux, emit}].
+      handle_tick, [QName, Metrics, all_nodes(State)]}].
 
 -spec overview(state()) -> map().
 overview(#?MODULE{consumers = Cons,
@@ -643,9 +643,11 @@ handle_aux(_, cast, Cmd, {Name, Use0}, Log, _) ->
     Use = case Cmd of
               _ when Cmd == active orelse Cmd == inactive ->
                   update_use(Use0, Cmd);
-              emit ->
+              tick ->
                   true = ets:insert(rabbit_fifo_usage,
                                     {Name, utilisation(Use0)}),
+                  Use0;
+              eval ->
                   Use0
           end,
     {no_reply, {Name, Use}, Log}.

--- a/test/rabbit_fifo_SUITE.erl
+++ b/test/rabbit_fifo_SUITE.erl
@@ -483,8 +483,7 @@ tick_test(_) ->
       [#resource{},
        {?FUNCTION_NAME, 1, 1, 2, 1, 3, 3},
        [_Node]
-      ]},
-     {aux, emit}] = rabbit_fifo:tick(1, S4),
+      ]}] = rabbit_fifo:tick(1, S4),
     ok.
 
 
@@ -1266,8 +1265,7 @@ purge_nodes_test(_) ->
        [{mod_call, rabbit_quorum_queue, handle_tick,
          [#resource{}, _Metrics,
           [ThisNode, Node]
-         ]},
-        {aux, emit}] , rabbit_fifo:tick(1, State4)),
+         ]}] , rabbit_fifo:tick(1, State4)),
     %% assert there are both enqueuers and consumers
     {State, _, _} = apply(meta(5),
                           rabbit_fifo:make_purge_nodes([Node]),
@@ -1283,8 +1281,7 @@ purge_nodes_test(_) ->
        [{mod_call, rabbit_quorum_queue, handle_tick,
          [#resource{}, _Metrics,
           [ThisNode]
-         ]},
-        {aux, emit}] , rabbit_fifo:tick(1, State)),
+         ]}] , rabbit_fifo:tick(1, State)),
     ok.
 
 meta(Idx) ->
@@ -1360,7 +1357,7 @@ aux_test(_) ->
     Log = undefined,
     {no_reply, Aux, undefined} = handle_aux(leader, cast, active, Aux0,
                                             Log, MacState),
-    {no_reply, _Aux, undefined} = handle_aux(leader, cast, emit, Aux,
+    {no_reply, _Aux, undefined} = handle_aux(leader, cast, tick, Aux,
                                              Log, MacState),
     [X] = ets:lookup(rabbit_fifo_usage, aux_test),
     ?assert(X > 0.0),


### PR DESCRIPTION
Ra now will automatically pass `eval` and `tick` to handle_aux after
each applied batch and tick even respectively. This updates the state
machine to handle this.

requires https://github.com/rabbitmq/ra/pull/151