### PR TITLE
Run rabbit_prelaunch_conf:setup/1 earlier in startup

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -99,13 +99,16 @@ do_run() ->
     rabbit_env:context_to_code_path(Context),
     rabbit_env:context_to_app_env_vars(Context),
 
-    %% 1. Erlang/OTP compatibility check.
+    %% Erlang/OTP compatibility check.
     ok = rabbit_prelaunch_erlang_compat:check(Context),
 
-    %% 2. Erlang distribution check + start.
+    %% Erlang distribution check + start.
     ok = rabbit_prelaunch_dist:setup(Context),
 
-    %% 3. Write PID file.
+    %% Configuration check + loading.
+    ok = rabbit_prelaunch_conf:setup(Context),
+
+    %% Write PID file.
     rabbit_log_prelaunch:debug(""),
     _ = write_pid_file(Context),
     ignore.

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -331,13 +331,10 @@ run_prelaunch_second_phase() ->
             ok
     end,
 
-    %% 1. Feature flags registry.
+    %% Feature flags registry.
     ok = rabbit_prelaunch_feature_flags:setup(Context),
 
-    %% 2. Configuration check + loading.
-    ok = rabbit_prelaunch_conf:setup(Context),
-
-    %% 3. Logging.
+    %% Logging.
     ok = rabbit_prelaunch_logging:setup(Context),
 
     case IsInitialPass of
@@ -348,7 +345,7 @@ run_prelaunch_second_phase() ->
             ok
     end,
 
-    %% 5. Clustering.
+    %% Clustering.
     ok = rabbit_prelaunch_cluster:setup(Context),
 
     %% Start Mnesia now that everything is ready.
@@ -488,7 +485,6 @@ start_it(StartType) ->
                 {ok, _} = application:ensure_all_started(rabbit,
                                                          StartType),
                 ok = wait_for_ready_or_stopped(),
-
                 T1 = erlang:timestamp(),
                 rabbit_log_prelaunch:debug(
                   "Time to start RabbitMQ: ~p µs",

--- a/src/rabbit_prelaunch_conf.erl
+++ b/src/rabbit_prelaunch_conf.erl
@@ -23,9 +23,9 @@ setup(Context) ->
     %% TODO: Support glob patterns & directories in RABBITMQ_CONFIG_FILE.
     %% TODO: Always try parsing of both erlang and cuttlefish formats.
 
-    update_enabled_plugins_file(Context),
+    ok = update_enabled_plugins_file(Context),
 
-    set_default_config(),
+    ok = set_default_config(),
 
     AdvancedConfigFile = find_actual_advanced_config_file(Context),
     State = case find_actual_main_config_file(Context) of
@@ -63,7 +63,7 @@ setup(Context) ->
                       config_files => [],
                       config_advanced_file => undefined}
             end,
-    override_with_hard_coded_critical_config(),
+    ok = override_with_hard_coded_critical_config(),
     rabbit_log_prelaunch:debug(
       "Saving config state to application env: ~p", [State]),
     store_config_state(State).
@@ -393,7 +393,7 @@ apply_erlang_term_based_config([{_, []} | Rest]) ->
     apply_erlang_term_based_config(Rest);
 apply_erlang_term_based_config([{App, Vars} | Rest]) ->
     rabbit_log_prelaunch:debug("  Applying configuration for '~s':", [App]),
-    apply_app_env_vars(App, Vars),
+    ok = apply_app_env_vars(App, Vars),
     apply_erlang_term_based_config(Rest);
 apply_erlang_term_based_config([]) ->
     ok.


### PR DESCRIPTION
This appears to address issues where ra and syslog_handler configuration were applied after the applications started.