### PR TITLE
Run rabbit_prelaunch_conf:setup/1 earlier in startup

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -105,7 +105,10 @@ do_run() ->
     %% 2. Erlang distribution check + start.
     ok = rabbit_prelaunch_dist:setup(Context),
 
-    %% 3. Write PID file.
+    %% 3. Configuration check + loading.
+    ok = rabbit_prelaunch_conf:setup(Context),
+
+    %% 4. Write PID file.
     rabbit_log_prelaunch:debug(""),
     _ = write_pid_file(Context),
     ignore.

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -43,11 +43,11 @@ do_setup(#{nodename := Node, nodename_type := NameType}) ->
 duplicate_node_check(#{split_nodename := {NodeName, NodeHost}}) ->
     rabbit_log_prelaunch:debug(
       "Checking if node name ~s is already used", [NodeName]),
-    PrelaunchName = rabbit_nodes:make(
+    PrelaunchName = rabbit_nodes_common:make(
                       {NodeName ++ "_prelaunch_" ++ os:getpid(),
                        "localhost"}),
     {ok, _} = net_kernel:start([PrelaunchName, shortnames]),
-    case rabbit_nodes:names(NodeHost) of
+    case rabbit_nodes_common:names(NodeHost) of
         {ok, NamePorts}  ->
             case proplists:is_defined(NodeName, NamePorts) of
                 true ->
@@ -93,7 +93,7 @@ dist_port_use_check_ipv6(NodeHost, Port) ->
                                          no_return().
 
 dist_port_use_check_fail(Port, Host) ->
-    {ok, Names} = rabbit_nodes:names(Host),
+    {ok, Names} = rabbit_nodes_common:names(Host),
     case [N || {N, P} <- Names, P =:= Port] of
         [] ->
             throw({error, {dist_port_already_used, Port, not_erlang, Host}});

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_errors.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_errors.erl
@@ -44,7 +44,7 @@ format_error({error, {erlang_dist_running_with_unexpected_nodename,
 format_error({bad_config_entry_decoder, missing_passphrase}) ->
     rabbit_misc:format(
       "Missing passphrase or missing passphrase read method in "
-      "`config_entry_decoder`");
+      "`config_entry_decoder`", []);
 format_error({config_decryption_error, {key, Key}, _Msg}) ->
     rabbit_misc:format(
       "Error while decrypting key '~p'. Please check encrypted value, "

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -331,24 +331,27 @@ run_prelaunch_second_phase() ->
             ok
     end,
 
-    %% 1. Feature flags registry.
+    %% 1. Enabled plugins file.
+    ok = rabbit_prelaunch_enabled_plugins_file:setup(Context),
+
+    %% 2. Feature flags registry.
     ok = rabbit_prelaunch_feature_flags:setup(Context),
 
-    %% 2. Configuration check + loading.
+    %% 3. Configuration check + loading.
     ok = rabbit_prelaunch_conf:setup(Context),
 
-    %% 3. Logging.
+    %% 4. Logging.
     ok = rabbit_prelaunch_logging:setup(Context),
 
     case IsInitialPass of
         true ->
-            %% 4. HiPE compilation.
+            %% 5. HiPE compilation.
             ok = rabbit_prelaunch_hipe:setup(Context);
         false ->
             ok
     end,
 
-    %% 5. Clustering.
+    %% 6. Clustering.
     ok = rabbit_prelaunch_cluster:setup(Context),
 
     %% Start Mnesia now that everything is ready.

--- a/src/rabbit_prelaunch_enabled_plugins_file.erl
+++ b/src/rabbit_prelaunch_enabled_plugins_file.erl
@@ -1,0 +1,46 @@
+-module(rabbit_prelaunch_enabled_plugins_file).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([setup/1]).
+
+setup(Context) ->
+    rabbit_log_prelaunch:debug(""),
+    rabbit_log_prelaunch:debug("== Enabled plugins file =="),
+    update_enabled_plugins_file(Context).
+
+%% -------------------------------------------------------------------
+%% `enabled_plugins` file content initialization.
+%% -------------------------------------------------------------------
+
+update_enabled_plugins_file(#{enabled_plugins := undefined}) ->
+    ok;
+update_enabled_plugins_file(#{enabled_plugins := all,
+                              plugins_path := Path} = Context) ->
+    List = [P#plugin.name || P <- rabbit_plugins:list(Path)],
+    do_update_enabled_plugins_file(Context, List);
+update_enabled_plugins_file(#{enabled_plugins := List} = Context) ->
+    do_update_enabled_plugins_file(Context, List).
+
+do_update_enabled_plugins_file(#{enabled_plugins_file := File}, List) ->
+    SortedList = lists:usort(List),
+    case SortedList of
+        [] ->
+            rabbit_log_prelaunch:debug("Marking all plugins as disabled");
+        _ ->
+            rabbit_log_prelaunch:debug(
+              "Marking the following plugins as enabled:"),
+            [rabbit_log_prelaunch:debug("  - ~s", [P]) || P <- SortedList]
+    end,
+    Content = io_lib:format("~p.~n", [SortedList]),
+    case file:write_file(File, Content) of
+        ok ->
+            rabbit_log_prelaunch:debug("Wrote plugins file: ~ts", [File]),
+            ok;
+        {error, Reason} ->
+            rabbit_log_prelaunch:error(
+              "Failed to update enabled plugins file \"~ts\" "
+              "from $RABBITMQ_ENABLED_PLUGINS: ~ts",
+              [File, file:format_error(Reason)]),
+            throw({error, failed_to_update_enabled_plugins_file})
+    end.


### PR DESCRIPTION
This appears to address issues where ra and syslog_handler configuration were applied after the applications started.

Follow-up to #2186