### PR TITLE
Broker can resume work when "recovery.dets" is damaged.

### DIFF
--- a/src/rabbit_recovery_terms.erl
+++ b/src/rabbit_recovery_terms.erl
@@ -196,9 +196,19 @@ code_change(_OldVsn, State, _Extra) ->
 open_table(VHost) ->
     VHostDir = rabbit_vhost:msg_store_dir_path(VHost),
     File = filename:join(VHostDir, "recovery.dets"),
-    {ok, _} = dets:open_file(VHost, [{file,      File},
-                                     {ram_file,  true},
-                                     {auto_save, infinity}]).
+    try
+        {ok, _} = dets:open_file(VHost, [{file,      File},
+                                        {ram_file,  true},
+                                        {auto_save, infinity}])
+    catch _:_ ->
+        file:delete(File),
+        %% Sleep for a period of time to avoid the CPU surge caused by repeated operation
+        Wait_time = 1000,
+        rabbit_log:warning("Failed to open '~p', deleted it and retry after ~pms.", 
+            [File, Wait_time]),
+        timer:sleep(Wait_time),
+        open_table(VHost)
+     end.
 
 flush(VHost) ->
     try


### PR DESCRIPTION
When the file is damaged, for example, because the disk is full, the service fails to return to normal after the disk space is enough.
The PR is to delete the file,try to recover all queues without the use of the recovery hints, and regain availability after that.

To reproduce the issue:

[root@pc4 test]# python msg_test.py create_queue 10.43.178.220 'queue=q11;durable=true'
connect to 10.43.178.220 ok
2019-12-26 09:18:10.418 create_queue q11
2019-12-26 09:18:10.421 to close connection
[root@pc4 test]# python msg_test.py create_exchange 10.43.178.220 'exchange=ex11;exchange_type=topic'
connect to 10.43.178.220 ok
2019-12-26 09:18:10.604 create_exchange ex11 topic
2019-12-26 09:18:10.606 to close connection
[msg_test.txt](https://github.com/rabbitmq/rabbitmq-server/files/4001130/msg_test.txt)


[root@pc4 test]# python msg_test.py bind 10.43.178.220 'exchange=ex11;queue=q11;routing_key=exq11'
connect to 10.43.178.220 ok
2019-12-26 09:18:10.778 bind ex11 q11 r_key:exq11
2019-12-26 09:18:10.782 to close connection
[root@pc4 test]# python msg_test.py publish 10.43.178.220 'exchange=ex11;routing_key=exq11;msg="_unique_id:123-10";persistent=true;count=1'
connect to 10.43.178.220 ok
2019-12-26 09:18:11.605 publish ex11 r_key:exq11, 0
2019-12-26 09:18:12.645 to close connection

[root@pc4 SOURCES]# rabbitmqctl list_queues
Timeout: 60.0 seconds ...
Listing queues for vhost / ...
name    consumers       messages_ready  messages_unacknowledged
q11     0       1       0


[root@pc4 home]# systemctl stop rabbitmq-server
%%%%%% to destroy the "recovery.dets" by vim tool
[root@pc4 home]#  vim /var/lib/rabbitmq/mnesia/rabbit@pc4/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/recovery.dets
[root@pc4 home]# systemctl start rabbitmq-server

%%%%% crash log in broker:
2019-12-26 09:21:22.269 [error] <0.365.0> CRASH REPORT Process <0.365.0> with 0 neighbours crashed with reason: no match of right hand value {error,{format_8_no_longer_supported,"/var/lib/rabbitmq/mnesia/rabbit@pc4/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/recovery.dets"}} in rabbit_recovery_terms:open_table/1 line 191


%%%%% Messages in the q11 were not recovered
[root@pc4 home]# rabbitmqctl list_queues
Timeout: 60.0 seconds ...
Listing queues for vhost / ...
name    consumers       messages_ready  messages_unacknowledged
q11

%%%%% declaring a new queue will failed:
[root@pc4 test]# python msg_test.py create_queue 10.43.178.220 'queue=q12;durable=false'
Traceback (most recent call last):
  File "msg_test.py", line 24, in <module>
    credentials=pika.credentials.PlainCredentials('guest', 'guest')))
  File "build/bdist.linux-x86_64/egg/pika/adapters/blocking_connection.py", line 366, in __init__
  File "build/bdist.linux-x86_64/egg/pika/adapters/blocking_connection.py", line 458, in _create_connection
pika.exceptions.ConnectionClosedByBroker: (541, "INTERNAL_ERROR - access to vhost '/' refused for user 'guest': vhost '/' is down")

%%%%% error log in broker:
2019-12-26 09:21:43.562 [error] <0.408.0> Error on AMQP connection <0.408.0> (10.43.178.217:59762 -> 10.43.178.220:5672, vhost: 'none', user: 'guest', state: opening), channel 0:
 {handshake_error,opening,
                 {amqp_error,internal_error,
                             "access to vhost '/' refused for user 'guest': vhost '/' is down",
                             'connection.open'}}