### PR TITLE
do not check msg size for undefined gc threshold

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -2708,7 +2708,12 @@ handle_deliver(ConsumerTag, AckRequired,
         false ->
             ok = rabbit_writer:send_command(WriterPid, Deliver, Content)
     end,
-    rabbit_basic:maybe_gc_large_msg(Content, GCThreshold),
+    case GCThreshold of
+        undefined ->
+            ok;
+        _ ->
+            rabbit_basic:maybe_gc_large_msg(Content, GCThreshold)
+    end,
     record_sent(deliver, ConsumerTag, AckRequired, Msg, State).
 
 handle_basic_get(WriterPid, DeliveryTag, NoAck, MessageCount,


### PR DESCRIPTION
Simple improvment to
https://github.com/rabbitmq/rabbitmq-server/pull/2182
For undefined gc threshold we do not need to call rabbit_basic:maybe_gc_large_msg
This PR should be merged into master and v3.8.x branch