### PR TITLE
Autoheal: loser node may miss the "autoheal_safe_to_start" notification from the winner

### DIFF
--- a/src/rabbit_autoheal.erl
+++ b/src/rabbit_autoheal.erl
@@ -381,6 +381,11 @@ restart_loser(State, Winner) ->
                       not_healing;
                   autoheal_safe_to_start ->
                       State
+		  after 60000 ->
+                      rabbit_log:warning(
+                          "Autoheal: Timed out waiting for autoheal_safe_to_start, 
+                           winner is ~p; Start and retry autoheal", [Winner]),
+                      not_healing
               end,
               erlang:demonitor(MRef, [flush]),
               %% During the restart, the autoheal state is lost so we


### PR DESCRIPTION
"await_cluster_recovery" and "Autoheal" use the same name "rabbit_outside_app_process" to run
outside process.

Let's call "await_cluster_recovery outside process" process_1 and "Autoheal outside process" process_2.

If process_1 starts first, process_2 will wait for process_1 to exit before starting. If the winner sends "autoheal_safe_to_start" at this time, the notification will be received and ignored by process_1. When process_1 exits, process_2 starts, stop rabbit, and wait to receive "autoheal_safe_to_start". In this case, process_2 will miss the notification and never start rabbit again. The PR will start rabbit and retry autoheal, there is a greate chance to regain availability.