### PR TITLE
Autoheal: the "autoheal_safe_to_start" state transition is not guaranteed to arrive on time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ define PROJECT_ENV
 	    {reverse_dns_lookups, false},
 	    {cluster_partition_handling, ignore},
 	    {cluster_keepalive_interval, 10000},
+	    {autoheal_state_transition_timeout, 60000},
 	    {tcp_listen_options, [{backlog,       128},
 	                          {nodelay,       true},
 	                          {linger,        {true, 0}},

--- a/src/rabbit_autoheal.erl
+++ b/src/rabbit_autoheal.erl
@@ -381,6 +381,11 @@ restart_loser(State, Winner) ->
                       not_healing;
                   autoheal_safe_to_start ->
                       State
+                  after 60000 ->
+                      rabbit_log:warning(
+                          "Autoheal: Timed out waiting for autoheal_safe_to_start, 
+                           winner is ~p; Start and retry autoheal", [Winner]),
+                      not_healing
               end,
               erlang:demonitor(MRef, [flush]),
               %% During the restart, the autoheal state is lost so we

--- a/src/rabbit_autoheal.erl
+++ b/src/rabbit_autoheal.erl
@@ -372,6 +372,7 @@ wait_for_supervisors(Monitors) ->
 restart_loser(State, Winner) ->
     rabbit_log:warning(
       "Autoheal: we were selected to restart; winner is ~p~n", [Winner]),
+    NextStateTimeout = application:get_env(rabbit, autoheal_state_transition_timeout, 60000),
     rabbit_node_monitor:run_outside_applications(
       fun () ->
               MRef = erlang:monitor(process, {?SERVER, Winner}),
@@ -381,10 +382,10 @@ restart_loser(State, Winner) ->
                       not_healing;
                   autoheal_safe_to_start ->
                       State
-                  after 60000 ->
+                  after NextStateTimeout ->
                       rabbit_log:warning(
-                          "Autoheal: Timed out waiting for autoheal_safe_to_start, 
-                           winner is ~p; Start and retry autoheal", [Winner]),
+                          "Autoheal: timed out waiting for a safe-to-start message from the winner (~p); will retry",
+                          [Winner]),
                       not_healing
               end,
               erlang:demonitor(MRef, [flush]),

--- a/test/partitions_SUITE.erl
+++ b/test/partitions_SUITE.erl
@@ -21,7 +21,7 @@
 
 -compile(export_all).
 
-%% We set ticktime to 1s and setuptime is 7s so to make sure it
+%% We set ticktime to 1s and setup time is 7s so to make sure it
 %% passes...
 -define(DELAY, 8000).
 
@@ -119,7 +119,7 @@ end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config1, Testcase).
 
 %% -------------------------------------------------------------------
-%% Testcases.
+%% Test cases.
 %% -------------------------------------------------------------------
 
 ignore(Config) ->
@@ -400,6 +400,7 @@ partial_pause_minority(Config) ->
     ok.
 
 partial_pause_if_all_down(Config) ->
+    rabbit_ct_broker_helpers:rpc_all(Config, application, set_env, [rabbit, autoheal_state_transition_timeout, 3000]),
     [A, B, C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     set_mode(Config, {pause_if_all_down, [B], ignore}),
     block([{A, B}]),


### PR DESCRIPTION
This is an extended version of #2208 by @tomyouyou which also updates a test so that it does not time out.

@tomyouyou if you have a way to reproduce the original problem, please give this PR a shot.