### PR TITLE
Filter policies that cannot be applied to quorum queues

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -60,6 +60,8 @@
 -export([rebalance/3]).
 -export([collect_info_all/2]).
 
+-export([is_policy_applicable/2]).
+
 %% internal
 -export([internal_declare/2, internal_delete/2, run_backing_queue/3,
          set_ram_duration_target/2, set_maximum_since_use/2,
@@ -458,6 +460,17 @@ policy_changed(Q1, Q2) ->
     %% Make sure we emit a stats event even if nothing
     %% mirroring-related has changed - the policy may have changed anyway.
     notify_policy_changed(Q1).
+
+is_policy_applicable(QName, Policy) ->
+    case lookup(QName) of
+        {ok, Q} when ?amqqueue_is_quorum(Q) ->
+            rabbit_quorum_queue:is_policy_applicable(Q, Policy);
+        {ok, Q} when ?amqqueue_is_classic(Q) ->
+            rabbit_amqqueue_process:is_policy_applicable(Q, Policy);
+        _ ->
+            %% Defaults to previous behaviour. Apply always
+            true
+    end.
 
 -spec lookup
         (name()) ->

--- a/src/rabbit_amqqueue_process.erl
+++ b/src/rabbit_amqqueue_process.erl
@@ -33,6 +33,7 @@
          handle_info/2, handle_pre_hibernate/1, prioritise_call/4,
          prioritise_cast/3, prioritise_info/3, format_message_queue/2]).
 -export([format/1]).
+-export([is_policy_applicable/2]).
 
 %% Queue's state
 -record(q, {
@@ -1782,6 +1783,10 @@ format(Q) when ?is_amqqueue(Q) ->
              {synchronised_slave_nodes, [node(S) || S <- SSlaves]},
              {node, node(amqqueue:get_pid(Q))}]
     end.
+
+-spec is_policy_applicable(amqqueue:amqqueue(), any()) -> boolean().
+is_policy_applicable(_Q, _Policy) ->
+    true.
 
 log_delete_exclusive({ConPid, _ConRef}, State) ->
     log_delete_exclusive(ConPid, State);

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -45,6 +45,7 @@
 -export([list_with_minimum_quorum/0, list_with_minimum_quorum_for_cli/0,
          filter_quorum_critical/1, filter_quorum_critical/2,
          all_replica_states/0]).
+-export([is_policy_applicable/2]).
 
 -include_lib("stdlib/include/qlc.hrl").
 -include("rabbit.hrl").
@@ -298,6 +299,15 @@ filter_quorum_critical(Queues, ReplicaStates) ->
                     MinQuorum = length(MemberNodes) div 2 + 1,
                     length(AllUp) =< MinQuorum
                  end, Queues).
+
+-spec is_policy_applicable(amqqueue:amqqueue(), any()) -> boolean().
+is_policy_applicable(_Q, Policy) ->
+    Applicable = [<<"max-length">>, <<"max-length-bytes">>, <<"max-in-memory-length">>,
+                  <<"max-in-memory-bytes">>, <<"delivery-limit">>, <<"dead-letter-exchange">>,
+                  <<"dead-letter-routing-key">>],
+    lists:all(fun({P, _}) ->
+                      lists:member(P, Applicable)
+              end, Policy).
 
 rpc_delete_metrics(QName) ->
     ets:delete(queue_coarse_metrics, QName),


### PR DESCRIPTION
Some policies, such as queue mirroring, do not apply to all types of queues.
Even though quorum queues ignores some policies, they're still listed as
an applied policy on this type of queue. This commit ignores filters these
policies when applied, so they'll never be listed on the wrong type of queue.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
