### PR TITLE
Unsupported if_empty and if_unused flags for delete quorum queues

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -444,6 +444,16 @@ stop(VHost) ->
              rabbit_types:username()) ->
     {ok, QLen :: non_neg_integer()}.
 
+delete(Q, true, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
+    rabbit_misc:protocol_error(
+      not_implemented,
+      "cannot delete ~s. queue.delete operations with if-unused flag set are not supported by quorum queues",
+      [rabbit_misc:rs(amqqueue:get_name(Q))]);
+delete(Q, _IfUnused, true, ActingUser) when ?amqqueue_is_quorum(Q) ->
+    rabbit_misc:protocol_error(
+      not_implemented,
+      "cannot delete ~s. queue.delete operations with if-empty flag set are not supported by quorum queues",
+      [rabbit_misc:rs(amqqueue:get_name(Q))]);
 delete(Q,
        _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
     {Name, _} = amqqueue:get_pid(Q),

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -444,12 +444,12 @@ stop(VHost) ->
              rabbit_types:username()) ->
     {ok, QLen :: non_neg_integer()}.
 
-delete(Q, true, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
+delete(Q, true, _IfEmpty, _ActingUser) when ?amqqueue_is_quorum(Q) ->
     rabbit_misc:protocol_error(
       not_implemented,
       "cannot delete ~s. queue.delete operations with if-unused flag set are not supported by quorum queues",
       [rabbit_misc:rs(amqqueue:get_name(Q))]);
-delete(Q, _IfUnused, true, ActingUser) when ?amqqueue_is_quorum(Q) ->
+delete(Q, _IfUnused, true, _ActingUser) when ?amqqueue_is_quorum(Q) ->
     rabbit_misc:protocol_error(
       not_implemented,
       "cannot delete ~s. queue.delete operations with if-empty flag set are not supported by quorum queues",


### PR DESCRIPTION
After discussions with @kjnilsson we decided the flags `if_empty` and `if_unused` won't be implemented for quorum queues. It's a feature of transient queues which also requires big changes on `ra`.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
