### PR TITLE
Move all RabbitMQ-specific environment variables to `rabbit_env`

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -17,6 +17,11 @@
          initial_pass_finished/0,
          shutdown_func/1]).
 
+-ifdef(TEST).
+-export([store_context/1,
+         clear_context_cache/0]).
+-endif.
+
 -define(PT_KEY_CONTEXT,       {?MODULE, context}).
 -define(PT_KEY_BOOT_STATE,    {?MODULE, boot_state}).
 -define(PT_KEY_INITIAL_PASS,  {?MODULE, initial_pass_finished}).
@@ -124,6 +129,11 @@ get_context() ->
         undefined -> undefined;
         Context   -> Context#{initial_pass => is_initial_pass()}
     end.
+
+-ifdef(TEST).
+clear_context_cache() ->
+    persistent_term:erase(?PT_KEY_CONTEXT).
+-endif.
 
 get_boot_state() ->
     persistent_term:get(?PT_KEY_BOOT_STATE, stopped).

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -386,10 +386,9 @@ maybe_sd_notify() ->
     end.
 
 sd_notify_ready() ->
-    case {os:type(), os:getenv("NOTIFY_SOCKET")} of
-        {{win32, _}, _} ->
-            true;
-        {_, [_|_]} -> %% Non-empty NOTIFY_SOCKET, give it a try
+    case rabbit_prelaunch:get_context() of
+        #{systemd_notify_socket := Socket} when Socket =/= undefined ->
+            %% Non-empty NOTIFY_SOCKET, give it a try
             sd_notify_legacy() orelse sd_notify_socat();
         _ ->
             true
@@ -432,9 +431,11 @@ socat_socket_arg(UnixSocket) ->
     "unix-sendto:" ++ UnixSocket.
 
 sd_open_port() ->
+    #{systemd_notify_socket := Socket} = rabbit_prelaunch:get_context(),
+    true = Socket =/= undefined,
     open_port(
       {spawn_executable, os:find_executable("socat")},
-      [{args, [socat_socket_arg(os:getenv("NOTIFY_SOCKET")), "STDIO"]},
+      [{args, [socat_socket_arg(Socket), "STDIO"]},
        use_stdio, out]).
 
 sd_notify_socat(Unit) ->

--- a/src/rabbit_mnesia_rename.erl
+++ b/src/rabbit_mnesia_rename.erl
@@ -281,4 +281,5 @@ become(BecomeNode) ->
 
 start_distribution(Name) ->
     rabbit_nodes:ensure_epmd(),
-    net_kernel:start([Name, rabbit_nodes:name_type()]).
+    NameType = rabbit_nodes_common:name_type(Name),
+    net_kernel:start([Name, NameType]).

--- a/src/rabbit_nodes.erl
+++ b/src/rabbit_nodes.erl
@@ -41,10 +41,8 @@ boot() ->
   seed_user_provided_cluster_name().
 
 name_type() ->
-    case os:getenv("RABBITMQ_USE_LONGNAME") of
-        "true" -> longnames;
-        _      -> shortnames
-    end.
+    #{nodename_type := NodeType} = rabbit_prelaunch:get_context(),
+    NodeType.
 
 -spec names(string()) ->
           rabbit_types:ok_or_error2([{string(), integer()}], term()).


### PR DESCRIPTION
The reading of `$NOTIFY_SOCKET` is also moved at the same time. This is in preparation of the work around start/stop status.

There is an associated commit in rabbitmq-common to update `rabbit_env` and record the origin of each variable.

Depends on rabbitmq/rabbitmq-common#352.
References rabbitmq/rabbitmq-server#2180.