### PR TITLE
Introduce a persistent internal cluster ID

### DIFF
--- a/src/rabbit_nodes.erl
+++ b/src/rabbit_nodes.erl
@@ -23,23 +23,22 @@
          all_running/0, name_type/0, running_count/0,
          await_running_count/2,
          boot/0]).
+-export([persistent_cluster_id/0, seed_internal_cluster_id/0, seed_user_provided_cluster_name/0]).
 
 -include_lib("kernel/include/inet.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -define(SAMPLING_INTERVAL, 1000).
 
+-define(INTERNAL_CLUSTER_ID_PARAM_NAME, internal_cluster_id).
+
 %%----------------------------------------------------------------------------
 %% API
 %%----------------------------------------------------------------------------
 
 boot() ->
-  case application:get_env(rabbit, cluster_name) of
-    undefined  -> ok;
-    {ok, Name} ->
-      rabbit_log:info("Setting cluster name to '~s' as configured", [Name]),
-      set_cluster_name(rabbit_data_coercion:to_binary(Name))
-  end.
+  seed_internal_cluster_id(),
+  seed_user_provided_cluster_name().
 
 name_type() ->
     case os:getenv("RABBITMQ_USE_LONGNAME") of
@@ -89,6 +88,38 @@ cluster_name_default() ->
     {ID, _} = parts(node()),
     FQDN = rabbit_net:hostname(),
     list_to_binary(atom_to_list(make({ID, FQDN}))).
+
+-spec persistent_cluster_id() -> binary().
+persistent_cluster_id() ->
+    case rabbit_runtime_parameters:lookup_global(?INTERNAL_CLUSTER_ID_PARAM_NAME) of
+        not_found ->
+            seed_internal_cluster_id(),
+            persistent_cluster_id();
+        Param ->
+            #{value := Val, name := ?INTERNAL_CLUSTER_ID_PARAM_NAME} = maps:from_list(Param),
+            Val
+    end.
+
+-spec seed_internal_cluster_id() -> binary().
+seed_internal_cluster_id() ->
+    case rabbit_runtime_parameters:lookup_global(?INTERNAL_CLUSTER_ID_PARAM_NAME) of
+        not_found ->
+            Id = rabbit_guid:binary(rabbit_guid:gen(), "rabbitmq-cluster-id"),
+            rabbit_log:info("Seeding internal cluster ID to '~p'", [Id]),
+            rabbit_runtime_parameters:set_global(?INTERNAL_CLUSTER_ID_PARAM_NAME, Id, ?INTERNAL_USER),
+            Id;
+        Param ->
+            #{value := Val, name := ?INTERNAL_CLUSTER_ID_PARAM_NAME} = maps:from_list(Param),
+            Val
+    end.
+
+seed_user_provided_cluster_name() ->
+    case application:get_env(rabbit, cluster_name) of
+        undefined -> ok;
+        {ok, Name} ->
+            rabbit_log:info("Setting cluster name to '~s' as configured", [Name]),
+            set_cluster_name(rabbit_data_coercion:to_binary(Name))
+    end.
 
 -spec set_cluster_name(binary()) -> 'ok'.
 

--- a/src/rabbit_nodes.erl
+++ b/src/rabbit_nodes.erl
@@ -105,7 +105,7 @@ seed_internal_cluster_id() ->
     case rabbit_runtime_parameters:lookup_global(?INTERNAL_CLUSTER_ID_PARAM_NAME) of
         not_found ->
             Id = rabbit_guid:binary(rabbit_guid:gen(), "rabbitmq-cluster-id"),
-            rabbit_log:info("Seeding internal cluster ID to '~p'", [Id]),
+            rabbit_log:info("Initialising internal cluster ID to '~s'", [Id]),
             rabbit_runtime_parameters:set_global(?INTERNAL_CLUSTER_ID_PARAM_NAME, Id, ?INTERNAL_USER),
             Id;
         Param ->


### PR DESCRIPTION
## Proposed Changes

That the operator cannot and are not supposed to control.
The ID is cluster-wide and stored as a global runtime parameter to make
sure it is replicated across all nodes.

It is intentionally excluded from imported definitions because it is not
meant to be reused.

This ID would be useful in several features/plugins under development.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
