### PR TITLE
Override OTP handlers to gracefully shut down on SIGTERM, SIGQUIT

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -235,6 +235,12 @@
                     {requires,    pre_flight}
                     ]}).
 
+-rabbit_boot_step({os_signal_handler,
+                   [{description, "registers an OS signal handler"},
+                    {mfa,         {rabbit_sup, start_restartable_child,
+                                   [rabbit_os_signal_handler]}},
+                    {requires,    pre_flight}]}).
+
 -rabbit_boot_step({direct_client,
                    [{description, "direct client"},
                     {mfa,         {rabbit_direct, boot, []}},

--- a/src/rabbit_os_signal_handler.erl
+++ b/src/rabbit_os_signal_handler.erl
@@ -1,0 +1,57 @@
+-module(rabbit_os_signal_handler).
+
+-behaviour(gen_event).
+
+-export([start_link/0, init/1,
+         handle_event/2, handle_call/2, handle_info/2,
+         terminate/2]).
+
+%%
+%% API
+%%
+
+start_link() ->
+    rabbit_log:info("Swapping OS signal event handler (erl_signal_server) for our own"),
+    %% delete any previous incarnations, otherwise we would be accumulating
+    %% handlers
+    _ = gen_event:delete_handler(erl_signal_server, ?MODULE, []),
+    %% swap the standard OTP signal handler if there is one
+    ok = gen_event:swap_sup_handler(
+        erl_signal_server,
+        %% what to swap
+        {erl_signal_handler, []},
+        %% new event handler
+        {?MODULE, []}),
+    gen_event:start_link({local, ?MODULE}).
+
+init(_) ->
+    {ok, #{}}.
+
+handle_event(sigterm, State) ->
+    rabbit_log:info("Received a SIGTERM, will shut down gracefully"),
+    rabbit:stop_and_halt(),
+    {ok, State};
+handle_event(sigquit, State) ->
+    rabbit_log:info("Received a SIGQUIT, will shut down gracefully"),
+    rabbit:stop_and_halt(),
+    {ok, State};
+handle_event(sigusr1, State) ->
+    rabbit_log:info("Received a SIGUSR1, ignoring it"),
+    {ok, State};
+%% note: SIGHUP can/will be handled by shells and process managers
+handle_event(sighup, State) ->
+    rabbit_log:info("Received a SIGHUP, ignoring it"),
+    {ok, State};
+handle_event(Msg, S) ->
+    %% delegate all unknown events to the default OTP signal handler
+    erl_signal_handler:handle_event(Msg, S),
+    {ok, S}.
+
+handle_info(_, State) ->
+    {ok, State}.
+
+handle_call(_Request, State) ->
+    {ok, ok, State}.
+
+terminate(_Args, _State) ->
+    ok.


### PR DESCRIPTION
## Proposed Changes

This overrides default OTP signal handler (available as of OTP 20+) with our own, otherwise the default handler will terminate the runtime.

Pair: @vanlightly.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2222)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #2222.
