### PR TITLE
Handle and raise protocol error for absent queues assumed to be alive

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -770,7 +770,7 @@ priv_absent(QueueName, _QPid, _IsDurable, timeout) ->
 priv_absent(QueueName, QPid, _IsDurable, alive) ->
     rabbit_misc:protocol_error(
       not_found,
-      "failed to perform operation on ~s: its master replica ~s may be stopping or being demoted",
+      "failed to perform operation on ~s: its master replica ~w may be stopping or being demoted",
       [rabbit_misc:rs(QueueName), QPid]).
 
 -spec assert_equivalence


### PR DESCRIPTION
## Proposed Changes

Hey guys, I think this was supposed to be part of https://github.com/rabbitmq/rabbitmq-server/pull/1685. An `E({absent, Q, alive});` was introduced, but the appropriate handling in the error handler fun `E`, was not implemented.

This is `priv_absent\4` in **master** & **v3.8.x**, and `rabbit_misc:absent\2` in **v3.7.x**.
Opening a separate PR for **v3.7.x**



## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
