### PR TITLE
rabbitmq_prelaunch: Fix all warnings reported by Dialyzer

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -219,6 +219,7 @@ remove_pid_file(#{pid_file := PidFile, keep_pid_file_on_exit := true}) ->
     ok;
 remove_pid_file(#{pid_file := PidFile}) ->
     rabbit_log_prelaunch:debug("Deleting PID file: ~s", [PidFile]),
-    _ = file:delete(PidFile);
+    _ = file:delete(PidFile),
+    ok;
 remove_pid_file(_) ->
     ok.

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -33,9 +33,11 @@ do_setup(#{nodename := Node, nodename_type := NameType}) ->
             %% "minimum transition traffic interval" as defined in
             %% net_kernel:set_net_ticktime/1.
             MTTI = Ticktime * 1000 div 4,
-            {ok, _} = net_kernel:start([Node, NameType, MTTI]);
+            {ok, _} = net_kernel:start([Node, NameType, MTTI]),
+            ok;
         _ ->
-            {ok, _} = net_kernel:start([Node, NameType])
+            {ok, _} = net_kernel:start([Node, NameType]),
+            ok
     end,
     ok.
 
@@ -53,7 +55,7 @@ duplicate_node_check(#{split_nodename := {NodeName, NodeHost}}) ->
                 true ->
                     throw({error, {duplicate_node_name, NodeName, NodeHost}});
                 false ->
-                    net_kernel:stop(),
+                    ok = net_kernel:stop(),
                     ok
             end;
         {error, EpmdReason} ->

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -35,8 +35,9 @@ do_setup_early_logging(#{log_levels := LogLevels} = Context,
                             #{global := Level} -> Level;
                             _                  -> warning
                         end,
-            lager_app:start_handler(
-              lager_event, ConsoleBackend, [{level, GLogLevel}]);
+            _ = lager_app:start_handler(
+                  lager_event, ConsoleBackend, [{level, GLogLevel}]),
+            ok;
         false ->
             ok
     end,
@@ -99,8 +100,10 @@ get_log_level(LogLevels, Sink) ->
 
 enable_quick_dbg(#{dbg_output := Output, dbg_mods := Mods}) ->
     case Output of
-        stdout -> {ok, _} = dbg:tracer();
-        _      -> {ok, _} = dbg:tracer(port, dbg:trace_port(file, Output))
+        stdout -> {ok, _} = dbg:tracer(),
+                  ok;
+        _      -> {ok, _} = dbg:tracer(port, dbg:trace_port(file, Output)),
+                  ok
     end,
     {ok, _} = dbg:p(all, c),
     lists:foreach(fun(M) -> {ok, _} = dbg:tp(M, cx) end, Mods).

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_errors.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_errors.erl
@@ -103,7 +103,10 @@ log_message(Message) ->
               ?BOOT_FAILED_FOOTER,
               [$\n],
               all),
-    [rabbit_log_prelaunch:error("~s", [Line]) || Line <- Lines],
-    [io:format(standard_error, "~s~n", [Line]) || Line <- Lines],
+    lists:foreach(
+      fun(Line) ->
+              rabbit_log_prelaunch:error("~s", [Line]),
+              io:format(standard_error, "~s~n", [Line])
+      end, Lines),
     timer:sleep(1000),
     ok.


### PR DESCRIPTION
Those are all return values being unmatched. Many were related to list comprehensions being used as a loop mechanism but the result was unused. These list comprehensions were replaced by `lists:foreach/2`.

References #2180.