### PR TITLE
Add ability to customize product name, version & banner

### DIFF
--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -520,6 +520,17 @@
 ##
 # proxy_protocol = false
 
+## Overriden product name and version.
+## They are set to "RabbitMQ" and the release version by default.
+# product.name = RabbitMQ
+# product.version = 1.2.3
+
+## "Message of the day" file.
+## Its content is used to expand the logged and printed banners.
+## Default to /etc/rabbitmq/motd on Unix, %APPDATA%\RabbitMQ\motd.txt
+## on Windows.
+# motd_file = /etc/rabbitmq/motd
+
 ## ----------------------------------------------------------------------------
 ## Advanced Erlang Networking/Clustering Options.
 ##

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1,3 +1,4 @@
+% vim:ft=erlang:
 % ==============================
 % Rabbit app section
 % ==============================
@@ -1108,6 +1109,23 @@ end}.
 {mapping, "consumer_timeout", "rabbit.consumer_timeout", [
     {datatype, integer},
     {validators, ["non_zero_positive_integer"]}
+]}.
+
+%% Product name & version overrides.
+
+{mapping, "product.name", "rabbit.product_name", [
+    {datatype, string}
+]}.
+{mapping, "product.version", "rabbit.product_version", [
+    {datatype, string}
+]}.
+
+%% Message of the day file.
+%% The content of that file is added to the banners, both logged and
+%% printed.
+
+{mapping, "motd_file", "rabbit.motd_file", [
+    {datatype, string}
 ]}.
 
 % ==========================


### PR DESCRIPTION
To override the product name (defaulting to "RabbitMQ"):
* set the `$RABBITMQ_PRODUCT_NAME` environment variable, or
* set the `rabbit` application `product_name` variable.

To override the product version:
* set the `$RABBITMQ_PRODUCT_VERSION` environment variable, or
* set the `rabbit` application `product_version` variable.

To add content to the banner (both the copy logged and the one printed to stdout), indicate the filename which contains it, à la `/etc/motd` using:
* the `$RABBITMQ_MOTD_FILE` environment variable, or
* the `rabbit` application `motd_file` variable.

The default motd file is `/etc/rabbitmq/motd` on Unix and `%APPDATA%\RabbitMQ\motd.txt` on Windows.

Here is an example of the printed banner with name, version & motd configured:

```
  ##  ##      WeatherMQ 1.2.3
  ##  ##
  ##########  Copyright (c) 2007-2020 Pivotal Software, Inc.
  ######  ##
  ##########  Licensed under the MPL 1.1. Website: https://rabbitmq.com

  This is an example of a RabbitMQ message of the day.

  The message is written in Paris, France.    \  /
  It is partly cloudy outside, with a       _ /"".-.
  temperature of 12°C. Wind is around         \_(   ).
  30-40 km/h, from south-west.                /(___(__)

  Doc guides: https://rabbitmq.com/documentation.html
  Support:    https://rabbitmq.com/contact.html
  Tutorials:  https://rabbitmq.com/getstarted.html
  Monitoring: https://rabbitmq.com/monitoring.html

  Logs: /tmp/rabbitmq-test-instances/rabbit/log/rabbit@cassini.log
        /tmp/rabbitmq-test-instances/rabbit/log/rabbit@cassini_upgrade.log

  Config file(s): /tmp/rabbitmq-test-instances/test.config

  Starting broker... completed with 0 plugins.
```

New APIS are available to query those product informations and use them in e.g. plugins such as the management API/UI:
* `rabbit:product_info/0`
* `rabbit:product_name/0`
* `rabbit:product_version/0`
* `rabbit:motd_file/0`
* `rabbit:motd/0`

Depends on rabbitmq/rabbitmq-common#356.