### PR TITLE
Split QQ remove member into two operations

### DIFF
--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -1419,12 +1419,10 @@ delete_member_during_node_down(Config) ->
                                     Config, nodename),
 
     stop_node(Config, DownServer),
-    % rabbit_ct_broker_helpers:stop_node(Config, DownServer),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     QQ = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', QQ, 0, 0},
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
-    % RaName = ra_name(QQ),
     timer:sleep(200),
     ?assertEqual(ok, rpc:call(Server, rabbit_quorum_queue, delete_member,
                               [<<"/">>, QQ, Server])),


### PR DESCRIPTION
To avoid not updating the amqqueue record if the server data delete part
failed but the Raft cluster was still updated. Also add a function to
repair the quorum queue queue type nodes in the amqqrecord if it should
diverge from what the Ra cluster thinks.

[#171434221]

Works best with latest Ra master, specifically: https://github.com/rabbitmq/ra/commit/6923e079134b92b4e1f193af5e23d7be300750bb