### PR TITLE
Fix QQ crash recovery bug

### DIFF
--- a/src/rabbit_fifo.hrl
+++ b/src/rabbit_fifo.hrl
@@ -104,9 +104,9 @@
 -record(cfg,
         {name :: atom(),
          resource :: rabbit_types:r('queue'),
-         release_cursor_interval =
-             {?RELEASE_CURSOR_EVERY, ?RELEASE_CURSOR_EVERY} ::
-             non_neg_integer() | {non_neg_integer(), non_neg_integer()},
+         release_cursor_interval ::
+             undefined | non_neg_integer() |
+             {non_neg_integer(), non_neg_integer()},
          dead_letter_handler :: option(applied_mfa()),
          become_leader_handler :: option(applied_mfa()),
          max_length :: option(non_neg_integer()),


### PR DESCRIPTION
When using dead letter handlers the state machine would crash when a
prefix_msg was being dead-lettered on recovery. This handles this case
and also fixes an issue where the incorrect initial release cursor
interval would have been set when overriding the release cursor default.

[#171463230]
