### PR TITLE
rabbit_prelaunch_sighandler: Comment out code which is unused

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_sighandler.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_sighandler.erl
@@ -65,11 +65,14 @@ handle_event(Signal, State) when ?SIGNAL_HANDLED_BY_ERLANG(Signal) ->
     {ok, State};
 handle_event(Signal, State) ->
     case ?SIGNALS_HANDLED_BY_US of
-        #{Signal := stop} ->
-            error_logger:info_msg(
-              "~s received - shutting down~n",
-              [string:uppercase(atom_to_list(Signal))]),
-            ok = init:stop();
+        %% The code below can be uncommented if we introduce a signal
+        %% which should stop RabbitMQ.
+        %
+        %#{Signal := stop} ->
+        %    error_logger:info_msg(
+        %      "~s received - shutting down~n",
+        %      [string:uppercase(atom_to_list(Signal))]),
+        %    ok = init:stop();
         _ ->
             error_logger:info_msg(
               "~s received - unhandled signal~n",


### PR DESCRIPTION
As it is ready to handle the stop of RabbitMQ and has been tested, we can keep the code around just in case.

However, this causes a Dialyzer error which must be fixed, so let's comment it out.

Follow-up to #2244.
References #2180.