### PR TITLE
Optimise messages_ready function by keeping counts of prefix messages

### DIFF
--- a/src/rabbit_fifo.hrl
+++ b/src/rabbit_fifo.hrl
@@ -119,6 +119,10 @@
          max_in_memory_bytes :: option(non_neg_integer())
         }).
 
+-type prefix_msgs() :: {list(), list()} |
+                       {non_neg_integer(), list(),
+                        non_neg_integer(), list()}.
+
 -record(rabbit_fifo,
         {cfg :: #cfg{},
          % unassigned messages
@@ -161,8 +165,7 @@
          %% overflow calculations).
          %% This is done so that consumers are still served in a deterministic
          %% order on recovery.
-         prefix_msgs = {[], []} :: {Return :: [msg_header() | {'$empty_msg', msg_header()}],
-                                    PrefixMsgs :: [msg_header() | {msg_header(), 'empty'}]},
+         prefix_msgs = {0, [], 0, []} :: prefix_msgs(),
          msg_bytes_enqueue = 0 :: non_neg_integer(),
          msg_bytes_checkout = 0 :: non_neg_integer(),
          %% waiting consumers, one is picked active consumer is cancelled or dies

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -249,7 +249,7 @@ all_replica_states() ->
 list_with_minimum_quorum() ->
     filter_quorum_critical(rabbit_amqqueue:list_local_quorum_queues()).
 
--spec list_with_minimum_quorum_for_cli() -> [amqqueue:amqqueue()].
+-spec list_with_minimum_quorum_for_cli() -> [#{binary() => term()}].
 list_with_minimum_quorum_for_cli() ->
     QQs = list_with_minimum_quorum(),
     [begin


### PR DESCRIPTION
rather than taking length/1. There could be a lot of prefix messages
during during recovery which could make recovery unbearably slow.
