### PR TITLE
Require Erlang/OTP 21.3 + Add support for Erlang/OTP 23.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 elixir:
   - '1.9'
 otp_release:
-  - '20.3'
+  - '21.3'
   - '22.2'
 
 install:

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -587,8 +587,8 @@ handle_cast({method, Method, Content, Flow},
         exit:Reason = #amqp_error{} ->
             MethodName = rabbit_misc:method_record_type(Method),
             handle_exception(Reason#amqp_error{method = MethodName}, State);
-        _:Reason ->
-            {stop, {Reason, erlang:get_stacktrace()}, State}
+        _:Reason:Stacktrace ->
+            {stop, {Reason, Stacktrace}, State}
     end;
 
 handle_cast(ready_for_close, State = #ch{state      = closing,

--- a/src/rabbit_node_monitor.erl
+++ b/src/rabbit_node_monitor.erl
@@ -740,10 +740,10 @@ register_outside_app_process(Fun, WaitForExistingProcess) ->
 do_run_outside_app_fun(Fun) ->
     try
         Fun()
-    catch _:E ->
+    catch _:E:Stacktrace ->
             rabbit_log:error(
               "rabbit_outside_app_process:~n~p~n~p~n",
-              [E, erlang:get_stacktrace()])
+              [E, Stacktrace])
     end.
 
 wait_for_cluster_recovery(Condition) ->

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1128,9 +1128,8 @@ handle_method0(MethodName, FieldsBin,
             throw({connection_closed_abruptly, State});
           exit:#amqp_error{method = none} = Reason ->
             handle_exception(State, 0, Reason#amqp_error{method = MethodName});
-          Type:Reason ->
-            Stack = erlang:get_stacktrace(),
-            handle_exception(State, 0, {Type, Reason, MethodName, Stack})
+          Type:Reason:Stacktrace ->
+            handle_exception(State, 0, {Type, Reason, MethodName, Stacktrace})
     end.
 
 handle_method0(#'connection.start_ok'{mechanism = Mechanism,

--- a/src/rabbit_vhost_process.erl
+++ b/src/rabbit_vhost_process.erl
@@ -59,11 +59,11 @@ init([VHost]) ->
         timer:send_interval(Interval, check_vhost),
         true = erlang:garbage_collect(),
         {ok, VHost}
-    catch _:Reason ->
+    catch _:Reason:Stacktrace ->
         rabbit_amqqueue:mark_local_durable_queues_stopped(VHost),
         rabbit_log:error("Unable to recover vhost ~p data. Reason ~p~n"
                          " Stacktrace ~p",
-                         [VHost, Reason, erlang:get_stacktrace()]),
+                         [VHost, Reason, Stacktrace]),
         {stop, Reason}
     end.
 


### PR DESCRIPTION
Depends on rabbitmq/rabbitmq-common#360.