### PR TITLE
rabbit_fifo: force gc when queue is empty

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -684,9 +684,9 @@ eval_gc(Log, #?MODULE{cfg = #cfg{resource = QR}} = MacState,
                Mem > ?GC_MEM_LIMIT_B ->
             garbage_collect(),
             {memory, MemAfter} = erlang:process_info(self(), memory),
-            rabbit_log:info("~s: forcing full sweep GC "
-                            "Before ~b After ~b",
-                            [rabbit_misc:rs(QR), Mem, MemAfter]),
+            rabbit_log:debug("~s: full GC sweep complete. "
+                            "Process memory reduced from ~.2fMB to ~.2fMB.",
+                            [rabbit_misc:rs(QR), Mem/?MB, MemAfter/?MB]),
             AuxState#aux{gc = Gc#aux_gc{last_raft_idx = Idx}};
         _ ->
             AuxState

--- a/src/rabbit_fifo.hrl
+++ b/src/rabbit_fifo.hrl
@@ -70,6 +70,9 @@
 -define(RELEASE_CURSOR_EVERY, 64000).
 -define(RELEASE_CURSOR_EVERY_MAX, 3200000).
 -define(USE_AVG_HALF_LIFE, 10000.0).
+%% an average QQ without any message uses about 100KB so setting this limit
+%% to ~10 times that should be relatively safe.
+-define(GC_MEM_LIMIT_B, 2000000).
 
 -record(consumer,
         {meta = #{} :: consumer_meta(),

--- a/src/rabbit_fifo.hrl
+++ b/src/rabbit_fifo.hrl
@@ -74,6 +74,8 @@
 %% to ~10 times that should be relatively safe.
 -define(GC_MEM_LIMIT_B, 2000000).
 
+-define(MB, 1048576).
+
 -record(consumer,
         {meta = #{} :: consumer_meta(),
          checked_out = #{} :: #{msg_id() => {msg_in_id(), indexed_msg()}},


### PR DESCRIPTION
And it uses more than a fixed limit of ~2Mb of total memory. An empty
queue should only need around ~100-200Kb of memory so this should avoid
any unnecessary full sweeps.

[#171644231]
