### PR TITLE
Always handle config files with Cuttlefish

### DIFF
--- a/src/rabbit_config.erl
+++ b/src/rabbit_config.erl
@@ -1,10 +1,12 @@
 -module(rabbit_config).
 
 -export([
-         schema_dir/0,
          config_files/0,
          get_advanced_config/0
         ]).
+
+-export([schema_dir/0]).
+-deprecated([{schema_dir, 0, eventually}]).
 
 -export_type([config_location/0]).
 
@@ -17,14 +19,7 @@ get_confs() ->
     end.
 
 schema_dir() ->
-    case init:get_argument(conf_schema_dir) of
-        {ok, SchemaDir} -> SchemaDir;
-        _ ->
-            case code:priv_dir(rabbit) of
-                {error, bad_name} -> filename:join([".", "priv", "schema"]);
-                PrivDir           -> filename:join([PrivDir, "schema"])
-            end
-    end.
+    undefined.
 
 get_advanced_config() ->
     case get_prelaunch_config_state() of

--- a/src/rabbit_config.erl
+++ b/src/rabbit_config.erl
@@ -10,24 +10,10 @@
 
 -type config_location() :: string().
 
-%% we support both the classic Erlang term
-%% config file (rabbitmq.config) as well as rabbitmq.conf
-legacy_erlang_term_config_used() ->
-    case get_prelaunch_config_state() of
-        #{config_type := erlang,
-          config_advanced_file := undefined} ->
-            true;
-        _ ->
-            false
-    end.
-
 get_confs() ->
     case get_prelaunch_config_state() of
-        #{config_files := Confs} ->
-            [ filename:rootname(Conf, ".conf") ++ ".conf"
-              || Conf <- Confs ];
-        _ ->
-            []
+        #{config_files := Confs} -> Confs;
+        _                        -> []
     end.
 
 schema_dir() ->
@@ -43,7 +29,7 @@ schema_dir() ->
 get_advanced_config() ->
     case get_prelaunch_config_state() of
         %% There can be only one advanced.config
-        #{config_advanced_file := FileName} ->
+        #{config_advanced_file := FileName} when FileName =/= undefined ->
             case rabbit_file:is_file(FileName) of
                 true  -> FileName;
                 false -> none
@@ -53,47 +39,13 @@ get_advanced_config() ->
 
 -spec config_files() -> [config_location()].
 config_files() ->
-    case legacy_erlang_term_config_used() of
-        true ->
-            case get_prelaunch_config_state() of
-                #{config_files := Files} ->
-                    [ filename:absname(filename:rootname(File) ++ ".config")
-                      || File <- Files];
-                _ ->
-                    case config_setting() of
+    ConfFiles = [filename:absname(File) || File <- get_confs(),
+                                           filelib:is_regular(File)],
+    AdvancedFiles = case get_advanced_config() of
                         none -> [];
-                        File -> [filename:absname(filename:rootname(File, ".config") ++ ".config")
-                                 ++
-                                 " (not found)"]
-                    end
-            end;
-        false ->
-            ConfFiles = [filename:absname(File) || File <- get_confs(),
-                                                   filelib:is_regular(File)],
-            AdvancedFiles = case get_advanced_config() of
-                none -> [];
-                FileName -> [filename:absname(FileName)]
-            end,
-            AdvancedFiles ++ ConfFiles
-
-    end.
+                        FileName -> [filename:absname(FileName)]
+                    end,
+    AdvancedFiles ++ ConfFiles.
 
 get_prelaunch_config_state() ->
     rabbit_prelaunch_conf:get_config_state().
-
-%% This is a pain. We want to know where the config file is. But we
-%% can't specify it on the command line if it is missing or the VM
-%% will fail to start, so we need to find it by some mechanism other
-%% than init:get_arguments/0. We can look at the environment variable
-%% which is responsible for setting it... but that doesn't work for a
-%% Windows service since the variable can change and the service not
-%% be reinstalled, so in that case we add a magic application env.
-config_setting() ->
-    case application:get_env(rabbit, windows_service_config) of
-        {ok, File1} -> File1;
-        undefined   ->
-            case application:get_env(rabbitmq_prelaunch, context) of
-                #{main_config_file := File2} -> File2;
-                _                            -> none
-            end
-    end.


### PR DESCRIPTION
This has several benefits:

1.  It simplifies the code, all configuration being handled by the same code path (no more condition on Erlang-term-based vs. Cuttlefish). `rabbit_config` shrinks quite a lot in the process.

2.  We can use additional configuration files AND an Erlang-term-based configuration file. In other words, it is possible to use the same existing Erlang-term-based file and introduce Cuttlefish files when needed.

    It allows a user to run RabbitMQ with:

    ```
    RABBITMQ_CONFIG_FILE=/path/to/rabbitmq.config \
    RABBITMQ_CONFIG_FILES=/path/to/conf.d/*.conf \
    ./sbin/rabbitmq-server
    ```

    A developer can do the same with `make run-broker`:

    ```
    make run-broker \
    RABBITMQ_CONFIG_FILES=/path/to/conf.d/*.conf
    ```

    In the example above, the main configuration file generated by rabbitmq-run.mk is an Erlang-term-based one.

This is implemented by calling Cuttlefish with a (possibly empty) list of additional files and the Erlang-term-based file as the advanced configuration file.

References #2180.