### PR TITLE
clustering_management_SUITE: No need to stop node after start_app failure in `erlang_config`

### DIFF
--- a/test/clustering_management_SUITE.erl
+++ b/test/clustering_management_SUITE.erl
@@ -632,35 +632,26 @@ erlang_config(Config) ->
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, {["Mike's computer"], disc}]),
-    %% Rabbit app stops abnormally, node goes down
+    %% Rabbit app stops abnormally
     assert_failure(fun () -> start_app(Hare) end),
     assert_not_clustered(Rabbit),
 
     %% If we use an invalid node type, the node fails to start.
-    %% The Erlang VM has stopped after previous rabbit app failure
-    rabbit_ct_broker_helpers:start_node(Config, Hare),
-    ok = stop_app(Hare),
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, {[Rabbit], blue}]),
-    %% Rabbit app stops abnormally, node goes down
+    %% Rabbit app stops abnormally
     assert_failure(fun () -> start_app(Hare) end),
     assert_not_clustered(Rabbit),
 
     %% If we use an invalid cluster_nodes conf, the node fails to start.
-    %% The Erlang VM has stopped after previous rabbit app failure
-    rabbit_ct_broker_helpers:start_node(Config, Hare),
-    ok = stop_app(Hare),
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, true]),
-    %% Rabbit app stops abnormally, node goes down
+    %% Rabbit app stops abnormally
     assert_failure(fun () -> start_app(Hare) end),
     assert_not_clustered(Rabbit),
 
-    %% The Erlang VM has stopped after previous rabbit app failure
-    rabbit_ct_broker_helpers:start_node(Config, Hare),
-    ok = stop_app(Hare),
     ok = reset(Hare),
     ok = rpc:call(Hare, application, set_env,
                   [rabbit, cluster_nodes, "Yes, please"]),


### PR DESCRIPTION
Since #2180, a failed `start_app` does not take the node down anymore. Restarting the node just after was failing since (because the node is still there), but this remained unnoticed so far because the return value of `start_node()` is not checked.

However, since rabbitmq/rabbitmq-ct-helpers@c033d9272afaf3575505533c81f1c0c7cfcb6206, the Make recipe which starts the node automatically stops it if the start failed somewhere. This is in order to not leave an unwanted node around.

This means that after the failing `rabbit_ct_broker_helpers:start_node()`, the node was effectively stopped this time, leading to the rest of the testcase to fail.