### PR TITLE
Remove Ra segment_max_entries override

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -105,8 +105,6 @@ set_default_config() ->
     Config = [
               {ra,
                [
-                %% Use a larger segments size for queues.
-                {segment_max_entries, 32768},
                 {wal_max_size_bytes, 536870912} %% 5 * 2 ^ 20
                ]},
               {sysmon_handler,


### PR DESCRIPTION
So that it uses Ra's internal default of 4096 instead which is safer for
larger message sizes.
