### PR TITLE
Ensure randomized_startup_delay_range custom value is used

### DIFF
--- a/src/rabbit_peer_discovery.erl
+++ b/src/rabbit_peer_discovery.erl
@@ -29,16 +29,22 @@
          lock_acquisition_failure_mode/0]).
 
 -define(DEFAULT_BACKEND,   rabbit_peer_discovery_classic_config).
+
 %% what node type is used by default for this node when joining
 %% a new cluster as a virgin node
 -define(DEFAULT_NODE_TYPE, disc).
+
 %% default node prefix to attach to discovered hostnames
 -define(DEFAULT_PREFIX, "rabbit").
+
 %% default randomized delay range, in seconds
 -define(DEFAULT_STARTUP_RANDOMIZED_DELAY, {5, 60}).
 
--define(NODENAME_PART_SEPARATOR, "@").
+%% default discovery retries and interval.
+-define(DEFAULT_DISCOVERY_RETRY_COUNT, 10).
+-define(DEFAULT_DISCOVERY_RETRY_INTERVAL_MS, 500).
 
+-define(NODENAME_PART_SEPARATOR, "@").
 
 -spec backend() -> atom().
 
@@ -155,11 +161,11 @@ maybe_unregister() ->
 discovery_retries() ->
     case application:get_env(rabbit, cluster_formation) of
         {ok, Proplist} ->
-            Retries  = proplists:get_value(discovery_retry_limit,    Proplist, 10),
-            Interval = proplists:get_value(discovery_retry_interval, Proplist, 500),
+            Retries  = proplists:get_value(discovery_retry_limit,    Proplist, ?DEFAULT_DISCOVERY_RETRY_COUNT),
+            Interval = proplists:get_value(discovery_retry_interval, Proplist, ?DEFAULT_DISCOVERY_RETRY_INTERVAL_MS),
             {Retries, Interval};
         undefined ->
-            {10, 500}
+            {?DEFAULT_DISCOVERY_RETRY_COUNT, ?DEFAULT_DISCOVERY_RETRY_INTERVAL_MS}
     end.
 
 

--- a/test/peer_discovery_classic_config_SUITE.erl
+++ b/test/peer_discovery_classic_config_SUITE.erl
@@ -34,11 +34,11 @@ all() ->
 
 groups() ->
     [
-      {non_parallel, [], [
-                          successful_discovery
-                          , successful_discovery_with_a_subset_of_nodes_coming_online
-                          , no_nodes_configured
-                         ]}
+     {non_parallel, [], [
+                         successful_discovery,
+                         successful_discovery_with_a_subset_of_nodes_coming_online,
+                         no_nodes_configured
+                        ]}
     ].
 
 suite() ->
@@ -64,7 +64,7 @@ init_per_group(_, Config) ->
 end_per_group(_, Config) ->
     Config.
 
-init_per_testcase(Testcase, Config) when Testcase =:= successful_discovery->
+init_per_testcase(successful_discovery = Testcase, Config) ->
     Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
 
     N = 3,
@@ -82,12 +82,14 @@ init_per_testcase(Testcase, Config) when Testcase =:= successful_discovery->
     Config3 = rabbit_ct_helpers:merge_app_env(Config2,
       {rabbit, [
           {cluster_nodes, {NodeNamesWithHostname, disc}},
-          {randomized_startup_delay_range, {1, 10}}
+          {cluster_formation, [
+              {randomized_startup_delay_range, {1, 10}}
+          ]}
       ]}),
     rabbit_ct_helpers:run_steps(Config3,
       rabbit_ct_broker_helpers:setup_steps() ++
       rabbit_ct_client_helpers:setup_steps());
-init_per_testcase(Testcase, Config) when Testcase =:= successful_discovery_with_a_subset_of_nodes_coming_online->
+init_per_testcase(successful_discovery_with_a_subset_of_nodes_coming_online = Testcase, Config) ->
     Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
 
     N = 2,
@@ -111,7 +113,9 @@ init_per_testcase(Testcase, Config) when Testcase =:= successful_discovery_with_
               {discovery_retry_interval, 200}
           ]},
           {cluster_nodes, {NodeNamesWithHostname, disc}},
-          {randomized_startup_delay_range, {1, 10}}
+          {cluster_formation, [
+              {randomized_startup_delay_range, {1, 10}}
+          ]}
       ]}),
     rabbit_ct_helpers:run_steps(Config3,
       rabbit_ct_broker_helpers:setup_steps() ++
@@ -126,7 +130,9 @@ init_per_testcase(no_nodes_configured = Testcase, Config) ->
     Config3 = rabbit_ct_helpers:merge_app_env(Config2,
       {rabbit, [
           {cluster_nodes, {[], disc}},
-          {randomized_startup_delay_range, {1, 10}}
+          {cluster_formation, [
+              {randomized_startup_delay_range, {1, 10}}
+          ]}
       ]}),
     rabbit_ct_helpers:run_steps(Config3,
       rabbit_ct_broker_helpers:setup_steps() ++


### PR DESCRIPTION
This ensure the test completes within the 90sec time limit

https://pivotal.slack.com/archives/C055BSG8E/p1585840790221000

https://github.com/rabbitmq/rabbitmq-server/commit/609501c46d7e18a7ea103bfa0188e73c3c4fc951#commitcomment-38268475

https://github.com/rabbitmq/rabbitmq-server/runs/554943501?check_suite_focus=true#step:6:74