### PR TITLE
feature_flags_SUITE: Work around CLI/rabbitmq-server circular dependency

### DIFF
--- a/scripts/rabbitmq-env
+++ b/scripts/rabbitmq-env
@@ -105,8 +105,8 @@ saved_RABBITMQ_PID_FILE="$RABBITMQ_PID_FILE"
 ## Get configuration variables from the configure environment file
 [ "x" = "x$RABBITMQ_CONF_ENV_FILE" ] && RABBITMQ_CONF_ENV_FILE=${CONF_ENV_FILE}
 if [ -f "${RABBITMQ_CONF_ENV_FILE}" ]; then
-	CONF_ENV_FILE_PHASE=rabbitmq-env
-	. ${RABBITMQ_CONF_ENV_FILE} || true
+    CONF_ENV_FILE_PHASE=rabbitmq-env
+    . ${RABBITMQ_CONF_ENV_FILE} || true
 fi
 
 [ -n "$ERL_EPMD_PORT" ] && export ERL_EPMD_PORT

--- a/test/feature_flags_SUITE.erl
+++ b/test/feature_flags_SUITE.erl
@@ -125,7 +125,8 @@ init_per_group(clustering, Config) ->
                  {rmq_nodes_clustered, false},
                  {start_rmq_with_plugins_disabled, true}]),
     rabbit_ct_helpers:run_setup_steps(Config1, [
-        fun build_my_plugin/1
+        fun build_my_plugin/1,
+        fun work_around_cli_and_rabbit_circular_dep/1
       ]);
 init_per_group(activating_plugin, Config) ->
     Config1 = rabbit_ct_helpers:set_config(
@@ -134,7 +135,8 @@ init_per_group(activating_plugin, Config) ->
                  {rmq_nodes_clustered, true},
                  {start_rmq_with_plugins_disabled, true}]),
     rabbit_ct_helpers:run_setup_steps(Config1, [
-        fun build_my_plugin/1
+        fun build_my_plugin/1,
+        fun work_around_cli_and_rabbit_circular_dep/1
       ]);
 init_per_group(_, Config) ->
     Config.
@@ -958,9 +960,42 @@ list_my_plugin_plugins(PluginSrcDir) ->
       end, Files).
 
 remove_other_plugins(PluginSrcDir, OtherPlugins) ->
-    [ok = file:delete(
-            filename:join(PluginSrcDir, Filename))
+    [ok = file:delete(filename:join(PluginSrcDir, Filename))
      || Filename <- OtherPlugins].
+
+work_around_cli_and_rabbit_circular_dep(Config) ->
+    %% FIXME: We also need to copy `rabbit` in `my_plugins` plugins
+    %% directory, not because `my_plugin` depends on it, but because the
+    %% CLI erroneously depends on the broker.
+    %%
+    %% This can't be fixed easily because this is a circular dependency
+    %% (i.e. the broker depends on the CLI). So until a proper solution
+    %% is implemented, keep this second copy of the broker for the CLI
+    %% to find it.
+    InitialPluginsDir = filename:join(
+                          ?config(current_srcdir, Config),
+                          "plugins"),
+    PluginsDir = ?config(rmq_plugins_dir, Config),
+    lists:foreach(
+      fun(Path) ->
+              Filename = filename:basename(Path),
+              IsRabbit = re:run(
+                           Filename,
+                           "^rabbit-", [{capture, none}]) =:= match,
+              case IsRabbit of
+                  true ->
+                      Dest = filename:join(PluginsDir, Filename),
+                      ct:pal(
+                        ?LOW_IMPORTANCE,
+                        "Copy `~s` to `~s` to fix CLI erroneous "
+                        "dependency on `rabbit`", [Path, Dest]),
+                      {ok, _} = file:copy(Path, Dest);
+                  false ->
+                      ok
+              end
+      end,
+      filelib:wildcard(filename:join(InitialPluginsDir, "*"))),
+    Config.
 
 enable_feature_flag_on(Config, Node, FeatureName) ->
     rabbit_ct_broker_helpers:rpc(


### PR DESCRIPTION
We need to copy `rabbit` in `my_plugins` plugins directory, not because `my_plugin` depends on it, but because the CLI erroneously depends on the broker.

This can't be fixed easily because this is a circular dependency (i.e. the broker depends on the CLI). So until a proper solution is implemented, keep this second copy of the broker for the CLI to find it.
