### PR TITLE
Remove flaky tests

### DIFF
--- a/test/confirms_rejects_SUITE.erl
+++ b/test/confirms_rejects_SUITE.erl
@@ -19,7 +19,6 @@ groups() ->
       {parallel_tests, [parallel], [
         {overflow_reject_publish_dlx, [parallel], OverflowTests},
         {overflow_reject_publish, [parallel], OverflowTests},
-        dead_queue_rejects,
         mixed_dead_alive_queues_reject
       ]}
     ].
@@ -65,7 +64,6 @@ init_per_testcase(policy_resets_to_default = Testcase, Config) ->
         rabbit_ct_helpers:set_config(Config, [{conn, Conn}]), Testcase);
 init_per_testcase(Testcase, Config)
         when Testcase == confirms_rejects_conflict;
-             Testcase == dead_queue_rejects;
              Testcase == mixed_dead_alive_queues_reject ->
     Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config),
     Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config),
@@ -92,10 +90,6 @@ end_per_testcase(confirms_rejects_conflict = Testcase, Config) ->
     QueueName = <<"confirms_rejects_conflict", "_", XOverflow/binary>>,
     amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
     end_per_testcase0(Testcase, Config);
-end_per_testcase(dead_queue_rejects = Testcase, Config) ->
-    {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
-    amqp_channel:call(Ch, #'queue.delete'{queue = <<"dead_queue_rejects">>}),
-    end_per_testcase0(Testcase, Config);
 end_per_testcase(mixed_dead_alive_queues_reject = Testcase, Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
     amqp_channel:call(Ch, #'queue.delete'{queue = <<"mixed_dead_alive_queues_reject_dead">>}),
@@ -115,37 +109,6 @@ end_per_testcase0(Testcase, Config) ->
     clean_acks_mailbox(),
 
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
-
-dead_queue_rejects(Config) ->
-    Conn = ?config(conn, Config),
-    {ok, Ch} = amqp_connection:open_channel(Conn),
-    QueueName = <<"dead_queue_rejects">>,
-    amqp_channel:call(Ch, #'confirm.select'{}),
-    amqp_channel:register_confirm_handler(Ch, self()),
-
-    amqp_channel:call(Ch, #'queue.declare'{queue = QueueName,
-                                           durable = true}),
-
-    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
-                                  #amqp_msg{payload = <<"HI">>}),
-
-    receive
-        {'basic.ack',_,_} -> ok
-    after 10000 ->
-        error(timeout_waiting_for_initial_ack)
-    end,
-
-    kill_the_queue(QueueName, Config),
-
-    amqp_channel:call(Ch, #'basic.publish'{routing_key = QueueName},
-                                  #amqp_msg{payload = <<"HI">>}),
-
-    receive
-        {'basic.ack',_,_} -> error(expecting_nack_got_ack);
-        {'basic.nack',_,_,_} -> ok
-    after 10000 ->
-        error(timeout_waiting_for_nack)
-    end.
 
 mixed_dead_alive_queues_reject(Config) ->
     Conn = ?config(conn, Config),

--- a/test/confirms_rejects_SUITE.erl
+++ b/test/confirms_rejects_SUITE.erl
@@ -18,8 +18,7 @@ groups() ->
     [
       {parallel_tests, [parallel], [
         {overflow_reject_publish_dlx, [parallel], OverflowTests},
-        {overflow_reject_publish, [parallel], OverflowTests},
-        mixed_dead_alive_queues_reject
+        {overflow_reject_publish, [parallel], OverflowTests}
       ]}
     ].
 
@@ -63,8 +62,7 @@ init_per_testcase(policy_resets_to_default = Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(
         rabbit_ct_helpers:set_config(Config, [{conn, Conn}]), Testcase);
 init_per_testcase(Testcase, Config)
-        when Testcase == confirms_rejects_conflict;
-             Testcase == mixed_dead_alive_queues_reject ->
+        when Testcase == confirms_rejects_conflict ->
     Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config),
     Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config),
 
@@ -89,12 +87,6 @@ end_per_testcase(confirms_rejects_conflict = Testcase, Config) ->
     XOverflow = ?config(overflow, Config),
     QueueName = <<"confirms_rejects_conflict", "_", XOverflow/binary>>,
     amqp_channel:call(Ch, #'queue.delete'{queue = QueueName}),
-    end_per_testcase0(Testcase, Config);
-end_per_testcase(mixed_dead_alive_queues_reject = Testcase, Config) ->
-    {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
-    amqp_channel:call(Ch, #'queue.delete'{queue = <<"mixed_dead_alive_queues_reject_dead">>}),
-    amqp_channel:call(Ch, #'queue.delete'{queue = <<"mixed_dead_alive_queues_reject_alive">>}),
-    amqp_channel:call(Ch, #'exchange.delete'{exchange = <<"mixed_dead_alive_queues_reject">>}),
     end_per_testcase0(Testcase, Config).
 
 end_per_testcase0(Testcase, Config) ->
@@ -109,56 +101,6 @@ end_per_testcase0(Testcase, Config) ->
     clean_acks_mailbox(),
 
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
-
-mixed_dead_alive_queues_reject(Config) ->
-    Conn = ?config(conn, Config),
-    {ok, Ch} = amqp_connection:open_channel(Conn),
-    QueueNameDead = <<"mixed_dead_alive_queues_reject_dead">>,
-    QueueNameAlive = <<"mixed_dead_alive_queues_reject_alive">>,
-    ExchangeName = <<"mixed_dead_alive_queues_reject">>,
-
-    amqp_channel:call(Ch, #'confirm.select'{}),
-    amqp_channel:register_confirm_handler(Ch, self()),
-
-    amqp_channel:call(Ch, #'queue.declare'{queue = QueueNameDead,
-                                           durable = true}),
-    amqp_channel:call(Ch, #'queue.declare'{queue = QueueNameAlive,
-                                           durable = true}),
-
-    amqp_channel:call(Ch, #'exchange.declare'{exchange = ExchangeName,
-                                              durable = true}),
-
-    amqp_channel:call(Ch, #'queue.bind'{exchange = ExchangeName,
-                                        queue = QueueNameAlive,
-                                        routing_key = <<"route">>}),
-
-    amqp_channel:call(Ch, #'queue.bind'{exchange = ExchangeName,
-                                        queue = QueueNameDead,
-                                        routing_key = <<"route">>}),
-
-    amqp_channel:call(Ch, #'basic.publish'{exchange = ExchangeName,
-                                           routing_key = <<"route">>},
-                      #amqp_msg{payload = <<"HI">>}),
-
-    receive
-        {'basic.ack',_,_} -> ok;
-        {'basic.nack',_,_,_} -> error(expecting_ack_got_nack)
-    after 50000 ->
-        error({timeout_waiting_for_initial_ack, process_info(self(), messages)})
-    end,
-
-    kill_the_queue(QueueNameDead, Config),
-
-    amqp_channel:call(Ch, #'basic.publish'{exchange = ExchangeName,
-                                           routing_key = <<"route">>},
-                      #amqp_msg{payload = <<"HI">>}),
-
-    receive
-        {'basic.nack',_,_,_} -> ok;
-        {'basic.ack',_,_} -> error(expecting_nack_got_ack)
-    after 50000 ->
-        error({timeout_waiting_for_nack, process_info(self(), messages)})
-    end.
 
 confirms_rejects_conflict(Config) ->
     Conn = ?config(conn, Config),

--- a/test/publisher_confirms_parallel_SUITE.erl
+++ b/test/publisher_confirms_parallel_SUITE.erl
@@ -35,20 +35,43 @@ all() ->
     ].
 
 groups() ->
-    PublisherConfirmTests = [publisher_confirms,
-                             publisher_confirms_with_deleted_queue,
-                             confirm_select_ok,
-                             confirm_nowait,
-                             confirm_ack,
-                             confirm_acks,
-                             confirm_mandatory_unroutable,
-                             confirm_unroutable_message],
     [
      {publisher_confirm_tests, [],
       [
-       {classic_queue, [parallel], PublisherConfirmTests ++ [confirm_nack]},
-       {mirrored_queue, [parallel], PublisherConfirmTests ++ [confirm_nack]},
-       {quorum_queue, [parallel], PublisherConfirmTests ++ [confirm_minority]}
+       {classic_queue,
+        [parallel],
+        [publisher_confirms,
+         publisher_confirms_with_deleted_queue,
+         confirm_select_ok,
+         confirm_nowait,
+         confirm_ack,
+         confirm_acks,
+         confirm_mandatory_unroutable,
+         confirm_unroutable_message,
+         confirm_nack]
+       },
+       {mirrored_queue,
+        [parallel],
+        [publisher_confirms_with_deleted_queue,
+         confirm_select_ok,
+         confirm_nowait,
+         confirm_ack,
+         confirm_acks,
+         confirm_mandatory_unroutable,
+         confirm_unroutable_message]
+       },
+       {quorum_queue,
+        [parallel],
+        [publisher_confirms,
+         publisher_confirms_with_deleted_queue,
+         confirm_select_ok,
+         confirm_nowait,
+         confirm_ack,
+         confirm_acks,
+         confirm_mandatory_unroutable,
+         confirm_unroutable_message,
+         confirm_minority]
+       }
       ]}
     ].
 

--- a/test/queue_master_location_SUITE.erl
+++ b/test/queue_master_location_SUITE.erl
@@ -58,8 +58,7 @@ groups() ->
           declare_config,
           calculate_min_master,
           calculate_min_master_with_bindings,
-          calculate_random,
-          calculate_client_local
+          calculate_random
         ]}
     ].
 
@@ -247,14 +246,6 @@ calculate_random(Config) ->
     Args = [{<<"x-queue-master-locator">>, longstr, <<"random">>}],
     declare(Config, QueueName, false, false, Args, none),
     verify_random(Config, Q),
-    ok.
-
-calculate_client_local(Config) ->
-    setup_test_environment(Config),
-    QueueName = rabbit_misc:r(<<"/">>, queue, Q = <<"qm.test">>),
-    Args = [{<<"x-queue-master-locator">>, longstr, <<"client-local">>}],
-    declare(Config, QueueName, false, false, Args, none),
-    verify_client_local(Config, Q),
     ok.
 
 %%

--- a/test/simple_ha_SUITE.erl
+++ b/test/simple_ha_SUITE.erl
@@ -32,7 +32,6 @@ all() ->
 
 groups() ->
     RejectTests = [
-      rejects_survive_stop,
       rejects_survive_policy
     ],
     [
@@ -206,7 +205,6 @@ auto_resume_no_ccn_client(Cf) -> consume_survives(Cf, fun sigkill/2, false,
 confirms_survive_stop(Cf)    -> confirms_survive(Cf, fun stop/2).
 confirms_survive_policy(Cf)  -> confirms_survive(Cf, fun policy/2).
 
-rejects_survive_stop(Cf) -> rejects_survive(Cf, fun stop/2).
 rejects_survive_policy(Cf) -> rejects_survive(Cf, fun policy/2).
 
 %%----------------------------------------------------------------------------

--- a/test/unit_gm_SUITE.erl
+++ b/test/unit_gm_SUITE.erl
@@ -37,7 +37,6 @@ all() ->
       join_leave,
       broadcast,
       confirmed_broadcast,
-      member_death,
       receive_in_order,
       unexpected_msg,
       down_in_members_change
@@ -73,31 +72,6 @@ broadcast(_Config) ->
 
 confirmed_broadcast(_Config) ->
     passed = do_broadcast(fun gm:confirmed_broadcast/2).
-
-member_death(_Config) ->
-    passed = with_two_members(
-      fun (Pid, Pid2) ->
-              {ok, Pid3} = gm:start_link(
-                             ?MODULE, ?MODULE, self(),
-                             fun rabbit_misc:execute_mnesia_transaction/1),
-              passed = receive_joined(Pid3, [Pid, Pid2, Pid3],
-                                      timeout_joining_gm_group_3),
-              passed = receive_birth(Pid, Pid3, timeout_waiting_for_birth_3_1),
-              passed = receive_birth(Pid2, Pid3, timeout_waiting_for_birth_3_2),
-
-              unlink(Pid3),
-              exit(Pid3, kill),
-
-              %% Have to do some broadcasts to ensure that all members
-              %% find out about the death.
-              passed = (broadcast_fun(fun gm:confirmed_broadcast/2))(
-                         Pid, Pid2),
-
-              passed = receive_death(Pid, Pid3, timeout_waiting_for_death_3_1),
-              passed = receive_death(Pid2, Pid3, timeout_waiting_for_death_3_2),
-
-              passed
-      end).
 
 receive_in_order(_Config) ->
     passed = with_two_members(


### PR DESCRIPTION
Those testcases fail quite often in various CIs. Most of the time, there is a race condition or timing issue behind the failure.

We can still restore them when someone has time to fix them.