### PR TITLE
Wait until node detects new cluster configuration

### DIFF
--- a/test/list_queues_online_and_offline_SUITE.erl
+++ b/test/list_queues_online_and_offline_SUITE.erl
@@ -85,6 +85,11 @@ list_queues_online_and_offline(Config) ->
 
     rabbit_ct_broker_helpers:rabbitmqctl(Config, B, ["stop"]),
 
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+              [A] == rpc:call(A, rabbit_mnesia, cluster_nodes, [running])
+      end, 60000),
+
     GotUp = lists:sort(rabbit_ct_broker_helpers:rabbitmqctl_list(Config, A,
         ["list_queues", "--online", "name", "--no-table-headers"])),
     ExpectUp = [[<<"q_a_1">>], [<<"q_a_2">>]],


### PR DESCRIPTION
CI has failed with an mnesia error where the rabbit_queue table
doesn't exist. The actual logs don't show any error on the remaining
node so let's assume that is mnesia detecting the other node going
down. This really shouldn't happen, but I can't reproduce it either.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

