### PR TITLE
Changed default configuration values related to quorum queues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ define PROJECT_ENV
 	    %% see rabbitmq-server#143,
 	    %% rabbitmq-server#949, rabbitmq-server#1098
 	    {credit_flow_default_credit, {400, 200}},
-	    {quorum_commands_soft_limit, 256},
+	    {quorum_commands_soft_limit, 32},
 	    {quorum_cluster_size, 5},
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -86,7 +86,8 @@ set_default_config() ->
     Config = [
               {ra,
                [
-                {wal_max_size_bytes, 536870912} %% 5 * 2 ^ 20
+                {wal_max_size_bytes, 536870912}, %% 5 * 2 ^ 20
+                {wal_max_batch_size, 4096}
                ]},
               {sysmon_handler,
                [{process_limit, 100},

--- a/docs/rabbitmq.conf.example
+++ b/docs/rabbitmq.conf.example
@@ -453,7 +453,7 @@
 ##
 # raft.segment_max_entries = 65536
 # raft.wal_max_size_bytes = 1048576
-# raft.wal_max_batch_size = 32768
+# raft.wal_max_batch_size = 4096
 # raft.snapshot_chunk_size = 1000000
 
 ##

--- a/src/rabbit_fifo_client.erl
+++ b/src/rabbit_fifo_client.erl
@@ -46,7 +46,7 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
--define(SOFT_LIMIT, 256).
+-define(SOFT_LIMIT, 32).
 -define(TIMER_TIME, 10000).
 
 -type seq() :: non_neg_integer().

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -682,9 +682,9 @@ credential_validator.regexp = ^abc\\d+",
    []},
 
    {raft_wal_max_batch_size,
-    "raft.wal_max_batch_size = 32768",
+    "raft.wal_max_batch_size = 4096",
     [{ra, [
-       {wal_max_batch_size, 32768}
+       {wal_max_batch_size, 4096}
       ]}],
     []},
 


### PR DESCRIPTION
Based on performance testing, new defaults help back pressure on publishers when quorum queues are under heavy load from many publishers.

Specifically:
- changed default `quorum_commands_soft_limit` from 256 to 32
- override Ra `wal_max_batch_size` with value 4096
