### PR TITLE
Fix errors reported by Dialyzer

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -1088,7 +1088,8 @@ list_local_mirrored_classic_names() ->
            is_local_to_node(amqqueue:get_pid(Q), node()),
            is_replicated(Q)].
 
--spec list_local_mirrored_classic_without_synchronised_mirrors() -> [amqqueue:amqqueue()].
+-spec list_local_mirrored_classic_without_synchronised_mirrors() ->
+    [amqqueue:amqqueue()].
 list_local_mirrored_classic_without_synchronised_mirrors() ->
     [ Q || Q <- list(),
          amqqueue:get_state(Q) =/= crashed,
@@ -1097,7 +1098,8 @@ list_local_mirrored_classic_without_synchronised_mirrors() ->
          is_replicated(Q),
          not has_synchronised_mirrors_online(Q)].
 
--spec list_local_mirrored_classic_without_synchronised_mirrors_for_cli() -> [amqqueue:amqqueue()].
+-spec list_local_mirrored_classic_without_synchronised_mirrors_for_cli() ->
+    [#{binary => any()}].
 list_local_mirrored_classic_without_synchronised_mirrors_for_cli() ->
     ClassicQs = list_local_mirrored_classic_without_synchronised_mirrors(),
     [begin

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -494,11 +494,7 @@ put_user(User, Version, ActingUser) ->
                       end,
 
     UserExists      = case rabbit_auth_backend_internal:lookup_user(Username) of
-                          %% expected
                           {error, not_found} -> false;
-                          %% shouldn't normally happen but worth guarding
-                          %% against
-                          {error, _}         -> false;
                           _                  -> true
                       end,
 

--- a/src/rabbit_connection_tracking.erl
+++ b/src/rabbit_connection_tracking.erl
@@ -261,6 +261,7 @@ tracked_connection_per_vhost_table_name_for(Node) ->
 
 
 -spec register_connection(rabbit_types:tracked_connection()) -> ok.
+-dialyzer([{nowarn_function, [register_connection/1]}, race_conditions]).
 
 register_connection(#tracked_connection{vhost = VHost, id = ConnId, node = Node} = Conn) when Node =:= node() ->
     TableName = tracked_connection_table_name_for(Node),

--- a/src/rabbit_definitions.erl
+++ b/src/rabbit_definitions.erl
@@ -597,24 +597,11 @@ build_filtered_map([Queue|Rest], AccMap0) ->
     {Rec, VHost} = build_queue_data(Queue),
     case rabbit_amqqueue:lookup(Rec) of
         {error, not_found} ->
-            AccMap1 = maps_update_with(VHost, fun(V) -> V + 1 end, 1, AccMap0),
+            AccMap1 = maps:update_with(VHost, fun(V) -> V + 1 end, 1, AccMap0),
             build_filtered_map(Rest, AccMap1);
         {ok, _} ->
             build_filtered_map(Rest, AccMap0)
     end.
-
-%% Copy of maps:with_util/3 from Erlang 20.0.1.
-maps_update_with(Key,Fun,Init,Map) when is_function(Fun,1), is_map(Map) ->
-    case maps:find(Key,Map) of
-        {ok,Val} -> maps:update(Key,Fun(Val),Map);
-        error -> maps:put(Key,Init,Map)
-    end;
-maps_update_with(Key,Fun,Init,Map) ->
-    erlang:error(maps_error_type(Map),[Key,Fun,Init,Map]).
-
-%% Copy of maps:error_type/1 from Erlang 20.0.1.
-maps_error_type(M) when is_map(M) -> badarg;
-maps_error_type(V) -> {badmap, V}.
 
 validate_vhost_limit(VHost, AddCount, ok) ->
     WouldExceed = rabbit_vhost_limit:would_exceed_queue_limit(AddCount, VHost),

--- a/src/rabbit_feature_flags.erl
+++ b/src/rabbit_feature_flags.erl
@@ -845,6 +845,11 @@ initialize_registry(NewSupportedFeatureFlags,
         Error   -> Error
     end.
 
+-spec maybe_initialize_registry(feature_flags(),
+                                feature_states(),
+                                boolean()) ->
+    ok | restart | {error, any()} | no_return().
+
 maybe_initialize_registry(NewSupportedFeatureFlags,
                           NewFeatureStates,
                           WrittenToDisk) ->
@@ -975,7 +980,7 @@ does_registry_need_refresh(AllFeatureFlags,
                              feature_flags(),
                              feature_states(),
                              boolean()) ->
-    ok | {error, any()} | no_return().
+    ok | restart | {error, any()} | no_return().
 %% @private
 
 do_initialize_registry(RegistryVsn,

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -128,13 +128,6 @@ init_with_lock(Retries, Timeout, RunPeerDiscovery) ->
                 rabbit_peer_discovery:maybe_register()
             after
                 rabbit_peer_discovery:unlock(Data)
-            end;
-        Data when is_binary(Data) or is_list(Data) ->
-            try
-                RunPeerDiscovery(),
-                rabbit_peer_discovery:maybe_register()
-            after
-                rabbit_peer_discovery:unlock(Data)
             end
     end.
 

--- a/src/rabbit_peer_discovery.erl
+++ b/src/rabbit_peer_discovery.erl
@@ -250,7 +250,7 @@ unregister() ->
       ok
   end.
 
--spec lock() -> ok | {ok, Data :: term()} | not_supported | {error, Reason :: string()}.
+-spec lock() -> {ok, Data :: term()} | not_supported | {error, Reason :: string()}.
 
 lock() ->
     Backend = backend(),

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -618,7 +618,8 @@ basic_get(Q, NoAck, CTag0, QState0) when ?amqqueue_is_quorum(Q) ->
                     rabbit_types:ctag(), ExclusiveConsume :: boolean(),
                     Args :: rabbit_framing:amqp_table(), ActingUser :: binary(),
                     any(), rabbit_fifo_client:state()) ->
-    {'ok', rabbit_fifo_client:state()}.
+    {'ok', rabbit_fifo_client:state()} |
+    {error, timeout | term()}.
 
 basic_consume(Q, NoAck, ChPid,
               ConsumerPrefetchCount, ConsumerTag0, ExclusiveConsume, Args,

--- a/src/rabbit_ssl.erl
+++ b/src/rabbit_ssl.erl
@@ -108,9 +108,10 @@ format_cipher_openssl22(Cipher) ->
 format_cipher_openssl21(Cipher) ->
     ssl_cipher_format:suite_to_str(Cipher).
 
--spec get_highest_protocol_version() -> tls_record:tls_version().
+-spec get_highest_protocol_version() -> tls_record:tls_atom_version().
 get_highest_protocol_version() ->
-    tls_record:highest_protocol_version([]).
+    tls_record:protocol_version(
+      tls_record:highest_protocol_version([])).
 
 %%--------------------------------------------------------------------------
 %% High-level functions used by reader

--- a/src/rabbit_vhost.erl
+++ b/src/rabbit_vhost.erl
@@ -366,7 +366,7 @@ update(VHost, Fun) ->
     end.
 
 set_limits(VHost, undefined) ->
-    vhost:set_limits(VHost, undefined);
+    vhost:set_limits(VHost, []);
 set_limits(VHost, Limits) ->
     vhost:set_limits(VHost, Limits).
 


### PR DESCRIPTION
The last remaining error is:

```
rabbit_quorum_queue.erl:953: The variable Err can never match since previous clauses completely covered the type
          'ok' | {'error', _}
```

It depends on rabbitmq/ra#183.