### PR TITLE
Emit a consumer.created event for quorum queues

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -198,11 +198,7 @@ cancel_consumer_handler(QName, {ConsumerTag, ChPid}) ->
 
 cancel_consumer(QName, ChPid, ConsumerTag) ->
     catch rabbit_core_metrics:consumer_deleted(ChPid, ConsumerTag, QName),
-    rabbit_event:notify(consumer_deleted,
-                        [{consumer_tag, ConsumerTag},
-                         {channel,      ChPid},
-                         {queue,        QName},
-                         {user_who_performed_action, ?INTERNAL_USER}]).
+    emit_consumer_deleted(ChPid, ConsumerTag, QName, ?INTERNAL_USER).
 
 local_or_remote_handler(ChPid, Module, Function, Args) ->
     Node = node(ChPid),
@@ -637,7 +633,8 @@ basic_consume(Q, NoAck, ChPid,
                    Other -> Other
                end,
     %% consumer info is used to describe the consumer properties
-    ConsumerMeta = #{ack => not NoAck,
+    AckRequired = not NoAck,
+    ConsumerMeta = #{ack => AckRequired,
                      prefetch => ConsumerPrefetchCount,
                      args => Args,
                      username => ActingUser},
@@ -648,7 +645,6 @@ basic_consume(Q, NoAck, ChPid,
     case ra:local_query(QPid,
                         fun rabbit_fifo:query_single_active_consumer/1) of
         {ok, {_, SacResult}, _} ->
-
             SingleActiveConsumerOn = single_active_consumer_on(Q),
             {IsSingleActiveConsumer, ActivityStatus} = case {SingleActiveConsumerOn, SacResult} of
                                                            {false, _} ->
@@ -658,12 +654,14 @@ basic_consume(Q, NoAck, ChPid,
                                                            _ ->
                                                                {false, waiting}
                                                        end,
-
-            %% TODO: emit as rabbit_fifo effect
-            rabbit_core_metrics:consumer_created(ChPid, ConsumerTag, ExclusiveConsume,
-                                                 not NoAck, QName,
-                                                 ConsumerPrefetchCount, IsSingleActiveConsumer,
-                                                 ActivityStatus, Args),
+            rabbit_core_metrics:consumer_created(
+                    ChPid, ConsumerTag, ExclusiveConsume,
+                    AckRequired, QName,
+                    ConsumerPrefetchCount, IsSingleActiveConsumer,
+                    ActivityStatus, Args),
+            emit_consumer_created(ChPid, ConsumerTag, ExclusiveConsume,
+                    AckRequired, QName, Prefetch,
+                    Args, none, ActingUser),
             {ok, QState};
         {error, Error} ->
             Error;
@@ -677,6 +675,25 @@ basic_consume(Q, NoAck, ChPid,
 basic_cancel(ConsumerTag, ChPid, OkMsg, QState0) ->
     maybe_send_reply(ChPid, OkMsg),
     rabbit_fifo_client:cancel_checkout(quorum_ctag(ConsumerTag), QState0).
+
+emit_consumer_created(ChPid, CTag, Exclusive, AckRequired, QName, PrefetchCount, Args, Ref, ActingUser) ->
+    rabbit_event:notify(consumer_created,
+                        [{consumer_tag,   CTag},
+                         {exclusive,      Exclusive},
+                         {ack_required,   AckRequired},
+                         {channel,        ChPid},
+                         {queue,          QName},
+                         {prefetch_count, PrefetchCount},
+                         {arguments,      Args},
+                         {user_who_performed_action, ActingUser}],
+                        Ref).
+
+emit_consumer_deleted(ChPid, ConsumerTag, QName, ActingUser) ->
+    rabbit_event:notify(consumer_deleted,
+        [{consumer_tag, ConsumerTag},
+            {channel, ChPid},
+            {queue, QName},
+            {user_who_performed_action, ActingUser}]).
 
 -spec stateless_deliver(amqqueue:ra_server_id(), rabbit_types:delivery()) -> 'ok'.
 


### PR DESCRIPTION
## Proposed Changes

This makes sure that `consumer.created` internal events are emitted for quorum queues.

To verify, use `rabbitmq-diagnostics consume_event_stream` then

 * Open a connection
 * Open a channel
 * Declare a classic queue
 * Add a consumer to the CQ
 * Observe a `consumer.created` event in the event log
 * Declare a quorum queue
 * Add a consumer to the QQ
 * Observe another `consumer.created` event in the event log

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2341)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #2341