### PR TITLE
Node drain (maintenance mode) operations

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_errors.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_errors.erl
@@ -19,7 +19,7 @@ log_error(Error) ->
 
 format_error({error, {duplicate_node_name, NodeName, NodeHost}}) ->
     rabbit_misc:format(
-      "ERROR: node with name ~p already running on ~p",
+      "ERROR: node with name ~p is already running on host ~p",
       [NodeName, NodeHost]);
 format_error({error, {epmd_error, NodeHost, EpmdReason}}) ->
     rabbit_misc:format(
@@ -30,11 +30,11 @@ format_error({error, {invalid_dist_port_range, DistTcpPort}}) ->
       "Invalid Erlang distribution TCP port: ~b", [DistTcpPort]);
 format_error({error, {dist_port_already_used, Port, not_erlang, Host}}) ->
     rabbit_misc:format(
-      "ERROR: distribution port ~b in use on ~s "
+      "ERROR: distribution port ~b in use on host ~s "
       "(by non-Erlang process?)", [Port, Host]);
 format_error({error, {dist_port_already_used, Port, Name, Host}}) ->
     rabbit_misc:format(
-      "ERROR: distribution port ~b in use by ~s@~s", [Port, Name, Host]);
+      "ERROR: distribution port ~b in use by another node: ~s@~s", [Port, Name, Host]);
 format_error({error, {erlang_dist_running_with_unexpected_nodename,
                       Unexpected, Node}}) ->
     rabbit_misc:format(

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -910,7 +910,7 @@ do_run_postlaunch_phase() ->
                       Error   -> throw(Error)
                   end
           end, Plugins),
-        
+
         rabbit_log_prelaunch:info("Resetting node maintenance status"),
         %% successful boot resets node maintenance state
         rabbit_maintenance:unmark_as_being_drained(),

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -910,10 +910,13 @@ do_run_postlaunch_phase() ->
                       Error   -> throw(Error)
                   end
           end, Plugins),
-
+        
+        rabbit_log_prelaunch:info("Resetting node maintenance status"),
+        %% successful boot resets node maintenance state
+        rabbit_maintenance:unmark_as_being_drained(),
         rabbit_log_prelaunch:debug("Marking ~s as running", [product_name()]),
         rabbit_boot_state:set(ready),
-
+        
         ok = rabbit_lager:broker_is_started(),
         ok = log_broker_started(
                rabbit_plugins:strictly_plugins(rabbit_plugins:active())),

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -916,7 +916,7 @@ do_run_postlaunch_phase() ->
         rabbit_maintenance:unmark_as_being_drained(),
         rabbit_log_prelaunch:debug("Marking ~s as running", [product_name()]),
         rabbit_boot_state:set(ready),
-        
+
         ok = rabbit_lager:broker_is_started(),
         ok = log_broker_started(
                rabbit_plugins:strictly_plugins(rabbit_plugins:active())),

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -654,6 +654,7 @@ status() ->
           {erlang_version,       erlang:system_info(system_version)},
           {memory,               rabbit_vm:memory()},
           {alarms,               alarms()},
+          {is_under_maintenance, rabbit_maintenance:is_being_drained_local_read(node())},
           {listeners,            listeners()},
           {vm_memory_calculation_strategy, vm_memory_monitor:get_memory_calculation_strategy()}],
     S2 = rabbit_misc:filter_exit_map(

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -23,7 +23,6 @@
          emit_info_local/4, emit_info_down/4]).
 -export([count/0]).
 -export([list_down/1, count/1, list_names/0, list_names/1, list_local_names/0,
-         list_local_mirrored_classic_names/0,
          list_local_names_down/0, list_with_possible_retry/1]).
 -export([list_by_type/1, sample_local_queues/0, sample_n_by_name/2, sample_n/2]).
 -export([force_event_refresh/1, notify_policy_changed/1]).
@@ -38,6 +37,7 @@
 -export([has_synchronised_mirrors_online/1]).
 -export([is_replicated/1, is_exclusive/1, is_not_exclusive/1, is_dead_exclusive/1]).
 -export([list_local_quorum_queues/0, list_local_quorum_queue_names/0,
+         list_local_mirrored_classic_queues/0, list_local_mirrored_classic_names/0,
          list_local_leaders/0, list_local_followers/0, get_quorum_nodes/1,
          list_local_mirrored_classic_without_synchronised_mirrors/0,
          list_local_mirrored_classic_without_synchronised_mirrors_for_cli/0]).
@@ -1071,6 +1071,14 @@ list_local_followers() ->
          amqqueue:is_quorum(Q),
          amqqueue:get_state(Q) =/= crashed, amqqueue:get_leader(Q) =/= node(),
         lists:member(node(), get_quorum_nodes(Q))].
+
+-spec list_local_mirrored_classic_queues() -> [amqqueue:amqqueue()].
+list_local_mirrored_classic_queues() ->
+    [ Q || Q <- list(),
+        amqqueue:get_state(Q) =/= crashed,
+        amqqueue:is_classic(Q),
+        is_local_to_node(amqqueue:get_pid(Q), node()),
+        is_replicated(Q)].
 
 -spec list_local_mirrored_classic_names() -> [rabbit_amqqueue:name()].
 list_local_mirrored_classic_names() ->

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -313,6 +313,7 @@ declare_classic_queue(Q, Node) ->
                 _ ->
                     case rabbit_queue_master_location_misc:get_location(Q)  of
                         {ok, Node0}  -> Node0;
+                        undefined    -> Node;
                         {error, _}   -> Node
                     end
             end,

--- a/src/rabbit_core_ff.erl
+++ b/src/rabbit_core_ff.erl
@@ -130,12 +130,11 @@ virtual_host_metadata_migration(_FeatureName, _FeatureProps, is_enabled) ->
 maintenance_mode_status_migration(FeatureName, _FeatureProps, enable) ->
     TableName = rabbit_maintenance:status_table_name(),
     rabbit_log:info("Creating table ~s for feature flag `~s`", [TableName, FeatureName]),
-    case rabbit_table:create(TableName, rabbit_maintenance:status_table_definition()) of
-        ok ->
-            rabbit_table:ensure_table_copy(TableName, node());
-        {error, Reason} ->
-            rabbit_log:error("Failed to create maintenance status table: ~p", [Reason]),
-            {error, Reason}
+    try
+        _ = rabbit_table:create(TableName, rabbit_maintenance:status_table_definition()),
+        _ = rabbit_table:ensure_table_copy(TableName, node())
+    catch throw:Reason  ->
+        rabbit_log:error("Failed to create maintenance status table: ~p", [Reason])
     end;
 maintenance_mode_status_migration(_FeatureName, _FeatureProps, is_enabled) ->
     rabbit_table:exists(rabbit_maintenance:status_table_name()).

--- a/src/rabbit_core_ff.erl
+++ b/src/rabbit_core_ff.erl
@@ -9,7 +9,8 @@
 
 -export([quorum_queue_migration/3,
          implicit_default_bindings_migration/3,
-         virtual_host_metadata_migration/3]).
+         virtual_host_metadata_migration/3,
+         maintenance_mode_status_migration/3]).
 
 -rabbit_feature_flag(
    {quorum_queue,
@@ -33,6 +34,14 @@
       stability     => stable,
       migration_fun => {?MODULE, virtual_host_metadata_migration}
      }}).
+
+-rabbit_feature_flag(
+    {maintenance_mode_status,
+     #{
+         desc          => "Maintenance mode status",
+         stability     => stable,
+         migration_fun => {?MODULE, maintenance_mode_status_migration}
+      }}).
 
 %% -------------------------------------------------------------------
 %% Quorum queues.
@@ -112,3 +121,21 @@ virtual_host_metadata_migration(_FeatureName, _FeatureProps, enable) ->
     end;
 virtual_host_metadata_migration(_FeatureName, _FeatureProps, is_enabled) ->
     mnesia:table_info(rabbit_vhost, attributes) =:= vhost:fields(vhost_v2).
+
+
+%%
+%% Maintenance mode
+%%
+
+maintenance_mode_status_migration(FeatureName, _FeatureProps, enable) ->
+    TableName = rabbit_maintenance:status_table_name(),
+    rabbit_log:info("Creating table ~s for feature flag `~s`", [TableName, FeatureName]),
+    case rabbit_table:create(TableName, rabbit_maintenance:status_table_definition()) of
+        ok ->
+            rabbit_table:ensure_table_copy(TableName, node());
+        {error, Reason} ->
+            rabbit_log:error("Failed to create maintenance status table: ~p", [Reason]),
+            {error, Reason}
+    end;
+maintenance_mode_status_migration(_FeatureName, _FeatureProps, is_enabled) ->
+    rabbit_table:exists(rabbit_maintenance:status_table_name()).

--- a/src/rabbit_maintenance.erl
+++ b/src/rabbit_maintenance.erl
@@ -21,6 +21,8 @@
  -export([
      mark_as_drained/0,
      unmark_as_drained/0,
+     is_drained_using_dirty_read/1,
+     is_drained_using_consistent_read/1,
      suspend_all_client_listeners/0,
      resume_all_client_listeners/0,
      close_all_client_connections/0]).
@@ -34,6 +36,14 @@ mark_as_drained() ->
 
 unmark_as_drained() ->
     ok.
+
+-spec is_drained_using_dirty_read(node()) -> boolean().
+is_drained_using_dirty_read(_Node) ->
+    false.
+
+-spec is_drained_using_consistent_read(node()) -> boolean().
+is_drained_using_consistent_read(_Node) ->
+    false.
 
 -spec suspend_all_client_listeners() -> rabbit_types:ok_or_error(any()).
  

--- a/src/rabbit_maintenance.erl
+++ b/src/rabbit_maintenance.erl
@@ -1,0 +1,43 @@
+ %% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_maintenance).
+
+ -export([
+     mark_as_drained/0,
+     unmark_as_drained/0,
+     pause_all_listeners/0,
+     resume_all_listeners/0,
+     close_all_client_connections/0]).
+
+%%
+%% API
+%%
+
+mark_as_drained() ->
+    ok.
+
+unmark_as_drained() ->
+    ok.
+
+pause_all_listeners() ->
+    ok.
+
+resume_all_listeners() ->
+    ok.
+
+close_all_client_connections() ->
+    ok.

--- a/src/rabbit_maintenance.erl
+++ b/src/rabbit_maintenance.erl
@@ -64,8 +64,11 @@ drain() ->
     ok.
 
 revive() ->
+    rabbit_log:alert("This node is being revived from maintenance (drain) mode"),
     resume_all_client_listeners(),
+    rabbit_log:alert("Resumed all listeners and will accept client connections again"),
     unmark_as_being_drained(),
+    rabbit_log:info("Marked this node as back from maintenance and ready to serve clients"),
 
     ok.
 

--- a/src/rabbit_maintenance.erl
+++ b/src/rabbit_maintenance.erl
@@ -77,10 +77,12 @@ revive() ->
 
 -spec mark_as_being_drained() -> boolean().
 mark_as_being_drained() ->
+    rabbit_log:debug("Marking the node as undergoing maintenance"),
     set_maintenance_state_status(?DRAINING_STATUS).
  
 -spec unmark_as_being_drained() -> boolean().
 unmark_as_being_drained() ->
+    rabbit_log:debug("Unmarking the node as undergoing maintenance"),
     set_maintenance_state_status(?DEFAULT_STATUS).
 
 set_maintenance_state_status(Status) ->

--- a/src/rabbit_maintenance.erl
+++ b/src/rabbit_maintenance.erl
@@ -1,17 +1,8 @@
- %% The contents of this file are subject to the Mozilla Public License
-%% Version 1.1 (the "License"); you may not use this file except in
-%% compliance with the License. You may obtain a copy of the License
-%% at https://www.mozilla.org/MPL/
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Software distributed under the License is distributed on an "AS IS"
-%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
-%% the License for the specific language governing rights and
-%% limitations under the License.
-%%
-%% The Original Code is RabbitMQ.
-%%
-%% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(rabbit_maintenance).

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -824,10 +824,17 @@ schema_ok_or_move() ->
 %% up only
 create_schema() ->
     stop_mnesia(),
+    rabbit_log:debug("Will bootstrap a schema database..."),
     rabbit_misc:ensure_ok(mnesia:create_schema([node()]), cannot_create_schema),
+    rabbit_log:debug("Bootstraped a schema database successfully"),
     start_mnesia(),
+    
+    rabbit_log:debug("Will create schema database tables"),
     ok = rabbit_table:create(),
+    rabbit_log:debug("Created schema database tables successfully"),
+    rabbit_log:debug("Will check schema database integrity..."),
     ensure_schema_integrity(),
+    rabbit_log:debug("Schema database schema integrity check passed"),
     ok = rabbit_version:record_desired().
 
 move_db() ->

--- a/src/rabbit_mnesia.erl
+++ b/src/rabbit_mnesia.erl
@@ -571,7 +571,7 @@ init_db(ClusterNodes, NodeType, CheckOtherNodes) ->
             %% Subsequent node in cluster, catch up
             maybe_force_load(),
             ok = rabbit_table:wait_for_replicated(_Retry = true),
-            ok = rabbit_table:create_local_copy(NodeType)
+            ok = rabbit_table:ensure_local_copies(NodeType)
     end,
     ensure_feature_flags_are_in_sync(Nodes, NodeIsVirgin),
     ensure_schema_integrity(),

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -21,7 +21,8 @@
 
 -export([boot/0, start_tcp_listener/2, start_ssl_listener/3,
          stop_tcp_listener/1, on_node_down/1, active_listeners/0,
-         node_listeners/1, register_connection/1, unregister_connection/1,
+         node_listeners/1, node_client_listeners/1,
+         register_connection/1, unregister_connection/1,
          connections/0, connection_info_keys/0,
          connection_info/1, connection_info/2,
          connection_info_all/0, connection_info_all/1,
@@ -296,6 +297,17 @@ active_listeners() ->
 
 node_listeners(Node) ->
     mnesia:dirty_read(rabbit_listener, Node).
+
+-spec node_client_listeners(node()) -> [rabbit_types:listener()].
+
+node_client_listeners(Node) ->
+    case node_listeners(Node) of
+        [] -> [];
+        Xs ->
+            lists:filter(fun (#listener{protocol = clustering}) -> false;
+                             (_) -> true
+                         end, Xs)
+    end.
 
 -spec on_node_down(node()) -> 'ok'.
 

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -30,7 +30,7 @@
          close_connection/2, close_connections/2,
          force_connection_event_refresh/1, handshake/2, tcp_host/1,
          ranch_ref/1, ranch_ref/2, ranch_ref_of_protocol/1,
-         listener_of_protocol/1]).
+         listener_of_protocol/1, stop_ranch_listener_of_protocol/1]).
 
 %% Used by TCP-based transports, e.g. STOMP adapter
 -export([tcp_listener_addresses/1, tcp_listener_spec/9,
@@ -233,6 +233,16 @@ listener_of_protocol(Protocol) ->
                 [Row] -> Row
             end
         end).
+
+-spec stop_ranch_listener_of_protocol(atom()) -> ok | {error, not_found}.
+stop_ranch_listener_of_protocol(Protocol) ->
+    case rabbit_networking:ranch_ref_of_protocol(Protocol) of
+        {error, not_found} -> ok;
+        undefined          -> ok;
+        Ref                ->
+            rabbit_log:debug("Stopping Ranch listener for protocol ~s", [Protocol]),
+            ranch:stop_listener(Ref)
+    end.
 
 -spec start_tcp_listener(
         listener_config(), integer()) -> 'ok' | {'error', term()}.

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -198,14 +198,16 @@ tcp_listener_spec(NamePrefix, {IPAddress, Port, Family}, SocketOpts,
         modules => [tcp_listener_sup]
     }.
 
--spec ranch_ref(#listener{} | [{atom(), any()}]) -> ranch:ref().
+-spec ranch_ref(#listener{} | [{atom(), any()}] | 'undefined') -> ranch:ref().
 ranch_ref(#listener{port = Port}) ->
     [{IPAddress, Port, _Family} | _] = tcp_listener_addresses(Port),
     {acceptor, IPAddress, Port};
 ranch_ref(Listener) when is_list(Listener) ->
     Port = rabbit_misc:pget(port, Listener),
     [{IPAddress, Port, _Family} | _] = tcp_listener_addresses(Port),
-    {acceptor, IPAddress, Port}.
+    {acceptor, IPAddress, Port};
+ranch_ref(undefined) ->
+    undefined.
 
 -spec ranch_ref(inet:ip_address(), ip_port()) -> ranch:ref().
 

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -198,7 +198,7 @@ tcp_listener_spec(NamePrefix, {IPAddress, Port, Family}, SocketOpts,
         modules => [tcp_listener_sup]
     }.
 
--spec ranch_ref(#listener{} | [{atom(), any()}] | 'undefined') -> ranch:ref().
+-spec ranch_ref(#listener{} | [{atom(), any()}] | 'undefined') -> ranch:ref() | undefined.
 ranch_ref(#listener{port = Port}) ->
     [{IPAddress, Port, _Family} | _] = tcp_listener_addresses(Port),
     {acceptor, IPAddress, Port};
@@ -215,7 +215,7 @@ ranch_ref(undefined) ->
 ranch_ref(IPAddress, Port) ->
     {acceptor, IPAddress, Port}.
 
--spec ranch_ref_of_protocol(atom()) -> ranch:ref().
+-spec ranch_ref_of_protocol(atom()) -> ranch:ref() | undefined.
 ranch_ref_of_protocol(Protocol) ->
     ranch_ref(listener_of_protocol(Protocol)).
 
@@ -237,9 +237,8 @@ listener_of_protocol(Protocol) ->
 -spec stop_ranch_listener_of_protocol(atom()) -> ok | {error, not_found}.
 stop_ranch_listener_of_protocol(Protocol) ->
     case rabbit_networking:ranch_ref_of_protocol(Protocol) of
-        {error, not_found} -> ok;
-        undefined          -> ok;
-        Ref                ->
+        undefined -> ok;
+        Ref       ->
             rabbit_log:debug("Stopping Ranch listener for protocol ~s", [Protocol]),
             ranch:stop_listener(Ref)
     end.

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -180,12 +180,12 @@ tcp_listener_addresses_auto(Port) ->
 
 tcp_listener_spec(NamePrefix, {IPAddress, Port, Family}, SocketOpts,
                   Transport, ProtoSup, ProtoOpts, Protocol, NumAcceptors, Label) ->
+    Args = [IPAddress, Port, Transport, [Family | SocketOpts], ProtoSup, ProtoOpts,
+            {?MODULE, tcp_listener_started, [Protocol, SocketOpts]},
+            {?MODULE, tcp_listener_stopped, [Protocol, SocketOpts]},
+            NumAcceptors, Label],
     {rabbit_misc:tcp_name(NamePrefix, IPAddress, Port),
-     {tcp_listener_sup, start_link,
-      [IPAddress, Port, Transport, [Family | SocketOpts], ProtoSup, ProtoOpts,
-       {?MODULE, tcp_listener_started, [Protocol, SocketOpts]},
-       {?MODULE, tcp_listener_stopped, [Protocol, SocketOpts]},
-       NumAcceptors, Label]},
+     {tcp_listener_sup, start_link, Args},
      transient, infinity, supervisor, [tcp_listener_sup]}.
 
 -spec start_tcp_listener(

--- a/src/rabbit_queue_location_client_local.erl
+++ b/src/rabbit_queue_location_client_local.erl
@@ -30,4 +30,10 @@ description() ->
     [{description, <<"Locate queue master node as the client local node">>}].
 
 queue_master_location(Q) when ?is_amqqueue(Q) ->
+    %% unlike with other locator strategies we do not check node maintenance
+    %% status for two reasons:
+    %%
+    %% * nodes in maintenance mode will drop their client connections
+    %% * with other strategies, if no nodes are available, the current node
+    %%   is returned but this strategy already does just that
     {ok, node()}.

--- a/src/rabbit_queue_location_random.erl
+++ b/src/rabbit_queue_location_random.erl
@@ -30,7 +30,13 @@ description() ->
       <<"Locate queue master node from cluster in a random manner">>}].
 
 queue_master_location(Q) when ?is_amqqueue(Q) ->
-    Cluster    = rabbit_queue_master_location_misc:all_nodes(Q),
-    RandomPos  = erlang:phash2(erlang:monotonic_time(), length(Cluster)),
-    MasterNode = lists:nth(RandomPos + 1, Cluster),
-    {ok, MasterNode}.
+    Cluster0   = rabbit_queue_master_location_misc:all_nodes(Q),
+    Cluster    = rabbit_maintenance:filter_out_drained_nodes(Cluster0),
+    case Cluster of
+        [] ->
+            undefined;
+        Candidates when is_list(Candidates) ->
+            RandomPos  = erlang:phash2(erlang:monotonic_time(), length(Candidates)),
+            MasterNode = lists:nth(RandomPos + 1, Candidates),
+            {ok, MasterNode}
+    end.

--- a/src/rabbit_queue_location_random.erl
+++ b/src/rabbit_queue_location_random.erl
@@ -31,7 +31,7 @@ description() ->
 
 queue_master_location(Q) when ?is_amqqueue(Q) ->
     Cluster0   = rabbit_queue_master_location_misc:all_nodes(Q),
-    Cluster    = rabbit_maintenance:filter_out_drained_nodes(Cluster0),
+    Cluster    = rabbit_maintenance:filter_out_drained_nodes_local_read(Cluster0),
     case Cluster of
         [] ->
             undefined;

--- a/src/rabbit_queue_master_location_misc.erl
+++ b/src/rabbit_queue_master_location_misc.erl
@@ -18,6 +18,7 @@
          get_location_mod_by_policy/1,
          all_nodes/1]).
 
+-spec lookup_master(binary(), binary()) -> {ok, node()} | {error, not_found}.
 lookup_master(QueueNameBin, VHostPath) when is_binary(QueueNameBin),
                                             is_binary(VHostPath) ->
     QueueR = rabbit_misc:r(VHostPath, queue, QueueNameBin),

--- a/src/rabbit_table.erl
+++ b/src/rabbit_table.erl
@@ -30,6 +30,7 @@
 create() ->
     lists:foreach(fun ({Tab, TabDef}) ->
                           TabDef1 = proplists:delete(match, TabDef),
+                          rabbit_log:debug("Will create a schema database table named '~s'", [Tab]),
                           case mnesia:create_table(Tab, TabDef1) of
                               {atomic, ok} -> ok;
                               {aborted, Reason} ->
@@ -363,7 +364,12 @@ definitions() ->
      {rabbit_queue,
       [{record_name, amqqueue},
        {attributes, amqqueue:fields()},
-       {match, amqqueue:pattern_match_on_name(queue_name_match())}]}]
+       {match, amqqueue:pattern_match_on_name(queue_name_match())}]},
+     {rabbit_node_maintenance_states,
+      [{record_name, node_maintenance_state},
+       {attributes, record_info(fields, node_maintenance_state)},
+       {match, #node_maintenance_state{_='_'}}]}
+    ]
         ++ gm:table_definitions()
         ++ mirrored_supervisor:table_definitions().
 

--- a/src/rabbit_table.erl
+++ b/src/rabbit_table.erl
@@ -7,10 +7,12 @@
 
 -module(rabbit_table).
 
--export([create/0, create_local_copy/1, wait_for_replicated/1, wait/1, wait/2,
-         force_load/0, is_present/0, is_empty/0, needs_default_data/0,
-         check_schema_integrity/1, clear_ram_only_tables/0, retry_timeout/0,
-         wait_for_replicated/0]).
+-export([
+    create/0, create/2, ensure_local_copies/1, ensure_table_copy/2,
+    wait_for_replicated/1, wait/1, wait/2,
+    force_load/0, is_present/0, is_empty/0, needs_default_data/0,
+    check_schema_integrity/1, clear_ram_only_tables/0, retry_timeout/0,
+    wait_for_replicated/0, exists/1]).
 
 %% for testing purposes
 -export([definitions/0]).
@@ -28,18 +30,28 @@
 -spec create() -> 'ok'.
 
 create() ->
-    lists:foreach(fun ({Tab, TabDef}) ->
-                          TabDef1 = proplists:delete(match, TabDef),
-                          rabbit_log:debug("Will create a schema database table named '~s'", [Tab]),
-                          case mnesia:create_table(Tab, TabDef1) of
-                              {atomic, ok} -> ok;
-                              {aborted, Reason} ->
-                                  throw({error, {table_creation_failed,
-                                                 Tab, TabDef1, Reason}})
-                          end
-                  end, definitions()),
+    lists:foreach(
+        fun ({Table, Def}) -> create(Table, Def) end,
+        definitions()),
     ensure_secondary_indexes(),
     ok.
+
+-spec create(mnesia:table(), list()) -> rabbit_types:ok_or_error(any()).
+
+create(TableName, TableDefinition) ->
+    TableDefinition1 = proplists:delete(match, TableDefinition),
+    rabbit_log:debug("Will create a schema database table '~s'", [TableName]),
+    case mnesia:create_table(TableName, TableDefinition1) of
+        {atomic, ok}                              -> ok;
+        {aborted,{already_exists, TableName}}     -> ok;
+        {aborted, {already_exists, TableName, _}} -> ok;
+        {aborted, Reason}                         ->
+            throw({error, {table_creation_failed, TableName, TableDefinition1, Reason}})
+    end.
+
+-spec exists(mnesia:table()) -> boolean().
+exists(Table) ->
+    lists:member(Table, mnesia:system_info(tables)).
 
 %% Sets up secondary indexes in a blank node database.
 ensure_secondary_indexes() ->
@@ -52,19 +64,15 @@ ensure_secondary_index(Table, Field) ->
     {aborted, {already_exists, Table, _}} -> ok
   end.
 
-%% The sequence in which we delete the schema and then the other
-%% tables is important: if we delete the schema first when moving to
-%% RAM mnesia will loudly complain since it doesn't make much sense to
-%% do that. But when moving to disc, we need to move the schema first.
-
--spec create_local_copy('disc' | 'ram') -> 'ok'.
-
-create_local_copy(disc) ->
-    create_local_copy(schema, disc_copies),
-    create_local_copies(disc);
-create_local_copy(ram)  ->
-    create_local_copies(ram),
-    create_local_copy(schema, ram_copies).
+-spec ensure_table_copy(mnesia:table(), node()) -> ok | {error, any()}.
+ensure_table_copy(TableName, Node) ->
+    rabbit_log:debug("Will add a local schema database copy for table '~s'", [TableName]),
+    case mnesia:add_table_copy(TableName, Node, disc_copies) of
+        {atomic, ok}                              -> ok;
+        {aborted,{already_exists, TableName}}     -> ok;
+        {aborted, {already_exists, TableName, _}} -> ok;
+        {aborted, Reason}                         -> {error, Reason}
+    end.
 
 %% This arity only exists for backwards compatibility with certain
 %% plugins. See https://github.com/rabbitmq/rabbitmq-clusterer/issues/19.
@@ -180,6 +188,20 @@ clear_ram_only_tables() ->
               end
       end, names()),
     ok.
+
+%% The sequence in which we delete the schema and then the other
+%% tables is important: if we delete the schema first when moving to
+%% RAM mnesia will loudly complain since it doesn't make much sense to
+%% do that. But when moving to disc, we need to move the schema first.
+
+-spec ensure_local_copies('disc' | 'ram') -> 'ok'.
+
+ensure_local_copies(disc) ->
+    create_local_copy(schema, disc_copies),
+    create_local_copies(disc);
+ensure_local_copies(ram)  ->
+    create_local_copies(ram),
+    create_local_copy(schema, ram_copies).
 
 %%--------------------------------------------------------------------
 %% Internal helpers
@@ -364,11 +386,7 @@ definitions() ->
      {rabbit_queue,
       [{record_name, amqqueue},
        {attributes, amqqueue:fields()},
-       {match, amqqueue:pattern_match_on_name(queue_name_match())}]},
-     {rabbit_node_maintenance_states,
-      [{record_name, node_maintenance_state},
-       {attributes, record_info(fields, node_maintenance_state)},
-       {match, #node_maintenance_state{_='_'}}]}
+       {match, amqqueue:pattern_match_on_name(queue_name_match())}]}
     ]
         ++ gm:table_definitions()
         ++ mirrored_supervisor:table_definitions().

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -656,6 +656,7 @@ transform(TableName, Fun, FieldList, NewRecordName) ->
     ok.
 
 create(Tab, TabDef) ->
+    rabbit_log:debug("Will create a schema table named '~s'", [Tab]),
     {atomic, ok} = mnesia:create_table(Tab, TabDef),
     ok.
 

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -48,10 +48,11 @@
 -rabbit_upgrade({user_password_hashing, mnesia, [hash_passwords]}).
 -rabbit_upgrade({operator_policies,     mnesia, [slave_pids_pending_shutdown, internal_system_x]}).
 -rabbit_upgrade({vhost_limits,          mnesia, []}).
--rabbit_upgrade({queue_vhost_field,     mnesia, [operator_policies]}).
+-rabbit_upgrade({queue_vhost_field,      mnesia, [operator_policies]}).
 -rabbit_upgrade({topic_permission,      mnesia,  []}).
 -rabbit_upgrade({queue_options,         mnesia, [queue_vhost_field]}).
 -rabbit_upgrade({exchange_options,      mnesia, [operator_policies]}).
+-rabbit_upgrade({node_maintenance_states, mnesia, []}).
 
 %% -------------------------------------------------------------------
 
@@ -610,6 +611,7 @@ user_password_hashing() ->
       end,
       [username, password_hash, tags, hashing_algorithm]).
 
+-spec topic_permission() -> 'ok'.
 topic_permission() ->
     create(rabbit_topic_permission,
         [{record_name, topic_permission},
@@ -632,6 +634,13 @@ exchange_options(Table) ->
       end,
       [name, type, durable, auto_delete, internal, arguments, scratches, policy,
        operator_policy, decorators, options]).
+
+-spec node_maintenance_states() -> 'ok'.
+node_maintenance_states() ->
+    create(rabbit_node_maintenance_states,
+        [{record_name, node_maintenance_state},
+         {attributes, [node, state, context]},
+         {disc_copies, [node()]}]).
 
 %%--------------------------------------------------------------------
 

--- a/src/rabbit_upgrade_functions.erl
+++ b/src/rabbit_upgrade_functions.erl
@@ -52,7 +52,6 @@
 -rabbit_upgrade({topic_permission,      mnesia,  []}).
 -rabbit_upgrade({queue_options,         mnesia, [queue_vhost_field]}).
 -rabbit_upgrade({exchange_options,      mnesia, [operator_policies]}).
--rabbit_upgrade({node_maintenance_states, mnesia, []}).
 
 %% -------------------------------------------------------------------
 
@@ -634,13 +633,6 @@ exchange_options(Table) ->
       end,
       [name, type, durable, auto_delete, internal, arguments, scratches, policy,
        operator_policy, decorators, options]).
-
--spec node_maintenance_states() -> 'ok'.
-node_maintenance_states() ->
-    create(rabbit_node_maintenance_states,
-        [{record_name, node_maintenance_state},
-         {attributes, [node, state, context]},
-         {disc_copies, [node()]}]).
 
 %%--------------------------------------------------------------------
 

--- a/src/tcp_listener_sup.erl
+++ b/src/tcp_listener_sup.erl
@@ -17,10 +17,7 @@
 -behaviour(supervisor).
 
 -export([start_link/10]).
-
 -export([init/1]).
-
-%%----------------------------------------------------------------------------
 
 -type mfargs() :: {atom(), atom(), [any()]}.
 
@@ -57,7 +54,7 @@ init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, On
         type => worker,
         modules => [tcp_listener]
     },
-    RanchChildSpec = ranch:child_spec({acceptor, IPAddress, Port},
+    RanchChildSpec = ranch:child_spec(rabbit_networking:ranch_ref(IPAddress, Port),
         Transport, RanchListenerOpts,
         ProtoSup, ProtoOpts),
     {ok, {Flags, [RanchChildSpec, OurChildSpec]}}.

--- a/src/tcp_listener_sup.erl
+++ b/src/tcp_listener_sup.erl
@@ -48,11 +48,16 @@ init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, On
                       {port, Port} |
                       SocketOpts]
      },
-    {ok, {{one_for_all, 10, 10}, [
-        ranch:child_spec({acceptor, IPAddress, Port},
-            Transport, RanchListenerOpts,
-            ProtoSup, ProtoOpts),
-        {tcp_listener, {tcp_listener, start_link,
-                        [IPAddress, Port,
-                         OnStartup, OnShutdown, Label]},
-         transient, 16#ffffffff, worker, [tcp_listener]}]}}.
+    Flags = #{strategy => one_for_all, intensity => 10, period => 10},
+    OurChildSpec = #{
+        id => tcp_listener,
+        start => {tcp_listener, start_link, [IPAddress, Port, OnStartup, OnShutdown, Label]},
+        restart => transient,
+        shutdown => 16#ffffffff,
+        type => worker,
+        modules => [tcp_listener]
+    },
+    RanchChildSpec = ranch:child_spec({acceptor, IPAddress, Port},
+        Transport, RanchListenerOpts,
+        ProtoSup, ProtoOpts),
+    {ok, {Flags, [RanchChildSpec, OurChildSpec]}}.

--- a/test/maintenance_mode_SUITE.erl
+++ b/test/maintenance_mode_SUITE.erl
@@ -1,16 +1,7 @@
-%% The contents of this file are subject to the Mozilla Public License
-%% Version 1.1 (the "License"); you may not use this file except in
-%% compliance with the License. You may obtain a copy of the License
-%% at https://www.mozilla.org/MPL/
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Software distributed under the License is distributed on an "AS IS"
-%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
-%% the License for the specific language governing rights and
-%% limitations under the License.
-%%
-%% The Original Code is RabbitMQ.
-%%
-%% The Initial Developer of the Original Code is GoPivotal, Inc.
 %% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 

--- a/test/maintenance_mode_SUITE.erl
+++ b/test/maintenance_mode_SUITE.erl
@@ -33,7 +33,8 @@ groups() ->
           maintenance_mode_status,
           listener_suspension_status,
           client_connection_closure,
-          queue_leadership_transition
+          classic_mirrored_queue_leadership_transfer,
+          quorum_queue_leadership_transfer
         ]}
     ].
 
@@ -176,7 +177,7 @@ client_connection_closure(Config) ->
     rabbit_ct_broker_helpers:revive_node(Config, A).
 
 
-queue_leadership_transition(Config) ->
+classic_mirrored_queue_leadership_transfer(Config) ->
     [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     ct:pal("Picked node ~s for maintenance tests...", [A]),
 
@@ -202,3 +203,34 @@ queue_leadership_transition(Config) ->
     rabbit_ct_broker_helpers:revive_node(Config, A),
     %% rabbit_ct_broker_helpers:set_ha_policy/4 uses pattern for policy name
     rabbit_ct_broker_helpers:clear_policy(Config, A, PolicyPattern).
+
+quorum_queue_leadership_transfer(Config) ->
+    [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ct:pal("Picked node ~s for maintenance tests...", [A]),
+
+    rabbit_ct_helpers:await_condition(
+        fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+
+    Conn = rabbit_ct_client_helpers:open_connection(Config, A),
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+    QName = <<"qq.1">>,
+    amqp_channel:call(Ch, #'queue.declare'{queue = QName, durable = true, arguments = [
+        {<<"x-queue-type">>, longstr, <<"quorum">>}
+    ]}),
+    
+    %% we cannot assert on the number of local leaders here: declaring a QQ on node A
+    %% does not guarantee that the leader will be hosted on node A
+    
+    rabbit_ct_broker_helpers:drain_node(Config, A),
+    rabbit_ct_helpers:await_condition(
+        fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+    
+    %% quorum queue leader election is asynchronous
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            LocalLeaders = rabbit_ct_broker_helpers:rpc(Config, A,
+                            rabbit_amqqueue, list_local_leaders, []),
+            length(LocalLeaders) =:= 0
+        end, 20000),
+
+    rabbit_ct_broker_helpers:revive_node(Config, A).

--- a/test/maintenance_mode_SUITE.erl
+++ b/test/maintenance_mode_SUITE.erl
@@ -1,0 +1,156 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(maintenance_mode_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+      {group, cluster_size_3}
+    ].
+
+groups() ->
+    [
+      {cluster_size_3, [], [
+          maintenance_mode_status,
+          listener_suspension_status
+        ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Setup and teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(cluster_size_3, Config) ->
+    rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodes_count, 3}
+      ]).
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    ClusterSize = ?config(rmq_nodes_count, Config),
+    TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodes_clustered, true},
+        {rmq_nodename_suffix, Testcase},
+        {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps() ++ [
+        fun rabbit_ct_broker_helpers:set_ha_policy_all/1
+      ]).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test Cases
+%% -------------------------------------------------------------------
+
+maintenance_mode_status(Config) ->
+    Nodes = [A, B, C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    
+    [begin
+         ?assertNot(rabbit_ct_broker_helpers:is_being_drained_local_read(Config, Node)),
+         ?assertNot(rabbit_ct_broker_helpers:is_being_drained_consistent_read(Config, Node))
+     end || Node <- Nodes],
+    
+    [begin
+        [begin
+             ?assertNot(rabbit_ct_broker_helpers:is_being_drained_consistent_read(Config, TargetNode, NodeToCheck))
+        end || NodeToCheck <- Nodes]
+     end || TargetNode <- Nodes],
+
+    rabbit_ct_broker_helpers:mark_as_being_drained(Config, B),
+    rabbit_ct_helpers:await_condition(
+        fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, B) end,
+        10000),
+    
+    [begin
+         ?assert(rabbit_ct_broker_helpers:is_being_drained_consistent_read(Config, TargetNode, B))
+     end || TargetNode <- Nodes],
+    
+    ?assertEqual(
+        lists:usort([A, C]),
+        lists:usort(rabbit_ct_broker_helpers:rpc(Config, B,
+                        rabbit_maintenance, primary_replica_transfer_candidate_nodes, []))),
+    
+    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, B),
+    rabbit_ct_helpers:await_condition(
+        fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, B) end,
+        10000),
+    
+    [begin
+         ?assertNot(rabbit_ct_broker_helpers:is_being_drained_local_read(Config, TargetNode, B)),
+         ?assertNot(rabbit_ct_broker_helpers:is_being_drained_consistent_read(Config, TargetNode, B))
+     end || TargetNode <- Nodes],
+    
+    ?assertEqual(
+        lists:usort([A, C]),
+        lists:usort(rabbit_ct_broker_helpers:rpc(Config, B,
+                        rabbit_maintenance, primary_replica_transfer_candidate_nodes, []))),
+    
+    ok.
+
+listener_suspension_status(Config) ->
+    Nodes = [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ct:pal("Picked node ~s for maintenance tests...", [A]),
+    
+    rabbit_ct_helpers:await_condition(
+        fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+
+    [begin
+         ?assertNot(rabbit_ct_broker_helpers:is_being_drained_consistent_read(Config, Node))
+     end || Node <- Nodes],
+
+    Conn1 = rabbit_ct_client_helpers:open_connection(Config, A),
+    ?assert(is_pid(Conn1)),
+    rabbit_ct_client_helpers:close_connection(Conn1),
+
+    rabbit_ct_broker_helpers:drain_node(Config, A),
+    rabbit_ct_helpers:await_condition(
+        fun () -> rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+
+    ?assertEqual({error, econnrefused}, rabbit_ct_client_helpers:open_unmanaged_connection(Config, A)),
+
+    rabbit_ct_broker_helpers:revive_node(Config, A),
+    rabbit_ct_helpers:await_condition(
+        fun () -> not rabbit_ct_broker_helpers:is_being_drained_local_read(Config, A) end, 10000),
+
+    Conn3 = rabbit_ct_client_helpers:open_connection(Config, A),
+    ?assert(is_pid(Conn3)),
+    rabbit_ct_client_helpers:close_connection(Conn3),
+
+    ok.

--- a/test/queue_master_location_SUITE.erl
+++ b/test/queue_master_location_SUITE.erl
@@ -245,7 +245,7 @@ declare_with_random_and_some_nodes_under_maintenance(Config) ->
     rabbit_ct_broker_helpers:mark_as_being_drained(Config, 0),
     rabbit_ct_broker_helpers:mark_as_being_drained(Config, 2),
     
-    QName = <<"qm.tests.min_masters.maintenance.case1">>,
+    QName = <<"qm.tests.random.maintenance.case1">>,
     Resource = rabbit_misc:r(<<"/">>, queue, QName),
     Record = declare(Config, Resource, false, false, _Args = [], none),
     %% the only node that's not being drained
@@ -264,7 +264,8 @@ declare_with_all_nodes_under_maintenance(Config, Locator) ->
     rabbit_ct_broker_helpers:mark_as_being_drained(Config, 1),
     rabbit_ct_broker_helpers:mark_as_being_drained(Config, 2),
     
-    QName = <<"qm.tests.min_masters.maintenance.case2">>,
+    QName = rabbit_data_coercion:to_binary(
+        rabbit_misc:format("qm.tests.~s.maintenance.case2", [Locator])),
     Resource = rabbit_misc:r(<<"/">>, queue, QName),
     Record = declare(Config, Resource, false, false, _Args = [], none),
     %% when queue master locator returns no node, the node that handles


### PR DESCRIPTION
## Proposed Changes

This introduce a concept of maintenance mode together with initial implementations of `drain` and `revive` commands.
See #2321 for the background and details.

This ability is hidden behind a new feature flag, `maintenance_mode_status`. While this node
is mostly node-local, it depends on a new table and if we add it on node boot unconditionally, it will
fail schema consistency checks in mixed-version clusters.

Depends on

 * https://github.com/rabbitmq/rabbitmq-common/pull/399
 * https://github.com/rabbitmq/rabbitmq-cli/pull/419
 * https://github.com/rabbitmq/rabbitmq-web-dispatch/pull/43
 * https://github.com/rabbitmq/rabbitmq-web-stomp/pull/125
 * https://github.com/rabbitmq/rabbitmq-stomp/pull/149
 * https://github.com/rabbitmq/rabbitmq-mqtt/pull/234
 * https://github.com/rabbitmq/rabbitmq-web-mqtt/pull/67

## How to QA with All Compatible Nodes

Start a three-node cluster where one node has multiple protocol plugins (some examples are provided below).

Then declare some classic and quorum queues, make the classic queues mirrored and open a few connections to a node from a REPL. Then put nodes into maintenance mode using `rabbit_maintenance:drain/0` and `rabbit_maintenance:revive/0` from their shells. Observe what is logged, how queue master replicas migrate, try opening new connections to a node in maintenance mode, and so on. #2321 explains what the `drain` command currently does.

``` shell
%% see peer_discovery.classic_config.1.conf
gmake run-broker PLUGINS="rabbitmq_management rabbitmq_amqp1_0 rabbitmq_mqtt rabbitmq_stomp rabbitmq_web_mqtt rabbitmq_web_stomp" RABBITMQ_CONFIG_FILE=/path/to/peer_discovery.classic_config.1.conf

%% see peer_discovery.classic_config.2.conf
gmake run-broker PLUGINS="rabbitmq_management" RABBITMQ_NODENAME=hare@localhost RABBITMQ_NODE_PORT=5673 RABBITMQ_DIST_PORT=25673 RABBITMQ_CONFIG_FILE=/path/to/peer_discovery.classic_config.2.conf

%% see peer_discovery.classic_config.3.conf
gmake run-broker PLUGINS="rabbitmq_management" RABBITMQ_NODENAME=flopsy@localhost RABBITMQ_NODE_PORT=5674 RABBITMQ_DIST_PORT=25674 RABBITMQ_CONFIG_FILE=/path/to/peer_discovery.classic_config.3.conf
```

``` ini
# peer_discovery.classic_config.1.conf
cluster_formation.peer_discovery_backend = rabbit_peer_discovery_classic_config

cluster_formation.classic_config.nodes.1 = rabbit@localhost
cluster_formation.classic_config.nodes.2 = hare@localhost
cluster_formation.classic_config.nodes.3 = flopsy@localhost

cluster_formation.randomized_startup_delay_range.min = 2
cluster_formation.randomized_startup_delay_range.max = 10

log.file.level = debug

listeners.tcp.1 = 127.0.0.1:5672
listeners.tcp.2 = :::5672
```

``` ini
# peer_discovery.classic_config.2.conf
cluster_formation.peer_discovery_backend = rabbit_peer_discovery_classic_config

cluster_formation.classic_config.nodes.1 = rabbit@localhost
cluster_formation.classic_config.nodes.2 = hare@localhost
cluster_formation.classic_config.nodes.3 = flopsy@localhost

cluster_formation.randomized_startup_delay_range.min = 3
cluster_formation.randomized_startup_delay_range.max = 6

log.file.level = debug

listeners.tcp.1 = 127.0.0.1:5673
listeners.tcp.2 = :::5673

management.tcp.port = 15673
```

``` ini
# peer_discovery.classic_config.3.conf
cluster_formation.peer_discovery_backend = rabbit_peer_discovery_classic_config

cluster_formation.classic_config.nodes.1 = rabbit@localhost
cluster_formation.classic_config.nodes.2 = hare@localhost
cluster_formation.classic_config.nodes.3 = flopsy@localhost

cluster_formation.randomized_startup_delay_range.min = 2
cluster_formation.randomized_startup_delay_range.max = 10

log.file.level = debug

listeners.tcp.1 = 127.0.0.1:5674
listeners.tcp.2 = :::5674

management.tcp.port = 15684
```

## How to QA with In a Mixed Version Cluster

 * Create a cluster of two `3.8.5` nodes (sufficient for this test), A and B
 * Declare a basic topology
 * Stop both nodes
 * Copy their data directories
 * Start node A
 * Start a node from source with data directory from node B (node B's data dir can be copied to `$TMPDIR/rabbitmq-test-instances/rabbit@{hostname}/mnesia/rabbit@{hostname}`, for example)
 * Inspect feature flags
 * Run `ERL_LIBS=../rabbit/plugins ./escript/rabbitmq-diagnostics cluster_status`
 * Stop node A
 * Start another node from source with node A's data directory
 * Inspect feature flags
 * Try draining and reviving either node


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #2321)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

