### PR TITLE
Update credentials_obfuscation to 2.0.0

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -67,6 +67,7 @@ setup(Context) ->
                       config_advanced_file => undefined}
             end,
     ok = override_with_hard_coded_critical_config(),
+    ok = set_credentials_obfuscation_secret(),
     rabbit_log_prelaunch:debug(
       "Saving config state to application env: ~p", [State]),
     store_config_state(State).
@@ -367,6 +368,12 @@ apply_app_env_vars(App, [{Var, Value} | Rest]) ->
     apply_app_env_vars(App, Rest);
 apply_app_env_vars(_, []) ->
     ok.
+
+set_credentials_obfuscation_secret() ->
+    CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
+    rabbit_log_prelaunch:debug(
+      "Setting credentials obfuscation secret to erlang cookie: ~p", [CookieBin]),
+    ok = credentials_obfuscation:set_secret(CookieBin).
 
 %% -------------------------------------------------------------------
 %% Config decryption.

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -370,6 +370,9 @@ apply_app_env_vars(_, []) ->
     ok.
 
 set_credentials_obfuscation_secret() ->
+    rabbit_log_prelaunch:debug("Refreshing credentials obfuscation configuration from env: ~p",
+                               [application:get_all_env(credentials_obfuscation)]),
+    ok = credentials_obfuscation:refresh_config(),
     CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
     rabbit_log_prelaunch:debug(
       "Setting credentials obfuscation secret to erlang cookie: ~p", [CookieBin]),

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -375,7 +375,7 @@ set_credentials_obfuscation_secret() ->
     ok = credentials_obfuscation:refresh_config(),
     CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
     rabbit_log_prelaunch:debug(
-      "Setting credentials obfuscation secret to erlang cookie: ~p", [CookieBin]),
+      "Setting credentials obfuscation secret to '~s'", [CookieBin]),
     ok = credentials_obfuscation:set_secret(CookieBin).
 
 %% -------------------------------------------------------------------

--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -415,15 +415,13 @@ decrypt_app(App, [{Key, Value} | Tail], Algo) ->
             end,
     decrypt_app(App, Tail, Algo2).
 
-decrypt({encrypted, EncValue},
-        {Cipher, Hash, Iterations, PassPhrase} = Algo) ->
-    {rabbit_pbe:decrypt_term(Cipher, Hash, Iterations, PassPhrase, EncValue),
-     Algo};
-decrypt({encrypted, _} = Value,
+decrypt({encrypted, _}=EncValue, {Cipher, Hash, Iterations, PassPhrase} = Algo) ->
+    {rabbit_pbe:decrypt_term(Cipher, Hash, Iterations, PassPhrase, EncValue), Algo};
+decrypt({encrypted, _}=EncValue,
         ConfigEntryDecoder)
   when is_list(ConfigEntryDecoder) ->
     Algo = config_entry_decoder_to_algo(ConfigEntryDecoder),
-    decrypt(Value, Algo);
+    decrypt(EncValue, Algo);
 decrypt(List, Algo) when is_list(List) ->
     decrypt_list(List, Algo, []);
 decrypt(Value, Algo) ->

--- a/src/rabbit_control_pbe.erl
+++ b/src/rabbit_control_pbe.erl
@@ -52,10 +52,9 @@ encode(Cipher, Hash, Iterations, Args) ->
             [Value, PassPhrase] = Args,
             try begin
                     TermValue = evaluate_input_as_term(Value),
-                    Result = rabbit_pbe:encrypt_term(Cipher, Hash, Iterations,
-                                                     list_to_binary(PassPhrase),
-                                                     TermValue),
-                    {ok, io_lib:format("~p", [{encrypted, Result}])}
+                    Result = {encrypted, _} = rabbit_pbe:encrypt_term(Cipher, Hash, Iterations,
+                                                                      list_to_binary(PassPhrase), TermValue),
+                    {ok, io_lib:format("~p", [Result])}
                 end
             catch
                 _:Msg -> {error, io_lib:format("Error during cipher operation: ~p", [Msg])}
@@ -70,10 +69,10 @@ decode(Cipher, Hash, Iterations, Args) ->
             try begin
                     TermValue = evaluate_input_as_term(Value),
                     TermToDecrypt = case TermValue of
-                        {encrypted, EncryptedTerm} ->
+                        {encrypted, _}=EncryptedTerm ->
                             EncryptedTerm;
                         _ ->
-                            TermValue
+                            {encrypted, TermValue}
                     end,
                     Result = rabbit_pbe:decrypt_term(Cipher, Hash, Iterations,
                                                      list_to_binary(PassPhrase),

--- a/test/unit_config_value_encryption_SUITE.erl
+++ b/test/unit_config_value_encryption_SUITE.erl
@@ -83,14 +83,14 @@ do_decrypt_config(Algo = {C, H, I, P}) ->
         msg_store_credit_disc_bound]],
     %% Special case: encrypt a value in a list.
     {ok, [LoopbackUser]} = application:get_env(rabbit, loopback_users),
-    EncLoopbackUser = rabbit_pbe:encrypt_term(C, H, I, P, LoopbackUser),
+    {encrypted, EncLoopbackUser} = rabbit_pbe:encrypt_term(C, H, I, P, LoopbackUser),
     application:set_env(rabbit, loopback_users, [{encrypted, EncLoopbackUser}]),
     %% Special case: encrypt a value in a key/value list.
     {ok, TCPOpts} = application:get_env(rabbit, tcp_listen_options),
     {_, Backlog} = lists:keyfind(backlog, 1, TCPOpts),
     {_, Linger} = lists:keyfind(linger, 1, TCPOpts),
-    EncBacklog = rabbit_pbe:encrypt_term(C, H, I, P, Backlog),
-    EncLinger = rabbit_pbe:encrypt_term(C, H, I, P, Linger),
+    {encrypted, EncBacklog} = rabbit_pbe:encrypt_term(C, H, I, P, Backlog),
+    {encrypted, EncLinger} = rabbit_pbe:encrypt_term(C, H, I, P, Linger),
     TCPOpts1 = lists:keyreplace(backlog, 1, TCPOpts, {backlog, {encrypted, EncBacklog}}),
     TCPOpts2 = lists:keyreplace(linger, 1, TCPOpts1, {linger, {encrypted, EncLinger}}),
     application:set_env(rabbit, tcp_listen_options, TCPOpts2),
@@ -103,7 +103,7 @@ do_decrypt_config(Algo = {C, H, I, P}) ->
 
 encrypt_value(Key, {C, H, I, P}) ->
     {ok, Value} = application:get_env(rabbit, Key),
-    EncValue = rabbit_pbe:encrypt_term(C, H, I, P, Value),
+    {encrypted, EncValue} = rabbit_pbe:encrypt_term(C, H, I, P, Value),
     application:set_env(rabbit, Key, {encrypted, EncValue}).
 
 decrypt_start_app(Config) ->


### PR DESCRIPTION
Required changes for the new library. Using the erlang cookie as the credential secret fixes an issue where clusters with out-of-sync secrets can't decrypt each other's data.