### PR TITLE
Add honeycomb integration for tests

### DIFF
--- a/.github/workflows/test-erlang-otp-21.3.yaml
+++ b/.github/workflows/test-erlang-otp-21.3.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: CHECK RABBITMQ COMPONENTS
         # https://github.community/t5/GitHub-Actions/How-can-I-set-an-expression-as-an-environment-variable-at/m-p/41804/highlight/true#M4751
         id: ref
@@ -59,12 +59,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: umbrellas
-          key: secondary-umbrellas-v3.7.x-v3.8.x-erlang-21.3-rev4
+          key: secondary-umbrellas-v3.7.26-v3.8.5-erlang-21.3-rev4
       - name: PREPARE SECONDARY UMBRELLA COPIES
         if: success() && 'oldest' == 'oldest'
         run: |
           set -ex
-          for version in v3.7.x v3.8.x; do
+          for version in v3.7.26 v3.8.5; do
             umbrella="umbrellas/$version"
             if ! test -d "$umbrella"  ||
                ! make -C "$umbrella/deps/rabbit" test-dist; then
@@ -124,7 +124,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         if: success() && 'oldest' == 'latest'
         uses: actions/download-artifact@v2
@@ -158,7 +158,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -192,7 +192,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -204,12 +204,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-amqqueue_backward_compatibility \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -237,7 +241,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -250,7 +255,23 @@ jobs:
         with:
           name: ct-amqqueue_backward_compatibility-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-backing_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -265,7 +286,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -277,12 +298,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-backing_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -310,7 +335,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -323,7 +349,23 @@ jobs:
         with:
           name: ct-backing_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-channel_interceptor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -338,7 +380,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -350,12 +392,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_interceptor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -383,7 +429,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -396,7 +443,23 @@ jobs:
         with:
           name: ct-channel_interceptor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-channel_operation_timeout:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -411,7 +474,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -423,12 +486,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_operation_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -456,7 +523,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -469,7 +537,23 @@ jobs:
         with:
           name: ct-channel_operation_timeout-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-cluster:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -484,7 +568,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -496,12 +580,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -529,7 +617,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -542,7 +631,23 @@ jobs:
         with:
           name: ct-cluster-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-cluster_rename:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -557,7 +662,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -569,12 +674,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster_rename \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -602,7 +711,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -615,7 +725,23 @@ jobs:
         with:
           name: ct-cluster_rename-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-clustering_management:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -630,7 +756,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -642,12 +768,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-clustering_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -675,7 +805,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -688,7 +819,23 @@ jobs:
         with:
           name: ct-clustering_management-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-config_schema:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -703,7 +850,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -715,12 +862,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-config_schema \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -748,7 +899,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -761,7 +913,23 @@ jobs:
         with:
           name: ct-config_schema-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-confirms_rejects:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -776,7 +944,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -788,12 +956,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-confirms_rejects \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -821,7 +993,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -834,7 +1007,23 @@ jobs:
         with:
           name: ct-confirms_rejects-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-consumer_timeout:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -849,7 +1038,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -861,12 +1050,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-consumer_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -894,7 +1087,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -907,7 +1101,23 @@ jobs:
         with:
           name: ct-consumer_timeout-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-crashing_queues:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -922,7 +1132,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -934,12 +1144,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-crashing_queues \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -967,7 +1181,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -980,7 +1195,23 @@ jobs:
         with:
           name: ct-crashing_queues-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-dead_lettering:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -995,7 +1226,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1007,12 +1238,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dead_lettering \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1040,7 +1275,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1053,7 +1289,23 @@ jobs:
         with:
           name: ct-dead_lettering-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-definition_import:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1068,7 +1320,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1080,12 +1332,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-definition_import \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1113,7 +1369,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1126,7 +1383,23 @@ jobs:
         with:
           name: ct-definition_import-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-disconnect_detected_during_alarm:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1141,7 +1414,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1153,12 +1426,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-disconnect_detected_during_alarm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1186,7 +1463,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1199,7 +1477,23 @@ jobs:
         with:
           name: ct-disconnect_detected_during_alarm-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-dynamic_ha:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1214,7 +1508,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1226,12 +1520,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1259,7 +1557,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1272,7 +1571,23 @@ jobs:
         with:
           name: ct-dynamic_ha-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-dynamic_qq:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1287,7 +1602,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1299,12 +1614,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_qq \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1332,7 +1651,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1345,7 +1665,23 @@ jobs:
         with:
           name: ct-dynamic_qq-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-eager_sync:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1360,7 +1696,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1372,12 +1708,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-eager_sync \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1405,7 +1745,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1418,7 +1759,23 @@ jobs:
         with:
           name: ct-eager_sync-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-feature_flags:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1433,7 +1790,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1445,12 +1802,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-feature_flags \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1478,7 +1839,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1491,7 +1853,23 @@ jobs:
         with:
           name: ct-feature_flags-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-health_check:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1506,7 +1884,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1518,12 +1896,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-health_check \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1551,7 +1933,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1564,7 +1947,23 @@ jobs:
         with:
           name: ct-health_check-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-lazy_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1579,7 +1978,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1591,12 +1990,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-lazy_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1624,7 +2027,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1637,7 +2041,23 @@ jobs:
         with:
           name: ct-lazy_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-list_consumers_sanity_check:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1652,7 +2072,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1664,12 +2084,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-list_consumers_sanity_check \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1697,7 +2121,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1710,7 +2135,23 @@ jobs:
         with:
           name: ct-list_consumers_sanity_check-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-list_queues_online_and_offline:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1725,7 +2166,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1737,12 +2178,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-list_queues_online_and_offline \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1770,7 +2215,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1783,7 +2229,23 @@ jobs:
         with:
           name: ct-list_queues_online_and_offline-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-many_node_ha:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1798,7 +2260,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1810,12 +2272,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-many_node_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1843,7 +2309,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1856,7 +2323,23 @@ jobs:
         with:
           name: ct-many_node_ha-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-message_size_limit:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1871,7 +2354,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1883,12 +2366,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-message_size_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1916,7 +2403,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1929,7 +2417,23 @@ jobs:
         with:
           name: ct-message_size_limit-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-metrics:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1944,7 +2448,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1956,12 +2460,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1989,7 +2497,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2002,7 +2511,23 @@ jobs:
         with:
           name: ct-metrics-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-mirrored_supervisor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2017,7 +2542,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2029,12 +2554,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-mirrored_supervisor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2062,7 +2591,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2075,7 +2605,23 @@ jobs:
         with:
           name: ct-mirrored_supervisor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-msg_store:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2090,7 +2636,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2102,12 +2648,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2135,7 +2685,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2148,7 +2699,23 @@ jobs:
         with:
           name: ct-msg_store-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-peer_discovery_classic_config:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2163,7 +2730,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2175,12 +2742,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_classic_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2208,7 +2779,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2221,7 +2793,23 @@ jobs:
         with:
           name: ct-peer_discovery_classic_config-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-peer_discovery_dns:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2236,7 +2824,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2248,12 +2836,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_dns \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2281,7 +2873,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2294,7 +2887,23 @@ jobs:
         with:
           name: ct-peer_discovery_dns-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_user_connection_tracking:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2309,7 +2918,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2321,12 +2930,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2354,7 +2967,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2367,7 +2981,23 @@ jobs:
         with:
           name: ct-per_user_connection_tracking-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_connection_limit:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2382,7 +3012,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2394,12 +3024,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2427,7 +3061,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2440,7 +3075,23 @@ jobs:
         with:
           name: ct-per_vhost_connection_limit-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_connection_limit_partitions:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2455,7 +3106,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2467,12 +3118,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit_partitions \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2500,7 +3155,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2513,7 +3169,23 @@ jobs:
         with:
           name: ct-per_vhost_connection_limit_partitions-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_msg_store:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2528,7 +3200,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2540,12 +3212,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2573,7 +3249,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2586,7 +3263,23 @@ jobs:
         with:
           name: ct-per_vhost_msg_store-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_queue_limit:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2601,7 +3294,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2613,12 +3306,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_queue_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2646,7 +3343,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2659,7 +3357,23 @@ jobs:
         with:
           name: ct-per_vhost_queue_limit-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-policy:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2674,7 +3388,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2686,12 +3400,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2719,7 +3437,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2732,7 +3451,23 @@ jobs:
         with:
           name: ct-policy-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-priority_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2747,7 +3482,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2759,12 +3494,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2792,7 +3531,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2805,7 +3545,23 @@ jobs:
         with:
           name: ct-priority_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-priority_queue_recovery:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2820,7 +3576,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2832,12 +3588,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue_recovery \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2865,7 +3625,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2878,7 +3639,23 @@ jobs:
         with:
           name: ct-priority_queue_recovery-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-product_info:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2893,7 +3670,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2905,12 +3682,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-product_info \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2938,7 +3719,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2951,7 +3733,23 @@ jobs:
         with:
           name: ct-product_info-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-proxy_protocol:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2966,7 +3764,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2978,12 +3776,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-proxy_protocol \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3011,7 +3813,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3024,7 +3827,23 @@ jobs:
         with:
           name: ct-proxy_protocol-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-publisher_confirms_parallel:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3039,7 +3858,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3051,12 +3870,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-publisher_confirms_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3084,7 +3907,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3097,7 +3921,23 @@ jobs:
         with:
           name: ct-publisher_confirms_parallel-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-queue_length_limits:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3112,7 +3952,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3124,12 +3964,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_length_limits \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3157,7 +4001,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3170,7 +4015,23 @@ jobs:
         with:
           name: ct-queue_length_limits-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-queue_master_location:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3185,7 +4046,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3197,12 +4058,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_master_location \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3230,7 +4095,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3243,7 +4109,23 @@ jobs:
         with:
           name: ct-queue_master_location-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-queue_parallel:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3258,7 +4140,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3270,12 +4152,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3303,7 +4189,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3316,7 +4203,23 @@ jobs:
         with:
           name: ct-queue_parallel-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-quorum_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3331,7 +4234,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3343,12 +4246,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-quorum_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3376,7 +4283,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3389,7 +4297,23 @@ jobs:
         with:
           name: ct-quorum_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_core_metrics_gc:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3404,7 +4328,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3416,12 +4340,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_core_metrics_gc \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3449,7 +4377,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3462,7 +4391,23 @@ jobs:
         with:
           name: ct-rabbit_core_metrics_gc-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_fifo:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3477,7 +4422,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3489,12 +4434,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3522,7 +4471,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3535,7 +4485,23 @@ jobs:
         with:
           name: ct-rabbit_fifo-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_fifo_int:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3550,7 +4516,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3562,12 +4528,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_int \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3595,7 +4565,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3608,7 +4579,23 @@ jobs:
         with:
           name: ct-rabbit_fifo_int-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_fifo_prop:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3623,7 +4610,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3635,12 +4622,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3668,7 +4659,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3681,7 +4673,23 @@ jobs:
         with:
           name: ct-rabbit_fifo_prop-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbitmq_queues_cli_integration:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3696,7 +4704,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3708,12 +4716,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmq_queues_cli_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3741,7 +4753,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3754,7 +4767,23 @@ jobs:
         with:
           name: ct-rabbitmq_queues_cli_integration-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbitmqctl_integration:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3769,7 +4798,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3781,12 +4810,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3814,7 +4847,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3827,7 +4861,23 @@ jobs:
         with:
           name: ct-rabbitmqctl_integration-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbitmqctl_shutdown:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3842,7 +4892,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3854,12 +4904,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_shutdown \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3887,7 +4941,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3900,7 +4955,23 @@ jobs:
         with:
           name: ct-rabbitmqctl_shutdown-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-signal_handling:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3915,7 +4986,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3927,12 +4998,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-signal_handling \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3960,7 +5035,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3973,7 +5049,23 @@ jobs:
         with:
           name: ct-signal_handling-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-simple_ha:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3988,7 +5080,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4000,12 +5092,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-simple_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4033,7 +5129,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4046,7 +5143,23 @@ jobs:
         with:
           name: ct-simple_ha-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-single_active_consumer:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4061,7 +5174,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4073,12 +5186,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-single_active_consumer \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4106,7 +5223,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4119,7 +5237,23 @@ jobs:
         with:
           name: ct-single_active_consumer-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-sup_delayed_restart:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4134,7 +5268,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4146,12 +5280,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-sup_delayed_restart \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4179,7 +5317,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4192,7 +5331,23 @@ jobs:
         with:
           name: ct-sup_delayed_restart-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-sync_detection:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4207,7 +5362,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4219,12 +5374,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-sync_detection \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4252,7 +5411,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4265,7 +5425,23 @@ jobs:
         with:
           name: ct-sync_detection-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-term_to_binary_compat_prop:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4280,7 +5456,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4292,12 +5468,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-term_to_binary_compat_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4325,7 +5505,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4338,7 +5519,23 @@ jobs:
         with:
           name: ct-term_to_binary_compat_prop-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-topic_permission:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4353,7 +5550,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4365,12 +5562,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-topic_permission \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4398,7 +5599,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4411,7 +5613,23 @@ jobs:
         with:
           name: ct-topic_permission-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_access_control:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4426,7 +5644,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4438,12 +5656,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4471,7 +5693,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4484,7 +5707,23 @@ jobs:
         with:
           name: ct-unit_access_control-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_access_control_authn_authz_context_propagation:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4499,7 +5738,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4511,12 +5750,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_authn_authz_context_propagation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4544,7 +5787,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4557,7 +5801,23 @@ jobs:
         with:
           name: ct-unit_access_control_authn_authz_context_propagation-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_access_control_credential_validation:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4572,7 +5832,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4584,12 +5844,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_credential_validation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4617,7 +5881,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4630,7 +5895,23 @@ jobs:
         with:
           name: ct-unit_access_control_credential_validation-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_amqp091_content_framing:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4645,7 +5926,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4657,12 +5938,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_content_framing \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4690,7 +5975,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4703,7 +5989,23 @@ jobs:
         with:
           name: ct-unit_amqp091_content_framing-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_amqp091_server_properties:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4718,7 +6020,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4730,12 +6032,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_server_properties \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4763,7 +6069,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4776,7 +6083,23 @@ jobs:
         with:
           name: ct-unit_amqp091_server_properties-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_app_management:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4791,7 +6114,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4803,12 +6126,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_app_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4836,7 +6163,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4849,7 +6177,23 @@ jobs:
         with:
           name: ct-unit_app_management-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_cluster_formation_locking_mocks:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4864,7 +6208,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4876,12 +6220,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_cluster_formation_locking_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4909,7 +6257,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4922,7 +6271,23 @@ jobs:
         with:
           name: ct-unit_cluster_formation_locking_mocks-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_collections:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4937,7 +6302,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4949,12 +6314,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_collections \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4982,7 +6351,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4995,7 +6365,23 @@ jobs:
         with:
           name: ct-unit_collections-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_config_value_encryption:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5010,7 +6396,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5022,12 +6408,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_config_value_encryption \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5055,7 +6445,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5068,7 +6459,23 @@ jobs:
         with:
           name: ct-unit_config_value_encryption-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_connection_tracking:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5083,7 +6490,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5095,12 +6502,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5128,7 +6539,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5141,7 +6553,23 @@ jobs:
         with:
           name: ct-unit_connection_tracking-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_credit_flow:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5156,7 +6584,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5168,12 +6596,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_credit_flow \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5201,7 +6633,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5214,7 +6647,23 @@ jobs:
         with:
           name: ct-unit_credit_flow-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_disk_monitor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5229,7 +6678,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5241,12 +6690,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5274,7 +6727,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5287,7 +6741,23 @@ jobs:
         with:
           name: ct-unit_disk_monitor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_disk_monitor_mocks:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5302,7 +6772,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5314,12 +6784,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5347,7 +6821,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5360,7 +6835,23 @@ jobs:
         with:
           name: ct-unit_disk_monitor_mocks-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_file_handle_cache:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5375,7 +6866,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5387,12 +6878,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_file_handle_cache \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5420,7 +6915,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5433,7 +6929,23 @@ jobs:
         with:
           name: ct-unit_file_handle_cache-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_gen_server2:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5448,7 +6960,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5460,12 +6972,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gen_server2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5493,7 +7009,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5506,7 +7023,23 @@ jobs:
         with:
           name: ct-unit_gen_server2-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_gm:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5521,7 +7054,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5533,12 +7066,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5566,7 +7103,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5579,7 +7117,23 @@ jobs:
         with:
           name: ct-unit_gm-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_log_config:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5594,7 +7148,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5606,12 +7160,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5639,7 +7197,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5652,7 +7211,23 @@ jobs:
         with:
           name: ct-unit_log_config-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_log_management:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5667,7 +7242,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5679,12 +7254,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5712,7 +7291,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5725,7 +7305,23 @@ jobs:
         with:
           name: ct-unit_log_management-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_operator_policy:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5740,7 +7336,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5752,12 +7348,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_operator_policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5785,7 +7385,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5798,7 +7399,23 @@ jobs:
         with:
           name: ct-unit_operator_policy-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_pg_local:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5813,7 +7430,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5825,12 +7442,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_pg_local \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5858,7 +7479,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5871,7 +7493,23 @@ jobs:
         with:
           name: ct-unit_pg_local-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_plugin_directories:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5886,7 +7524,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5898,12 +7536,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_directories \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5931,7 +7573,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5944,7 +7587,23 @@ jobs:
         with:
           name: ct-unit_plugin_directories-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_plugin_versioning:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5959,7 +7618,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5971,12 +7630,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_versioning \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6004,7 +7667,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6017,7 +7681,23 @@ jobs:
         with:
           name: ct-unit_plugin_versioning-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_policy_validators:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6032,7 +7712,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6044,12 +7724,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_policy_validators \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6077,7 +7761,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6090,7 +7775,23 @@ jobs:
         with:
           name: ct-unit_policy_validators-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_priority_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6105,7 +7806,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6117,12 +7818,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6150,7 +7855,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6163,7 +7869,23 @@ jobs:
         with:
           name: ct-unit_priority_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_queue_consumers:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6178,7 +7900,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6190,12 +7912,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_queue_consumers \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6223,7 +7949,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6236,7 +7963,23 @@ jobs:
         with:
           name: ct-unit_queue_consumers-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_stats_and_metrics:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6251,7 +7994,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6263,12 +8006,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_stats_and_metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6296,7 +8043,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6309,7 +8057,23 @@ jobs:
         with:
           name: ct-unit_stats_and_metrics-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_supervisor2:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6324,7 +8088,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6336,12 +8100,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_supervisor2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6369,7 +8137,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6382,7 +8151,23 @@ jobs:
         with:
           name: ct-unit_supervisor2-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_vm_memory_monitor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6397,7 +8182,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6409,12 +8194,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_vm_memory_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6442,7 +8231,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6455,7 +8245,23 @@ jobs:
         with:
           name: ct-unit_vm_memory_monitor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-upgrade_preparation:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6470,7 +8276,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6482,12 +8288,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-upgrade_preparation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6515,7 +8325,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6528,7 +8339,23 @@ jobs:
         with:
           name: ct-upgrade_preparation-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-vhost:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6543,7 +8370,7 @@ jobs:
         with:
           otp-version: 21.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6555,12 +8382,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.10.3
           make ct-vhost \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'oldest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6588,7 +8419,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6601,7 +8433,23 @@ jobs:
         with:
           name: ct-vhost-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   capture-tested-deps-versions:
     needs:
       - dialyzer

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: CHECK RABBITMQ COMPONENTS
         # https://github.community/t5/GitHub-Actions/How-can-I-set-an-expression-as-an-environment-variable-at/m-p/41804/highlight/true#M4751
         id: ref
@@ -59,12 +59,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: umbrellas
-          key: secondary-umbrellas-v3.7.x-v3.8.x-erlang-22.3-rev4
+          key: secondary-umbrellas-v3.7.26-v3.8.5-erlang-22.3-rev4
       - name: PREPARE SECONDARY UMBRELLA COPIES
         if: success() && 'latest' == 'oldest'
         run: |
           set -ex
-          for version in v3.7.x v3.8.x; do
+          for version in v3.7.26 v3.8.5; do
             umbrella="umbrellas/$version"
             if ! test -d "$umbrella"  ||
                ! make -C "$umbrella/deps/rabbit" test-dist; then
@@ -124,7 +124,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         if: success() && 'latest' == 'latest'
         uses: actions/download-artifact@v2
@@ -158,7 +158,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -192,7 +192,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -204,12 +204,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-amqqueue_backward_compatibility \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -237,7 +241,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -250,7 +255,23 @@ jobs:
         with:
           name: ct-amqqueue_backward_compatibility-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-backing_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -265,7 +286,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -277,12 +298,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-backing_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -310,7 +335,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -323,7 +349,23 @@ jobs:
         with:
           name: ct-backing_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-channel_interceptor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -338,7 +380,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -350,12 +392,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_interceptor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -383,7 +429,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -396,7 +443,23 @@ jobs:
         with:
           name: ct-channel_interceptor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-channel_operation_timeout:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -411,7 +474,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -423,12 +486,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_operation_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -456,7 +523,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -469,7 +537,23 @@ jobs:
         with:
           name: ct-channel_operation_timeout-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-cluster:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -484,7 +568,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -496,12 +580,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -529,7 +617,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -542,7 +631,23 @@ jobs:
         with:
           name: ct-cluster-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-cluster_rename:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -557,7 +662,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -569,12 +674,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster_rename \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -602,7 +711,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -615,7 +725,23 @@ jobs:
         with:
           name: ct-cluster_rename-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-clustering_management:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -630,7 +756,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -642,12 +768,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-clustering_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -675,7 +805,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -688,7 +819,23 @@ jobs:
         with:
           name: ct-clustering_management-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-config_schema:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -703,7 +850,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -715,12 +862,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-config_schema \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -748,7 +899,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -761,7 +913,23 @@ jobs:
         with:
           name: ct-config_schema-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-confirms_rejects:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -776,7 +944,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -788,12 +956,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-confirms_rejects \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -821,7 +993,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -834,7 +1007,23 @@ jobs:
         with:
           name: ct-confirms_rejects-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-consumer_timeout:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -849,7 +1038,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -861,12 +1050,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-consumer_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -894,7 +1087,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -907,7 +1101,23 @@ jobs:
         with:
           name: ct-consumer_timeout-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-crashing_queues:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -922,7 +1132,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -934,12 +1144,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-crashing_queues \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -967,7 +1181,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -980,7 +1195,23 @@ jobs:
         with:
           name: ct-crashing_queues-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-dead_lettering:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -995,7 +1226,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1007,12 +1238,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dead_lettering \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1040,7 +1275,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1053,7 +1289,23 @@ jobs:
         with:
           name: ct-dead_lettering-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-definition_import:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1068,7 +1320,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1080,12 +1332,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-definition_import \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1113,7 +1369,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1126,7 +1383,23 @@ jobs:
         with:
           name: ct-definition_import-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-disconnect_detected_during_alarm:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1141,7 +1414,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1153,12 +1426,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-disconnect_detected_during_alarm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1186,7 +1463,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1199,7 +1477,23 @@ jobs:
         with:
           name: ct-disconnect_detected_during_alarm-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-dynamic_ha:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1214,7 +1508,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1226,12 +1520,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1259,7 +1557,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1272,7 +1571,23 @@ jobs:
         with:
           name: ct-dynamic_ha-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-dynamic_qq:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1287,7 +1602,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1299,12 +1614,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_qq \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1332,7 +1651,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1345,7 +1665,23 @@ jobs:
         with:
           name: ct-dynamic_qq-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-eager_sync:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1360,7 +1696,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1372,12 +1708,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-eager_sync \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1405,7 +1745,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1418,7 +1759,23 @@ jobs:
         with:
           name: ct-eager_sync-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-feature_flags:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1433,7 +1790,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1445,12 +1802,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-feature_flags \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1478,7 +1839,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1491,7 +1853,23 @@ jobs:
         with:
           name: ct-feature_flags-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-health_check:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1506,7 +1884,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1518,12 +1896,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-health_check \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1551,7 +1933,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1564,7 +1947,23 @@ jobs:
         with:
           name: ct-health_check-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-lazy_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1579,7 +1978,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1591,12 +1990,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-lazy_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1624,7 +2027,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1637,7 +2041,23 @@ jobs:
         with:
           name: ct-lazy_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-list_consumers_sanity_check:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1652,7 +2072,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1664,12 +2084,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-list_consumers_sanity_check \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1697,7 +2121,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1710,7 +2135,23 @@ jobs:
         with:
           name: ct-list_consumers_sanity_check-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-list_queues_online_and_offline:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1725,7 +2166,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1737,12 +2178,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-list_queues_online_and_offline \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1770,7 +2215,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1783,7 +2229,23 @@ jobs:
         with:
           name: ct-list_queues_online_and_offline-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-many_node_ha:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1798,7 +2260,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1810,12 +2272,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-many_node_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1843,7 +2309,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1856,7 +2323,23 @@ jobs:
         with:
           name: ct-many_node_ha-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-message_size_limit:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1871,7 +2354,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1883,12 +2366,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-message_size_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1916,7 +2403,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -1929,7 +2417,23 @@ jobs:
         with:
           name: ct-message_size_limit-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-metrics:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -1944,7 +2448,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1956,12 +2460,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -1989,7 +2497,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2002,7 +2511,23 @@ jobs:
         with:
           name: ct-metrics-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-mirrored_supervisor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2017,7 +2542,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2029,12 +2554,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-mirrored_supervisor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2062,7 +2591,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2075,7 +2605,23 @@ jobs:
         with:
           name: ct-mirrored_supervisor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-msg_store:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2090,7 +2636,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2102,12 +2648,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2135,7 +2685,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2148,7 +2699,23 @@ jobs:
         with:
           name: ct-msg_store-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-peer_discovery_classic_config:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2163,7 +2730,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2175,12 +2742,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_classic_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2208,7 +2779,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2221,7 +2793,23 @@ jobs:
         with:
           name: ct-peer_discovery_classic_config-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-peer_discovery_dns:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2236,7 +2824,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2248,12 +2836,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_dns \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2281,7 +2873,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2294,7 +2887,23 @@ jobs:
         with:
           name: ct-peer_discovery_dns-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_user_connection_tracking:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2309,7 +2918,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2321,12 +2930,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2354,7 +2967,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2367,7 +2981,23 @@ jobs:
         with:
           name: ct-per_user_connection_tracking-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_connection_limit:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2382,7 +3012,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2394,12 +3024,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2427,7 +3061,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2440,7 +3075,23 @@ jobs:
         with:
           name: ct-per_vhost_connection_limit-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_connection_limit_partitions:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2455,7 +3106,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2467,12 +3118,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit_partitions \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2500,7 +3155,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2513,7 +3169,23 @@ jobs:
         with:
           name: ct-per_vhost_connection_limit_partitions-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_msg_store:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2528,7 +3200,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2540,12 +3212,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2573,7 +3249,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2586,7 +3263,23 @@ jobs:
         with:
           name: ct-per_vhost_msg_store-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-per_vhost_queue_limit:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2601,7 +3294,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2613,12 +3306,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_queue_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2646,7 +3343,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2659,7 +3357,23 @@ jobs:
         with:
           name: ct-per_vhost_queue_limit-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-policy:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2674,7 +3388,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2686,12 +3400,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2719,7 +3437,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2732,7 +3451,23 @@ jobs:
         with:
           name: ct-policy-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-priority_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2747,7 +3482,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2759,12 +3494,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2792,7 +3531,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2805,7 +3545,23 @@ jobs:
         with:
           name: ct-priority_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-priority_queue_recovery:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2820,7 +3576,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2832,12 +3588,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue_recovery \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2865,7 +3625,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2878,7 +3639,23 @@ jobs:
         with:
           name: ct-priority_queue_recovery-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-product_info:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2893,7 +3670,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2905,12 +3682,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-product_info \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -2938,7 +3719,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -2951,7 +3733,23 @@ jobs:
         with:
           name: ct-product_info-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-proxy_protocol:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -2966,7 +3764,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2978,12 +3776,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-proxy_protocol \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3011,7 +3813,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3024,7 +3827,23 @@ jobs:
         with:
           name: ct-proxy_protocol-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-publisher_confirms_parallel:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3039,7 +3858,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3051,12 +3870,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-publisher_confirms_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3084,7 +3907,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3097,7 +3921,23 @@ jobs:
         with:
           name: ct-publisher_confirms_parallel-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-queue_length_limits:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3112,7 +3952,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3124,12 +3964,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_length_limits \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3157,7 +4001,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3170,7 +4015,23 @@ jobs:
         with:
           name: ct-queue_length_limits-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-queue_master_location:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3185,7 +4046,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3197,12 +4058,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_master_location \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3230,7 +4095,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3243,7 +4109,23 @@ jobs:
         with:
           name: ct-queue_master_location-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-queue_parallel:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3258,7 +4140,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3270,12 +4152,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3303,7 +4189,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3316,7 +4203,23 @@ jobs:
         with:
           name: ct-queue_parallel-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-quorum_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3331,7 +4234,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3343,12 +4246,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-quorum_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3376,7 +4283,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3389,7 +4297,23 @@ jobs:
         with:
           name: ct-quorum_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_core_metrics_gc:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3404,7 +4328,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3416,12 +4340,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_core_metrics_gc \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3449,7 +4377,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3462,7 +4391,23 @@ jobs:
         with:
           name: ct-rabbit_core_metrics_gc-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_fifo:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3477,7 +4422,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3489,12 +4434,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3522,7 +4471,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3535,7 +4485,23 @@ jobs:
         with:
           name: ct-rabbit_fifo-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_fifo_int:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3550,7 +4516,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3562,12 +4528,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_int \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3595,7 +4565,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3608,7 +4579,23 @@ jobs:
         with:
           name: ct-rabbit_fifo_int-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbit_fifo_prop:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3623,7 +4610,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3635,12 +4622,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3668,7 +4659,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3681,7 +4673,23 @@ jobs:
         with:
           name: ct-rabbit_fifo_prop-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbitmq_queues_cli_integration:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3696,7 +4704,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3708,12 +4716,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmq_queues_cli_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3741,7 +4753,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3754,7 +4767,23 @@ jobs:
         with:
           name: ct-rabbitmq_queues_cli_integration-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbitmqctl_integration:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3769,7 +4798,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3781,12 +4810,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3814,7 +4847,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3827,7 +4861,23 @@ jobs:
         with:
           name: ct-rabbitmqctl_integration-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-rabbitmqctl_shutdown:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3842,7 +4892,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3854,12 +4904,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_shutdown \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3887,7 +4941,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3900,7 +4955,23 @@ jobs:
         with:
           name: ct-rabbitmqctl_shutdown-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-signal_handling:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3915,7 +4986,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3927,12 +4998,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-signal_handling \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -3960,7 +5035,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -3973,7 +5049,23 @@ jobs:
         with:
           name: ct-signal_handling-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-simple_ha:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -3988,7 +5080,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4000,12 +5092,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-simple_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4033,7 +5129,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4046,7 +5143,23 @@ jobs:
         with:
           name: ct-simple_ha-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-single_active_consumer:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4061,7 +5174,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4073,12 +5186,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-single_active_consumer \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4106,7 +5223,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4119,7 +5237,23 @@ jobs:
         with:
           name: ct-single_active_consumer-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-sup_delayed_restart:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4134,7 +5268,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4146,12 +5280,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-sup_delayed_restart \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4179,7 +5317,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4192,7 +5331,23 @@ jobs:
         with:
           name: ct-sup_delayed_restart-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-sync_detection:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4207,7 +5362,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4219,12 +5374,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-sync_detection \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4252,7 +5411,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4265,7 +5425,23 @@ jobs:
         with:
           name: ct-sync_detection-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-term_to_binary_compat_prop:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4280,7 +5456,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4292,12 +5468,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-term_to_binary_compat_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4325,7 +5505,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4338,7 +5519,23 @@ jobs:
         with:
           name: ct-term_to_binary_compat_prop-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-topic_permission:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4353,7 +5550,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4365,12 +5562,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-topic_permission \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4398,7 +5599,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4411,7 +5613,23 @@ jobs:
         with:
           name: ct-topic_permission-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_access_control:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4426,7 +5644,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4438,12 +5656,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4471,7 +5693,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4484,7 +5707,23 @@ jobs:
         with:
           name: ct-unit_access_control-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_access_control_authn_authz_context_propagation:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4499,7 +5738,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4511,12 +5750,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_authn_authz_context_propagation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4544,7 +5787,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4557,7 +5801,23 @@ jobs:
         with:
           name: ct-unit_access_control_authn_authz_context_propagation-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_access_control_credential_validation:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4572,7 +5832,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4584,12 +5844,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_credential_validation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4617,7 +5881,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4630,7 +5895,23 @@ jobs:
         with:
           name: ct-unit_access_control_credential_validation-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_amqp091_content_framing:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4645,7 +5926,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4657,12 +5938,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_content_framing \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4690,7 +5975,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4703,7 +5989,23 @@ jobs:
         with:
           name: ct-unit_amqp091_content_framing-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_amqp091_server_properties:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4718,7 +6020,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4730,12 +6032,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_server_properties \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4763,7 +6069,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4776,7 +6083,23 @@ jobs:
         with:
           name: ct-unit_amqp091_server_properties-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_app_management:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4791,7 +6114,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4803,12 +6126,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_app_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4836,7 +6163,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4849,7 +6177,23 @@ jobs:
         with:
           name: ct-unit_app_management-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_cluster_formation_locking_mocks:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4864,7 +6208,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4876,12 +6220,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_cluster_formation_locking_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4909,7 +6257,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4922,7 +6271,23 @@ jobs:
         with:
           name: ct-unit_cluster_formation_locking_mocks-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_collections:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -4937,7 +6302,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4949,12 +6314,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_collections \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -4982,7 +6351,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -4995,7 +6365,23 @@ jobs:
         with:
           name: ct-unit_collections-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_config_value_encryption:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5010,7 +6396,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5022,12 +6408,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_config_value_encryption \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5055,7 +6445,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5068,7 +6459,23 @@ jobs:
         with:
           name: ct-unit_config_value_encryption-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_connection_tracking:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5083,7 +6490,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5095,12 +6502,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5128,7 +6539,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5141,7 +6553,23 @@ jobs:
         with:
           name: ct-unit_connection_tracking-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_credit_flow:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5156,7 +6584,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5168,12 +6596,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_credit_flow \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5201,7 +6633,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5214,7 +6647,23 @@ jobs:
         with:
           name: ct-unit_credit_flow-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_disk_monitor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5229,7 +6678,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5241,12 +6690,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5274,7 +6727,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5287,7 +6741,23 @@ jobs:
         with:
           name: ct-unit_disk_monitor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_disk_monitor_mocks:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5302,7 +6772,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5314,12 +6784,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5347,7 +6821,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5360,7 +6835,23 @@ jobs:
         with:
           name: ct-unit_disk_monitor_mocks-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_file_handle_cache:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5375,7 +6866,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5387,12 +6878,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_file_handle_cache \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5420,7 +6915,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5433,7 +6929,23 @@ jobs:
         with:
           name: ct-unit_file_handle_cache-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_gen_server2:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5448,7 +6960,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5460,12 +6972,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gen_server2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5493,7 +7009,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5506,7 +7023,23 @@ jobs:
         with:
           name: ct-unit_gen_server2-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_gm:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5521,7 +7054,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5533,12 +7066,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5566,7 +7103,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5579,7 +7117,23 @@ jobs:
         with:
           name: ct-unit_gm-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_log_config:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5594,7 +7148,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5606,12 +7160,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5639,7 +7197,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5652,7 +7211,23 @@ jobs:
         with:
           name: ct-unit_log_config-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_log_management:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5667,7 +7242,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5679,12 +7254,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5712,7 +7291,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5725,7 +7305,23 @@ jobs:
         with:
           name: ct-unit_log_management-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_operator_policy:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5740,7 +7336,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5752,12 +7348,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_operator_policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5785,7 +7385,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5798,7 +7399,23 @@ jobs:
         with:
           name: ct-unit_operator_policy-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_pg_local:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5813,7 +7430,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5825,12 +7442,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_pg_local \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5858,7 +7479,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5871,7 +7493,23 @@ jobs:
         with:
           name: ct-unit_pg_local-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_plugin_directories:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5886,7 +7524,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5898,12 +7536,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_directories \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -5931,7 +7573,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -5944,7 +7587,23 @@ jobs:
         with:
           name: ct-unit_plugin_directories-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_plugin_versioning:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -5959,7 +7618,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5971,12 +7630,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_versioning \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6004,7 +7667,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6017,7 +7681,23 @@ jobs:
         with:
           name: ct-unit_plugin_versioning-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_policy_validators:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6032,7 +7712,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6044,12 +7724,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_policy_validators \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6077,7 +7761,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6090,7 +7775,23 @@ jobs:
         with:
           name: ct-unit_policy_validators-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_priority_queue:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6105,7 +7806,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6117,12 +7818,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6150,7 +7855,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6163,7 +7869,23 @@ jobs:
         with:
           name: ct-unit_priority_queue-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_queue_consumers:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6178,7 +7900,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6190,12 +7912,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_queue_consumers \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6223,7 +7949,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6236,7 +7963,23 @@ jobs:
         with:
           name: ct-unit_queue_consumers-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_stats_and_metrics:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6251,7 +7994,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6263,12 +8006,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_stats_and_metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6296,7 +8043,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6309,7 +8057,23 @@ jobs:
         with:
           name: ct-unit_stats_and_metrics-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_supervisor2:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6324,7 +8088,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6336,12 +8100,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_supervisor2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6369,7 +8137,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6382,7 +8151,23 @@ jobs:
         with:
           name: ct-unit_supervisor2-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-unit_vm_memory_monitor:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6397,7 +8182,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6409,12 +8194,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_vm_memory_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6442,7 +8231,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6455,7 +8245,23 @@ jobs:
         with:
           name: ct-unit_vm_memory_monitor-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-upgrade_preparation:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6470,7 +8276,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6482,12 +8288,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-upgrade_preparation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6515,7 +8325,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6528,7 +8339,23 @@ jobs:
         with:
           name: ct-upgrade_preparation-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   ct-vhost:
     needs: [checks]
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
@@ -6543,7 +8370,7 @@ jobs:
         with:
           otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6555,12 +8382,16 @@ jobs:
         run: |
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-vhost \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
             FULL= \
             FAIL_FAST=1 \
-            SKIP_AS_ERROR=1
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
       - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
         if: success() && 'latest' == 'oldest'
         uses: actions/download-artifact@v2
@@ -6588,7 +8419,8 @@ jobs:
               FAIL_FAST=1 \
               SKIP_AS_ERROR=1 \
               SECONDARY_UMBRELLA=$PWD/$umbrella \
-              RABBITMQ_FEATURE_FLAGS=
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
           done
       - name: ON FAILURE ARCHIVE TESTS LOGS
         if: failure()
@@ -6601,7 +8433,23 @@ jobs:
         with:
           name: ct-vhost-logs
           path: "*-ct-logs-*.tar.xz"
-  # vim:sw=2:et:
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done  # vim:sw=2:et:
   capture-tested-deps-versions:
     needs:
       - dialyzer

--- a/.github/workflows/test-jobs/30-CT_SUITE.yaml
+++ b/.github/workflows/test-jobs/30-CT_SUITE.yaml
@@ -1,0 +1,95 @@
+  # vim:sw=2:et:
+  ct-$(CT_SUITE):
+    needs: [checks]
+    # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts
+    name: ct-$(CT_SUITE)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: CHECKOUT REPOSITORY
+        uses: actions/checkout@v2
+      # https://github.com/marketplace/actions/setup-elixir
+      - name: CONFIGURE OTP & ELIXIR
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: $(ERLANG_VERSION)
+          # https://github.com/elixir-lang/elixir/releases
+          elixir-version: $(ELIXIR_VERSION)
+      - name: DOWNLOAD DEPS ARCHIVE
+        uses: actions/download-artifact@v2
+        with:
+          name: deps.tar.xz
+      - name: UNPACK DEPS ARCHIVE
+        run: |
+          tar Jxf deps.tar.xz
+      - name: RUN TESTS
+        run: |
+          branch_or_tag_name=${GITHUB_REF#refs/*/}
+          ! test -d ebin || touch ebin/*
+          export BASE_RMQ_REF=$(base_rmq_ref)
+          export ERLANG_VERSION=$(ERLANG_VERSION)
+          export ELIXIR_VERSION=$(ELIXIR_VERSION)
+          make ct-$(CT_SUITE) \
+            base_rmq_ref=$(base_rmq_ref) \
+            current_rmq_ref=$branch_or_tag_name \
+            FULL= \
+            FAIL_FAST=1 \
+            SKIP_AS_ERROR=1 \
+            CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
+      - name: DOWNLOAD SECONDARY UMBRELLAS ARCHIVE
+        if: success() && '$(ERLANG_VERSION_IS)' == 'oldest'
+        uses: actions/download-artifact@v2
+        with:
+          name: secondary-umbrellas.tar.xz
+      - name: UNPACK SECONDARY UMBRELLAS ARCHIVE
+        if: success() && '$(ERLANG_VERSION_IS)' == 'oldest'
+        run: |
+          set -ex
+          tar Jxf secondary-umbrellas.tar.xz
+          rm secondary-umbrellas.tar.xz
+      - name: RUN TESTS [mixed-versions]
+        if: success() && '$(ERLANG_VERSION_IS)' == 'oldest'
+        run: |
+          set -ex
+          branch_or_tag_name=${GITHUB_REF#refs/*/}
+          for umbrella in umbrellas/*; do
+            test -d "$umbrella"
+            printf '\n\033[1;32mMixing clusters with RabbitMQ %s\033[0m' \
+              $(basename "$umbrella")
+            make distclean-ct ct-$(CT_SUITE) \
+              base_rmq_ref=$(base_rmq_ref) \
+              current_rmq_ref=$branch_or_tag_name \
+              FULL= \
+              FAIL_FAST=1 \
+              SKIP_AS_ERROR=1 \
+              SECONDARY_UMBRELLA=$PWD/$umbrella \
+              RABBITMQ_FEATURE_FLAGS= \
+              CT_OPTS="-ct_hooks honeycomb_cth '[{directory,\"$PWD/honeycomb\"}]'"
+          done
+      - name: ON FAILURE ARCHIVE TESTS LOGS
+        if: failure()
+        run: |
+          make ct-logs-archive
+      - name: ON FAILURE UPLOAD TESTS LOGS ARTIFACT
+        # https://github.com/marketplace/actions/upload-artifact
+        uses: actions/upload-artifact@v2-preview
+        if: failure()
+        with:
+          name: ct-$(CT_SUITE)-logs
+          path: "*-ct-logs-*.tar.xz"
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls honeycomb | wc -l) events recorded"
+          for f in honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done

--- a/test/honeycomb_cth.erl
+++ b/test/honeycomb_cth.erl
@@ -1,0 +1,105 @@
+-module(honeycomb_cth).
+
+-export([id/1]).
+-export([init/2]).
+
+-export([pre_init_per_testcase/4]).
+-export([post_end_per_testcase/5]).
+
+-record(state, {directory, github_workflow, github_run_id,
+                github_repository, github_sha, github_ref,
+                base_rmq_ref, secondary_umbrella,
+                erlang_version, elixir_version,
+                otp_release, cpu_topology, schedulers,
+                system_architecture, system_memory_data,
+                start_times = #{}}).
+
+id(Opts) ->
+    proplists:get_value(directory, Opts, "/tmp/honeycomb").
+
+init(Id, _Opts) ->
+    application:ensure_all_started(os_mon),
+    {ok, #state{directory = Id,
+                github_workflow = os:getenv("GITHUB_WORKFLOW", "unknown"),
+                github_run_id = os:getenv("GITHUB_RUN_ID", "unknown"),
+                github_repository = os:getenv("GITHUB_REPOSITORY", "unknown"),
+                github_sha = os:getenv("GITHUB_SHA", "unknown"),
+                github_ref = os:getenv("GITHUB_REF", "unknown"),
+                base_rmq_ref = os:getenv("BASE_RMQ_REF", "unknown"),
+                secondary_umbrella = os:getenv("SECONDARY_UMBRELLA", "none"),
+                erlang_version = os:getenv("ERLANG_VERSION", "unknown"),
+                elixir_version = os:getenv("ELIXIR_VERSION", "unknown"),
+                otp_release = erlang:system_info(otp_release),
+                cpu_topology = erlang:system_info(cpu_topology),
+                schedulers = erlang:system_info(schedulers),
+                system_architecture = erlang:system_info(system_architecture),
+                system_memory_data = memsup:get_system_memory_data()}}.
+
+pre_init_per_testcase(Suite, TC, Config, #state{start_times = StartTimes} = State) ->
+    SuiteTimes = maps:get(Suite, StartTimes, #{}),
+    {Config, State#state{start_times =
+                             StartTimes#{Suite =>
+                                             SuiteTimes#{TC => erlang:timestamp()}}}}.
+
+post_end_per_testcase(Suite, TC, _Config, Return, #state{github_workflow = GithubWorkflow,
+                                                         github_run_id = GithubRunId,
+                                                         github_repository = GithubRepository,
+                                                         github_sha = GithubSha,
+                                                         github_ref = GithubRef,
+                                                         base_rmq_ref = BaseRmqRef,
+                                                         secondary_umbrella = SecondaryUmbrella,
+                                                         erlang_version = ErlangVersion,
+                                                         elixir_version = ElixirVersion,
+                                                         otp_release = OtpRelease,
+                                                         cpu_topology = CpuTopology,
+                                                         schedulers = Schedulers,
+                                                         system_architecture = SystemArchitecture,
+                                                         system_memory_data = SystemMemoryData,
+                                                         start_times = StartTimes} = State) ->
+    EndTime = erlang:timestamp(),
+    SuiteTimes = maps:get(Suite, StartTimes),
+    {StartTime, SuiteTimes1} = maps:take(TC, SuiteTimes),
+    DurationMicroseconds = timer:now_diff(EndTime, StartTime),
+
+    File = filename(Suite, TC, State),
+    ok = filelib:ensure_dir(File),
+    {ok, F} = file:open(File, [write]),
+
+    Json = jsx:encode([{<<"ci">>, <<"GitHub Actions">>},
+                       {<<"github_workflow">>, list_to_binary(GithubWorkflow)},
+                       {<<"github_run_id">>, list_to_binary(GithubRunId)},
+                       {<<"github_repository">>, list_to_binary(GithubRepository)},
+                       {<<"github_sha">>, list_to_binary(GithubSha)},
+                       {<<"github_ref">>, list_to_binary(GithubRef)},
+                       {<<"base_rmq_ref">>, list_to_binary(BaseRmqRef)},
+                       {<<"secondary_umbrella">>, list_to_binary(SecondaryUmbrella)},
+                       {<<"erlang_version">>, list_to_binary(ErlangVersion)},
+                       {<<"elixir_version">>, list_to_binary(ElixirVersion)},
+                       {<<"otp_release">>, list_to_binary(OtpRelease)},
+                       {<<"cpu_topology">>, cpu_topology_json_term(CpuTopology)},
+                       {<<"schedulers">>, Schedulers},
+                       {<<"system_architecture">>, list_to_binary(SystemArchitecture)},
+                       {<<"system_memory_data">>, memory_json_term(SystemMemoryData)},
+                       {<<"suite">>, list_to_binary(atom_to_list(Suite))},
+                       {<<"testcase">>, list_to_binary(atom_to_list(TC))},
+                       {<<"duration_seconds">>, DurationMicroseconds / 1000000},
+                       {<<"result">>, list_to_binary(io_lib:format("~p", [Return]))}]),
+
+    file:write(F, Json),
+    file:close(F),
+    {Return, State#state{start_times = StartTimes#{Suite := SuiteTimes1}}}.
+
+filename(Suite, TC, #state{directory = Dir}) ->
+    filename:join(Dir,
+                  integer_to_list(erlang:system_time())
+                  ++ "_" ++ atom_to_list(Suite)
+                  ++ "_" ++ atom_to_list(TC)
+                  ++ ".json").
+
+memory_json_term(SystemMemoryData) when is_list(SystemMemoryData) ->
+    [{list_to_binary(atom_to_list(K)), V} || {K, V} <- SystemMemoryData].
+
+cpu_topology_json_term([{processor, Cores}]) when is_list(Cores) ->
+    [{<<"processor">>, [begin
+                            [{<<"core">>, [{list_to_binary(atom_to_list(Kind)), Index}]}]
+                        end || {core, {Kind, Index}} <- Cores]}].


### PR DESCRIPTION
Report test results from Github Actions to honeycomb for statistical analysis

`honeycomb_cth.erl` has been duplicated from https://github.com/rabbitmq/rabbitmq-management/pull/811 but, I don't think it is worth determining it's proper home until it's clear whether honeycomb will be a long term thing.