### PR TITLE
Introduce raft.data_dir to new style configuration schema

### DIFF
--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1666,6 +1666,18 @@ end}.
     end
 }.
 
+{mapping, "raft.data_dir", "ra.data_dir", [
+  {datatype, string}
+]}.
+
+{translation, "ra.data_dir",
+    fun(Conf) ->
+        case cuttlefish:conf_get("raft.data_dir", Conf, undefined) of
+            undefined -> cuttlefish:unset();
+            Val       -> Val
+        end
+    end
+}.
 
 % ===============================
 % Validators

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -708,7 +708,8 @@ status() ->
           {enabled_plugin_file, rabbit_plugins:enabled_plugins_file()}],
     S6 = [{config_files, config_files()},
            {log_files, log_locations()},
-           {data_directory, rabbit_mnesia:dir()}],
+           {data_directory, rabbit_mnesia:dir()},
+           {raft_data_directory, ra_env:data_dir()}],
     Totals = case rabbit:is_running() of
                  true ->
                      [{virtual_host_count, rabbit_vhost:count()},

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -667,6 +667,13 @@ credential_validator.regexp = ^abc\\d+",
   %% Raft
   %%
 
+  {raft_data_dir,
+   "raft.data_dir = /data/rabbitmq/raft/log",
+   [{ra, [
+      {data_dir, "/data/rabbitmq/raft/log"}
+     ]}],
+   []},
+
   {raft_segment_max_entries,
    "raft.segment_max_entries = 65536",
    [{ra, [


### PR DESCRIPTION
As an experimental feature for now. To be sure that this value
has the desired effect we may have to tweak the way Ra dependency
is started.

Some early tests suggest this works as expected already.

Per discussion with @kjnilsson.

Closes #2354 together with https://github.com/rabbitmq/rabbitmq-cli/pull/423.
