### PR TITLE
Handle undefined exchange

### DIFF
--- a/src/rabbit_exchange.erl
+++ b/src/rabbit_exchange.erl
@@ -71,7 +71,10 @@ callback(X = #exchange{type       = XType,
     [ok = apply(M, Fun, [Serial(M:serialise_events(X)) | Args]) ||
         M <- rabbit_exchange_decorator:select(all, Decorators)],
     Module = type_to_module(XType),
-    apply(Module, Fun, [Serial(Module:serialise_events()) | Args]).
+    apply(Module, Fun, [Serial(Module:serialise_events()) | Args]);
+
+callback(undefined, _, _, _) ->
+    rabbit_log:warning("ignore undefined exchange").
 
 -spec policy_changed
         (rabbit_types:exchange(), rabbit_types:exchange()) -> 'ok'.


### PR DESCRIPTION
## Proposed Changes

Occasionally, I saw rabbitmq start failed because for some reason
exchange is undefined. Under this case, maybe it is reasonable to
skip this exchange and go on the clean up process.
