### PR TITLE
Use the newly defined MSG_STORE_WORKER_WAIT for rabbit_msg_store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ define PROJECT_ENV
 	    {connection_max, infinity},
 	    {heartbeat, 60},
 	    {msg_store_file_size_limit, 16777216},
+	    {msg_store_shutdown_timeout, 600000},
 	    {fhc_write_buffering, true},
 	    {fhc_read_buffering, false},
 	    {queue_index_max_journal_entries, 32768},

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1090,7 +1090,7 @@ end}.
 {mapping, "mnesia_table_loading_retry_limit", "rabbit.mnesia_table_loading_retry_limit",
     [{datatype, integer}]}.
 
-{mapping, "message_store_shutdown_timeout", "rabbit.message_store_shutdown_timeout",
+{mapping, "message_store_shutdown_timeout", "rabbit.msg_store_shutdown_timeout",
     [
         {datatype, integer},
         {validators, ["non_zero_positive_integer"]}

--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -1090,6 +1090,12 @@ end}.
 {mapping, "mnesia_table_loading_retry_limit", "rabbit.mnesia_table_loading_retry_limit",
     [{datatype, integer}]}.
 
+{mapping, "message_store_shutdown_timeout", "rabbit.message_store_shutdown_timeout",
+    [
+        {datatype, integer},
+        {validators, ["non_zero_positive_integer"]}
+    ]}.
+
 %% Size in bytes below which to embed messages in the queue index. See
 %% https://www.rabbitmq.com/persistence-conf.html
 %%

--- a/src/rabbit_vhost_msg_store.erl
+++ b/src/rabbit_vhost_msg_store.erl
@@ -29,7 +29,7 @@ start(VHost, Type, ClientRefs, StartupFunState) when is_list(ClientRefs);
             supervisor2:start_child(VHostSup,
                                     {Type, {rabbit_msg_store, start_link,
                                             [Type, VHostDir, ClientRefs, StartupFunState]},
-                                     transient, ?WORKER_WAIT, worker, [rabbit_msg_store]});
+                                     transient, ?MSG_STORE_WORKER_WAIT, worker, [rabbit_msg_store]});
         %% we can get here if a vhost is added and removed concurrently
         %% e.g. some integration tests do it
         {error, {no_such_vhost, VHost}} = E ->

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -602,6 +602,20 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
+  {rabbit_message_store_shutdown_timeout,
+   "message_store_shutdown_timeout = 600000",
+   [{rabbit, [
+      {message_store_shutdown_timeout, 600000}
+     ]}],
+   []},
+
+  {rabbit_mnesia_table_loading_retry_timeout,
+   "mnesia_table_loading_retry_timeout = 45000",
+   [{rabbit, [
+      {mnesia_table_loading_retry_timeout, 45000}
+     ]}],
+   []},
+
   {log_syslog_settings,
    "log.syslog = true
     log.syslog.identity = rabbitmq

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -602,10 +602,10 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
-  {rabbit_message_store_shutdown_timeout,
+  {rabbit_msg_store_shutdown_timeout,
    "message_store_shutdown_timeout = 600000",
    [{rabbit, [
-      {message_store_shutdown_timeout, 600000}
+      {msg_store_shutdown_timeout, 600000}
      ]}],
    []},
 


### PR DESCRIPTION
rabbit_msg_store in particular may need on the order of minutes to shutdown gracefully when there are millions of persistent messages