### PR TITLE
Deprecate 'ctl node_health_check'

### DIFF
--- a/docs/rabbitmqctl.8
+++ b/docs/rabbitmqctl.8
@@ -1440,9 +1440,11 @@ is located on the current node.
 .\" ------------------------------------------------------------------
 .It Cm node_health_check
 .Pp
-Performs several health checks of the target node.
+DEPRECATED. Performs intrusive, opinionated health checks on a fully booted node.
+To learn more, see the
+.Lk https://www.rabbitmq.com/monitoring.html#health-checks "Health Checks documentation"
 .Pp
-Verifies the rabbit application is running and alarms are not set,
+Verifies the RabbitMQ application is running and alarms are not set,
 then checks that every queue and channel on the node can emit basic stats.
 .sp
 Example:

--- a/src/rabbit_health_check.erl
+++ b/src/rabbit_health_check.erl
@@ -36,6 +36,8 @@ node(Node, Timeout) ->
 -spec local() -> ok | {error_string, string()}.
 
 local() ->
+    rabbit_log:warning("rabbitmqctl node_health_check and its HTTP API counterpart are DEPRECATED. "
+                       "See https://www.rabbitmq.com/monitoring.html#health-checks for replacement options."),
     run_checks([list_channels, list_queues, alarms, rabbit_node_monitor]).
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
 * It requires a fully booted node, so not generally suitable for a Kubernetes readiness probe.
 * It can produce false positives
 * It is too intrusive and CPU-intensive to use at scale
 * Most operators do not understand what it really does and when they learn about it,
   consider it to be too opinionated and intrusive

Time for the One True Health Check™ to retire from duty.

Part of rabbitmq/rabbitmq-cli#426

Per discussion with @lukebakken 