### PR TITLE
Ensure rabbitmq_management is loaded

### DIFF
--- a/src/rabbit_definitions.erl
+++ b/src/rabbit_definitions.erl
@@ -76,7 +76,12 @@ maybe_load_core_definitions() ->
     maybe_load_definitions(rabbit, load_definitions).
 
 maybe_load_management_definitions() ->
-    maybe_load_definitions(rabbitmq_management, load_definitions).
+    case application:load(rabbitmq_management) of
+        ok ->
+            maybe_load_definitions(rabbitmq_management, load_definitions);
+        _ ->
+            ok
+    end.
 
 -spec import_raw(Body :: binary() | iolist()) -> ok | {error, term()}.
 import_raw(Body) ->


### PR DESCRIPTION
This ensures that `rabbitmq_management` settings are available at this point in time.
If the plugin is not available, this step is skipped because the application can not be loaded.

To test:

```
RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS='-rabbitmq_management load_definitions "/tmp/defs.json"' ./sbin/rabbitmq-server
```