### PR TITLE
Support RABBITMQ_HOME paths containing brackets on windows

### DIFF
--- a/scripts/rabbitmq-env.bat
+++ b/scripts/rabbitmq-env.bat
@@ -15,9 +15,9 @@ set SCRIPT_NAME=%1
 for /f "delims=" %%F in ("%SCRIPT_DIR%..") do set RABBITMQ_HOME=%%~dpF%%~nF%%~xF
 
 if defined ERL_LIBS (
-    set ERL_LIBS=%RABBITMQ_HOME%\plugins;%ERL_LIBS%
+    set "ERL_LIBS=%RABBITMQ_HOME%\plugins;%ERL_LIBS%"
 ) else (
-    set ERL_LIBS=%RABBITMQ_HOME%\plugins
+    set "ERL_LIBS=%RABBITMQ_HOME%\plugins"
 )
 
 REM If ERLANG_HOME is not defined, check if "erl.exe" is available in


### PR DESCRIPTION
If the environment variable RABBITMQ_HOME contained a path with either
'(' or ')' (for example, a path under C:\Program Files (x86)\), then
the script would unexpectedly exit with the error
'\some\path was unexpected at this time'. This was caused by the
parenthesis being interpreted as part of the batch 'if/else'.

Adding quotes around the arguments to the SET command fixes the problem.

## Proposed Changes
This fixes a bug re-introduced in 3.8.4 which causes the rabbitmq service to fail to install on
Windows, if the installation path contains parenthesis ('(' or ')'): #1756

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #1756)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
I tested by downloading the windows .zip archive, applying this fix to the script, and installing the service manually by running `rabbitmq-service.bat install`. Without this fix it fails, with this fix it succeeds.
