### PR TITLE
Revert "Ensure rabbitmq_management is loaded"

### DIFF
--- a/src/rabbit_definitions.erl
+++ b/src/rabbit_definitions.erl
@@ -76,12 +76,7 @@ maybe_load_core_definitions() ->
     maybe_load_definitions(rabbit, load_definitions).
 
 maybe_load_management_definitions() ->
-    case application:load(rabbitmq_management) of
-        ok ->
-            maybe_load_definitions(rabbitmq_management, load_definitions);
-        _ ->
-            ok
-    end.
+    maybe_load_definitions(rabbitmq_management, load_definitions).
 
 -spec import_raw(Body :: binary() | iolist()) -> ok | {error, term()}.
 import_raw(Body) ->


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-server#2368. See #2368 comments to find out why.