### PR TITLE
rabbit_prelaunch: Load configuration before Erlang dist. is started

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -104,11 +104,11 @@ do_run() ->
     %% 1. Erlang/OTP compatibility check.
     ok = rabbit_prelaunch_erlang_compat:check(Context),
 
-    %% 2. Erlang distribution check + start.
-    ok = rabbit_prelaunch_dist:setup(Context),
-
-    %% 3. Configuration check + loading.
+    %% 2. Configuration check + loading.
     ok = rabbit_prelaunch_conf:setup(Context),
+
+    %% 3. Erlang distribution check + start.
+    ok = rabbit_prelaunch_dist:setup(Context),
 
     %% 4. Write PID file.
     rabbit_log_prelaunch:debug(""),


### PR DESCRIPTION
The reason is that kernel's `net_ticktime` can be configured in the Cuttlefish or Erlang configuration files. If we start the distribution first, then the configuration parameter is ignored.

Fixes #2377.