### PR TITLE
Import definitions in the post-launch phase

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -981,9 +981,14 @@ recover() ->
 -spec maybe_insert_default_data() -> 'ok'.
 
 maybe_insert_default_data() ->
-    case rabbit_table:needs_default_data() of
-        true  -> insert_default_data();
-        false -> ok
+    NoDefsToImport = not rabbit_definitions:has_configured_definitions_to_load(),
+    case rabbit_table:needs_default_data() andalso NoDefsToImport of
+        true  ->
+            rabbit_log:info("Will seed default virtual host and user..."),
+            insert_default_data();
+        false ->
+            rabbit_log:info("Will not seed default virtual host and user: have definitions to load..."),
+            ok
     end.
 
 insert_default_data() ->


### PR DESCRIPTION
To make sure definitions that depend on plugins (federation upstreams, shovels, exchanges of custom types) can be imported.

This preserves an implicit feature of the previous implementation: since definition import was performed in a boot step
that preceded the empty DB check one in the boot step DAG, a node with a definition file to load would not seed its default data (virtual host and user).

Closes #2384.