### PR TITLE
Definition import: pre-format more values as maps where possible

### DIFF
--- a/src/rabbit_definitions.erl
+++ b/src/rabbit_definitions.erl
@@ -656,7 +656,7 @@ exchange_definition(#exchange{name = #resource{virtual_host = VHost, name = Name
       <<"type">> => Type,
       <<"durable">> => Durable,
       <<"auto_delete">> => AD,
-      <<"arguments">> => Args}.
+      <<"arguments">> => rabbit_misc:amqp_table(Args)}.
 
 list_queues() ->
     %% exclude exclusive queues, they cannot be restored
@@ -679,7 +679,7 @@ queue_definition(Q) ->
         <<"type">> => Type,
         <<"durable">> => amqqueue:is_durable(Q),
         <<"auto_delete">> => amqqueue:is_auto_delete(Q),
-        <<"arguments">> => maps:from_list(Arguments)
+        <<"arguments">> => rabbit_misc:amqp_table(Arguments)
     }.
 
 list_bindings() ->
@@ -696,7 +696,7 @@ binding_definition(#binding{source      = S,
         <<"destination">> => D#resource.name,
         <<"destination_type">> => D#resource.kind,
         <<"routing_key">> => RoutingKey,
-        <<"arguments">> => maps:from_list(Arguments)
+        <<"arguments">> => rabbit_misc:amqp_table(Arguments)
     }.
 
 list_vhosts() ->

--- a/src/rabbit_definitions.erl
+++ b/src/rabbit_definitions.erl
@@ -727,7 +727,7 @@ runtime_parameter_definition(Param) ->
         <<"vhost">> => pget(vhost, Param),
         <<"component">> => pget(component, Param),
         <<"name">> => pget(name, Param),
-        <<"value">> => pget(value, Param)
+        <<"value">> => maps:from_list(pget(value, Param))
     }.
 
 list_global_runtime_parameters() ->


### PR DESCRIPTION
To make it easier to serialize the returned value and rely less on Erlang- or RabbitMQ-specific collection types such as proplists (meh) and AMQP 0-9-1 argument tables (which are typed proplists, still a meh).

This also adds some export-then-reimport tests that discovered the issue with x-argument formatting not being "JSON-friendly" without post-processing.

@lukebakken  I will investigate if the issue that https://github.com/rabbitmq/rabbitmq-server/commit/460a432ddb2337dad6a7ca350497a8e2aee5063f tries to address is still relevant in one of the commercial plugins. As far as I can tell, it should not be, or at least should be addressed on the import side.