### PR TITLE
rabbit_prelaunch_early_logging: Configure `rabbit_log` as a Logger handler

### DIFF
--- a/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -26,6 +26,7 @@ get_default_log_level() ->
 
 do_setup_early_logging(#{log_levels := LogLevels} = Context,
                        LagerEventToStdout) ->
+    redirect_logger_messages_to_lager(),
     Colored = use_colored_logging(Context),
     application:set_env(lager, colored, Colored),
     ConsoleBackend = lager_console_backend,
@@ -49,6 +50,11 @@ do_setup_early_logging(#{log_levels := LogLevels} = Context,
                 [{handlers, [{ConsoleBackend, [{level, CLogLevel}]}]}])
       end, list_expected_sinks()),
     ok.
+
+redirect_logger_messages_to_lager() ->
+    io:format(standard_error, "Configuring logger redirection~n", []),
+    ok = logger:add_handler(rabbit_log, rabbit_log, #{}),
+    ok = logger:set_primary_config(level, all).
 
 use_colored_logging() ->
     use_colored_logging(rabbit_prelaunch:get_context()).


### PR DESCRIPTION
Currently, when the new Logger API exposed by Erlang is being used by an application, messages are lost once Lager is configured. That is because Lager does not know about Logger in this context.

To fix this, `rabbit_log` is configured as a Logger handler which calls Lager API. This means that Logger messages are passed to Lager.

Logger's log level is to set to pass all messages (including debug). Message routing/filtering is done by Lager instead.

This change depends on new log/2 function being added to the `rabbit_log` module in rabbitmq-common.

References rabbitmq/rabbitmq-common#400.