### PR TITLE
Move networking boot step to end of startup

### DIFF
--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -935,6 +935,7 @@ do_run_postlaunch_phase() ->
 
         %% start listeners after all plugins have been enabled,
         %% see rabbitmq/rabbitmq-server#2405
+        rabbit_log_prelaunch:info("Ready to start client connection listeners"),
         ok = rabbit_networking:boot()
     catch
         throw:{error, _} = Error ->

--- a/src/rabbit.erl
+++ b/src/rabbit.erl
@@ -250,8 +250,8 @@
                     {requires,    pre_flight}]}).
 
 -rabbit_boot_step({networking,
-                   [{description, "TCP and TLS listeners"},
-                    {mfa,         {rabbit_networking, boot, []}},
+                   [{description, "TCP and TLS listeners (backwards compatibility)"},
+                    {mfa,         {rabbit_log, debug, ["'networking' boot step skipped and moved to end of startup", []]}},
                     {requires,    notify_cluster}]}).
 
 %%---------------------------------------------------------------------------
@@ -928,7 +928,14 @@ do_run_postlaunch_phase() ->
                rabbit_plugins:strictly_plugins(rabbit_plugins:active())),
         %% export definitions after all plugins have been enabled,
         %% see rabbitmq/rabbitmq-server#2384
-        rabbit_definitions:maybe_load_definitions()
+        case rabbit_definitions:maybe_load_definitions() of
+            ok -> ok;
+            DefLoadError -> throw(DefLoadError)
+        end,
+
+        %% start listeners after all plugins have been enabled,
+        %% see rabbitmq/rabbitmq-server#2405
+        ok = rabbit_networking:boot()
     catch
         throw:{error, _} = Error ->
             rabbit_prelaunch_errors:log_error(Error),

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -80,6 +80,7 @@
 boot() ->
     ok = record_distribution_listener(),
     _ = application:start(ranch),
+    rabbit_log:debug("Started Ranch"),
     %% Failures will throw exceptions
     _ = boot_listeners(fun boot_tcp/1, application:get_env(rabbit, num_tcp_acceptors, 10), "TCP"),
     _ = boot_listeners(fun boot_tls/1, application:get_env(rabbit, num_ssl_acceptors, 10), "TLS"),


### PR DESCRIPTION
This allows plugins to configure network listener settings and have
those settings apply to all listeners when started.

Fixes #2405