### PR TITLE
Fix parsing of queue arguments on definitions list

### DIFF
--- a/src/rabbit_definitions.erl
+++ b/src/rabbit_definitions.erl
@@ -663,14 +663,13 @@ queue_definition(Q) ->
                rabbit_quorum_queue -> quorum;
                T -> T
            end,
-    Arguments = [{Key, Value} || {Key, _Type, Value} <- amqqueue:get_arguments(Q)],
     #{
         <<"vhost">> => VHost,
         <<"name">> => Name,
         <<"type">> => Type,
         <<"durable">> => amqqueue:is_durable(Q),
         <<"auto_delete">> => amqqueue:is_auto_delete(Q),
-        <<"arguments">> => rabbit_misc:amqp_table(Arguments)
+        <<"arguments">> => rabbit_misc:amqp_table(amqqueue:get_arguments(Q))
     }.
 
 list_bindings() ->

--- a/test/definition_import_SUITE_data/case13.json
+++ b/test/definition_import_SUITE_data/case13.json
@@ -1,0 +1,55 @@
+{
+  "bindings": [],
+  "exchanges": [],
+  "global_parameters": [
+    {
+      "name": "cluster_name",
+      "value": "rabbit@localhost"
+    }
+  ],
+  "parameters": [],
+  "permissions": [
+    {
+      "configure": ".*",
+      "read": ".*",
+      "user": "guest",
+      "vhost": "/",
+      "write": ".*"
+    }
+  ],
+  "policies": [],
+  "queues": [
+    {
+      "arguments": {
+        "x-max-length": 991,
+        "x-queue-type": "quorum"
+      },
+      "auto_delete": false,
+      "durable": true,
+      "name": "definitions.import.case13.qq.1",
+      "type": "quorum",
+      "vhost": "/"
+    }
+  ],
+  "rabbit_version": "3.8.6.gad0c0bd",
+  "rabbitmq_version": "3.8.6.gad0c0bd",
+  "topic_permissions": [],
+  "users": [
+    {
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "name": "guest",
+      "password_hash": "e8lL5PHYcbv3Pd53EUoTOMnVDmsLDgVJXqSQMT+mrO4LVIdW",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts": [
+    {
+      "limits": [],
+      "metadata": {
+        "description": "Default virtual host",
+        "tags": []
+      },
+      "name": "/"
+    }
+  ]
+}


### PR DESCRIPTION
`rabbit_definitions:list_queues` was reporting an empty list of arguments, which causes queues to be imported but type and other parameters differ from the original one.

References #2400.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #2427)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
