### PR TITLE
Fix bug in get_metadata function in vhost.erl module.

### DIFF
--- a/src/vhost.erl
+++ b/src/vhost.erl
@@ -149,7 +149,7 @@ get_limits(VHost) -> vhost_v1:get_limits(VHost).
 
 -spec get_metadata(vhost()) -> metadata().
 get_metadata(#vhost{metadata = Value}) -> Value;
-get_metadata(VHost) -> vhost_v1:get_limits(VHost).
+get_metadata(VHost) -> vhost_v1:get_metadata(VHost).
 
 -spec get_description(vhost()) -> binary().
 get_description(#vhost{} = VHost) ->


### PR DESCRIPTION
## Proposed Changes
The get_metadata function in the vhost module has a bug. It calls vhost_v1:get_limits() instead of vhost_v1:get_metadata(). This pull request is for fixing the above mentioned bug.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
