### PR TITLE
Add auth attemp metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ define PROJECT_ENV
 	    %% interval at which connection/channel tracking executes post operations
 	    {tracking_execution_timeout, 15000},
 	    {stream_messages_soft_limit, 256},
-        {return_per_user_auth_attempt_metrics, false}
+        {track_auth_attempt_source, false}
 	  ]
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,8 @@ define PROJECT_ENV
 	    {writer_gc_threshold, 1000000000},
 	    %% interval at which connection/channel tracking executes post operations
 	    {tracking_execution_timeout, 15000},
-	    {stream_messages_soft_limit, 256}
+	    {stream_messages_soft_limit, 256},
+        {return_per_user_auth_attempt_metrics, false}
 	  ]
 endef
 

--- a/src/rabbit_core_metrics_gc.erl
+++ b/src/rabbit_core_metrics_gc.erl
@@ -36,6 +36,7 @@ handle_info(start_gc, State) ->
     gc_exchanges(),
     gc_nodes(),
     gc_gen_server2(),
+    gc_auth_attempts(),
     {noreply, start_timer(State)}.
 
 terminate(_Reason, #state{timer = TRef}) ->
@@ -193,3 +194,6 @@ gc_process_and_entities(Table, QueueGbSet, ExchangeGbSet) ->
                       gc_entity(Q, Table, Key, QueueGbSet),
                       gc_entity(X, Table, Key, ExchangeGbSet)
               end, none, Table).
+
+gc_auth_attempts() ->
+    ets:delete_all_objects(auth_attempt_detailed_metrics).

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1413,15 +1413,19 @@ auth_phase(Response,
                                        auth_mechanism = {Name, AuthMechanism},
                                        auth_state     = AuthState},
                        sock = Sock}) ->
+    Ip = list_to_binary(inet:ntoa(Connection#connection.host)),
     case AuthMechanism:handle_response(Response, AuthState) of
         {refused, Username, Msg, Args} ->
+            rabbit_core_metrics:auth_attempt_failed(Ip, Username),
             auth_fail(Username, Msg, Args, Name, State);
         {protocol_error, Msg, Args} ->
+            rabbit_core_metrics:auth_attempt_failed(Ip, ""),
             notify_auth_result(none, user_authentication_failure,
                                [{error, rabbit_misc:format(Msg, Args)}],
                                State),
             rabbit_misc:protocol_error(syntax_error, Msg, Args);
         {challenge, Challenge, AuthState1} ->
+            rabbit_core_metrics:auth_attempt_succeeded(Ip, ""),
             Secure = #'connection.secure'{challenge = Challenge},
             ok = send_on_channel0(Sock, Secure, Protocol),
             State#v1{connection = Connection#connection{
@@ -1429,9 +1433,11 @@ auth_phase(Response,
         {ok, User = #user{username = Username}} ->
             case rabbit_access_control:check_user_loopback(Username, Sock) of
                 ok ->
+                    rabbit_core_metrics:auth_attempt_succeeded(Ip, Username),
                     notify_auth_result(Username, user_authentication_success,
                                        [], State);
                 not_allowed ->
+                    rabbit_core_metrics:auth_attempt_failed(Ip, Username),
                     auth_fail(Username, "user '~s' can only connect via "
                               "localhost", [Username], Name, State)
             end,


### PR DESCRIPTION
## Proposed Changes

The number of successful and failed authorization attempts per ip and user can be useful for troubleshooting, however the addition of these metrics has some implications. When the attempt metrics contain the ip and username, they cardinality could grow infinitely. This is not only an issue for Prometheus, which we've configured to aggregate by default since 3.8.2, but internally the ets table containing the metrics doesn't have a criteria for clean up. Thus, these metrics will have special treatment.
Auth attempt metrics:
- Are aggregated by default with its own switch on the broker: {rabbit, [{return_per_user_auth_attempt_metrics, false}]}
-  Are not handled as other rabbit metrics, there is no aggregation or computation of stats
-  Have a HTTP API management endpoint to query and reset
-  Have a CLI command to enable/dissable aggregation, reset and list metrics
-  Should only be used by the operator in the non-aggregated mode for troubleshootting or on environments where the number of ip and users are guaranteed to be bound
- Could cause a memory leak if used on non-aggregated mode
- Are exported by the Prometheus plugin
- Must be incremented by each protocol, the server does it for AMQP 0.9.1 and  AMQP 1.0 and MQTT on their respective plugins. We don't have IP information when the AMQP 1.0 authorization happens, so this one reports an empty ip on non-aggregated mode.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

