### PR TITLE
Revert "tcp_listener_sup: use maps for supervisor flags and child spec"

### DIFF
--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -184,14 +184,9 @@ tcp_listener_spec(NamePrefix, {IPAddress, Port, Family}, SocketOpts,
             {?MODULE, tcp_listener_started, [Protocol, SocketOpts]},
             {?MODULE, tcp_listener_stopped, [Protocol, SocketOpts]},
             NumAcceptors, Label],
-    #{
-        id => rabbit_misc:tcp_name(NamePrefix, IPAddress, Port),
-        start => {tcp_listener_sup, start_link, Args},
-        restart => transient,
-        shutdown => infinity,
-        type => supervisor,
-        modules => [tcp_listener_sup]
-    }.
+    {rabbit_misc:tcp_name(NamePrefix, IPAddress, Port),
+     {tcp_listener_sup, start_link, Args},
+     transient, infinity, supervisor, [tcp_listener_sup]}.
 
 -spec ranch_ref(#listener{} | [{atom(), any()}] | 'undefined') -> ranch:ref() | undefined.
 ranch_ref(#listener{port = Port}) ->

--- a/src/tcp_listener_sup.erl
+++ b/src/tcp_listener_sup.erl
@@ -45,15 +45,9 @@ init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, On
                       {port, Port} |
                       SocketOpts]
      },
-    Flags = #{strategy => one_for_all, intensity => 10, period => 10},
-    OurChildSpec = #{
-        id => tcp_listener,
-        start => {tcp_listener, start_link, [IPAddress, Port, OnStartup, OnShutdown, Label]},
-        restart => transient,
-        shutdown => 16#ffffffff,
-        type => worker,
-        modules => [tcp_listener]
-    },
+    Flags = {one_for_all, 10, 10},
+    OurChildSpecStart = {tcp_listener, start_link, [IPAddress, Port, OnStartup, OnShutdown, Label]},
+    OurChildSpec = {tcp_listener, OurChildSpecStart, transient, 16#ffffffff, worker, [tcp_listener]},
     RanchChildSpec = ranch:child_spec(rabbit_networking:ranch_ref(IPAddress, Port),
         Transport, RanchListenerOpts,
         ProtoSup, ProtoOpts),


### PR DESCRIPTION
This reverts commit e86fa81a3f90599d03b2f9beaaa56cfb6a4226f1.
