### PR TITLE
Test with Erlang 22.3 and 23.0

### DIFF
--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -1,6 +1,6 @@
 # vim:sw=2:et:
 # https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow
-name: "Test - Erlang 21.3"
+name: "Test - Erlang 22.3"
 on:
   push:
   repository_dispatch:
@@ -18,9 +18,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: CHECK RABBITMQ COMPONENTS
         # https://github.community/t5/GitHub-Actions/How-can-I-set-an-expression-as-an-environment-variable-at/m-p/41804/highlight/true#M4751
         id: ref
@@ -59,12 +59,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: umbrellas
-          key: secondary-umbrellas-v3.7.27-rc.1-v3.8.5-erlang-21.3-rev4
+          key: secondary-umbrellas-v3.7.28-v3.8.8-erlang-22.3-rev4
       - name: PREPARE SECONDARY UMBRELLA COPIES
         if: success() && 'oldest' == 'oldest'
         run: |
           set -ex
-          for version in v3.7.27-rc.1 v3.8.5; do
+          for version in v3.7.28 v3.8.8; do
             umbrella="umbrellas/$version"
             if ! test -d "$umbrella"  ||
                ! make -C "$umbrella/deps/rabbit" test-dist; then
@@ -122,9 +122,9 @@ jobs:
         if: success() && 'oldest' == 'latest'
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         if: success() && 'oldest' == 'latest'
         uses: actions/download-artifact@v2
@@ -156,9 +156,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -190,9 +190,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -205,8 +205,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-amqqueue_backward_compatibility \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -285,9 +285,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -300,8 +300,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-backing_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -380,9 +380,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -395,8 +395,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_interceptor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -475,9 +475,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -490,8 +490,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_operation_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -570,9 +570,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -585,8 +585,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -665,9 +665,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -680,8 +680,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster_rename \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -760,9 +760,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -775,8 +775,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-clustering_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -855,9 +855,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -870,8 +870,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-config_schema \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -950,9 +950,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -965,8 +965,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-confirms_rejects \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1045,9 +1045,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1060,8 +1060,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-consumer_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1140,9 +1140,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1155,8 +1155,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-crashing_queues \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1235,9 +1235,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1250,8 +1250,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dead_lettering \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1330,9 +1330,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1345,8 +1345,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-definition_import \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1425,9 +1425,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1440,8 +1440,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-disconnect_detected_during_alarm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1520,9 +1520,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1535,8 +1535,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1615,9 +1615,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1630,8 +1630,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_qq \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1710,9 +1710,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1725,8 +1725,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-eager_sync \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1805,9 +1805,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1820,8 +1820,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-feature_flags \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1900,9 +1900,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1915,8 +1915,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-lazy_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1995,9 +1995,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2010,8 +2010,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-list_consumers_sanity_check \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2090,9 +2090,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2105,8 +2105,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-list_queues_online_and_offline \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2185,9 +2185,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2200,8 +2200,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-maintenance_mode \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2280,9 +2280,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2295,8 +2295,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-many_node_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2375,9 +2375,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2390,8 +2390,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-message_size_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2470,9 +2470,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2485,8 +2485,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2565,9 +2565,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2580,8 +2580,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-mirrored_supervisor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2660,9 +2660,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2675,8 +2675,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2755,9 +2755,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2770,8 +2770,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_classic_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2850,9 +2850,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2865,8 +2865,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_dns \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2945,9 +2945,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2960,8 +2960,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_channel_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3040,9 +3040,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3055,8 +3055,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_channel_limit_partitions \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3135,9 +3135,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3150,8 +3150,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_channel_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3230,9 +3230,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3245,8 +3245,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3325,9 +3325,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3340,8 +3340,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3420,9 +3420,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3435,8 +3435,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit_partitions \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3515,9 +3515,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3530,8 +3530,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3610,9 +3610,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3625,8 +3625,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_queue_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3705,9 +3705,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3720,8 +3720,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3800,9 +3800,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3815,8 +3815,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3895,9 +3895,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3910,8 +3910,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue_recovery \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3990,9 +3990,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4005,8 +4005,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-product_info \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4085,9 +4085,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4100,8 +4100,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-proxy_protocol \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4180,9 +4180,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4195,8 +4195,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-publisher_confirms_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4275,9 +4275,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4290,8 +4290,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_length_limits \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4370,9 +4370,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4385,8 +4385,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_master_location \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4465,9 +4465,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4480,8 +4480,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4560,9 +4560,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4575,8 +4575,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-quorum_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4655,9 +4655,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4670,8 +4670,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_core_metrics_gc \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4750,9 +4750,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4765,8 +4765,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4845,9 +4845,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4860,8 +4860,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_int \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4940,9 +4940,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4955,8 +4955,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5035,9 +5035,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5050,8 +5050,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmq_queues_cli_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5130,9 +5130,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5145,8 +5145,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5225,9 +5225,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5240,8 +5240,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_shutdown \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5320,9 +5320,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5335,8 +5335,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-signal_handling \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5415,9 +5415,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5430,8 +5430,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-simple_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5510,9 +5510,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5525,8 +5525,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-single_active_consumer \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5605,9 +5605,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5620,8 +5620,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-sup_delayed_restart \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5700,9 +5700,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5715,8 +5715,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-sync_detection \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5795,9 +5795,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5810,8 +5810,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-term_to_binary_compat_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5890,9 +5890,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5905,8 +5905,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-topic_permission \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5985,9 +5985,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6000,8 +6000,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6080,9 +6080,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6095,8 +6095,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_authn_authz_context_propagation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6175,9 +6175,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6190,8 +6190,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_credential_validation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6270,9 +6270,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6285,8 +6285,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_content_framing \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6365,9 +6365,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6380,8 +6380,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_server_properties \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6460,9 +6460,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6475,8 +6475,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_app_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6555,9 +6555,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6570,8 +6570,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_cluster_formation_locking_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6650,9 +6650,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6665,8 +6665,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_collections \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6745,9 +6745,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6760,8 +6760,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_config_value_encryption \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6840,9 +6840,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6855,8 +6855,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6935,9 +6935,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6950,8 +6950,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_credit_flow \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7030,9 +7030,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7045,8 +7045,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7125,9 +7125,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7140,8 +7140,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7220,9 +7220,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7235,8 +7235,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_file_handle_cache \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7315,9 +7315,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7330,8 +7330,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gen_server2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7410,9 +7410,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7425,8 +7425,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7505,9 +7505,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7520,8 +7520,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7600,9 +7600,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7615,8 +7615,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7695,9 +7695,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7710,8 +7710,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_operator_policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7790,9 +7790,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7805,8 +7805,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_pg_local \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7885,9 +7885,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7900,8 +7900,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_directories \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7980,9 +7980,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7995,8 +7995,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_versioning \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8075,9 +8075,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8090,8 +8090,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_policy_validators \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8170,9 +8170,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8185,8 +8185,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8265,9 +8265,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8280,8 +8280,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_queue_consumers \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8360,9 +8360,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8375,8 +8375,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_stats_and_metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8455,9 +8455,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8470,8 +8470,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_supervisor2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8550,9 +8550,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8565,8 +8565,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_vm_memory_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8645,9 +8645,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8660,8 +8660,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-upgrade_preparation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8740,9 +8740,9 @@ jobs:
       - name: CONFIGURE OTP & ELIXIR
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 21.3
+          otp-version: 22.3
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8755,8 +8755,8 @@ jobs:
           branch_or_tag_name=${GITHUB_REF#refs/*/}
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
-          export ERLANG_VERSION=21.3
-          export ELIXIR_VERSION=1.8.0
+          export ERLANG_VERSION=22.3
+          export ELIXIR_VERSION=1.10.3
           make ct-vhost \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8941,4 +8941,4 @@ jobs:
          AWS_REGION: ${{ secrets.AWS_REGION }}
          FILE: rabbit-rabbitmq-deps.mk
          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-         S3_KEY: rabbitmq-server/${{ steps.ref.outputs.branch_or_tag_name }}/${{ github.run_id }}/otp-21.3/rabbit-rabbitmq-deps.mk
+         S3_KEY: rabbitmq-server/${{ steps.ref.outputs.branch_or_tag_name }}/${{ github.run_id }}/otp-22.3/rabbit-rabbitmq-deps.mk

--- a/.github/workflows/test-erlang-otp-23.0.yaml
+++ b/.github/workflows/test-erlang-otp-23.0.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: CHECK RABBITMQ COMPONENTS
         # https://github.community/t5/GitHub-Actions/How-can-I-set-an-expression-as-an-environment-variable-at/m-p/41804/highlight/true#M4751
         id: ref
@@ -59,12 +59,12 @@ jobs:
         uses: actions/cache@v1
         with:
           path: umbrellas
-          key: secondary-umbrellas-v3.7.27-rc.1-v3.8.5-erlang-23.0-rev4
+          key: secondary-umbrellas-v3.7.28-v3.8.8-erlang-23.0-rev4
       - name: PREPARE SECONDARY UMBRELLA COPIES
         if: success() && 'latest' == 'oldest'
         run: |
           set -ex
-          for version in v3.7.27-rc.1 v3.8.5; do
+          for version in v3.7.28 v3.8.8; do
             umbrella="umbrellas/$version"
             if ! test -d "$umbrella"  ||
                ! make -C "$umbrella/deps/rabbit" test-dist; then
@@ -124,7 +124,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         if: success() && 'latest' == 'latest'
         uses: actions/download-artifact@v2
@@ -158,7 +158,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -192,7 +192,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -206,7 +206,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-amqqueue_backward_compatibility \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -287,7 +287,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -301,7 +301,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-backing_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -382,7 +382,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -396,7 +396,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_interceptor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -477,7 +477,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -491,7 +491,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-channel_operation_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -572,7 +572,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -586,7 +586,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -667,7 +667,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -681,7 +681,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-cluster_rename \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -762,7 +762,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -776,7 +776,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-clustering_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -857,7 +857,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -871,7 +871,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-config_schema \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -952,7 +952,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -966,7 +966,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-confirms_rejects \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1047,7 +1047,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1061,7 +1061,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-consumer_timeout \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1142,7 +1142,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1156,7 +1156,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-crashing_queues \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1237,7 +1237,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1251,7 +1251,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-dead_lettering \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1332,7 +1332,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1346,7 +1346,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-definition_import \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1427,7 +1427,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1441,7 +1441,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-disconnect_detected_during_alarm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1522,7 +1522,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1536,7 +1536,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1617,7 +1617,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1631,7 +1631,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-dynamic_qq \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1712,7 +1712,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1726,7 +1726,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-eager_sync \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1807,7 +1807,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1821,7 +1821,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-feature_flags \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1902,7 +1902,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -1916,7 +1916,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-lazy_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -1997,7 +1997,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2011,7 +2011,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-list_consumers_sanity_check \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2092,7 +2092,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2106,7 +2106,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-list_queues_online_and_offline \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2187,7 +2187,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2201,7 +2201,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-maintenance_mode \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2282,7 +2282,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2296,7 +2296,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-many_node_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2377,7 +2377,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2391,7 +2391,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-message_size_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2472,7 +2472,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2486,7 +2486,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2567,7 +2567,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2581,7 +2581,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-mirrored_supervisor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2662,7 +2662,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2676,7 +2676,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2757,7 +2757,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2771,7 +2771,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_classic_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2852,7 +2852,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2866,7 +2866,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-peer_discovery_dns \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -2947,7 +2947,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -2961,7 +2961,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_channel_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3042,7 +3042,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3056,7 +3056,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_channel_limit_partitions \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3137,7 +3137,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3151,7 +3151,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_channel_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3232,7 +3232,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3246,7 +3246,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_user_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3327,7 +3327,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3341,7 +3341,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3422,7 +3422,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3436,7 +3436,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_connection_limit_partitions \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3517,7 +3517,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3531,7 +3531,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_msg_store \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3612,7 +3612,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3626,7 +3626,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-per_vhost_queue_limit \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3707,7 +3707,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3721,7 +3721,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3802,7 +3802,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3816,7 +3816,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3897,7 +3897,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -3911,7 +3911,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-priority_queue_recovery \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -3992,7 +3992,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4006,7 +4006,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-product_info \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4087,7 +4087,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4101,7 +4101,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-proxy_protocol \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4182,7 +4182,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4196,7 +4196,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-publisher_confirms_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4277,7 +4277,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4291,7 +4291,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_length_limits \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4372,7 +4372,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4386,7 +4386,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_master_location \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4467,7 +4467,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4481,7 +4481,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-queue_parallel \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4562,7 +4562,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4576,7 +4576,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-quorum_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4657,7 +4657,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4671,7 +4671,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_core_metrics_gc \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4752,7 +4752,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4766,7 +4766,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4847,7 +4847,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4861,7 +4861,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_int \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -4942,7 +4942,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -4956,7 +4956,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbit_fifo_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5037,7 +5037,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5051,7 +5051,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmq_queues_cli_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5132,7 +5132,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5146,7 +5146,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_integration \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5227,7 +5227,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5241,7 +5241,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-rabbitmqctl_shutdown \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5322,7 +5322,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5336,7 +5336,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-signal_handling \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5417,7 +5417,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5431,7 +5431,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-simple_ha \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5512,7 +5512,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5526,7 +5526,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-single_active_consumer \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5607,7 +5607,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5621,7 +5621,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-sup_delayed_restart \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5702,7 +5702,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5716,7 +5716,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-sync_detection \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5797,7 +5797,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5811,7 +5811,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-term_to_binary_compat_prop \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5892,7 +5892,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -5906,7 +5906,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-topic_permission \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -5987,7 +5987,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6001,7 +6001,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6082,7 +6082,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6096,7 +6096,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_authn_authz_context_propagation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6177,7 +6177,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6191,7 +6191,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_access_control_credential_validation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6272,7 +6272,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6286,7 +6286,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_content_framing \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6367,7 +6367,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6381,7 +6381,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_amqp091_server_properties \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6462,7 +6462,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6476,7 +6476,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_app_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6557,7 +6557,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6571,7 +6571,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_cluster_formation_locking_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6652,7 +6652,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6666,7 +6666,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_collections \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6747,7 +6747,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6761,7 +6761,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_config_value_encryption \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6842,7 +6842,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6856,7 +6856,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_connection_tracking \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -6937,7 +6937,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -6951,7 +6951,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_credit_flow \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7032,7 +7032,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7046,7 +7046,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7127,7 +7127,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7141,7 +7141,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_disk_monitor_mocks \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7222,7 +7222,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7236,7 +7236,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_file_handle_cache \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7317,7 +7317,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7331,7 +7331,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gen_server2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7412,7 +7412,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7426,7 +7426,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_gm \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7507,7 +7507,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7521,7 +7521,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_config \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7602,7 +7602,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7616,7 +7616,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_log_management \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7697,7 +7697,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7711,7 +7711,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_operator_policy \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7792,7 +7792,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7806,7 +7806,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_pg_local \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7887,7 +7887,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7901,7 +7901,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_directories \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -7982,7 +7982,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -7996,7 +7996,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_plugin_versioning \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8077,7 +8077,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8091,7 +8091,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_policy_validators \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8172,7 +8172,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8186,7 +8186,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_priority_queue \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8267,7 +8267,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8281,7 +8281,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_queue_consumers \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8362,7 +8362,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8376,7 +8376,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_stats_and_metrics \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8457,7 +8457,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8471,7 +8471,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_supervisor2 \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8552,7 +8552,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8566,7 +8566,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-unit_vm_memory_monitor \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8647,7 +8647,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8661,7 +8661,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-upgrade_preparation \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \
@@ -8742,7 +8742,7 @@ jobs:
         with:
           otp-version: 23.0
           # https://github.com/elixir-lang/elixir/releases
-          elixir-version: 1.8.0
+          elixir-version: 1.10.3
       - name: DOWNLOAD DEPS ARCHIVE
         uses: actions/download-artifact@v2
         with:
@@ -8756,7 +8756,7 @@ jobs:
           ! test -d ebin || touch ebin/*
           export BASE_RMQ_REF=master
           export ERLANG_VERSION=23.0
-          export ELIXIR_VERSION=1.8.0
+          export ELIXIR_VERSION=1.10.3
           make ct-vhost \
             base_rmq_ref=master \
             current_rmq_ref=$branch_or_tag_name \


### PR DESCRIPTION
Replace the GitHub Actions workflow for Erlang 21.3 with 22.3

Therefore the set of tested Erlang is #{22.3, 23.0}.