### PR TITLE
Quorum queue: API to reclaim quorum memory

### DIFF
--- a/src/rabbit_fifo.erl
+++ b/src/rabbit_fifo.erl
@@ -788,7 +788,7 @@ eval_gc(Log, #?MODULE{cfg = #cfg{resource = QR}} = MacState,
             garbage_collect(),
             {memory, MemAfter} = erlang:process_info(self(), memory),
             rabbit_log:debug("~s: full GC sweep complete. "
-                            "Process memory reduced from ~.2fMB to ~.2fMB.",
+                            "Process memory changed from ~.2fMB to ~.2fMB.",
                             [rabbit_misc:rs(QR), Mem/?MB, MemAfter/?MB]),
             AuxState#aux{gc = Gc#aux_gc{last_raft_idx = Idx}};
         _ ->
@@ -804,7 +804,7 @@ force_eval_gc(Log, #?MODULE{cfg = #cfg{resource = QR}},
             garbage_collect(),
             {memory, MemAfter} = erlang:process_info(self(), memory),
             rabbit_log:debug("~s: full GC sweep complete. "
-                            "Process memory reduced from ~.2fMB to ~.2fMB.",
+                            "Process memory changed from ~.2fMB to ~.2fMB.",
                              [rabbit_misc:rs(QR), Mem/?MB, MemAfter/?MB]),
             AuxState#aux{gc = Gc#aux_gc{last_raft_idx = Idx}};
         false ->

--- a/src/rabbit_fifo_v0.erl
+++ b/src/rabbit_fifo_v0.erl
@@ -689,7 +689,7 @@ eval_gc(Log, #?STATE{cfg = #cfg{resource = QR}} = MacState,
             garbage_collect(),
             {memory, MemAfter} = erlang:process_info(self(), memory),
             rabbit_log:debug("~s: full GC sweep complete. "
-                            "Process memory reduced from ~.2fMB to ~.2fMB.",
+                            "Process memory changed from ~.2fMB to ~.2fMB.",
                             [rabbit_misc:rs(QR), Mem/?MB, MemAfter/?MB]),
             AuxState#aux{gc = Gc#aux_gc{last_raft_idx = Idx}};
         _ ->

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -40,6 +40,7 @@
 -export([repair_amqqueue_nodes/1,
          repair_amqqueue_nodes/2
          ]).
+-export([reclaim_memory/2]).
 
 -include_lib("stdlib/include/qlc.hrl").
 -include("rabbit.hrl").
@@ -1111,6 +1112,19 @@ file_handle_other_reservation() ->
 
 file_handle_release_reservation() ->
     file_handle_cache:release_reservation().
+
+-spec reclaim_memory(rabbit_types:vhost(), Name :: rabbit_misc:resource_name()) -> ok | {error, term()}.
+reclaim_memory(Vhost, QueueName) ->
+    QName = #resource{virtual_host = Vhost, name = QueueName, kind = queue},
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} when ?amqqueue_is_classic(Q) ->
+            {error, classic_queue_not_supported};
+        {ok, Q} when ?amqqueue_is_quorum(Q) ->
+            ok = ra:pipeline_command(amqqueue:get_pid(Q),
+                                     rabbit_fifo:make_garbage_collection());
+        {error, not_found} = E ->
+            E
+    end.
 
 %%----------------------------------------------------------------------------
 dlx_mfa(Q) ->


### PR DESCRIPTION
Operator can choose to force a garbage collection and flush of the WAL
on a specific quorum queue

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

