### PR TITLE
Shrink quorum queue must succeed if the target node is down or rabbit is stopped

### DIFF
--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -1000,6 +1000,11 @@ delete_member(Q, Node) when ?amqqueue_is_quorum(Q) ->
                     case ra:force_delete_server(ServerId) of
                         ok ->
                             ok;
+                        {error, {badrpc, nodedown}} ->
+                            ok;
+                        {error, {badrpc, {'EXIT', {badarg, _}}}} ->
+                            %% DETS/ETS tables can't be found, application isn't running
+                            ok;
                         {error, _} = Err ->
                             Err;
                         Err ->
@@ -1007,6 +1012,8 @@ delete_member(Q, Node) when ?amqqueue_is_quorum(Q) ->
                     end;
                 {timeout, _} ->
                     {error, timeout};
+                {badrpc, nodedown} ->
+                    ok;
                 E ->
                     E
             end

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -1012,8 +1012,6 @@ delete_member(Q, Node) when ?amqqueue_is_quorum(Q) ->
                     end;
                 {timeout, _} ->
                     {error, timeout};
-                {badrpc, nodedown} ->
-                    ok;
                 E ->
                     E
             end


### PR DESCRIPTION
Avoids false negatives when shrink gets included in forget_cluster_node command,
as at least the rabbit app is down. Required to fix https://github.com/rabbitmq/rabbitmq-server/issues/2414

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
