### PR TITLE
Explicitly start syslog application

### DIFF
--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -407,7 +407,7 @@ generate_handler(Backend, HandlerConfig) ->
                            lists:ukeysort(1, default_handler_config(Backend)))}].
 
 configure_handler_backend(syslog_lager_backend) ->
-    app_utils:load_applications([syslog]);
+    app_utils:start_applications([syslog]);
 configure_handler_backend(_Backend) ->
     ok.
 

--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -407,7 +407,7 @@ generate_handler(Backend, HandlerConfig) ->
                            lists:ukeysort(1, default_handler_config(Backend)))}].
 
 configure_handler_backend(syslog_lager_backend) ->
-    app_utils:start_applications([syslog]);
+    application:ensure_all_started(syslog);
 configure_handler_backend(_Backend) ->
     ok.
 

--- a/src/rabbit_lager.erl
+++ b/src/rabbit_lager.erl
@@ -407,7 +407,8 @@ generate_handler(Backend, HandlerConfig) ->
                            lists:ukeysort(1, default_handler_config(Backend)))}].
 
 configure_handler_backend(syslog_lager_backend) ->
-    application:ensure_all_started(syslog);
+    {ok, _} = application:ensure_all_started(syslog),
+    ok;
 configure_handler_backend(_Backend) ->
     ok.
 


### PR DESCRIPTION
Between RabbitMQ 3.8.3 and 3.8.4 logging to `syslog` broke because the
`syslog` OTP application was no longer started when needed. This is
probably due to changes in #2180.

This change explicitly starts the `syslog` app if the backend is configured.

Found while investigating this issue:

https://groups.google.com/forum/?oldui=1#!topic/rabbitmq-users/-aqS2BiHm4k

The following repo contains configurations used to test:

https://github.com/lukebakken/syslog-local-facility_-aqS2BiHm4k