### PR TITLE
Stream initial cluster size

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -780,9 +780,10 @@ declare_args() ->
      {<<"x-queue-mode">>,              fun check_queue_mode/2},
      {<<"x-single-active-consumer">>,  fun check_single_active_consumer_arg/2},
      {<<"x-queue-type">>,              fun check_queue_type/2},
-     {<<"x-quorum-initial-group-size">>,     fun check_default_quorum_initial_group_size_arg/2},
+     {<<"x-quorum-initial-group-size">>,     fun check_initial_cluster_size_arg/2},
      {<<"x-max-age">>,                 fun check_max_age_arg/2},
-     {<<"x-max-segment-size">>,        fun check_non_neg_int_arg/2}].
+     {<<"x-max-segment-size">>,        fun check_non_neg_int_arg/2},
+     {<<"x-initial-cluster-size">>,    fun check_initial_cluster_size_arg/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
                    {<<"x-cancel-on-ha-failover">>, fun check_bool_arg/2}].
@@ -829,7 +830,7 @@ check_single_active_consumer_arg({Type, Val}, Args) ->
         Error -> Error
     end.
 
-check_default_quorum_initial_group_size_arg({Type, Val}, Args) ->
+check_initial_cluster_size_arg({Type, Val}, Args) ->
     case check_non_neg_int_arg({Type, Val}, Args) of
         ok when Val == 0 -> {error, {value_zero, Val}};
         ok               -> ok;

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -56,8 +56,10 @@
 -export([collect_info_all/2]).
 
 -export([is_policy_applicable/2]).
+-export([is_server_named_allowed/1]).
 
 -export([check_max_age/1]).
+-export([get_queue_type/1]).
 
 %% internal
 -export([internal_declare/2, internal_delete/2, run_backing_queue/3,
@@ -365,6 +367,10 @@ is_policy_applicable(QName, Policy) ->
             %% Defaults to previous behaviour. Apply always
             true
     end.
+
+is_server_named_allowed(Args) ->
+    Type = get_queue_type(Args),
+    rabbit_queue_type:is_server_named_allowed(Type).
 
 -spec lookup
         (name()) ->

--- a/src/rabbit_classic_queue.erl
+++ b/src/rabbit_classic_queue.erl
@@ -38,7 +38,7 @@
          dequeue/4,
          info/2,
          state_info/1,
-         is_policy_applicable/2
+         capabilities/1
          ]).
 
 -export([delete_crashed/1,
@@ -438,19 +438,22 @@ recover_durable_queues(QueuesAndRecoveryTerms) ->
                       [Pid, Error]) || {Pid, Error} <- Failures],
     [Q || {_, {new, Q}} <- Results].
 
--spec is_policy_applicable(amqqueue:amqqueue(), any()) -> boolean().
-is_policy_applicable(_Q, Policy) ->
-    Applicable = [<<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
-                  <<"dead-letter-routing-key">>, <<"max-length">>,
-                  <<"max-length-bytes">>, <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
-                  <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
-                  <<"single-active-consumer">>, <<"delivery-limit">>,
-                  <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
-                  <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
-                  <<"queue-master-locator">>],
-    lists:all(fun({P, _}) ->
-                      lists:member(P, Applicable)
-              end, Policy).
+capabilities(_Q) ->
+    #{policies => [<<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
+                   <<"dead-letter-routing-key">>, <<"max-length">>,
+                   <<"max-length-bytes">>, <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
+                   <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
+                   <<"single-active-consumer">>, <<"delivery-limit">>,
+                   <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
+                   <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
+                   <<"queue-master-locator">>],
+      queue_arguments => [<<"x-expires">>, <<"x-message-ttl">>, <<"x-dead-letter-exchange">>,
+                          <<"x-dead-letter-routing-key">>, <<"x-max-length">>,
+                          <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,
+                          <<"x-max-in-memory-bytes">>, <<"x-max-priority">>,
+                          <<"x-overflow">>, <<"x-queue-mode">>, <<"x-single-active-consumer">>,
+                          <<"x-queue-type">>],
+      consumer_arguments => [<<"x-cancel-on-ha-failover">>]}.
 
 reject_seq_no(SeqNo, U0) ->
     reject_seq_no(SeqNo, U0, []).

--- a/src/rabbit_classic_queue.erl
+++ b/src/rabbit_classic_queue.erl
@@ -38,7 +38,7 @@
          dequeue/4,
          info/2,
          state_info/1,
-         capabilities/1
+         capabilities/0
          ]).
 
 -export([delete_crashed/1,
@@ -438,7 +438,7 @@ recover_durable_queues(QueuesAndRecoveryTerms) ->
                       [Pid, Error]) || {Pid, Error} <- Failures],
     [Q || {_, {new, Q}} <- Results].
 
-capabilities(_Q) ->
+capabilities() ->
     #{policies => [<<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
                    <<"dead-letter-routing-key">>, <<"max-length">>,
                    <<"max-length-bytes">>, <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
@@ -453,7 +453,8 @@ capabilities(_Q) ->
                           <<"x-max-in-memory-bytes">>, <<"x-max-priority">>,
                           <<"x-overflow">>, <<"x-queue-mode">>, <<"x-single-active-consumer">>,
                           <<"x-queue-type">>],
-      consumer_arguments => [<<"x-cancel-on-ha-failover">>]}.
+      consumer_arguments => [<<"x-cancel-on-ha-failover">>],
+      server_named => true}.
 
 reject_seq_no(SeqNo, U0) ->
     reject_seq_no(SeqNo, U0, []).

--- a/src/rabbit_queue_type_util.erl
+++ b/src/rabbit_queue_type_util.erl
@@ -16,8 +16,7 @@
 
 -module(rabbit_queue_type_util).
 
--export([check_invalid_arguments/3,
-         args_policy_lookup/3,
+-export([args_policy_lookup/3,
          qname_to_internal_name/1,
          check_auto_delete/1,
          check_exclusive/1,
@@ -25,16 +24,6 @@
 
 -include("rabbit.hrl").
 -include("amqqueue.hrl").
-
-check_invalid_arguments(QueueName, Args, Keys) ->
-    [case rabbit_misc:table_lookup(Args, Key) of
-         undefined -> ok;
-         _TypeVal   -> rabbit_misc:protocol_error(
-                         precondition_failed,
-                         "invalid arg '~s' for ~s",
-                         [Key, rabbit_misc:rs(QueueName)])
-     end || Key <- Keys],
-    ok.
 
 args_policy_lookup(Name, Resolve, Q) when ?is_amqqueue(Q) ->
     Args = amqqueue:get_arguments(Q),

--- a/src/rabbit_quorum_queue.erl
+++ b/src/rabbit_quorum_queue.erl
@@ -43,7 +43,7 @@
 -export([list_with_minimum_quorum/0, list_with_minimum_quorum_for_cli/0,
          filter_quorum_critical/1, filter_quorum_critical/2,
          all_replica_states/0]).
--export([capabilities/1]).
+-export([capabilities/0]).
 -export([repair_amqqueue_nodes/1,
          repair_amqqueue_nodes/2
          ]).
@@ -330,7 +330,7 @@ filter_quorum_critical(Queues, ReplicaStates) ->
                     length(AllUp) =< MinQuorum
                  end, Queues).
 
-capabilities(_Q) ->
+capabilities() ->
     #{policies => [<<"max-length">>, <<"max-length-bytes">>, <<"overflow">>,
                    <<"expires">>, <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
                    <<"delivery-limit">>, <<"dead-letter-exchange">>, <<"dead-letter-routing-key">>],
@@ -340,7 +340,8 @@ capabilities(_Q) ->
                           <<"x-max-in-memory-bytes">>, <<"x-overflow">>,
                           <<"x-single-active-consumer">>, <<"x-queue-type">>,
                           <<"x-quorum-initial-group-size">>, <<"x-delivery-limit">>],
-      consumer_arguments => [<<"x-priority">>]}.
+      consumer_arguments => [<<"x-priority">>],
+      server_named => false}.
 
 rpc_delete_metrics(QName) ->
     ets:delete(queue_coarse_metrics, QName),

--- a/src/rabbit_stream_queue.erl
+++ b/src/rabbit_stream_queue.erl
@@ -37,7 +37,7 @@
          update/2,
          state_info/1,
          stat/1,
-         capabilities/1]).
+         capabilities/0]).
 
 -export([set_retention_policy/3]).
 -export([add_replica/3,
@@ -649,10 +649,11 @@ msg_to_iodata(#basic_message{exchange_name = #resource{name = Exchange},
             <<"x-routing-key">> => {utf8, RKey}}, R0),
     rabbit_msg_record:to_iodata(R).
 
-capabilities(_Q) ->
+capabilities() ->
     #{policies => [<<"max-length-bytes">>, <<"max-age">>, <<"max-segment-size">>],
       queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
                           <<"x-max-length">>, <<"x-max-length-bytes">>,
                           <<"x-single-active-consumer">>, <<"x-queue-type">>,
                           <<"x-max-age">>, <<"x-max-segment-size">>],
-      consumer_arguments => [<<"x-stream-offset">>]}.
+      consumer_arguments => [<<"x-stream-offset">>],
+      server_named => false}.

--- a/src/rabbit_stream_queue.erl
+++ b/src/rabbit_stream_queue.erl
@@ -37,7 +37,7 @@
          update/2,
          state_info/1,
          stat/1,
-         is_policy_applicable/2]).
+         capabilities/1]).
 
 -export([set_retention_policy/3]).
 -export([add_replica/3,
@@ -80,7 +80,6 @@ is_enabled() ->
 declare(Q0, Node) when ?amqqueue_is_stream(Q0) ->
     Arguments = amqqueue:get_arguments(Q0),
     QName = amqqueue:get_name(Q0),
-    check_invalid_arguments(QName, Arguments),
     rabbit_queue_type_util:check_auto_delete(Q0),
     rabbit_queue_type_util:check_exclusive(Q0),
     rabbit_queue_type_util:check_non_durable(Q0),
@@ -543,13 +542,6 @@ max_age(Age) ->
 max_age(Age1, Age2) ->
     min(rabbit_amqqueue:check_max_age(Age1), rabbit_amqqueue:check_max_age(Age2)).
 
-check_invalid_arguments(QueueName, Args) ->
-    Keys = [<<"x-expires">>, <<"x-message-ttl">>,
-            <<"x-max-priority">>, <<"x-queue-mode">>, <<"x-overflow">>,
-            <<"x-max-in-memory-length">>, <<"x-max-in-memory-bytes">>,
-            <<"x-quorum-initial-group-size">>, <<"x-cancel-on-ha-failover">>],
-    rabbit_queue_type_util:check_invalid_arguments(QueueName, Args, Keys).
-
 queue_name(#resource{virtual_host = VHost, name = Name}) ->
     Timestamp = erlang:integer_to_binary(erlang:system_time()),
     osiris_util:to_base64uri(erlang:binary_to_list(<<VHost/binary, "_", Name/binary, "_",
@@ -657,9 +649,10 @@ msg_to_iodata(#basic_message{exchange_name = #resource{name = Exchange},
             <<"x-routing-key">> => {utf8, RKey}}, R0),
     rabbit_msg_record:to_iodata(R).
 
--spec is_policy_applicable(amqqueue:amqqueue(), any()) -> boolean().
-is_policy_applicable(_Q, Policy) ->
-    Applicable = [<<"max-length-bytes">>, <<"max-age">>, <<"max-segment-size">>],
-    lists:all(fun({P, _}) ->
-                      lists:member(P, Applicable)
-              end, Policy).
+capabilities(_Q) ->
+    #{policies => [<<"max-length-bytes">>, <<"max-age">>, <<"max-segment-size">>],
+      queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
+                          <<"x-max-length">>, <<"x-max-length-bytes">>,
+                          <<"x-single-active-consumer">>, <<"x-queue-type">>,
+                          <<"x-max-age">>, <<"x-max-segment-size">>],
+      consumer_arguments => [<<"x-stream-offset">>]}.

--- a/src/rabbit_stream_queue.erl
+++ b/src/rabbit_stream_queue.erl
@@ -495,7 +495,9 @@ make_stream_conf(Node, Q) ->
     MaxBytes = args_policy_lookup(<<"max-length-bytes">>, fun min/2, Q),
     MaxAge = max_age(args_policy_lookup(<<"max-age">>, fun max_age/2, Q)),
     MaxSegmentSize = args_policy_lookup(<<"max-segment-size">>, fun min/2, Q),
-    Replicas = rabbit_mnesia:cluster_nodes(all) -- [Node],
+    Replicas0 = rabbit_mnesia:cluster_nodes(all) -- [Node],
+    Arguments = amqqueue:get_arguments(Q),
+    Replicas = select_stream_nodes(get_initial_cluster_size(Arguments) - 1, Replicas0),
     Formatter = {?MODULE, format_osiris_event, [QName]},
     Retention = lists:filter(fun({_, R}) ->
                                      R =/= undefined
@@ -508,6 +510,23 @@ make_stream_conf(Node, Q) ->
                                                        replica_nodes => Replicas,
                                                        event_formatter => Formatter,
                                                        epoch => 1}).
+
+select_stream_nodes(Size, All) when length(All) =< Size ->
+    All;
+select_stream_nodes(Size, All) ->
+    Node = node(),
+    case lists:member(Node, All) of
+        true ->
+            select_stream_nodes(Size - 1, lists:delete(Node, All), [Node]);
+        false ->
+            select_stream_nodes(Size, All, [])
+    end.
+
+select_stream_nodes(0, _, Selected) ->
+    Selected;
+select_stream_nodes(Size, Rest, Selected) ->
+    S = lists:nth(rand:uniform(length(Rest)), Rest),
+    select_stream_nodes(Size - 1, lists:delete(S, Rest), [S | Selected]).
 
 update_stream_conf(#{reference := QName} = Conf) ->
     case rabbit_amqqueue:lookup(QName) of
@@ -654,6 +673,13 @@ capabilities() ->
       queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
                           <<"x-max-length">>, <<"x-max-length-bytes">>,
                           <<"x-single-active-consumer">>, <<"x-queue-type">>,
-                          <<"x-max-age">>, <<"x-max-segment-size">>],
+                          <<"x-max-age">>, <<"x-max-segment-size">>,
+                          <<"x-initial-cluster-size">>],
       consumer_arguments => [<<"x-stream-offset">>],
       server_named => false}.
+
+get_initial_cluster_size(Arguments) ->
+    case rabbit_misc:table_lookup(Arguments, <<"x-initial-cluster-size">>) of
+        undefined -> length(rabbit_mnesia:cluster_nodes(running));
+        {_Type, Val} -> Val
+    end.

--- a/test/quorum_queue_SUITE.erl
+++ b/test/quorum_queue_SUITE.erl
@@ -91,6 +91,7 @@ all_tests() ->
      declare_args,
      declare_invalid_args,
      declare_invalid_properties,
+     declare_server_named,
      start_queue,
      stop_queue,
      restart_queue,
@@ -377,6 +378,14 @@ declare_invalid_args(Config) ->
        declare(rabbit_ct_client_helpers:open_channel(Config, Server),
                LQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
                     {<<"x-quorum-initial-group-size">>, long, 0}])).
+
+declare_server_named(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(rabbit_ct_client_helpers:open_channel(Config, Server),
+               <<"">>, [{<<"x-queue-type">>, longstr, <<"quorum">>}])).
 
 start_queue(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/test/rabbit_stream_queue_SUITE.erl
+++ b/test/rabbit_stream_queue_SUITE.erl
@@ -59,6 +59,7 @@ all_tests() ->
      declare_max_age,
      declare_invalid_args,
      declare_invalid_properties,
+     declare_server_named,
      declare_queue,
      delete_queue,
      publish,
@@ -262,6 +263,14 @@ declare_invalid_args(Config) ->
        declare(rabbit_ct_client_helpers:open_channel(Config, Server),
                Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                     {<<"x-quorum-initial-group-size">>, longstr, <<"hop">>}])).
+
+declare_server_named(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    ?assertExit(
+       {{shutdown, {server_initiated_close, 406, _}}, _},
+       declare(rabbit_ct_client_helpers:open_channel(Config, Server),
+               <<"">>, [{<<"x-queue-type">>, longstr, <<"stream">>}])).
 
 declare_queue(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
## Proposed Changes

Allows to set an initial cluster size for stream queues instead of span over the whole rabbit cluster.
Depends on https://github.com/rabbitmq/rabbitmq-server/pull/2466, which should be merged first.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

