### PR TITLE
Fix concurrent startup of the stream coordinator

### DIFF
--- a/src/rabbit_stream_coordinator.erl
+++ b/src/rabbit_stream_coordinator.erl
@@ -115,7 +115,9 @@ delete_replica(StreamId, Node) ->
     process_command({delete_replica, #{stream_id => StreamId, node => Node}}).
 
 process_command(Cmd) ->
+    global:set_lock(?STREAM_COORDINATOR_STARTUP),
     Servers = ensure_coordinator_started(),
+    global:del_lock(?STREAM_COORDINATOR_STARTUP),
     process_command(Servers, Cmd).
 
 process_command([], _Cmd) ->


### PR DESCRIPTION
 The coordinator can return an error (unavailable) when we try to start it in parallel, as `ra:start_cluster` detects some nodes up when it thinks it should be fully down and shuts down the cluster. 

This happens because of the lazy initializacion of the coordinator, only on queue declare. We had implemented it initially as a boot step which is now commented out: https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit.erl#L124 The implementation is still there and starting the coordinator on node startup would also avoid this issue. My guess is that we decided to not start the coordinator until a declare happens, which means that the feature flag is enabled. But I really can't remember why, and with the single stream queues commit we lost all the commit history. Blame no longer blames! Should we remove the boot step forever? @kjnilsson @dumbbell ?

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

