### PR TITLE
Unsupported queue purge on stream queues

### DIFF
--- a/src/rabbit_stream_queue.erl
+++ b/src/rabbit_stream_queue.erl
@@ -132,8 +132,11 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
 
 -spec purge(amqqueue:amqqueue()) ->
     {'ok', non_neg_integer()}.
-purge(_Q) ->
-    {ok, 0}.
+purge(Q) ->
+    rabbit_misc:protocol_error(
+      not_implemented,
+      "queue.purge not supported by stream queues ~s",
+      [rabbit_misc:rs(amqqueue:get_name(Q))]).
 
 -spec policy_changed(amqqueue:amqqueue()) -> 'ok'.
 policy_changed(Q) ->

--- a/test/rabbit_stream_queue_SUITE.erl
+++ b/test/rabbit_stream_queue_SUITE.erl
@@ -89,7 +89,8 @@ all_tests() ->
      max_age,
      invalid_policy,
      max_age_policy,
-     max_segment_size_policy
+     max_segment_size_policy,
+     purge
     ].
 
 %% -------------------------------------------------------------------
@@ -1387,6 +1388,17 @@ max_segment_size_policy(Config) ->
     ?assertEqual([{<<"max-segment-size">>, 5000}],
                  proplists:get_value(effective_policy_definition, Info)),
     ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"segment">>).
+
+purge(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+
+    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
+                amqp_channel:call(Ch, #'queue.purge'{queue = Q})).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
Purge is not supported by stream queues, so it must return a not implemented
error instead of purge_ok and do nothing.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

