### PR TITLE
Add initial-cluster-size as a stream policy

### DIFF
--- a/src/rabbit_policies.erl
+++ b/src/rabbit_policies.erl
@@ -42,6 +42,7 @@ register() ->
                           {policy_validator, <<"max-age">>},
                           {policy_validator, <<"max-segment-size">>},
                           {policy_validator, <<"queue-leader-locator">>},
+                          {policy_validator, <<"initial-cluster-size">>},
                           {operator_policy_validator, <<"expires">>},
                           {operator_policy_validator, <<"message-ttl">>},
                           {operator_policy_validator, <<"max-length">>},
@@ -156,6 +157,12 @@ validate_policy0(<<"queue-leader-locator">>, <<"least-leaders">>) ->
     ok;
 validate_policy0(<<"queue-leader-locator">>, Value) ->
     {error, "~p is not a valid queue leader locator value", [Value]};
+
+validate_policy0(<<"initial-cluster-size">>, Value)
+  when is_integer(Value), Value >= 0 ->
+    ok;
+validate_policy0(<<"initial-cluster-size">>, Value) ->
+    {error, "~p is not a valid cluster size", [Value]};
 
 validate_policy0(<<"max-segment-size">>, Value)
   when is_integer(Value), Value >= 0 ->


### PR DESCRIPTION
It was only a queue argument

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

