### PR TITLE
Add missing 'byte' type to amqp 0.9.1 record conversion

### DIFF
--- a/src/rabbit_msg_record.erl
+++ b/src/rabbit_msg_record.erl
@@ -346,7 +346,8 @@ from_091(double, V) -> {double, V};
 from_091(float, V) -> {float, V};
 from_091(bool, V) -> {boolean, V};
 from_091(binary, V) -> {binary, V};
-from_091(timestamp, V) -> {timestamp, V * 1000}.
+from_091(timestamp, V) -> {timestamp, V * 1000};
+from_091(byte, V) -> {byte, V}.
 
 % convert_header(signedint, V) -> [$I, <<V:32/signed>>];
 % convert_header(decimal, V) -> {Before, After} = V,


### PR DESCRIPTION
The x-mqtt-publish-qos argument is a 'byte', without this MQTT can't publish
to stream queues

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

