### PR TITLE
Make it possible to extract username from certificate SANs

### DIFF
--- a/priv/schema/rabbit.schema
+++ b/priv/schema/rabbit.schema
@@ -408,12 +408,27 @@ end}.
 %% https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl for further
 %% details.
 %%
-%% To use the SSL cert's CN instead of its DN as the username
+%% To use the peer certificate's Common Name (CN) field
+%% instead of its Distinguished Name (DN) for username extraction.
 %%
 %% {ssl_cert_login_from, common_name},
+%%
+%% To use the first SAN value of type DNS:
+%%
+%% {ssl_cert_login_from,      subject_alternative_name},
+%% {ssl_cert_login_san_type,  dns},
+%% {ssl_cert_login_san_index, 0}
 
 {mapping, "ssl_cert_login_from", "rabbit.ssl_cert_login_from", [
-    {datatype, {enum, [distinguished_name, common_name]}}
+    {datatype, {enum, [distinguished_name, common_name, subject_alternative_name, subject_alt_name]}}
+]}.
+
+{mapping, "ssl_cert_login_san_type", "rabbit.ssl_cert_login_san_type", [
+    {datatype, {enum, [dns, ip, email, uri, other_name]}}
+]}.
+
+{mapping, "ssl_cert_login_san_index", "rabbit.ssl_cert_login_san_index", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
 ]}.
 
 %% TLS handshake timeout, in milliseconds.

--- a/test/config_schema_SUITE_data/rabbit.snippets
+++ b/test/config_schema_SUITE_data/rabbit.snippets
@@ -452,10 +452,28 @@ tcp_listen_options.exit_on_close = false",
              {fail_if_no_peer_cert, false},
              {honor_ecc_order, true}]}]}],
   []},
- {ssl_cert_login_from,
+  
+ {ssl_cert_login_from_cn,
   "ssl_cert_login_from = common_name",
-  [{rabbit,[{ssl_cert_login_from,common_name}]}],
+  [{rabbit,[{ssl_cert_login_from, common_name}]}],
   []},
+  
+ {ssl_cert_login_from_dn,
+  "ssl_cert_login_from = distinguished_name",
+  [{rabbit,[{ssl_cert_login_from, distinguished_name}]}],
+  []},
+ 
+ {ssl_cert_login_from_san_dns,
+  "ssl_cert_login_from      = subject_alternative_name
+   ssl_cert_login_san_type  = dns
+   ssl_cert_login_san_index = 0",
+  [{rabbit,[
+      {ssl_cert_login_from,      subject_alternative_name},
+      {ssl_cert_login_san_type,  dns},
+      {ssl_cert_login_san_index, 0}
+  ]}],
+  []},
+  
  {tcp_listen_options_linger_on,
   "tcp_listen_options.linger.on = true
    tcp_listen_options.linger.timeout = 100",


### PR DESCRIPTION
This makes it possible to use a subject alternative name of a certain type and position (since there can be more than one value available) like so:

``` ini
ssl_cert_login_from      = subject_alternative_name
ssl_cert_login_san_type  = email
ssl_cert_login_san_index = 0
```

Supported SAN value types currently are `dns`, `email,` `uri` and `other_name`. This should be a sufficient set
for starters.

Part of rabbitmq/rabbitmq-auth-mechanism-ssl#12.

