### PR TITLE
Avoid crash when acking deleted queue

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -1472,7 +1472,6 @@ handle_method(#'basic.cancel'{consumer_tag = ConsumerTag, nowait = NoWait},
             QName = amqqueue:get_name(Q),
 
             ConsumerMapping1 = maps:remove(ConsumerTag, ConsumerMapping),
-            % QRef = qpid_to_ref(QPid),
             QCons1 =
                 case maps:find(QName, QCons) of
                     error       -> QCons;

--- a/src/rabbit_queue_type.erl
+++ b/src/rabbit_queue_type.erl
@@ -36,9 +36,6 @@
          is_server_named_allowed/1
          ]).
 
-%% temporary
--export([with/3]).
-
 %% gah what is a good identity of a classic queue including all replicas
 -type queue_name() :: rabbit_types:r(queue).
 -type queue_ref() :: queue_name() | atom().
@@ -498,13 +495,6 @@ dequeue(Q, NoAck, LimiterPid, CTag, Ctxs) ->
         {error, _} = Err ->
             Err
     end.
-
-%% temporary
-with(QRef, Fun, Ctxs) ->
-    #ctx{state = State0} = Ctx = get_ctx(QRef, Ctxs),
-    {Res, State} = Fun(State0),
-    {Res, set_ctx(QRef, Ctx#ctx{state = State}, Ctxs)}.
-
 
 get_ctx(Q, #?STATE{ctxs = Contexts}) when ?is_amqqueue(Q) ->
     Ref = qref(Q),


### PR DESCRIPTION
If a queue has been deleted and the channel has removed its queue type
state we could get a crash if a late ack came in for the queue. Now we
just handle this case and ignore the ack/reject.
