### PR TITLE
Move all protocol errors from inside the queue types to the channel

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -763,7 +763,9 @@ handle_cast({queue_event, QRef, Evt},
                                      State1#ch{unconfirmed = UC1}),
             erase_queue_stats(QRef),
             noreply_coalesce(
-              State2#ch{queue_states = rabbit_queue_type:remove(QRef, QueueStates0)})
+              State2#ch{queue_states = rabbit_queue_type:remove(QRef, QueueStates0)});
+        {protocol_error, Type, Reason, ReasonArgs} ->
+            rabbit_misc:protocol_error(Type, Reason, ReasonArgs)
     end.
 
 handle_info({ra_event, {Name, _} = From, Evt}, State) ->
@@ -1339,7 +1341,7 @@ handle_method(#'basic.get'{queue = QueueNameBin, no_ack = NoAck},
            QueueName, ConnPid,
            %% Use the delivery tag as consumer tag for quorum queues
            fun (Q) ->
-                   rabbit_amqqueue:basic_get(
+                   rabbit_queue_type:dequeue(
                      Q, NoAck, rabbit_limiter:pid(Limiter),
                      DeliveryTag, QueueStates0)
            end) of
@@ -1362,7 +1364,9 @@ handle_method(#'basic.get'{queue = QueueNameBin, no_ack = NoAck},
             %% TODO add queue type to error message
             rabbit_misc:protocol_error(internal_error,
                                        "Cannot get a message from queue '~s': ~p",
-                                       [rabbit_misc:rs(QueueName), Reason])
+                                       [rabbit_misc:rs(QueueName), Reason]);
+        {protocol_error, Type, Reason, ReasonArgs} ->
+            rabbit_misc:protocol_error(Type, Reason, ReasonArgs)
     end;
 
 handle_method(#'basic.consume'{queue        = <<"amq.rabbitmq.reply-to">>,
@@ -1491,7 +1495,7 @@ handle_method(#'basic.cancel'{consumer_tag = ConsumerTag, nowait = NoWait},
             case rabbit_misc:with_exit_handler(
                    fun () -> {error, not_found} end,
                    fun () ->
-                           rabbit_amqqueue:basic_cancel(
+                           rabbit_queue_type:cancel(
                              Q, ConsumerTag, ok_msg(NoWait, OkMsg),
                              Username, QueueStates0)
                    end) of
@@ -1718,7 +1722,7 @@ handle_method(#'basic.credit'{consumer_tag = CTag,
                              queue_states = QStates0}) ->
     case maps:find(CTag, Consumers) of
         {ok, {Q, _CParams}} ->
-            QStates = rabbit_amqqueue:credit(Q, CTag, Credit, Drain, QStates0),
+            QStates = rabbit_queue_type:credit(Q, CTag, Credit, Drain, QStates0),
             {noreply, State#ch{queue_states = QStates}};
         error -> precondition_failed(
                    "unknown consumer tag '~s'", [CTag])
@@ -1770,7 +1774,9 @@ basic_consume(QueueName, NoAck, ConsumerPrefetch, ActualConsumerTag,
         {{error, exclusive_consume_unavailable} = E, _Q} ->
             E;
         {{error, global_qos_not_supported_for_queue_type} = E, _Q} ->
-            E
+            E;
+        {{protocol_error, Type, Reason, ReasonArgs}, _Q} ->
+            rabbit_misc:protocol_error(Type, Reason, ReasonArgs)
     end.
 
 maybe_stat(false, Q) -> rabbit_amqqueue:stat(Q);
@@ -1921,8 +1927,12 @@ internal_reject(Requeue, Acked, Limiter,
                            false -> discard;
                            true -> requeue
                        end,
-                  {ok, Acc, Actions} = rabbit_queue_type:settle(QRef, Op, CTag, MsgIds, Acc0),
-                  {Acc, Actions0 ++ Actions}
+                  case rabbit_queue_type:settle(QRef, Op, CTag, MsgIds, Acc0) of
+                      {ok, Acc, Actions} ->
+                          {Acc, Actions0 ++ Actions};
+                      {protocol_error, ErrorType, Reason, ReasonArgs} ->
+                          rabbit_misc:protocol_error(ErrorType, Reason, ReasonArgs)
+                  end
           end, Acked, {QueueStates0, []}),
     ok = notify_limiter(Limiter, Acked),
     {State#ch{queue_states = QueueStates}, Actions}.
@@ -1995,10 +2005,14 @@ ack(Acked, State = #ch{queue_states = QueueStates0}) ->
     {QueueStates, Actions} =
         foreach_per_queue(
           fun ({QRef, CTag}, MsgIds, {Acc0, ActionsAcc0}) ->
-                  {ok, Acc, ActionsAcc} = rabbit_queue_type:settle(QRef, complete, CTag,
-                                                                   MsgIds, Acc0),
-                  incr_queue_stats(QRef, MsgIds, State),
-                  {Acc, ActionsAcc0 ++ ActionsAcc}
+                  case rabbit_queue_type:settle(QRef, complete, CTag,
+                                                MsgIds, Acc0) of
+                      {ok, Acc, ActionsAcc} ->
+                          incr_queue_stats(QRef, MsgIds, State),
+                          {Acc, ActionsAcc0 ++ ActionsAcc};
+                      {protocol_error, ErrorType, Reason, ReasonArgs} ->
+                          rabbit_misc:protocol_error(ErrorType, Reason, ReasonArgs)
+                  end
           end, Acked, {QueueStates0, []}),
     ok = notify_limiter(State#ch.limiter, Acked),
     {State#ch{queue_states = QueueStates}, Actions}.
@@ -2465,7 +2479,9 @@ handle_method(#'queue.declare'{queue       = QueueNameBin,
                     %% Presumably our own days are numbered since the
                     %% connection has died. Pretend the queue exists though,
                     %% just so nothing fails.
-                    {ok, QueueName, 0, 0}
+                    {ok, QueueName, 0, 0};
+                {protocol_error, ErrorType, Reason, ReasonArgs} ->
+                    rabbit_misc:protocol_error(ErrorType, Reason, ReasonArgs)
             end;
         {error, {absent, Q, Reason}} ->
             rabbit_amqqueue:absent(Q, Reason)
@@ -2497,7 +2513,7 @@ handle_method(#'queue.delete'{queue     = QueueNameBin,
            QueueName,
            fun (Q) ->
                    rabbit_amqqueue:check_exclusive_access(Q, ConnPid),
-                   rabbit_amqqueue:delete(Q, IfUnused, IfEmpty, Username)
+                   rabbit_queue_type:delete(Q, IfUnused, IfEmpty, Username)
            end,
            fun (not_found) ->
                    {ok, 0};
@@ -2515,7 +2531,9 @@ handle_method(#'queue.delete'{queue     = QueueNameBin,
         {error, not_empty} ->
             precondition_failed("~s not empty", [rabbit_misc:rs(QueueName)]);
         {ok, Count} ->
-            {ok, Count}
+            {ok, Count};
+        {protocol_error, Type, Reason, ReasonArgs} ->
+            rabbit_misc:protocol_error(Type, Reason, ReasonArgs)
     end;
 handle_method(#'exchange.delete'{exchange  = ExchangeNameBin,
                                  if_unused = IfUnused},

--- a/src/rabbit_classic_queue.erl
+++ b/src/rabbit_classic_queue.erl
@@ -69,9 +69,8 @@ declare(Q, Node) when ?amqqueue_is_classic(Q) ->
               rabbit_amqqueue_sup_sup:start_queue_process(Node1, Q, declare),
               {init, new}, infinity);
         {error, Error} ->
-            rabbit_misc:protocol_error(internal_error,
-                            "Cannot declare a queue '~s' on node '~s': ~255p",
-                            [rabbit_misc:rs(QName), Node1, Error])
+            {protocol_error, internal_error, "Cannot declare a queue '~s' on node '~s': ~255p",
+             [rabbit_misc:rs(QName), Node1, Error]}
     end.
 
 delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_classic(Q) ->

--- a/src/rabbit_stream_queue.erl
+++ b/src/rabbit_stream_queue.erl
@@ -80,22 +80,30 @@ is_enabled() ->
 
 -spec declare(amqqueue:amqqueue(), node()) ->
     {'new' | 'existing', amqqueue:amqqueue()} |
-    rabbit_types:channel_exit().
+    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 declare(Q0, Node) when ?amqqueue_is_stream(Q0) ->
+    case rabbit_queue_type_util:run_checks(
+           [fun rabbit_queue_type_util:check_auto_delete/1,
+            fun rabbit_queue_type_util:check_exclusive/1,
+            fun rabbit_queue_type_util:check_non_durable/1],
+           Q0) of
+        ok ->
+            start_cluster(Q0, Node);
+        Err ->
+            Err
+    end.
+
+start_cluster(Q0, Node) ->
     Arguments = amqqueue:get_arguments(Q0),
     QName = amqqueue:get_name(Q0),
-    rabbit_queue_type_util:check_auto_delete(Q0),
-    rabbit_queue_type_util:check_exclusive(Q0),
-    rabbit_queue_type_util:check_non_durable(Q0),
     Opts = amqqueue:get_options(Q0),
     ActingUser = maps:get(user, Opts, ?UNKNOWN_USER),
     Conf0 = make_stream_conf(Node, Q0),
     case rabbit_stream_coordinator:start_cluster(
            amqqueue:set_type_state(Q0, Conf0)) of
         {ok, {error, already_started}, _} ->
-            rabbit_misc:protocol_error(precondition_failed,
-                                       "safe queue name already in use '~s'",
-                                       [Node]);
+            {protocol_error, precondition_failed, "safe queue name already in use '~s'",
+             [Node]};
         {ok, {created, Q}, _} ->
             rabbit_event:notify(queue_created,
                                 [{name, QName},
@@ -107,18 +115,15 @@ declare(Q0, Node) when ?amqqueue_is_stream(Q0) ->
             {new, Q};
         {ok, {error, Error}, _} ->
             _ = rabbit_amqqueue:internal_delete(QName, ActingUser),
-            rabbit_misc:protocol_error(
-              internal_error,
-              "Cannot declare a queue '~s' on node '~s': ~255p",
-              [rabbit_misc:rs(QName), node(), Error]);
+            {protocol_error, internal_error, "Cannot declare a queue '~s' on node '~s': ~255p",
+             [rabbit_misc:rs(QName), node(), Error]};
         {ok, {existing, Q}, _} ->
             {existing, Q};
         {error, coordinator_unavailable} ->
             _ = rabbit_amqqueue:internal_delete(QName, ActingUser),
-            rabbit_misc:protocol_error(
-              internal_error,
+            {protocol_error, internal_error,
               "Cannot declare a queue '~s' on node '~s': coordinator unavailable",
-              [rabbit_misc:rs(QName), node()])
+             [rabbit_misc:rs(QName), node()]}
     end.
 
 -spec delete(amqqueue:amqqueue(), boolean(),
@@ -146,52 +151,54 @@ stat(_) ->
 
 consume(Q, #{prefetch_count := 0}, _)
   when ?amqqueue_is_stream(Q) ->
-    rabbit_misc:protocol_error(precondition_failed,
-                               "consumer prefetch count is not set for '~s'",
-                               [rabbit_misc:rs(amqqueue:get_name(Q))]);
+    {protocol_error, precondition_failed, "consumer prefetch count is not set for '~s'",
+     [rabbit_misc:rs(amqqueue:get_name(Q))]};
 consume(Q, #{no_ack := true}, _)
   when ?amqqueue_is_stream(Q) ->
-    rabbit_misc:protocol_error(
-      not_implemented,
-      "automatic acknowledgement not supported by stream queues ~s",
-      [rabbit_misc:rs(amqqueue:get_name(Q))]);
+    {protocol_error, not_implemented,
+     "automatic acknowledgement not supported by stream queues ~s",
+     [rabbit_misc:rs(amqqueue:get_name(Q))]};
 consume(Q, #{limiter_active := true}, _State)
   when ?amqqueue_is_stream(Q) ->
     {error, global_qos_not_supported_for_queue_type};
 consume(Q, Spec, QState0) when ?amqqueue_is_stream(Q) ->
     %% Messages should include the offset as a custom header.
-    check_queue_exists_in_local_node(Q),
-    #{no_ack := NoAck,
-      channel_pid := ChPid,
-      prefetch_count := ConsumerPrefetchCount,
-      consumer_tag := ConsumerTag,
-      exclusive_consume := ExclusiveConsume,
-      args := Args,
-      ok_msg := OkMsg} = Spec,
-    QName = amqqueue:get_name(Q),
-    Offset = case rabbit_misc:table_lookup(Args, <<"x-stream-offset">>) of
-                 undefined ->
-                     next;
-                 {_, <<"first">>} ->
-                     first;
-                 {_, <<"last">>} ->
-                     last;
-                 {_, <<"next">>} ->
-                     next;
-                 {_, V} ->
-                     V
-             end,
-    rabbit_core_metrics:consumer_created(ChPid, ConsumerTag, ExclusiveConsume,
-                                         not NoAck, QName,
-                                         ConsumerPrefetchCount, false,
-                                         up, Args),
-    %% FIXME: reply needs to be sent before the stream begins sending
-    %% really it should be sent by the stream queue process like classic queues
-    %% do
-    maybe_send_reply(ChPid, OkMsg),
-    QState = begin_stream(QState0, Q, ConsumerTag, Offset,
-                          ConsumerPrefetchCount),
-    {ok, QState, []}.
+    case check_queue_exists_in_local_node(Q) of
+        ok ->
+            #{no_ack := NoAck,
+              channel_pid := ChPid,
+              prefetch_count := ConsumerPrefetchCount,
+              consumer_tag := ConsumerTag,
+              exclusive_consume := ExclusiveConsume,
+              args := Args,
+              ok_msg := OkMsg} = Spec,
+            QName = amqqueue:get_name(Q),
+            Offset = case rabbit_misc:table_lookup(Args, <<"x-stream-offset">>) of
+                         undefined ->
+                             next;
+                         {_, <<"first">>} ->
+                             first;
+                         {_, <<"last">>} ->
+                             last;
+                         {_, <<"next">>} ->
+                             next;
+                         {_, V} ->
+                             V
+                     end,
+            rabbit_core_metrics:consumer_created(ChPid, ConsumerTag, ExclusiveConsume,
+                                                 not NoAck, QName,
+                                                 ConsumerPrefetchCount, false,
+                                                 up, Args),
+            %% FIXME: reply needs to be sent before the stream begins sending
+            %% really it should be sent by the stream queue process like classic queues
+            %% do
+            maybe_send_reply(ChPid, OkMsg),
+            QState = begin_stream(QState0, Q, ConsumerTag, Offset,
+                                  ConsumerPrefetchCount),
+            {ok, QState, []};
+        Err ->
+            Err
+    end.
 
 get_local_pid(#{leader_pid := Pid}) when node(Pid) == node() ->
     Pid;
@@ -275,10 +282,8 @@ deliver(_Confirm, #delivery{message = Msg, msg_seq_no = MsgId},
                         slow = Slow}.
 -spec dequeue(_, _, _, client()) -> no_return().
 dequeue(_, _, _, #stream_client{name = Name}) ->
-    rabbit_misc:protocol_error(
-      not_implemented,
-      "basic.get not supported by stream queues ~s",
-      [rabbit_misc:rs(Name)]).
+    {protocol_error, not_implemented, "basic.get not supported by stream queues ~s",
+     [rabbit_misc:rs(Name)]}.
 
 handle_event({osiris_written, From, Corrs}, State = #stream_client{correlation = Correlation0,
                                                    soft_limit = SftLmt,
@@ -341,10 +346,9 @@ settle(complete, CTag, MsgIds, #stream_client{readers = Readers0,
                       end,
     {State#stream_client{readers = Readers}, [{deliver, CTag, true, Msgs}]};
 settle(_, _, _, #stream_client{name = Name}) ->
-    rabbit_misc:protocol_error(
-      not_implemented,
-      "basic.nack and basic.reject not supported by stream queues ~s",
-      [rabbit_misc:rs(Name)]).
+    {protocol_error, not_implemented,
+     "basic.nack and basic.reject not supported by stream queues ~s",
+     [rabbit_misc:rs(Name)]}.
 
 info(Q, all_items) ->
     info(Q, ?INFO_KEYS);
@@ -601,9 +605,9 @@ check_queue_exists_in_local_node(Q) ->
         true ->
             ok;
         false ->
-            rabbit_misc:protocol_error(precondition_failed,
-                                       "queue '~s' does not a have a replica on the local node",
-                                       [rabbit_misc:rs(amqqueue:get_name(Q))])
+            {protocol_error, precondition_failed,
+             "queue '~s' does not a have a replica on the local node",
+             [rabbit_misc:rs(amqqueue:get_name(Q))]}
     end.
 
 maybe_send_reply(_ChPid, undefined) -> ok;


### PR DESCRIPTION
Queue types should be protocol agnostic, it's up to the upper layers to decide what to do with this type of errors.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

