### PR TITLE
Allow "all" as a feature flag name

### DIFF
--- a/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
@@ -57,6 +57,12 @@ defmodule EnableFeatureFlagCommandTest do
     assert list_feature_flags(:enabled) |> Map.has_key?(context[:feature_flag])
   end
 
+  test "run: enabling all feature flags succeeds", context do
+    enable_feature_flag context[:feature_flag]
+    assert @command.run(["all"], context[:opts]) == :ok
+    assert list_feature_flags(:enabled) |> Map.has_key?(context[:feature_flag])
+  end
+
   test "banner", context do
     assert @command.banner([context[:feature_flag]], context[:opts])
       =~ ~r/Enabling feature flag \"#{context[:feature_flag]}\" \.\.\./


### PR DESCRIPTION
`rabbitmqctl enable_feature_flag all` enables all currently disabled feature flags.

While https://github.com/rabbitmq/rabbitmq-cli/issues/455 asked for `--all`, I decided to just use "all" for consistency with `rabbitmq-queues rebalance all`.

Closes rabbitmq/rabbitmq-cli#455