### PR TITLE
QQ: Emit release cursor for empty basic gets

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -299,7 +299,7 @@ apply(#{index := Index,
     Exists = maps:is_key(ConsumerId, Consumers),
     case messages_ready(State0) of
         0 ->
-            {State0, {dequeue, empty}};
+            update_smallest_raft_index(Index, {dequeue, empty}, State0, []);
         _ when Exists ->
             %% a dequeue using the same consumer_id isn't possible at this point
             {State0, {dequeue, empty}};


### PR DESCRIPTION
Else an application that polled an empty quorum queue frequently using basic.get
would never result in a snapshot being taken and results in unlimited
log growth.

Possible fix for: https://github.com/rabbitmq/discussions/issues/164

@michaelklishin do you think we can get this into 3.8.10?