### PR TITLE
Poison Message Handling in Classic Queues

### DIFF
--- a/deps/rabbit/src/message_properties.erl
+++ b/deps/rabbit/src/message_properties.erl
@@ -1,4 +1,3 @@
-
 %% This Source Code Form is subject to the terms of the Mozilla Public
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/deps/rabbit/src/message_properties.erl
+++ b/deps/rabbit/src/message_properties.erl
@@ -1,0 +1,169 @@
+
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(message_properties).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([
+  new/0,
+  new/1,
+  new/4,
+  record_version_to_use/0,
+  fields/0,
+  fields/1,
+  upgrade/1,
+  upgrade_to/2,
+  get_expiry/1,
+  get_needs_confirming/1,
+  get_size/1,
+  get_delivery_count/1,
+  set_expiry/2,
+  set_needs_confirming/2,
+  set_delivery_count/2
+]).
+
+-define(record_version, message_properties_v2).
+
+-type(expiry() :: pos_integer() | '_').
+
+-type(confirm() :: boolean() | '_').
+
+-type(size() :: pos_integer() | '_').
+
+-type(delivery_count() :: pos_integer() | '_').
+
+-type message_properties() :: message_properties_v1:message_properties_v1() |
+                                message_properties_v2().
+
+-record(message_properties, {
+    expiry :: expiry(),
+    needs_confirming :: confirm(),
+    size :: size(),
+    delivery_count :: delivery_count()}).
+
+-type(message_properties_v2() ::
+        #message_properties{expiry           :: expiry(),
+                            needs_confirming :: confirm(),
+                            size             :: size(),
+                            delivery_count   :: delivery_count()}).
+
+-type message_properties_pattern() :: message_properties_v1:message_properties_v1_pattern() |
+                                 message_properties_v2_pattern().
+
+-type message_properties_v2_pattern() :: #message_properties{
+                                                  expiry :: expiry(),
+                                                  needs_confirming :: confirm(),
+                                                  size :: size(),
+                                                  delivery_count :: delivery_count()
+                                                 }.
+
+-export_type([expiry/0, confirm/0, size/0, delivery_count/0,
+              message_properties_pattern/0,
+              message_properties_v2_pattern/0]).
+
+-spec new() -> message_properties().
+new() ->
+    case record_version_to_use() of
+        ?record_version ->
+            #message_properties{
+                expiry = undefined,
+                needs_confirming = false,
+                size = 0,
+                delivery_count = 0
+            };
+        _ ->
+            message_properties_v1:new()
+    end.
+
+-spec new(tuple()) -> message_properties().
+new({size, Size}) ->
+    new(undefined, false, Size, 0).
+
+-spec new(expiry(), confirm(), size(), delivery_count()) -> message_properties().
+new(Expiry, Confirm, Size, DC) ->
+    case record_version_to_use() of
+        ?record_version ->
+            #message_properties{
+                expiry = Expiry,
+                needs_confirming = Confirm,
+                size = Size,
+                delivery_count = DC
+            };
+        _ ->
+            message_properties_v1:new(Expiry, Confirm, Size, DC)
+    end.
+
+-spec record_version_to_use() -> message_properties_v1 | message_properties_v2.
+record_version_to_use() ->
+    case rabbit_feature_flags:is_enabled(classic_delivery_limits) of
+        true  -> ?record_version;
+        false -> message_properties_v1:record_version_to_use()
+    end.
+
+-spec fields() -> list().
+fields() ->
+    case record_version_to_use() of
+        ?record_version -> fields(?record_version);
+        _               -> message_properties_v1:fields()
+    end.
+
+-spec fields(atom()) -> list().
+fields(?record_version) -> record_info(fields, message_properties);
+fields(Version)         -> message_properties_v1:fields(Version).
+
+-spec upgrade(message_properties()) -> message_properties().
+upgrade(#message_properties{} = MessageProps) -> MessageProps;
+upgrade(OldMessageProps) -> upgrade_to(record_version_to_use(), OldMessageProps).
+
+-spec upgrade_to
+(message_properties_v2, message_properties()) -> message_properties_v2();
+(message_properties_v1, message_properties_v1:message_properties_v1()) ->
+    message_properties_v1:message_properties_v1().
+
+upgrade_to(?record_version, #message_properties{} = MessageProps) ->
+    MessageProps;
+upgrade_to(?record_version, OldMessageProps) ->
+    Fields = erlang:tuple_to_list(OldMessageProps) ++ [0],
+    #message_properties{} = erlang:list_to_tuple(Fields);
+upgrade_to(Version, OldMessageProps) ->
+    message_properties_v1:upgrade_to(Version, OldMessageProps).
+
+-spec get_expiry(message_properties()) -> expiry().
+get_expiry(#message_properties{expiry = Value}) -> Value;
+get_expiry(MessageProps) -> message_properties_v1:get_expiry(MessageProps).
+
+-spec get_needs_confirming(message_properties()) -> confirm().
+get_needs_confirming(#message_properties{needs_confirming = Value}) -> Value;
+get_needs_confirming(MessageProps) -> message_properties_v1:get_needs_confirming(MessageProps).
+
+-spec get_size(message_properties()) -> integer().
+get_size(#message_properties{size = Value}) -> Value;
+get_size(MessageProps) -> message_properties_v1:get_size(MessageProps).
+
+-spec get_delivery_count(message_properties()) -> integer().
+get_delivery_count(#message_properties{delivery_count = Value}) -> Value;
+get_delivery_count(MessageProps) -> message_properties_v1:get_delivery_count(MessageProps).
+
+-spec set_expiry(message_properties(), expiry()) -> message_properties().
+set_expiry(#message_properties{} = MessageProps, Expiry) ->
+    MessageProps#message_properties{expiry = Expiry};
+set_expiry(MessageProps, Expiry) ->
+    message_properties_v1:set_expiry(MessageProps, Expiry).
+
+-spec set_needs_confirming(message_properties(), confirm()) -> message_properties().
+set_needs_confirming(#message_properties{} = MessageProps, Confirm) ->
+    MessageProps#message_properties{needs_confirming = Confirm};
+set_needs_confirming(MessageProps, Confirm) ->
+    message_properties_v1:set_needs_confirming(MessageProps, Confirm).
+
+-spec set_delivery_count(message_properties(), delivery_count()) -> message_properties().
+set_delivery_count(#message_properties{} = MessageProps, DeliveryCount) ->
+    MessageProps#message_properties{delivery_count = DeliveryCount};
+set_delivery_count(MessageProps, DeliveryCount) ->
+    message_properties_v1:set_delivery_count(MessageProps, DeliveryCount).

--- a/deps/rabbit/src/message_properties_v1.erl
+++ b/deps/rabbit/src/message_properties_v1.erl
@@ -1,0 +1,114 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(message_properties_v1).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([
+  new/0,
+  new/4,
+  record_version_to_use/0,
+  fields/0,
+  fields/1,
+  upgrade/1,
+  upgrade_to/2,
+  get_expiry/1,
+  get_needs_confirming/1,
+  get_size/1,
+  get_delivery_count/1,
+  set_expiry/2,
+  set_needs_confirming/2,
+  set_delivery_count/2
+]).
+
+-define(record_version, ?MODULE).
+
+-record(message_properties, {
+    expiry :: message_properties:expiry(),
+    needs_confirming :: message_properties:confirm(),
+    size :: message_properties:size()}).
+
+-type message_properties() :: message_properties_v1().
+
+-type message_properties_v1() ::
+        #message_properties{expiry           :: message_properties:expiry(),
+                            needs_confirming :: message_properties:confirm(),
+                            size             :: message_properties:size()}.
+
+-type message_properties_pattern() :: message_properties_v1_pattern().
+
+-type message_properties_v1_pattern() ::
+        #message_properties{expiry           :: message_properties:expiry(),
+                            needs_confirming :: message_properties:confirm(),
+                            size             :: message_properties:size()
+                           }.
+
+-export_type([message_properties/0,
+              message_properties_v1/0,
+              message_properties_pattern/0,
+              message_properties_v1_pattern/0]).
+
+-spec record_version_to_use() -> message_properties_v1.
+record_version_to_use() ->
+    ?record_version.
+
+-spec new() -> message_properties().
+new() ->
+    #message_properties{
+        expiry = undefined,
+        needs_confirming = false,
+        size = 0
+    }.
+
+-spec new(message_properties:expiry(), message_properties:confirm(),
+          message_properties:size(), message_properties:delivery_count()) -> message_properties().
+new(Expiry, Confirm, Size, _DC) ->
+    #message_properties{
+        expiry = Expiry,
+        needs_confirming = Confirm,
+        size = Size
+    }.
+
+-spec fields() -> list().
+fields() -> fields(?record_version).
+
+-spec fields(atom()) -> list().
+fields(?record_version) -> record_info(fields, message_properties).
+
+-spec upgrade(message_properties()) -> message_properties().
+upgrade(#message_properties{} = MessageProps) -> MessageProps.
+
+-spec upgrade_to(message_properties_v1, message_properties()) -> message_properties().
+upgrade_to(?record_version, #message_properties{} = MessageProps) ->
+    MessageProps.
+
+-spec get_expiry(message_properties()) -> message_properties:expiry().
+get_expiry(#message_properties{expiry = Value}) -> Value.
+
+-spec get_needs_confirming(message_properties()) -> message_properties:confirm().
+get_needs_confirming(#message_properties{needs_confirming = Value}) -> Value.
+
+-spec get_size(message_properties()) -> message_properties:size().
+get_size(#message_properties{size = Value}) -> Value.
+
+-spec get_delivery_count(message_properties()) -> message_properties:delivery_count().
+get_delivery_count(_MessageProps) -> 0.
+
+-spec set_expiry(message_properties(), message_properties:expiry()) -> message_properties().
+set_expiry(#message_properties{} = MessageProps, Expiry) ->
+    MessageProps#message_properties{expiry = Expiry}.
+
+-spec set_needs_confirming(message_properties(), message_properties:confirm()) ->
+    message_properties().
+set_needs_confirming(#message_properties{} = MessageProps, Confirm) ->
+    MessageProps#message_properties{needs_confirming = Confirm}.
+
+-spec set_delivery_count(message_properties(), message_properties:delivery_count()) ->
+    message_properties().
+set_delivery_count(#message_properties{} = MessageProps, _DeliveryCount) ->
+    MessageProps.

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1782,9 +1782,9 @@ transform(_TF, _Fun, _Qs = []) -> ok;
 transform(TF = #transform{options = Opts}, Fun, Qs = [_|_]) ->
     Ref = make_ref(),
     Opts1 = maps:put(transform_ref, Ref, Opts),
-    AllSPids = lists:flatten([amqqueue:get_slave_pids(Q) || Q <- Qs]),
     Opts2 = maps:put(transform_client, TClient = self(), Opts1),
-    TF1 = TF#transform{options = maps:put(transform_ref, Ref, Opts2)},
+    TF1 = TF#transform{options = Opts2},
+    AllSPids = lists:flatten([amqqueue:get_slave_pids(Q) || Q <- Qs]),
     Pids = [spawn_link(rabbit_amqqueue, emit_transform, [TF1, Fun, Q, Ref, TClient])
                 || Q <- Qs],
     case wait_for_transform_pids(Ref, Pids ++ AllSPids, transform_complete) of

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1008,9 +1008,10 @@ subtract_acks(ChPid, AckTags, State = #q{consumers = Consumers}, Fun) ->
 message_properties(Message = #basic_message{content = Content},
                    Confirm, #q{ttl = TTL}) ->
     #content{payload_fragments_rev = PFR} = Content,
-    #message_properties{expiry           = calculate_msg_expiry(Message, TTL),
-                        needs_confirming = Confirm == eventually,
-                        size             = iolist_size(PFR)}.
+    message_properties:new(calculate_msg_expiry(Message, TTL),
+                           Confirm == eventually,
+                           iolist_size(PFR),
+                           0).
 
 calculate_msg_expiry(#basic_message{content = Content}, TTL) ->
     #content{properties = Props} =

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -168,6 +168,10 @@
 -callback fetch(true,  state()) -> {fetch_result(ack()), state()};
                (false, state()) -> {fetch_result(undefined), state()}.
 
+%% Produce the next message for delivery to a channel (i.e. consumer).
+-callback fetch_delivery(true,  state()) -> {fetch_result(ack()), state()};
+                        (false, state()) -> {fetch_result(undefined), state()}.
+
 %% Remove the next message.
 -callback drop(true,  state()) -> {drop_result(ack()), state()};
               (false, state()) -> {drop_result(undefined), state()}.

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -24,9 +24,9 @@
 -type flow() :: 'flow' | 'noflow'.
 -type msg_ids() :: [rabbit_types:msg_id()].
 -type publish() :: {rabbit_types:basic_message(),
-                    rabbit_types:message_properties(), boolean()}.
+                    message_properties:message_properties(), boolean()}.
 -type delivered_publish() :: {rabbit_types:basic_message(),
-                              rabbit_types:message_properties()}.
+                              message_properties:message_properties()}.
 -type fetch_result(Ack) ::
         ('empty' | {rabbit_types:basic_message(), boolean(), Ack}).
 -type drop_result(Ack) ::
@@ -39,7 +39,7 @@
 -type duration() :: ('undefined' | 'infinity' | number()).
 
 -type msg_fun(A) :: fun ((rabbit_types:basic_message(), ack(), A) -> A).
--type msg_pred() :: fun ((rabbit_types:message_properties()) -> boolean()).
+-type msg_pred() :: fun ((message_properties:message_properties()) -> boolean()).
 
 -type queue_mode() :: atom().
 
@@ -95,7 +95,7 @@
 
 %% Publish a message.
 -callback publish(rabbit_types:basic_message(),
-                  rabbit_types:message_properties(), boolean(), pid(), flow(),
+                  message_properties:message_properties(), boolean(), pid(), flow(),
                   state()) -> state().
 
 %% Like publish/6 but for batches of publishes.
@@ -105,7 +105,7 @@
 %% out to a client. The queue will be empty for these calls
 %% (i.e. saves the round trip through the backing queue).
 -callback publish_delivered(rabbit_types:basic_message(),
-                            rabbit_types:message_properties(), pid(), flow(),
+                            message_properties:message_properties(), pid(), flow(),
                             state())
                            -> {ack(), state()}.
 
@@ -153,7 +153,7 @@
 %% 'undefined' if the whole backing queue was traversed w/o the
 %% predicate ever returning false.
 -callback dropwhile(msg_pred(), state())
-                   -> {rabbit_types:message_properties() | undefined, state()}.
+                   -> {message_properties:message_properties() | undefined, state()}.
 
 %% Like dropwhile, except messages are fetched in "require
 %% acknowledgement" mode and are passed, together with their ack tag,
@@ -161,7 +161,7 @@
 %% accumulator. The result of fetchwhile is as for dropwhile plus the
 %% accumulator.
 -callback fetchwhile(msg_pred(), msg_fun(A), A, state())
-                     -> {rabbit_types:message_properties() | undefined,
+                     -> {message_properties:message_properties() | undefined,
                          A, state()}.
 
 %% Produce the next message.
@@ -191,7 +191,7 @@
 %% Fold over all the messages in a queue and return the accumulated
 %% results, leaving the queue undisturbed.
 -callback fold(fun((rabbit_types:basic_message(),
-                    rabbit_types:message_properties(),
+                    message_properties:message_properties(),
                     boolean(), A) -> {('stop' | 'cont'), A}),
                A, state()) -> {A, state()}.
 

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -254,6 +254,12 @@
 
 -callback set_queue_mode(queue_mode(), state()) -> state().
 
+%% Called when transforming queue(s) state to a different format, e.g. during
+%% upgrades or feature flag enablement. See 'rabbit_transform'.
+-callback transform(rabbit_types:transform_type(),
+                    rabbit_types:transform_version(),
+                    rabbit_types:transform_options(), function(), state()) -> state().
+
 -callback zip_msgs_and_acks([delivered_publish()],
                             [ack()], Acc, state())
                            -> Acc.

--- a/deps/rabbit/src/rabbit_basic.erl
+++ b/deps/rabbit/src/rabbit_basic.erl
@@ -17,6 +17,7 @@
          maybe_gc_large_msg/1, maybe_gc_large_msg/2]).
 -export([add_header/4,
          peek_fmt_message/1]).
+-export([inc_delivery_count/2, inc_delivery_count/3]).
 
 %%----------------------------------------------------------------------------
 
@@ -352,3 +353,39 @@ header_key(A) ->
 
 binary_prefix_64(Bin, Len) ->
     binary:part(Bin, 0, min(byte_size(Bin), Len)).
+
+%% Delivery count (classic queues)
+
+-spec inc_delivery_count(rabbit_types:basic_message(),
+                         message_properties:message_properties()) ->
+    {rabbit_types:basic_message(), message_properties:message_properties()}.
+
+inc_delivery_count(Message, Props) ->
+    inc_delivery_count(Message, Props, 1).
+
+-spec inc_delivery_count(rabbit_types:basic_message() | any(),
+                         message_properties:message_properties(), integer()) ->
+    {rabbit_types:basic_message(), message_properties:message_properties()}.
+
+inc_delivery_count(Message = #basic_message{content = Content}, Props, Delta) ->
+    case rabbit_feature_flags:is_enabled(classic_delivery_limits) of
+        true ->
+            case extract_headers(Content) of
+                undefined ->
+                    {add_header(<<"x-delivery-count">>, long, 0, Message),
+                        message_properties:set_delivery_count(Props, 0)};
+                Headers ->
+                    case rabbit_misc:table_lookup(Headers, <<"x-delivery-count">>) of
+                        {_Type, DeliveryCount} ->
+                            Count = rabbit_data_coercion:to_integer(DeliveryCount) + Delta,
+                            {add_header(<<"x-delivery-count">>, long, Count, Message),
+                                message_properties:set_delivery_count(Props, Count)};
+                        undefined ->
+                            {add_header(<<"x-delivery-count">>, long, 0, Message),
+                                message_properties:set_delivery_count(Props, 0)}
+                    end
+            end;
+        false ->
+            {Message, Props}
+    end;
+inc_delivery_count(Message, Props, _Delta) -> {Message, Props}.

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -12,7 +12,8 @@
          implicit_default_bindings_migration/3,
          virtual_host_metadata_migration/3,
          maintenance_mode_status_migration/3,
-         user_limits_migration/3]).
+         user_limits_migration/3,
+         classic_delivery_limits_migration/3]).
 
 -rabbit_feature_flag(
    {quorum_queue,
@@ -58,6 +59,13 @@
      #{desc          => "Configure connection and channel limits for a user",
        stability     => stable,
        migration_fun => {?MODULE, user_limits_migration}
+     }}).
+
+-rabbit_feature_flag(
+    {classic_delivery_limits,
+     #{desc          => "Classic queue delivery limits",
+       stability     => stable,
+       migration_fun => {?MODULE, classic_delivery_limits_migration}
      }}).
 
 %% -------------------------------------------------------------------
@@ -177,3 +185,62 @@ user_limits_migration(_FeatureName, _FeatureProps, enable) ->
     end;
 user_limits_migration(_FeatureName, _FeatureProps, is_enabled) ->
     mnesia:table_info(rabbit_user, attributes) =:= internal_user:fields(internal_user_v2).
+
+%% -------------------------------------------------------------------
+%% Classic queue delivery limits.
+%% -------------------------------------------------------------------
+
+classic_delivery_limits_migration(FeatureName, _FeatureProps, enable) ->
+    T0 = erlang:timestamp(),
+    rabbit_table:wait([rabbit_queue]),
+    rabbit_log:info("Creating table ~s for feature flag ~s",
+        [rabbit_transform:table_name(), FeatureName]),
+    Queues = mnesia:dirty_match_object(rabbit_queue,
+                 amqqueue:pattern_match_on_type(rabbit_classic_queue)),
+    QNodes = lists:usort([node(amqqueue:get_pid(Q)) || Q <- Queues]),
+    try
+        ok = rabbit_transform:check_safety(Queues),
+        case rabbit_transform:create_table() of
+            ok ->
+                Fun = fun(MsgProp) ->
+                          message_properties:upgrade_to(message_properties_v2, MsgProp)
+                      end,
+                TF = rabbit_transform:new(message_properties, message_properties_v2),
+                %% Transient transforms (queue message status)
+                case rabbit_amqqueue:transform(TF, Fun, Queues) of
+                    ok ->
+                        %% Persistent transform (queue index)
+                        case rabbit_transform:add_delivery_count_to_classic_queue_index(QNodes) of
+                            ok ->
+                                Result = rabbit_transform:add(TF),
+                                Time = timer:now_diff(erlang:timestamp(), T0),
+                                Msg = rabbit_misc:format("~p queues", [length(Queues)]),
+                                rabbit_transform:log_success(Msg, TF, Time),
+                                Result;
+                            {error, Errors} ->
+                                rabbit_log:error("Failed to transform queue indices "
+                                                 "during ~p migration: ~p",
+                                                 [FeatureName, Errors]),
+                                {error, Errors}
+                        end;
+                    {error, Reason} = Error ->
+                        rabbit_log:error("Failed to transform queues during "
+                                         "~p migration: ~p", [FeatureName, Reason]),
+                        Error;
+                    Reason ->
+                        rabbit_log:error("Failed to transform queues during ~p migration: ~p",
+                            [FeatureName, Reason]),
+                        {error, Reason}
+                end;
+            {error, Reason} = Error ->
+                rabbit_log:error("Failed to create transform table: ~p", [Reason]),
+                Error
+        end
+    catch
+        _:Reason1 ->
+            rabbit_log:error("Failed to start transform operation for "
+                             "~p migration: ~p", [FeatureName, Reason1]),
+            {error, Reason1}
+    end;
+classic_delivery_limits_migration(_FeatureName, _FeatureProps, is_enabled) ->
+    rabbit_transform:exists(message_properties, message_properties_v2).

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -106,7 +106,8 @@
          sync_feature_flags_with_cluster/2,
          sync_feature_flags_with_cluster/3,
          refresh_feature_flags_after_app_load/1,
-         enabled_feature_flags_list_file/0
+         enabled_feature_flags_list_file/0,
+         read_enabled_feature_flags_list/0
         ]).
 
 %% RabbitMQ internal use only.

--- a/deps/rabbit/src/rabbit_mirror_queue_master.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_master.erl
@@ -15,7 +15,7 @@
          dropwhile/2, fetchwhile/4, set_ram_duration_target/2, ram_duration/1,
          needs_timeout/1, timeout/1, handle_pre_hibernate/1, resume/1,
          msg_rates/1, info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
-         zip_msgs_and_acks/4, handle_info/2]).
+         transform/5, zip_msgs_and_acks/4, handle_info/2]).
 
 -export([start/2, stop/1, delete_crashed/1]).
 
@@ -495,6 +495,13 @@ set_queue_mode(Mode, State = #state { gm                  = GM,
     ok = gm:broadcast(GM, {set_queue_mode, Mode}),
     BQS1 = BQ:set_queue_mode(Mode, BQS),
     State #state { backing_queue_state = BQS1 }.
+
+transform(Name, Vsn, Opts, Fun, State = #state {gm                  = GM,
+                                                backing_queue       = BQ,
+                                                backing_queue_state = BQS}) ->
+    BQS1 = BQ:transform(Name, Vsn, Opts, Fun, BQS),
+    ok = gm:broadcast(GM, {transform, Name, Vsn, Opts, Fun}),
+    State#state{backing_queue_state = BQS1}.
 
 zip_msgs_and_acks(Msgs, AckTags, Accumulator,
                   #state { backing_queue = BQ,

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -1041,7 +1041,7 @@ process_instruction({transform, TName, TVersion, TOpts, TFun},
             transform_mirror_queue(QName, TPid, TF, TFun, BQ, BQS)
         of
             {ok, BQS1} ->
-                {mirror_transform_complete, BQS1};
+                {transform_complete, BQS1};
             {error, mirror_transform_not_permitted = Reason} = Error ->
                 rabbit_transform:log_error(QName, TF, Reason),
                 {Error, BQS}

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -1027,7 +1027,48 @@ process_instruction({set_queue_mode, Mode},
                     State = #state { backing_queue       = BQ,
                                      backing_queue_state = BQS }) ->
     BQS1 = BQ:set_queue_mode(Mode, BQS),
-    {ok, State #state { backing_queue_state = BQS1 }}.
+    {ok, State #state { backing_queue_state = BQS1 }};
+process_instruction({transform, TName, TVersion, TOpts, TFun},
+                     State = #state { q                   = Q,
+                                      backing_queue       = BQ,
+                                      backing_queue_state = BQS }) ->
+    TPid = maps:get(transform_client, TOpts, undefined),
+    TRef = maps:get(transform_ref, TOpts, undefined),
+    QName = "mirror " ++ rabbit_misc:rs(amqqueue:get_name(Q)),
+    TF = rabbit_transform:new(TName, TVersion, TOpts), %% internal encoding
+    {Reply, BQS2} =
+        try
+            transform_mirror_queue(QName, TPid, TF, TFun, BQ, BQS)
+        of
+            {ok, BQS1} ->
+                {mirror_transform_complete, BQS1};
+            {error, mirror_transform_not_permitted = Reason} = Error ->
+                rabbit_transform:log_error(QName, TF, Reason),
+                {Error, BQS}
+        catch
+            _:Reason1 ->
+                rabbit_transform:log_error(QName, TF, Reason1),
+                {{error, Reason1}, BQS}
+        end,
+
+    catch rabbit_control_misc:emit(TPid, TRef, fun() -> Reply end),
+
+    {ok, State #state{backing_queue_state = BQS2}}.
+
+transform_mirror_queue(QName, TPid, TF = #transform{name     = TName,
+                                                    versions = [TVersion],
+                                                    options  = TOpts}, TFun, BQ, BQS) ->
+    rabbit_transform:log_info(QName, TF),
+    BQS1 = BQ:transform(TName, TVersion, TOpts, TFun, BQS),
+    %% Only apply transformation if still permitted and master reacheable
+    case rabbit_transform:is_permitted([TPid]) of
+        true  ->
+            rabbit_transform:log_success(QName, TF),
+            {ok, BQS1};
+        false ->
+            rabbit_transform:log_error(QName, TF, Reason = mirror_transform_not_permitted),
+            {error, Reason}
+    end.
 
 maybe_flow_ack(Sender, flow)    -> credit_flow:ack(Sender);
 maybe_flow_ack(_Sender, noflow) -> ok.

--- a/deps/rabbit/src/rabbit_mirror_queue_sync.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_sync.erl
@@ -417,4 +417,4 @@ batch_publish_delivered(Batch, MA, BQ, BQS) ->
     {MA1, BQS1}.
 
 props(Props) ->
-    Props#message_properties{needs_confirming = false}.
+    message_properties:set_needs_confirming(Props, false).

--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -33,7 +33,7 @@
          requeue/2, ackfold/4, fold/3, len/1, is_empty/1, depth/1,
          set_ram_duration_target/2, ram_duration/1, needs_timeout/1, timeout/1,
          handle_pre_hibernate/1, resume/1, msg_rates/1,
-         info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
+         info/2, invoke/3, is_duplicate/2, set_queue_mode/2, transform/5,
          zip_msgs_and_acks/4, handle_info/2]).
 
 -record(state, {bq, bqss, max_priority}).
@@ -449,6 +449,11 @@ set_queue_mode(Mode, State = #state{bq = BQ}) ->
     foreach1(fun (_P, BQSN) -> BQ:set_queue_mode(Mode, BQSN) end, State);
 set_queue_mode(Mode, State = #passthrough{bq = BQ, bqs = BQS}) ->
     ?passthrough1(set_queue_mode(Mode, BQS)).
+
+transform(Type, Vsn, Opts, Fun, State = #state{bq = BQ}) ->
+    foreach1(fun (_P, BQSN) -> BQ:transform(Type, Vsn, Opts, Fun, BQSN) end, State);
+transform(Type, Vsn, Opts, Fun, State = #passthrough{bq = BQ, bqs = BQS}) ->
+    ?passthrough1(transform(Type, Vsn, Opts, Fun, BQS)).
 
 zip_msgs_and_acks(Msgs, AckTags, Accumulator, #state{bqss = [{MaxP, _} |_]}) ->
     MsgsByPriority = partition_publish_delivered_batch(Msgs, MaxP),

--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -29,8 +29,8 @@
          purge/1, purge_acks/1,
          publish/6, publish_delivered/5, discard/4, drain_confirmed/1,
          batch_publish/4, batch_publish_delivered/4,
-         dropwhile/2, fetchwhile/4, fetch/2, drop/2, ack/2, requeue/2,
-         ackfold/4, fold/3, len/1, is_empty/1, depth/1,
+         dropwhile/2, fetchwhile/4, fetch/2, fetch_delivery/2, drop/2, ack/2,
+         requeue/2, ackfold/4, fold/3, len/1, is_empty/1, depth/1,
          set_ram_duration_target/2, ram_duration/1, needs_timeout/1, timeout/1,
          handle_pre_hibernate/1, resume/1, msg_rates/1,
          info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
@@ -289,15 +289,23 @@ fetchwhile(Pred, Fun, Acc, State = #passthrough{bq = BQ, bqs = BQS}) ->
     ?passthrough3(fetchwhile(Pred, Fun, Acc, BQS)).
 
 fetch(AckRequired, State = #state{bq = BQ}) ->
+    process_fetch(fun BQ:fetch/2, AckRequired, State);
+fetch(AckRequired, State = #passthrough{bq = BQ, bqs = BQS}) ->
+    ?passthrough2(fetch(AckRequired, BQS)).
+
+fetch_delivery(AckRequired, State = #state{bq = BQ}) ->
+    process_fetch(fun BQ:fetch_delivery/2, AckRequired, State);
+fetch_delivery(AckRequired, State = #passthrough{bq = BQ, bqs = BQS}) ->
+    ?passthrough2(fetch_delivery(AckRequired, BQS)).
+
+process_fetch(FetchFun, AckRequired, State) ->
     find2(
       fun (P, BQSN) ->
-              case BQ:fetch(AckRequired, BQSN) of
+              case FetchFun(AckRequired, BQSN) of
                   {empty,            BQSN1} -> {empty, BQSN1};
                   {{Msg, Del, ATag}, BQSN1} -> {{Msg, Del, {P, ATag}}, BQSN1}
               end
-      end, empty, State);
-fetch(AckRequired, State = #passthrough{bq = BQ, bqs = BQS}) ->
-    ?passthrough2(fetch(AckRequired, BQS)).
+      end, empty, State).
 
 drop(AckRequired, State = #state{bq = BQ}) ->
     find2(fun (P, BQSN) ->

--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -153,15 +153,25 @@
 -define(SIZE_BYTES, 4).
 -define(SIZE_BITS, (?SIZE_BYTES * 8)).
 
+%% Delivery count field 4 bytes
+-define(DC_BYTES, 4).
+-define(DC_BITS, (?DC_BYTES * 8)).
+
 %% This is the size of the message record embedded in the queue
 %% index. If 0, the message can be found in the message store.
 -define(EMBEDDED_SIZE_BYTES, 4).
 -define(EMBEDDED_SIZE_BITS, (?EMBEDDED_SIZE_BYTES * 8)).
 
-%% 16 bytes for md5sum + 8 for expiry
--define(PUB_RECORD_BODY_BYTES, (?MSG_ID_BYTES + ?EXPIRY_BYTES + ?SIZE_BYTES)).
+%% 16 bytes for md5sum + 8 for expiry + 4 for size
+-define(PUB_RECORD_BODY_BYTES_v1, (?MSG_ID_BYTES + ?EXPIRY_BYTES + ?SIZE_BYTES)).
+
+%% 16 bytes for md5sum + 8 for expiry + 4 for size + 4 for delivery count
+-define(PUB_RECORD_BODY_BYTES_v2, (?MSG_ID_BYTES + ?EXPIRY_BYTES + ?SIZE_BYTES + ?DC_BYTES)).
+
 %% + 4 for size
--define(PUB_RECORD_SIZE_BYTES, (?PUB_RECORD_BODY_BYTES + ?EMBEDDED_SIZE_BYTES)).
+-define(PUB_RECORD_SIZE_BYTES_v1, (?PUB_RECORD_BODY_BYTES_v1 + ?EMBEDDED_SIZE_BYTES)).
+
+-define(PUB_RECORD_SIZE_BYTES_v2, (?PUB_RECORD_BODY_BYTES_v2 + ?EMBEDDED_SIZE_BYTES)).
 
 %% + 2 for seq, bits and prefix
 -define(PUB_RECORD_PREFIX_BYTES, 2).
@@ -378,7 +388,7 @@ flush_delivered_cache(State = #qistate{delivered_cache = DC}) ->
     State1#qistate{delivered_cache = []}.
 
 -spec publish(rabbit_types:msg_id(), seq_id(),
-                    rabbit_types:message_properties(), boolean(),
+                    message_properties:message_properties(), boolean(),
                     non_neg_integer(), qistate()) -> qistate().
 
 publish(MsgOrId, SeqId, MsgProps, IsPersistent, JournalSizeHint, State) ->
@@ -406,7 +416,7 @@ maybe_needs_confirming(MsgProps, MsgOrId,
                 Id when is_binary(Id)   -> Id
             end,
     ?MSG_ID_BYTES = size(MsgId),
-    case {MsgProps#message_properties.needs_confirming, MsgOrId} of
+    case {message_properties:get_needs_confirming(MsgProps), MsgOrId} of
       {true,  MsgId} -> UC1  = gb_sets:add_element(MsgId, UC),
                         State#qistate{unconfirmed     = UC1};
       {true,  _}     -> UCM1 = gb_sets:add_element(MsgId, UCM),
@@ -457,7 +467,7 @@ flush(State)                                -> flush_journal(State).
 
 -spec read(seq_id(), seq_id(), qistate()) ->
                      {[{rabbit_types:msg_id(), seq_id(),
-                        rabbit_types:message_properties(),
+                        message_properties:message_properties(),
                         boolean(), boolean()}], qistate()}.
 
 read(StartEnd, StartEnd, State) ->
@@ -669,7 +679,7 @@ recover_segment(ContainsCheckFun, CleanShutdown,
               {recover_message(ContainsCheckFun(MsgOrId), CleanShutdown,
                                Del, RelSeq, SegmentAndDirtyCount, MaxJournal),
                Bytes + case IsPersistent of
-                           true  -> MsgProps#message_properties.size;
+                           true  -> message_properties:get_size(MsgProps);
                            false -> 0
                        end}
       end,
@@ -682,7 +692,7 @@ recover_message( true, false,    del, _RelSeq, SegmentAndDirtyCount, _MaxJournal
     SegmentAndDirtyCount;
 recover_message( true, false, no_del,  RelSeq, {Segment, _DirtyCount}, MaxJournal) ->
     %% force to flush the segment
-    {add_to_journal(RelSeq, del, Segment), MaxJournal + 1}; 
+    {add_to_journal(RelSeq, del, Segment), MaxJournal + 1};
 recover_message(false,     _,    del,  RelSeq, {Segment, DirtyCount}, _MaxJournal) ->
     {add_to_journal(RelSeq, ack, Segment), DirtyCount + 1};
 recover_message(false,     _, no_del,  RelSeq, {Segment, DirtyCount}, _MaxJournal) ->
@@ -750,14 +760,24 @@ scan_queue_segments(Fun, Acc, VHostDir, QueueName) ->
 %% expiry/binary manipulation
 %%----------------------------------------------------------------------------
 
-create_pub_record_body(MsgOrId, #message_properties { expiry = Expiry,
-                                                      size   = Size }) ->
+create_pub_record_body(MsgOrId, MsgProps) ->
+    Expiry = message_properties:get_expiry(MsgProps),
+    Size = message_properties:get_size(MsgProps),
+    DC = message_properties:get_delivery_count(MsgProps),
     ExpiryBin = expiry_to_binary(Expiry),
     case MsgOrId of
         MsgId when is_binary(MsgId) ->
-            {<<MsgId/binary, ExpiryBin/binary, Size:?SIZE_BITS>>, <<>>};
+            create_pub_record_body(MsgId, ExpiryBin, Size, DC, <<>>);
         #basic_message{id = MsgId} ->
             MsgBin = term_to_binary(MsgOrId),
+            create_pub_record_body(MsgId, ExpiryBin, Size, DC, MsgBin)
+    end.
+
+create_pub_record_body(MsgId, ExpiryBin, Size, DC, MsgBin) ->
+    case rabbit_feature_flags:is_enabled(classic_delivery_limits) of
+        true ->
+            {<<MsgId/binary, ExpiryBin/binary, Size:?SIZE_BITS, DC:?DC_BITS>>, MsgBin};
+        false ->
             {<<MsgId/binary, ExpiryBin/binary, Size:?SIZE_BITS>>, MsgBin}
     end.
 
@@ -765,15 +785,21 @@ expiry_to_binary(undefined) -> <<?NO_EXPIRY:?EXPIRY_BITS>>;
 expiry_to_binary(Expiry)    -> <<Expiry:?EXPIRY_BITS>>.
 
 parse_pub_record_body(<<MsgIdNum:?MSG_ID_BITS, Expiry:?EXPIRY_BITS,
-                        Size:?SIZE_BITS>>, MsgBin) ->
+                        Size:?SIZE_BITS, Rest/binary>>, MsgBin) ->
+    DC =
+        case rabbit_feature_flags:is_enabled(classic_delivery_limits) of
+            true ->
+                <<DC0:?DC_BITS, _/binary>> = Rest, DC0;
+            false ->
+                <<>> = Rest, 0
+        end,
     %% work around for binary data fragmentation. See
     %% rabbit_msg_file:read_next/2
     <<MsgId:?MSG_ID_BYTES/binary>> = <<MsgIdNum:?MSG_ID_BITS>>,
-    Props = #message_properties{expiry = case Expiry of
-                                             ?NO_EXPIRY -> undefined;
-                                             X          -> X
-                                         end,
-                                size   = Size},
+    Props = message_properties:new(case Expiry of
+                                       ?NO_EXPIRY -> undefined;
+                                       X          -> X
+                                   end, false, Size, DC),
     case MsgBin of
         <<>> -> {MsgId, Props};
         _    -> Msg = #basic_message{id = MsgId} = binary_to_term(MsgBin),
@@ -907,7 +933,8 @@ load_journal(State = #qistate { dir = Dir }) ->
                  Size = rabbit_file:file_size(Path),
                  {ok, 0} = file_handle_cache:position(JournalHdl, 0),
                  {ok, JournalBin} = file_handle_cache:read(JournalHdl, Size),
-                 parse_journal_entries(JournalBin, State1);
+                 parse_journal_entries(JournalBin, State1,
+                    rabbit_feature_flags:is_enabled(classic_delivery_limits));
         false -> State
     end.
 
@@ -934,28 +961,43 @@ recover_journal(State) ->
     State1 #qistate { segments = Segments1 }.
 
 parse_journal_entries(<<?DEL_JPREFIX:?JPREFIX_BITS, SeqId:?SEQ_BITS,
-                        Rest/binary>>, State) ->
-    parse_journal_entries(Rest, add_to_journal(SeqId, del, State));
+                        Rest/binary>>, State, FF) ->
+    parse_journal_entries(Rest, add_to_journal(SeqId, del, State), FF);
 
 parse_journal_entries(<<?ACK_JPREFIX:?JPREFIX_BITS, SeqId:?SEQ_BITS,
-                        Rest/binary>>, State) ->
-    parse_journal_entries(Rest, add_to_journal(SeqId, ack, State));
+                        Rest/binary>>, State, FF) ->
+    parse_journal_entries(Rest, add_to_journal(SeqId, ack, State), FF);
 parse_journal_entries(<<0:?JPREFIX_BITS, 0:?SEQ_BITS,
-                        0:?PUB_RECORD_SIZE_BYTES/unit:8, _/binary>>, State) ->
+                        0:?PUB_RECORD_SIZE_BYTES_v1/unit:8, _/binary>>, State, false) ->
+    %% Journal entry composed only of zeroes was probably
+    %% produced during a dirty shutdown so stop reading
+    State;
+parse_journal_entries(<<0:?JPREFIX_BITS, 0:?SEQ_BITS,
+                        0:?PUB_RECORD_SIZE_BYTES_v2/unit:8, _/binary>>, State, true) ->
     %% Journal entry composed only of zeroes was probably
     %% produced during a dirty shutdown so stop reading
     State;
 parse_journal_entries(<<Prefix:?JPREFIX_BITS, SeqId:?SEQ_BITS,
-                        Bin:?PUB_RECORD_BODY_BYTES/binary,
+                        Bin:?PUB_RECORD_BODY_BYTES_v1/binary,
                         MsgSize:?EMBEDDED_SIZE_BITS, MsgBin:MsgSize/binary,
-                        Rest/binary>>, State) ->
+                        Rest/binary>>, State, false = FF) ->
     IsPersistent = case Prefix of
                        ?PUB_PERSIST_JPREFIX -> true;
                        ?PUB_TRANS_JPREFIX   -> false
                    end,
     parse_journal_entries(
-      Rest, add_to_journal(SeqId, {IsPersistent, Bin, MsgBin}, State));
-parse_journal_entries(_ErrOrEoF, State) ->
+      Rest, add_to_journal(SeqId, {IsPersistent, Bin, MsgBin}, State), FF);
+parse_journal_entries(<<Prefix:?JPREFIX_BITS, SeqId:?SEQ_BITS,
+                        Bin:?PUB_RECORD_BODY_BYTES_v2/binary,
+                        MsgSize:?EMBEDDED_SIZE_BITS, MsgBin:MsgSize/binary,
+                        Rest/binary>>, State, true = FF) ->
+    IsPersistent = case Prefix of
+                       ?PUB_PERSIST_JPREFIX -> true;
+                       ?PUB_TRANS_JPREFIX   -> false
+                   end,
+    parse_journal_entries(
+      Rest, add_to_journal(SeqId, {IsPersistent, Bin, MsgBin}, State), FF);
+parse_journal_entries(_ErrOrEoF, State, _FF) ->
     State.
 
 deliver_or_ack(_Kind, [], State) ->
@@ -1130,7 +1172,8 @@ parse_segment_entries(<<?PUB_PREFIX:?PUB_PREFIX_BITS,
                         IsPersistNum:1, RelSeq:?REL_SEQ_BITS, Rest/binary>>,
                       KeepAcked, Acc) ->
     parse_segment_publish_entry(
-      Rest, 1 == IsPersistNum, RelSeq, KeepAcked, Acc);
+      Rest, 1 == IsPersistNum, RelSeq, KeepAcked, Acc,
+      rabbit_feature_flags:is_enabled(classic_delivery_limits));
 parse_segment_entries(<<?REL_SEQ_ONLY_PREFIX:?REL_SEQ_ONLY_PREFIX_BITS,
                        RelSeq:?REL_SEQ_BITS, Rest/binary>>, KeepAcked, Acc) ->
     parse_segment_entries(
@@ -1138,15 +1181,23 @@ parse_segment_entries(<<?REL_SEQ_ONLY_PREFIX:?REL_SEQ_ONLY_PREFIX_BITS,
 parse_segment_entries(<<>>, _KeepAcked, Acc) ->
     Acc.
 
-parse_segment_publish_entry(<<Bin:?PUB_RECORD_BODY_BYTES/binary,
+parse_segment_publish_entry(<<Bin:?PUB_RECORD_BODY_BYTES_v1/binary,
                               MsgSize:?EMBEDDED_SIZE_BITS,
                               MsgBin:MsgSize/binary, Rest/binary>>,
                             IsPersistent, RelSeq, KeepAcked,
-                            {SegEntries, Unacked}) ->
+                            {SegEntries, Unacked}, false) ->
     Obj = {{IsPersistent, Bin, MsgBin}, no_del, no_ack},
     SegEntries1 = array:set(RelSeq, Obj, SegEntries),
     parse_segment_entries(Rest, KeepAcked, {SegEntries1, Unacked + 1});
-parse_segment_publish_entry(Rest, _IsPersistent, _RelSeq, KeepAcked, Acc) ->
+parse_segment_publish_entry(<<Bin:?PUB_RECORD_BODY_BYTES_v2/binary,
+                              MsgSize:?EMBEDDED_SIZE_BITS,
+                              MsgBin:MsgSize/binary, Rest/binary>>,
+                            IsPersistent, RelSeq, KeepAcked,
+                            {SegEntries, Unacked}, true) ->
+    Obj = {{IsPersistent, Bin, MsgBin}, no_del, no_ack},
+    SegEntries1 = array:set(RelSeq, Obj, SegEntries),
+    parse_segment_entries(Rest, KeepAcked, {SegEntries1, Unacked + 1});
+parse_segment_publish_entry(Rest, _IsPersistent, _RelSeq, KeepAcked, Acc, _FF) ->
     parse_segment_entries(Rest, KeepAcked, Acc).
 
 add_segment_relseq_entry(KeepAcked, RelSeq, {SegEntries, Unacked}) ->

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -12,7 +12,7 @@
     wait_for_replicated/1, wait/1, wait/2,
     force_load/0, is_present/0, is_empty/0, needs_default_data/0,
     check_schema_integrity/1, clear_ram_only_tables/0, retry_timeout/0,
-    wait_for_replicated/0, exists/1]).
+    wait_for_replicated/0, exists/1, delete/1]).
 
 %% for testing purposes
 -export([definitions/0]).
@@ -53,6 +53,13 @@ create(TableName, TableDefinition) ->
 -spec exists(mnesia_table()) -> boolean().
 exists(Table) ->
     lists:member(Table, mnesia:system_info(tables)).
+
+-spec delete(mnesia:table()) -> 'ok'.
+delete(TableName) ->
+    case mnesia:delete_table(TableName) of
+        {atomic, ok}                      -> ok;
+        {aborted, {no_exists, TableName}} -> ok
+    end.
 
 %% Sets up secondary indexes in a blank node database.
 ensure_secondary_indexes() ->

--- a/deps/rabbit/src/rabbit_transform.erl
+++ b/deps/rabbit/src/rabbit_transform.erl
@@ -11,7 +11,7 @@
 % a change/transformation - whose name and version needs to retained be in the
 % broker. The actual transform function remains private / hard-codedin the system.
 % During upgrade, permission to carry-out certains "steps" is queried through a
-% rabbit_transform:is_permited/{1,2} operation, which checks for any active
+% rabbit_transform:is_permitted/{0,1} operation, which checks for any active
 % partitions or alarms.
 
 -module(rabbit_transform).
@@ -40,6 +40,8 @@
     application:get_env(rabbit, queue_transform_memory_threshold, 1073741824)).
 -define(QUEUE_TRANSFORM_TOTAL_MESSAGE_THRESHOLD,
     application:get_env(rabbit, queue_transform_total_message_threshold, 10000000)).
+
+%% ----------------------------------------------------------------------------
 
 -spec table_name() -> atom().
 table_name() -> ?TAB.

--- a/deps/rabbit/src/rabbit_transform.erl
+++ b/deps/rabbit/src/rabbit_transform.erl
@@ -222,7 +222,7 @@ add_delivery_count_to_classic_queue_index(Nodes) ->
                 [rpc:call(N, rabbit_queue_index, add_delivery_count, [],
                     rabbit_transform:get_queue_index_transform_timeout())
                   || N <- Nodes],
-            case lists:delete(ok, Results) of
+            case lists:delete(ok, lists:usort(Results)) of
                 []     -> ok;
                 Errors -> Errors
             end;

--- a/deps/rabbit/src/rabbit_transform.erl
+++ b/deps/rabbit/src/rabbit_transform.erl
@@ -1,0 +1,241 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+% The rabbit_transform interface creates a rabbit_transform Mnesia table for
+% retaining transformation identities and versions that have been applied to the
+% broker. This interface can be used for any other internal entity that undergoes
+% a change/transformation - whose name and version needs to retained be in the
+% broker. The actual transform function remains private / hard-codedin the system.
+% During upgrade, permission to carry-out certains "steps" is queried through a
+% rabbit_transform:is_permited/{1,2} operation, which checks for any active
+% partitions or alarms.
+
+-module(rabbit_transform).
+
+-export([table_name/0, create_table/0]).
+-export([new/2, new/3, add/1, add/3, lookup/1, exists/2]).
+-export([check_safety/1, is_permitted/0, is_permitted/1]).
+-export([delete/1, delete_version/2]).
+-export([format/1, log_info/2, log_success/2, log_success/3, log_error/3]).
+-export([get_timeout/0, get_queue_index_transform_timeout/0]).
+-export([add_delivery_count_to_classic_queue_index/1]).
+
+-include("rabbit.hrl").
+
+-define(TAB, ?MODULE).
+
+%% Transform timeouts
+-define(TRANSFORM_TIMEOUT, application:get_env(rabbit, transform_timeout, 300000)).
+-define(QUEUE_INDEX_TRANSFORM_TIMEOUT,
+    application:get_env(rabbit, queue_index_transform_timeout, 600000)).
+
+%% Queue transform thresholds
+-define(QUEUE_TRANSFORM_MESSAGE_THRESHOLD,
+    application:get_env(rabbit, queue_transform_message_threshold, 100000)).
+-define(QUEUE_TRANSFORM_MEMORY_THRESHOLD,
+    application:get_env(rabbit, queue_transform_memory_threshold, 1073741824)).
+-define(QUEUE_TRANSFORM_TOTAL_MESSAGE_THRESHOLD,
+    application:get_env(rabbit, queue_transform_total_message_threshold, 10000000)).
+
+-spec table_name() -> atom().
+table_name() -> ?TAB.
+
+-spec create_table() -> rabbit_types:ok_or_error(any()).
+create_table() ->
+    try
+        rabbit_table:create(table_name(),
+            [{record_name, transform},
+             {attributes, record_info(fields, transform)}])
+    catch
+        throw:Reason -> {error, Reason}
+    end.
+
+-spec new(rabbit_types:transform_name(), rabbit_types:transform_version()) ->
+    rabbit_types:transform().
+new(Name, Version) ->
+    new(Name, Version, #{}).
+
+-spec new(rabbit_types:transform_name(),
+          rabbit_types:transform_version() | [rabbit_types:transform_version()],
+          rabbit_types:transform_options()) -> rabbit_types:transform().
+new(Name, Versions, Options) when is_list(Versions) ->
+    #transform{
+        name     = Name,
+        versions = Versions,
+        options  = Options
+    };
+new(Name, Version, Options) ->
+    new(Name, [Version], Options).
+
+-spec add(rabbit_types:transform()) -> ok.
+add(#transform{name     = Name,
+               versions = Versions,
+               options  = Options
+              }) ->
+    add(Name, Versions, Options).
+
+-spec add(rabbit_types:transform_name(),
+          rabbit_types:transform_version() | [rabbit_types:transform_version()],
+          rabbit_types:transform_options()) -> ok.
+add(Name, Versions, Options) when is_list(Versions), is_map(Options) ->
+    rabbit_misc:execute_mnesia_transaction(
+        fun() ->
+            case mnesia:wread({?TAB, Name}) of
+              [#transform{versions = Versions1, options = Options1} = TF] ->
+                  TF1 = TF#transform{versions = lists:usort(lists:append(Versions, Versions1)),
+                                     options  = maps:merge(Options, Options1)},
+                  ok = mnesia:write(?TAB, TF1, write);
+              [] ->
+                  TF = new(Name, Versions, Options),
+                  ok = mnesia:write(?TAB, TF, write)
+            end
+        end);
+add(Name, Version, Options) when is_map(Options) ->
+    add(Name, [Version], Options).
+
+-spec lookup(rabbit_types:transform_name()) ->
+    {ok, rabbit_types:transform()} | rabbit_types:error(any()).
+lookup(Name) ->
+    rabbit_misc:dirty_read({?TAB, Name}).
+
+-spec exists(rabbit_types:transform_name(), rabbit_types:transform_version()) -> boolean().
+exists(Name, Version) ->
+    try lookup(Name) of
+        {ok, #transform{versions = Versions}} ->
+            lists:member(Version, Versions);
+        _ ->
+            false
+    catch
+        _:_ -> false
+    end.
+
+-spec check_safety([amqqueue:amqqueue()]) -> rabbit_types:ok_or_error(any()).
+check_safety(Queues) ->
+    %% Ensure permitted (no alarms and partition state)
+    case is_permitted() of
+        true  -> ok;
+        false -> throw({error, transform_not_permitted})
+    end,
+
+    %% Check transform thresholds aren't exceeded
+    TotalMsgs =
+        lists:sum(
+            [begin
+                QInfo = rabbit_amqqueue:info(Q, [messages, memory]),
+                NMessages = rabbit_misc:pget(messages, QInfo),
+                Memory = rabbit_misc:pget(memory, QInfo),
+                QName = rabbit_misc:rs(amqqueue:get_name(Q)),
+                check_safety(QName, NMessages, ?QUEUE_TRANSFORM_MESSAGE_THRESHOLD,
+                    transform_message_threshold_exceeded),
+                check_safety(QName, Memory, ?QUEUE_TRANSFORM_MEMORY_THRESHOLD,
+                    transform_memory_threshold_exceeded),
+                NMessages
+             end || Q <- Queues]),
+
+    %% Check transform total message threshold isn't exceeded
+    case TotalMsgs =< ?QUEUE_TRANSFORM_TOTAL_MESSAGE_THRESHOLD of
+        true ->
+            ok;
+        false ->
+            throw(transform_total_message_threshold_exceeded)
+    end.
+
+-spec is_permitted() -> boolean().
+is_permitted() ->
+    (rabbit_node_monitor:pause_partition_guard() =:= ok) and
+        (rabbit_alarm:lookup_alarms() =:= []).
+
+-spec is_permitted([pid() | node()]) -> boolean().
+is_permitted(NodesOrPids) ->
+    Result =
+        (is_permitted()) and
+            (lists:all(fun(NodeOrPid) -> check_if_permitted(NodeOrPid) end, NodesOrPids)),
+    timer:sleep(100),
+    Result.
+
+-spec delete(rabbit_types:transform_name()) -> ok.
+delete(Name) ->
+    rabbit_misc:execute_mnesia_transaction(
+        fun() -> mnesia:delete({?TAB, Name}) end).
+
+-spec delete_version(rabbit_types:transform_name(), rabbit_types:transform_version()) -> ok.
+delete_version(Name, Version) ->
+    rabbit_misc:execute_mnesia_transaction(
+        fun() ->
+            try lookup(Name) of
+                {ok, TF = #transform{versions = Versions}} ->
+                    case lists:member(Version, Versions) of
+                        true ->
+                            Versions1 = lists:delete(Version, Versions),
+                            TF1 = TF#transform{versions = Versions1},
+                            ok = mnesia:write(?TAB, TF1, write);
+                        false ->
+                            ok
+                    end;
+                _ ->
+                    ok
+            catch
+                _:_ -> ok
+            end
+        end).
+
+-spec get_timeout() -> non_neg_integer().
+get_timeout() -> ?TRANSFORM_TIMEOUT.
+
+-spec get_queue_index_transform_timeout() -> non_neg_integer().
+get_queue_index_transform_timeout() -> ?QUEUE_INDEX_TRANSFORM_TIMEOUT.
+
+-spec format(rabbit_types:transform()) -> string().
+format(#transform{name = Name, versions = [Version]}) ->
+    rabbit_misc:format("transform ~p of version ~p", [Name, Version]).
+
+-spec log_info(any(), rabbit_types:transform()) -> ok.
+log_info(Element, TF = #transform{}) ->
+    rabbit_log:info("Transforming ~s using ~s", [Element, format(TF)]).
+
+-spec log_success(any(), rabbit_types:transform()) -> ok.
+log_success(Element, TF = #transform{}) ->
+    rabbit_log:info("Successfully transformed ~s using ~s", [Element, format(TF)]).
+
+-spec log_success(any(), rabbit_types:transform(), pos_integer()) -> ok.
+log_success(Element, TF = #transform{}, Time) ->
+    rabbit_log:info("Successfully transformed ~s using ~s in ~p µs",
+        [Element, format(TF), Time]).
+
+-spec log_error(any(), rabbit_types:transform(), any()) -> ok.
+log_error(Element, TF = #transform{}, Reason) ->
+    Err = rabbit_misc:format("Failed transformation of ~s using ~s with reason: ~w",
+              [Element, format(TF), Reason]),
+    rabbit_log:error(Err).
+
+-spec add_delivery_count_to_classic_queue_index([node()]) -> rabbit_types:ok_or_error(any()).
+add_delivery_count_to_classic_queue_index(Nodes) ->
+    case rabbit_transform:is_permitted(Nodes) of
+        true ->
+            Results =
+                [rpc:call(N, rabbit_queue_index, add_delivery_count, [],
+                    rabbit_transform:get_queue_index_transform_timeout())
+                  || N <- Nodes],
+            case lists:delete(ok, Results) of
+                []     -> ok;
+                Errors -> Errors
+            end;
+        false ->
+            {error, transform_queue_index_not_permitted}
+    end.
+
+%% Internal
+check_safety(QName, Messages, Threshold, Error) ->
+    case (Messages =< Threshold) of
+        true  -> ok;
+        false -> throw({QName, Error})
+    end.
+
+check_if_permitted(Pid) when is_pid(Pid) ->
+    rabbit_misc:is_process_alive(Pid);
+check_if_permitted(Node) when is_atom(Node) ->
+    net_adm:ping(Node) =:= pong.

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1738,12 +1738,13 @@ collect_by_predicate(Pred, QAcc, State) ->
 %%----------------------------------------------------------------------------
 
 transform(message_properties, _Vsn = message_properties_v2, _Opts, Fun,
-          State = #vqstate{q1 = Q1, q2 = Q2, q3 = Q3, q4 = Q4}) ->
+          State = #vqstate{q1 = Q1, q2 = Q2, q3 = Q3, q4 = Q4, index_state = IndexState}) ->
     NQ1 = transform_internal_queue(Q1, Fun),
     NQ2 = transform_internal_queue(Q2, Fun),
     NQ3 = transform_internal_queue(Q3, Fun),
     NQ4 = transform_internal_queue(Q4, Fun),
-    State#vqstate{q1 = NQ1, q2 = NQ2, q3 = NQ3, q4 = NQ4};
+    State#vqstate{q1 = NQ1, q2 = NQ2, q3 = NQ3, q4 = NQ4,
+                  index_state = rabbit_queue_index:flush(IndexState)};
 
 transform(Transform, Vsn, _Opts, _Fun, _State) ->
     throw({unsupported_transform, {Transform, Vsn}}).

--- a/deps/rabbit/test/channel_operation_timeout_test_queue.erl
+++ b/deps/rabbit/test/channel_operation_timeout_test_queue.erl
@@ -17,7 +17,7 @@
          set_ram_duration_target/2, ram_duration/1, needs_timeout/1, timeout/1,
          handle_pre_hibernate/1, resume/1, msg_rates/1,
          info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
-         start/2, stop/1, zip_msgs_and_acks/4, handle_info/2]).
+         start/2, stop/1, transform/5, zip_msgs_and_acks/4, handle_info/2]).
 
 %%----------------------------------------------------------------------------
 %% This test backing queue follows the variable queue implementation, with
@@ -296,6 +296,9 @@ is_duplicate(Msg, State) -> rabbit_variable_queue:is_duplicate(Msg, State).
 
 set_queue_mode(Mode, State) ->
     rabbit_variable_queue:set_queue_mode(Mode, State).
+
+transform(Type, Vsn, Opts, Fun, State) ->
+    rabbit_variable_queue:transform(Type, Vsn, Opts, Fun, State).
 
 zip_msgs_and_acks(Msgs, AckTags, Accumulator, State) ->
     rabbit_variable_queue:zip_msgs_and_acks(Msgs, AckTags, Accumulator, State).

--- a/deps/rabbit/test/channel_operation_timeout_test_queue.erl
+++ b/deps/rabbit/test/channel_operation_timeout_test_queue.erl
@@ -12,8 +12,8 @@
          publish/6, publish_delivered/5,
          batch_publish/4, batch_publish_delivered/4,
          discard/4, drain_confirmed/1,
-         dropwhile/2, fetchwhile/4, fetch/2, drop/2, ack/2, requeue/2,
-         ackfold/4, fold/3, len/1, is_empty/1, depth/1,
+         dropwhile/2, fetchwhile/4, fetch/2, fetch_delivery/2, drop/2, ack/2,
+         requeue/2, ackfold/4, fold/3, len/1, is_empty/1, depth/1,
          set_ram_duration_target/2, ram_duration/1, needs_timeout/1, timeout/1,
          handle_pre_hibernate/1, resume/1, msg_rates/1,
          info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
@@ -235,6 +235,9 @@ fetchwhile(Pred, Fun, Acc, State) ->
 
 fetch(AckRequired, State) ->
     rabbit_variable_queue:fetch(AckRequired, State).
+
+fetch_delivery(AckRequired, State) ->
+    rabbit_variable_queue:fetch_delivery(AckRequired, State).
 
 drop(AckRequired, State) ->
     rabbit_variable_queue:drop(AckRequired, State).

--- a/deps/rabbit/test/classic_delivery_limits_SUITE.erl
+++ b/deps/rabbit/test/classic_delivery_limits_SUITE.erl
@@ -37,7 +37,7 @@ groups() ->
         subscribe_redelivery_operator_policy,
         subscribe_redelivery_limit_with_dlx,
         consume_redelivery_count,
-        subscribe_redelivery_limit_with_mirror_promotion
+        consume_redelivery_limit_with_mirror_promotion
     ],
     [
       {cluster_size_1_network, [], ClusterSize1Tests},
@@ -394,7 +394,7 @@ consume_redelivery_count(Config) ->
                                         requeue      = true}),
     ok.
 
-subscribe_redelivery_limit_with_mirror_promotion(Config) ->
+consume_redelivery_limit_with_mirror_promotion(Config) ->
     [Node1, Node2] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     %% Stop replica node

--- a/deps/rabbit/test/classic_delivery_limits_SUITE.erl
+++ b/deps/rabbit/test/classic_delivery_limits_SUITE.erl
@@ -1,0 +1,512 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(classic_delivery_limits_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+-compile(export_all).
+
+-import(quorum_queue_utils, [wait_for_messages/2, wait_for_messages/3]).
+
+all() ->
+    [
+     {group, cluster_size_1_network},
+     {group, cluster_size_2_network}
+    ].
+
+groups() ->
+    ClusterSize1Tests = [
+        subscribe_redelivery_count,
+        subscribe_redelivery_limit,
+        subscribe_redelivery_policy,
+        subscribe_redelivery_operator_policy,
+        subscribe_redelivery_limit_with_dlx,
+        consume_redelivery_count
+    ],
+    ClusterSize2Tests = [
+        subscribe_redelivery_count,
+        subscribe_redelivery_limit,
+        subscribe_redelivery_operator_policy,
+        subscribe_redelivery_limit_with_dlx,
+        consume_redelivery_count,
+        subscribe_redelivery_limit_with_mirror_promotion
+    ],
+    [
+      {cluster_size_1_network, [], ClusterSize1Tests},
+      {cluster_size_2_network, [], ClusterSize2Tests}
+    ].
+
+suite() ->
+    [
+      %% If a test hangs, no need to wait for 30 minutes.
+      {timetrap, {minutes, 8}}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(cluster_size_1_network, Config) ->
+    Config1 = rabbit_ct_helpers:set_config(Config, [{connection_type, network}]),
+    init_per_node_group(cluster_size_1_network, Config1, 1);
+init_per_group(cluster_size_2_network, Config) ->
+    Config1 = rabbit_ct_helpers:set_config(Config, [{connection_type, network}]),
+    init_per_node_group(cluster_size_2_network, Config1, 2).
+
+init_per_node_group(Group, Config, NodeCount) ->
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+                                                    {rmq_nodes_count, NodeCount},
+                                                    {rmq_nodename_suffix, Suffix}
+      ]),
+    Config2 =
+      rabbit_ct_helpers:run_steps(Config1,
+          rabbit_ct_broker_helpers:setup_steps() ++
+          rabbit_ct_client_helpers:setup_steps()),
+    rabbit_ct_broker_helpers:enable_feature_flag(Config2, classic_delivery_limits),
+    init_per_multinode_group(Group, Config2).
+
+init_per_multinode_group(cluster_size_2_network, Config) ->
+    rabbit_ct_broker_helpers:set_ha_policy_all(Config,
+        [{<<"ha-sync-mode">>, <<"automatic">>}]);
+init_per_multinode_group(_Group, Config) -> Config.
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
+    Q = rabbit_data_coercion:to_binary(Testcase),
+    rabbit_ct_helpers:set_config(Config, {queue_name, Q}).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test cases.
+%% -------------------------------------------------------------------
+subscribe_redelivery_count(Config) ->
+    [Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node),
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+    subscribe(Ch, CQ, false),
+
+    DCHeader = <<"x-delivery-count">>,
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag,
+                          redelivered  = false},
+         #amqp_msg{props = #'P_basic'{headers = H0}}} ->
+            ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag1,
+                          redelivered  = true},
+         #amqp_msg{props = #'P_basic'{headers = H1}}} ->
+            ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag2,
+                          redelivered  = true},
+         #amqp_msg{props = #'P_basic'{headers = H2}}} ->
+            ?assertMatch({DCHeader, _, 2}, rabbit_basic:header(DCHeader, H2)),
+            amqp_channel:cast(Ch, #'basic.ack'{delivery_tag = DeliveryTag2,
+                                               multiple     = false}),
+            wait_for_messages(Config, [[CQ, <<"0">>, <<"0">>, <<"0">>]])
+    end.
+
+subscribe_redelivery_limit(Config) ->
+    [Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node),
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>},
+                                  {<<"x-delivery-limit">>, long, 1}])),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+    subscribe(Ch, CQ, false),
+
+    DCHeader = <<"x-delivery-count">>,
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag,
+                          redelivered  = false},
+         #amqp_msg{props = #'P_basic'{headers = H0}}} ->
+            ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"0">>, <<"1">>]]),
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag1,
+                          redelivered  = true},
+         #amqp_msg{props = #'P_basic'{headers = H1}}} ->
+            ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"0">>, <<"0">>, <<"0">>]]),
+    receive
+        {#'basic.deliver'{redelivered  = true}, #amqp_msg{}} ->
+            throw(unexpected_redelivery)
+    after 2000 ->
+            ok
+    end.
+
+subscribe_redelivery_policy(Config) ->
+    [Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node),
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    ok = rabbit_ct_broker_helpers:set_policy(
+           Config, 0, <<"delivery-limit">>, <<".*">>, <<"queues">>,
+           [{<<"delivery-limit">>, 1}]),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+    subscribe(Ch, CQ, false),
+
+    DCHeader = <<"x-delivery-count">>,
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag,
+                          redelivered  = false},
+         #amqp_msg{props = #'P_basic'{headers = H0}}} ->
+            ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"0">>, <<"1">>]]),
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag1,
+                          redelivered  = true},
+         #amqp_msg{props = #'P_basic'{headers = H1}}} ->
+            ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"0">>, <<"0">>, <<"0">>]]),
+    receive
+        {#'basic.deliver'{redelivered  = true}, #amqp_msg{}} ->
+            throw(unexpected_redelivery)
+    after 2000 ->
+            ok
+    end,
+    ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"delivery-limit">>).
+
+subscribe_redelivery_operator_policy(Config) ->
+    [Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node),
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    ok = rabbit_ct_broker_helpers:set_operator_policy(
+           Config, 0, <<"delivery-limit">>, <<".*">>, <<"queues">>,
+           [{<<"delivery-limit">>, 1}]),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+    subscribe(Ch, CQ, false),
+
+    DCHeader = <<"x-delivery-count">>,
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag,
+                          redelivered  = false},
+         #amqp_msg{props = #'P_basic'{headers = H0}}} ->
+            ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"0">>, <<"1">>]]),
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag1,
+                          redelivered  = true},
+         #amqp_msg{props = #'P_basic'{headers = H1}}} ->
+            ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"0">>, <<"0">>, <<"0">>]]),
+    receive
+        {#'basic.deliver'{redelivered  = true}, #amqp_msg{}} ->
+            throw(unexpected_redelivery)
+    after 2000 ->
+            ok
+    end,
+    ok = rabbit_ct_broker_helpers:clear_operator_policy(Config, 0, <<"delivery-limit">>).
+
+subscribe_redelivery_limit_with_dlx(Config) ->
+    [Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node),
+    CQ = ?config(queue_name, Config),
+    DLX = <<"dlx_queue">>,
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>},
+                                  {<<"x-delivery-limit">>, long, 1},
+                                  {<<"x-dead-letter-exchange">>, longstr, <<>>},
+                                  {<<"x-dead-letter-routing-key">>, longstr, DLX}
+                                 ])),
+    ?assertEqual({'queue.declare_ok', DLX, 0, 0},
+                 declare(Ch, DLX, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+    subscribe(Ch, CQ, false),
+
+    DCHeader = <<"x-delivery-count">>,
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag,
+                          redelivered  = false},
+         #amqp_msg{props = #'P_basic'{headers = H0}}} ->
+            ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"0">>, <<"1">>]]),
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag1,
+                          redelivered  = true},
+         #amqp_msg{props = #'P_basic'{headers = H1}}} ->
+            ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+            amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                                multiple     = false,
+                                                requeue      = true})
+    end,
+
+    wait_for_messages(Config, [[CQ, <<"0">>, <<"0">>, <<"0">>]]),
+    wait_for_messages(Config, [[DLX, <<"1">>, <<"1">>, <<"0">>]]),
+
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Node),
+    DAHeaderDLX = <<"delivery-attempts">>,
+    {#'basic.get_ok'{delivery_tag = DeliveryTag2,
+                     redelivered = false},
+     #amqp_msg{props = #'P_basic'{headers = H2}}} =
+        amqp_channel:call(Ch2, #'basic.get'{queue  = DLX,
+                                            no_ack = false}),
+    ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H2)),
+    {<<"x-death">>, array, [{table, DLXTable}]} = rabbit_basic:header(<<"x-death">>, H2),
+    ?assertMatch({DAHeaderDLX, _, 1}, rabbit_basic:header(DAHeaderDLX, DLXTable)),
+    ?assertMatch({<<"count">>, _, 1}, rabbit_basic:header(<<"count">>, DLXTable)),
+    ?assertMatch({<<"reason">>, _, <<"expired">>}, rabbit_basic:header(<<"reason">>, DLXTable)),
+    ?assertMatch({<<"queue">>, _, CQ}, rabbit_basic:header(<<"queue">>, DLXTable)),
+    amqp_channel:cast(Ch2, #'basic.nack'{delivery_tag = DeliveryTag2,
+                                         multiple     = false,
+                                         requeue      = false}),
+
+    wait_for_messages(Config, [[CQ, <<"0">>, <<"0">>, <<"0">>]]),
+    wait_for_messages(Config, [[DLX, <<"0">>, <<"0">>, <<"0">>]]).
+
+consume_redelivery_count(Config) ->
+    [Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node),
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+
+    DCHeader = <<"x-delivery-count">>,
+
+    {#'basic.get_ok'{delivery_tag = DeliveryTag,
+                     redelivered = false},
+     #amqp_msg{props = #'P_basic'{headers = H0}}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = CQ,
+                                           no_ack = false}),
+    ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                        multiple     = false,
+                                        requeue      = true}),
+    %% wait for requeuing
+    timer:sleep(500),
+
+    {#'basic.get_ok'{delivery_tag = DeliveryTag1,
+                     redelivered = true},
+     #amqp_msg{props = #'P_basic'{headers = H1}}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = CQ,
+                                           no_ack = false}),
+    ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                        multiple     = false,
+                                        requeue      = true}),
+
+    {#'basic.get_ok'{delivery_tag = DeliveryTag2,
+                     redelivered = true},
+     #amqp_msg{props = #'P_basic'{headers = H2}}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = CQ,
+                                           no_ack = false}),
+    ?assertMatch({DCHeader, _, 2}, rabbit_basic:header(DCHeader, H2)),
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag2,
+                                        multiple     = false,
+                                        requeue      = true}),
+    ok.
+
+subscribe_redelivery_limit_with_mirror_promotion(Config) ->
+    [Node1, Node2] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    %% Stop replica node
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Node2),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Node1),
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    ok = rabbit_ct_broker_helpers:set_operator_policy(
+           Config, 0, <<"delivery-limit">>, <<".*">>, <<"queues">>,
+           [{<<"delivery-limit">>, 3}]),
+
+    publish(Ch, CQ),
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+
+    DCHeader = <<"x-delivery-count">>,
+    {#'basic.get_ok'{delivery_tag = DeliveryTag,
+                     redelivered = false},
+     #amqp_msg{props = #'P_basic'{headers = H0}}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = CQ,
+                                           no_ack = false}),
+    ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
+                                        multiple     = false,
+                                        requeue      = true}),
+
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+
+    {#'basic.get_ok'{delivery_tag = DeliveryTag1,
+                     redelivered = true},
+     #amqp_msg{props = #'P_basic'{headers = H1}}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = CQ,
+                                           no_ack = false}),
+    ?assertMatch({DCHeader, _, 1}, rabbit_basic:header(DCHeader, H1)),
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag1,
+                                        multiple     = false,
+                                        requeue      = true}),
+
+    wait_for_messages(Config, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+
+    {#'basic.get_ok'{delivery_tag = DeliveryTag2,
+                     redelivered = true},
+     #amqp_msg{props = #'P_basic'{headers = H2}}} =
+        amqp_channel:call(Ch, #'basic.get'{queue = CQ,
+                                           no_ack = false}),
+    ?assertMatch({DCHeader, _, 2}, rabbit_basic:header(DCHeader, H2)),
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag2,
+                                        multiple     = false,
+                                        requeue      = true}),
+
+    %% Start node and wait for sync.
+    ok = rabbit_ct_broker_helpers:start_node(Config, Node2),
+
+    timer:sleep(500),
+
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Node1),
+
+    %% Mirror promoted on a different node - ensure delivery-count is consistent
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Node2),
+
+    wait_for_messages(Config, 1, [[CQ, <<"1">>, <<"1">>, <<"0">>]]),
+
+    %% Ensure delivery count now at 3
+    {#'basic.get_ok'{delivery_tag = DeliveryTag3,
+                     redelivered = true},
+     #amqp_msg{props = #'P_basic'{headers = H3}}} =
+        amqp_channel:call(Ch1, #'basic.get'{queue = CQ,
+                                            no_ack = false}),
+    ?assertMatch({DCHeader, _, 3}, rabbit_basic:header(DCHeader, H3)),
+    amqp_channel:cast(Ch1, #'basic.nack'{delivery_tag = DeliveryTag3,
+                                        multiple     = false,
+                                        requeue      = true}),
+
+    wait_for_messages(Config, 1, [[CQ, <<"0">>, <<"0">>, <<"0">>]]),
+
+    ok = rabbit_ct_broker_helpers:start_node(Config, Node1),
+    ok = rabbit_ct_broker_helpers:clear_operator_policy(Config, 1, <<"delivery-limit">>).
+
+%% -----------------------------------------------------------------------------
+
+declare(Ch, Q) ->
+    declare(Ch, Q, []).
+
+declare(Ch, Q, Args) ->
+    amqp_channel:call(Ch, #'queue.declare'{queue     = Q,
+                                           durable   = true,
+                                           auto_delete = false,
+                                           arguments = Args}).
+
+delete_queues() ->
+   [rabbit_amqqueue:delete(Q, false, false, <<"dummy">>)
+    || Q <- rabbit_amqqueue:list()].
+
+publish(Ch, Queue) ->
+    publish(Ch, Queue, <<"msg">>).
+
+publish(Ch, Queue, Msg) ->
+    ok = amqp_channel:cast(Ch,
+                           #'basic.publish'{routing_key = Queue},
+                           #amqp_msg{props   = #'P_basic'{delivery_mode = 1},
+                                     payload = Msg}).
+
+subscribe(Ch, Queue, NoAck) ->
+    subscribe(Ch, Queue, NoAck, <<"ctag">>).
+subscribe(Ch, Queue, NoAck, CTag) ->
+    amqp_channel:subscribe(Ch, #'basic.consume'{queue = Queue,
+                                                no_ack = NoAck,
+                                                consumer_tag = CTag},
+                          self()),
+    receive
+       #'basic.consume_ok'{consumer_tag = CTag} ->
+            ok
+    end.

--- a/deps/rabbit/test/priority_queue_SUITE.erl
+++ b/deps/rabbit/test/priority_queue_SUITE.erl
@@ -387,7 +387,7 @@ info_head_message_timestamp1(_Config) ->
         }},
       is_persistent = false
     },
-    BQS2 = PQ:publish(Msg1, #message_properties{size = 0}, false, self(),
+    BQS2 = PQ:publish(Msg1, message_properties:new({size, 0}), false, self(),
       noflow, BQS1),
     1000 = PQ:info(head_message_timestamp, BQS2),
     %% Publish a higher priority message with no timestamp.
@@ -399,7 +399,7 @@ info_head_message_timestamp1(_Config) ->
         }},
       is_persistent = false
     },
-    BQS3 = PQ:publish(Msg2, #message_properties{size = 0}, false, self(),
+    BQS3 = PQ:publish(Msg2, message_properties:new({size, 0}), false, self(),
       noflow, BQS2),
     '' = PQ:info(head_message_timestamp, BQS3),
     %% Consume message with no timestamp.

--- a/deps/rabbit/test/rabbit_transform_SUITE.erl
+++ b/deps/rabbit/test/rabbit_transform_SUITE.erl
@@ -1,0 +1,274 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_transform_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+-compile(export_all).
+
+-import(quorum_queue_utils, [wait_for_messages/2]).
+
+-define(NET_TICKTIME, 60).
+
+all() ->
+    [
+     {group, cluster_size_1},
+     {group, cluster_size_3}
+    ].
+
+groups() ->
+    ClusterSize1Tests = [
+        successful_supported_transform,
+        unsuccessful_unsupported_transform,
+        unsuccessful_supported_transform,
+        validate_transform_safety_checks
+    ],
+    ClusterSize3Tests = [
+        successful_supported_transform,
+        unsuccessful_unsupported_transform,
+        unsuccessful_supported_transform,
+        unsuccessful_supported_mirror_transform
+    ],
+    [
+      {cluster_size_1, [], ClusterSize1Tests},
+      {cluster_size_3, [], ClusterSize3Tests}
+    ].
+
+suite() ->
+    [
+      %% If a test hangs, no need to wait for 30 minutes.
+      {timetrap, {minutes, 8}}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(cluster_size_1, Config) ->
+    Config1 = rabbit_ct_helpers:set_config(Config, [{connection_type, network}]),
+    init_per_multinode_group(cluster_size_1, Config1, 1, []);
+init_per_group(cluster_size_3, Config) ->
+    Config1 = rabbit_ct_helpers:set_config(Config, [{connection_type, network}]),
+    Config2 = rabbit_ct_helpers:set_config(Config1, [{net_ticktime, ?NET_TICKTIME}]),
+    Policy = [fun rabbit_ct_broker_helpers:set_ha_policy_all/1],
+    init_per_multinode_group(cluster_size_3, Config2, 3, Policy).
+
+init_per_multinode_group(_Group, Config, NodeCount, Policy) ->
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+                                                    {rmq_nodes_count, NodeCount},
+                                                    {rmq_nodename_suffix, Suffix}
+      ]),
+    Config2 =
+      rabbit_ct_helpers:run_steps(Config1,
+          rabbit_ct_broker_helpers:setup_steps() ++
+          rabbit_ct_client_helpers:setup_steps() ++ Policy),
+    Config2.
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
+    Q = rabbit_data_coercion:to_binary(Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, {queue_name, Q}),
+    setup_queues(Config1).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test cases.
+%% -------------------------------------------------------------------
+successful_supported_transform(Config) ->
+    [Node1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_table, delete, [rabbit_transform])),
+
+    %% explictly trigger successful transform
+    ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_core_ff, classic_delivery_limits_migration,
+        [classic_delivery_limits, [], enable])),
+
+    ?assertEqual(true, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, exists, [message_properties, message_properties_v2])),
+    rabbit_ct_broker_helpers:rpc(Config, Node1, rabbit_transform, delete_version,
+        [message_properties, message_properties_v2]),
+    ?assertEqual({ok, {'transform', message_properties, [], #{}}},
+        rabbit_ct_broker_helpers:rpc(Config, Node1, rabbit_transform, lookup, [message_properties])),
+    ok = rabbit_ct_broker_helpers:rpc(Config, Node1, rabbit_transform, delete, [message_properties]),
+    ?assertEqual(false, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, exists, [message_properties, message_properties_v2])).
+
+unsuccessful_unsupported_transform(Config) ->
+    [Node1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Queues = get_classic_queues(Config, Node1),
+    Fun = fun(MsgProp) -> ok, MsgProp end,
+    TF = #transform{} = rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, new, [undefined_transform, undefined_transform_v1]),
+    ?assertEqual([{error, {unsupported_transform, {undefined_transform, undefined_transform_v1}}}],
+        rabbit_ct_broker_helpers:rpc(Config, Node1, rabbit_amqqueue, transform, [TF, Fun, Queues])),
+    ?assertEqual(true, ensure_all_queues_alive(Config, Node1, Queues)),
+    ?assertEqual(false, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, exists, [unsupported_transform, unsupported_transform_v1])).
+
+unsuccessful_supported_transform(Config) ->
+    [Node1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_table, delete, [rabbit_transform])),
+
+    Queues = get_classic_queues(Config, Node1),
+    Fun = fun(MsgProp) -> throw({error, unsuccessful_transform}), MsgProp end,
+    TF = #transform{} = rabbit_transform:new(message_properties, message_properties_v2),
+    ?assertEqual([{error, unsuccessful_transform}], rabbit_ct_broker_helpers:rpc(Config,
+        Node1, rabbit_amqqueue, transform, [TF, Fun, Queues])),
+    ?assertEqual(true, ensure_all_queues_alive(Config, Node1, Queues)),
+    ?assertEqual(false, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, exists, [message_properties, message_properties_v2])).
+
+unsuccessful_supported_mirror_transform(Config) ->
+    [Node1 | _] = _Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Queues = get_classic_queues(Config, Node1),
+    Fun = fun(MsgProp) -> throw(mirror_queue_error), MsgProp end,
+    TF = #transform{} = rabbit_transform:new(message_properties, message_properties_v2),
+    Replies = rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_amqqueue, transform, [TF, Fun, Queues]),
+
+    ErrorReplies = lists:flatten([R || R <- Replies, R =:= {error, mirror_queue_error}]),
+    % ?assertEqual(length(Nodes), length(ErrorReplies)),
+    ?assertEqual(1, length(ErrorReplies)),
+    ?assertEqual(true, ensure_all_queues_alive(Config, Node1, Queues)),
+    ?assertEqual(false, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, exists, [message_properties, message_properties_v2])).
+
+validate_transform_safety_checks(Config) ->
+    [Node1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    %% 3 queues with 10 messages each
+    Queues = get_classic_queues(Config, Node1),
+    FirstQName = rabbit_misc:rs(amqqueue:get_name(hd(Queues))),
+
+    ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, check_safety, [Queues])),
+
+    %% verify 'queue_transform_message_threshold'
+    OriginalMsgThreshold =
+        rabbit_ct_broker_helpers:rpc(Config, Node1,
+            application, get_env, [rabbit, queue_transform_memory_threshold]),
+
+    rabbit_ct_broker_helpers:rpc(Config, Node1,
+        application, set_env, [rabbit, queue_transform_message_threshold, 9]),
+
+    ?assertEqual({FirstQName, transform_message_threshold_exceeded},
+                  rabbit_ct_broker_helpers:rpc(Config, Node1,
+                      rabbit_transform, check_safety, [Queues])),
+
+    rabbit_ct_broker_helpers:rpc(Config, Node1,
+       application, set_env, [rabbit, queue_transform_message_threshold,
+       OriginalMsgThreshold]),
+
+    %% verify 'queue_transform_memory_threshold'
+    OriginalMemThreshold =
+        rabbit_ct_broker_helpers:rpc(Config, Node1,
+            application, get_env, [rabbit, queue_transform_memory_threshold]),
+
+    rabbit_ct_broker_helpers:rpc(Config, Node1,
+        application, set_env, [rabbit, queue_transform_memory_threshold, 100]),
+
+    ?assertEqual({FirstQName, transform_memory_threshold_exceeded},
+        rabbit_ct_broker_helpers:rpc(Config, Node1,
+            rabbit_transform, check_safety, [Queues])),
+
+    rabbit_ct_broker_helpers:rpc(Config, Node1,
+        application, set_env, [rabbit, queue_transform_memory_threshold,
+        OriginalMemThreshold]),
+
+    %% verify 'queue_transform_total_message_threshold'
+    OriginalTotalMsgThreshold =
+        rabbit_ct_broker_helpers:rpc(Config, Node1,
+            application, get_env, [rabbit, queue_transform_total_message_threshold]),
+
+    rabbit_ct_broker_helpers:rpc(Config, Node1,
+        application, set_env, [rabbit, queue_transform_total_message_threshold, 25]),
+
+    ?assertEqual(transform_total_message_threshold_exceeded,
+        rabbit_ct_broker_helpers:rpc(Config, Node1,
+                 rabbit_transform, check_safety, [Queues])),
+
+    rabbit_ct_broker_helpers:rpc(Config, Node1,
+        application, set_env, [rabbit, queue_transform_total_message_threshold,
+        OriginalTotalMsgThreshold]),
+
+    ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, Node1,
+        rabbit_transform, check_safety, [Queues])).
+
+%% -----------------------------------------------------------------------------
+setup_queues(Config) ->
+    Ch = rabbit_ct_client_helpers:open_channel(Config, 0),
+    CQ = ?config(queue_name, Config),
+    [begin
+        ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                  declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+        publish(Ch, Q, 10),
+        Q
+     end
+      || Q <- [<< CQ/binary, N/binary >> || N <- [<< "1" >>, <<"2">>, <<"3">>]]],
+    Config.
+
+declare(Ch, Q) ->
+    declare(Ch, Q, []).
+
+declare(Ch, Q, Args) ->
+    amqp_channel:call(Ch, #'queue.declare'{queue     = Q,
+                                           durable   = true,
+                                           auto_delete = false,
+                                           arguments = Args}).
+
+get_classic_queues(Config, Node) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, ?MODULE, get_classic_queues_remote, []).
+
+get_classic_queues_remote() ->
+    mnesia:dirty_match_object(rabbit_queue,
+        amqqueue:pattern_match_on_type(rabbit_classic_queue)).
+
+delete_queues() ->
+   [rabbit_amqqueue:delete(Q, false, false, <<"dummy">>)
+    || Q <- rabbit_amqqueue:list()].
+
+publish(Ch, Queue, N) ->
+    [publish_msg(Ch, Queue, <<"msg">>) || _ <- lists:seq(1, N)].
+
+publish_msg(Ch, Queue, Msg) ->
+    ok = amqp_channel:cast(Ch,
+                           #'basic.publish'{routing_key = Queue},
+                           #amqp_msg{props   = #'P_basic'{delivery_mode = 1},
+                                     payload = Msg}).
+
+ensure_all_queues_alive(Config, Node, Queues) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, ?MODULE, ensure_all_queues_alive_remote, [Queues]).
+
+ensure_all_queues_alive_remote(Queues) ->
+    lists:all(fun(Q) -> erlang:is_process_alive(amqqueue:get_pid(Q)) end, Queues).

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -128,8 +128,6 @@
 
 -record(event, {type, props, reference = undefined, timestamp}).
 
--record(message_properties, {expiry, needs_confirming = false, size}).
-
 -record(plugin, {name,             %% atom()
                  version,          %% string()
                  description,      %% string()
@@ -206,6 +204,14 @@
           status = regular,
           context = #{}
         }).
+
+%% Transformations for changing entities in a node
+-record(transform, {
+            name,
+            versions = [],
+            options
+        }).
+
 %%----------------------------------------------------------------------------
 
 -define(COPYRIGHT_MESSAGE, "Copyright (c) 2007-2020 VMware, Inc. or its affiliates.").
@@ -251,6 +257,9 @@
 %% If user configures a greater rabbit.max_message_size,
 %% this value is used instead.
 -define(MAX_MSG_SIZE, 536870912).
+
+%% Time after which, messages exceeding configured delivery-limit policy expire
+-define(CLASSIC_QUEUE_DELIVERY_LIMIT_TTL, 5000).
 
 -define(store_proc_name(N), rabbit_misc:store_proc_name(?MODULE, N)).
 

--- a/deps/rabbit_common/src/rabbit_control_misc.erl
+++ b/deps/rabbit_common/src/rabbit_control_misc.erl
@@ -7,11 +7,12 @@
 
 -module(rabbit_control_misc).
 
--export([emitting_map/4, emitting_map/5, emitting_map_with_exit_handler/4,
+-export([emit/3, emitting_map/4, emitting_map/5, emitting_map_with_exit_handler/4,
          emitting_map_with_exit_handler/5, wait_for_info_messages/6,
          spawn_emitter_caller/7, await_emitters_termination/1,
          print_cmd_result/2]).
 
+-spec emit(pid(), reference(), function()) -> 'ok'.
 -spec emitting_map(pid(), reference(), fun(), list()) -> 'ok'.
 -spec emitting_map(pid(), reference(), fun(), list(), atom()) -> 'ok'.
 -spec emitting_map_with_exit_handler
@@ -27,6 +28,15 @@
 -spec await_emitters_termination([pid()]) -> 'ok'.
 
 -spec print_cmd_result(atom(), term()) -> 'ok'.
+
+emit(ReplyPid, Ref, Fun) ->
+    Result = try Fun()
+             catch
+                _:{error, _Reason} = Error -> Error;
+                _:Reason -> {error, Reason}
+             end,
+    ReplyPid ! {Ref, Result, finished},
+    ok.
 
 emitting_map(AggregatorPid, Ref, Fun, List) ->
     emitting_map(AggregatorPid, Ref, Fun, List, continue),

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -22,7 +22,8 @@
          protocol_error/3, protocol_error/4, protocol_error/1]).
 -export([type_class/1, assert_args_equivalence/4, assert_field_equivalence/4]).
 -export([dirty_read/1]).
--export([table_lookup/2, set_table_value/4, amqp_table/1, to_amqp_table/1]).
+-export([table_lookup/2, set_table_value/4, amqp_table/1, to_amqp_table/1,
+         table_delete/2]).
 -export([r/3, r/2, r_arg/4, rs/1]).
 -export([enable_cover/0, report_cover/0]).
 -export([enable_cover/1, report_cover/1]).
@@ -137,6 +138,8 @@
           rabbit_types:ok_or_error2(any(), 'not_found').
 -spec table_lookup(rabbit_framing:amqp_table(), binary()) ->
           'undefined' | {rabbit_framing:amqp_field_type(), any()}.
+-spec table_delete(rabbit_framing:amqp_table(), binary()) ->
+          rabbit_framing:amqp_table().
 -spec set_table_value
         (rabbit_framing:amqp_table(), binary(), rabbit_framing:amqp_field_type(),
          rabbit_framing:amqp_value()) ->
@@ -377,6 +380,9 @@ table_lookup(Table, Key) ->
         {value, {_, TypeBin, ValueBin}} -> {TypeBin, ValueBin};
         false                           -> undefined
     end.
+
+table_delete(Table, Key) ->
+    lists:keydelete(Key, 1, Table).
 
 set_table_value(Table, Key, Type, Value) ->
     sort_field_table(

--- a/deps/rabbit_common/src/rabbit_types.erl
+++ b/deps/rabbit_common/src/rabbit_types.erl
@@ -12,7 +12,7 @@
 -export_type([maybe/1, info/0, infos/0, info_key/0, info_keys/0,
               message/0, msg_id/0, basic_message/0,
               delivery/0, content/0, decoded_content/0, undecoded_content/0,
-              unencoded_content/0, encoded_content/0, message_properties/0,
+              unencoded_content/0, encoded_content/0,
               vhost/0, ctag/0, amqp_error/0, r/1, r2/2, r3/3, listener/0,
               binding/0, binding_source/0, binding_destination/0,
               exchange/0,
@@ -24,7 +24,8 @@
               proc_type_and_name/0, timestamp/0, tracked_connection_id/0,
               tracked_connection/0, tracked_channel_id/0, tracked_channel/0,
               node_type/0, topic_access_context/0,
-              authz_data/0, authz_context/0]).
+              authz_data/0, authz_context/0,
+              transform/0, transform_name/0, transform_version/0, transform_options/0]).
 
 -type(maybe(T) :: T | 'none').
 -type(timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}).
@@ -67,9 +68,6 @@
         #delivery{mandatory :: boolean(),
                   sender    :: pid(),
                   message   :: message()}).
--type(message_properties() ::
-        #message_properties{expiry :: pos_integer() | 'undefined',
-                            needs_confirming :: boolean()}).
 
 -type(info_key() :: atom()).
 -type(info_keys() :: [info_key()]).
@@ -194,3 +192,11 @@
                                   _ => _}).
 
 -type(authz_context() :: map()).
+
+-type(transform_name() :: atom()).
+-type(transform_version() :: any()).
+-type(transform_options() :: map()).
+-type(transform() ::
+        #transform{name     :: transform_name(),
+                   versions :: [transform_version()],
+                   options  :: transform_options()}).

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -117,7 +117,8 @@
                   </br>
                   <span class="argument-link" field="definition" key="message-ttl" type="number">Message TTL</span> |
                   <span class="argument-link" field="definition" key="queue-mode" type="string" value="lazy">Lazy mode</span> |
-                  <span class="argument-link" field="definition" key="queue-master-locator" type="string">Master Locator</span></br>
+                  <span class="argument-link" field="definition" key="queue-master-locator" type="string">Master Locator</span> |
+                  <span class="argument-link" field="definition" key="delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span></br>
                 </td>
               </tr>
               <tr>
@@ -271,7 +272,9 @@
                   <span class="argument-link" field="definitionop" key="max-length" type="number">Max length</span> |
                   <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
                   <span class="argument-link" field="definitionop" key="overflow" type="string">Overflow behaviour</span>
-                  <span class="help" id="queue-overflow"></span>
+                  <span class="help" id="queue-overflow"></span></br>
+                  <span class="argument-link" field="definitionop" key="delivery-limit" type="number">Delivery limit</span>
+                  <span class="help" id="delivery-limit"></span>
                 </td>
               </tr>
               <tr>
@@ -287,9 +290,7 @@
                   <span class="argument-link" field="definitionop" key="max-in-memory-length" type="number">Max in memory length</span>
                   <span class="help" id="queue-max-in-memory-length"></span> |
                   <span class="argument-link" field="definitionop" key="max-in-memory-bytes" type="number">Max in memory bytes</span>
-                  <span class="help" id="queue-max-in-memory-bytes"></span> |
-                  <span class="argument-link" field="definitionop" key="delivery-limit" type="string">Delivery limit</span>
-                  <span class="help" id="delivery-limit"></span>
+                  <span class="help" id="queue-max-in-memory-bytes"></span>
                 </td>
               </tr>
             </table>
@@ -302,4 +303,3 @@
   </div>
 </div>
 <% } %>
-

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -320,7 +320,8 @@
                   <span class="argument-link" field="arguments" key="x-overflow" type="string">Overflow behaviour</span> <span class="help" id="queue-overflow"></span> |
                   <span class="argument-link" field="arguments" key="x-single-active-consumer" type="boolean">Single active consumer</span> <span class="help" id="queue-single-active-consumer"></span><br/>
                   <span class="argument-link" field="arguments" key="x-dead-letter-exchange" type="string">Dead letter exchange</span> <span class="help" id="queue-dead-letter-exchange"></span> |
-                  <span class="argument-link" field="arguments" key="x-dead-letter-routing-key" type="string">Dead letter routing key</span> <span class="help" id="queue-dead-letter-routing-key"></span><br/>
+                  <span class="argument-link" field="arguments" key="x-dead-letter-routing-key" type="string">Dead letter routing key</span> <span class="help" id="queue-dead-letter-routing-key"></span> |
+                  <span class="argument-link" field="arguments" key="x-delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span><br/>
                   <span class="argument-link" field="arguments" key="x-max-length" type="number">Max length</span> <span class="help" id="queue-max-length"></span> |
                 <% } %>
                   <span class="argument-link" field="arguments" key="x-max-length-bytes" type="number">Max length bytes</span> <span class="help" id="queue-max-length-bytes"></span><br/>
@@ -330,8 +331,7 @@
                 | <span class="argument-link" field="arguments" key="x-queue-master-locator" type="string" value="">Master locator</span> <span class="help" id="queue-master-locator"></span>
                 <% } %>
                 <% if (queue_type == "quorum") { %>
-                  <span class="argument-link" field="arguments" key="x-delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span>
-                  | <span class="argument-link" field="arguments" key="x-max-in-memory-length" type="number">Max in memory length</span><span class="help" id="queue-max-in-memory-length"></span>
+                  <span class="argument-link" field="arguments" key="x-max-in-memory-length" type="number">Max in memory length</span><span class="help" id="queue-max-in-memory-length"></span>
                   | <span class="argument-link" field="arguments" key="x-max-in-memory-bytes" type="number">Max in memory bytes</span><span class="help" id="queue-max-in-memory-bytes"></span>
                   | <span class="argument-link" field="arguments" key="x-quorum-initial-group-size" type="number">Initial cluster size</span><span class="help" id="queue-quorum-initial-group-size"></span><br/>
                 <% } %>


### PR DESCRIPTION
## Proposed Changes

The following changes are an implementation of message delivery limits
in Classic Queues, mainly for the purpose of handling and processing
poison messages in Classic Queues, as is the case with [Quorum Queues](https://www.rabbitmq.com/quorum-queues.html#poison-message-handling).

These changes allow Message delivery limits in Classic Queues to be
configured as follows:

### 1. Standard Policy

```
rabbitmqctl set_policy my-custom-dl-policy ".*"   '{ "delivery-limit": 10 }' --apply-to queues
```

### 2. Operator Policy

```
rabbitmqctl set_operator_policy my-custom-dl-policy ".*"   '{ "delivery-limit": 10 }' --apply-to queues
```

### 3. Queue Declare Argument

```
args.put( "x-delivery-limit", 10 );
channel.queueDeclare( “my-new-queue”, false, false, false, args );
```

## Notes

- Message delivery limits in Classic Queues are for `default` queue only.
- Queues of mode `lazy` are not (yet) supported.
- A new `classic_delivery_limits` feature flag is introduced.
- On enabling `classic_delivery_limits` feature flag, `message_properties` of each
  message are expanded to include a message delivery counter, i.e. `message_properties_v2`
- Expanding the `message_properties` is carried out both in the transient state
  and persistence layer of each queue.
- In the persistence layer, the queue index (on disk) journal and segment files
  are scanned and each publish record binary payload header is extended to include
  a 4-byte delivery counter field.
- In the transient layer, the internal backing queue working queues for alpha, beta and
  gamma message contents are updated/upgraded to include the new delivery counter field
- Delta message records are updated when the queue index publish records are extended.
- A `rabbit_transform` interface is introduced, for managing and keeping track of changes
  and transition versions of `message_properties` message record. This is also used for
  verifying if the `classic_delivery_limits` feature flag is enabled/active or not.
- The `rabbit_transform` interface creates a `rabbit_transform` Mnesia table for retaining
  transformation identities and versions that have been applied to the broker
- The `rabbit_transform` interface can be used for any other internal entity that undergoes
  a change/transformation - whose name and version needs to be retained in the broker. The
  actual transform function remains private/hard-coded in the system.
- During upgrade, permission to carry-out certain "steps" is queried through a 
  `rabbit_transform:is_permitted/{1,2}` operation, which also check for any active alarms.
- For this purpose, the `rabbit_alarm` manager is extended to retain active alarm activity
  in a local ETS table, configured for `{read_concurrency, true}`.
- When multiple queues are upgraded to use this feature/delivery limits, they concurrently
  verify permission to do so through the `rabbit_alarm` manager, hence need for concurrent
  read(s) optimization.
- Messages exceeding configured delivery limit are dropped/dead-lettered with reason `expired`,
  to maximize performance of delivery limit expiry, with message expiry, retaining O(N) time
  complexity on the expiry run (where N is the queue depth).

## Sponsors

### This work has been carried out by [Erlang Solutions](https://www.erlang-solutions.com/home.html) and sponsored by [Bloomberg](https://www.bloomberg.com/)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
