### PR TITLE
Per object endpoint

### DIFF
--- a/deps/rabbitmq_prometheus/README.md
+++ b/deps/rabbitmq_prometheus/README.md
@@ -67,9 +67,9 @@ In order to not put unnecessary pressure on your metrics system, metrics are agg
 
 When debugging, it may be useful to return metrics per object (unaggregated).
 
-This can be done by scraping the `/metrics/per_object` endpoint:
+This can be done by scraping the `/metrics/per-object` endpoint:
 ```shell
-curl -v -H "Accept:text/plain" "http://localhost:15692/metrics/per_object"
+curl -v -H "Accept:text/plain" "http://localhost:15692/metrics/per-object"
 ```
 
 This can also be enabled as the default behavior of the `/metrics` endpoint on-the-fly,

--- a/deps/rabbitmq_prometheus/README.md
+++ b/deps/rabbitmq_prometheus/README.md
@@ -66,7 +66,14 @@ When metrics are returned per object, nodes with 80k queues have been measured t
 In order to not put unnecessary pressure on your metrics system, metrics are aggregated by default.
 
 When debugging, it may be useful to return metrics per object (unaggregated).
-This can be enabled on-the-fly, without restarting or configuring RabbitMQ, using the following command:
+
+This can be done by scraping the `/metrics/per_object` endpoint:
+```shell
+curl -v -H "Accept:text/plain" "http://localhost:15692/metrics/per_object"
+```
+
+This can also be enabled as the default behavior of the `/metrics` endpoint on-the-fly,
+without restarting or configuring RabbitMQ, using the following command:
 
 ```
 rabbitmqctl eval 'application:set_env(rabbitmq_prometheus, return_per_object_metrics, true).'

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -221,8 +221,13 @@ register() ->
 
 deregister_cleanup(_) -> ok.
 
+collect_mf(per_object, Callback) ->
+    collect(true, Callback);
 collect_mf(_Registry, Callback) ->
-    {ok, PerObjectMetrics} = application:get_env(rabbitmq_prometheus, return_per_object_metrics),
+    PerObjectMetrics = application:get_env(rabbitmq_prometheus, return_per_object_metrics, false),
+    collect(PerObjectMetrics, Callback).
+
+collect(PerObjectMetrics, Callback) ->
     [begin
          Data = get_data(Table, PerObjectMetrics),
          mf(Callback, Contents, Data)

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -221,7 +221,7 @@ register() ->
 
 deregister_cleanup(_) -> ok.
 
-collect_mf(per_object, Callback) ->
+collect_mf('per-object', Callback) ->
     collect(true, Callback);
 collect_mf(_Registry, Callback) ->
     PerObjectMetrics = application:get_env(rabbitmq_prometheus, return_per_object_metrics, false),

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
@@ -27,8 +27,7 @@ build_dispatcher() ->
     cowboy_router:compile([{'_', dispatcher()}]).
 
 dispatcher() ->
-    [{path() ++ "/[:registry]", rabbit_prometheus_handler, []},
-    {path() ++ "/[:per_object]", rabbit_prometheus_handler, []}].
+    [{path() ++ "/[:registry]", rabbit_prometheus_handler, []}].
 
 path() ->
     application:get_env(rabbitmq_prometheus, path, ?DEFAULT_PATH).

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
@@ -14,11 +14,21 @@
 build_dispatcher() ->
     {ok, _} = application:ensure_all_started(prometheus),
     prometheus_registry:register_collectors([prometheus_rabbitmq_core_metrics_collector]),
+    prometheus_registry:register_collectors(per_object, [
+        prometheus_vm_system_info_collector,
+        prometheus_vm_dist_collector,
+        prometheus_vm_memory_collector,
+        prometheus_mnesia_collector,
+        prometheus_vm_statistics_collector,
+        prometheus_vm_msacc_collector,
+        prometheus_rabbitmq_core_metrics_collector
+        ]),
     rabbit_prometheus_handler:setup(),
     cowboy_router:compile([{'_', dispatcher()}]).
 
 dispatcher() ->
-    [{path() ++ "/[:registry]", rabbit_prometheus_handler, []}].
+    [{path() ++ "/[:registry]", rabbit_prometheus_handler, []},
+    {path() ++ "/[:per_object]", rabbit_prometheus_handler, []}].
 
 path() ->
     application:get_env(rabbitmq_prometheus, path, ?DEFAULT_PATH).

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
@@ -14,7 +14,7 @@
 build_dispatcher() ->
     {ok, _} = application:ensure_all_started(prometheus),
     prometheus_registry:register_collectors([prometheus_rabbitmq_core_metrics_collector]),
-    prometheus_registry:register_collectors(per_object, [
+    prometheus_registry:register_collectors('per-object', [
         prometheus_vm_system_info_collector,
         prometheus_vm_dist_collector,
         prometheus_vm_memory_collector,

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
@@ -32,7 +32,7 @@ is_authorized(ReqData, Context) ->
 
 setup() ->
     setup_metrics(telemetry_registry()),
-    setup_metrics(per_object).
+    setup_metrics('per-object').
 
 setup_metrics(Registry) ->
     ScrapeDuration = [{name, ?SCRAPE_DURATION},

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
@@ -108,8 +108,6 @@ format_metrics(Request, Registry) ->
     encode_format(ContentType, binary_to_list(Encoding), Scrape, Registry).
 
 render_format(ContentType, Registry) ->
-    %TelemetryRegistry = telemetry_registry(),
-
     Scrape = prometheus_summary:observe_duration(
                Registry,
                ?SCRAPE_DURATION,

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
@@ -31,20 +31,22 @@ is_authorized(ReqData, Context) ->
     {true, ReqData, Context}.
 
 setup() ->
-    TelemetryRegistry = telemetry_registry(),
+    setup_metrics(telemetry_registry()),
+    setup_metrics(per_object).
 
+setup_metrics(Registry) ->
     ScrapeDuration = [{name, ?SCRAPE_DURATION},
                       {help, "Scrape duration"},
                       {labels, ["registry", "content_type"]},
-                      {registry, TelemetryRegistry}],
+                      {registry, Registry}],
     ScrapeSize = [{name, ?SCRAPE_SIZE},
                   {help, "Scrape size, not encoded"},
                   {labels, ["registry", "content_type"]},
-                  {registry, TelemetryRegistry}],
+                  {registry, Registry}],
     ScrapeEncodedSize = [{name, ?SCRAPE_ENCODED_SIZE},
                          {help, "Scrape size, encoded"},
                          {labels, ["registry", "content_type", "encoding"]},
-                         {registry, TelemetryRegistry}],
+                         {registry, Registry}],
 
     prometheus_summary:declare(ScrapeDuration),
     prometheus_summary:declare(ScrapeSize),
@@ -106,14 +108,14 @@ format_metrics(Request, Registry) ->
     encode_format(ContentType, binary_to_list(Encoding), Scrape, Registry).
 
 render_format(ContentType, Registry) ->
-    TelemetryRegistry = telemetry_registry(),
+    %TelemetryRegistry = telemetry_registry(),
 
     Scrape = prometheus_summary:observe_duration(
-               TelemetryRegistry,
+               Registry,
                ?SCRAPE_DURATION,
                [Registry, ContentType],
                fun () -> prometheus_text_format:format(Registry) end),
-    prometheus_summary:observe(TelemetryRegistry,
+    prometheus_summary:observe(Registry,
                                ?SCRAPE_SIZE,
                                [Registry, ContentType],
                                iolist_size(Scrape)),

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -226,7 +226,7 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^rabbitmq_raft_entry_commit_latency_seconds ", [{capture, none}, multiline])).
 
 endpoint_per_object_metrics(Config) ->
-    per_object_metrics_test(Config, "/metrics/per_object").
+    per_object_metrics_test(Config, "/metrics/per-object").
 
 globally_configure_per_object_metrics_test(Config) ->
     per_object_metrics_test(Config, "/metrics").


### PR DESCRIPTION
## Proposed Changes

This PR creates a `/metrics/per_object` prometheus endpoint which returns unaggregated metrics
without requiring a configuration change. This enables users who wish to collect both aggregated
and unaggregated metrics, perhaps at differing collection rates, to do so.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
