### PR TITLE
Ensure safe call timeouts in AMQP Erlang Client

### DIFF
--- a/deps/amqp_client/Makefile
+++ b/deps/amqp_client/Makefile
@@ -30,7 +30,7 @@ PACKAGES_DIR ?= $(abspath PACKAGES)
 
 LOCAL_DEPS = xmerl
 DEPS = rabbit_common
-TEST_DEPS = rabbitmq_ct_helpers rabbit
+TEST_DEPS = rabbitmq_ct_helpers rabbit meck
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-test.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \

--- a/deps/amqp_client/include/amqp_client_internal.hrl
+++ b/deps/amqp_client/include/amqp_client_internal.hrl
@@ -28,3 +28,6 @@
      {<<"authentication_failure_close">>, bool, true}]).
 
 -define(WAIT_FOR_CONFIRMS_TIMEOUT, {60000, millisecond}).
+
+-define(DIRECT_OPERATION_TIMEOUT,  120000).
+-define(CALL_TIMEOUT_DEVIATION,    10000).

--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -170,6 +170,7 @@ start(AmqpParams, ConnName) when ConnName == undefined; is_binary(ConnName) ->
         end,
     AmqpParams2 = set_connection_name(ConnName, AmqpParams1),
     AmqpParams3 = amqp_ssl:maybe_enhance_ssl_options(AmqpParams2),
+    ok = ensure_safe_call_timeout(AmqpParams3, amqp_util:call_timeout()),
     {ok, _Sup, Connection} = amqp_sup:start_connection_sup(AmqpParams3),
     amqp_gen_connection:connect(Connection).
 
@@ -393,3 +394,30 @@ connection_name(ConnectionPid) ->
         {<<"connection_name">>, _, ConnName} -> ConnName;
         false                                -> undefined
     end.
+
+ensure_safe_call_timeout(#amqp_params_network{connection_timeout = ConnTimeout}, CallTimeout) ->
+    maybe_update_call_timeout(ConnTimeout, CallTimeout);
+ensure_safe_call_timeout(#amqp_params_direct{}, CallTimeout) ->
+    case net_kernel:get_net_ticktime() of
+        NetTicktime when is_integer(NetTicktime) ->
+            maybe_update_call_timeout(tick_or_direct_timeout(NetTicktime * 1000),
+                CallTimeout);
+        {ongoing_change_to, NetTicktime} ->
+            maybe_update_call_timeout(tick_or_direct_timeout(NetTicktime * 1000),
+                CallTimeout);
+        ignore ->
+            maybe_update_call_timeout(?DIRECT_OPERATION_TIMEOUT, CallTimeout)
+    end.
+
+maybe_update_call_timeout(BaseTimeout, CallTimeout)
+  when is_integer(BaseTimeout), CallTimeout > BaseTimeout ->
+    ok;
+maybe_update_call_timeout(BaseTimeout, CallTimeout) ->
+    EffectiveSafeCallTimeout = amqp_util:safe_call_timeout(BaseTimeout),
+    ?LOG_WARN("AMQP client call timeout was ~p millseconds, is updated to a safe effective "
+              "value of ~p millseconds", [CallTimeout, EffectiveSafeCallTimeout]),
+    amqp_util:update_call_timeout(EffectiveSafeCallTimeout),
+    ok.
+
+tick_or_direct_timeout(Timeout) when Timeout >= ?DIRECT_OPERATION_TIMEOUT -> Timeout;
+tick_or_direct_timeout(_Timeout) -> ?DIRECT_OPERATION_TIMEOUT.

--- a/deps/amqp_client/src/amqp_direct_connection.erl
+++ b/deps/amqp_client/src/amqp_direct_connection.erl
@@ -143,7 +143,7 @@ connect(Params = #amqp_params_direct{username     = Username,
     DecryptedPassword = credentials_obfuscation:decrypt(Password),
     case rpc:call(Node, rabbit_direct, connect,
                   [{Username, DecryptedPassword}, VHost, ?PROTOCOL, self(),
-                   connection_info(State1)]) of
+                   connection_info(State1)], ?DIRECT_OPERATION_TIMEOUT) of
         {ok, {User, ServerProperties}} ->
             {ok, ChMgr, Collector} = SIF(i(name, State1)),
             State2 = State1#state{user      = User,
@@ -158,8 +158,8 @@ connect(Params = #amqp_params_direct{username     = Username,
             {ok, {ServerProperties, 0, ChMgr, State2}};
         {error, _} = E ->
             E;
-        {badrpc, nodedown} ->
-            {error, {nodedown, Node}}
+        {badrpc, Reason} ->
+            {error, {Reason, Node}}
     end.
 
 ensure_adapter_info(none) ->

--- a/deps/amqp_client/src/amqp_gen_connection.erl
+++ b/deps/amqp_client/src/amqp_gen_connection.erl
@@ -49,12 +49,14 @@ connect(Pid) ->
     gen_server:call(Pid, connect, amqp_util:call_timeout()).
 
 open_channel(Pid, ProposedNumber, Consumer) ->
-    case gen_server:call(Pid,
+    try gen_server:call(Pid,
                          {command, {open_channel, ProposedNumber, Consumer}},
                          amqp_util:call_timeout()) of
         {ok, ChannelPid} -> ok = amqp_channel:open(ChannelPid),
                             {ok, ChannelPid};
         Error            -> Error
+    catch
+        _:Reason         -> {error, Reason}
     end.
 
 hard_error_in_channel(Pid, ChannelPid, Reason) ->

--- a/deps/amqp_client/src/amqp_util.erl
+++ b/deps/amqp_client/src/amqp_util.erl
@@ -2,7 +2,7 @@
 
 -include("amqp_client_internal.hrl").
 
--export([call_timeout/0]).
+-export([call_timeout/0, update_call_timeout/1, safe_call_timeout/1]).
 
 call_timeout() ->
     case get(gen_server_call_timeout) of
@@ -15,3 +15,11 @@ call_timeout() ->
         Timeout ->
             Timeout
     end.
+
+update_call_timeout(Timeout) ->
+    application:set_env(amqp_client, gen_server_call_timeout, Timeout),
+    put(gen_server_call_timeout, Timeout),
+    ok.
+
+safe_call_timeout(Threshold) ->
+    Threshold + ?CALL_TIMEOUT_DEVIATION.


### PR DESCRIPTION
## Proposed Changes

AMQP Client defines and sets call timeouts on the calling client
application. These currently do not put into consideration the
underlying AMQP connection timeouts set on the protocol layer.
Underlying network operations should always be guaranteed to
timeout first, before call timeouts. If not, we could see a can of
worms with lingering connection establishment operations taking
long, eventually succeeding while client application(s) terminates
on the call timeout - resulting in a unmanaged connection process
leaks under-the-hood. These changes ensure call timeouts are
always safe, both for AMQP **network** connections as well as AMQP
**direct** connections.

See: https://twitter.com/whatyouhide/status/1329182911506092032

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
