### PR TITLE
Windows service: allow overriding base service location

### DIFF
--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -223,6 +223,7 @@ rem user-specific directory.
 -env ERL_LIBS="!ERL_LIBS!" ^
 -env ERL_MAX_ETS_TABLES="!ERL_MAX_ETS_TABLES!" ^
 -env ERL_MAX_PORTS="!ERL_MAX_PORTS!" ^
+-env RABBITMQ_BASE="!RABBITMQ_BASE!" ^
 -workdir "!RABBITMQ_BASE!" ^
 -stopaction "rabbit:stop_and_halt()." ^
 !RABBITMQ_NAME_TYPE! !RABBITMQ_NODENAME! ^


### PR DESCRIPTION
Hi,

Currently RABBITMQ_BASE is always dynamically picked up from the
environment. This change would fix it at the time of configuration
of the service allowing multiple RabbitMQ services to be configured.

## Proposed Changes

I have this unusual requirement to be able to start multiple RabbitMQs for testing on the same Windows node. Seems like the environment is always dynamic, making it impossible to have multiple BASE-s or CONF_ENV_FILE-s.  

Let me know what you think.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [?] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
