### PR TITLE
Pass RABBITMQ_NODENAME via Windows service environment

### DIFF
--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -224,6 +224,7 @@ rem user-specific directory.
 -env ERL_MAX_ETS_TABLES="!ERL_MAX_ETS_TABLES!" ^
 -env ERL_MAX_PORTS="!ERL_MAX_PORTS!" ^
 -env RABBITMQ_BASE="!RABBITMQ_BASE!" ^
+-env RABBITMQ_NODENAME="!RABBITMQ_NODENAME!" ^
 -workdir "!RABBITMQ_BASE!" ^
 -stopaction "rabbit:stop_and_halt()." ^
 !RABBITMQ_NAME_TYPE! !RABBITMQ_NODENAME! ^


### PR DESCRIPTION
Without this change using anything other than `rabbit` or the `rabbitmq-env-conf.bat` file will result in `erlang_dist_running_with_unexpected_nodename`

Follow-up to #2673

cc @dumbbell @michaelklishin