### PR TITLE
Fixup workflow caching

### DIFF
--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -584,23 +584,17 @@ jobs:
       with:
         key: erlang-22.3-rabbitmq-${{ github.sha }}
         path: ci.tar
-    - name: LOAD CI DOCKER IMAGE FROM CACHE
+    - name: LOAD ci DOCKER IMAGE FROM CACHE
       run: |
         docker load --input ci.tar
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
     - name: RUN CHECKS
-      uses: docker/build-push-action@v2
-      with:
-        load: true
-        file: ci/dockerfiles/ci-dep
-        tags: eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-22.3-rabbitmq-${{ github.sha }}
-        build-args: |
-          IMAGE_TAG=erlang-22.3-rabbitmq-${{ github.sha }}
-          BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
-          project=rabbit
+      run: |
+        docker build . \
+          --file ci/dockerfiles/ci-dep \
+          --build-arg IMAGE_TAG=erlang-22.3-rabbitmq-${{ github.sha }} \
+          --build-arg BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }} \
+          --build-arg project=rabbit \
+          --tag eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-22.3-rabbitmq-${{ github.sha }}
     - name: FETCH ci-rabbit DOCKER IMAGE CACHE
       uses: actions/cache@v2
       with:

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -579,17 +579,19 @@ jobs:
         project: rabbit
       run: |
         ci/scripts/validate-workflow.sh amqqueue_backward_compatibility backing_queue channel_interceptor channel_operation_timeout cluster cluster_rename clustering_management config_schema confirms_rejects consumer_timeout crashing_queues dead_lettering definition_import disconnect_detected_during_alarm dynamic_ha dynamic_qq eager_sync feature_flags lazy_queue list_consumers_sanity_check list_queues_online_and_offline maintenance_mode many_node_ha message_size_limit metrics mirrored_supervisor msg_store peer_discovery_classic_config peer_discovery_dns per_user_connection_channel_limit per_user_connection_channel_limit_partitions per_user_connection_channel_tracking per_user_connection_tracking per_vhost_connection_limit per_vhost_connection_limit_partitions per_vhost_msg_store per_vhost_queue_limit policy priority_queue priority_queue_recovery product_info proxy_protocol publisher_confirms_parallel queue_length_limits queue_master_location queue_parallel queue_type quorum_queue rabbit_confirms rabbit_core_metrics_gc rabbit_fifo rabbit_fifo_int rabbit_fifo_prop rabbit_fifo_v0 rabbit_msg_record rabbit_stream_queue rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown signal_handling simple_ha single_active_consumer sync_detection term_to_binary_compat_prop topic_permission unit_access_control unit_access_control_authn_authz_context_propagation unit_access_control_credential_validation unit_amqp091_content_framing unit_amqp091_server_properties unit_app_management unit_cluster_formation_locking_mocks unit_collections unit_config_value_encryption unit_connection_tracking unit_credit_flow unit_disk_monitor unit_disk_monitor_mocks unit_file_handle_cache unit_gen_server2 unit_gm unit_log_config unit_log_management unit_operator_policy unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue unit_queue_consumers unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor upgrade_preparation vhost
+    - uses: actions/cache@v2
+      with:
+        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        path: |
+          ci.tar
+          ci-rabbit.tar
+    - name: LOAD CI DOCKER IMAGE FROM CACHE
+      run: |
+        docker load --input ci.tar
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - uses: actions/cache@v2
-      with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
-        path: ci.tar
-    - name: LOAD CI DOCKER IMAGE FROM CACHE
-      run: |
-        docker load --input ci.tar
     - name: RUN CHECKS
       uses: docker/build-push-action@v2
       with:
@@ -600,10 +602,6 @@ jobs:
           IMAGE_TAG=erlang-22.3-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
-    - uses: actions/cache@v2
-      with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
-        path: ci-rabbit.tar
     - name: SAVE CI DOCKER IMAGE IN CACHE
       run: |
         docker save --output ci-rabbit.tar eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-22.3-rabbitmq-${{ github.sha }}

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -583,19 +583,13 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
+    - uses: actions/cache@v2
       with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Login to GCR
-      uses: docker/login-action@v1
-      with:
-        registry: eu.gcr.io
-        username: _json_key
-        password: ${{ secrets.GCR_JSON_KEY }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        path: ci.tar
+    - name: LOAD CI DOCKER IMAGE FROM CACHE
+      run: |
+        docker load --input ci.tar
     - name: RUN CHECKS
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -600,8 +600,6 @@ jobs:
           IMAGE_TAG=erlang-22.3-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
     - uses: actions/cache@v2
       with:
         key: erlang-22.3-rabbitmq-${{ github.sha }}

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -579,12 +579,11 @@ jobs:
         project: rabbit
       run: |
         ci/scripts/validate-workflow.sh amqqueue_backward_compatibility backing_queue channel_interceptor channel_operation_timeout cluster cluster_rename clustering_management config_schema confirms_rejects consumer_timeout crashing_queues dead_lettering definition_import disconnect_detected_during_alarm dynamic_ha dynamic_qq eager_sync feature_flags lazy_queue list_consumers_sanity_check list_queues_online_and_offline maintenance_mode many_node_ha message_size_limit metrics mirrored_supervisor msg_store peer_discovery_classic_config peer_discovery_dns per_user_connection_channel_limit per_user_connection_channel_limit_partitions per_user_connection_channel_tracking per_user_connection_tracking per_vhost_connection_limit per_vhost_connection_limit_partitions per_vhost_msg_store per_vhost_queue_limit policy priority_queue priority_queue_recovery product_info proxy_protocol publisher_confirms_parallel queue_length_limits queue_master_location queue_parallel queue_type quorum_queue rabbit_confirms rabbit_core_metrics_gc rabbit_fifo rabbit_fifo_int rabbit_fifo_prop rabbit_fifo_v0 rabbit_msg_record rabbit_stream_queue rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown signal_handling simple_ha single_active_consumer sync_detection term_to_binary_compat_prop topic_permission unit_access_control unit_access_control_authn_authz_context_propagation unit_access_control_credential_validation unit_amqp091_content_framing unit_amqp091_server_properties unit_app_management unit_cluster_formation_locking_mocks unit_collections unit_config_value_encryption unit_connection_tracking unit_credit_flow unit_disk_monitor unit_disk_monitor_mocks unit_file_handle_cache unit_gen_server2 unit_gm unit_log_config unit_log_management unit_operator_policy unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue unit_queue_consumers unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor upgrade_preparation vhost
-    - uses: actions/cache@v2
+    - name: FETCH ci DOCKER IMAGE CACHE
+      uses: actions/cache@v2
       with:
         key: erlang-22.3-rabbitmq-${{ github.sha }}
-        path: |
-          ci.tar
-          ci-rabbit.tar
+        path: ci.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
         docker load --input ci.tar
@@ -602,6 +601,11 @@ jobs:
           IMAGE_TAG=erlang-22.3-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
+    - name: FETCH ci-rabbit DOCKER IMAGE CACHE
+      uses: actions/cache@v2
+      with:
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
+        path: ci-rabbit.tar
     - name: SAVE CI DOCKER IMAGE IN CACHE
       run: |
         docker save --output ci-rabbit.tar eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-22.3-rabbitmq-${{ github.sha }}
@@ -615,7 +619,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -686,7 +690,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -757,7 +761,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -828,7 +832,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -899,7 +903,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -970,7 +974,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1041,7 +1045,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1112,7 +1116,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1183,7 +1187,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1254,7 +1258,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1325,7 +1329,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1396,7 +1400,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1467,7 +1471,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1538,7 +1542,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1609,7 +1613,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1680,7 +1684,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1751,7 +1755,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1822,7 +1826,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1893,7 +1897,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1964,7 +1968,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2035,7 +2039,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2106,7 +2110,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2177,7 +2181,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2248,7 +2252,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2319,7 +2323,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2390,7 +2394,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2461,7 +2465,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2532,7 +2536,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2603,7 +2607,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2674,7 +2678,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2745,7 +2749,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2816,7 +2820,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2887,7 +2891,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2958,7 +2962,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3029,7 +3033,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3100,7 +3104,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3171,7 +3175,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3242,7 +3246,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3313,7 +3317,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3384,7 +3388,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3455,7 +3459,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3526,7 +3530,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3597,7 +3601,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3668,7 +3672,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3739,7 +3743,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3810,7 +3814,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3881,7 +3885,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3952,7 +3956,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4023,7 +4027,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4094,7 +4098,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4165,7 +4169,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4236,7 +4240,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4307,7 +4311,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4378,7 +4382,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4449,7 +4453,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4520,7 +4524,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4591,7 +4595,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4662,7 +4666,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4733,7 +4737,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4804,7 +4808,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4875,7 +4879,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4946,7 +4950,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5017,7 +5021,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5088,7 +5092,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5159,7 +5163,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5230,7 +5234,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5301,7 +5305,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5372,7 +5376,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5443,7 +5447,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5514,7 +5518,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5585,7 +5589,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5656,7 +5660,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5727,7 +5731,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5798,7 +5802,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5869,7 +5873,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -5940,7 +5944,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6011,7 +6015,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6082,7 +6086,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6153,7 +6157,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6224,7 +6228,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6295,7 +6299,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6366,7 +6370,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6437,7 +6441,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6508,7 +6512,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6579,7 +6583,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6650,7 +6654,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6721,7 +6725,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6792,7 +6796,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6863,7 +6867,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -6934,7 +6938,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -7005,7 +7009,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -7076,7 +7080,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -7147,7 +7151,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -7218,7 +7222,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -7289,7 +7293,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -7454,7 +7458,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-22.3-rabbitmq-${{ github.sha }}
+        key: erlang-22.3-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |

--- a/.github/workflows/test-erlang-otp-23.1.yaml
+++ b/.github/workflows/test-erlang-otp-23.1.yaml
@@ -751,17 +751,19 @@ jobs:
         project: rabbit
       run: |
         ci/scripts/validate-workflow.sh amqqueue_backward_compatibility backing_queue channel_interceptor channel_operation_timeout cluster cluster_rename clustering_management config_schema confirms_rejects consumer_timeout crashing_queues dead_lettering definition_import disconnect_detected_during_alarm dynamic_ha dynamic_qq eager_sync feature_flags lazy_queue list_consumers_sanity_check list_queues_online_and_offline maintenance_mode many_node_ha message_size_limit metrics mirrored_supervisor msg_store peer_discovery_classic_config peer_discovery_dns per_user_connection_channel_limit per_user_connection_channel_limit_partitions per_user_connection_channel_tracking per_user_connection_tracking per_vhost_connection_limit per_vhost_connection_limit_partitions per_vhost_msg_store per_vhost_queue_limit policy priority_queue priority_queue_recovery product_info proxy_protocol publisher_confirms_parallel queue_length_limits queue_master_location queue_parallel queue_type quorum_queue rabbit_confirms rabbit_core_metrics_gc rabbit_fifo rabbit_fifo_int rabbit_fifo_prop rabbit_fifo_v0 rabbit_msg_record rabbit_stream_queue rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown signal_handling simple_ha single_active_consumer sync_detection term_to_binary_compat_prop topic_permission unit_access_control unit_access_control_authn_authz_context_propagation unit_access_control_credential_validation unit_amqp091_content_framing unit_amqp091_server_properties unit_app_management unit_cluster_formation_locking_mocks unit_collections unit_config_value_encryption unit_connection_tracking unit_credit_flow unit_disk_monitor unit_disk_monitor_mocks unit_file_handle_cache unit_gen_server2 unit_gm unit_log_config unit_log_management unit_operator_policy unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue unit_queue_consumers unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor upgrade_preparation vhost
+    - uses: actions/cache@v2
+      with:
+        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        path: |
+          ci.tar
+          ci-rabbit.tar
+    - name: LOAD CI DOCKER IMAGE FROM CACHE
+      run: |
+        docker load --input ci.tar
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - uses: actions/cache@v2
-      with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
-        path: ci.tar
-    - name: LOAD CI DOCKER IMAGE FROM CACHE
-      run: |
-        docker load --input ci.tar
     - name: RUN CHECKS
       uses: docker/build-push-action@v2
       with:
@@ -772,10 +774,6 @@ jobs:
           IMAGE_TAG=erlang-23.1-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
-    - uses: actions/cache@v2
-      with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
-        path: ci-rabbit.tar
     - name: SAVE CI DOCKER IMAGE IN CACHE
       run: |
         docker save --output ci-rabbit.tar eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-23.1-rabbitmq-${{ github.sha }}

--- a/.github/workflows/test-erlang-otp-23.1.yaml
+++ b/.github/workflows/test-erlang-otp-23.1.yaml
@@ -755,19 +755,13 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
+    - uses: actions/cache@v2
       with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Login to GCR
-      uses: docker/login-action@v1
-      with:
-        registry: eu.gcr.io
-        username: _json_key
-        password: ${{ secrets.GCR_JSON_KEY }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        path: ci.tar
+    - name: LOAD CI DOCKER IMAGE FROM CACHE
+      run: |
+        docker load --input ci.tar
     - name: RUN CHECKS
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/test-erlang-otp-23.1.yaml
+++ b/.github/workflows/test-erlang-otp-23.1.yaml
@@ -751,12 +751,11 @@ jobs:
         project: rabbit
       run: |
         ci/scripts/validate-workflow.sh amqqueue_backward_compatibility backing_queue channel_interceptor channel_operation_timeout cluster cluster_rename clustering_management config_schema confirms_rejects consumer_timeout crashing_queues dead_lettering definition_import disconnect_detected_during_alarm dynamic_ha dynamic_qq eager_sync feature_flags lazy_queue list_consumers_sanity_check list_queues_online_and_offline maintenance_mode many_node_ha message_size_limit metrics mirrored_supervisor msg_store peer_discovery_classic_config peer_discovery_dns per_user_connection_channel_limit per_user_connection_channel_limit_partitions per_user_connection_channel_tracking per_user_connection_tracking per_vhost_connection_limit per_vhost_connection_limit_partitions per_vhost_msg_store per_vhost_queue_limit policy priority_queue priority_queue_recovery product_info proxy_protocol publisher_confirms_parallel queue_length_limits queue_master_location queue_parallel queue_type quorum_queue rabbit_confirms rabbit_core_metrics_gc rabbit_fifo rabbit_fifo_int rabbit_fifo_prop rabbit_fifo_v0 rabbit_msg_record rabbit_stream_queue rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown signal_handling simple_ha single_active_consumer sync_detection term_to_binary_compat_prop topic_permission unit_access_control unit_access_control_authn_authz_context_propagation unit_access_control_credential_validation unit_amqp091_content_framing unit_amqp091_server_properties unit_app_management unit_cluster_formation_locking_mocks unit_collections unit_config_value_encryption unit_connection_tracking unit_credit_flow unit_disk_monitor unit_disk_monitor_mocks unit_file_handle_cache unit_gen_server2 unit_gm unit_log_config unit_log_management unit_operator_policy unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue unit_queue_consumers unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor upgrade_preparation vhost
-    - uses: actions/cache@v2
+    - name: FETCH ci DOCKER IMAGE CACHE
+      uses: actions/cache@v2
       with:
         key: erlang-23.1-rabbitmq-${{ github.sha }}
-        path: |
-          ci.tar
-          ci-rabbit.tar
+        path: ci.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
         docker load --input ci.tar
@@ -774,6 +773,11 @@ jobs:
           IMAGE_TAG=erlang-23.1-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
+    - name: FETCH ci-rabbit DOCKER IMAGE CACHE
+      uses: actions/cache@v2
+      with:
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
+        path: ci-rabbit.tar
     - name: SAVE CI DOCKER IMAGE IN CACHE
       run: |
         docker save --output ci-rabbit.tar eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-23.1-rabbitmq-${{ github.sha }}
@@ -787,7 +791,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -820,7 +824,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -853,7 +857,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -886,7 +890,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -919,7 +923,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -952,7 +956,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -985,7 +989,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1018,7 +1022,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1051,7 +1055,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1084,7 +1088,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1117,7 +1121,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1150,7 +1154,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1183,7 +1187,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1216,7 +1220,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1249,7 +1253,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1282,7 +1286,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1315,7 +1319,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1348,7 +1352,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1381,7 +1385,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1414,7 +1418,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1447,7 +1451,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1480,7 +1484,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1513,7 +1517,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1546,7 +1550,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1579,7 +1583,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1612,7 +1616,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1645,7 +1649,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1678,7 +1682,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1711,7 +1715,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1744,7 +1748,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1777,7 +1781,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1810,7 +1814,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1843,7 +1847,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1876,7 +1880,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1909,7 +1913,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1942,7 +1946,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1975,7 +1979,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2008,7 +2012,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2041,7 +2045,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2074,7 +2078,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2107,7 +2111,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2140,7 +2144,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2173,7 +2177,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2206,7 +2210,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2239,7 +2243,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2272,7 +2276,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2305,7 +2309,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2338,7 +2342,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2371,7 +2375,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2404,7 +2408,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2437,7 +2441,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2470,7 +2474,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2503,7 +2507,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2536,7 +2540,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2569,7 +2573,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2602,7 +2606,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2635,7 +2639,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2668,7 +2672,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2701,7 +2705,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2734,7 +2738,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2767,7 +2771,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2800,7 +2804,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2833,7 +2837,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2866,7 +2870,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2899,7 +2903,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2932,7 +2936,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2965,7 +2969,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2998,7 +3002,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3031,7 +3035,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3064,7 +3068,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3097,7 +3101,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3130,7 +3134,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3163,7 +3167,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3196,7 +3200,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3229,7 +3233,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3262,7 +3266,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3295,7 +3299,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3328,7 +3332,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3361,7 +3365,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3394,7 +3398,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3427,7 +3431,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3460,7 +3464,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3493,7 +3497,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3526,7 +3530,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3559,7 +3563,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3592,7 +3596,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3625,7 +3629,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3658,7 +3662,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3691,7 +3695,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3724,7 +3728,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3757,7 +3761,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3790,7 +3794,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3823,7 +3827,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3856,7 +3860,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3889,7 +3893,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -4016,7 +4020,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-23.1-rabbitmq-${{ github.sha }}
+        key: erlang-23.1-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |

--- a/.github/workflows/test-erlang-otp-23.1.yaml
+++ b/.github/workflows/test-erlang-otp-23.1.yaml
@@ -756,23 +756,17 @@ jobs:
       with:
         key: erlang-23.1-rabbitmq-${{ github.sha }}
         path: ci.tar
-    - name: LOAD CI DOCKER IMAGE FROM CACHE
+    - name: LOAD ci DOCKER IMAGE FROM CACHE
       run: |
         docker load --input ci.tar
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
     - name: RUN CHECKS
-      uses: docker/build-push-action@v2
-      with:
-        load: true
-        file: ci/dockerfiles/ci-dep
-        tags: eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-23.1-rabbitmq-${{ github.sha }}
-        build-args: |
-          IMAGE_TAG=erlang-23.1-rabbitmq-${{ github.sha }}
-          BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
-          project=rabbit
+      run: |
+        docker build . \
+          --file ci/dockerfiles/ci-dep \
+          --build-arg IMAGE_TAG=erlang-23.1-rabbitmq-${{ github.sha }} \
+          --build-arg BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }} \
+          --build-arg project=rabbit \
+          --tag eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-23.1-rabbitmq-${{ github.sha }}
     - name: FETCH ci-rabbit DOCKER IMAGE CACHE
       uses: actions/cache@v2
       with:

--- a/.github/workflows/test-erlang-otp-23.1.yaml
+++ b/.github/workflows/test-erlang-otp-23.1.yaml
@@ -772,8 +772,6 @@ jobs:
           IMAGE_TAG=erlang-23.1-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
     - uses: actions/cache@v2
       with:
         key: erlang-23.1-rabbitmq-${{ github.sha }}

--- a/.github/workflows/test-erlang-otp-git.yaml
+++ b/.github/workflows/test-erlang-otp-git.yaml
@@ -624,23 +624,17 @@ jobs:
       with:
         key: erlang-git-rabbitmq-${{ github.sha }}
         path: ci.tar
-    - name: LOAD CI DOCKER IMAGE FROM CACHE
+    - name: LOAD ci DOCKER IMAGE FROM CACHE
       run: |
         docker load --input ci.tar
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
     - name: RUN CHECKS
-      uses: docker/build-push-action@v2
-      with:
-        load: true
-        file: ci/dockerfiles/ci-dep
-        tags: eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-git-rabbitmq-${{ github.sha }}
-        build-args: |
-          IMAGE_TAG=erlang-git-rabbitmq-${{ github.sha }}
-          BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
-          project=rabbit
+      run: |
+        docker build . \
+          --file ci/dockerfiles/ci-dep \
+          --build-arg IMAGE_TAG=erlang-git-rabbitmq-${{ github.sha }} \
+          --build-arg BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }} \
+          --build-arg project=rabbit \
+          --tag eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-git-rabbitmq-${{ github.sha }}
     - name: FETCH ci-rabbit DOCKER IMAGE CACHE
       uses: actions/cache@v2
       with:

--- a/.github/workflows/test-erlang-otp-git.yaml
+++ b/.github/workflows/test-erlang-otp-git.yaml
@@ -640,8 +640,6 @@ jobs:
           IMAGE_TAG=erlang-git-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
     - uses: actions/cache@v2
       with:
         key: erlang-git-rabbitmq-${{ github.sha }}

--- a/.github/workflows/test-erlang-otp-git.yaml
+++ b/.github/workflows/test-erlang-otp-git.yaml
@@ -619,17 +619,19 @@ jobs:
         project: rabbit
       run: |
         ci/scripts/validate-workflow.sh amqqueue_backward_compatibility backing_queue channel_interceptor channel_operation_timeout cluster cluster_rename clustering_management config_schema confirms_rejects consumer_timeout crashing_queues dead_lettering definition_import disconnect_detected_during_alarm dynamic_ha dynamic_qq eager_sync feature_flags lazy_queue list_consumers_sanity_check list_queues_online_and_offline maintenance_mode many_node_ha message_size_limit metrics mirrored_supervisor msg_store peer_discovery_classic_config peer_discovery_dns per_user_connection_channel_limit per_user_connection_channel_limit_partitions per_user_connection_channel_tracking per_user_connection_tracking per_vhost_connection_limit per_vhost_connection_limit_partitions per_vhost_msg_store per_vhost_queue_limit policy priority_queue priority_queue_recovery product_info proxy_protocol publisher_confirms_parallel queue_length_limits queue_master_location queue_parallel queue_type quorum_queue rabbit_confirms rabbit_core_metrics_gc rabbit_fifo rabbit_fifo_int rabbit_fifo_prop rabbit_fifo_v0 rabbit_msg_record rabbit_stream_queue rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown signal_handling simple_ha single_active_consumer sync_detection term_to_binary_compat_prop topic_permission unit_access_control unit_access_control_authn_authz_context_propagation unit_access_control_credential_validation unit_amqp091_content_framing unit_amqp091_server_properties unit_app_management unit_cluster_formation_locking_mocks unit_collections unit_config_value_encryption unit_connection_tracking unit_credit_flow unit_disk_monitor unit_disk_monitor_mocks unit_file_handle_cache unit_gen_server2 unit_gm unit_log_config unit_log_management unit_operator_policy unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue unit_queue_consumers unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor upgrade_preparation vhost
+    - uses: actions/cache@v2
+      with:
+        key: erlang-git-rabbitmq-${{ github.sha }}
+        path: |
+          ci.tar
+          ci-rabbit.tar
+    - name: LOAD CI DOCKER IMAGE FROM CACHE
+      run: |
+        docker load --input ci.tar
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - uses: actions/cache@v2
-      with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
-        path: ci.tar
-    - name: LOAD CI DOCKER IMAGE FROM CACHE
-      run: |
-        docker load --input ci.tar
     - name: RUN CHECKS
       uses: docker/build-push-action@v2
       with:
@@ -640,10 +642,6 @@ jobs:
           IMAGE_TAG=erlang-git-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
-    - uses: actions/cache@v2
-      with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
-        path: ci-rabbit.tar
     - name: SAVE CI DOCKER IMAGE IN CACHE
       run: |
         docker save --output ci-rabbit.tar eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-git-rabbitmq-${{ github.sha }}

--- a/.github/workflows/test-erlang-otp-git.yaml
+++ b/.github/workflows/test-erlang-otp-git.yaml
@@ -619,12 +619,11 @@ jobs:
         project: rabbit
       run: |
         ci/scripts/validate-workflow.sh amqqueue_backward_compatibility backing_queue channel_interceptor channel_operation_timeout cluster cluster_rename clustering_management config_schema confirms_rejects consumer_timeout crashing_queues dead_lettering definition_import disconnect_detected_during_alarm dynamic_ha dynamic_qq eager_sync feature_flags lazy_queue list_consumers_sanity_check list_queues_online_and_offline maintenance_mode many_node_ha message_size_limit metrics mirrored_supervisor msg_store peer_discovery_classic_config peer_discovery_dns per_user_connection_channel_limit per_user_connection_channel_limit_partitions per_user_connection_channel_tracking per_user_connection_tracking per_vhost_connection_limit per_vhost_connection_limit_partitions per_vhost_msg_store per_vhost_queue_limit policy priority_queue priority_queue_recovery product_info proxy_protocol publisher_confirms_parallel queue_length_limits queue_master_location queue_parallel queue_type quorum_queue rabbit_confirms rabbit_core_metrics_gc rabbit_fifo rabbit_fifo_int rabbit_fifo_prop rabbit_fifo_v0 rabbit_msg_record rabbit_stream_queue rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown signal_handling simple_ha single_active_consumer sync_detection term_to_binary_compat_prop topic_permission unit_access_control unit_access_control_authn_authz_context_propagation unit_access_control_credential_validation unit_amqp091_content_framing unit_amqp091_server_properties unit_app_management unit_cluster_formation_locking_mocks unit_collections unit_config_value_encryption unit_connection_tracking unit_credit_flow unit_disk_monitor unit_disk_monitor_mocks unit_file_handle_cache unit_gen_server2 unit_gm unit_log_config unit_log_management unit_operator_policy unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue unit_queue_consumers unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor upgrade_preparation vhost
-    - uses: actions/cache@v2
+    - name: FETCH ci DOCKER IMAGE CACHE
+      uses: actions/cache@v2
       with:
         key: erlang-git-rabbitmq-${{ github.sha }}
-        path: |
-          ci.tar
-          ci-rabbit.tar
+        path: ci.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
         docker load --input ci.tar
@@ -642,6 +641,11 @@ jobs:
           IMAGE_TAG=erlang-git-rabbitmq-${{ github.sha }}
           BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
           project=rabbit
+    - name: FETCH ci-rabbit DOCKER IMAGE CACHE
+      uses: actions/cache@v2
+      with:
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
+        path: ci-rabbit.tar
     - name: SAVE CI DOCKER IMAGE IN CACHE
       run: |
         docker save --output ci-rabbit.tar eu.gcr.io/cf-rabbitmq-core/ci-rabbit:erlang-git-rabbitmq-${{ github.sha }}
@@ -655,7 +659,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -688,7 +692,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -721,7 +725,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -754,7 +758,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -787,7 +791,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -820,7 +824,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -853,7 +857,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -886,7 +890,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -919,7 +923,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -952,7 +956,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -985,7 +989,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1018,7 +1022,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1051,7 +1055,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1084,7 +1088,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1117,7 +1121,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1150,7 +1154,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1183,7 +1187,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1216,7 +1220,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1249,7 +1253,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1282,7 +1286,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1315,7 +1319,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1348,7 +1352,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1381,7 +1385,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1414,7 +1418,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1447,7 +1451,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1480,7 +1484,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1513,7 +1517,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1546,7 +1550,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1579,7 +1583,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1612,7 +1616,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1645,7 +1649,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1678,7 +1682,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1711,7 +1715,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1744,7 +1748,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1777,7 +1781,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1810,7 +1814,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1843,7 +1847,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1876,7 +1880,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1909,7 +1913,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1942,7 +1946,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -1975,7 +1979,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2008,7 +2012,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2041,7 +2045,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2074,7 +2078,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2107,7 +2111,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2140,7 +2144,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2173,7 +2177,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2206,7 +2210,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2239,7 +2243,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2272,7 +2276,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2305,7 +2309,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2338,7 +2342,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2371,7 +2375,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2404,7 +2408,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2437,7 +2441,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2470,7 +2474,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2503,7 +2507,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2536,7 +2540,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2569,7 +2573,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2602,7 +2606,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2635,7 +2639,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2668,7 +2672,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2701,7 +2705,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2734,7 +2738,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2767,7 +2771,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2800,7 +2804,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2833,7 +2837,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2866,7 +2870,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2899,7 +2903,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2932,7 +2936,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2965,7 +2969,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -2998,7 +3002,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3031,7 +3035,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3064,7 +3068,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3097,7 +3101,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3130,7 +3134,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3163,7 +3167,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3196,7 +3200,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3229,7 +3233,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3262,7 +3266,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3295,7 +3299,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3328,7 +3332,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3361,7 +3365,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3394,7 +3398,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3427,7 +3431,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3460,7 +3464,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3493,7 +3497,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3526,7 +3530,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3559,7 +3563,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3592,7 +3596,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3625,7 +3629,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3658,7 +3662,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3691,7 +3695,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3724,7 +3728,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3757,7 +3761,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |
@@ -3884,7 +3888,7 @@ jobs:
     steps:
     - uses: actions/cache@v2
       with:
-        key: erlang-git-rabbitmq-${{ github.sha }}
+        key: erlang-git-rabbitmq-${{ github.sha }}+rabbit
         path: ci-rabbit.tar
     - name: LOAD CI DOCKER IMAGE FROM CACHE
       run: |

--- a/.github/workflows/test-erlang-otp-git.yaml
+++ b/.github/workflows/test-erlang-otp-git.yaml
@@ -623,19 +623,13 @@ jobs:
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Cache Docker layers
-      uses: actions/cache@v2
+    - uses: actions/cache@v2
       with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Login to GCR
-      uses: docker/login-action@v1
-      with:
-        registry: eu.gcr.io
-        username: _json_key
-        password: ${{ secrets.GCR_JSON_KEY }}
+        key: erlang-git-rabbitmq-${{ github.sha }}
+        path: ci.tar
+    - name: LOAD CI DOCKER IMAGE FROM CACHE
+      run: |
+        docker load --input ci.tar
     - name: RUN CHECKS
       uses: docker/build-push-action@v2
       with:

--- a/workflow_sources/test/ct.lib.yml
+++ b/workflow_sources/test/ct.lib.yml
@@ -25,12 +25,11 @@ steps:
     #@ None if is_unique(suite_names) else assert.fail('{} suite names are not unique'.format(dep.name))
     run: |
       ci/scripts/validate-workflow.sh (@= " ".join(suite_names) @)
-  - uses: actions/cache@v2
+  - name: FETCH ci DOCKER IMAGE CACHE
+    uses: actions/cache@v2
     with:
       key: #@ ci_image_tag(erlang_version)
-      path: |
-        ci.tar
-        ci-(@= dep.name @).tar
+      path: ci.tar
   - name: LOAD CI DOCKER IMAGE FROM CACHE
     run: |
       docker load --input ci.tar
@@ -48,6 +47,11 @@ steps:
         IMAGE_TAG=(@= ci_image_tag(erlang_version) @)
         BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
         project=(@= dep.name @)
+  - name: FETCH ci-(@= dep.name @) DOCKER IMAGE CACHE
+    uses: actions/cache@v2
+    with:
+      key: #@ ci_image_tag(erlang_version) + "+" + dep.name
+      path: ci-(@= dep.name @).tar
   - name: SAVE CI DOCKER IMAGE IN CACHE
     run: |
       docker save --output ci-(@= dep.name @).tar (@= ci_dep_image(erlang_version, dep.name) @)
@@ -64,7 +68,7 @@ if: #@ skip_ci_condition()
 steps:
   - uses: actions/cache@v2
     with:
-      key: #@ ci_image_tag(erlang_version)
+      key: #@ ci_image_tag(erlang_version) + "+" + dep.name
       path: ci-(@= dep.name @).tar
   - name: LOAD CI DOCKER IMAGE FROM CACHE
     run: |
@@ -129,7 +133,7 @@ if: #@ skip_ci_condition() + " && (success() || failure())"
 steps:
   - uses: actions/cache@v2
     with:
-      key: #@ ci_image_tag(erlang_version)
+      key: #@ ci_image_tag(erlang_version) + "+" + dep.name
       path: ci-(@= dep.name @).tar
   - name: LOAD CI DOCKER IMAGE FROM CACHE
     run: |

--- a/workflow_sources/test/ct.lib.yml
+++ b/workflow_sources/test/ct.lib.yml
@@ -30,23 +30,17 @@ steps:
     with:
       key: #@ ci_image_tag(erlang_version)
       path: ci.tar
-  - name: LOAD CI DOCKER IMAGE FROM CACHE
+  - name: LOAD ci DOCKER IMAGE FROM CACHE
     run: |
       docker load --input ci.tar
-  - name: Set up QEMU
-    uses: docker/setup-qemu-action@v1
-  - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v1
   - name: RUN CHECKS
-    uses: docker/build-push-action@v2
-    with:
-      load: true
-      file: ci/dockerfiles/ci-dep
-      tags: #@ 'eu.gcr.io/cf-rabbitmq-core/ci-{}:{}'.format(dep.name, ci_image_tag(erlang_version))
-      build-args: |
-        IMAGE_TAG=(@= ci_image_tag(erlang_version) @)
-        BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
-        project=(@= dep.name @)
+    run: |
+      docker build . \
+        --file ci/dockerfiles/ci-dep \
+        --build-arg IMAGE_TAG=(@= ci_image_tag(erlang_version) @) \
+        --build-arg BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }} \
+        --build-arg project=(@= dep.name @) \
+        --tag eu.gcr.io/cf-rabbitmq-core/ci-(@= dep.name @):(@= ci_image_tag(erlang_version) @)
   - name: FETCH ci-(@= dep.name @) DOCKER IMAGE CACHE
     uses: actions/cache@v2
     with:

--- a/workflow_sources/test/ct.lib.yml
+++ b/workflow_sources/test/ct.lib.yml
@@ -29,19 +29,13 @@ steps:
     uses: docker/setup-qemu-action@v1
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@v1
-  - name: Cache Docker layers
-    uses: actions/cache@v2
+  - uses: actions/cache@v2
     with:
-      path: /tmp/.buildx-cache
-      key: ${{ runner.os }}-buildx-${{ github.sha }}
-      restore-keys: |
-        ${{ runner.os }}-buildx-
-  - name: Login to GCR
-    uses: docker/login-action@v1 
-    with:
-      registry: eu.gcr.io
-      username: _json_key
-      password: ${{ secrets.GCR_JSON_KEY }}
+      key: #@ ci_image_tag(erlang_version)
+      path: ci.tar
+  - name: LOAD CI DOCKER IMAGE FROM CACHE
+    run: |
+      docker load --input ci.tar
   - name: RUN CHECKS
     uses: docker/build-push-action@v2
     with:

--- a/workflow_sources/test/ct.lib.yml
+++ b/workflow_sources/test/ct.lib.yml
@@ -46,8 +46,6 @@ steps:
         IMAGE_TAG=(@= ci_image_tag(erlang_version) @)
         BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
         project=(@= dep.name @)
-      cache-from: type=local,src=/tmp/.buildx-cache
-      cache-to: type=local,dest=/tmp/.buildx-cache
   - uses: actions/cache@v2
     with:
       key: #@ ci_image_tag(erlang_version)

--- a/workflow_sources/test/ct.lib.yml
+++ b/workflow_sources/test/ct.lib.yml
@@ -25,17 +25,19 @@ steps:
     #@ None if is_unique(suite_names) else assert.fail('{} suite names are not unique'.format(dep.name))
     run: |
       ci/scripts/validate-workflow.sh (@= " ".join(suite_names) @)
+  - uses: actions/cache@v2
+    with:
+      key: #@ ci_image_tag(erlang_version)
+      path: |
+        ci.tar
+        ci-(@= dep.name @).tar
+  - name: LOAD CI DOCKER IMAGE FROM CACHE
+    run: |
+      docker load --input ci.tar
   - name: Set up QEMU
     uses: docker/setup-qemu-action@v1
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@v1
-  - uses: actions/cache@v2
-    with:
-      key: #@ ci_image_tag(erlang_version)
-      path: ci.tar
-  - name: LOAD CI DOCKER IMAGE FROM CACHE
-    run: |
-      docker load --input ci.tar
   - name: RUN CHECKS
     uses: docker/build-push-action@v2
     with:
@@ -46,10 +48,6 @@ steps:
         IMAGE_TAG=(@= ci_image_tag(erlang_version) @)
         BUILDEVENT_APIKEY=${{ secrets.HONEYCOMB_API_KEY }}
         project=(@= dep.name @)
-  - uses: actions/cache@v2
-    with:
-      key: #@ ci_image_tag(erlang_version)
-      path: ci-(@= dep.name @).tar
   - name: SAVE CI DOCKER IMAGE IN CACHE
     run: |
       docker save --output ci-(@= dep.name @).tar (@= ci_dep_image(erlang_version, dep.name) @)


### PR DESCRIPTION
Previous commits on master broke the handling of docker images used during the actions workflows. These commits restore the build. We use the GitHub Actions cache rather than Artifacts, as artifacts upload too slowly. This does mean that cache misses will fail the build, currently I don't see an obvious solution that doesn't result in pushing the images to GCR again (which was too costly).