### PR TITLE
Ensure leader is deleted from supervisor in case of re-election

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -750,14 +750,12 @@ phase_stop_replicas(#{replica_nodes := Replicas,
 phase_start_new_leader(#{name := StreamId, leader_node := Node, leader_pid := LPid} = Conf) ->
     spawn(fun() ->
                   osiris_replica:stop(Node, Conf),
+                  osiris_writer:stop(Conf),
                   %% If the start fails, the monitor will capture the crash and restart it
                   case osiris_writer:start(Conf) of
                       {ok, Pid} ->
                           ra:pipeline_command({?MODULE, node()},
                                               {leader_elected, StreamId, Pid});
-                      {error, already_present} ->
-                          ra:pipeline_command({?MODULE, node()},
-                                              {leader_elected, StreamId, LPid});
                       {error, {already_started, Pid}} ->
                           ra:pipeline_command({?MODULE, node()},
                                               {leader_elected, StreamId, Pid})

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -747,7 +747,7 @@ phase_stop_replicas(#{replica_nodes := Replicas,
               ra:pipeline_command({?MODULE, node()}, {replicas_stopped, StreamId})
       end).
 
-phase_start_new_leader(#{name := StreamId, leader_node := Node, leader_pid := LPid} = Conf) ->
+phase_start_new_leader(#{name := StreamId, leader_node := Node} = Conf) ->
     spawn(fun() ->
                   osiris_replica:stop(Node, Conf),
                   osiris_writer:stop(Conf),


### PR DESCRIPTION
If the supervisor returns `{error, already_present}` we can't assume it is the same pid stored as the process is dead

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

