### PR TITLE
Expose `bypass_pem_cache` through rabbitmq.conf

### DIFF
--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -131,6 +131,8 @@
 # ssl_options.ciphers.35 = ECDH-ECDSA-AES128-SHA
 # ssl_options.ciphers.36 = ECDH-RSA-AES128-SHA
 
+# ssl_options.bypass_pem_cache = true
+
 ## Select an authentication/authorisation backend to use.
 ##
 ## Alternative backends are provided by plugins, such as rabbitmq-auth-backend-ldap.

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -294,6 +294,9 @@ fun(Conf) ->
     lists:reverse([V || {_, V} <- Settings])
 end}.
 
+{mapping, "ssl_options.bypass_pem_cache", "ssl.bypass_pem_cache",
+    [{datatype, {enum, [true, false]}}]}.
+
 %% ===========================================================================
 
 %% Choose the available SASL mechanism(s) to expose.

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -510,6 +510,14 @@ tcp_listen_options.exit_on_close = false",
   ]}],
   []},
   
+
+  {ssl_options_bypass_pem_cache,
+   "ssl_options.bypass_pem_cache = true",
+   [{ssl, [
+      {bypass_pem_cache, true}
+     ]}],
+   []},
+
  {tcp_listen_options_linger_on,
   "tcp_listen_options.linger.on = true
    tcp_listen_options.linger.timeout = 100",


### PR DESCRIPTION
Bypassing PEM cache may speed up TLS handshakes in some cases as described
here:
https://blog.heroku.com/how-we-sped-up-sni-tls-handshakes-by-5x

Please note that Heroku's use cases with certificates provided directly to RabbitMQ is unusual. When certificates are stored on disk, PEM cache should generally improve performance but may delay certificate rotation (if the certificate changes on disk, RabbitMQ will still use the cached certificate).