### PR TITLE
Remove Ranch dependency from rabbit_common

### DIFF
--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -16,7 +16,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 LOCAL_DEPS = compiler crypto public_key sasl ssl syntax_tools tools xmerl
-DEPS = lager jsx ranch recon credentials_obfuscation
+DEPS = lager jsx recon credentials_obfuscation
 
 dep_credentials_obfuscation = hex 2.3.0
 


### PR DESCRIPTION
It is not actually used there and may complicate dependency resolution
for RabbitMQ Erlang client users.

Per discussion with @dumbbell
