### PR TITLE
Stream: Channel resend on leader change

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -462,6 +462,8 @@ filter_per_type(all, _) ->
     true;
 filter_per_type(quorum, Q) ->
     ?amqqueue_is_quorum(Q);
+filter_per_type(stream, Q) ->
+    ?amqqueue_is_stream(Q);
 filter_per_type(classic, Q) ->
     ?amqqueue_is_classic(Q).
 
@@ -1714,10 +1716,11 @@ cancel_sync_mirrors(QPid) ->
 
 -spec is_replicated(amqqueue:amqqueue()) -> boolean().
 
-is_replicated(Q) when ?amqqueue_is_quorum(Q) ->
-    true;
-is_replicated(Q) ->
-    rabbit_mirror_queue_misc:is_mirrored(Q).
+is_replicated(Q) when ?amqqueue_is_classic(Q) ->
+    rabbit_mirror_queue_misc:is_mirrored(Q);
+is_replicated(_Q) ->
+    %% streams and quorum queues are all replicated
+    true.
 
 is_exclusive(Q) when ?amqqueue_exclusive_owner_is(Q, none) ->
     false;
@@ -1792,6 +1795,7 @@ on_node_down(Node) ->
     ok.
 
 delete_queues_on_node_down(Node) ->
+    rabbit_log:info("delete_queues_on_node_down GAHHH", []),
     lists:unzip(lists:flatten([
         rabbit_misc:execute_mnesia_transaction(
           fun () -> [{Queue, delete_queue(Queue)} || Queue <- Queues] end

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1795,7 +1795,6 @@ on_node_down(Node) ->
     ok.
 
 delete_queues_on_node_down(Node) ->
-    rabbit_log:info("delete_queues_on_node_down GAHHH", []),
     lists:unzip(lists:flatten([
         rabbit_misc:execute_mnesia_transaction(
           fun () -> [{Queue, delete_queue(Queue)} || Queue <- Queues] end

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -366,9 +366,10 @@ apply(_Meta, {phase_finished, StreamId, Reply}, #?MODULE{streams = Streams0} = S
             Streams = Streams0#{StreamId => clear_stream_state(SState)},
             reply_and_run_pending(From, StreamId, ok, Reply, [], State#?MODULE{streams = Streams})
     end;
-apply(#{from := From}, {start_replica, #{stream_id := StreamId, node := Node,
+apply(Meta, {start_replica, #{stream_id := StreamId, node := Node,
                                          retries := Retries}} = Cmd,
       #?MODULE{streams = Streams0} = State) ->
+    From = maps:get(from, Meta, undefined),
     case maps:get(StreamId, Streams0, undefined) of
         undefined ->
             case From of

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -45,7 +45,7 @@
 -export([format_osiris_event/2]).
 -export([update_stream_conf/2]).
 
--include("rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 -include("amqqueue.hrl").
 
 -define(INFO_KEYS, [name, durable, auto_delete, arguments, leader, members, online, state,
@@ -53,6 +53,9 @@
                     policy, operator_policy, effective_policy_definition, type]).
 
 -type appender_seq() :: non_neg_integer().
+
+-type msg_id() :: non_neg_integer().
+-type msg() :: term(). %% TODO: refine
 
 -record(stream, {name :: rabbit_types:r('queue'),
                  credit :: integer(),
@@ -64,10 +67,11 @@
 -record(stream_client, {name :: term(),
                         leader :: pid(),
                         next_seq = 1 :: non_neg_integer(),
-                        correlation = #{} :: #{appender_seq() => term()},
+                        correlation = #{} :: #{appender_seq() => {msg_id(), msg()}},
                         soft_limit :: non_neg_integer(),
                         slow = false :: boolean(),
-                        readers = #{} :: #{term() => #stream{}}
+                        readers = #{} :: #{term() => #stream{}},
+                        writer_id :: binary()
                        }).
 
 -import(rabbit_queue_type_util, [args_policy_lookup/3]).
@@ -284,16 +288,17 @@ deliver(QSs, #delivery{confirm = Confirm} = Delivery) ->
 deliver(_Confirm, #delivery{message = Msg, msg_seq_no = MsgId},
        #stream_client{name = Name,
                       leader = LeaderPid,
+                      writer_id = WriterId,
                       next_seq = Seq,
                       correlation = Correlation0,
                       soft_limit = SftLmt,
                       slow = Slow0} = State) ->
-    ok = osiris:write(LeaderPid, undefined, Seq, msg_to_iodata(Msg)),
+    ok = osiris:write(LeaderPid, WriterId, Seq, msg_to_iodata(Msg)),
     Correlation = case MsgId of
                       undefined ->
                           Correlation0;
                       _ when is_number(MsgId) ->
-                          Correlation0#{Seq => MsgId}
+                          Correlation0#{Seq => {MsgId, Msg}}
                   end,
     Slow = case maps:size(Correlation) >= SftLmt of
                true when not Slow0 ->
@@ -305,16 +310,21 @@ deliver(_Confirm, #delivery{message = Msg, msg_seq_no = MsgId},
     State#stream_client{next_seq = Seq + 1,
                         correlation = Correlation,
                         slow = Slow}.
+
 -spec dequeue(_, _, _, client()) -> no_return().
 dequeue(_, _, _, #stream_client{name = Name}) ->
     {protocol_error, not_implemented, "basic.get not supported by stream queues ~s",
      [rabbit_misc:rs(Name)]}.
 
-handle_event({osiris_written, From, _WriterId, Corrs}, State = #stream_client{correlation = Correlation0,
-                                                   soft_limit = SftLmt,
-                                                   slow = Slow0,
-                                                   name = Name}) ->
-    MsgIds = maps:values(maps:with(Corrs, Correlation0)),
+handle_event({osiris_written, From, _WriterId, Corrs},
+             State = #stream_client{correlation = Correlation0,
+                                    soft_limit = SftLmt,
+                                    slow = Slow0,
+                                    name = Name}) ->
+    MsgIds = lists:sort(maps:fold(
+                          fun (_Seq, {I, _M}, Acc) ->
+                                  [I | Acc]
+                          end, [], maps:with(Corrs, Correlation0))),
     Correlation = maps:without(Corrs, Correlation0),
     Slow = case maps:size(Correlation) < SftLmt of
                true when Slow0 ->
@@ -325,9 +335,10 @@ handle_event({osiris_written, From, _WriterId, Corrs}, State = #stream_client{co
            end,
     {ok, State#stream_client{correlation = Correlation,
                              slow = Slow}, [{settled, From, MsgIds}]};
-handle_event({osiris_offset, _From, _Offs}, State = #stream_client{leader = Leader,
-                                                                   readers = Readers0,
-                                                                   name = Name}) ->
+handle_event({osiris_offset, _From, _Offs},
+             State = #stream_client{leader = Leader,
+                                    readers = Readers0,
+                                    name = Name}) ->
     %% offset isn't actually needed as we use the atomic to read the
     %% current committed
     {Readers, TagMsgs} = maps:fold(
@@ -342,7 +353,9 @@ handle_event({osiris_offset, _From, _Offs}, State = #stream_client{leader = Lead
     Ack = true,
     Deliveries = [{deliver, Tag, Ack, OffsetMsg}
                   || {Tag, _LeaderPid, OffsetMsg} <- TagMsgs],
-    {ok, State#stream_client{readers = Readers}, Deliveries}.
+    {ok, State#stream_client{readers = Readers}, Deliveries};
+handle_event({stream_leader_change, Pid}, State) ->
+    {ok, update_leader_pid(Pid, State), []}.
 
 is_recoverable(Q) ->
     Node = node(),
@@ -358,8 +371,8 @@ recover(_VHost, Queues) ->
       end, {[], []}, Queues).
 
 settle(complete, CTag, MsgIds, #stream_client{readers = Readers0,
-                                    name = Name,
-                                    leader = Leader} = State) ->
+                                              name = Name,
+                                              leader = Leader} = State) ->
     Credit = length(MsgIds),
     {Readers, Msgs} = case Readers0 of
                           #{CTag := #stream{credit = Credit0} = Str0} ->
@@ -450,9 +463,13 @@ i(_, _) ->
 
 init(Q) when ?is_amqqueue(Q) ->
     Leader = amqqueue:get_pid(Q),
+    {ok, ok, _} = rabbit_stream_coordinator:register_listener(Q),
+    Prefix = erlang:pid_to_list(self()) ++ "_",
+    WriterId = rabbit_guid:binary(rabbit_guid:gen(), Prefix),
     {ok, SoftLimit} = application:get_env(rabbit, stream_messages_soft_limit),
     #stream_client{name = amqqueue:get_name(Q),
                    leader = Leader,
+                   writer_id = WriterId,
                    soft_limit = SoftLimit}.
 
 close(#stream_client{readers = Readers}) ->
@@ -461,8 +478,15 @@ close(#stream_client{readers = Readers}) ->
                  end, Readers),
     ok.
 
-update(_, State) ->
-    State.
+update(Q, State)
+  when ?is_amqqueue(Q) ->
+    Pid = amqqueue:get_pid(Q),
+    update_leader_pid(Pid, State).
+
+update_leader_pid(Pid, #stream_client{leader = Pid} =  State) ->
+    State;
+update_leader_pid(Pid, #stream_client{} =  State) ->
+    resend_all(State#stream_client{leader = Pid}).
 
 state_info(_) ->
     #{}.
@@ -611,7 +635,7 @@ initial_cluster_size(Val) ->
 
 res_arg(PolVal, undefined) -> PolVal;
 res_arg(_, ArgVal) ->  ArgVal.
-    
+
 queue_name(#resource{virtual_host = VHost, name = Name}) ->
     Timestamp = erlang:integer_to_binary(erlang:system_time()),
     osiris_util:to_base64uri(erlang:binary_to_list(<<VHost/binary, "_", Name/binary, "_",
@@ -729,3 +753,12 @@ capabilities() ->
                           <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],
       consumer_arguments => [<<"x-stream-offset">>],
       server_named => false}.
+
+resend_all(#stream_client{leader = LeaderPid,
+                          writer_id = WriterId,
+                          correlation = Corrs} = State) ->
+    Msgs = lists:sort(maps:values(Corrs)),
+    [begin
+         ok = osiris:write(LeaderPid, WriterId, Seq, msg_to_iodata(Msg))
+     end || {Seq, Msg} <- Msgs],
+    State.

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -47,6 +47,7 @@ groups() ->
            delete_quorum_replica,
            consume_from_replica,
            leader_failover,
+           leader_failover_dedupe,
            initial_cluster_size_one,
            initial_cluster_size_two,
            initial_cluster_size_one_policy,
@@ -1194,6 +1195,76 @@ leader_failover(Config) ->
     ?assert(NewLeader =/= Server1),
     ok = rabbit_ct_broker_helpers:start_node(Config, Server1).
 
+leader_failover_dedupe(Config) ->
+    %% tests that in-flight messages are automatically handled in the case where
+    %% a leader change happens during publishing
+    [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
+    Q = ?config(queue_name, Config),
+
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+
+    check_leader_and_replicas(Config, Q, Server1, [Server2, Server3]),
+
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server2),
+    #'confirm.select_ok'{} = amqp_channel:call(Ch2, #'confirm.select'{}),
+
+    Self= self(),
+    F = fun F(N) ->
+                receive
+                    go ->
+                        [publish(Ch2, Q, integer_to_binary(N + I))
+                         || I <- lists:seq(1, 100)],
+                        true = amqp_channel:wait_for_confirms(Ch2, 25),
+                        F(N + 100);
+                    stop ->
+                        Self ! {last_msg, N},
+                        ct:pal("stop"),
+                        ok
+                after 2 ->
+                          self() ! go,
+                          F(N)
+                end
+        end,
+    Pid = spawn(fun () ->
+                        amqp_channel:register_confirm_handler(Ch2, self()),
+                        F(0)
+                end),
+    erlang:monitor(process, Pid),
+    Pid ! go,
+    timer:sleep(10),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Server1),
+    %% this should cause a new leader to be elected and the channel on node 2
+    %% to have to resend any pending messages to ensure none is lost
+    timer:sleep(30000),
+    [Info] = lists:filter(
+               fun(Props) ->
+                       QName = rabbit_misc:r(<<"/">>, queue, Q),
+                       lists:member({name, QName}, Props)
+               end,
+               rabbit_ct_broker_helpers:rpc(Config, 1, rabbit_amqqueue,
+                                            info_all, [<<"/">>, [name, leader, members]])),
+    NewLeader = proplists:get_value(leader, Info),
+    ?assert(NewLeader =/= Server1),
+    flush(),
+    ?assert(erlang:is_process_alive(Pid)),
+    Pid ! stop,
+    ok = rabbit_ct_broker_helpers:start_node(Config, Server1),
+
+    N = receive
+            {last_msg, X} -> X
+        after 2000 ->
+                  exit(last_msg_timeout)
+        end,
+    %% validate that no duplicates were written even though an internal
+    %% resend might have taken place
+    qos(Ch2, 100, false),
+    subscribe(Ch2, Q, false, 0),
+    validate_dedupe(Ch2, 1, N),
+
+    ok.
+
 initial_cluster_size_one(Config) ->
     [Server1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
@@ -1598,6 +1669,30 @@ qos(Ch, Prefetch, Global) ->
                  amqp_channel:call(Ch, #'basic.qos'{global = Global,
                                                     prefetch_count = Prefetch})).
 
+validate_dedupe(Ch, N, N) ->
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag},
+         #amqp_msg{payload = B}} ->
+            I = binary_to_integer(B),
+            ?assertEqual(N, I),
+            ok = amqp_channel:cast(Ch, #'basic.ack'{delivery_tag = DeliveryTag,
+                                                    multiple     = false})
+    after 60000 ->
+            exit({missing_record, N})
+    end;
+validate_dedupe(Ch, N, M) ->
+    receive
+        {#'basic.deliver'{delivery_tag = DeliveryTag},
+         #amqp_msg{payload = B}} ->
+            I = binary_to_integer(B),
+            ?assertEqual(N, I),
+            ok = amqp_channel:cast(Ch, #'basic.ack'{delivery_tag = DeliveryTag,
+                                                    multiple     = false}),
+            validate_dedupe(Ch, N + 1, M)
+    after 60000 ->
+            exit({missing_record, N})
+    end.
+
 receive_batch(Ch, N, N) ->
     receive
         {#'basic.deliver'{delivery_tag = DeliveryTag},
@@ -1642,3 +1737,12 @@ run_proper(Fun, Args, NumTests) ->
           {on_output, fun(".", _) -> ok; % don't print the '.'s on new lines
                          (F, A) -> ct:pal(?LOW_IMPORTANCE, F, A)
                       end}])).
+
+flush() ->
+    receive
+        Any ->
+            ct:pal("flush ~p", [Any]),
+            flush()
+    after 0 ->
+              ok
+    end.


### PR DESCRIPTION
Detect when a new stream leader is elected and make stream_queues
re-send any unconfirmed, pending messages to ensure they did not get
lost during the leader change. This is done using the osiris
deduplication feature to ensure the resend does not create duplicates of
messages in the stream.
