### PR TITLE
Avoid double resolving client hostname

### DIFF
--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -1413,7 +1413,16 @@ auth_phase(Response,
                                        auth_mechanism = {Name, AuthMechanism},
                                        auth_state     = AuthState},
                        sock = Sock}) ->
-    RemoteAddress = list_to_binary(inet:ntoa(Connection#connection.host)),
+    rabbit_log:debug("Raw client connection hostname during authN phase: ~p", [Connection#connection.host]),
+    RemoteAddress = case Connection#connection.host of
+        %% the hostname was already resolved, e.g. by reverse DNS lookups
+        Bin when is_binary(Bin) -> Bin;
+        %% the hostname is an IP address
+        Tuple when is_tuple(Tuple) ->
+            rabbit_data_coercion:to_binary(inet:ntoa(Connection#connection.host));
+        Other -> rabbit_data_coercion:to_binary(Other)
+    end,
+    rabbit_log:debug("Resolved client hostname during authN phase: ~s", [RemoteAddress]),
     case AuthMechanism:handle_response(Response, AuthState) of
         {refused, Username, Msg, Args} ->
             rabbit_core_metrics:auth_attempt_failed(RemoteAddress, Username, amqp091),


### PR DESCRIPTION
when `reverse_dns_lookups` is set to `true`.

Closes #2730.
