### PR TITLE
Improve config validation: check whether the file is readable

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1773,8 +1773,10 @@ end}.
 
 {validator, "file_accessible", "file doesn't exist or isn't readable",
 fun(File) ->
-    ReadFile = file:read_file_info(File),
-    element(1, ReadFile) == ok
+    case file:read_file_info(File) of
+        {ok, FileInfo} -> (element(4, FileInfo) == read) or (element(4, FileInfo) == read_write);
+        _ -> false
+    end
 end}.
 
 {validator, "is_ip", "string is a valid IP address",


### PR DESCRIPTION
Since the validation fails with "or isn't readable", we should actually
check whether we can read the file. This way, when configuring TLS for
example, you get early feedback if the cert files are not readable.

Closes #2685 