### PR TITLE
[amqp_client] Resolve DNS until first success

### DIFF
--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -108,9 +108,8 @@ info_keys() ->
 
 connect(AmqpParams = #amqp_params_network{host = Host}, SIF, TypeSup, State) ->
     case gethostaddr(Host) of
-        []     -> {error, unknown_host};
-        [AF|_] -> do_connect(
-                    AF, AmqpParams, SIF, State#state{type_sup = TypeSup})
+        {error, Reason}     -> {error, Reason};
+        AF -> do_connect(AF, AmqpParams, SIF, State#state{type_sup = TypeSup})
     end.
 
 do_connect({Addr, Family},
@@ -163,9 +162,16 @@ inet_address_preference() ->
     end.
 
 gethostaddr(Host) ->
-    Lookups = [{Family, inet:getaddr(Host, Family)}
-               || Family <- inet_address_preference()],
-    [{IP, Family} || {Family, {ok, IP}} <- Lookups].
+    resolve_address(Host, inet_address_preference()).
+
+resolve_address(Host, [Family | Other]) ->
+    case inet:getaddr(Host, Family) of
+        {ok, IP} -> {IP, Family};
+        _ -> resolve_address(Host, Other)
+    end;
+resolve_address(Host, []) ->
+    {error, unknown_host}.
+
 
 try_handshake(AmqpParams, SIF, State = #state{sock = Sock}) ->
     Name = case rabbit_net:connection_string(Sock, outbound) of


### PR DESCRIPTION
## Proposed Changes

Resolves #2748 

In short - there is no point to resolve the DNS multiple times, if our preferred address family has already resolved, e.g. if we prefer IPv4 and we successfully resolved the DNS name to an IPv4 address, there's no need to also try to resolve an IPv6 address. It's a small performance optimization that 

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue #2748)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

I am not sure I have to sign the CA for this?

- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
