### PR TITLE
Start mirrors synchronously when transferring CMQ leadership

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -505,12 +505,12 @@ maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
         [{_, Q, false} = Queue | Queues] = All when length(All) > MaxQueuesDesired ->
             Name = amqqueue:get_name(Q),
             Module = rebalance_module(Q),
-            OtherNodes = Module:get_replicas(Q) -- [N],
-            case OtherNodes of
+            Candidates = Module:get_replicas(Q) -- [N],
+            case Candidates of
                 [] ->
                     {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};
                 _ ->
-                    [{Length, Destination} | _] = sort_by_number_of_queues(OtherNodes, ByNode),
+                    [{Length, Destination} | _] = sort_by_number_of_queues(Candidates, ByNode),
                     rabbit_log:warning("Migrating queue ~p from node ~p with ~p queues to node ~p with ~p queues",
                                        [Name, N, length(All), Destination, Length]),
                     case Module:transfer_leadership(Q, Destination) of

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -436,7 +436,7 @@ rebalance(Type, VhostSpec, QueueSpec) ->
 maybe_rebalance({true, Id}, Type, VhostSpec, QueueSpec) ->
     rabbit_log:info("Starting queue rebalance operation: '~s' for vhosts matching '~s' and queues matching '~s'",
                     [Type, VhostSpec, QueueSpec]),
-    Running = rabbit_nodes:all_running(),
+    Running = rabbit_maintenance:filter_out_drained_nodes_consistent_read(rabbit_nodes:all_running()),
     NumRunning = length(Running),
     ToRebalance = [Q || Q <- rabbit_amqqueue:list(),
                         filter_per_type(Type, Q),

--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -265,7 +265,7 @@ transfer_leadership_of_classic_mirrored_queues(TransferCandidates) ->
              {ok, Pick} ->
                  rabbit_log:debug("Will transfer leadership of local ~s to node ~s",
                           [rabbit_misc:rs(Name), Pick]),
-                 case rabbit_mirror_queue_misc:transfer_leadership(Q, Pick) of
+                 case rabbit_mirror_queue_misc:migrate_leadership_to_existing_replica(Q, Pick) of
                      {migrated, _} ->
                          rabbit_log:debug("Successfully transferred leadership of queue ~s to node ~s",
                                           [rabbit_misc:rs(Name), Pick]);

--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -25,7 +25,7 @@
     resume_all_client_listeners/0,
     close_all_client_connections/0,
     primary_replica_transfer_candidate_nodes/0,
-    random_primary_replica_transfer_candidate_node/1,
+    random_primary_replica_transfer_candidate_node/2,
     transfer_leadership_of_quorum_queues/1,
     transfer_leadership_of_classic_mirrored_queues/1,
     status_table_name/0,
@@ -256,12 +256,14 @@ transfer_leadership_of_classic_mirrored_queues(TransferCandidates) ->
     ReadableCandidates = readable_candidate_list(TransferCandidates),
     rabbit_log:info("Will transfer leadership of ~b classic mirrored queues hosted on this node to these peer nodes: ~s",
                     [length(Queues), ReadableCandidates]),
-    
     [begin
          Name = amqqueue:get_name(Q),
-         case random_primary_replica_transfer_candidate_node(TransferCandidates) of
+         ExistingReplicaNodes = [node(Pid) || Pid <- amqqueue:get_sync_slave_pids(Q)],
+         rabbit_log:debug("Local ~s has replicas on nodes ~s",
+                          [rabbit_misc:rs(Name), readable_candidate_list(ExistingReplicaNodes)]),
+         case random_primary_replica_transfer_candidate_node(TransferCandidates, ExistingReplicaNodes) of
              {ok, Pick} ->
-                 rabbit_log:debug("Will transfer leadership of local queue ~s to node ~s",
+                 rabbit_log:debug("Will transfer leadership of local ~s to node ~s",
                           [rabbit_misc:rs(Name), Pick]),
                  case rabbit_mirror_queue_misc:transfer_leadership(Q, Pick) of
                      {migrated, _} ->
@@ -300,17 +302,29 @@ stop_local_quorum_queue_followers() ->
      end || Q <- Queues],
     rabbit_log:info("Stopped all local replicas of quorum queues hosted on this node").
 
- -spec primary_replica_transfer_candidate_nodes() -> [node()].
+-spec primary_replica_transfer_candidate_nodes() -> [node()].
 primary_replica_transfer_candidate_nodes() ->
     filter_out_drained_nodes_consistent_read(rabbit_nodes:all_running() -- [node()]).
 
--spec random_primary_replica_transfer_candidate_node([node()]) -> {ok, node()} | undefined.
-random_primary_replica_transfer_candidate_node([]) ->
+-spec random_primary_replica_transfer_candidate_node([node()], [node()]) -> {ok, node()} | undefined.
+random_primary_replica_transfer_candidate_node([], _Preferred) ->
     undefined;
-random_primary_replica_transfer_candidate_node(Candidates) ->
-    Nth = erlang:phash2(erlang:monotonic_time(), length(Candidates)),
-    Candidate = lists:nth(Nth + 1, Candidates),
+random_primary_replica_transfer_candidate_node(Candidates, PreferredNodes) ->
+    Overlap = sets:to_list(sets:intersection(sets:from_list(Candidates), sets:from_list(PreferredNodes))),
+    Candidate = case Overlap of
+                    [] ->
+                        %% Since ownership transfer is meant to be run only when we are sure
+                        %% there are in-sync replicas to transfer to, this is an edge case.
+                        %% We skip the transfer.
+                        undefined;
+                    Nodes ->
+                        random_nth(Nodes)
+                end,
     {ok, Candidate}.
+
+random_nth(Nodes) ->
+    Nth = erlang:phash2(erlang:monotonic_time(), length(Nodes)),
+    lists:nth(Nth + 1, Nodes).
 
 revive_local_quorum_queue_replicas() ->
     Queues = rabbit_amqqueue:list_local_followers(),

--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -263,10 +263,10 @@ add_mirror(QName, MirrorNode, SyncMode) ->
 report_deaths(_MirrorPid, _IsMaster, _QueueName, []) ->
     ok;
 report_deaths(MirrorPid, IsMaster, QueueName, DeadPids) ->
-    log_info(QueueName, "~s ~s saw deaths of mirrors~s~n",
+    log_info(QueueName, "~s replica of queue ~s detected replica ~s to be down~n",
                     [case IsMaster of
-                         true  -> "Master";
-                         false -> "Slave"
+                         true  -> "Primary";
+                         false -> "Secondary"
                      end,
                      rabbit_misc:pid_to_string(MirrorPid),
                      [[$ , rabbit_misc:pid_to_string(P)] || P <- DeadPids]]).


### PR DESCRIPTION
## Proposed Changes

This changes classic mirror queue leadership transfer to add mirrors synchronously and also delete
fewer mirrors where it's not warranted.

We also used this as an opportunity to rename a few things around the relevant code paths.

Closes #2749.
References #2737.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2749)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Pairs: @dcorbacho @mkuratczyk.