### PR TITLE
Use `quorum_cluster_size` as the default cluster size parameter from configuration

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -81,7 +81,7 @@ define PROJECT_ENV
 	    %% rabbitmq-server#949, rabbitmq-server#1098
 	    {credit_flow_default_credit, {400, 200}},
 	    {quorum_commands_soft_limit, 32},
-	    {quorum_cluster_size, 5},
+	    {quorum_cluster_size, 3},
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667
 	    {channel_operation_timeout, 15000},

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -158,7 +158,7 @@ start_cluster(Q) ->
     NewQ0 = amqqueue:set_pid(Q, Id),
     NewQ1 = amqqueue:set_type_state(NewQ0, #{nodes => Nodes}),
 
-    rabbit_log:debug("Will start up to ~s replicas for quorum queue ~s", [QuorumSize, rabbit_misc:rs(QName)]),
+    rabbit_log:debug("Will start up to ~p replicas for quorum queue ~s", [QuorumSize, rabbit_misc:rs(QName)]),
     case rabbit_amqqueue:internal_declare(NewQ1, false) of
         {created, NewQ} ->
             TickTimeout = application:get_env(rabbit, quorum_tick_interval, ?TICK_TIMEOUT),
@@ -1447,8 +1447,7 @@ queue_name(RaFifoState) ->
 get_default_quorum_initial_group_size(Arguments) ->
     case rabbit_misc:table_lookup(Arguments, <<"x-quorum-initial-group-size">>) of
         undefined ->
-            {ok, Val} = application:get_env(rabbit, quorum_cluster_size),
-            Val;
+            application:get_env(rabbit, quorum_cluster_size, 3);
         {_Type, Val} ->
             Val
     end.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1444,8 +1444,11 @@ queue_name(RaFifoState) ->
 
 get_default_quorum_initial_group_size(Arguments) ->
     case rabbit_misc:table_lookup(Arguments, <<"x-quorum-initial-group-size">>) of
-        undefined -> application:get_env(rabbit, quorum_cluster_size);
-        {_Type, Val} -> Val
+        undefined ->
+            {ok, Val} = application:get_env(rabbit, quorum_cluster_size),
+            Val;
+        {_Type, Val} ->
+            Val
     end.
 
 select_quorum_nodes(Size, All) when length(All) =< Size ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1444,7 +1444,7 @@ queue_name(RaFifoState) ->
 
 get_default_quorum_initial_group_size(Arguments) ->
     case rabbit_misc:table_lookup(Arguments, <<"x-quorum-initial-group-size">>) of
-        undefined -> application:get_env(rabbit, default_quorum_initial_group_size);
+        undefined -> application:get_env(rabbit, quorum_cluster_size);
         {_Type, Val} -> Val
     end.
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -157,6 +157,8 @@ start_cluster(Q) ->
     Nodes = select_quorum_nodes(QuorumSize, rabbit_mnesia:cluster_nodes(all)),
     NewQ0 = amqqueue:set_pid(Q, Id),
     NewQ1 = amqqueue:set_type_state(NewQ0, #{nodes => Nodes}),
+
+    rabbit_log:debug("Will start up to ~s replicas for quorum queue ~s", [QuorumSize, rabbit_misc:rs(QName)]),
     case rabbit_amqqueue:internal_declare(NewQ1, false) of
         {created, NewQ} ->
             TickTimeout = application:get_env(rabbit, quorum_tick_interval, ?TICK_TIMEOUT),


### PR DESCRIPTION
Use `quorum_cluster_size` as the default cluster size parameter from configuration, as documented.
Set default to 3

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
