### PR TITLE
Remove a log line related to CMQ leader transfer

### DIFF
--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -86,8 +86,6 @@ do_drain() ->
 
     TransferCandidates = primary_replica_transfer_candidate_nodes(),
     ReadableCandidates = readable_candidate_list(TransferCandidates),
-    rabbit_log:info("Node will transfer primary replicas of its queues to ~b peers: ~s",
-                    [length(TransferCandidates), ReadableCandidates]),
     %% Note: only QQ leadership is transferred because it is a reasonably quick thing to do a lot of queues
     %% in the cluster, unlike with CMQs.
     transfer_leadership_of_quorum_queues(TransferCandidates),


### PR DESCRIPTION
We've removed this functionality in https://github.com/rabbitmq/rabbitmq-server/commit/c7b9c393527fa69633383b856700a6d151c27e3d
so we shouldn't log that we would do that.