### PR TITLE
Add sleep after beam starting to rabbitmq-server-ha.ocf

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -1238,6 +1238,8 @@ start_beam_process() {
             sleep 1
         done
         if [ "${pid}" != "0" -a -d "/proc/${pid}" ] ; then
+            # waiting for initializing beam process
+            sleep 5
             rc=$OCF_SUCCESS
             break
         fi


### PR DESCRIPTION
## Proposed Changes

In the _rabbitmq-server-ha.ocf_ script, 5s pause has been added after starting **beam** process. It needs for a normally starting beam process (need some time to initialize it).

This change fixes a bug:
There is no pause between starting the beam process and checking its status in the _rabbitmq-server-ha.ocf_. 
Beam process does not have time to start, and _get_status()_ cmd fails with code 69. Then beam process is killed due to bad status and '_rabbitctl start_app_' cmd can't execute.  And resource-agent falls in the loop. 
See logs: https://groups.google.com/g/rabbitmq-users/c/4Sq4nJN69XI 
Link to the bug: https://github.com/rabbitmq/rabbitmq-server/issues/2768

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes issue #2768)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

