### PR TITLE
New command to close all connections of a user

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -29,6 +29,7 @@
          connection_info_all/0, connection_info_all/1,
          emit_connection_info_all/4, emit_connection_info_local/3,
          close_connection/2, close_connections/2, close_all_connections/1,
+         close_all_user_connections/2,
          force_connection_event_refresh/1, force_non_amqp_connection_event_refresh/1,
          handshake/2, tcp_host/1,
          ranch_ref/1, ranch_ref/2, ranch_ref_of_protocol/1,

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -470,6 +470,12 @@ close_connections(Pids, Explanation) ->
     [close_connection(Pid, Explanation) || Pid <- Pids],
     ok.
 
+-spec close_all_user_connections(string(), string()) -> 'ok'.
+close_all_user_connections(Username, Explanation) ->
+    Pids = lists:map(fun(X) -> element(6, X) end, rabbit_connection_tracking:list_of_user(Username)),
+    [close_connection(Pid, Explanation) || Pid <- Pids],
+    ok.
+
 %% Meant to be used by tests only
 -spec close_all_connections(string()) -> 'ok'.
 close_all_connections(Explanation) ->

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -471,7 +471,7 @@ close_connections(Pids, Explanation) ->
     [close_connection(Pid, Explanation) || Pid <- Pids],
     ok.
 
--spec close_all_user_connections(string(), string()) -> 'ok'.
+-spec close_all_user_connections(rabbit_types:username(), string()) -> 'ok'.
 close_all_user_connections(Username, Explanation) ->
     Pids = [Pid || #tracked_connection{pid = Pid} <- rabbit_connection_tracking:list_of_user(Username)],
     [close_connection(Pid, Explanation) || Pid <- Pids],

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -473,7 +473,7 @@ close_connections(Pids, Explanation) ->
 
 -spec close_all_user_connections(string(), string()) -> 'ok'.
 close_all_user_connections(Username, Explanation) ->
-    Pids = lists:map(fun(X) -> element(6, X) end, rabbit_connection_tracking:list_of_user(Username)),
+    Pids = [Pid || #tracked_connection{pid = Pid} <- rabbit_connection_tracking:list_of_user(Username)],
     [close_connection(Pid, Explanation) || Pid <- Pids],
     ok.
 

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -168,6 +168,7 @@
           node,
           vhost,
           name,
+          %% Main connection process pid
           pid,
           protocol,
           %% network or direct

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_user_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_user_connections_command.ex
@@ -1,0 +1,57 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllUserConnectionsCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsTwoPositionalArguments
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  ## rabbit_networking:close_connections(lists:map(fun(X) -> element(6, X) end, rabbit_connection_tracking:list_of_user(<<"guest">>)), "because").
+  # def run([username, explanation], %{node: node_name}) do
+  #   :rabbit_misc.rpc_call(node_name, :rabbit_networking, :close_connections, [
+  #     Enum.map(:rabbit_connection_tracking.list_of_user(username), fn x -> elem(6, x) end),
+  #     explanation
+  #   ])
+  # end
+  def run([username, explanation], %{node: node_name}) do
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_networking,
+      :close_all_user_connections,
+      [username, explanation]
+    )
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "close_all_user_connections <username> <explanation>"
+
+  def usage_additional do
+    [
+      ["<username>", "TODO"],
+      ["<explanation>", "reason for connection closure"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.connections()
+    ]
+  end
+
+  def help_section(), do: :operations
+
+  def description(),
+    do: "Instructs the broker to close all connections of the specified user"
+
+  def banner([username, explanation], _),
+    do: "Closing connections of user #{username}, reason: #{explanation}..."
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_user_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_user_connections_command.ex
@@ -14,13 +14,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllUserConnectionsCommand do
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  ## rabbit_networking:close_connections(lists:map(fun(X) -> element(6, X) end, rabbit_connection_tracking:list_of_user(<<"guest">>)), "because").
-  # def run([username, explanation], %{node: node_name}) do
-  #   :rabbit_misc.rpc_call(node_name, :rabbit_networking, :close_connections, [
-  #     Enum.map(:rabbit_connection_tracking.list_of_user(username), fn x -> elem(6, x) end),
-  #     explanation
-  #   ])
-  # end
   def run([username, explanation], %{node: node_name}) do
     :rabbit_misc.rpc_call(
       node_name,
@@ -36,7 +29,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllUserConnectionsCommand do
 
   def usage_additional do
     [
-      ["<username>", "TODO"],
+      ["<username>", "Self-explanatory"],
       ["<explanation>", "reason for connection closure"]
     ]
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_user_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_user_connections_command.ex
@@ -30,7 +30,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllUserConnectionsCommand do
   def usage_additional do
     [
       ["<username>", "Self-explanatory"],
-      ["<explanation>", "reason for connection closure"]
+      ["<explanation>", "reason for connection closure, will be logged and provided to clients"]
     ]
   end
 

--- a/deps/rabbitmq_cli/test/ctl/close_all_user_connections_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/close_all_user_connections_command_test.exs
@@ -1,0 +1,88 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule CloseAllUserConnectionsCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  # alias RabbitMQ.CLI.Ctl.RpcStream
+
+  @helpers RabbitMQ.CLI.Core.Helpers
+
+  @command RabbitMQ.CLI.Ctl.Commands.CloseAllUserConnectionsCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    close_all_connections(get_rabbit_hostname())
+
+    on_exit([], fn ->
+      close_all_connections(get_rabbit_hostname())
+    end)
+
+    :ok
+  end
+
+  test "validate: with an invalid number of arguments returns an arg count error", context do
+    assert @command.validate(["username", "explanation", "extra"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["username"], context[:opts]) ==
+             {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: with the correct number of arguments returns ok", context do
+    assert @command.validate(["username", "test"], context[:opts]) == :ok
+  end
+
+  test "run: a close connections request on a user with open connections", context do
+    with_connection("/", fn _ ->
+      node = @helpers.normalise_node(context[:node], :shortnames)
+      Process.sleep(500)
+
+      # make sure there is a connection to close
+      conns = fetch_user_connections("guest", context)
+      assert length(conns) > 0
+
+      # make sure closing yeti's connections doesn't affect guest's connections
+      assert :ok == @command.run(["yeti", "test"], %{node: node})
+      Process.sleep(500)
+      conns = fetch_user_connections("guest", context)
+      assert length(conns) > 0
+
+      # finally, make sure we can close guest's connections
+      assert :ok == @command.run(["guest", "test"], %{node: node})
+      Process.sleep(500)
+      conns = fetch_user_connections("guest", context)
+      assert length(conns) == 0
+    end)
+  end
+
+  test "run: a close connections request on for a non existing user returns successfully",
+       context do
+    assert match?(
+             :ok,
+             @command.run(["yeti", "test"], %{
+               node: @helpers.normalise_node(context[:node], :shortnames)
+             })
+           )
+  end
+
+  test "banner", context do
+    s = @command.banner(["username", "some reason"], context[:opts])
+    assert s =~ ~r/Closing connections/
+    assert s =~ ~r/user username/
+    assert s =~ ~r/reason: some reason/
+  end
+
+  defp fetch_user_connections(username, context) do
+    node = @helpers.normalise_node(context[:node], :shortnames)
+
+    :rabbit_misc.rpc_call(node, :rabbit_connection_tracking, :list_of_user, [
+      username
+    ])
+  end
+end

--- a/deps/rabbitmq_cli/test/ctl/close_all_user_connections_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/close_all_user_connections_command_test.exs
@@ -41,7 +41,10 @@ defmodule CloseAllUserConnectionsCommandTest do
   test "run: a close connections request on a user with open connections", context do
     with_connection("/", fn _ ->
       node = @helpers.normalise_node(context[:node], :shortnames)
-      Process.sleep(500)
+      await_condition(fn ->
+        conns = fetch_user_connections("guest", context)
+        length(conns) > 0
+      end, 10000)
 
       # make sure there is a connection to close
       conns = fetch_user_connections("guest", context)
@@ -55,7 +58,11 @@ defmodule CloseAllUserConnectionsCommandTest do
 
       # finally, make sure we can close guest's connections
       assert :ok == @command.run(["guest", "test"], %{node: node})
-      Process.sleep(500)
+      await_condition(fn ->
+        conns = fetch_user_connections("guest", context)
+        length(conns) == 0
+      end, 10000)
+
       conns = fetch_user_connections("guest", context)
       assert length(conns) == 0
     end)


### PR DESCRIPTION
All connections of the specified user, on all nodes, are closed and the reason is logged.

```
rabbitmqctl close_all_user_connections username reason
```

Closes #2715 

