### PR TITLE
Avoid federation crashes for non-classic queue types

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1554,7 +1554,7 @@ basic_cancel(Q, ConsumerTag, OkMsg, ActingUser, QStates) ->
 notify_decorators(Q) when ?amqqueue_is_classic(Q) ->
     QPid = amqqueue:get_pid(Q),
     delegate:invoke_no_result(QPid, {gen_server2, cast, [notify_decorators]});
-notify_decorators(Q) ->
+notify_decorators(_Q) ->
     %% Not supported by any other queue type
     ok.
 

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1551,9 +1551,12 @@ basic_cancel(Q, ConsumerTag, OkMsg, ActingUser, QStates) ->
 
 -spec notify_decorators(amqqueue:amqqueue()) -> 'ok'.
 
-notify_decorators(Q) ->
+notify_decorators(Q) when ?amqqueue_is_classic(Q) ->
     QPid = amqqueue:get_pid(Q),
-    delegate:invoke_no_result(QPid, {gen_server2, cast, [notify_decorators]}).
+    delegate:invoke_no_result(QPid, {gen_server2, cast, [notify_decorators]});
+notify_decorators(Q) ->
+    %% Not supported by any other queue type
+    ok.
 
 notify_sent(QPid, ChPid) ->
     rabbit_amqqueue_common:notify_sent(QPid, ChPid).


### PR DESCRIPTION
Quorum and stream queues do not currently support federation, so we must avoid calling `notify_decorators` over any of them.

I could not reproduce #2756 without manual intervention, but this patch will avoid the reported crash anyway.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

