### PR TITLE
Implement `is_unresponsive` for stream queues

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1207,6 +1207,17 @@ is_unresponsive(Q, Timeout) when ?amqqueue_is_quorum(Q) ->
     catch
         exit:{timeout, _} ->
             true
+    end;
+is_unresponsive(Q, Timeout) when ?amqqueue_is_stream(Q) ->
+    try
+        #{leader_pid := LeaderPid} = amqqueue:get_type_state(Q),
+        case gen_batch_server:call(LeaderPid, get_reader_context, Timeout) of
+            #{dir := _} -> false;
+            _ -> true
+        end
+    catch
+        exit:{timeout, _} ->
+            true
     end.
 
 format(Q) when ?amqqueue_is_quorum(Q) -> rabbit_quorum_queue:format(Q);


### PR DESCRIPTION
Implementation of `rabbit_amqqueue:is_unresponsive` for stream queues.

To test create a stream queue and run `./sbin/rabbitmqctl list_unresponsive_queues`. It will succeed with this PR, without it you'll get something like:
```
$ ./sbin/rabbitmqctl list_unresponsive_queues
Listing unresponsive queues for vhost / ...
{:badrpc, {:EXIT, {:function_clause, [{:rabbit_amqqueue, :is_unresponsive, [{:amqqueue, {:resource, "/", :queue, "asdf"}, true, false, :none, [{"x-queue-type", :longstr, "stream"}], #PID<11366.12833.2>, [], [], [], [vhost: "/", name: "federate-me", pattern: "\\.*", "apply-to": "all", definition: [{"federation-upstream-set", "all"}], priority: 0], :undefined, [], [:rabbit_federation_queue], :live, 0, [], "/", %{user: "guest"}, :rabbit_stream_queue, %{epoch: 1, event_formatter: {:rabbit_stream_queue, :format_osiris_event, [{:resource, "/", :queue, "asdf"}]}, external_ref: {:resource, "/", :queue, "asdf"}, leader_locator_strategy: "client-local", leader_node: :"rabbit@dparracorba-a01", leader_pid: #PID<11366.12833.2>, name: '__asdf_1612194475255371000', reference: {:resource, "/", :queue, "asdf"}, replica_nodes: [], replica_pids: [], retention: []}}, 15000], [file: 'src/rabbit_amqqueue.erl', line: 1187]}, {:rabbit_amqqueue, :"-emit_unresponsive_local/5-fun-0-", 3, [file: 'src/rabbit_amqqueue.erl', line: 1280]}, {:rabbit_misc, :with_exit_handler, 2, [file: 'src/rabbit_misc.erl', line: 524]}, {:rabbit_control_misc, :step_with_exit_handler, 4, [file: 'src/rabbit_control_misc.erl', line: 58]}, {:rabbit_control_misc, :"-emitting_map0/5-lc$^0/1-0-", 5, [file: 'src/rabbit_control_misc.erl', line: 50]}, {:rabbit_control_misc, :"-emitting_map0/5-lc$^0/1-0-", 5, [file: 'src/rabbit_control_misc.erl', line: 50]}, {:rabbit_control_misc, :emitting_map_with_exit_handler, 5, [file: 'src/rabbit_control_misc.erl', line: 46]}, {:rabbit_control_misc, :emitting_map_with_exit_handler, 4, [file: 'src/rabbit_control_misc.erl', line: 41]}]}}}
```

Found while investigating #2772 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

