### PR TITLE
Add OTP version to the startup banner

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -858,8 +858,9 @@ start(normal, []) ->
                    #{domain => ?RMQLOG_DOMAIN_PRELAUNCH});
             _ ->
                 ?LOG_INFO(
-                   "~n Starting ~s ~s on Erlang ~s~n ~s~n ~s",
+                   "~n Starting ~s ~s on Erlang ~s [~s]~n ~s~n ~s",
                    [product_name(), product_version(), rabbit_misc:otp_release(),
+                    emu_flavor(),
                     ?COPYRIGHT_MESSAGE, ?INFORMATION_MESSAGE],
                    #{domain => ?RMQLOG_DOMAIN_PRELAUNCH})
         end,
@@ -1183,18 +1184,33 @@ print_banner() ->
     io:format(Logo ++
               "~n" ++
               MOTDFormat ++
-              "~n  Doc guides: https://rabbitmq.com/documentation.html"
-              "~n  Support:    https://rabbitmq.com/contact.html"
-              "~n  Tutorials:  https://rabbitmq.com/getstarted.html"
-              "~n  Monitoring: https://rabbitmq.com/monitoring.html"
+              "~n  Erlang:      ~ts [~ts]"
+              "~n  SSL Library: ~ts"
+              "~n"
+              "~n  Doc guides:  https://rabbitmq.com/documentation.html"
+              "~n  Support:     https://rabbitmq.com/contact.html"
+              "~n  Tutorials:   https://rabbitmq.com/getstarted.html"
+              "~n  Monitoring:  https://rabbitmq.com/monitoring.html"
               "~n"
               "~n  Logs: ~ts" ++ LogFmt ++ "~n"
               "~n  Config file(s): ~ts" ++ CfgFmt ++ "~n"
               "~n  Starting broker...",
               [Product, Version, ?COPYRIGHT_MESSAGE, ?INFORMATION_MESSAGE] ++
+              [rabbit_misc:otp_release(), emu_flavor(), crypto_version()] ++
               MOTDArgs ++
               LogLocations ++
               CfgLocations).
+
+emu_flavor() ->
+    %% emu_flavor was introduced in Erlang 24 so we need to catch the error on Erlang 23
+    case catch(erlang:system_info(emu_flavor)) of
+        {'EXIT', _} -> "emu";
+        EmuFlavor -> EmuFlavor
+    end.
+
+crypto_version() ->
+    [{CryptoLibName, _, CryptoLibVersion}] = crypto:info_lib(),
+    [CryptoLibName, " - ", CryptoLibVersion].
 
 log_motd() ->
     case motd() of


### PR DESCRIPTION
Print Erlang/OTP version after the RabbitMQ version in the startup banner. This is purely for information purposes - often users will copy-paste console output when reporting issues. This way we don't have ask about the Erlang version.

```
RabbitMQ 3.8.10+18.gea1f4a3.dirty, Erlang/OTP 23.2.3
```