### PR TITLE
Provide a means to disable and enable classic queue mirroring within a vhost

### DIFF
--- a/deps/rabbit/src/rabbit_runtime_parameters_acl.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters_acl.erl
@@ -40,8 +40,8 @@ create_table() ->
              N <- ClusterNodes],
         ok
     catch
-        throw:Reason ->
-            {error, Reason}
+        _:{error, _Reason} = Error -> Error;
+        _:Reason -> {error, Reason}
     end.
 
 -spec new(rabbit_types:vhost(), binary()) -> rabbit_types:runtime_parameters_acl().

--- a/deps/rabbit/src/rabbit_runtime_parameters_acl.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters_acl.erl
@@ -18,7 +18,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("amqqueue.hrl").
 
--export([table_name/0, create_table/0]).
+-export([table_name/0, create_table/0, ensure_table/0]).
 -export([new/2, new/3, allow/4, disallow/4, is_allowed/3]).
 -export([lookup/2, get_disallowed_list/2, format_error/3]).
 
@@ -146,6 +146,22 @@ format_error(<<"ha-mode">>, <<"policy">>, VHost) ->
 format_error(Attribute, Component, VHost) ->
     rabbit_misc:format("'~s' ~s is not allowed in vhost '~s'",
         [Attribute, Component, VHost]).
+
+%% This function is for test purposes, ensure runtime parameters ACL table still
+%% exists if feature flag had been previously enabled following changes in mnesia
+-spec ensure_table() -> 'ok'.
+ensure_table() ->
+    case rabbit_feature_flags:is_enabled(runtime_parameters_acl) of
+        true ->
+            case rabbit_table:exists(?TAB) of
+                false ->
+                    create_table();
+                true ->
+                    ok
+            end;
+        false ->
+            ok
+    end.
 
 %% Internal
 

--- a/deps/rabbit/src/rabbit_runtime_parameters_acl.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters_acl.erl
@@ -1,0 +1,196 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_runtime_parameters_acl).
+
+%% Access Control List for runtime parameters per virtual host. This provides
+%% a generic framework for different parameters to support ACL. e.g. <<"policy">>.
+%%
+%% e.g. ACL entry, disallowing classic mirroring:
+%% #runtime_parameters_acl{component       = {<<"/">>, <<"policy">>},
+%%                         disallowed_list = [<<"ha-mode">>, ...]}
+
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include("amqqueue.hrl").
+
+-export([table_name/0, create_table/0]).
+-export([new/2, new/3, allow/4, disallow/4, is_allowed/3]).
+-export([lookup/2, get_disallowed_list/2, format_error/3]).
+
+-define(TAB, ?MODULE).
+
+-spec table_name() -> atom().
+table_name() -> ?TAB.
+
+-spec create_table() -> rabbit_types:ok_or_error(any()).
+create_table() ->
+    try
+        rabbit_table:create(?MODULE,
+            [{record_name, runtime_parameters_acl},
+             {attributes, record_info(fields, runtime_parameters_acl)}])
+    catch
+        throw:Reason ->
+            {error, Reason}
+    end.
+
+-spec new(rabbit_types:vhost(), binary()) -> rabbit_types:runtime_parameters_acl().
+new(VHost, Component) ->
+    new(VHost, Component, []).
+
+-spec new(rabbit_types:vhost(), [binary()] | binary(), term()) ->
+  rabbit_types:runtime_parameters_acl().
+new(VHost, Component, Attributes) when is_list(Attributes) ->
+    #runtime_parameters_acl{
+        component       = {VHost, Component},
+        disallowed_list = Attributes};
+new(VHost, Component, Attribute) ->
+    new(VHost, Component, [Attribute]).
+
+-spec allow(rabbit_types:vhost(), binary(), any(), rabbit_types:username()) -> 'ok'.
+allow(VHost, Component, Attribute, ActingUser) ->
+    try is_supported(Attribute, Component) of
+        true ->
+            rabbit_misc:execute_mnesia_transaction(
+                fun() ->
+                    case mnesia:wread({?TAB, _Key = {VHost, Component}}) of
+                        [#runtime_parameters_acl{disallowed_list = DL} = RPA] ->
+                            rabbit_log:info("Allowing '~s' ~s in vhost '~s'",
+                                            [Attribute, Component, VHost]),
+                            RPA1 = RPA#runtime_parameters_acl{
+                                       disallowed_list = lists:delete(Attribute, DL)},
+                            ok = mnesia:write(?TAB, RPA1, write),
+                            event_notify(parameter_allow, VHost, Component,
+                                [{attribute, Attribute},
+                                 {user_who_performed_action, ActingUser}]);
+                        [] ->
+                            ok
+                    end
+                end);
+        false ->
+            {error_string, rabbit_misc:format("'~s' is not a supported '~s' parameter",
+                                              [Attribute, Component])};
+        ignore ->
+            ok
+    catch
+        _:_ ->
+            {error_string, rabbit_misc:format("'~s' is not a supported '~s' parameter",
+                                              [Attribute, Component])}
+    end.
+
+-spec disallow(rabbit_types:vhost(), binary(), any(), rabbit_types:username()) -> 'ok'.
+disallow(VHost, Component, Attribute, ActingUser) ->
+    try is_supported(Attribute, Component) of
+        true ->
+            rabbit_misc:execute_mnesia_transaction(
+                fun() ->
+                    rabbit_log:info("Disallowing '~s' ~s in vhost '~s'",
+                                    [Attribute, Component, VHost]),
+                    case mnesia:read(?TAB, Key = {VHost, Component}, read) of
+                        [#runtime_parameters_acl{component = Key, disallowed_list = DL} = RPA] ->
+                            RPA1 = RPA#runtime_parameters_acl{
+                                       disallowed_list = lists:usort([Attribute | DL])},
+                            ok = mnesia:write(?TAB, RPA1, write);
+                        [] ->
+                            RPA = new(VHost, Component, Attribute),
+                            ok = mnesia:write(?TAB, RPA, write)
+                    end,
+                    event_notify(parameter_disallow, VHost, Component,
+                        [{attribute, Attribute},
+                         {user_who_performed_action, ActingUser}])
+                end);
+        false ->
+            {error_string, rabbit_misc:format("'~s' is not a supported '~s' parameter",
+                                              [Attribute, Component])};
+        ignore ->
+            ok
+    catch
+        _:_ ->
+            {error_string, rabbit_misc:format("'~s' is not a supported '~s' parameter",
+                                              [Attribute, Component])}
+    end.
+
+-spec is_allowed(rabbit_types:vhost(), binary(), any()) ->
+  boolean() | {boolean(), any()}.
+is_allowed(VHost, Component = <<"policy">>, Term) when is_list(Term) ->
+    check_if_allowed(VHost, Component, Term);
+is_allowed(VHost, Component, Attribute) when is_binary(Attribute) ->
+    is_allowed(VHost, Component, [{<<"definition">>, [{Attribute, []}]}]);
+%% Extensible, e.g. for operator-policies, shovel, federation, ... ACL rules.
+is_allowed(_VHost, _Component, _Term) ->
+    true.
+
+-spec lookup(rabbit_types:vhost(), binary()) ->
+  rabbit_types:ok_or_error2(rabbit_types:runtime_parameters_acl(), 'not_found').
+lookup(VHost, Component) ->
+    try
+        rabbit_misc:dirty_read({?TAB, {VHost, Component}})
+    catch
+        _:_ -> {error, not_found}
+    end.
+
+-spec get_disallowed_list(rabbit_types:vhost(), binary()) -> list().
+get_disallowed_list(VHost, Component) ->
+    case lookup(VHost, Component) of
+        {ok, #runtime_parameters_acl{disallowed_list = DL}} -> DL;
+        {error, not_found}                                  -> []
+    end.
+
+-spec format_error(binary(), binary(), rabbit_types:vhost()) -> string().
+format_error(<<"ha-mode">>, <<"policy">>, VHost) ->
+    rabbit_misc:format("classic mirroring is not allowed in vhost '~s'", [VHost]);
+format_error(Attribute, Component, VHost) ->
+    rabbit_misc:format("'~s' ~s is not allowed in vhost '~s'",
+        [Attribute, Component, VHost]).
+
+%% Internal
+
+check_if_allowed(VHost, Component, Term) ->
+    case rabbit_feature_flags:is_enabled(runtime_parameters_acl) of
+        true ->
+            case lookup(VHost, Component) of
+                {ok, #runtime_parameters_acl{disallowed_list = DL}} ->
+                    try
+                        lists:map(
+                            fun({Attribute, _Value}) ->
+                                case lists:member(Attribute, DL) of
+                                    true ->
+                                        throw({not_allowed, Attribute});
+                                    false ->
+                                        ok
+                                end
+                            end, rabbit_misc:pget(<<"definition">>, Term, [])),
+                        true
+                    catch
+                        throw:{not_allowed, Attribute} ->
+                            {false, Attribute}
+                    end;
+                {error, not_found} ->
+                    true
+            end;
+        false ->
+            true
+    end.
+
+event_notify(Event, none, Component, Props) ->
+    rabbit_event:notify(Event, [{component, Component} | Props]);
+event_notify(Event, VHost, Component, Props) ->
+    rabbit_event:notify(Event, [{vhost,     VHost},
+                                {component, Component} | Props]).
+
+is_supported(Attribute, Component) ->
+    case rabbit_feature_flags:is_enabled(runtime_parameters_acl) of
+        true ->
+            Attribute1 = rabbit_data_coercion:to_list(string:lowercase(Attribute)),
+            Attribute2 = list_to_existing_atom(Attribute1),
+            proplists:is_defined(Attribute2, get_supported_attributes(Component));
+        false ->
+            ignore
+    end.
+
+get_supported_attributes(<<"policy">>) ->
+    rabbit_registry:lookup_all(policy_validator).

--- a/deps/rabbit/test/rabbit_runtime_parameters_acl_SUITE.erl
+++ b/deps/rabbit/test/rabbit_runtime_parameters_acl_SUITE.erl
@@ -1,0 +1,230 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2011-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_runtime_parameters_acl_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+-compile(export_all).
+
+-import(quorum_queue_utils, [wait_for_messages/2]).
+
+all() ->
+    [
+      {group, cluster_size_2}
+    ].
+
+groups() ->
+    [
+     {cluster_size_2, [], [
+                           policies_acl
+                          ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(cluster_size_2, Config) ->
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+                                                    {rmq_nodes_count, 2},
+                                                    {rmq_nodename_suffix, Suffix}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_client_helpers:setup_steps(),
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_client_helpers:teardown_steps(),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test cases.
+%% -------------------------------------------------------------------
+
+policies_acl(Config) ->
+    {_Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),
+    Q = <<"policy_acl-queue">>,
+    declare(Ch, Q),
+    publish(Ch, Q, lists:seq(1, 20)),
+
+    disallow_policy(Config, 0, <<"/">>, <<"ha-mode">>),
+    ?assertEqual({error_string, "'ha-mode' policy is not allowed in vhost '/'"},
+        set_ha_all_policy(Config, 0, <<"/">>, <<".*">>)),
+    ?assertEqual(0, count_mirrors(Config, 0, Q, <<"/">>)),
+    wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
+
+    DL0 = get_disallowed_list(Config, 0, <<"/">>, <<"policy">>),
+    ?assertEqual(1, length(DL0)),
+    ?assertEqual(true, lists:member(<<"ha-mode">>, DL0)),
+
+    allow_policy(Config, 0, <<"/">>, <<"ha-mode">>),
+    ?assertEqual(ok, set_ha_all_policy(Config, 0, <<"/">>, <<".*">>)),
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            count_mirrors(Config, 0, Q, <<"/">>) =:= 1
+        end),
+    wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
+
+    DL1 = get_disallowed_list(Config, 0, <<"/">>, <<"policy">>),
+    ?assertEqual(0, length(DL1)),
+    ?assertEqual(false, lists:member(<<"ha-mode">>, DL1)),
+
+    rabbit_ct_broker_helpers:clear_policy(Config, 0, <<".*">>),
+
+    disallow_policy(Config, 0, <<"/">>, <<"ha-sync-mode">>),
+    ?assertEqual({error_string, "'ha-sync-mode' policy is not allowed in vhost '/'"},
+        set_ha_all_policy(Config, 0, <<"/">>, <<".*">>,
+        [{<<"ha-sync-mode">>, <<"automatic">>}])),
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            count_mirrors(Config, 0, Q, <<"/">>) =:= 0
+        end),
+    wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
+
+    DL2 = get_disallowed_list(Config, 0, <<"/">>, <<"policy">>),
+    ?assertEqual(1, length(DL2)),
+    ?assertEqual(true, lists:member(<<"ha-sync-mode">>, DL2)),
+
+    ?assertEqual(ok, set_ha_all_policy(Config, 0, <<"/">>, <<".*">>)),
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            count_mirrors(Config, 0, Q, <<"/">>) =:= 1
+        end),
+    wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
+
+    rabbit_ct_broker_helpers:clear_policy(Config, 0, <<".*">>),
+
+    disallow_policy(Config, 0, <<"/">>, <<"ha-mode">>),
+    ?assertEqual({error_string, "'ha-mode' policy is not allowed in vhost '/'"},
+        set_ha_all_policy(Config, 0, <<"/">>, <<".*">>)),
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            count_mirrors(Config, 0, Q, <<"/">>) =:= 0
+        end),
+    wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
+
+    DL3 = get_disallowed_list(Config, 0, <<"/">>, <<"policy">>),
+    ?assertEqual(2, length(DL3)),
+    ?assertEqual(true, lists:member(<<"ha-mode">>, DL3)),
+    ?assertEqual(true, lists:member(<<"ha-sync-mode">>, DL3)),
+
+    allow_policy(Config, 0, <<"/">>, <<"ha-mode">>),
+    allow_policy(Config, 0, <<"/">>, <<"ha-sync-mode">>),
+    ?assertEqual(ok, set_ha_all_policy(Config, 0, <<"/">>, <<".*">>,
+        [{<<"ha-sync-mode">>, <<"automatic">>}])),
+    rabbit_ct_helpers:await_condition(
+        fun () ->
+            count_mirrors(Config, 0, Q, <<"/">>, get_sync_slave_pids) =:= 1
+        end),
+    wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
+
+    DL4 = get_disallowed_list(Config, 0, <<"/">>, <<"policy">>),
+    ?assertEqual(0, length(DL4)),
+    ?assertEqual(false, lists:member(<<"ha-mode">>, DL4)),
+    ?assertEqual(false, lists:member(<<"ha-sync-mode">>, DL4)),
+
+    rabbit_ct_broker_helpers:clear_policy(Config, 0, <<".*">>),
+
+    get_messages(20, Ch, Q),
+    delete(Ch, Q),
+
+    passed.
+
+%%----------------------------------------------------------------------------
+
+
+declare(Ch, Q) ->
+    amqp_channel:call(Ch, #'queue.declare'{queue     = Q,
+                                           durable   = true}).
+
+delete(Ch, Q) ->
+    amqp_channel:call(Ch, #'queue.delete'{queue = Q}).
+
+publish(Ch, Q, Ps) ->
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    [publish1(Ch, Q, P) || P <- Ps],
+    amqp_channel:wait_for_confirms(Ch).
+
+publish1(Ch, Q, P) ->
+    amqp_channel:cast(Ch, #'basic.publish'{routing_key = Q},
+                      #amqp_msg{props   = props(P),
+                                payload = erlang:md5(term_to_binary(P))}).
+
+publish1(Ch, Q, P, Pd) ->
+    amqp_channel:cast(Ch, #'basic.publish'{routing_key = Q},
+                      #amqp_msg{props   = props(P),
+                                payload = Pd}).
+
+disallow_policy(Config, NodeIndex, Vhost, Attribute) ->
+    rabbit_ct_broker_helpers:rpc(Config, NodeIndex, rabbit_runtime_parameters_acl,
+        disallow, [Vhost, <<"policy">>, Attribute, <<"test-user">>]).
+
+allow_policy(Config, NodeIndex, Vhost, Attribute) ->
+    rabbit_ct_broker_helpers:rpc(Config, NodeIndex, rabbit_runtime_parameters_acl,
+        allow, [Vhost, <<"policy">>, Attribute, <<"test-user">>]).
+
+count_mirrors(Config, NodeIndex, QueueName, Vhost) ->
+    count_mirrors(Config, NodeIndex, QueueName, Vhost, get_slave_pids).
+
+count_mirrors(Config, NodeIndex, QueueName, Vhost, Type) ->
+    rabbit_ct_broker_helpers:rpc(Config, NodeIndex, ?MODULE, count_mirrors_remote,
+        [QueueName, Vhost, Type]).
+
+count_mirrors_remote(QueueName, Vhost, Type) ->
+    {ok, Q} = rabbit_amqqueue:lookup(rabbit_misc:r(Vhost, queue, QueueName)),
+    length(amqqueue:Type(Q)).
+
+get_disallowed_list(Config, NodeIndex, Vhost, Component) ->
+    rabbit_ct_broker_helpers:rpc(Config, NodeIndex, rabbit_runtime_parameters_acl,
+        get_disallowed_list, [Vhost, Component]).
+
+set_ha_all_policy(Config, NodeIndex, Vhost, Pattern) ->
+    set_ha_all_policy(Config, NodeIndex, Vhost, Pattern, []).
+
+set_ha_all_policy(Config, NodeIndex, Vhost, Pattern, Extra) ->
+    rabbit_ct_broker_helpers:rpc(Config, NodeIndex, rabbit_policy, set,
+        [Vhost, Pattern, Pattern, [{<<"ha-mode">>, <<"all">>}]  ++ Extra, 0,
+        <<"queues">>, <<"acting-user">>]).
+
+props(undefined) -> #'P_basic'{delivery_mode = 2};
+props(P)         -> #'P_basic'{priority      = P,
+                               delivery_mode = 2}.
+
+get_empty(Ch, Q) ->
+    #'basic.get_empty'{} = amqp_channel:call(Ch, #'basic.get'{queue = Q}).
+
+get_messages(0, Ch, Q) ->
+    get_empty(Ch, Q);
+get_messages(Number, Ch, Q) ->
+    case amqp_channel:call(Ch, #'basic.get'{queue = Q}) of
+        {#'basic.get_ok'{}, _} ->
+            get_messages(Number - 1, Ch, Q);
+        #'basic.get_empty'{} ->
+            exit(failed)
+    end.
+
+%%----------------------------------------------------------------------------

--- a/deps/rabbit/test/rabbit_runtime_parameters_acl_SUITE.erl
+++ b/deps/rabbit/test/rabbit_runtime_parameters_acl_SUITE.erl
@@ -72,7 +72,7 @@ policies_acl(Config) ->
     publish(Ch, Q, lists:seq(1, 20)),
 
     disallow_policy(Config, 0, <<"/">>, <<"ha-mode">>),
-    ?assertEqual({error_string, "'ha-mode' policy is not allowed in vhost '/'"},
+    ?assertEqual({error_string, "classic mirroring is not allowed in vhost '/'"},
         set_ha_all_policy(Config, 0, <<"/">>, <<".*">>)),
     ?assertEqual(0, count_mirrors(Config, 0, Q, <<"/">>)),
     wait_for_messages(Config, [[Q, <<"20">>, <<"20">>, <<"0">>]]),
@@ -119,7 +119,7 @@ policies_acl(Config) ->
     rabbit_ct_broker_helpers:clear_policy(Config, 0, <<".*">>),
 
     disallow_policy(Config, 0, <<"/">>, <<"ha-mode">>),
-    ?assertEqual({error_string, "'ha-mode' policy is not allowed in vhost '/'"},
+    ?assertEqual({error_string, "classic mirroring is not allowed in vhost '/'"},
         set_ha_all_policy(Config, 0, <<"/">>, <<".*">>)),
     rabbit_ct_helpers:await_condition(
         fun () ->

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -207,6 +207,13 @@
           status = regular,
           context = #{}
         }).
+
+%% Runtime parameter access control list
+-record(runtime_parameters_acl, {
+            component,
+            disallowed_list = []
+        }).
+
 %%----------------------------------------------------------------------------
 
 -define(COPYRIGHT_MESSAGE, "Copyright (c) 2007-2021 VMware, Inc. or its affiliates.").

--- a/deps/rabbit_common/src/rabbit_types.erl
+++ b/deps/rabbit_common/src/rabbit_types.erl
@@ -24,7 +24,7 @@
               proc_type_and_name/0, timestamp/0, tracked_connection_id/0,
               tracked_connection/0, tracked_channel_id/0, tracked_channel/0,
               node_type/0, topic_access_context/0,
-              authz_data/0, authz_context/0]).
+              authz_data/0, authz_context/0, runtime_parameters_acl/0]).
 
 -type(maybe(T) :: T | 'none').
 -type(timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}).
@@ -194,3 +194,7 @@
                                   _ => _}).
 
 -type(authz_context() :: map()).
+
+-type(runtime_parameters_acl() ::
+        #runtime_parameters_acl{component :: {vhost(), binary()},
+                                disallowed_list :: [binary()]}).

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/disable_classic_mirroring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/disable_classic_mirroring_command.ex
@@ -1,0 +1,53 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.DisableClassicMirroringCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide, Helpers}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def switches(), do: [hard: :boolean]
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{vhost: "/", hard: false}, opts)}
+  end
+
+  def validate([_ | _] = args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, vhost: vhost}) do
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_runtime_parameters_acl,
+      :disallow,
+      [vhost, "policy", "ha-mode", Helpers.cli_acting_user()]
+    )
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "disable_classic_mirroring [--vhost <vhost>]"
+
+  def usage_doc_guides() do
+    [
+      DocGuide.mirroring(),
+      DocGuide.parameters()
+    ]
+  end
+
+  def help_section(), do: :parameters
+
+  def description(), do: "Disables HA mirroring for classic queues"
+
+  def banner([], %{vhost: vhost}) do
+    "Disabling HA mirroring for classic queues in vhost \"#{vhost}\" ..."
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/disable_classic_mirroring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/disable_classic_mirroring_command.ex
@@ -9,10 +9,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DisableClassicMirroringCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: [hard: :boolean]
-
   def merge_defaults(args, opts) do
-    {args, Map.merge(%{vhost: "/", hard: false}, opts)}
+    {args, Map.merge(%{vhost: "/"}, opts)}
   end
 
   def validate([_ | _] = args, _) when length(args) > 1 do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_classic_mirroring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_classic_mirroring_command.ex
@@ -1,0 +1,51 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.EnableClassicMirroringCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide, Helpers}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{vhost: "/"}, opts)}
+  end
+
+  def validate([_ | _] = args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, vhost: vhost}) do
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_runtime_parameters_acl,
+      :allow,
+      [vhost, "policy", "ha-mode", Helpers.cli_acting_user()]
+    )
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "enable_classic_mirroring [--vhost <vhost>]"
+
+  def usage_doc_guides() do
+    [
+      DocGuide.mirroring(),
+      DocGuide.parameters()
+    ]
+  end
+
+  def help_section(), do: :parameters
+
+  def description(), do: "Enables HA mirroring for classic queues"
+
+  def banner([], %{vhost: vhost}) do
+    "Enabling HA mirroring for classic queues in vhost \"#{vhost}\" ..."
+  end
+end

--- a/deps/rabbitmq_cli/test/ctl/disable_classic_mirroring_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/disable_classic_mirroring_command_test.exs
@@ -1,0 +1,56 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+
+
+defmodule DisableClassicMirroringCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.DisableClassicMirroringCommand
+
+  @vhost "test1"
+  @policy_name "ha-all-test-policy"
+  @pattern "\.*"
+  @key "ha-mode"
+  @value "{\"ha-mode\":\"all\"}"
+  @component_name "policy"
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    add_vhost @vhost
+    enable_feature_flag :runtime_parameters_acl
+    allow_parameter @vhost, @component_name, @key
+
+    on_exit([], fn ->
+      delete_vhost @vhost
+    end)
+
+    :ok
+  end
+
+  setup _context do
+    {:ok, opts: %{node: get_rabbit_hostname()}}
+  end
+
+  test "validate: no positional arguments passes" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  test "validate: too many positional arguments fails" do
+    assert @command.validate(["soft", "extra"], %{}) ==
+      {:validation_failure, :too_many_args}
+  end
+
+  test "run: disallowed ha policy is successfully not allowed to be set", context do
+    assert match?(:ok, set_policy(@vhost, @policy_name, @pattern, @value))
+    assert match?(:ok, @command.run([], Map.merge(context[:opts], %{vhost: @vhost})))
+    expected_error_string = 'classic mirroring is not allowed in vhost \'#{@vhost}\''
+    assert match?({:error_string, ^expected_error_string},
+                  set_policy(@vhost, @policy_name, @pattern, @value))
+  end
+
+end

--- a/deps/rabbitmq_cli/test/ctl/enable_classic_mirroring_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_classic_mirroring_command_test.exs
@@ -1,0 +1,59 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+
+
+defmodule EnableClassicMirroringCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.EnableClassicMirroringCommand
+
+  @vhost "test1"
+  @policy_name "ha-all-test-policy"
+  @pattern "\.*"
+  @key "ha-mode"
+  @value "{\"ha-mode\":\"all\"}"
+  @component_name "policy"
+
+
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    add_vhost @vhost
+    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters_acl, :ensure_table, [])
+    disallow_parameter @vhost, @component_name, @key
+
+    on_exit([], fn ->
+      allow_parameter @vhost, @component_name, @key
+      delete_vhost @vhost
+    end)
+
+    :ok
+  end
+
+  setup _context do
+    {:ok, opts: %{node: get_rabbit_hostname()}}
+  end
+
+  test "validate: no positional arguments passes" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  test "validate: too many positional arguments fails" do
+    assert @command.validate(["soft", "extra"], %{}) ==
+      {:validation_failure, :too_many_args}
+  end
+
+  test "run: disallowed ha policy is successfully allowed to be set", context do
+    expected_error_string = 'classic mirroring is not allowed in vhost \'#{@vhost}\''
+    assert match?({:error_string, ^expected_error_string},
+                  set_policy(@vhost, @policy_name, @pattern, @value))
+    assert match?(:ok, @command.run([], Map.merge(context[:opts], %{vhost: @vhost})))
+    assert match?(:ok, set_policy(@vhost, @policy_name, @pattern, @value))
+  end
+
+end

--- a/deps/rabbitmq_cli/test/ctl/enable_classic_mirroring_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_classic_mirroring_command_test.exs
@@ -24,6 +24,7 @@ defmodule EnableClassicMirroringCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
 
     add_vhost @vhost
+    enable_feature_flag :runtime_parameters_acl
     :ok = :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters_acl, :ensure_table, [])
     disallow_parameter @vhost, @component_name, @key
 

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -120,6 +120,14 @@ defmodule TestHelper do
     :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :list_global_formatted, [])
   end
 
+  def allow_parameter(vhost, component_name, key) do
+    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters_acl, :allow, [vhost, component_name, key, "acting-user"])
+  end
+
+  def disallow_parameter(vhost, component_name, key) do
+    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters_acl, :disallow, [vhost, component_name, key, "acting-user"])
+  end
+
   def set_permissions(user, vhost, [conf, write, read]) do
     :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :set_permissions, [user, vhost, conf, write, read, "acting-user"])
   end
@@ -131,7 +139,7 @@ defmodule TestHelper do
   def set_policy(vhost, name, pattern, value) do
     {:ok, decoded} = :rabbit_json.try_decode(value)
     parsed = :maps.to_list(decoded)
-    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_policy, :set, [vhost, name, pattern, parsed, 0, "all", "acting-user"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_policy, :set, [vhost, name, pattern, parsed, 0, "all", "acting-user"])
   end
 
   def clear_policy(vhost, key) do


### PR DESCRIPTION
## Proposed Changes

The following changes provide a means of enabling and disabling
HA mirroring for classic queues in a virtual host. The following CLI
commands are implemented:

```
rabbitmqctl -p vhost-1  disable_classic_mirroring
```
```
rabbitmqctl -p vhost-1  enable_classic_mirroring
```

Internally, a generic ACL for runtime parameters is used to manage
the policies and parameters which are allowed/disallowed. Only HA
mirroring is currently implemented.

Reference: https://groups.google.com/g/rabbitmq-users/c/PR5D8GAbWyo


## Sponsors

### This work has been carried out by [Erlang Solutions](https://www.erlang-solutions.com/) and sponsored by [Orange S.A.](https://www.orange.com/en)


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments


