### PR TITLE
Make it possible to use a single channel for message transfers and commands

### DIFF
--- a/deps/rabbitmq_federation/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation/include/rabbit_federation.hrl
@@ -19,7 +19,9 @@
                    ha_policy,
                    name,
                    bind_nowait,
-                   resource_cleanup_mode}).
+                   resource_cleanup_mode,
+                   channel_use_mode
+    }).
 
 -record(upstream_params,
         {uri,

--- a/deps/rabbitmq_federation/src/rabbit_federation_parameters.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_parameters.erl
@@ -87,9 +87,12 @@ shared_validation() ->
      {<<"trust-user-id">>,  fun rabbit_parameter_validation:boolean/2, optional},
      {<<"ack-mode">>,       rabbit_parameter_validation:enum(
                               ['no-ack', 'on-publish', 'on-confirm']), optional},
-     {<<"resource-cleanup-mode">>, rabbit_parameter_validation:enum(['default', 'never']), optional},
+     {<<"resource-cleanup-mode">>, rabbit_parameter_validation:enum(
+                              ['default', 'never']), optional},
      {<<"ha-policy">>,      fun rabbit_parameter_validation:binary/2, optional},
-     {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional}].
+     {<<"bind-nowait">>,    fun rabbit_parameter_validation:boolean/2, optional},
+     {<<"channel-use-mode">>, rabbit_parameter_validation:enum(
+                              ['multiple', 'single']), optional}].
 
 validate_uri(Name, Term) when is_binary(Term) ->
     case rabbit_parameter_validation:binary(Name, Term) of

--- a/deps/rabbitmq_federation/src/rabbit_federation_upstream.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_upstream.erl
@@ -139,7 +139,9 @@ from_upstream_or_set(US, Name, U, XorQ) ->
               ha_policy       = bget('ha-policy',       US, U, none),
               name            = Name,
               bind_nowait     = bget('bind-nowait',     US, U, false),
-              resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"default">>))}.
+              resource_cleanup_mode = to_atom(bget('resource-cleanup-mode', US, U, <<"default">>)),
+              channel_use_mode      = to_atom(bget('channel-use-mode', US, U, multiple))
+    }.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_federation/test/rabbit_federation_test_util.erl
+++ b/deps/rabbitmq_federation/test/rabbit_federation_test_util.erl
@@ -16,14 +16,19 @@
 -import(rabbit_misc, [pget/2]).
 
 setup_federation(Config) ->
+    setup_federation_with_upstream_params(Config, []).
+
+setup_federation_with_upstream_params(Config, ExtraParams) ->
     rabbit_ct_broker_helpers:set_parameter(Config, 0,
       <<"federation-upstream">>, <<"localhost">>, [
         {<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, 0)},
-        {<<"consumer-tag">>, <<"fed.tag">>}]),
+        {<<"consumer-tag">>, <<"fed.tag">>}
+        ] ++ ExtraParams),
 
     rabbit_ct_broker_helpers:set_parameter(Config, 0,
       <<"federation-upstream">>, <<"local5673">>, [
-        {<<"uri">>, <<"amqp://localhost:1">>}]),
+        {<<"uri">>, <<"amqp://localhost:1">>}
+        ] ++ ExtraParams),
 
     rabbit_ct_broker_helpers:set_parameter(Config, 0,
       <<"federation-upstream-set">>, <<"upstream">>, [


### PR DESCRIPTION
For the rare case where federated exchange experience rapid
binding changes. As of rabbitmq/rabbitmq-federation#97,
such environments have a race condition between binding
and message propagation.
