### PR TITLE
Oauth2 cuttlefish support

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/demo/rsa_docker/rabbitmq/rabbitmq.conf
+++ b/deps/rabbitmq_auth_backend_oauth2/demo/rsa_docker/rabbitmq/rabbitmq.conf
@@ -1,0 +1,6 @@
+auth_backends.1 = oauth2
+auth_oauth2.resource_server_id = new_resource_server_id
+auth_oauth2.additional_scopes_key = my_custom_scope_key
+auth_oauth2.default_key = id1
+auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
+auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -1,0 +1,86 @@
+%% ----------------------------------------------------------------------------
+%% RabbitMQ OAuth2 Plugin
+%%
+%% See https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_auth_backend_oauth2/ for details.
+%%
+%% ----------------------------------------------------------------------------
+
+%% A prefix used for scopes in UAA to avoid scope collisions (or unintended overlap). It is an empty string by default.
+%%
+%% {resource_server_id, <<"my_rabbit_server">>},
+
+{mapping,
+ "auth_oauth2.resource_server_id",
+ "rabbitmq_auth_backend_oauth2.resource_server_id",
+ [{datatype, string}]}.
+
+{translation,
+ "rabbitmq_auth_backend_oauth2.resource_server_id",
+ fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.resource_server_id", Conf))
+ end}.
+
+%% Configure the plugin to also look in other fields using additional_scopes_key (maps to additional_rabbitmq_scopes in the old format)
+%%
+%% {additional_rabbitmq_scopes, <<"my_custom_scope_key">>},
+
+{mapping,
+ "auth_oauth2.additional_scopes_key",
+ "rabbitmq_auth_backend_oauth2.additional_rabbitmq_scopes",
+ [{datatype, string}]}.
+
+{translation,
+ "rabbitmq_auth_backend_oauth2.additional_rabbitmq_scopes",
+ fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("auth_oauth2.additional_scopes_key", Conf))
+ end}.
+
+%% ID of the default signing key
+%%
+%% {default_key, <<"key-1">>},
+
+{mapping,
+ "auth_oauth2.default_key",
+ "rabbitmq_auth_backend_oauth2.key_config.default_key",
+ [{datatype, string}]}.
+
+{translation,
+ "rabbitmq_auth_backend_oauth2.key_config.default_key",
+ fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.default_key", Conf)) end}.
+
+%% A map of signing keys
+%%
+%% {signing_keys, #{<<"id1">> => <<"value1">>,<<"id2">> => <<"value2">>}}
+%% validator doesn't work
+
+{mapping,
+ "auth_oauth2.signing_keys.$name",
+ "rabbitmq_auth_backend_oauth2.key_config.signing_keys",
+ [{datatype, file}, {validators, ["file_accessible"]}]}.
+
+{translation,
+ "rabbitmq_auth_backend_oauth2.key_config.signing_keys",
+ fun(Conf) ->
+    case cuttlefish:conf_get("auth_oauth2.signing_keys", Conf, undefined) of
+        none ->
+            #{};
+        _ ->
+            Settings = cuttlefish_variable:filter_by_prefix("auth_oauth2.signing_keys", Conf),
+            Read_file =
+                fun(Path) ->
+                   case file:read_file(Path) of
+                       {ok, Bin} ->
+                           string:trim(Bin, trailing, "\n");
+                       _ ->
+                           % cuttlefish validators don't work for properties with $name
+                           cuttlefish:invalid(["file does not exist or cannot be read by the node: ", Path])
+                   end
+                end,
+            SigningKeys =
+                lists:map(fun(Key) ->
+                             {Id, Path} = Key,
+                             {list_to_binary(lists:last(Id)), Read_file(Path)}
+                          end,
+                          Settings),
+            maps:from_list(SigningKeys)
+    end
+ end}.

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -60,27 +60,22 @@
 {translation,
  "rabbitmq_auth_backend_oauth2.key_config.signing_keys",
  fun(Conf) ->
-    case cuttlefish:conf_get("auth_oauth2.signing_keys", Conf, undefined) of
-        none ->
-            #{};
-        _ ->
-            Settings = cuttlefish_variable:filter_by_prefix("auth_oauth2.signing_keys", Conf),
-            ReadFileFun =
-                fun(Path) ->
-                   case file:read_file(Path) of
-                       {ok, Bin} ->
-                           string:trim(Bin, trailing, "\n");
-                       _ ->
-                           % cuttlefish validators are not invoked for properties with $variables?
-                           cuttlefish:invalid("file does not exist or cannot be read by the node")
-                   end
-                end,
-            SigningKeys =
-                lists:map(fun(Key) ->
-                             {Id, Path} = Key,
-                             {list_to_binary(lists:last(Id)), ReadFileFun(Path)}
-                          end,
-                          Settings),
-            maps:from_list(SigningKeys)
-    end
+    Settings = cuttlefish_variable:filter_by_prefix("auth_oauth2.signing_keys", Conf),
+    TryReadingFileFun =
+        fun(Path) ->
+            case file:read_file(Path) of
+                {ok, Bin} ->
+                    string:trim(Bin, trailing, "\n");
+                _ ->
+                    %% this throws and makes Cuttlefish treak the key as invalid
+                    cuttlefish:invalid("file does not exist or cannot be read by the node")
+            end
+        end,
+    SigningKeys =
+        lists:map(fun(Key) ->
+                        {Id, Path} = Key,
+                        {list_to_binary(lists:last(Id)), TryReadingFileFun(Path)}
+                    end,
+                    Settings),
+    maps:from_list(SigningKeys)
  end}.

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -72,10 +72,8 @@
             end
         end,
     SigningKeys =
-        lists:map(fun(Key) ->
-                        {Id, Path} = Key,
-                        {list_to_binary(lists:last(Id)), TryReadingFileFun(Path)}
-                    end,
-                    Settings),
+        lists:map(fun({Id, Path}) ->
+                    {list_to_binary(lists:last(Id)), TryReadingFileFun(Path)}
+                  end, Settings),
     maps:from_list(SigningKeys)
  end}.

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -71,8 +71,8 @@
                        {ok, Bin} ->
                            string:trim(Bin, trailing, "\n");
                        _ ->
-                           % cuttlefish validators don't work for properties with $name
-                           cuttlefish:invalid(["file does not exist or cannot be read by the node: ", Path])
+                           % cuttlefish validators are not invoked for properties with $variables?
+                           cuttlefish:invalid("file does not exist or cannot be read by the node")
                    end
                 end,
             SigningKeys =

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -65,7 +65,7 @@
             #{};
         _ ->
             Settings = cuttlefish_variable:filter_by_prefix("auth_oauth2.signing_keys", Conf),
-            Read_file =
+            ReadFileFun =
                 fun(Path) ->
                    case file:read_file(Path) of
                        {ok, Bin} ->
@@ -78,7 +78,7 @@
             SigningKeys =
                 lists:map(fun(Key) ->
                              {Id, Path} = Key,
-                             {list_to_binary(lists:last(Id)), Read_file(Path)}
+                             {list_to_binary(lists:last(Id)), ReadFileFun(Path)}
                           end,
                           Settings),
             maps:from_list(SigningKeys)

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE.erl
@@ -1,0 +1,49 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2016-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(config_schema_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [run_snippets].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:run_setup_steps(Config),
+    rabbit_ct_config_schema:init_schemas(rabbitmq_auth_backend_oauth2, Config1).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [{rmq_nodename_suffix, Testcase}]),
+    rabbit_ct_helpers:run_steps(Config1,
+                                rabbit_ct_broker_helpers:setup_steps()
+                                ++ rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 =
+        rabbit_ct_helpers:run_steps(Config,
+                                    rabbit_ct_client_helpers:teardown_steps()
+                                    ++ rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+run_snippets(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, run_snippets1, [Config]).
+
+run_snippets1(Config) ->
+    rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/certs/cacert.pem
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/certs/cacert.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/certs/cert.pem
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/certs/cert.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/certs/key.pem
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/certs/key.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -1,9 +1,25 @@
 [
   {oauth2_pem_config2,
-       "auth_oauth2.resource_server_id = new_resource_server_id",
+       "auth_oauth2.resource_server_id = new_resource_server_id
+        auth_oauth2.additional_scopes_key = my_custom_scope_key
+        auth_oauth2.default_key = id1
+        auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
+        auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem",
         [
         {rabbitmq_auth_backend_oauth2, [
-            {resource_server_id,<<"new_resource_server_id">>}]}
-        ]
+            {resource_server_id,<<"new_resource_server_id">>},
+            {additional_rabbitmq_scopes, <<"my_custom_scope_key">>},
+            {key_config, [
+            {default_key, <<"id1">>},
+            {signing_keys,
+                #{
+                    <<"id1">> => <<"I'm not a certificate">>,
+                    <<"id2">> => <<"I'm not a certificate">>
+                }
+            }
+            ]
+            }
+        ]}
+        ],[]
   }
 ].

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -1,0 +1,9 @@
+[
+  {oauth2_pem_config2,
+       "auth_oauth2.resource_server_id = new_resource_server_id",
+        [
+        {rabbitmq_auth_backend_oauth2, [
+            {resource_server_id,<<"new_resource_server_id">>}]}
+        ]
+  }
+].


### PR DESCRIPTION
This PR adds support for cuttlefish-syntax configuration to the OAuth2 plugin.

Symmetric key configuration still requires the old syntax and therefore can be configured using advanced config file.

Closes #2550 