### PR TITLE
Fix the docker image for use with uncompressed plugins

### DIFF
--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -275,21 +275,27 @@ RUN rabbitmq-plugins enable --offline rabbitmq_management && \
     rabbitmq-plugins is_enabled rabbitmq_management --offline
 # extract "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z.ez" plugin zipfile
 # see https://github.com/docker-library/rabbitmq/issues/207
+# RabbitMQ 3.9 onwards uses uncompressed plugins by default, in which case extraction is
+# unnecesary
 RUN set -eux; \
-	erl -noinput -eval ' \
-		{ ok, AdminBin } = zip:foldl(fun(FileInArchive, GetInfo, GetBin, Acc) -> \
-			case Acc of \
-				"" -> \
-					case lists:suffix("/rabbitmqadmin", FileInArchive) of \
-						true -> GetBin(); \
-						false -> Acc \
-					end; \
-				_ -> Acc \
-			end \
-		end, "", init:get_plain_arguments()), \
-		io:format("~s", [ AdminBin ]), \
-		init:stop(). \
-	' -- /plugins/rabbitmq_management-*.ez > /usr/local/bin/rabbitmqadmin; \
+	if [ -s /plugins/rabbitmq_management-*.ez ]; then \
+		erl -noinput -eval ' \
+			{ ok, AdminBin } = zip:foldl(fun(FileInArchive, GetInfo, GetBin, Acc) -> \
+				case Acc of \
+					"" -> \
+						case lists:suffix("/rabbitmqadmin", FileInArchive) of \
+							true -> GetBin(); \
+							false -> Acc \
+						end; \
+					_ -> Acc \
+				end \
+			end, "", init:get_plain_arguments()), \
+			io:format("~s", [ AdminBin ]), \
+			init:stop(). \
+		' -- /plugins/rabbitmq_management-*.ez > /usr/local/bin/rabbitmqadmin; \
+	else \
+		cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
+	fi; \
 	[ -s /usr/local/bin/rabbitmqadmin ]; \
 	chmod +x /usr/local/bin/rabbitmqadmin; \
 	apt-get update; apt-get install -y --no-install-recommends python3; rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
Historically the docker image build extracts the rabbitmqadmin cli from the
management .ez. This step is now conditional.

This should address #2837