### PR TITLE
Clean up rabbit_fifo_usage table on queue.delete

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -677,7 +677,8 @@ state_enter(eol, #?MODULE{enqueuers = Enqs,
     AllConsumers = maps:merge(Custs, WaitingConsumers1),
     [{send_msg, P, eol, ra_event}
      || P <- maps:keys(maps:merge(Enqs, AllConsumers))] ++
-        [{mod_call, rabbit_quorum_queue, file_handle_release_reservation, []}];
+                   [{aux, eol},
+                    {mod_call, rabbit_quorum_queue, file_handle_release_reservation, []}];
 state_enter(State, #?MODULE{cfg = #cfg{resource = _Resource}}) when State =/= leader ->
     FHReservation = {mod_call, rabbit_quorum_queue, file_handle_other_reservation, []},
     [FHReservation];
@@ -789,6 +790,9 @@ handle_aux(_RaState, cast, tick, #aux{name = Name,
     true = ets:insert(rabbit_fifo_usage,
                       {Name, utilisation(Use0)}),
     Aux = eval_gc(Log, MacState, State0),
+    {no_reply, Aux, Log};
+handle_aux(_RaState, cast, eol, #aux{name = Name} = Aux, Log, _) ->
+    ets:delete(rabbit_fifo_usage, Name),
     {no_reply, Aux, Log};
 handle_aux(_RaState, {call, _From}, {peek, Pos}, Aux0,
            Log0, MacState) ->

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -1036,7 +1036,8 @@ single_active_consumer_state_enter_eol_include_waiting_consumers_test(_) ->
     Effects = rabbit_fifo:state_enter(eol, State1),
     %% 1 effect for each consumer process (channel process),
     %% 1 effect for file handle reservation
-    ?assertEqual(4, length(Effects)).
+    %% 1 effect for eol to handle rabbit_fifo_usage entries
+    ?assertEqual(5, length(Effects)).
 
 query_consumers_test(_) ->
     State0 = init(#{name => ?FUNCTION_NAME,


### PR DESCRIPTION
The entries on the `rabbit_fifo_usage` table used to calculate `consumer_capacity` were never cleared on `queue.delete`. A very high queue churn - unlikely if quorum queues are used properly - could potentially cause unbounded memory growth.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

