### PR TITLE
rabbitmq-server-ha OCF fixes

### DIFF
--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -811,6 +811,10 @@ block_client_access()
 
 unblock_client_access()
 {
+    local lhtext="none"
+    if [ -z $1 ] ; then
+        lhtext=$1
+    fi
     # When OCF_RESKEY_avoid_using_iptables is true iptables calls are noops
     if [ "${OCF_RESKEY_avoid_using_iptables}" == 'true' ] ; then
         return
@@ -820,6 +824,7 @@ unblock_client_access()
       iptables --wait -D INPUT -p tcp -m tcp --dport ${OCF_RESKEY_node_port} -m state --state NEW,RELATED,ESTABLISHED \
       -m comment --comment 'temporary RMQ block' -j REJECT --reject-with tcp-reset
     done
+    ocf_log info "${lhtext} unblocked access to RMQ port"
 }
 
 get_nodes__base(){
@@ -1369,7 +1374,7 @@ start_rmq_server_app() {
 
     ocf_log info "${LH} begin."
     # Safe-unblock the rules, if there are any
-    unblock_client_access
+    unblock_client_access "${LH}"
     # Apply the blocking rule
     block_client_access
     rc=$?
@@ -1386,8 +1391,7 @@ start_rmq_server_app() {
         start_beam_process
         rc=$?
         if [ $rc -ne $OCF_SUCCESS ]; then
-            unblock_client_access
-            ocf_log info "${LH} unblocked access to RMQ port"
+            unblock_client_access "${LH}"
             return $OCF_ERR_GENERIC
         fi
     fi
@@ -1403,8 +1407,7 @@ start_rmq_server_app() {
         if [ $rc -ne 0 ] ; then
             ocf_log err "${LH} RMQ-server app can't be stopped. Beam will be killed."
             kill_rmq_and_remove_pid
-            unblock_client_access
-            ocf_log info "${LH} unblocked access to RMQ port"
+            unblock_client_access "${LH}"
             return $OCF_ERR_GENERIC
         fi
     else
@@ -1426,8 +1429,7 @@ start_rmq_server_app() {
                 else
                     ocf_log err "${LH} RMQ-server app can't be stopped during Mnesia cleaning. Beam will be killed."
                     kill_rmq_and_remove_pid
-                    unblock_client_access
-                    ocf_log info "${LH} unblocked access to RMQ port"
+                    unblock_client_access "${LH}"
                     return $OCF_ERR_GENERIC
                 fi
             fi
@@ -1438,8 +1440,7 @@ start_rmq_server_app() {
          kill_rmq_and_remove_pid
     fi
     ocf_log info "${LH} end."
-    unblock_client_access
-    ocf_log info "${LH} unblocked access to RMQ port"
+    unblock_client_access "${LH}"
     return $rc
 }
 

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -53,6 +53,7 @@ OCF_RESKEY_rmq_feature_health_check_default=true
 OCF_RESKEY_rmq_feature_local_list_queues_default=true
 OCF_RESKEY_limit_nofile_default=65535
 OCF_RESKEY_avoid_using_iptables_default=false
+OCF_RESKEY_allowed_cluster_nodes_default=""
 
 : ${HA_LOGTAG="lrmd"}
 : ${HA_LOGFACILITY="daemon"}
@@ -80,6 +81,7 @@ OCF_RESKEY_avoid_using_iptables_default=false
 : ${OCF_RESKEY_rmq_feature_local_list_queues=${OCF_RESKEY_rmq_feature_local_list_queues_default}}
 : ${OCF_RESKEY_limit_nofile=${OCF_RESKEY_limit_nofile_default}}
 : ${OCF_RESKEY_avoid_using_iptables=${OCF_RESKEY_avoid_using_iptables_default}}
+: ${OCF_RESKEY_allowed_cluster_nodes=${OCF_RESKEY_allowed_cluster_nodes_default}}
 
 #######################################################################
 
@@ -366,6 +368,18 @@ noops. This is useful when we run inside containers.
 </longdesc>
 <shortdesc lang="en">Disable iptables use entirely</shortdesc>
 <content type="boolean" default="${OCF_RESKEY_avoid_using_iptables_default}" />
+</parameter>
+
+<parameter name="allowed_cluster_nodes" unique="0" required="0">
+<longdesc lang="en">
+When set to anything other than the empty string it must container the list of
+cluster node names, separated by spaces, where the rabbitmq resource is allowed to run.
+Tis is needed when rabbitmq is running on a subset of nodes part of a larger
+cluster. The default ("") is to assume that all nodes part of the cluster will
+run the rabbitmq resource.
+</longdesc>
+<shortdesc lang="en">List of cluster nodes where rabbitmq is allowed to run</shortdesc>
+<content type="string" default="${OCF_RESKEY_allowed_cluster_nodes}" />
 </parameter>
 
 $EXTENDED_OCF_PARAMS
@@ -845,10 +859,18 @@ get_running_nodes() {
 get_alive_pacemaker_nodes_but()
 {
     if [ -z "$1" ]; then
-        echo `crm_node -l -p | sed -e '/(null)/d'`
+        tmp_pcmk_node_list=`crm_node -l -p | sed -e '/(null)/d'`
     else
-        echo `crm_node -l -p | sed -e "s/${1}//g" | sed -e '/(null)/d'`
+        tmp_pcmk_node_list=`crm_node -l -p | sed -e "s/${1}//g" | sed -e '/(null)/d'`
     fi
+    # If OCF_RESKEY_allowed_cluster_nodes is set then we only want the intersection
+    # of the cluster node output and the allowed_cluster_nodes list
+    if [ -z "${OCF_RESKEY_allowed_cluster_nodes}" ]; then
+      pcmk_node_list=$tmp_pcmk_node_list
+    else
+      pcmk_node_list=`for i in $tmp_pcmk_node_list ${OCF_RESKEY_allowed_cluster_nodes}; do echo $i; done | sort | uniq -d`
+    fi
+    echo $pcmk_node_list
 }
 
 # Get current master. If a parameter is provided,

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -693,7 +693,9 @@ rmq_setup_env() {
     local dir
     H="$(get_hostname)"
     export RABBITMQ_NODENAME=$(rabbit_node_name $H)
-    export RABBITMQ_NODE_PORT=$OCF_RESKEY_node_port
+    if [ "$OCF_RESKEY_node_port" != "$OCF_RESKEY_node_port_default" ]; then
+        export RABBITMQ_NODE_PORT=$OCF_RESKEY_node_port
+    fi
     export RABBITMQ_PID_FILE=$OCF_RESKEY_pid_file
     MNESIA_FILES="${OCF_RESKEY_mnesia_base}/$(rabbit_node_name $H)"
     RMQ_START_TIME="${MNESIA_FILES}/ocf_server_start_time.txt"


### PR DESCRIPTION
## Proposed Changes

These three commits are (hopefully the last ones) needed to get the rabbitmq-server-ha ocf on par with another, older, resource agent for rabbitmq HA (https://github.com/ClusterLabs/resource-agents/blob/master/heartbeat/rabbitmq-cluster)
With these changes I am finally able to deploy an openstack control plane using more than three controllers and with tls-everywhere enabled.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fix a couple of limitations in the current RA)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

I did test all patches in my environment (both with and without TLS). 

## Further Comments

The rough plan with these patches is to get this OCF resource agent on par with https://github.com/ClusterLabs/resource-agents/blob/master/heartbeat/rabbitmq-cluster, add support for this resource agent in our openstack deployment framework (https://review.opendev.org/c/openstack/puppet-tripleo/+/685068). Then the idea, time/resources allowing, is to test all our failure scenarios with the new RA, validate all our use cases and finally switch to this one by default and deprecate the one at clusterlabs.org.
