### PR TITLE
Replace Async threads warning with Dirty I/O schedulers warning

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -271,7 +271,7 @@
 
 -define(APPS, [os_mon, mnesia, rabbit_common, rabbitmq_prelaunch, ra, sysmon_handler, rabbit, osiris]).
 
--define(ASYNC_THREADS_WARNING_THRESHOLD, 8).
+-define(DIRTY_IO_SCHEDULERS_WARNING_THRESHOLD, 10).
 
 %% 1 minute
 -define(BOOT_START_TIMEOUT,     1 * 60 * 1000).
@@ -1230,11 +1230,11 @@ warn_if_kernel_config_dubious() ->
                            "and CPU utilization may worsen.~n")
             end
     end,
-    AsyncThreads = erlang:system_info(thread_pool_size),
-    case AsyncThreads < ?ASYNC_THREADS_WARNING_THRESHOLD of
+    DirtyIOSchedulers = erlang:system_info(dirty_io_schedulers),
+    case DirtyIOSchedulers < ?DIRTY_IO_SCHEDULERS_WARNING_THRESHOLD of
         true  -> rabbit_log:warning(
-                   "Erlang VM is running with ~b I/O threads, "
-                   "file I/O performance may worsen~n", [AsyncThreads]);
+                   "Erlang VM is running with ~b dirty I/O schedulers, "
+                   "file I/O performance may worsen~n", [DirtyIOSchedulers]);
         false -> ok
     end,
     IDCOpts = case application:get_env(kernel, inet_default_connect_options) of


### PR DESCRIPTION
Async threads are basically not used these days - there is no reason to warn about a low number of them (the default is 1 so the warning is displayed in almost all environments). Dirty I/O schedulers, on the other hand, are used a lot so we can warn when there are only a few (the default in Erlang is 10 so I made it the warning threshold).