### PR TITLE
WIP Add metric for quorum queue availability

### DIFF
--- a/deps/rabbitmq_prometheus/erlang.mk
+++ b/deps/rabbitmq_prometheus/erlang.mk
@@ -6640,7 +6640,7 @@ help::
 		"  ct          Run all the common_test suites for this project" \
 		"" \
 		"All your common_test suites have their associated targets." \
-		"A suite named http_SUITE can be ran using the ct-http target."
+		"A suite named http_SUITE can be run using the ct-http target."
 
 # Plugin-specific targets.
 

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -202,6 +202,7 @@ aggregated_metrics_test(Config) ->
     ?assertEqual(match, re:run(Body, "^# TYPE", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^# HELP", [{capture, none}, multiline])),
     ?assertEqual(nomatch, re:run(Body, ?config(queue_name, Config), [{capture, none}])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_queues_up 1$", [{capture, none}, multiline])),
     %% Check the first metric value from each ETS table owned by rabbitmq_metrics
     ?assertEqual(match, re:run(Body, "^rabbitmq_channel_consumers ", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_channel_messages_published_total ", [{capture, none}, multiline])),
@@ -238,6 +239,7 @@ per_object_metrics_test(Config, Path) ->
     ?assertEqual(match, re:run(Body, "^# TYPE", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^# HELP", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, ?config(queue_name, Config), [{capture, none}])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_queues_up{.*} 1$", [{capture, none}, multiline])),
     %% Check the first metric value from each ETS table owned by rabbitmq_metrics
     ?assertEqual(match, re:run(Body, "^rabbitmq_channel_consumers{", [{capture, none}, multiline])),
     ?assertEqual(match, re:run(Body, "^rabbitmq_channel_messages_published_total{", [{capture, none}, multiline])),


### PR DESCRIPTION
**Why this change?**
Having a metric reporting availability for a quorum queue enables us to define alerts if quorum queues are down and to define SLOs on quorum queue availability.

**How this change has been tested**:

1. Built docker image, deployed on 3-node K8s cluster.
2. Declared quorum queue `A` with leader on node 0.
3. Declared quorum queue `B` with leader on node 1.
4. ` kubectl exec r-server-2 -- rabbitmqctl stop_app`
5. ` kubectl exec r-server-1 -- rabbitmqctl stop_app`
6. The following PromQL alerting rule will result in 2 active alerts (one for `A`, one for `B`):

```yaml
# Alert if some node reports that a quorum queue exists without having the leader reporting that the quorurm queue is up.
# This alert covers the following two use cases:
# 1. Leader explicitly reports that quorum queue is down because ra:consistent_query() failed - i.e. leader is live, but doesn't have a majority.
# 2. No rabbitmq_quorum_queues_up got reported for a quorum queue although some node reported that the quorum queue exists. This happens if there is no leader at all but at least a follower or candidate is live.
# NB: This alert will NOT fire if ALL replicas of a quorum queue are down (since we can't differentiate between deleted quorum queues and all replicas are down). In future, we can solve this by having the messaging topology operator report the desired quorum queues.
# Prerequisite for this alert to fire is `prometheus.return_per_object_metrics = true`.
- alert: QuorumQueueDown
  expr: |
    group by (namespace, rabbitmq_cluster, vhost, queue) (rabbitmq_raft_term_total{queue!=""} * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info)
    unless on(namespace, rabbitmq_cluster, vhost, queue)
    max by (namespace, rabbitmq_cluster, vhost, queue) (rabbitmq_quorum_queues_up * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info) == 1
  for: 15m
  labels:
    severity: warning
  annotations:
    description: "Quorum queue `{{ $labels.queue }}` is unavailable in vhost `{{ $labels.vhost }}` in RabbitMQ cluster `{{ $labels.rabbitmq_cluster }}` in namespace `{{ $labels.namespace }}`."
    summary: |
      This alert fires if nodes report that a quorum queue exists for which no majority is available.
      For example, in a 3-node RabbitMQ cluster with a 3-replicas quorum queue, this alert fires if 2 out of 3 replicas are down.
      Check the logs of the RabbitMQ nodes: `kubectl -n {{ $labels.namespace }} logs --tail 100 -l app.kubernetes.io/component=rabbitmq,app.kubernetes.io/name={{ $labels.rabbitmq_cluster }} | grep {{ $labels.queue }}`
```



**Implementation Details**

- The per-object metric returns `1` for up, and `0` for down.
- The aggregated metric returns the sum of quorum queues having a leader on this node for which the leader reports that a majority is available in the Raft cluster.
- Reuse ETS table `queue_metrics` since it already gets initialised and destroyed for us. This table already contains different metrics depending on queue type.
- I first implemented a version where `ra:consistent_query()` is only executed if `prometheus.return_per_object_metrics = true` to not cause unnecessary load. However, this results in `/metrics/per-object` endpoint to not contain this new metric. Therefore, I discarded that optimisation again.

**Open questions**
- In certain scenarios `ra:consistent_query()` failed although I could write to and read from the quorum queue and all replicas were up. This happens for example after nodes were restarted. It took a while (10 - 90 seconds) until the query was successful again. It seems that `ra:consistent_query()` is stricter than a "leader is active and has a majority" check. Should we therefore rename the metric from `rabbitmq_quorum_queues_up` to `rabbitmq_quorum_queues_consistent`?
- As of now, a  `ra:consistent_query()` is executed every 5 seconds (configured via [TICK_TIMEOUT](https://github.com/rabbitmq/rabbitmq-server/blob/4465071820e143d8f380baca9dd2b4802da42840/deps/rabbit/src/rabbit_quorum_queue.erl#L90)). It's sufficient to execute the check less often. (I expected increasing `collect_statistics_interval` results in collecting statistics less often for a quorum queue. However, this configuration setting didn't have any effect at all on quorum queue statistics. It seems to apply primarily to the management plugin.) Increasing `TICK_TIMEOUT` seems to have other side effects since this value is not only used for how often [tick/2](https://github.com/rabbitmq/rabbitmq-server/blob/4465071820e143d8f380baca9dd2b4802da42840/deps/rabbit/src/rabbit_fifo.erl#L692-L710) is called, but also used for leader election algorithm in Ra. Do you think it's necessary to execute the check less often? If so, should we either add a new variable to the Raft state which is only used for how often `tick/2` is called? Or, should we instead write a timestamp into the `queue_metrics` ETS table in addition to (or instead of) the `{up, 1}` when having executed a `ra:consistent_query()` and in the next tick only execute `ra:consistent_query()` if the timestamp is old enough (e.g. older than 15 seconds)? Looking at Prometheus best practices, it's cleaner to simply report `1` for "up" instead of reporting a timestamp.

