### PR TITLE
pg2 => pg for OTP 24 compatibility

### DIFF
--- a/deps/rabbitmq_federation/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation/include/rabbit_federation.hrl
@@ -44,3 +44,5 @@
 -define(DEF_PREFETCH, 1000).
 
 -define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/federation.html">>).
+
+-define(FEDERATION_PG_SCOPE, rabbitmq_federation_pg_scope).

--- a/deps/rabbitmq_federation/src/rabbit_federation_app.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_app.erl
@@ -10,7 +10,7 @@
 -include("rabbit_federation.hrl").
 
 -behaviour(application).
--export([start/2, stop/1, start_federation_links/0]).
+-export([start/2, stop/1]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
 %% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
@@ -29,16 +29,11 @@
 -export([init/1]).
 
 start(_Type, _StartArgs) ->
-    _ = timer:apply_after(500, ?MODULE, start_federation_links, []),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 stop(_State) ->
     rabbit_federation_pg:stop_scope(),
     ok.
-
-start_federation_links() ->
-    rabbit_federation_exchange_link:go(),
-    rabbit_federation_queue_link:go().
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_federation/src/rabbit_federation_app.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_app.erl
@@ -10,7 +10,7 @@
 -include("rabbit_federation.hrl").
 
 -behaviour(application).
--export([start/2, stop/1]).
+-export([start/2, stop/1, start_federation_links/0]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
 %% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
@@ -29,13 +29,17 @@
 -export([init/1]).
 
 start(_Type, _StartArgs) ->
-    rabbit_federation_exchange_link:go(),
-    rabbit_federation_queue_link:go(),
+    _ = timer:apply_after(500, ?MODULE, start_federation_links, []),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 stop(_State) ->
     rabbit_federation_pg:stop_scope(),
     ok.
+
+start_federation_links() ->
+    rabbit_federation_exchange_link:go(),
+    rabbit_federation_queue_link:go().
+
 %%----------------------------------------------------------------------------
 
 init([]) ->

--- a/deps/rabbitmq_federation/src/rabbit_federation_app.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_app.erl
@@ -7,6 +7,8 @@
 
 -module(rabbit_federation_app).
 
+-include("rabbit_federation.hrl").
+
 -behaviour(application).
 -export([start/2, stop/1]).
 
@@ -32,7 +34,14 @@ start(_Type, _StartArgs) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 stop(_State) ->
+    rabbit_federation_pg:stop_scope(),
     ok.
 %%----------------------------------------------------------------------------
 
-init([]) -> {ok, {{one_for_one, 3, 10}, []}}.
+init([]) ->
+    Flags = #{
+        strategy  => one_for_one,
+        intensity => 3,
+        period    => 10
+    },
+    {ok, {Flags, []}}.

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
@@ -256,7 +256,8 @@ x(XName) ->
 
 %%----------------------------------------------------------------------------
 
-federation_up() -> is_pid(whereis(rabbit_federation_app)).
+federation_up() ->
+    is_pid(whereis(rabbit_federation_app)).
 
 handle_command({add_binding, Binding}, State) ->
     add_binding(Binding, State);

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -21,6 +21,11 @@
 %%----------------------------------------------------------------------------
 
 start_link() ->
+    _ = pg:start_link(),
+    %% This scope is used by concurrently starting exchange and queue links,
+    %% and other places, so we have to start it very early outside of the supervision tree.
+    %% The scope is stopped in stop/1.
+    rabbit_federation_pg:start_scope(),
     mirrored_supervisor:start_link({local, ?SUPERVISOR}, ?SUPERVISOR,
                                    fun rabbit_misc:execute_mnesia_transaction/1,
                                    ?MODULE, []).

--- a/deps/rabbitmq_federation/src/rabbit_federation_pg.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_pg.erl
@@ -1,0 +1,25 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_federation_pg).
+
+-include("rabbit_federation.hrl").
+
+-export([start_scope/0, stop_scope/0]).
+
+start_scope() ->
+  rabbit_log_federation:debug("Starting pg scope ~s", [?FEDERATION_PG_SCOPE]),
+  _ = pg:start_link(?FEDERATION_PG_SCOPE).
+
+stop_scope() ->
+  case whereis(?FEDERATION_PG_SCOPE) of
+      Pid when is_pid(Pid) ->
+          rabbit_log_federation:debug("Stopping pg scope ~s", [?FEDERATION_PG_SCOPE]),
+          exit(Pid, normal);
+      _ ->
+          ok
+  end.

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -43,7 +43,7 @@ join(Name) ->
     ok = pg:join(?FEDERATION_PG_SCOPE, pgname(Name), self()).
 
 all() ->
-    pg:get_members(pgname(rabbit_federation_queues)).
+    pg:get_members(?FEDERATION_PG_SCOPE, pgname(rabbit_federation_queues)).
 
 q(QName) ->
     case pg:get_members(?FEDERATION_PG_SCOPE, pgname({rabbit_federation_queue, QName})) of

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -54,8 +54,7 @@ q(QName) ->
     end.
 
 federation_up() ->
-    proplists:is_defined(rabbitmq_federation,
-                         application:which_applications(infinity)).
+    is_pid(whereis(rabbit_federation_app)).
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -53,10 +53,10 @@ q(QName) ->
             Members
     end.
 
+%%----------------------------------------------------------------------------
+
 federation_up() ->
     is_pid(whereis(rabbit_federation_app)).
-
-%%----------------------------------------------------------------------------
 
 init({Upstream, Queue}) when ?is_amqqueue(Queue) ->
     QName = amqqueue:get_name(Queue),
@@ -85,7 +85,9 @@ handle_call(Msg, _From, State) ->
 handle_cast(maybe_go, State) ->
     case federation_up() of
         true  -> go(State);
-        false -> {noreply, State}
+        false ->
+            _ = timer:apply_after(1000, ?MODULE, go, []),
+            {noreply, State}
     end;
 
 handle_cast(go, State = #not_started{}) ->

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link_sup_sup.erl
@@ -22,6 +22,11 @@
 %%----------------------------------------------------------------------------
 
 start_link() ->
+    _ = pg:start_link(),
+    %% This scope is used by concurrently starting exchange and queue links,
+    %% and other places, so we have to start it very early outside of the supervision tree.
+    %% The scope is stopped in stop/1.
+    rabbit_federation_pg:start_scope(),
     mirrored_supervisor:start_link({local, ?SUPERVISOR}, ?SUPERVISOR,
                                    fun rabbit_misc:execute_mnesia_transaction/1,
                                    ?MODULE, []).

--- a/deps/rabbitmq_federation/test/queue_SUITE.erl
+++ b/deps/rabbitmq_federation/test/queue_SUITE.erl
@@ -274,6 +274,7 @@ dynamic_plugin_stop_start(Config) ->
           expect_federation(Ch, UpQ, DownQ2, ?EXPECT_FEDERATION_TIMEOUT),
 
           %% Disable the plugin, the link disappears
+          ct:pal("Stopping rabbitmq_federation"),
           ok = rabbit_ct_broker_helpers:disable_plugin(Config, 0, "rabbitmq_federation"),
 
           expect_no_federation(Ch, UpQ, DownQ1),
@@ -281,7 +282,9 @@ dynamic_plugin_stop_start(Config) ->
 
           declare_queue(Ch, q(DownQ1, Args)),
           declare_queue(Ch, q(DownQ2, Args)),
+          ct:pal("Re-starting rabbitmq_federation"),
           ok = rabbit_ct_broker_helpers:enable_plugin(Config, 0, "rabbitmq_federation"),
+          timer:sleep(?INITIAL_WAIT),
 
           %% Declare a queue then re-enable the plugin, the links appear
           wait_for_federation(

--- a/deps/rabbitmq_management/include/rabbit_mgmt.hrl
+++ b/deps/rabbitmq_management/include/rabbit_mgmt.hrl
@@ -18,5 +18,5 @@
 
 -define(HEALTH_CHECK_FAILURE_STATUS, 503).
 
--define(MANAGEMENT_PG_SCOPE, rabbit_mgmt).
+-define(MANAGEMENT_PG_SCOPE, rabbitmq_management).
 -define(MANAGEMENT_PG_GROUP, management_db).

--- a/deps/rabbitmq_management_agent/include/rabbit_mgmt_agent.hrl
+++ b/deps/rabbitmq_management_agent/include/rabbit_mgmt_agent.hrl
@@ -14,5 +14,5 @@
 %% Copyright (c) 2020-2021 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
--define(MANAGEMENT_PG_SCOPE, rabbit_mgmt).
+-define(MANAGEMENT_PG_SCOPE, rabbitmq_management).
 -define(MANAGEMENT_PG_GROUP, management_db).


### PR DESCRIPTION
there is still one failing queue federation test.

Since `pg` is not available in OTP 22, this would lose OTP 22 compatibility.
