### PR TITLE
Remove federation_up/0 check

### DIFF
--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
@@ -92,12 +92,7 @@ handle_call(Msg, _From, State) ->
     {stop, {unexpected_call, Msg}, State}.
 
 handle_cast(maybe_go, State = {not_started, _Args}) ->
-    case federation_up() of
-        true  -> go(State);
-        false ->
-            _ = timer:apply_after(1000, ?MODULE, go, []),
-            {noreply, State}
-    end;
+    go(State);
 
 handle_cast(go, S0 = {not_started, _Args}) ->
     go(S0);

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -83,12 +83,7 @@ handle_call(Msg, _From, State) ->
     {stop, {unexpected_call, Msg}, State}.
 
 handle_cast(maybe_go, State) ->
-    case federation_up() of
-        true  -> go(State);
-        false ->
-            _ = timer:apply_after(1000, ?MODULE, go, []),
-            {noreply, State}
-    end;
+    go(State);
 
 handle_cast(go, State = #not_started{}) ->
     go(State);


### PR DESCRIPTION
Decorators are only executed if the plugin is enabled (registered in
rabbit_queue_decorator), thus initialising the links through `startup`.
There is no obvious way for a fed link to start if the plugin isn't running,
so this check can be removed.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

