### PR TITLE
Use AMQP subject for routing key in AMQP 1.0 source shovels.

### DIFF
--- a/deps/amqp10_client/src/amqp10_msg.erl
+++ b/deps/amqp10_client/src/amqp10_msg.erl
@@ -11,6 +11,7 @@
          % "read" api
          delivery_id/1,
          delivery_tag/1,
+         subject/1,
          handle/1,
          settled/1,
          message_format/1,
@@ -124,6 +125,10 @@ to_amqp_records(#amqp10_msg{transfer = T,
 -spec delivery_tag(amqp10_msg()) -> delivery_tag().
 delivery_tag(#amqp10_msg{transfer = #'v1_0.transfer'{delivery_tag = Tag}}) ->
     unpack(Tag).
+
+-spec subject(amqp10_msg()) -> string().
+subject(#amqp10_msg{properties = #'v1_0.properties'{subject = Subject}}) ->
+    unpack(Subject).
 
 -spec delivery_id(amqp10_msg()) -> non_neg_integer().
 delivery_id(#amqp10_msg{transfer = #'v1_0.transfer'{delivery_id = Id}}) ->

--- a/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
@@ -155,7 +155,12 @@ forward(IncomingTag, Props, Payload,
     SrcUri = rabbit_shovel_behaviour:source_uri(State0),
     % do publish
     Exchange = maps:get(exchange, Props, undefined),
-    RoutingKey = maps:get(routing_key, Props, undefined),
+    % If no routing key is set or routing key is undefined, use an empty string.
+    RoutingKey = case maps:get(routing_key, Props, undefined) of
+        undefined -> <<"">>;
+        Value     -> Value
+    end,
+
     Method = #'basic.publish'{exchange = Exchange, routing_key = RoutingKey},
     Method1 = FieldsFun(SrcUri, DstUri, Method),
     Msg1 = #amqp_msg{props = PropsFun(SrcUri, DstUri, props_from_map(Props)),

--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -175,7 +175,8 @@ dest_endpoint(#{shovel_type := dynamic,
 handle_source({amqp10_msg, _LinkRef, Msg}, State) ->
     Tag = amqp10_msg:delivery_id(Msg),
     Payload = amqp10_msg:body_bin(Msg),
-    rabbit_shovel_behaviour:forward(Tag, #{}, Payload, State);
+    Subject = amqp10_msg:subject(Msg),
+    rabbit_shovel_behaviour:forward(Tag, #{routing_key => Subject}, Payload, State);
 handle_source({amqp10_event, {connection, Conn, opened}},
               State = #{source := #{current := #{conn := Conn}}}) ->
     State;

--- a/deps/rabbitmq_shovel/test/amqp10_shovel_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_shovel_SUITE.erl
@@ -84,8 +84,10 @@ amqp_encoded_data_list(_Config) ->
 amqp_encoded_amqp_value(_Config) ->
     meck:new(rabbit_shovel_behaviour, [passthrough]),
     meck:expect(rabbit_shovel_behaviour, forward,
-                fun (_, _, Pay, S) ->
+                fun (_, Props, Pay, S) ->
+                        RoutingKey = maps:get(routing_key, Props, undefined),
                         ?assert(erlang:is_binary(Pay)),
+                        ?assertNot(RoutingKey, undefined),
                         S
                 end),
     %% fake some shovel state


### PR DESCRIPTION
## Proposed Changes

In dynamic shovels, `dst-exchange-key` may be omitted. In such a case, the source routing key, or, in case of AMQP 1.0 source shovels, the AMQP 1.0 `subject` is supposed to be used as routing key. However, as discussed in https://groups.google.com/g/rabbitmq-users/c/3n0lNVmVbNo, this does not work for AMQP 1.0 source shovels.

This PR introduces a fix to actually 
a) use the AMQP 1.0 subject as routing key
b) gracefully handle `undefined` routing keys in shovelled messages.

Unfortunately, Erlang is an entirely new concept to me, I tried my best to follow the conventions I learned by browsing the project.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue (not issue #))

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

I wasn't able to run the test suite, due to the following error: 
```Failed to locate Elixir lib dir```.
