### PR TITLE
Avoid network calls

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1027,8 +1027,8 @@ list_local_names() ->
 
 list_local_names_down() ->
     [ amqqueue:get_name(Q) || Q <- list(),
-                              is_down(Q),
-                              is_local_to_node(amqqueue:get_pid(Q), node())].
+                              is_local_to_node(amqqueue:get_pid(Q), node()),
+                              is_down(Q)].
 
 is_down(Q) ->
     try


### PR DESCRIPTION
by flipping the two list comprehension conditions.
If not `is_local_to_node`, then `is_down` will not be evaluated.
This saves (R-1) * Q network calls every 2 minutes where R is the number
of replicas per quorum queue and Q is the number of quorum queues in the
RabbitMQ cluster.