### PR TITLE
erlang_ls config file for better dev experience

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,0 +1,24 @@
+# otp_path: "/path/to/otp/lib/erlang"
+deps_dirs:
+  - "deps/*"
+diagnostics:
+  disabled: []
+  enabled:
+    - crossref
+    - dialyzer
+    - elvis
+    - compiler
+include_dirs:
+  - "deps"
+  - "deps/*/include"
+# lenses:
+#   enabled:
+#     - ct-run-test
+#     - show-behaviour-usages
+#   disabled: []
+# macros:
+#   - name: DEFINED_WITH_VALUE
+#     value: 42
+code_reload:
+  node: rabbit@localhost
+plt_path: .rabbitmq_server_release.plt


### PR DESCRIPTION
https://github.com/erlang-ls/erlang_ls/ provides Erlang support for any editor that supports Language Server Protocol. Due to the structure of our repository, some configuration is necessary to avoid hundreds of warnings about missing include files and undefined symbols. With this config file, when you have the right editor and plugin, everything should just work:

- code navigation between different sub-projects/dependencies
- compiler, dialyzer, crossref warnings/errors in the editor
- reloading code on the configured node (I set it to `rabbit@localhost` but it may need to be adjusted for each user)

You can find more about the configuration options and how to take advantage of this plugin from your editor here:
https://erlang-ls.github.io/configuration/