### PR TITLE
Make 'rabbitmq-queues await_online_quorum_plus_one' a no-op for single node clusters

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/await_online_quorum_plus_one_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/await_online_quorum_plus_one_command.ex
@@ -6,6 +6,7 @@
 
 defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineQuorumPlusOneCommand do
   alias RabbitMQ.CLI.Core.DocGuide
+  import RabbitMQ.CLI.Core.Config, only: [output_less?: 1]
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -28,18 +29,37 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineQuorumPlusOneCommand do
 
   def run([], %{node: node_name, timeout: timeout}) do
     rpc_timeout = timeout + 500
-    case :rabbit_misc.rpc_call(node_name, :rabbit_upgrade_preparation, :await_online_quorum_plus_one, [timeout], rpc_timeout) do
-      {:error, _} = err -> err
-      {:error, _, _} = err -> err
-      {:badrpc, _} = err -> err
+    case :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :is_single_node_cluster, [], rpc_timeout) do
+      # if target node is the only one in the cluster, the command makes little sense
+      # and false positives can be misleading
+      true  -> {:ok, :single_node_cluster}
+      false ->
+        case :rabbit_misc.rpc_call(node_name, :rabbit_upgrade_preparation, :await_online_quorum_plus_one, [timeout], rpc_timeout) do
+          {:error, _} = err -> err
+          {:error, _, _} = err -> err
+          {:badrpc, _} = err -> err
 
-      true  -> :ok
-      false -> {:error, "time is up, no quorum + 1 online replicas came online for at least some quorum queues"}
+          true  -> :ok
+          false -> {:error, "time is up, no quorum + 1 online replicas came online for at least some quorum queues"}
+        end
+      other -> other
     end
   end
 
+  def output({:ok, :single_node_cluster}, %{formatter: "json"}) do
+    {:ok, %{
+      "result"  => "ok",
+      "message" => "Target node seems to be the only one in a single node cluster, the check does not apply"
+    }}
+  end
   def output({:error, msg}, %{node: node_name, formatter: "json"}) do
     {:error, %{"result" => "error", "node" => node_name, "message" => msg}}
+  end
+  def output({:ok, :single_node_cluster}, opts) do
+    case output_less?(opts) do
+      true  -> :ok;
+      false -> {:ok, "Target node seems to be the only one in a single node cluster, the command does not apply"}
+    end
   end
   use RabbitMQ.CLI.DefaultOutput
 


### PR DESCRIPTION
Since it does not make sense in that case. We previously did the same thing for e.g. `rabbitmq-diagnostics check_if_node_is_quorum_critical`.

Per discussion with @ferozjilla @ansd.
