### PR TITLE
Make ranch parameter `num_conns_sups` configurable

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -19,7 +19,8 @@
 %%
 %% See also tcp_listener_sup and tcp_listener.
 
--export([boot/0, start_tcp_listener/2, start_ssl_listener/3,
+-export([boot/0, start_tcp_listener/2, start_tcp_listener/3,
+         start_ssl_listener/3, start_ssl_listener/4,
          stop_tcp_listener/1, on_node_down/1, active_listeners/0,
          node_listeners/1, node_client_listeners/1,
          register_connection/1, unregister_connection/1,
@@ -36,7 +37,8 @@
          listener_of_protocol/1, stop_ranch_listener_of_protocol/1]).
 
 %% Used by TCP-based transports, e.g. STOMP adapter
--export([tcp_listener_addresses/1, tcp_listener_spec/9,
+-export([tcp_listener_addresses/1,
+         tcp_listener_spec/9, tcp_listener_spec/10,
          ensure_ssl/0, fix_ssl_options/1, poodle_check/1]).
 
 -export([tcp_listener_started/4, tcp_listener_stopped/4]).
@@ -79,12 +81,14 @@ boot() ->
     _ = application:start(ranch),
     rabbit_log:debug("Started Ranch"),
     %% Failures will throw exceptions
-    _ = boot_listeners(fun boot_tcp/1, application:get_env(rabbit, num_tcp_acceptors, 10), "TCP"),
-    _ = boot_listeners(fun boot_tls/1, application:get_env(rabbit, num_ssl_acceptors, 10), "TLS"),
+    _ = boot_listeners(fun boot_tcp/2, application:get_env(rabbit, num_tcp_acceptors, 10),
+                       application:get_env(rabbit, num_conns_sups, 1), "TCP"),
+    _ = boot_listeners(fun boot_tls/2, application:get_env(rabbit, num_ssl_acceptors, 10),
+                       application:get_env(rabbit, num_conns_sups, 1), "TLS"),
     ok.
 
-boot_listeners(Fun, NumAcceptors, Type) ->
-    case Fun(NumAcceptors) of
+boot_listeners(Fun, NumAcceptors, ConcurrentConnsSupsCount, Type) ->
+    case Fun(NumAcceptors, ConcurrentConnsSupsCount) of
         ok                                                                  ->
             ok;
         {error, {could_not_start_listener, Address, Port, Details}} = Error ->
@@ -93,10 +97,10 @@ boot_listeners(Fun, NumAcceptors, Type) ->
             throw(Error)
     end.
 
-boot_tcp(NumAcceptors) ->
+boot_tcp(NumAcceptors, ConcurrentConnsSupsCount) ->
     {ok, TcpListeners} = application:get_env(tcp_listeners),
     case lists:foldl(fun(Listener, ok) ->
-                             start_tcp_listener(Listener, NumAcceptors);
+                             start_tcp_listener(Listener, NumAcceptors, ConcurrentConnsSupsCount);
                         (_Listener, Error) ->
                              Error
                      end,
@@ -105,14 +109,15 @@ boot_tcp(NumAcceptors) ->
         {error, _} = Error -> Error
     end.
 
-boot_tls(NumAcceptors) ->
+boot_tls(NumAcceptors, ConcurrentConnsSupsCount) ->
     case application:get_env(ssl_listeners) of
         {ok, []} ->
             ok;
         {ok, SslListeners} ->
             SslOpts = ensure_ssl(),
             case poodle_check('AMQP') of
-                ok     -> [start_ssl_listener(L, SslOpts, NumAcceptors) || L <- SslListeners];
+                ok     -> [start_ssl_listener(L, SslOpts, NumAcceptors, ConcurrentConnsSupsCount)
+                           || L <- SslListeners];
                 danger -> ok
             end,
             ok
@@ -180,15 +185,21 @@ tcp_listener_addresses_auto(Port) ->
 
 -spec tcp_listener_spec
         (name_prefix(), address(), [gen_tcp:listen_option()], module(), module(),
-         any(), protocol(), non_neg_integer(), label()) ->
+         any(), protocol(), non_neg_integer(), non_neg_integer(), label()) ->
             supervisor:child_spec().
 
+tcp_listener_spec(NamePrefix, Address, SocketOpts, Transport, ProtoSup, ProtoOpts,
+                  Protocol, NumAcceptors, Label) ->
+    tcp_listener_spec(NamePrefix, Address, SocketOpts, Transport, ProtoSup, ProtoOpts,
+                      Protocol, NumAcceptors, 1, Label).
+
 tcp_listener_spec(NamePrefix, {IPAddress, Port, Family}, SocketOpts,
-                  Transport, ProtoSup, ProtoOpts, Protocol, NumAcceptors, Label) ->
+                  Transport, ProtoSup, ProtoOpts, Protocol, NumAcceptors,
+                  ConcurrentConnsSupsCount, Label) ->
     Args = [IPAddress, Port, Transport, [Family | SocketOpts], ProtoSup, ProtoOpts,
             {?MODULE, tcp_listener_started, [Protocol, SocketOpts]},
             {?MODULE, tcp_listener_stopped, [Protocol, SocketOpts]},
-            NumAcceptors, Label],
+            NumAcceptors, ConcurrentConnsSupsCount, Label],
     {rabbit_misc:tcp_name(NamePrefix, IPAddress, Port),
      {tcp_listener_sup, start_link, Args},
      transient, infinity, supervisor, [tcp_listener_sup]}.
@@ -242,29 +253,44 @@ stop_ranch_listener_of_protocol(Protocol) ->
         listener_config(), integer()) -> 'ok' | {'error', term()}.
 
 start_tcp_listener(Listener, NumAcceptors) ->
-    start_listener(Listener, NumAcceptors, amqp, "TCP listener", tcp_opts()).
+    start_tcp_listener(Listener, NumAcceptors, 1).
+
+-spec start_tcp_listener(
+        listener_config(), integer(), integer()) -> 'ok' | {'error', term()}.
+
+start_tcp_listener(Listener, NumAcceptors, ConcurrentConnsSupsCount) ->
+    start_listener(Listener, NumAcceptors, ConcurrentConnsSupsCount, amqp,
+                   "TCP listener", tcp_opts()).
 
 -spec start_ssl_listener(
         listener_config(), rabbit_types:infos(), integer()) -> 'ok' | {'error', term()}.
 
 start_ssl_listener(Listener, SslOpts, NumAcceptors) ->
-    start_listener(Listener, NumAcceptors, 'amqp/ssl', "TLS (SSL) listener", tcp_opts() ++ SslOpts).
+    start_ssl_listener(Listener, SslOpts, NumAcceptors, 1).
 
+-spec start_ssl_listener(
+        listener_config(), rabbit_types:infos(), integer(), integer()) -> 'ok' | {'error', term()}.
+
+start_ssl_listener(Listener, SslOpts, ConcurrentConnsSupsCount, NumAcceptors) ->
+    start_listener(Listener, NumAcceptors, ConcurrentConnsSupsCount, 'amqp/ssl',
+                   "TLS (SSL) listener", tcp_opts() ++ SslOpts).
 
 -spec start_listener(
-        listener_config(), integer(), protocol(), label(), list()) -> 'ok' | {'error', term()}.
-start_listener(Listener, NumAcceptors, Protocol, Label, Opts) ->
+        listener_config(), integer(), integer(), protocol(), label(), list()) ->
+          'ok' | {'error', term()}.
+start_listener(Listener, NumAcceptors, ConcurrentConnsSupsCount, Protocol, Label, Opts) ->
     lists:foldl(fun (Address, ok) ->
-                        start_listener0(Address, NumAcceptors, Protocol, Label, Opts);
+                        start_listener0(Address, NumAcceptors, ConcurrentConnsSupsCount, Protocol,
+                                        Label, Opts);
                     (_Address, {error, _} = Error) ->
                         Error
                 end, ok, tcp_listener_addresses(Listener)).
 
-start_listener0(Address, NumAcceptors, Protocol, Label, Opts) ->
+start_listener0(Address, NumAcceptors, ConcurrentConnsSupsCount, Protocol, Label, Opts) ->
     Transport = transport(Protocol),
     Spec = tcp_listener_spec(rabbit_tcp_listener_sup, Address, Opts,
                              Transport, rabbit_connection_sup, [], Protocol,
-                             NumAcceptors, Label),
+                             NumAcceptors, ConcurrentConnsSupsCount, Label),
     case supervisor:start_child(rabbit_sup, Spec) of
         {ok, _}          -> ok;
         {error, {{shutdown, {failed_to_start_child, _,

--- a/deps/rabbit/src/tcp_listener_sup.erl
+++ b/deps/rabbit/src/tcp_listener_sup.erl
@@ -16,26 +16,27 @@
 
 -behaviour(supervisor).
 
--export([start_link/10]).
+-export([start_link/11]).
 -export([init/1]).
 
 -type mfargs() :: {atom(), atom(), [any()]}.
 
 -spec start_link
         (inet:ip_address(), inet:port_number(), module(), [gen_tcp:listen_option()],
-         module(), any(), mfargs(), mfargs(), integer(), string()) ->
+         module(), any(), mfargs(), mfargs(), integer(), integer(), string()) ->
                            rabbit_types:ok_pid_or_error().
 
 start_link(IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, OnShutdown,
-           ConcurrentAcceptorCount, Label) ->
+           ConcurrentAcceptorCount, ConcurrentConnsSups, Label) ->
     supervisor:start_link(
       ?MODULE, {IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, OnShutdown,
-                ConcurrentAcceptorCount, Label}).
+                ConcurrentAcceptorCount, ConcurrentConnsSups, Label}).
 
 init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, OnShutdown,
-      ConcurrentAcceptorCount, Label}) ->
+      ConcurrentAcceptorCount, ConcurrentConnsSups, Label}) ->
     {ok, AckTimeout} = application:get_env(rabbit, ssl_handshake_timeout),
-    MaxConnections = rabbit_misc:get_env(rabbit, connection_max, infinity),
+    MaxConnections = max_conn(rabbit_misc:get_env(rabbit, connection_max, infinity),
+                              ConcurrentConnsSups),
     RanchListenerOpts = #{
       num_acceptors => ConcurrentAcceptorCount,
       max_connections => MaxConnections,
@@ -43,7 +44,8 @@ init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, On
       connection_type => supervisor,
       socket_opts => [{ip, IPAddress},
                       {port, Port} |
-                      SocketOpts]
+                      SocketOpts],
+      num_conns_sups => ConcurrentConnsSups
      },
     Flags = {one_for_all, 10, 10},
     OurChildSpecStart = {tcp_listener, start_link, [IPAddress, Port, OnStartup, OnShutdown, Label]},
@@ -52,3 +54,8 @@ init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, On
         Transport, RanchListenerOpts,
         ProtoSup, ProtoOpts),
     {ok, {Flags, [RanchChildSpec, OurChildSpec]}}.
+
+max_conn(infinity, _) ->
+    infinity;
+max_conn(Max, Sups) ->
+    Max * Sups.

--- a/deps/rabbit/src/tcp_listener_sup.erl
+++ b/deps/rabbit/src/tcp_listener_sup.erl
@@ -58,4 +58,5 @@ init({IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, On
 max_conn(infinity, _) ->
     infinity;
 max_conn(Max, Sups) ->
-    Max * Sups.
+  %% connection_max in Ranch is per connection supervisor
+  Max div Sups.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
@@ -20,6 +20,7 @@ start_link(Listeners, []) ->
 
 init([{Listeners, SslListeners0}]) ->
     NumTcpAcceptors = application:get_env(rabbitmq_mqtt, num_tcp_acceptors, 10),
+    ConcurrentConnsSups = application:get_env(rabbitmq_mqtt, num_conns_sups, 1),
     {ok, SocketOpts} = application:get_env(rabbitmq_mqtt, tcp_listen_options),
     {SslOpts, NumSslAcceptors, SslListeners}
         = case SslListeners0 of
@@ -36,9 +37,10 @@ init([{Listeners, SslListeners0}]) ->
             {rabbit_mqtt_retainer_sup, start_link, [{local, rabbit_mqtt_retainer_sup}]},
              transient, ?SUPERVISOR_WAIT, supervisor, [rabbit_mqtt_retainer_sup]} |
            listener_specs(fun tcp_listener_spec/1,
-                          [SocketOpts, NumTcpAcceptors], Listeners) ++
+                          [SocketOpts, NumTcpAcceptors, ConcurrentConnsSups], Listeners) ++
            listener_specs(fun ssl_listener_spec/1,
-                          [SocketOpts, SslOpts, NumSslAcceptors], SslListeners)]}}.
+                          [SocketOpts, SslOpts, NumSslAcceptors, ConcurrentConnsSups],
+                          SslListeners)]}}.
 
 stop_listeners() ->
     rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
@@ -54,17 +56,17 @@ listener_specs(Fun, Args, Listeners) ->
         Listener <- Listeners,
         Address  <- rabbit_networking:tcp_listener_addresses(Listener)].
 
-tcp_listener_spec([Address, SocketOpts, NumAcceptors]) ->
+tcp_listener_spec([Address, SocketOpts, NumAcceptors, ConcurrentConnsSups]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_mqtt_listener_sup, Address, SocketOpts,
       transport(?TCP_PROTOCOL), rabbit_mqtt_connection_sup, [],
-      mqtt, NumAcceptors, "MQTT TCP listener").
+      mqtt, NumAcceptors, ConcurrentConnsSups, "MQTT TCP listener").
 
-ssl_listener_spec([Address, SocketOpts, SslOpts, NumAcceptors]) ->
+ssl_listener_spec([Address, SocketOpts, SslOpts, NumAcceptors, ConcurrentConnsSups]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_mqtt_listener_sup, Address, SocketOpts ++ SslOpts,
       transport(?TLS_PROTOCOL), rabbit_mqtt_connection_sup, [],
-      'mqtt/ssl', NumAcceptors, "MQTT TLS listener").
+      'mqtt/ssl', NumAcceptors, ConcurrentConnsSups, "MQTT TLS listener").
 
 transport(Protocol) ->
     case Protocol of

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_sup.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_sup.erl
@@ -28,6 +28,7 @@ start_link(Listeners, Configuration) ->
 
 init([{Listeners, SslListeners0}, Configuration]) ->
     NumTcpAcceptors = application:get_env(rabbitmq_stomp, num_tcp_acceptors, 10),
+    ConcurrentConnsSups = application:get_env(rabbitmq_stomp, num_conns_sups, 1),
     {ok, SocketOpts} = application:get_env(rabbitmq_stomp, tcp_listen_options),
     {SslOpts, NumSslAcceptors, SslListeners}
         = case SslListeners0 of
@@ -46,9 +47,11 @@ init([{Listeners, SslListeners0}, Configuration]) ->
     },
     {ok, {Flags,
            listener_specs(fun tcp_listener_spec/1,
-                          [SocketOpts, Configuration, NumTcpAcceptors], Listeners) ++
+                          [SocketOpts, Configuration, NumTcpAcceptors, ConcurrentConnsSups],
+                          Listeners) ++
            listener_specs(fun ssl_listener_spec/1,
-                          [SocketOpts, SslOpts, Configuration, NumSslAcceptors], SslListeners)}}.
+                          [SocketOpts, SslOpts, Configuration, NumSslAcceptors, ConcurrentConnsSups],
+                          SslListeners)}}.
 
 stop_listeners() ->
     rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
@@ -64,17 +67,17 @@ listener_specs(Fun, Args, Listeners) ->
         Listener <- Listeners,
         Address  <- rabbit_networking:tcp_listener_addresses(Listener)].
 
-tcp_listener_spec([Address, SocketOpts, Configuration, NumAcceptors]) ->
+tcp_listener_spec([Address, SocketOpts, Configuration, NumAcceptors, ConcurrentConnsSups]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_stomp_listener_sup, Address, SocketOpts,
       transport(?TCP_PROTOCOL), rabbit_stomp_client_sup, Configuration,
-      stomp, NumAcceptors, "STOMP TCP listener").
+      stomp, NumAcceptors, ConcurrentConnsSups, "STOMP TCP listener").
 
-ssl_listener_spec([Address, SocketOpts, SslOpts, Configuration, NumAcceptors]) ->
+ssl_listener_spec([Address, SocketOpts, SslOpts, Configuration, NumAcceptors, ConcurrentConnsSups]) ->
     rabbit_networking:tcp_listener_spec(
       rabbit_stomp_listener_sup, Address, SocketOpts ++ SslOpts,
       transport(?TLS_PROTOCOL), rabbit_stomp_client_sup, Configuration,
-      'stomp/ssl', NumAcceptors, "STOMP TLS listener").
+      'stomp/ssl', NumAcceptors, ConcurrentConnsSups, "STOMP TLS listener").
 
 transport(Protocol) ->
     case Protocol of

--- a/deps/rabbitmq_trust_store/test/system_SUITE.erl
+++ b/deps/rabbitmq_trust_store/test/system_SUITE.erl
@@ -212,7 +212,7 @@ validation_success_for_AMQP_client1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                      {cert, Certificate2},
-                                                     {key, Key2} | cfg()], 1),
+                                                     {key, Key2} | cfg()], 1, 1),
 
     %% Then: a client presenting a certifcate rooted at the same
     %% authority connects successfully.
@@ -245,7 +245,7 @@ validation_failure_for_AMQP_client1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                      {cert, Cert},
-                                                     {key, Key} | cfg()], 1),
+                                                     {key, Key} | cfg()], 1, 1),
 
     %% Then: a client presenting a certificate rooted with another
     %% authority is REJECTED.
@@ -297,7 +297,7 @@ validate_chain1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                      {cert, Cert},
-                                                     {key, Key} | cfg()], 1),
+                                                     {key, Key} | cfg()], 1, 1),
 
     %% When: a client connects and present `RootTrusted` as well as the `CertTrusted`
     %% Then: the connection is successful.
@@ -341,7 +341,7 @@ validate_longer_chain1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                      {cert, Cert},
-                                                     {key, Key} | cfg()], 1),
+                                                     {key, Key} | cfg()], 1, 1),
 
     %% When: a client connects and present `CertInter` as well as the `CertTrusted`
     %% Then: the connection is successful.
@@ -439,7 +439,7 @@ validate_chain_without_whitelisted1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                      {cert, Cert},
-                                                     {key, Key} | cfg()], 1),
+                                                     {key, Key} | cfg()], 1, 1),
 
     %% When: Rabbit validates paths
     %% Then: a client presenting the non-whitelisted certificate `CertUntrusted` and `RootUntrusted`
@@ -487,7 +487,7 @@ whitelisted_certificate_accepted_from_AMQP_client_regardless_of_validation_to_ro
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                      {cert, Cert},
-                                                     {key, Key} | cfg()], 1),
+                                                     {key, Key} | cfg()], 1, 1),
 
     %% Then: a client presenting the whitelisted certificate `C`
     %% is allowed.
@@ -521,7 +521,7 @@ removed_certificate_denied_from_AMQP_client1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                       {cert, Cert},
-                                                      {key, Key} | cfg()], 1),
+                                                      {key, Key} | cfg()], 1, 1),
 
     wait_for_file_system_time(),
     ok = delete("bob.pem", Config),
@@ -572,7 +572,7 @@ installed_certificate_accepted_from_AMQP_client1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                       {cert, Cert},
-                                                      {key, Key} | cfg()], 1),
+                                                      {key, Key} | cfg()], 1, 1),
 
     wait_for_file_system_time(),
     ok = whitelist(Config, "charlie", CertOther,  KeyOther),
@@ -619,7 +619,7 @@ whitelist_directory_DELTA1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                       {cert, Cert},
-                                                      {key, Key} | cfg()], 1),
+                                                      {key, Key} | cfg()], 1, 1),
 
     wait_for_file_system_time(),
     ok = delete("bar.pem", Config),
@@ -680,7 +680,7 @@ replaced_whitelisted_certificate_should_be_accepted1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                     {cert, Cert},
-                                                    {key, Key} | cfg()], 1),
+                                                    {key, Key} | cfg()], 1, 1),
     %% And: the first certificate has been whitelisted
     ok = whitelist(Config, "bart", CertFirst,  KeyFirst),
     rabbit_trust_store:refresh(),
@@ -789,7 +789,7 @@ ignore_corrupt_cert1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                       {cert, Cert},
-                                                      {key, Key} | cfg()], 1),
+                                                      {key, Key} | cfg()], 1, 1),
 
     %% Then: the trust store should keep functioning
     %% And: a client presenting the whitelisted certificate `CertTrusted`
@@ -825,7 +825,7 @@ ignore_same_cert_with_different_name1(Config) ->
     catch rabbit_networking:stop_tcp_listener(Port),
     ok = rabbit_networking:start_ssl_listener(Port, [{cacerts, [Root]},
                                                       {cert, Cert},
-                                                      {key, Key} | cfg()], 1),
+                                                      {key, Key} | cfg()], 1, 1),
 
     %% Then: the trust store should keep functioning.
     %% And: a client presenting the whitelisted certificate `CertTrusted`

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
@@ -104,7 +104,8 @@ start_tcp_listener(TCPConf0, CowboyOpts) ->
     socket_opts => TCPConf,
     connection_type => supervisor,
     max_connections => get_max_connections(),
-    num_acceptors => get_env(num_tcp_acceptors, 10)
+    num_acceptors => get_env(num_tcp_acceptors, 10),
+    num_conns_sups => get_env(num_conns_sup, 1)
   },
   case ranch:start_listener(rabbit_networking:ranch_ref(TCPConf),
                             ranch_tcp,
@@ -131,7 +132,8 @@ start_tls_listener(TLSConf0, CowboyOpts) ->
     socket_opts => TLSConf,
     connection_type => supervisor,
     max_connections => get_max_connections(),
-    num_acceptors => get_env(num_ssl_acceptors, 10)
+    num_acceptors => get_env(num_ssl_acceptors, 10),
+    num_conns_sups => get_env(num_conns_sup, 1)
   },
   case ranch:start_listener(rabbit_networking:ranch_ref(TLSConf),
                             ranch_ssl,

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
@@ -98,7 +98,8 @@ start_tcp_listener(TCPConf0, CowboyOpts0, Routes) ->
     socket_opts     => TCPConf,
     connection_type => supervisor,
     max_connections => get_max_connections(),
-    num_acceptors   => NumTcpAcceptors
+    num_acceptors   => NumTcpAcceptors,
+    num_conns_sups => 1
   },
   CowboyOpts = CowboyOpts0#{env => #{dispatch => Routes},
                             middlewares => [cowboy_router,
@@ -136,7 +137,8 @@ start_tls_listener(TLSConf0, CowboyOpts0, Routes) ->
     socket_opts     => TLSConf,
     connection_type => supervisor,
     max_connections => get_max_connections(),
-    num_acceptors   => NumSslAcceptors
+    num_acceptors   => NumSslAcceptors,
+    num_conns_sups => 1
   },
   CowboyOpts = CowboyOpts0#{env => #{dispatch => Routes},
                             middlewares => [cowboy_router,


### PR DESCRIPTION
Defaults to 1

`rabbit` - `num_conns_sup`
`rabbitmq_mqtt` - `num_conns_sup`
`rabbitmq_stomp` - `num_conns_sup`

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

