### PR TITLE
Rename policies to unsupported_policies in capabilities/0

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -442,9 +442,9 @@ recover_durable_queues(QueuesAndRecoveryTerms) ->
     [Q || {_, {new, Q}} <- Results].
 
 capabilities() ->
-    #{policies => [ %% Stream policies
-                    <<"max-age">>, <<"max-segment-size">>,
-                    <<"queue-leader-locator">>, <<"initial-cluster-size">>],
+    #{unsupported_policies => [ %% Stream policies
+                                <<"max-age">>, <<"max-segment-size">>,
+                                <<"queue-leader-locator">>, <<"initial-cluster-size">>],
       queue_arguments => [<<"x-expires">>, <<"x-message-ttl">>, <<"x-dead-letter-exchange">>,
                           <<"x-dead-letter-routing-key">>, <<"x-max-length">>,
                           <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -302,7 +302,7 @@ i_down(_K, _Q, _DownReason) -> ''.
 is_policy_applicable(Q, Policy) ->
     Mod = amqqueue:get_type(Q),
     Capabilities = Mod:capabilities(),
-    NotApplicable = maps:get(policies, Capabilities, []),
+    NotApplicable = maps:get(unsupported_policies, Capabilities, []),
     lists:all(fun({P, _}) ->
                       not lists:member(P, NotApplicable)
               end, Policy).

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -353,14 +353,15 @@ filter_quorum_critical(Queues, ReplicaStates) ->
                  end, Queues).
 
 capabilities() ->
-    #{policies => [ %% Classic policies
-                    <<"message-ttl">>, <<"max-priority">>, <<"queue-mode">>,
-                    <<"single-active-consumer">>, <<"ha-mode">>, <<"ha-params">>,
-                    <<"ha-sync-mode">>, <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
-                    <<"queue-master-locator">>,
-                    %% Stream policies
-                    <<"max-age">>, <<"max-segment-size">>,
-                    <<"queue-leader-locator">>, <<"initial-cluster-size">>],
+    #{unsupported_policies =>
+          [ %% Classic policies
+            <<"message-ttl">>, <<"max-priority">>, <<"queue-mode">>,
+            <<"single-active-consumer">>, <<"ha-mode">>, <<"ha-params">>,
+            <<"ha-sync-mode">>, <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
+            <<"queue-master-locator">>,
+            %% Stream policies
+            <<"max-age">>, <<"max-segment-size">>,
+            <<"queue-leader-locator">>, <<"initial-cluster-size">>],
       queue_arguments => [<<"x-expires">>, <<"x-dead-letter-exchange">>,
                           <<"x-dead-letter-routing-key">>, <<"x-max-length">>,
                           <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -786,15 +786,16 @@ msg_to_iodata(#basic_message{exchange_name = #resource{name = Exchange},
     rabbit_msg_record:to_iodata(R).
 
 capabilities() ->
-    #{policies => [ %% Classic policies
-                    <<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
-                    <<"dead-letter-routing-key">>, <<"max-length">>,
-                    <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
-                    <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
-                    <<"single-active-consumer">>, <<"delivery-limit">>,
-                    <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
-                    <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
-                    <<"queue-master-locator">>],
+    #{unsupported_policies =>
+          [ %% Classic policies
+            <<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
+            <<"dead-letter-routing-key">>, <<"max-length">>,
+            <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
+            <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
+            <<"single-active-consumer">>, <<"delivery-limit">>,
+            <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
+            <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
+            <<"queue-master-locator">>],
       queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
                           <<"x-max-length">>, <<"x-max-length-bytes">>,
                           <<"x-single-active-consumer">>, <<"x-queue-type">>,


### PR DESCRIPTION
The policies listed in the `capabilities/0` callback of queue types are the known unsupported policies for every queue type (core policies that don't apply), as we can't guess what plugins will do/use. Keeping the old naming is confusing, so they are renamed here to `unsupported_policies`

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

