### PR TITLE
CLI command for stream details

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -508,11 +508,12 @@ status(Vhost, QueueName) ->
             Data = osiris_counters:overview(),
             case maps:get({osiris_writer, QName}, Data, undefined) of
                 undefined ->
-                    #{};
-                #{segments := Segments} = Map ->
+                    [];
+                #{} = Cnt0 ->
+                    Cnt = maps:without([chunks], Cnt0),
                     Conf = amqqueue:get_type_state(Q),
                     Max = maps:get(max_segment_size, Conf, osiris_log:get_default_max_segment_size()),
-                    Map#{max_disk_size => Segments * Max}
+                    [maps:to_list(Cnt#{max_segment_size => Max})]
             end;
         {error, not_found} = E->
             E

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/stream_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/stream_status_command.ex
@@ -1,0 +1,71 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.StreamStatusCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  def scopes(), do: [:diagnostics, :queues]
+
+  def merge_defaults(args, opts), do: {args, Map.merge(%{tracking: false, vhost: "/"}, opts)}
+
+  def switches(), do: [tracking: :boolean]
+  
+  use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([name] = _args, %{node: node_name, vhost: vhost, tracking: :false}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :status, [vhost, name]) do
+      {:error, :classic_queue_not_supported} ->
+        {:error, "Cannot get stream status of a classic queue"}
+
+      {:error, :quorum_queue_not_supported} ->
+        {:error, "Cannot get stream status of a quorum queue"}
+        
+      other ->
+        other
+    end
+  end
+  def run([name] = _args, %{node: node_name, vhost: vhost, tracking: :true}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :tracking_status, [vhost, name]) do
+      {:error, :classic_queue_not_supported} ->
+        {:error, "Cannot get stream status of a classic queue"}
+
+      {:error, :quorum_queue_not_supported} ->
+        {:error, "Cannot get stream status of a quorum queue"}
+        
+      other ->
+        other
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.PrettyTable
+
+  def usage() do
+    "stream_status [--vhost <vhost>] [--tracking] <queue>"
+  end
+
+  def usage_additional do
+    [
+      ["<queue>", "Name of the queue"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.stream_queues()
+    ]
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays the status of a stream queue"
+
+  def banner([name], %{node: node_name}),
+    do: "Status of stream queue #{name} on node #{node_name} ..."
+end

--- a/deps/rabbitmq_cli/test/queues/stream_status_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/stream_status_command_test.exs
@@ -1,0 +1,45 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.StreamStatusCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Queues.Commands.StreamStatusCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+
+  test "validate: treats no arguments as a failure" do
+    assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: accepts a single positional argument" do
+    assert @command.validate(["stream-queue-a"], %{}) == :ok
+  end
+
+  test "validate: when two or more arguments are provided, returns a failure" do
+    assert @command.validate(["stream-queue-a", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["stream-queue-a", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc" do
+    assert match?({:badrpc, _}, @command.run(["stream-queue-a"],
+                                             %{node: :jake@thedog, vhost: "/", timeout: 200, tracking: false}))
+  end
+end


### PR DESCRIPTION
`rabbitmq-queues stream_status [--tracking] <queue>`
If the --tracking option is enabled, it returns a table with all offset tracking
for that queue.

Depends on https://github.com/rabbitmq/osiris/pull/23

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
