### PR TITLE
Logging: Add journald support

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -133,13 +133,15 @@ APPS_DIR := $(CURDIR)/apps
 LOCAL_DEPS = sasl rabbitmq_prelaunch os_mon inets compiler public_key crypto ssl syntax_tools xmerl
 
 BUILD_DEPS = rabbitmq_cli
-DEPS = ranch rabbit_common ra sysmon_handler stdout_formatter recon observer_cli osiris amqp10_common syslog
+DEPS = ranch rabbit_common ra sysmon_handler stdout_formatter recon observer_cli osiris amqp10_common syslog systemd
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck proper
 
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
 dep_osiris = git https://github.com/rabbitmq/osiris master
+# TODO: Use systemd from Hex.pm, once there is a new post-0.6.0 release.
+dep_systemd = git https://github.com/hauleth/erlang-systemd 0ce748edffcb72bb028733e9ca4707cb30add853
 
 define usage_xml_to_erl
 $(subst __,_,$(patsubst $(DOCS_DIR)/rabbitmq%.1.xml, src/rabbit_%_usage.erl, $(subst -,_,$(1))))

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1304,6 +1304,21 @@ end}.
          rabbit_prelaunch_early_logging:translate_formatter_conf("log.exchange.formatter", Conf)
  end}.
 
+{mapping, "log.journald", "rabbit.log.journald.enabled", [
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "log.journald.level", "rabbit.log.journald.level", [
+    {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, none]}}
+]}.
+{mapping, "log.journald.fields", "rabbit.log.journald.fields", [
+    {default, "SYSLOG_IDENTIFIER=\"rabbitmq-server\" syslog_timestamp syslog_pid priority ERL_PID=pid CODE_FILE=file CODE_LINE=line CODE_MFA=mfa"},
+    {datatype, string}
+]}.
+{translation, "rabbit.log.journald.fields",
+ fun(Conf) ->
+         rabbit_prelaunch_early_logging:translate_journald_fields_conf("log.journald.fields", Conf)
+ end}.
+
 {mapping, "log.syslog", "rabbit.log.syslog.enabled", [
     {datatype, {enum, [true, false]}}
 ]}.


### PR DESCRIPTION
The implementation depends on [erlang-systemd](https://github.com/rabbitmq/erlang-systemd) which uses Unix socket support introduced in Erlang 19. Therefore it doesn't rely on a native library. We also don't need special handling if the host doesn't use journald.

To enable the journald handler, add the following configuration variable:
```
log.journald = true
```

The log level can also be set the same way it is with other handlers:
```
log.journald.level = debug
```

The log messages are communicated to journald using structured data. It is possible to configure which fields are transmitted and how they are named:
```
log.journald.fields = SYSLOG_IDENTIFIER="rabbitmq-server" syslog_timestamp syslog_pid priority ERL_PID=pid
```

In this example:
  * the `SYSLOG_IDENTIFIER` is set to a string literal
  * `syslog_timestamp and `syslog_pid` are aliases for SYSLOG_TIMESTAMP=time and SYSLOG_PID=os_pid
  * `priority` is a special field computed from the log level
  * `ERL_PID=pid` indicates `pid` should be sent as the `ERL_PID` field.

The message itself is implicit and always sent. Otherwise, the list of fields must be exhaustive: fields which are unset in a particular log event meta are sent as an empty string and non-mentionned fields are not sent. The order is not important.

Here are some messages printed by `journalctl -f` during RabbitMQ startup:
```
Mar 26 11:58:31 ip-172-31-43-179 rabbitmq-server[19286]: Ready to start client connection listeners
Mar 26 11:58:31 ip-172-31-43-179 rabbitmq-server[19286]: started TCP listener on [::]:5672
Mar 26 11:58:31 ip-172-31-43-179 rabbitmq-server[19286]: Server startup complete; 0 plugins started.
```