### PR TITLE
Get destination address from PROXY protocol

### DIFF
--- a/deps/rabbit/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbit/test/proxy_protocol_SUITE.erl
@@ -64,7 +64,7 @@ proxy_protocol(Config) ->
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -79,7 +79,7 @@ proxy_protocol_tls(Config) ->
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -228,19 +228,15 @@ socket_ends(Sock, Direction) when ?IS_SSL(Sock);
         {_, {error, _Reason} = Error} ->
             Error
     end;
-socket_ends({rabbit_proxy_socket, CSocket, ProxyInfo}, Direction = inbound) ->
+socket_ends({rabbit_proxy_socket, _, ProxyInfo}, _) ->
     #{
-        src_address := FromAddress,
-        src_port := FromPort
-    } = ProxyInfo,
-    {_From, To} = sock_funs(Direction),
-    case To(CSocket) of
-        {ok, {ToAddress, ToPort}} ->
-            {ok, {rdns(FromAddress), FromPort,
-                rdns(ToAddress),   ToPort}};
-        {error, _Reason} = Error ->
-            Error
-    end.
+      src_address := FromAddress,
+      src_port := FromPort,
+      dest_address := ToAddress,
+      dest_port := ToPort
+     } = ProxyInfo,
+    {ok, {rdns(FromAddress), FromPort,
+          rdns(ToAddress),   ToPort}}.
 
 maybe_ntoab(Addr) when is_tuple(Addr) -> rabbit_misc:ntoab(Addr);
 maybe_ntoab(Host)                     -> Host.

--- a/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
@@ -64,7 +64,7 @@ proxy_protocol(Config) ->
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -81,7 +81,7 @@ proxy_protocol_tls(Config) ->
     timer:sleep(1000),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
@@ -68,7 +68,7 @@ proxy_protocol(Config) ->
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -83,7 +83,7 @@ proxy_protocol_tls(Config) ->
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
@@ -68,7 +68,7 @@ proxy_protocol(Config) ->
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -83,7 +83,7 @@ proxy_protocol_tls(Config) ->
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_web_mqtt/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/proxy_protocol_SUITE.erl
@@ -94,7 +94,7 @@ proxy_protocol(Config) ->
     {binary, _P} = rfc6455_client:recv(WS),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     {close, _} = rfc6455_client:close(WS),
     ok.
 

--- a/deps/rabbitmq_web_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/proxy_protocol_SUITE.erl
@@ -91,7 +91,7 @@ proxy_protocol(Config) ->
     {ok, _P} = rfc6455_client:recv(WS),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 ">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     {close, _} = rfc6455_client:close(WS),
     ok.
 


### PR DESCRIPTION
## Proposed Changes

Before this patch the destination (local) address of any connection was the destination address of the actual socket, not that of the PROXY server. 
![Screenshot from 2021-03-30 11-42-02](https://user-images.githubusercontent.com/180046/113016787-1ab6e500-917f-11eb-982b-90e6d917eff7.png)
![Screenshot from 2021-03-30 11-41-44](https://user-images.githubusercontent.com/180046/113016791-1b4f7b80-917f-11eb-891c-acabdb723788.png)


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ x Any dependent changes have been merged and published in related repositories

## Further Comments

This patch doesn't address TLS via PROXY protocol issue.