### PR TITLE
Logging: Allow to set timezone in rfc3339- and format-string-based time formats

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -181,9 +181,11 @@ translate_formatter_conf(Var, Conf) when is_list(Var) ->
 -type time_format_string_arg() :: year | month | day |
                                   hour | minute | second |
                                   {second_fractional, non_neg_integer()}.
--type time_format() :: {rfc3339, char()} |
+-type time_format() :: {rfc3339, char(), string() | integer()} |
                        {epoch, secs | usecs, binary | int} |
-                       {string(), [time_format_string_arg()]}.
+                       {local | universal,
+                        string(),
+                        [time_format_string_arg()]}.
 -type level_format() :: lc | uc | lc3 | uc3 | lc4 | uc4.
 -type formatter_generic_conf() :: #{time_format := time_format(),
                                     level_format := level_format(),
@@ -201,9 +203,9 @@ translate_generic_conf(Var, Conf) ->
     Formatter = cuttlefish:conf_get(Var, Conf),
     TimeFormat = case cuttlefish:conf_get(Var ++ ".time_format", Conf) of
                      rfc3339_T ->
-                         {rfc3339, $T};
+                         {rfc3339, $T, ""};
                      rfc3339_space ->
-                         {rfc3339, $\s};
+                         {rfc3339, $\s, ""};
                      epoch_secs when Formatter =:= json ->
                          {epoch, secs, int};
                      epoch_usecs when Formatter =:= json ->
@@ -213,7 +215,8 @@ translate_generic_conf(Var, Conf) ->
                      epoch_usecs ->
                          {epoch, usecs, binary};
                      lager_default ->
-                         {"~4..0b-~2..0b-~2..0b "
+                         {local,
+                          "~4..0b-~2..0b-~2..0b "
                           "~2..0b:~2..0b:~2..0b.~3..0b",
                           [year, month, day,
                            hour, minute, second,

--- a/deps/rabbit/test/logging_SUITE.erl
+++ b/deps/rabbit/test/logging_SUITE.erl
@@ -495,19 +495,20 @@ setting_level_format_works(LevelFormat, LevelName, Config) ->
        Line).
 
 setting_time_format_works(Config) ->
-    DateTime = "2018-02-01T16:17:58.123456+01:00",
+    DateTime = "2018-05-01T16:17:58.123456+01:00",
     Timestamp = calendar:rfc3339_to_system_time(
                   DateTime, [{unit, microsecond}]),
     TimeFormats =
-    #{{rfc3339, $T}  => DateTime,
-      {rfc3339, $\s} => "2018-02-01 16:17:58.123456+01:00",
+    #{{rfc3339, $T, "+01:00"} => DateTime,
+      {rfc3339, $\s, "+01:00"} => "2018-05-01 16:17:58.123456+01:00",
       {epoch, usecs, binary} => integer_to_list(Timestamp),
       {epoch, secs, binary} => io_lib:format("~.6.0f", [Timestamp / 1000000]),
-      {"~4..0b-~2..0b-~2..0b "
+      {universal,
+       "~4..0b-~2..0b-~2..0b "
        "~2..0b:~2..0b:~2..0b.~3..0b",
        [year, month, day,
         hour, minute, second,
-        {second_fractional, 3}]} => "2018-02-01 16:17:58.123"},
+        {second_fractional, 3}]} => "2018-05-01 15:17:58.123"},
     maps:fold(
       fun(TimeFormat, TimeValue, Acc) ->
               remove_all_handlers(),


### PR DESCRIPTION
This is not exposed to the end user (yet) through the Cuttlefish configuration. But this is required to make `logging_SUITE` timezone agnostic (i.e. the timezone of the host running the testsuite should not affect the formatted times).

Follow up to #2927.