### PR TITLE
Build & push container image on every commit

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -1,0 +1,53 @@
+# https://github.com/marketplace/actions/build-and-push-docker-images
+name: OCI
+on:
+  push:
+    paths:
+      - 'deps/**'
+      - 'escript/**'
+      - 'packaging/**'
+      - 'scripts/**'
+      - Makefile
+      - plugins.mk
+      - rabbitmq-components.mk
+env:
+  GENERIC_UNIX_ARCHIVE: ${{ github.workspace }}/PACKAGES/rabbitmq-server-generic-unix-${{ github.sha }}.tar.xz
+  RABBITMQ_VERSION: ${{ github.sha }}
+  VERSION: ${{ github.sha }}
+jobs:
+  build-publish-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # RabbitMQ master requires Erlang 23 (correct at Mar 2021)
+      # Source of truth for released versions: https://www.rabbitmq.com/which-erlang.html
+      #
+      # For Elixir: https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
+      - name: Set up min required Erlang & Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '23.2'
+          elixir-version: '1.11.4'
+
+      - name: Build generic unix package
+        run: |
+          make package-generic-unix PROJECT_VERSION=${GITHUB_SHA}
+
+      - name: Build container image
+        working-directory: packaging/docker-image
+        run: |
+          make dist
+
+      - name: Login to DockerHub
+        working-directory: packaging/docker-image
+        run: |
+          docker login \
+            --username '${{ secrets.DOCKERHUB_USERNAME }}' \
+            --password '${{ secrets.DOCKERHUB_PASSWORD }}'
+
+      - name: Push container image to DockerHub
+        working-directory: packaging/docker-image
+        run: |
+          make push

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -188,9 +188,6 @@ RUN set -eux; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
-# Use the latest alpha RabbitMQ 3.8 release - https://dl.bintray.com/rabbitmq/all-dev/rabbitmq-server/
-ARG RABBITMQ_VERSION
-ENV RABBITMQ_VERSION=${RABBITMQ_VERSION}
 # https://www.rabbitmq.com/signatures.html#importing-gpg
 # ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
@@ -215,21 +212,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-        # RABBITMQ_SOURCE_URL="https://dl.bintray.com/rabbitmq/all-dev/rabbitmq-server/$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-${RABBITMQ_VERSION}.tar.xz"; \
-	# RABBITMQ_PATH="/usr/local/src/rabbitmq-$RABBITMQ_VERSION"; \
-	\
-	# wget --progress dot:giga --output-document "$RABBITMQ_PATH.tar.xz.asc" "$RABBITMQ_SOURCE_URL.asc"; \
-	# wget --progress dot:giga --output-document "$RABBITMQ_PATH.tar.xz" "$RABBITMQ_SOURCE_URL"; \
-	\
-	# export GNUPGHOME="$(mktemp -d)"; \
-	# gpg --batch --keyserver "$PGP_KEYSERVER" --recv-keys "$RABBITMQ_PGP_KEY_ID"; \
-	# gpg --batch --verify "$RABBITMQ_PATH.tar.xz.asc" "$RABBITMQ_PATH.tar.xz"; \
-	# gpgconf --kill all; \
-	# rm -rf "$GNUPGHOME"; \
-	\
-	# mkdir -p "$RABBITMQ_HOME"; \
-	# tar --extract --file "$RABBITMQ_PATH.tar.xz" --directory "$RABBITMQ_HOME" --strip-components 1; \
-	# rm -rf "$RABBITMQ_PATH"*; \
 # Do not default SYS_PREFIX to RABBITMQ_HOME, leave it empty
 	grep -qE '^SYS_PREFIX=\$\{RABBITMQ_HOME\}$' "$RABBITMQ_HOME/sbin/rabbitmq-defaults"; \
 	sed -i 's/^SYS_PREFIX=.*$/SYS_PREFIX=/' "$RABBITMQ_HOME/sbin/rabbitmq-defaults"; \

--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -43,13 +43,12 @@ dist:
 	  --build-arg PGP_KEYSERVER=pgpkeys.uk \
 	  --build-arg OTP_VERSION=$(OTP_VERSION) \
 	  --build-arg OTP_SHA256=$(OTP_SHA256) \
-	  --build-arg RABBITMQ_VERSION=$(VERSION) \
 	  --build-arg RABBITMQ_BUILD=rabbitmq_server-$(VERSION) \
 	  --tag pivotalrabbitmq/rabbitmq:$(subst +,-,$(VERSION)) \
 	  .
 
-push: dist
-	docker push pivotalrabbitmq/rabbitmq:$(VERSION)
+push:
+	docker push pivotalrabbitmq/rabbitmq:$(subst +,-,$(VERSION))
 
 clean:
 	rm -rf rabbitmq_server-*


### PR DESCRIPTION
Before this, someone would need to run the package-generic-unix and docker-image make targets in order to produce a container image. This wouldn't always work: more than one archive in the PACKAGES dir, VERSION & RABBITMQ_VERSION had to be specified, + characters in VERSION. It also required me to have Docker running, which I am reluctant to leave running on macOS because it uses CPU even when idle, and starting it every time that I wanted an ad-hoc container image implied waiting a few minutes, and then waiting another 15 minutes for the container image to be produced and published to hub.docker.com.

This commit delegates all the above to GitHub Actions. The best part is that it happens asynchronously - every commit triggers it - and a container image for that commit will appear on hub.docker.com within ~15 minutes. In other words, anyone can test any commit in their container runtime within 20 minutes, without needing to lift a finger.  No Docker, no make targets, just reference the new tag (matches the git sha) and off you go. It's the beginning of something better, for sure.

This is what that looks like on https://hub.docker.com/r/pivotalrabbitmq/rabbitmq/tags?page=1&ordering=last_updated
![image](https://user-images.githubusercontent.com/3342/113287038-e826fc80-92e4-11eb-914a-9b982b894401.png)

For the first one that reviews this: does this work for you?
```
docker run -it --rm --network host pivotalrabbitmq/rabbitmq:f7a36f9f87853077b49a4bc54e23a24c71f9384c
```

If you are reviewing this on a Mac, try this docker one-liner instead ([this explains why](https://docs.docker.com/docker-for-mac/networking/)):

```
docker run -it --rm -p 5672:5672 -p 15672:15672 pivotalrabbitmq/rabbitmq:f7a36f9f87853077b49a4bc54e23a24c71f9384c
```

Should be added to `v3.8.x` as-is after merge.