### PR TITLE
Support rabbit_peer_discovery_aws to work with instance metadata serv…

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1733,6 +1733,19 @@ end}.
     end
 }.
 
+
+% ===============================
+% AWS section
+% ===============================
+
+%% Whether or not to prefer IMDSv2 when querying instance metadata service (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
+%% If not set or set to true, IMDSv2 will be preferred to use first. If fails, IMDSv1 will be used.
+%% {aws_prefer_imdsv2, false}
+
+{mapping, "aws_prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
+    [{datatype, {enum, [true, false]}}]}.
+
+
 % ===============================
 % Validators
 % ===============================

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -54,6 +54,8 @@ configuration or to impact configuration behavior:
  ``rabbitmq_aws:set_region/1``          | Manually specify the AWS region to make requests to.
  ``rabbitmq_aws:set_credentials/2``     | Manually specify the request credentials to use.
  ``rabbitmq_aws:refresh_credentials/0`` | Refresh the credentials from the environment, filesystem, or EC2 Instance Metadata service.
+ ``rabbitmq_aws:ensure_imdsv2_token_valid/0`` | Make sure IMDSv2 token is acctive and valid.
+ ``rabbitmq_aws:api_get_request/2``           | Perform an AWS service API request.
  ``rabbitmq_aws:get/2``                 | Perform a GET request to the API specifying the service and request path.
  ``rabbitmq_aws:get/3``                 | Perform a GET request specifying the service, path, and headers.
  ``rabbitmq_aws:post/4``                | Perform a POST request specifying the service, path, headers, and body.

--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -29,6 +29,18 @@
 
 -define(INSTANCE_CREDENTIALS, "iam/security-credentials").
 -define(INSTANCE_METADATA_BASE, "latest/meta-data").
+-define(INSTANCE_ID, "instance-id").
+
+-define(TOKEN_URL, "latest/api/token").
+
+-define(METADATA_TOKEN_TLL_HEADER, "X-aws-ec2-metadata-token-ttl-seconds").
+
+% AWS IMDSv2 is session-based and instance metadata service requests which are only needed for loading/refreshing credentials.
+% We dont need to have long-live metadata token. In fact, we only need the token is valid for a sufficient period to successfully
+% load/refresh credentials. 60 seconds is more than enough for that goal.
+-define(METADATA_TOKEN_TLL_SECONDS, 60).
+
+-define(METADATA_TOKEN, "X-aws-ec2-metadata-token").
 
 -type access_key() :: nonempty_string().
 -type secret_access_key() :: nonempty_string().
@@ -41,11 +53,17 @@
 -type sc_error() :: {error, Reason :: atom()}.
 -type security_credentials() :: sc_ok() | sc_error().
 
+-record(imdsv2token, { token :: security_token() | undefined,
+                       expiration :: expiration() | undefined}).
+
+-type imdsv2token() :: #imdsv2token{}.
+
 -record(state, {access_key :: access_key() | undefined,
                 secret_access_key :: secret_access_key() | undefined,
                 expiration :: expiration() | undefined,
                 security_token :: security_token() | undefined,
                 region :: region() | undefined,
+                imdsv2_token:: imdsv2token() | undefined,
                 error :: atom() | string() | undefined}).
 -type state() :: #state{}.
 

--- a/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
+++ b/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
@@ -23,16 +23,6 @@
 -compile(export_all).
 -endif.
 
-% rabbitmq/rabbitmq-peer-discovery-aws#25
-
-% Note: this timeout must not be greater than the default
-% gen_server:call timeout of 5000ms. Note that `timeout`,
-% when set, is used as the connect and then request timeout
-% by `httpc`
--define(INSTANCE_ID_TIMEOUT, 2250).
--define(INSTANCE_ID_URL,
-        "http://169.254.169.254/latest/meta-data/instance-id").
-
 -define(CONFIG_MODULE, rabbit_peer_discovery_config).
 -define(UTIL_MODULE,   rabbit_peer_discovery_util).
 
@@ -91,14 +81,15 @@ init() ->
 list_nodes() ->
     M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
     {ok, _} = application:ensure_all_started(rabbitmq_aws),
-    rabbit_log:debug("Started rabbitmq_aws"),
     rabbit_log:debug("Will use AWS access key of '~s'", [get_config_key(aws_access_key, M)]),
     ok = maybe_set_region(get_config_key(aws_ec2_region, M)),
     ok = maybe_set_credentials(get_config_key(aws_access_key, M),
                                get_config_key(aws_secret_key, M)),
     case get_config_key(aws_autoscaling, M) of
         true ->
-            get_autoscaling_group_node_list(instance_id(), get_tags());
+            {ok, InstanceId} = rabbitmq_aws_config:instance_id(),
+            rabbit_log:debug("EC2 instance ID is determined from metadata service: ~p", [InstanceId]),
+            get_autoscaling_group_node_list(InstanceId, get_tags());
         false ->
             get_node_list_from_tags(get_tags())
     end.
@@ -160,14 +151,18 @@ maybe_set_credentials(AccessKey, SecretKey) ->
 %% @doc Set the region from the configuration value, if it was set.
 %% @end
 %%
-maybe_set_region("undefined") -> ok;
+maybe_set_region("undefined") ->
+    case rabbitmq_aws_config:region() of
+        {ok, Region} -> maybe_set_region(Region);
+        _            -> ok
+    end;
 maybe_set_region(Value) ->
     rabbit_log:debug("Setting AWS region to ~p", [Value]),
     rabbitmq_aws:set_region(Value).
 
 get_autoscaling_group_node_list(error, _) ->
     rabbit_log:warning("Cannot discover any nodes: failed to fetch this node's EC2 "
-                       "instance id from ~s", [?INSTANCE_ID_URL]),
+                       "instance id from ~s", rabbitmq_aws_config:instance_id_url()),
     {ok, {[], disc}};
 get_autoscaling_group_node_list(Instance, Tag) ->
     case get_all_autoscaling_instances([]) of
@@ -222,7 +217,7 @@ get_all_autoscaling_instances(Accum, NextToken) ->
 
 fetch_all_autoscaling_instances(QArgs, Accum) ->
     Path = "/?" ++ rabbitmq_aws_urilib:build_query_string(QArgs),
-    case api_get_request("autoscaling", Path) of
+    case rabbitmq_aws:api_get_request("autoscaling", Path) of
         {ok, Payload} ->
             Instances = flatten_autoscaling_datastructure(Payload),
             NextToken = get_next_token(Payload),
@@ -243,16 +238,6 @@ get_next_token(Value) ->
     Result = proplists:get_value("DescribeAutoScalingInstancesResult", Response),
     NextToken = proplists:get_value("NextToken", Result),
     NextToken.
-
-api_get_request(Service, Path) ->
-    case rabbitmq_aws:get(Service, Path) of
-        {ok, {_Headers, Payload}} ->
-            rabbit_log:debug("AWS request: ~s~nResponse: ~p",
-                             [Path, Payload]),
-            {ok, Payload};
-        {error, {credentials, _}} -> {error, credentials};
-        {error, Message, _} -> {error, Message}
-    end.
 
 -spec find_autoscaling_group(Instances :: list(), Instance :: string())
                             -> string() | error.
@@ -320,7 +305,7 @@ get_hostname_name_from_reservation_set([{"item", RI}|T], Accum) ->
     get_hostname_name_from_reservation_set(T, Accum ++ Hostnames).
 
 get_hostname_names(Path) ->
-    case api_get_request("ec2", Path) of
+    case rabbitmq_aws:api_get_request("ec2", Path) of
         {ok, Payload} ->
             Response = proplists:get_value("DescribeInstancesResponse", Payload),
             ReservationSet = proplists:get_value("reservationSet", Response),
@@ -349,24 +334,6 @@ select_hostname() ->
         true  -> "privateIpAddress";
         false -> "privateDnsName";
         _     -> "privateDnsName"
-    end.
-
--spec instance_id() -> string() | error.
-%% @private
-%% @doc Return the local instance ID from the EC2 metadata service
-%% @end
-%%
-instance_id() ->
-    case httpc:request(get, {?INSTANCE_ID_URL, []},
-                       [{timeout, ?INSTANCE_ID_TIMEOUT}], []) of
-        {ok, {{_, 200, _}, _, Value}} ->
-            rabbit_log:debug("Fetched EC2 instance ID from ~p: ~p",
-                             [?INSTANCE_ID_URL, Value]),
-            Value;
-        Other ->
-            rabbit_log:error("Failed to fetch EC2 instance ID from ~p: ~p",
-                             [?INSTANCE_ID_URL, Other]),
-            error
     end.
 
 -spec get_tags() -> tags().


### PR DESCRIPTION
…ice v2 (IMDSv2).

IMDSv2 uses session-oriented requests. With session-oriented requests, a session token is retrieved first
then used in subsequent GET requests for instance metadata values such as instance-id, credentials, etc.

Details could be found here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

## Proposed Changes

The following change is an implementation to the support aws_peer_discover_aws plugin to work with EC2 instance metadata service version 2 (IMDSv2). IMDSv2 is a new version of the instance metadata service which adds defense in depth against open firewalls, reverse proxies, and SSRF vulnerabilities. With IMDSv2, every request submitted to the instance metadata service is now protected by session authentication. Specifically, querying IMDSv2 is done in 2 steps:

* Start a session with an HTTP PUT request to IMDSv2. IMDSv2 then returns a secret token.
* Use the secret token to make any HTTP GET request to retrieve interested metadata values such as availability zone, instance role, instance ID, credentials, etc.

This change is backward compatible. If for some reason, it fails to obtain a secret token from IMDSv2, rabbit_peer_discovery_aws plugin will fallback to use IMDSv1. 

In addition, a new configuration flag `aws_prefer_imdsv2` is also introduced to allow users explicitly enable or disable using IMDSv1. Per AWS security recommendation, IMDSv2 is preferable. Specifically, if the configuration flag a new configuration flag: `aws_prefer_imdsv2` is not set or set to true, the rabbitmq_peer_discovery_aws plugin will attempt to retrieve a secret token first. If a secret token is received successfully, it will be used in subsequent requests submitted to the instance metadata service. On the other hand, if  `aws_prefer_imdsv2` is set to false, the rabbitmq_peer_discovery_aws plugin will use IMDSv1 for instance metadata queries. 


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested this change with AWS and with both IMDSv2 and failure scenario to fallback to IMDSv1 as well as explicitly turn off IMDSv2 preference.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

IMDSv2 secret token retrieval result (both success and failure) is cached and reused. This is to guarantee that there is at most 1 HTTP PUT request is used to request IMDSv2 secret token per session which included multiple HTTP GET requests to query metadata values: instance-id, availability zone, instance role, and credentials. 
