### PR TITLE
Set segment_entry_count per vhost and use a better default

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -131,12 +131,7 @@ _APP_ENV = """[
 	    %% interval at which connection/channel tracking executes post operations
 	    {tracking_execution_timeout, 15000},
 	    {stream_messages_soft_limit, 256},
-        {track_auth_attempt_source, false},
-        %% Number of entries per index segment.
-        %% This value can only be changed safely
-        %% on an empty node. Default calculated
-        %% as trunc(math:pow(2,?REL_SEQ_BITS))).
-        {queue_index_segment_entry_count, 16384}
+        {track_auth_attempt_source, false}
 	  ]
 """
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -121,12 +121,7 @@ define PROJECT_ENV
 	    %% interval at which connection/channel tracking executes post operations
 	    {tracking_execution_timeout, 15000},
 	    {stream_messages_soft_limit, 256},
-        {track_auth_attempt_source, false},
-        %% Number of entries per index segment.
-        %% This value can only be changed safely
-        %% on an empty node. Default calculated
-        %% as trunc(math:pow(2,?REL_SEQ_BITS))).
-        {queue_index_segment_entry_count, 16384}
+        {track_auth_attempt_source, false}
 	  ]
 endef
 


### PR DESCRIPTION
## Proposed Changes

Lower values of `queue_index_segment_entry_count` have shown to
potentially improve the performance of the queue. This PR allows
changing the default to a better value without breaking existing
installations.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

At this point I have not tested it nor have I confirmed it works when upgrading.

The new default needs to be figured out by testing with values 512 1024 2056 4096 8192 16384. Since @gerhard already has a setup comparing 1024 and 16384 I think we should just extend the testing by adding more clusters for comparison.