### PR TITLE
CLI: handle {:relative, val} cases when formatting effective memory watermark value

### DIFF
--- a/deps/rabbit/src/rabbit_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_disk_monitor.erl
@@ -66,7 +66,7 @@
 
 %%----------------------------------------------------------------------------
 
--type disk_free_limit() :: (integer() | string() | {'mem_relative', float() | integer()}).
+-type disk_free_limit() :: (integer() | {'absolute', integer()} | string() | {'mem_relative', float() | integer()}).
 
 %%----------------------------------------------------------------------------
 %% Public API
@@ -272,6 +272,8 @@ parse_free_win32(CommandResult) ->
 interpret_limit({mem_relative, Relative})
     when is_number(Relative) ->
     round(Relative * vm_memory_monitor:get_total_memory());
+interpret_limit({absolute, Absolute}) ->
+    interpret_limit(Absolute);
 interpret_limit(Absolute) ->
     case rabbit_resource_monitor_misc:parse_information_unit(Absolute) of
         {ok, ParsedAbsolute} -> ParsedAbsolute;

--- a/deps/rabbit/src/rabbit_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_disk_monitor.erl
@@ -66,7 +66,7 @@
 
 %%----------------------------------------------------------------------------
 
--type disk_free_limit() :: (integer() | {'absolute', integer()} | string() | {'mem_relative', float() | integer()}).
+-type disk_free_limit() :: integer() | {'absolute', integer()} | string() | {'mem_relative', float() | integer()}.
 
 %%----------------------------------------------------------------------------
 %% Public API

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
@@ -56,6 +56,9 @@ defmodule RabbitMQ.CLI.Core.Memory do
   def formatted_watermark(val) when is_float(val) do
     %{relative: val}
   end
+  def formatted_watermark({:relative, val}) when is_float(val) do
+    %{relative: val}
+  end
   def formatted_watermark({:absolute, val}) do
     %{absolute: parse_watermark(val)}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
@@ -59,6 +59,9 @@ defmodule RabbitMQ.CLI.Core.Memory do
   def formatted_watermark({:relative, val}) when is_float(val) do
     %{relative: val}
   end
+  def formatted_watermark(:infinity) do
+    %{relative: 1.0}
+  end
   def formatted_watermark({:absolute, val}) do
     %{absolute: parse_watermark(val)}
   end


### PR DESCRIPTION
## Proposed Changes

CLI: handle `{:relative, val}` cases when formatting effective memory watermark value.

It can be exposed to CLI tools when relative watermark value is
configured via advanced.config.

I fixed a couple of tiny related things discovered along the way.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2964)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #2964.