### PR TITLE
High VM watermark: support {relative, N} values set via advanced.config

### DIFF
--- a/deps/rabbit/test/unit_vm_memory_monitor_SUITE.erl
+++ b/deps/rabbit/test/unit_vm_memory_monitor_SUITE.erl
@@ -21,7 +21,8 @@ groups() ->
     [
       {sequential_tests, [], [
           parse_line_linux,
-          set_vm_memory_high_watermark_command
+          set_vm_memory_high_watermark_relative1,
+          set_vm_memory_high_watermark_relative2
         ]}
     ].
 
@@ -75,21 +76,26 @@ parse_line_linux(_Config) ->
                    {"MemTotal     50296866   ",   {'MemTotal', 50296866}}]),
     ok.
 
-set_vm_memory_high_watermark_command(Config) ->
+set_vm_memory_high_watermark_relative1(Config) ->
     rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, set_vm_memory_high_watermark_command1, [Config]).
+      ?MODULE, set_and_verify_vm_memory_high_watermark_relative, [1.0]).
 
-set_vm_memory_high_watermark_command1(_Config) ->
-    MemLimitRatio = 1.0,
+%% an alternative way of setting it via advanced.config, equivalent to the relative1 case above
+set_vm_memory_high_watermark_relative2(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, set_and_verify_vm_memory_high_watermark_relative, [{relative, 1.0}]).
+
+
+set_and_verify_vm_memory_high_watermark_relative(MemLimitRatio) ->
     MemTotal = vm_memory_monitor:get_total_memory(),
 
     vm_memory_monitor:set_vm_memory_high_watermark(MemLimitRatio),
     MemLimit = vm_memory_monitor:get_memory_limit(),
     case MemLimit of
         MemTotal -> ok;
-        _        -> MemTotalToMemLimitRatio = MemLimit * 100.0 / MemTotal / 100,
+        _        -> MemTotalToMemLimitRatio = (MemLimit * 100) / (MemTotal * 100),
                     ct:fail(
-                        "Expected memory high watermark to be ~p (~s), but it was ~p (~.1f)",
+                        "Expected memory high watermark to be ~p (~p), but it was ~p (~.1f)",
                         [MemTotal, MemLimitRatio, MemLimit, MemTotalToMemLimitRatio]
                     )
     end.


### PR DESCRIPTION
for usability. It is not any different from when a float value
is used and only exists as a counterpart to '{absolute, N}'.

Also nothing changes for rabbitmq.conf users as that format performs
validation and correct value translation.

See #2694, #2965 for background.
