### PR TITLE
Allow quorum queue names to exceed atom max chars

### DIFF
--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -92,6 +92,7 @@ all_tests() ->
      declare_invalid_properties,
      declare_server_named,
      start_queue,
+     long_name,
      stop_queue,
      restart_queue,
      restart_all_types,
@@ -347,8 +348,6 @@ start_queue(Config) ->
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     LQ = ?config(queue_name, Config),
-    %% The stream coordinator is also a ra process, we need to ensure the quorum tests
-    %% are not affected by any other ra cluster that could be added in the future
     Children = length(rpc:call(Server, supervisor, which_children, [?SUPNAME])),
 
     ?assertEqual({'queue.declare_ok', LQ, 0, 0},
@@ -376,7 +375,28 @@ start_queue(Config) ->
     ?assertMatch({ra, _, _}, lists:keyfind(ra, 1,
                                            rpc:call(Server, application, which_applications, []))),
     ?assertMatch(Expected,
-                 length(rpc:call(Server, supervisor, which_children, [?SUPNAME]))).
+                 length(rpc:call(Server, supervisor, which_children, [?SUPNAME]))),
+
+    ok.
+
+
+long_name(Config) ->
+    Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    %% 64 + chars
+    VHost = <<"long_name_vhost____________________________________">>,
+    QName = atom_to_binary(?FUNCTION_NAME, utf8),
+    User = ?config(rmq_username, Config),
+    ok = rabbit_ct_broker_helpers:add_vhost(Config, Node, VHost, User),
+    ok = rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, Node,
+                                                              VHost),
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+    %% long name
+    LongName = binary:copy(QName, 240 div byte_size(QName)),
+    ?assertEqual({'queue.declare_ok', LongName, 0, 0},
+                 declare(Ch, LongName,
+                         [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    ok.
 
 start_queue_concurrent(Config) ->
     Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
If the concatenation of the vhost and the queue name exceeds 255 chars
we instead generate an arbitrary atom name instead of throwing an
exception.

Fixes: #2968 
