### PR TITLE
Improvements to the source-dist recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,8 @@ $(SOURCE_DIST): $(ERLANG_MK_RECURSIVE_DEPS_LIST)
 		mix_exs=$@/deps/$$(basename $$dep)/mix.exs; \
 		if test -f $$mix_exs; then \
 			(cd $$(dirname "$$mix_exs") && \
-			 env DEPS_DIR=$@/deps HOME=$@/deps MIX_ENV=prod FILL_HEX_CACHE=yes mix local.hex --force && \
-			 env DEPS_DIR=$@/deps HOME=$@/deps MIX_ENV=prod FILL_HEX_CACHE=yes mix deps.get --only prod && \
+			 (test -d $@/deps/.hex || env DEPS_DIR=$@/deps MIX_HOME=$@/deps/.mix HEX_HOME=$@/deps/.hex MIX_ENV=prod FILL_HEX_CACHE=yes mix local.hex --force) && \
+			 env DEPS_DIR=$@/deps MIX_HOME=$@/deps/.mix HEX_HOME=$@/deps/.hex MIX_ENV=prod FILL_HEX_CACHE=yes mix deps.get --only prod && \
 			 cp $(CURDIR)/mk/rabbitmq-mix.mk . && \
 			 rm -rf _build deps); \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ $(SOURCE_DIST): $(ERLANG_MK_RECURSIVE_DEPS_LIST)
 #
 # The ETS file must be recreated before compiling RabbitMQ. See the
 # `restore-hex-cache-ets-file` Make target.
-	$(verbose) $(call erlang,$(call dump_hex_cache_to_erl_term,$@,$@.git-time.txt))
+	$(verbose) $(call erlang,$(call dump_hex_cache_to_erl_term,$(call core_native_path,$@),$(call core_native_path,$@.git-time.txt)))
 # Fix file timestamps to have reproducible source archives.
 	$(verbose) find $@ -print0 | xargs -0 touch -t "$$(cat "$@.git-time.txt")"
 	$(verbose) rm "$@.git-times.txt" "$@.git-time.txt"

--- a/Makefile
+++ b/Makefile
@@ -498,24 +498,12 @@ install-windows-erlapp: dist
 	$(verbose) mkdir -p $(DESTDIR)$(WINDOWS_PREFIX)
 	$(inst_verbose) cp -r \
 		LICENSE* \
-		$(DEPS_DIR)/rabbit/ebin \
-		$(DEPS_DIR)/rabbit/priv \
 		$(DEPS_DIR)/rabbit/INSTALL \
 		$(DIST_DIR) \
 		$(DESTDIR)$(WINDOWS_PREFIX)
 	$(verbose) echo "Put your EZs here and use rabbitmq-plugins.bat to enable them." \
 		> $(DESTDIR)$(WINDOWS_PREFIX)/$(notdir $(DIST_DIR))/README.txt
 	$(verbose) $(UNIX_TO_DOS) $(DESTDIR)$(WINDOWS_PREFIX)/plugins/README.txt
-
-	@# FIXME: Why do we copy headers?
-	$(verbose) cp -r \
-		$(DEPS_DIR)/rabbit/include \
-		$(DESTDIR)$(WINDOWS_PREFIX)
-	@# rabbitmq-common provides headers too: copy them to
-	@# rabbitmq_server/include.
-	$(verbose) cp -r \
-		$(DEPS_DIR)/rabbit_common/include \
-		$(DESTDIR)$(WINDOWS_PREFIX)
 
 install-windows-escripts:
 	$(verbose) $(MAKE) -C $(DEPS_DIR)/rabbitmq_cli install \

--- a/mk/rabbitmq-mix.mk
+++ b/mk/rabbitmq-mix.mk
@@ -13,9 +13,9 @@ HEX_OFFLINE := 1
 
 override MIX_HOME := $(DEPS_DIR)/.mix
 
-# In addition to `$MIX_HOME`, we still have to set `$HOME` which is used
-# to find `~/.hex` where the Hex.pm cache and packages are stored.
+# In addition to `$MIX_HOME`, we still have to set `$HEX_HOME` which is used to
+# find `~/.hex` where the Hex.pm cache and packages are stored.
 
-override HOME := $(DEPS_DIR)
+override HEX_HOME := $(DEPS_DIR)/.hex
 
-export HEX_OFFLINE MIX_HOME HOME
+export HEX_OFFLINE MIX_HOME HEX_HOME


### PR DESCRIPTION
This is a collection of patches to improvements to the creation of the source archive:
* It uses `$MIX_HOME` and `$HEX_HOME` environment variables to manage the offline Hex.pm cache instead of messing with `$HOME`.
* It fixes the recipe to make it work on Microsoft Windows (still inside an MSYS2 environment).
* It removes redundant files from the Windows installer: the `ebin`, `include` and `ebin` directories are already available in the `rabbit` "plugin" archive or directory.

All of them can be backported to the `v3.8.x` release branch, but only after a successful package build in the Concourse pipeline: indeed, I can't test the offline build of the package because I need the connection to the VM.