### PR TITLE
Classic queue mirrors should also continue pushing messages to disk when syncing

### DIFF
--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -385,8 +385,13 @@ handle_info({bump_credit, Msg}, State) ->
     credit_flow:handle_bump_msg(Msg),
     noreply(State);
 
-handle_info(bump_reduce_memory_use, State) ->
-    noreply(State);
+handle_info(bump_reduce_memory_use, State = #state{backing_queue       = BQ,
+                                                backing_queue_state = BQS}) ->
+    BQS1 = BQ:handle_info(bump_reduce_memory_use, BQS),
+    BQS2 = BQ:resume(BQS1),
+    noreply(State#state{
+        backing_queue_state = BQS2
+    });
 
 %% In the event of a short partition during sync we can detect the
 %% master's 'death', drop out of sync, and then receive sync messages


### PR DESCRIPTION
## Proposed Changes

 Hi,

I have two RabbitMQs, full of 2 kb messages, memory limit 1.2 GB, sync mode automatic:

![kép](https://user-images.githubusercontent.com/923194/114669971-cd03b600-9d02-11eb-8c8b-6e3b35bc27b0.png)


The synchronisation can get stuck because the queue does not reduce its memory usage on the mirror process:

![kép](https://user-images.githubusercontent.com/923194/114670006-d856e180-9d02-11eb-8dcd-33789103883a.png)

```
(rabbit@rmq2.monitored.host)4> erlang:process_info(<0.1066.0>, messages).
{messages,[emit_gen_server2_stats,bump_reduce_memory_use]}
```

Because it's not handling `bump_reduce_memory_use`, it is only scheduling the next batch to disk when `set_ram_duration_target` is received, as that call is calling `reduce_memory_use`. 

You can see it on this graph that it takes around 10 minutes to synchronise this queue, because it's constantly hitting the watermark, because the queue is not sending messages to disk:

![kép](https://user-images.githubusercontent.com/923194/114670061-e86ec100-9d02-11eb-930a-0e9800a1caf3.png)


Even after the sync is finished, there I think unexpectedly many messages in memory:

![kép](https://user-images.githubusercontent.com/923194/114670114-f58bb000-9d02-11eb-810c-9356e7094434.png)


Total memory usage for the mirror:

![kép](https://user-images.githubusercontent.com/923194/114670153-ff151800-9d02-11eb-85a3-907cb64c9b3a.png)


After the fix, sync takes around 3 minutes:

![kép](https://user-images.githubusercontent.com/923194/114670440-47ccd100-9d03-11eb-8d70-a4097525242e.png)
![kép](https://user-images.githubusercontent.com/923194/114670458-4c918500-9d03-11eb-8282-f58c759f154e.png)


There are still some messages in memory but significantly lower as the message store actually is sending these bump_reduce_memory_use messages but they were not handled properly:

![kép](https://user-images.githubusercontent.com/923194/114670487-561aed00-9d03-11eb-8584-1dd28b9bd081.png)


Interestingly, same test using lazy queues:

![kép](https://user-images.githubusercontent.com/923194/114670506-5adfa100-9d03-11eb-8cbf-2e0cb53e94dd.png)


Done in under 30 seconds.

Probably `wait_for_resources` should also handle `bump_reduce_memory_usage`, it's in the critical path, basically it does not do anything instead of pushing messages to disk.

I think there are some issues with `set_ram_duration_target` as well as it looks like flip flopping around, even though the calculated target ram messages should be 0, as the queue has no consumers, but it's setting non zero targets.

I've tried to handle set_ram_duration_target in the sync slave process to force the duration to 0, but curiously that did not really help, possibly because wait_for_resources does not handle the bump message.

These resume 'bump_reduce_memory_use' messages were not handled on the mirror, which I think may lead to high memory usage on the queue mirror process, so I added that as well.

Here is the proof of concept fix, let me know what you think. As I said, with this it takes around 3 minutes to sync the queue, which is still pretty far from the lazy queue version. 


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

