### PR TITLE
Mk decode other name as directory string

### DIFF
--- a/deps/rabbit_common/src/rabbit_cert_info.erl
+++ b/deps/rabbit_common/src/rabbit_cert_info.erl
@@ -114,8 +114,8 @@ sanitize_other_name(Bin) when is_binary(Bin) ->
     %% but ASN.1 decoding functions in OTP only offer so much and SAN values
     %% are expected to be "string-like" by RabbitMQ
     case 'OTP-PUB-KEY':decode('DirectoryString', Bin) of
-        {ok, {utf8String, Val}} -> Val;
-        Other                   -> Other
+        {ok, {_, Val}} -> Val;
+        Other          -> Other
     end.
 
 %% Format and rdnSequence as a RFC4514 subject string.

--- a/deps/rabbit_common/src/rabbit_cert_info.erl
+++ b/deps/rabbit_common/src/rabbit_cert_info.erl
@@ -110,9 +110,11 @@ find_by_type(Type, {rdnSequence, RDNs}) ->
 %%--------------------------------------------------------------------------
 
 sanitize_other_name(Bin) when is_binary(Bin) ->
-    %% strip off leading values that seem to be ASN.1 UTF value encoding artifacts
-    case Bin of
-        <<_:2/binary, Rest/binary>> -> Rest;
+    %% We make a wild assumption about the types here
+    %% but ASN.1 decoding functions in OTP only offer so much and SAN values
+    %% are expected to be "string-like" by RabbitMQ
+    case 'OTP-PUB-KEY':decode('DirectoryString', Bin) of
+        {ok, {utf8String, Val}} -> Val;
         Other                   -> Other
     end.
 

--- a/deps/rabbit_common/src/rabbit_cert_info.erl
+++ b/deps/rabbit_common/src/rabbit_cert_info.erl
@@ -112,7 +112,7 @@ find_by_type(Type, {rdnSequence, RDNs}) ->
 sanitize_other_name(Bin) when is_binary(Bin) ->
     %% strip off leading values that seem to be ASN.1 UTF value encoding artifacts
     case Bin of
-        <<12, 14, Rest/binary>> -> Rest;
+        <<_:2/binary, Rest/binary>> -> Rest;
         Other                   -> Other
     end.
 


### PR DESCRIPTION
Decode other name using 'OTP-PUB-KEY':decode/2

and assume it is a string-like value ("directory string")
because other values would not make much sense in the
username extraction context.

References #2983.