### PR TITLE
Allow AMQP error responses in channel interceptors

### DIFF
--- a/deps/rabbit/test/channel_interceptor_SUITE.erl
+++ b/deps/rabbit/test/channel_interceptor_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
 
@@ -21,6 +22,7 @@ groups() ->
     [
       {non_parallel_tests, [], [
           register_interceptor,
+          register_interceptor_failing_with_amqp_error,
           register_failing_interceptors
         ]}
     ].
@@ -92,6 +94,55 @@ register_interceptor1(Config, Interceptor) ->
     [{interceptors, []}] = rabbit_channel:info(ChannelProc, [interceptors]),
 
     check_send_receive(Ch1, QName, <<"bar">>, <<"bar">>),
+    passed.
+
+register_interceptor_failing_with_amqp_error(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, register_interceptor_failing_with_amqp_error1,
+      [Config, dummy_interceptor]).
+
+register_interceptor_failing_with_amqp_error1(Config, Interceptor) ->
+    PredefinedChannels = rabbit_channel:list(),
+
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, 0),
+
+    [ChannelProc] = rabbit_channel:list() -- PredefinedChannels,
+
+    [{interceptors, []}] = rabbit_channel:info(ChannelProc, [interceptors]),
+
+    ok = rabbit_registry:register(channel_interceptor,
+                                  <<"dummy interceptor">>,
+                                  Interceptor),
+    [{interceptors, [{Interceptor, undefined}]}] =
+      rabbit_channel:info(ChannelProc, [interceptors]),
+
+    Q1 = <<"succeeding-q">>,
+    #'queue.declare_ok'{} =
+        amqp_channel:call(Ch1, #'queue.declare'{queue = Q1}),
+
+    Q2 = <<"failing-q">>,
+    try
+        amqp_channel:call(Ch1, #'queue.declare'{queue = Q2})
+    catch
+      _:Reason ->
+          ?assertMatch(
+              {{shutdown, {_, _, <<"PRECONDITION_FAILED - operation not allowed">>}}, _},
+              Reason)
+    end,
+
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, 0),
+    [ChannelProc1] = rabbit_channel:list() -- PredefinedChannels,
+
+    ok = rabbit_registry:unregister(channel_interceptor,
+                                  <<"dummy interceptor">>),
+    [{interceptors, []}] = rabbit_channel:info(ChannelProc1, [interceptors]),
+
+    #'queue.declare_ok'{} =
+        amqp_channel:call(Ch2, #'queue.declare'{queue = Q2}),
+
+    #'queue.delete_ok'{} = amqp_channel:call(Ch2, #'queue.delete' {queue = Q1}),
+    #'queue.delete_ok'{} = amqp_channel:call(Ch2, #'queue.delete' {queue = Q2}),
+
     passed.
 
 register_failing_interceptors(Config) ->

--- a/deps/rabbit/test/dummy_interceptor.erl
+++ b/deps/rabbit/test/dummy_interceptor.erl
@@ -19,8 +19,14 @@ intercept(#'basic.publish'{} = Method, Content, _IState) ->
     Content2 = Content#content{payload_fragments_rev = []},
     {Method, Content2};
 
+%% Use 'queue.declare' to test #amqp_error{} handling
+intercept(#'queue.declare'{queue = <<"failing-q">>}, _Content, _IState) ->
+    rabbit_misc:amqp_error(
+        'precondition_failed', "operation not allowed", [],
+        'queue.declare');
+
 intercept(Method, Content, _VHost) ->
     {Method, Content}.
 
 applies_to() ->
-    ['basic.publish'].
+    ['basic.publish', 'queue.declare'].


### PR DESCRIPTION
## Proposed Changes

Channel interceptors should be able to return `#amqp_error{}`
on failing AMQP operations. This allows the parent channel
process to handle such errors/failures as expected, to fail safe
and terminate the channel. Currently, explicitly returning such
AMQP errors from interceptors is unhandled and results in
channels terminating unsafely.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

