### PR TITLE
Set a default for consumer_timeout

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -85,6 +85,8 @@ define PROJECT_ENV
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667
 	    {channel_operation_timeout, 15000},
+	    %% 15 minutes
+	    {consumer_timeout, 900000},
 
 	    %% see rabbitmq-server#486
 	    {autocluster,

--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -576,6 +576,13 @@
 ## on Windows.
 # motd_file = /etc/rabbitmq/motd
 
+## Consumer timeout
+## If a message delivered to a consumer has not been acknowledge before this timer
+## triggers the channel will be force closed by the broker. This ensure that
+## faultly consumers that never ack will not hold on to messages indefinitely.
+##
+# consumer_timeout = 900000
+
 ## ----------------------------------------------------------------------------
 ## Advanced Erlang Networking/Clustering Options.
 ##


### PR DESCRIPTION
So that faulty consumers that will never ack a pending messages have
their channels closed after 15 minutes.
