### PR TITLE
Ignore drained nodes when rebalancing

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -85,6 +85,8 @@ define PROJECT_ENV
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667
 	    {channel_operation_timeout, 15000},
+	    %% 15 minutes
+	    {consumer_timeout, 900000},
 
 	    %% see rabbitmq-server#486
 	    {autocluster,

--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -576,6 +576,13 @@
 ## on Windows.
 # motd_file = /etc/rabbitmq/motd
 
+## Consumer timeout
+## If a message delivered to a consumer has not been acknowledge before this timer
+## triggers the channel will be force closed by the broker. This ensure that
+## faultly consumers that never ack will not hold on to messages indefinitely.
+##
+# consumer_timeout = 900000
+
 ## ----------------------------------------------------------------------------
 ## Advanced Erlang Networking/Clustering Options.
 ##

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -504,7 +504,7 @@ maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
         [{_, Q, false} = Queue | Queues] = All when length(All) > MaxQueuesDesired ->
             Name = amqqueue:get_name(Q),
             Module = rebalance_module(Q),
-            Candidates = rabbit_maintenance:filter_out_drained_nodes_consistent_read(Module:get_replicas(Q) -- [N]),
+            Candidates = rabbit_maintenance:filter_out_drained_nodes_local_read(Module:get_replicas(Q) -- [N]),
             case Candidates of
                 [] ->
                     {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -504,7 +504,7 @@ maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
         [{_, Q, false} = Queue | Queues] = All when length(All) > MaxQueuesDesired ->
             Name = amqqueue:get_name(Q),
             Module = rebalance_module(Q),
-            Candidates = Module:get_replicas(Q) -- [N],
+            Candidates = rabbit_maintenance:filter_out_drained_nodes_consistent_read(Module:get_replicas(Q) -- [N]),
             case Candidates of
                 [] ->
                     {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -385,8 +385,13 @@ handle_info({bump_credit, Msg}, State) ->
     credit_flow:handle_bump_msg(Msg),
     noreply(State);
 
-handle_info(bump_reduce_memory_use, State) ->
-    noreply(State);
+handle_info(bump_reduce_memory_use, State = #state{backing_queue       = BQ,
+                                                backing_queue_state = BQS}) ->
+    BQS1 = BQ:handle_info(bump_reduce_memory_use, BQS),
+    BQS2 = BQ:resume(BQS1),
+    noreply(State#state{
+        backing_queue_state = BQS2
+    });
 
 %% In the event of a short partition during sync we can detect the
 %% master's 'death', drop out of sync, and then receive sync messages

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -104,6 +104,7 @@
 -define(TICK_TIMEOUT, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
 -define(ADD_MEMBER_TIMEOUT, 5000).
+-define(TRANSFER_TIMEOUT, 60000).
 
 %%----------- rabbit_queue_type ---------------------------------------------
 
@@ -1173,7 +1174,7 @@ transfer_leadership(Q, Destination) ->
     {RaName, _} = Pid = amqqueue:get_pid(Q),
     case ra:transfer_leadership(Pid, {RaName, Destination}) of
         ok ->
-          case ra:members(Pid) of
+          case ra:members(Pid, ?TRANSFER_TIMEOUT) of
             {_, _, {_, NewNode}} ->
               {migrated, NewNode};
             {timeout, _} ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -104,7 +104,6 @@
 -define(TICK_TIMEOUT, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
 -define(ADD_MEMBER_TIMEOUT, 5000).
--define(TRANSFER_TIMEOUT, 60000).
 
 %%----------- rabbit_queue_type ---------------------------------------------
 
@@ -1174,7 +1173,7 @@ transfer_leadership(Q, Destination) ->
     {RaName, _} = Pid = amqqueue:get_pid(Q),
     case ra:transfer_leadership(Pid, {RaName, Destination}) of
         ok ->
-          case ra:members(Pid, ?TRANSFER_TIMEOUT) of
+          case ra:members(Pid) of
             {_, _, {_, NewNode}} ->
               {migrated, NewNode};
             {timeout, _} ->


### PR DESCRIPTION
When running `rabbitmq-queues rebalance`, drained nodes (nodes in maintenance mode) should not be considered for queue leader replica placement.
