### PR TITLE
Streams: safer replica addition

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -642,9 +642,7 @@ add_replica(VHost, Name, Node) ->
                 false ->
                     {error, node_not_running};
                 true ->
-                    #{name := StreamId} = amqqueue:get_type_state(Q),
-                    {ok, Reply, _} = rabbit_stream_coordinator:add_replica(StreamId, Node),
-                    Reply
+                    rabbit_stream_coordinator:add_replica(Q, Node)
             end;
         E ->
             E


### PR DESCRIPTION
Disallow replica additions if any of the existing replicas are more than
10 seconds out of date.
