### PR TITLE
Tag docker image with branch name

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Build container image
         working-directory: packaging/docker-image
         run: |
-          make dist
+          make dist IMAGE_TAG=${GITHUB_REF##*/}
 
       - name: Login to DockerHub
         working-directory: packaging/docker-image
@@ -50,4 +50,4 @@ jobs:
       - name: Push container image to DockerHub
         working-directory: packaging/docker-image
         run: |
-          make push
+          make push IMAGE_TAG=${GITHUB_REF##*/}

--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -34,6 +34,7 @@ endif
 
 OTP_VERSION ?= 23.2.4
 OTP_SHA256 ?= e72aa084907e0f34f932cf00caa33aba93147b0a7c9c35569d6bd1c402f532de
+REPO ?= pivotalrabbitmq/rabbitmq
 
 all: dist
 
@@ -44,11 +45,17 @@ dist:
 	  --build-arg OTP_VERSION=$(OTP_VERSION) \
 	  --build-arg OTP_SHA256=$(OTP_SHA256) \
 	  --build-arg RABBITMQ_BUILD=rabbitmq_server-$(VERSION) \
-	  --tag pivotalrabbitmq/rabbitmq:$(subst +,-,$(VERSION)) \
+	  --tag $(REPO):$(subst +,-,$(VERSION)) \
 	  .
+ifdef IMAGE_TAG
+	docker tag $(REPO):$(subst +,-,$(VERSION)) $(REPO):$(IMAGE_TAG)
+endif
 
 push:
-	docker push pivotalrabbitmq/rabbitmq:$(subst +,-,$(VERSION))
+	docker push $(REPO):$(subst +,-,$(VERSION))
+ifdef IMAGE_TAG
+	docker push $(REPO):$(IMAGE_TAG)
+endif
 
 clean:
 	rm -rf rabbitmq_server-*


### PR DESCRIPTION
Tag docker image with branch name in addition to tagging the docker image with the Git commit SHA (introduced in https://github.com/rabbitmq/rabbitmq-server/pull/2945).

This enables the cluster-operator to [run system-tests](https://github.com/rabbitmq/cluster-operator/blob/9909d3b769e9b2c77c738afa03f740937b38de0d/.github/workflows/pr.yml#L42-L65) against latest
rabbitmq-server `master` branch which allows us to fix any breaking
changes early and to test unreleased features such as rabbitmq_stream
plugin (https://github.com/rabbitmq/cluster-operator/pull/665).

As part of the commit in this PR, the GitHub action created an image tagged with this PR's branch name `tag-branch`:
```
docker pull pivotalrabbitmq/rabbitmq:tag-branch
```