### PR TITLE
Support streams in STOMP plugin

### DIFF
--- a/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
+++ b/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
@@ -26,6 +26,7 @@
 -define(HEADER_PASSCODE, "passcode").
 -define(HEADER_PERSISTENT, "persistent").
 -define(HEADER_PREFETCH_COUNT, "prefetch-count").
+-define(HEADER_X_STREAM_OFFSET, "x-stream-offset").
 -define(HEADER_PRIORITY, "priority").
 -define(HEADER_RECEIPT, "receipt").
 -define(HEADER_REDELIVERED, "redelivered").

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_frame.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_frame.erl
@@ -27,6 +27,7 @@
          boolean_header/2, boolean_header/3,
          integer_header/2, integer_header/3,
          binary_header/2, binary_header/3]).
+-export([stream_offset_header/2]).
 -export([serialize/1, serialize/2]).
 
 initial_state() -> none.
@@ -221,6 +222,26 @@ binary_header(F, K) ->
     end.
 
 binary_header(F, K, D) -> default_value(binary_header(F, K), D).
+
+stream_offset_header(F, D) ->
+    OffsetPrefix = <<"offset:">>,
+    OffsetPrefixLength = byte_size(OffsetPrefix),
+    TimestampPrefix = <<"timestamp:">>,
+    TimestampPrefixLength = byte_size(TimestampPrefix),
+    case binary_header(F, ?HEADER_X_STREAM_OFFSET, D) of
+        <<"first">> ->
+            {longstr, <<"first">>};
+        <<"last">> ->
+            {longstr, <<"last">>};
+        <<"next">> ->
+            {longstr, <<"next">>};
+        <<OffsetPrefix:OffsetPrefixLength/binary, OffsetValue/binary>> ->
+            {long, binary_to_integer(OffsetValue)};
+        <<TimestampPrefix:TimestampPrefixLength/binary, TimestampValue/binary>> ->
+            {timestamp, binary_to_integer(TimestampValue)};
+        _ ->
+            D
+    end.
 
 serialize(Frame) ->
     serialize(Frame, true).

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_frame.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_frame.erl
@@ -224,10 +224,6 @@ binary_header(F, K) ->
 binary_header(F, K, D) -> default_value(binary_header(F, K), D).
 
 stream_offset_header(F, D) ->
-    OffsetPrefix = <<"offset:">>,
-    OffsetPrefixLength = byte_size(OffsetPrefix),
-    TimestampPrefix = <<"timestamp:">>,
-    TimestampPrefixLength = byte_size(TimestampPrefix),
     case binary_header(F, ?HEADER_X_STREAM_OFFSET, D) of
         <<"first">> ->
             {longstr, <<"first">>};
@@ -235,9 +231,9 @@ stream_offset_header(F, D) ->
             {longstr, <<"last">>};
         <<"next">> ->
             {longstr, <<"next">>};
-        <<OffsetPrefix:OffsetPrefixLength/binary, OffsetValue/binary>> ->
+        <<"offset=", OffsetValue/binary>> ->
             {long, binary_to_integer(OffsetValue)};
-        <<TimestampPrefix:TimestampPrefixLength/binary, TimestampValue/binary>> ->
+        <<"timestamp=", TimestampValue/binary>> ->
             {timestamp, binary_to_integer(TimestampValue)};
         _ ->
             D

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_util.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_util.erl
@@ -115,6 +115,8 @@ adhoc_convert_headers(Headers, Existing) ->
                         [{binary_to_list(K), binary_to_list(V)} | Acc];
                     ({K, signedint, V}, Acc) ->
                         [{binary_to_list(K), integer_to_list(V)} | Acc];
+                    ({K, long, V}, Acc) ->
+                        [{binary_to_list(K), integer_to_list(V)} | Acc];
                     (_, Acc) ->
                         Acc
                 end, Existing, Headers).

--- a/deps/rabbitmq_stomp/test/frame_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/frame_SUITE.erl
@@ -168,8 +168,8 @@ stream_offset_header(_) ->
         {{"x-stream-offset", "first"}, {longstr, <<"first">>}},
         {{"x-stream-offset", "last"}, {longstr, <<"last">>}},
         {{"x-stream-offset", "next"}, {longstr, <<"next">>}},
-        {{"x-stream-offset", "offset:5000"}, {long, 5000}},
-        {{"x-stream-offset", "timestamp:1000"}, {timestamp, 1000}},
+        {{"x-stream-offset", "offset=5000"}, {long, 5000}},
+        {{"x-stream-offset", "timestamp=1000"}, {timestamp, 1000}},
         {{"x-stream-offset", "foo"}, undefined},
         {{"some-header", "some value"}, undefined}
     ],


### PR DESCRIPTION
This commit introduces the support of an x-stream-offset header
in the SUBSCRIBE frame to start consuming from a specific place
in a stream. The possible values are first, last, next, offset:<offset-value>
(e.g. offset:40000), timestamp:<timestamp-in-seconds> (e.g. timestamp:1619428685).

This commit also propagates the x-stream-offset header in the MESSAGE frame
to know the offset of a the delivered message in the stream.