### PR TITLE
Emit policy update event after schema database changes

### DIFF
--- a/deps/rabbit/src/rabbit_policy.erl
+++ b/deps/rabbit/src/rabbit_policy.erl
@@ -351,23 +351,23 @@ validate(_VHost, <<"operator_policy">>, Name, Term, _User) ->
       Name, operator_policy_validation(), Term).
 
 notify(VHost, <<"policy">>, Name, Term, ActingUser) ->
+    update_policies(VHost),
     rabbit_event:notify(policy_set, [{name, Name}, {vhost, VHost},
-                                     {user_who_performed_action, ActingUser} | Term]),
-    update_policies(VHost);
+                                     {user_who_performed_action, ActingUser} | Term]);
 notify(VHost, <<"operator_policy">>, Name, Term, ActingUser) ->
+    update_policies(VHost),
     rabbit_event:notify(policy_set, [{name, Name}, {vhost, VHost},
-                                     {user_who_performed_action, ActingUser} | Term]),
-    update_policies(VHost).
+                                     {user_who_performed_action, ActingUser} | Term]).
 
 notify_clear(VHost, <<"policy">>, Name, ActingUser) ->
+    update_policies(VHost),
     rabbit_event:notify(policy_cleared, [{name, Name}, {vhost, VHost},
-                                         {user_who_performed_action, ActingUser}]),
-    update_policies(VHost);
+                                         {user_who_performed_action, ActingUser}]);
 notify_clear(VHost, <<"operator_policy">>, Name, ActingUser) ->
+    update_policies(VHost),
     rabbit_event:notify(operator_policy_cleared,
                         [{name, Name}, {vhost, VHost},
-                         {user_who_performed_action, ActingUser}]),
-    update_policies(VHost).
+                         {user_who_performed_action, ActingUser}]).
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbit/test/rabbit_ha_test_consumer.erl
+++ b/deps/rabbit/test/rabbit_ha_test_consumer.erl
@@ -51,15 +51,9 @@ run(TestPid, Channel, Queue, CancelOnFailover, LowestSeen, MsgsToConsume) ->
             %% counter.
             if
                 MsgNum + 1 == LowestSeen ->
-                    error_logger:info_msg("recording ~w left ~w",
-                                          [MsgNum, MsgsToConsume]),
                     run(TestPid, Channel, Queue,
                         CancelOnFailover, MsgNum, MsgsToConsume - 1);
                 MsgNum >= LowestSeen ->
-                    error_logger:info_msg(
-                      "consumer ~p on ~p ignoring redelivered msg ~p"
-                      "lowest seen ~w~n",
-                      [self(), Channel, MsgNum, LowestSeen]),
                     true = Redelivered, %% ASSERTION
                     run(TestPid, Channel, Queue,
                         CancelOnFailover, LowestSeen, MsgsToConsume);


### PR DESCRIPTION
## Proposed Changes

Emit an internal event about policy change after all schema DB changes were completed.
This way handlers won't run into heavy lock congestion the updates entail.

Per discussion with @kjnilsson.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
