### PR TITLE
Convert policy event keys to atoms

### DIFF
--- a/deps/rabbit/src/rabbit_policy.erl
+++ b/deps/rabbit/src/rabbit_policy.erl
@@ -350,12 +350,14 @@ validate(_VHost, <<"operator_policy">>, Name, Term, _User) ->
     rabbit_parameter_validation:proplist(
       Name, operator_policy_validation(), Term).
 
-notify(VHost, <<"policy">>, Name, Term, ActingUser) ->
+notify(VHost, <<"policy">>, Name, Term0, ActingUser) ->
     update_policies(VHost),
+    Term = rabbit_data_coercion:atomize_keys(Term0),
     rabbit_event:notify(policy_set, [{name, Name}, {vhost, VHost},
                                      {user_who_performed_action, ActingUser} | Term]);
-notify(VHost, <<"operator_policy">>, Name, Term, ActingUser) ->
+notify(VHost, <<"operator_policy">>, Name, Term0, ActingUser) ->
     update_policies(VHost),
+    Term = rabbit_data_coercion:atomize_keys(Term0),
     rabbit_event:notify(policy_set, [{name, Name}, {vhost, VHost},
                                      {user_who_performed_action, ActingUser} | Term]).
 

--- a/deps/rabbit_common/src/rabbit_data_coercion.erl
+++ b/deps/rabbit_common/src/rabbit_data_coercion.erl
@@ -8,7 +8,7 @@
 -module(rabbit_data_coercion).
 
 -export([to_binary/1, to_list/1, to_atom/1, to_integer/1, to_proplist/1, to_map/1]).
--export([to_atom/2]).
+-export([to_atom/2, atomize_keys/1]).
 
 -spec to_binary(Val :: binary() | list() | atom() | integer()) -> binary().
 to_binary(Val) when is_list(Val)    -> list_to_binary(Val);
@@ -45,3 +45,10 @@ to_proplist(Val) when is_map(Val) -> maps:to_list(Val).
 -spec to_map(Val :: map() | list()) -> map().
 to_map(Val) when is_map(Val) -> Val;
 to_map(Val) when is_list(Val) -> maps:from_list(Val).
+
+
+-spec atomize_keys(Val :: map() | list()) -> map() | list().
+atomize_keys(Val) when is_list(Val) ->
+  [{to_atom(K), V} || {K, V} <- Val];
+atomize_keys(Val) when is_map(Val) ->
+  maps:from_list(atomize_keys(maps:to_list(Val))).

--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -33,6 +33,8 @@ groups() ->
             data_coercion_to_proplist,
             data_coercion_to_list,
             data_coercion_to_map,
+            data_coercion_atomize_keys_proplist,
+            data_coercion_atomize_keys_map,
             pget,
             encrypt_decrypt,
             encrypt_decrypt_term,
@@ -298,6 +300,16 @@ data_coercion_to_map(_Config) ->
 data_coercion_to_proplist(_Config) ->
     ?assertEqual([{a, 1}], rabbit_data_coercion:to_proplist([{a, 1}])),
     ?assertEqual([{a, 1}], rabbit_data_coercion:to_proplist(#{a => 1})).
+
+data_coercion_atomize_keys_map(_Config) ->
+    A = #{a => 1, b => 2, c => 3},
+    B = rabbit_data_coercion:atomize_keys(#{a => 1, "b" => 2, <<"c">> => 3}),
+    ?assertEqual(A, B).
+
+data_coercion_atomize_keys_proplist(_Config) ->
+    A = [{a, 1}, {b, 2}, {c, 3}],
+    B = rabbit_data_coercion:atomize_keys([{a, 1}, {"b", 2}, {<<"c">>, 3}]),
+    ?assertEqual(lists:usort(A), lists:usort(B)).
 
 data_coercion_to_list(_Config) ->
     ?assertEqual([{a, 1}], rabbit_data_coercion:to_list([{a, 1}])),


### PR DESCRIPTION
so that they are easier to match on