### PR TITLE
More accurate ack mode description in the UI

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -310,7 +310,7 @@
           <td>
             <select name="ackmode">
                 <option value="ack_requeue_true" selected>Nack message requeue true</option>
-                <option value="ack_requeue_false">Auto ack message requeue false</option>
+                <option value="ack_requeue_false">Automatic ack</option>
                 <option value="reject_requeue_true">Reject requeue true</option>
                 <option value="reject_requeue_false">Reject requeue false</option>
             </select>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -310,7 +310,7 @@
           <td>
             <select name="ackmode">
                 <option value="ack_requeue_true" selected>Nack message requeue true</option>
-                <option value="ack_requeue_false">Ack message requeue false</option>
+                <option value="ack_requeue_false">Auto ack message requeue false</option>
                 <option value="reject_requeue_true">Reject requeue true</option>
                 <option value="reject_requeue_false">Reject requeue false</option>
             </select>


### PR DESCRIPTION
I ran into this when working on metrics. This option sets `no_ack = true` which means an automatic ack. However, the old description, `Ack message requeue false`, suggests to me that there is a manual ack. I spent a lot of time trying to find a bug in the metrics code that counted this as an auto-acked message, when in fact it was an auto-acked message. :)

