### PR TITLE
Link to the connection to avoid stuck unacked messages when using get messages

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -963,6 +963,7 @@ with_channel(VHost, ReqData,
                                  virtual_host = VHost},
     case amqp_connection:start(Params) of
         {ok, Conn} ->
+            _ = erlang:link(Conn),
             {ok, Ch} = amqp_connection:open_channel(Conn),
             try
                 Fun(Ch)
@@ -983,6 +984,7 @@ with_channel(VHost, ReqData,
                        ServerClose =:= server_initiated_hard_close ->
                     bad_request_exception(Code, Reason, ReqData, Context)
             after
+            erlang:unlink(Conn),
             catch amqp_channel:close(Ch),
             catch amqp_connection:close(Conn)
             end;


### PR DESCRIPTION
When using the get messages functionality with a high message count the request
may time out if it can not be completed in one minute. This leaves the connection
hanging around.

## Proposed Changes

When running "Get messages" with a high message count the request may time out, causing messages to be stuck in the Unacknowledged state. To reproduce, create a queue with 100k messages and try to get 10k out of it. 

By linking to the connection the connection will be killed when the cowboy request is killed by timeout. 

One drawback of this method may be is that if the connection crashes for any reason this will not provide a proper error message for the user, as it will kill the request. 

Any thoughts?

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist


- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

