### PR TITLE
Escape username before displaying it

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/dispatcher.js
+++ b/deps/rabbitmq_management/priv/www/js/dispatcher.js
@@ -189,7 +189,7 @@ dispatcher_add(function(sammy) {
             res = sync_put(this, '/users/:username');
             if (res) {
                 if (res.http_status === 204) {
-                    username = res.req_params.username;
+                    username = fmt_escape_html(res.req_params.username);
                     show_popup('warn', "Updated an existing user: '" + username + "'");
                 }
                 update();


### PR DESCRIPTION
All other values displayed in pop-ups are already escaped.