### PR TITLE
Bump consumer acknowledgement timeout default to 30 minutes

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -85,8 +85,9 @@ define PROJECT_ENV
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667
 	    {channel_operation_timeout, 15000},
-	    %% 15 minutes
-	    {consumer_timeout, 900000},
+	    %% See https://www.rabbitmq.com/consumers.html#acknowledgement-timeout
+	    %% 30 minutes
+	    {consumer_timeout, 1800000},
 
 	    %% see rabbitmq-server#486
 	    {autocluster,

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1152,9 +1152,9 @@ end}.
     [{datatype, {enum, [stop_node, continue, transient, persistent]}}]}.
 
 %% Approximate maximum time a consumer can spend processing a message before
-%% the channel is terminated, in milliseconds. Default is no timeout.
+%% the channel is terminated, in milliseconds.
 %%
-%% {consumer_timeout, 10000},
+%% {consumer_timeout, 1800000},
 
 {mapping, "consumer_timeout", "rabbit.consumer_timeout", [
     {datatype, integer},


### PR DESCRIPTION
Apparently 15 minutes is not enough for some. 1 hour seems to be
unreasonably long to our team, though.

References #2990, #3032
