### PR TITLE
Avoid a badmatch when advanced Cowboy options are set for HTTPS/TLS listener

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_app.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_app.erl
@@ -133,11 +133,11 @@ get_tls_listener() ->
                  {ssl_opts, Listener0}
              ];
         CowboyOpts ->
-            Listener1 = lists:keydelete(cowboy_opts, 1, Listener0),
+            WithoutCowboyOpts = lists:keydelete(cowboy_opts, 1, Listener0),
             [
                 {port, Port},
                 {ssl, true},
-                {ssl_opts, Listener1},
+                {ssl_opts, WithoutCowboyOpts},
                 {cowboy_opts, CowboyOpts}
             ]
      end.


### PR DESCRIPTION
For example, with the following config file snippet provided in
community Slack:

``` ini
management.ssl.port = 15671

management.ssl.cacertfile = /path/to/tls-gen.git/basic/result/ca_certificate.pem
management.ssl.certfile = /path/to/tls-gen.git/basic/result/server_certificate.pem
management.ssl.keyfile = /path/to/tls-gen.git/basic/result/server_key.pem

management.ssl.shutdown_timeout   = 7000
management.ssl.max_keepalive      = 120
management.ssl.idle_timeout       = 120
management.ssl.inactivity_timeout = 120
management.ssl.request_timeout    = 120
management.ssl.compress           = true
management.ssl.honor_cipher_order   = true
management.ssl.honor_ecc_order      = true
management.ssl.client_renegotiation = false
management.ssl.secure_renegotiate   = true
management.ssl.versions.1 = tlsv1.2
management.ssl.versions.2 = tlsv1.1
management.ssl.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
management.ssl.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
management.ssl.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
management.ssl.ciphers.4 = ECDHE-RSA-AES256-SHA384
management.ssl.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
management.ssl.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
management.ssl.ciphers.7 = ECDH-ECDSA-AES256-SHA384
management.ssl.ciphers.8 = ECDH-RSA-AES256-SHA384
management.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384
```
