### PR TITLE
CQ: don't deliver right before acking in the index

### DIFF
--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -831,9 +831,9 @@ action_to_entry(RelSeq, Action, JEntries) ->
              end};
         ({Pub,    no_del, no_ack}) when Action == del ->
             {set, {Pub,    del, no_ack}};
-        ({no_pub,    del, no_ack}) when Action == ack ->
+        ({no_pub,    _del, no_ack}) when Action == ack ->
             {set, {no_pub, del,    ack}};
-        ({?PUB,      del, no_ack}) when Action == ack ->
+        ({?PUB,      _del, no_ack}) when Action == ack ->
             {reset, none}
     end.
 


### PR DESCRIPTION
## Proposed Changes

Per short discussion with @michaelklishin I have removed the deliver before ack when writing into the index. This is used during purge and when removing expired messages.

I have not ran tests, let's see what CI tells us.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
