### PR TITLE
Add consumer offset_lag to rabbitmq-stream CLI command & Management

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/stream_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/stream_status_command.ex
@@ -13,7 +13,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
   def merge_defaults(args, opts), do: {args, Map.merge(%{tracking: false, vhost: "/"}, opts)}
 
   def switches(), do: [tracking: :boolean]
-  
+
   use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
@@ -24,7 +24,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
 
       {:error, :quorum_queue_not_supported} ->
         {:error, "Cannot get stream status of a quorum queue"}
-        
+
       other ->
         other
     end
@@ -36,7 +36,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
 
       {:error, :quorum_queue_not_supported} ->
         {:error, "Cannot get stream status of a quorum queue"}
-        
+
       other ->
         other
     end
@@ -47,12 +47,12 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.PrettyTable
 
   def usage() do
-    "stream_status [--vhost <vhost>] [--tracking] <queue>"
+    "stream_status [--vhost <vhost>] [--tracking] <stream>"
   end
 
   def usage_additional do
     [
-      ["<queue>", "Name of the queue"]
+      ["<stream>", "Name of the stream"]
     ]
   end
 
@@ -64,8 +64,8 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Displays the status of a stream queue"
+  def description(), do: "Displays the status of a stream"
 
   def banner([name], %{node: node_name}),
-    do: "Status of stream queue #{name} on node #{node_name} ..."
+    do: "Status of stream #{name} on node #{node_name} ..."
 end

--- a/deps/rabbitmq_stream/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream/include/rabbit_stream.hrl
@@ -77,19 +77,20 @@
     ]).
 
 -define(CONSUMER_INFO_ITEMS, [
-  stream,
   connection_pid,
   subscription_id,
-  credits,
-  messages,
+  stream,
+  messages_consumed,
   offset,
+  offset_lag,
+  credits,
   properties
   ]).
 
 -define(PUBLISHER_INFO_ITEMS, [
-  stream,
   connection_pid,
   publisher_id,
+  stream,
   reference,
   messages_published,
   messages_confirmed,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConnectionsCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConnectionsCommand.erl
@@ -35,7 +35,7 @@
          help_section/0]).
 
 formatter() ->
-    'Elixir.RabbitMQ.CLI.Formatters.Table'.
+    'Elixir.RabbitMQ.CLI.Formatters.PrettyTable'.
 
 scopes() ->
     [ctl, diagnostics, streams].

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumersCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumersCommand.erl
@@ -35,7 +35,7 @@
          help_section/0]).
 
 formatter() ->
-    'Elixir.RabbitMQ.CLI.Formatters.Table'.
+    'Elixir.RabbitMQ.CLI.Formatters.PrettyTable'.
 
 scopes() ->
     [ctl, diagnostics, streams].

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamPublishersCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamPublishersCommand.erl
@@ -35,7 +35,7 @@
          help_section/0]).
 
 formatter() ->
-    'Elixir.RabbitMQ.CLI.Formatters.Table'.
+    'Elixir.RabbitMQ.CLI.Formatters.PrettyTable'.
 
 scopes() ->
     [ctl, diagnostics, streams].

--- a/deps/rabbitmq_stream/src/rabbit_stream_metrics.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_metrics.erl
@@ -20,8 +20,8 @@
 
 %% API
 -export([init/0]).
--export([consumer_created/7,
-         consumer_updated/7,
+-export([consumer_created/8,
+         consumer_updated/8,
          consumer_cancelled/3]).
 -export([publisher_created/4,
          publisher_updated/7,
@@ -40,11 +40,13 @@ consumer_created(Connection,
                  Credits,
                  MessageCount,
                  Offset,
+                 OffsetLag,
                  Properties) ->
     Values =
         [{credits, Credits},
          {consumed, MessageCount},
          {offset, Offset},
+         {offset_lag, OffsetLag},
          {properties, Properties}],
     ets:insert(?TABLE_CONSUMER,
                {{StreamResource, Connection, SubscriptionId}, Values}),
@@ -69,11 +71,13 @@ consumer_updated(Connection,
                  Credits,
                  MessageCount,
                  Offset,
+                 OffsetLag,
                  Properties) ->
     Values =
         [{credits, Credits},
          {consumed, MessageCount},
          {offset, Offset},
+         {offset_lag, OffsetLag},
          {properties, Properties}],
     ets:insert(?TABLE_CONSUMER,
                {{StreamResource, Connection, SubscriptionId}, Values}),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -302,6 +302,9 @@ messages_confirmed(Counters) ->
 messages_errored(Counters) ->
     atomics:get(Counters, 3).
 
+stream_committed_offset(Log) ->
+    osiris_log:committed_offset(Log).
+
 listen_loop_pre_auth(Transport,
                      #stream_connection{socket = S} = Connection,
                      State,
@@ -1365,12 +1368,9 @@ handle_frame_post_auth(Transport,
                          OffsetSpec,
                          Credit,
                          Properties}}) ->
+    QueueResource = #resource{name = Stream, kind = queue, virtual_host = VirtualHost},
     %% FIXME check the max number of subs is not reached already
-    case rabbit_stream_utils:check_read_permitted(#resource{name = Stream,
-                                                            kind = queue,
-                                                            virtual_host =
-                                                                VirtualHost},
-                                                  User, #{})
+    case rabbit_stream_utils:check_read_permitted(QueueResource, User, #{})
     of
         ok ->
             case rabbit_stream_manager:lookup_local_member(VirtualHost, Stream)
@@ -1408,7 +1408,7 @@ handle_frame_post_auth(Transport,
                                              OffsetSpec,
                                              Properties]),
                             CounterSpec =
-                                {{?MODULE, Stream, SubscriptionId, self()}, []},
+                                {{?MODULE, QueueResource, SubscriptionId, self()}, []},
                             {ok, Segment} =
                                 osiris:init_reader(LocalMemberPid, OffsetSpec,
                                                    CounterSpec),
@@ -1463,6 +1463,7 @@ handle_frame_post_auth(Transport,
                                 ConsumerState1,
 
                             ConsumerOffset = osiris_log:next_offset(Segment1),
+                            ConsumerOffsetLag = consumer_i(offset_lag, ConsumerState1),
 
                             rabbit_log:info("Subscription ~p is now at offset ~p with ~p message(s) "
                                             "distributed after subscription",
@@ -1476,6 +1477,7 @@ handle_frame_post_auth(Transport,
                                                                    Credit1,
                                                                    messages_consumed(ConsumerCounters1),
                                                                    ConsumerOffset,
+                                                                   ConsumerOffsetLag,
                                                                    Properties),
                             {Connection1#stream_connection{stream_subscriptions
                                                                =
@@ -2290,12 +2292,13 @@ emit_stats(#stream_connection{publishers = Publishers} = Connection,
                                             Credit,
                                             messages_consumed(Counters),
                                             consumer_offset(Counters),
+                                            consumer_i(offset_lag, Consumer),
                                             Properties)
      || #consumer{stream = S,
                   subscription_id = Id,
                   credit = Credit,
                   counters = Counters,
-                  properties = Properties}
+                  properties = Properties} = Consumer
             <- maps:values(Consumers)],
     [rabbit_stream_metrics:publisher_updated(self(),
                                              stream_r(S, Connection),
@@ -2345,16 +2348,18 @@ consumer_i(subscription_id, #consumer{subscription_id = SubId}) ->
     SubId;
 consumer_i(credits, #consumer{credit = Credits}) ->
     Credits;
-consumer_i(messages, #consumer{counters = Counters}) ->
+consumer_i(messages_consumed, #consumer{counters = Counters}) ->
     messages_consumed(Counters);
 consumer_i(offset, #consumer{counters = Counters}) ->
     consumer_offset(Counters);
+consumer_i(offset_lag, #consumer{counters = Counters, segment = Log}) ->
+    stream_committed_offset(Log) - consumer_offset(Counters);
 consumer_i(connection_pid, _) ->
     self();
-consumer_i(stream, #consumer{stream = S}) ->
-    S;
 consumer_i(properties, #consumer{properties = Properties}) ->
-    Properties.
+    Properties;
+consumer_i(stream, #consumer{stream = Stream}) ->
+    Stream.
 
 publishers_info(Pid, InfoItems) ->
     case InfoItems -- ?PUBLISHER_INFO_ITEMS of

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -102,6 +102,7 @@ test_gc_consumers(Config) ->
                                   10,
                                   0,
                                   0,
+                                  0,
                                   #{}]),
     ok = test_utils:wait_until(fun() -> consumer_count(Config) == 0 end),
     ok.

--- a/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConsumersList.ejs
+++ b/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConsumersList.ejs
@@ -3,10 +3,11 @@
       <thead>
         <tr>
           <th>Subscription ID</th>
-          <th>Queue</th>
-          <th>Credits</th>
-          <th>Offset</th>
+          <th>Stream</th>
           <th>Messages Consumed</th>
+          <th>Offset</th>
+          <th>Offset Lag</th>
+          <th>Credits</th>
         </tr>
       </thead>
 <%
@@ -16,9 +17,10 @@
       <tr<%= alt_rows(i) %>>
         <td><%= consumer.subscription_id %></td>
         <td><%= link_queue(consumer.queue.vhost, consumer.queue.name) %></td>
-        <td class="c"><%= consumer.credits %></td>
-        <td class="c"><%= consumer.offset %></td>
         <td class="c"><%= consumer.consumed %></td>
+        <td class="c"><%= consumer.offset %></td>
+        <td class="c"><%= consumer.offset_lag %></td>
+        <td class="c"><%= consumer.credits %></td>
       </tr>
 <% } %>
     </table>


### PR DESCRIPTION
This is an important metric to keep track of and be aware (maybe even alert on) when consumers fall behind consuming stream messages. While they should be able to catch up, if they fall behind too much and the stream gets truncated, they may miss on messages.

This is something that we want to expose via Prometheus metrics as well, but we've started closer to the core, CLI & Management.

While at it, we've made the commands use `PrettyTable by default`.

This should be merged as soon as it passes CI, we shouldn't wait on the Prometheus changes - they can come later.

Pair: @kjnilsson

![image](https://user-images.githubusercontent.com/3342/118643631-ba364280-b7d4-11eb-9a72-f61e4960cd43.png)
![image](https://user-images.githubusercontent.com/3342/118643668-c6220480-b7d4-11eb-8ea5-6e244edd2960.png)
