### PR TITLE
MQTT: use consistent Ra operation timeout values

### DIFF
--- a/deps/rabbitmq_mqtt/src/mqtt_node.erl
+++ b/deps/rabbitmq_mqtt/src/mqtt_node.erl
@@ -66,7 +66,7 @@ start(Delay, AttemptsLeft) ->
           _ ->
               join_peers(NodeId, Nodes),
               ra:restart_server(?RA_SYSTEM, NodeId),
-              ra:trigger_election(NodeId)
+              ra:trigger_election(NodeId, ?RA_OPERATION_TIMEOUT)
     end,
     ok.
 
@@ -90,7 +90,7 @@ start_server() ->
     ra:start_server(?RA_SYSTEM, Conf).
 
 trigger_election() ->
-    ra:trigger_election(server_id()).
+    ra:trigger_election(server_id(), ?RA_OPERATION_TIMEOUT).
 
 join_peers(_NodeId, []) ->
     ok;


### PR DESCRIPTION
of more than the default 5s which is really low.
