### PR TITLE
Make rabbit_prelaunch GC before returning

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -117,6 +117,13 @@ do_run() ->
     %% 4. Write PID file.
     ?LOG_DEBUG(""),
     _ = write_pid_file(Context),
+
+    %% Garbage collect before returning because we do not want
+    %% to keep memory around forever unnecessarily, even if just
+    %% a few MiBs, because it will pollute output from tools like
+    %% Observer or observer_cli.
+    _ = erlang:garbage_collect(),
+
     ignore.
 
 assert_mnesia_is_stopped() ->


### PR DESCRIPTION
Because it runs in the context of a supervisor that does very
little work, the supervisor would end up with MiBs of memory
allocated and never freed. An explicit GC frees memory completely
and the process is no longer prominent in tools like observer_cli.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
