### PR TITLE
{consistent_hash,recent_history}_exchange plugins: add retries to schema sync

### DIFF
--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
@@ -53,7 +53,7 @@ init() ->
                                                  {attributes, record_info(fields, chx_hash_ring)},
                                                  {type, ordered_set}]),
     mnesia:add_table_copy(?HASH_RING_STATE_TABLE, node(), ram_copies),
-    mnesia:wait_for_tables([?HASH_RING_STATE_TABLE], 30000),
+    rabbit_table:wait([?HASH_RING_STATE_TABLE]),
     recover(),
     ok.
 

--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_exchange_type_recent_history.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_exchange_type_recent_history.erl
@@ -127,7 +127,7 @@ setup_schema() ->
                               {record_name, cached},
                               {type, set}]),
     mnesia:add_table_copy(?RH_TABLE, node(), ram_copies),
-    mnesia:wait_for_tables([?RH_TABLE], 30000),
+    rabbit_table:wait([?RH_TABLE]),
     ok.
 
 disable_plugin() ->


### PR DESCRIPTION
So, do what RabbitMQ core does as of 3.6.7 or so.

This makes it possible for nodes with those plugins enabled to be
restarted in arbitrary order within a certain time window, just
like nodes without those plugins.
