### PR TITLE
Handle cases where virtual host config file does not yet exist

### DIFF
--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -17,7 +17,7 @@
 -export([parse_tags/1, update_metadata/2, tag_with/2, untag_from/2, update_tags/2, update_tags/3]).
 -export([lookup/1]).
 -export([info/1, info/2, info_all/0, info_all/1, info_all/2, info_all/3]).
--export([dir/1, msg_store_dir_path/1, msg_store_dir_wildcard/0, config_file_path/1]).
+-export([dir/1, msg_store_dir_path/1, msg_store_dir_wildcard/0, config_file_path/1, ensure_config_file/1]).
 -export([delete_storage/1]).
 -export([vhost_down/1]).
 -export([put_vhost/5]).
@@ -85,7 +85,7 @@ ensure_config_file(VHost) ->
                 %% default of 16384 for forward compatibility. Historic
                 %% default calculated as trunc(math:pow(2,?REL_SEQ_BITS)).
                 _ ->
-                    16384
+                    ?LEGACY_INDEX_SEGMENT_ENTRY_COUNT
             end,
             rabbit_log:info("Setting segment_entry_count for vhost '~s' with ~b queues to '~b'",
                             [VHost, length(QueueDirs), SegmentEntryCount]),
@@ -96,8 +96,15 @@ ensure_config_file(VHost) ->
     end.
 
 read_config(VHost) ->
-    {ok, Config} = file:consult(config_file_path(VHost)),
-    maps:from_list(Config).
+    Config = case file:consult(config_file_path(VHost)) of
+        {ok, Val}       -> Val;
+        %% the file does not exist yet, likely due to an upgrade from a pre-3.7
+        %% message store layout so use the history default.
+        {error, _}      -> #{
+            segment_entry_count => ?LEGACY_INDEX_SEGMENT_ENTRY_COUNT
+        }
+    end,
+    rabbit_data_coercion:to_map(Config).
 
 -define(INFO_KEYS, vhost:info_keys()).
 

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -266,3 +266,6 @@
 %% Execution timeout of connection and channel tracking operations
 -define(TRACKING_EXECUTION_TIMEOUT,
         rabbit_misc:get_env(rabbit, tracking_execution_timeout, 5000)).
+
+%% 3.6, 3.7, early 3.8
+-define(LEGACY_INDEX_SEGMENT_ENTRY_COUNT, 16384).


### PR DESCRIPTION
This happens during queue migration from a pre-3.7 version.

References #2954.
