### PR TITLE
Make Web-MQTT obtain/release a FD via file_handle_cache

### DIFF
--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -79,6 +79,7 @@ init(Req, Opts) ->
                       }, WsOpts}.
 
 websocket_init(State0 = #state{socket = Sock, peername = PeerAddr}) ->
+    ok = file_handle_cache:obtain(),
     case rabbit_net:connection_string(Sock, inbound) of
         {ok, ConnStr} ->
             State = State0#state{
@@ -236,6 +237,7 @@ stop(State) ->
     stop(State, 1000, "MQTT died").
 
 stop(State, CloseCode, Error0) ->
+    ok = file_handle_cache:release(),
     stop_rabbit_mqtt_processor(State),
     Error1 = rabbit_data_coercion:to_binary(Error0),
     {[{close, CloseCode, Error1}], State}.

--- a/deps/rabbitmq_web_mqtt_examples/priv/echo.html
+++ b/deps/rabbitmq_web_mqtt_examples/priv/echo.html
@@ -45,7 +45,7 @@
   <link href="main.css" rel="stylesheet" type="text/css"/>
   </head>
   <body lang="en">
-    <h1>RabbitMQ Web MQTT Example</h1>
+    <h1><a href="index.html">RabbitMQ Web MQTT Examples</a> > Echo Server</h1>
 
     <div id="first" class="box">
       <h2>Received</h2>


### PR DESCRIPTION
I have noticed that Web-MQTT does not keep track of its own FD usage,
meaning that when a Websocket connection is open, it is invisible. On
the other hand Web-STOMP connections are visible when calling
`file_handle_cache:info()` and counted when checking limits.

I have therefore applied a small patch to Web-MQTT to make it
behave just like Web-STOMP. I have also added a missing link
in a Web-MQTT example.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
