### PR TITLE
When reacting to a forced event refresh command, emit consumer creation events for all consumers 

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1620,30 +1620,16 @@ handle_cast({credit, ChPid, CTag, Credit, Drain},
 % This event is necessary for the stats timer to be initialized with
 % the correct values once the management agent has started
 handle_cast({force_event_refresh, Ref},
-            State = #q{consumers       = Consumers,
-                       active_consumer = Holder}) ->
+            State = #q{consumers = Consumers}) ->
     rabbit_event:notify(queue_created, infos(?CREATION_EVENT_KEYS, State), Ref),
     QName = qname(State),
     AllConsumers = rabbit_queue_consumers:all(Consumers),
-    case Holder of
-        none ->
-            [emit_consumer_created(
-               Ch, CTag, false, AckRequired, QName, Prefetch,
-               Args, Ref, ActingUser) ||
-                {Ch, CTag, AckRequired, Prefetch, _, _, Args, ActingUser}
-                    <- AllConsumers];
-        {_Ch, CTag} ->
-            case AllConsumers of
-                [] -> ok;
-                Cs ->
-                    case lists:keyfind(CTag, 1, Cs) of
-                        false -> ok;
-                        {Ch, CTag, AckRequired, Prefetch, _, _, Args, ActingUser} ->
-                            emit_consumer_created(
-                                Ch, CTag, true, AckRequired, QName, Prefetch, Args, Ref, ActingUser)
-                    end
-            end
-    end,
+    rabbit_log:debug("Queue ~s forced to re-emit events, consumers: ~p", [rabbit_misc:rs(QName), AllConsumers]),
+    [emit_consumer_created(
+       Ch, CTag, ActiveOrExclusive, AckRequired, QName, Prefetch,
+       Args, Ref, ActingUser) ||
+        {Ch, CTag, AckRequired, Prefetch, ActiveOrExclusive, _, Args, ActingUser}
+            <- AllConsumers],
     noreply(rabbit_event:init_stats_timer(State, #q.stats_timer));
 
 handle_cast(notify_decorators, State) ->

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1632,10 +1632,17 @@ handle_cast({force_event_refresh, Ref},
                Args, Ref, ActingUser) ||
                 {Ch, CTag, AckRequired, Prefetch, _, _, Args, ActingUser}
                     <- AllConsumers];
-        {Ch, CTag} ->
-            [{Ch, CTag, AckRequired, Prefetch, _, _, Args, ActingUser}] = AllConsumers,
-            emit_consumer_created(
-              Ch, CTag, true, AckRequired, QName, Prefetch, Args, Ref, ActingUser)
+        {_Ch, CTag} ->
+            case AllConsumers of
+                [] -> ok;
+                Cs ->
+                    case lists:keyfind(CTag, 1, Cs) of
+                        false -> ok;
+                        {Ch, CTag, AckRequired, Prefetch, _, _, Args, ActingUser} ->
+                            emit_consumer_created(
+                                Ch, CTag, true, AckRequired, QName, Prefetch, Args, Ref, ActingUser)
+                    end
+            end
     end,
     noreply(rabbit_event:init_stats_timer(State, #q.stats_timer));
 


### PR DESCRIPTION
## Proposed Changes

Emit consumer creation events for all consumers
when force refreshing events. We do that when consumers are registered
online. Inactive consumers in case of SAC queues are still present
and their presence should be broadcast as an internal event.

This also simplifies the code updated for #3072.

Per discussion with @pjk25.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #3072)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #3072