### PR TITLE
Raw reader option

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1436,11 +1436,12 @@ handle_frame_post_auth(Transport,
                                   SubscriptionId,
                                   self()},
                                  []},
-                            {ok, Segment} =
-                                osiris:init_reader(LocalMemberPid,
-                                                   OffsetSpec,
-                                                   CounterSpec,
-                                                   ConnTransport),
+                            Options = #{transport => ConnTransport,
+                                        chunk_selector => get_chunk_selector(Properties)},
+                            {ok, Segment} = osiris:init_reader(LocalMemberPid,
+                                                               OffsetSpec,
+                                                               CounterSpec,
+                                                               Options),
                             rabbit_log:info("Next offset for subscription ~p is ~p",
                                             [SubscriptionId,
                                              osiris_log:next_offset(Segment)]),
@@ -2570,3 +2571,6 @@ ssl_info(F, #stream_connection{socket = Sock}) ->
                 proplists:get_value(selected_cipher_suite, Items),
             F({P, {K, C, H}})
     end.
+
+get_chunk_selector(Properties) ->
+    binary_to_atom(maps:get(<<"chunk_selector">>, Properties, <<"user_data">>)).


### PR DESCRIPTION
Use the properties to select the 'mode' of the data reader: normal offset or raw offset (which also sends the trailer)

Depends on https://github.com/rabbitmq/osiris/pull/38

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

