### PR TITLE
Improve performance of federation

### DIFF
--- a/deps/rabbit/src/rabbit_nodes.erl
+++ b/deps/rabbit/src/rabbit_nodes.erl
@@ -73,8 +73,10 @@ is_process_running(Node, Process) ->
 -spec cluster_name() -> binary().
 
 cluster_name() ->
-    rabbit_runtime_parameters:value_global(
-      cluster_name, cluster_name_default()).
+    case rabbit_runtime_parameters:value_global(cluster_name) of 
+        not_found -> cluster_name_default();
+        Name -> Name
+    end.
 
 cluster_name_default() ->
     {ID, _} = parts(node()),


### PR DESCRIPTION
When a federated message is processed, certain headers are added,
cluster_name is called for every message.
This every single time creates an UDP port and queries into the
inet_drv to get the hostname.
Now we first try to look it up in the database instead of
calculating a default which will not be needed.

Some benchmarks on my local machine: 

```
Old version:
lists:sum([begin {R, _ } = timer:tc(rabbit_nodes, cluster_name, []), R end || _ <- lists:seq(0,1000)])/1000.
2052.328 microseconds (2 milliseconds) average

Tested this not on my local and it still takes around 0.2 ms, which seems lower but it's very often I can see the exchange link federation process in `inet gethostname`. 

New version:

lists:sum([begin {R, _ } = timer:tc(rabbit_nodes, cluster_name, []), R end || _ <- lists:seq(0,1000)])/1000.
1.296 microseconds
``` 

## Proposed Changes

Defer the calculation of a default value when we know it's needed.

## Types of Changes

- [x] Performance improvement


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
