### PR TITLE
"handle_method(#'queue.delete'{},_)" can not process the case "{error,{exit, _, _}}"

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2612,6 +2612,9 @@ handle_method(#'queue.delete'{queue     = QueueNameBin,
             precondition_failed("~s in use", [rabbit_misc:rs(QueueName)]);
         {error, not_empty} ->
             precondition_failed("~s not empty", [rabbit_misc:rs(QueueName)]);
+        {error, {exit, _, _}} ->
+            %% rabbit_amqqueue:delete()/delegate:invoke might return {error, {exit, _, _}}
+            {ok, 0};
         {ok, Count} ->
             {ok, Count};
         {protocol_error, Type, Reason, ReasonArgs} ->


### PR DESCRIPTION
In my test of "queue.delete", this has happened:

```
2021-06-05 16:31:26.281 [error] <0.9903.21> ** Generic server <0.9903.21> terminating
** Last message in was {'$gen_cast',{method,{'queue.delete',0,<<"nbm_alive_c0fb2eb6-c822-4641-adda-0ea9c2c02fef">>,false,false,false},none,noflow,false}}
** When Server state == {ch,{conf,running,rabbit_framing_amqp_0_9_1,1,<0.9893.21>,<0.9902.21>,<0.9893.21>,<<"174.11.10.28:48839 -> 174.11.10.23:5674">>,undefined,{user,<<"guest">>,[administrator],[{rabbit_auth_backend_internal,none}]},<<"/">>,<<"nbm_alive_c0fb2eb6-c822-4641-adda-0ea9c2c02fef">>,<0.9897.21>,[{<<"authentication_failure_close">>,bool,true},{<<"basic.nack">>,bool,true},{<<"connection.blocked">>,bool,true},{<<"consumer_cancel_notify">>,bool,true},{<<"publisher_confirms">>,bool,true}],none,0,134217728,undefined,#{},1000000000},{lstate,undefined,false,#Fun<rabbit_channel.8.31076537>},none,1,{0,{[],[]}},#{},{state,#{},erlang},#{},#{},{set,0,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}},{state,none,30000,undefined},false,1,{unconfirmed,{0,nil},#{},#{}},[],[],none,flow,[],#{},#Ref<0.2883551392.790364161.215222>,false,false,undefined,undefined,{erlang,#Ref<0.2883551392.790364161.214783>},{{174,11,10,28},48839,"174.11.10.28:48839 -> 174.11.10.23:5674","none"},#{},#{}}


** Reason for termination ==
** {{case_clause,{error,{exit,{normal,{gen_server2,call,[<0.10232.21>,{delete,false,false,<<"guest">>},infinity]}},[{gen_server2,call,3,[{file,"src/gen_server2.erl"},{line,346}]},{delegate,safe_invoke,2,[{file,"src/delegate.erl"},{line,274}]},{delegate,invoke,2,[{file,"src/delegate.erl"},{line,92}]},{rabbit_misc,with_exit_handler,2,[{file,"src/rabbit_misc.erl"},{line,602}]},{rabbit_channel,handle_method,6,[{file,"src/rabbit_channel.erl"},{line,3082}]},{rabbit_channel,handle_method,3,[{file,"src/rabbit_channel.erl"},{line,2021}]},{rabbit_channel,handle_cast,2,[{file,"src/rabbit_channel.erl"},{line,823}]},{gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1067}]}]}}},[{rabbit_channel,handle_method,6,[{file,"src/rabbit_channel.erl"},{line,3082}]},{rabbit_channel,handle_method,3,[{file,"src/rabbit_channel.erl"},{line,2021}]},{rabbit_channel,handle_cast,2,[{file,"src/rabbit_channel.erl"},{line,823}]},{gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1067}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]}
2021-06-05 16:31:26.281 [error] <0.9893.21> Error on AMQP connection <0.9893.21> (174.11.10.28:48839 -> 174.11.10.23:5674, vhost: '/', user: 'guest', state: running), channel 1:
 {{case_clause,
     {error,
         {exit,
             {normal,
                 {gen_server2,call,
                     [<0.10232.21>,
                      {delete,false,false,<<"guest">>},
                      infinity]}},
             [{gen_server2,call,3,[{file,"src/gen_server2.erl"},{line,346}]},
              {delegate,safe_invoke,2,[{file,"src/delegate.erl"},{line,274}]},
              {delegate,invoke,2,[{file,"src/delegate.erl"},{line,92}]},
              {rabbit_misc,with_exit_handler,2,
                  [{file,"src/rabbit_misc.erl"},{line,602}]},
              {rabbit_channel,handle_method,6,
[{rabbit_channel,handle_method,6,
      [{file,"src/rabbit_channel.erl"},{line,3082}]},
  {rabbit_channel,handle_method,3,
      [{file,"src/rabbit_channel.erl"},{line,2021}]},
  {rabbit_channel,handle_cast,2,[{file,"src/rabbit_channel.erl"},{line,823}]},
  {gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1067}]},
  {proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]}
```
