### PR TITLE
Fix recovery when terms are accidentally empty

### DIFF
--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -307,8 +307,10 @@ recover(#resource{ virtual_host = VHost } = Name, Terms, MsgStoreRecovered,
                             on_sync_msg = OnSyncMsgFun},
     CleanShutdown = Terms /= non_clean_shutdown,
     case CleanShutdown andalso MsgStoreRecovered of
-        true  -> RecoveredCounts = proplists:get_value(segments, Terms, []),
-                 init_clean(RecoveredCounts, State1);
+        true  -> case proplists:get_value(segments, Terms, non_clean_shutdown) of
+                     non_clean_shutdown -> init_dirty(false, ContainsCheckFun, State1);
+                     RecoveredCounts    -> init_clean(RecoveredCounts, State1)
+                 end;
         false -> init_dirty(CleanShutdown, ContainsCheckFun, State1)
     end.
 


### PR DESCRIPTION
This is a fix for an issue that occurs when shutting down
a node (via SIGTERM) while the queues and more specifically
the queue index is recovering. When that happens
rabbit_recovery_terms has already started, and when
it starts it calls dets:open_file/2 which creates an
empty recovery.dets file. After the node is down and
restarted again, the node thinks the shutdown was clean
because the recovery file is there, except it is empty
and therefore the queues have lost all their state.

This results in RabbitMQ thinking there are 0 messages
in all classic queues.

To avoid this issue, we consider a shutdown to be dirty
in the case where we have a recovery file BUT we do not
find our state in the recovery terms.

To reliably reproduce the issue this fixes:

* Start a node

* Fill it with many messages (800k is more than enough)

* Wait a little and then kill the node via Ctrl+C twice
  (to force dirty recovery next start)

* Start the node again

* While it says "Starting broker", after waiting
  about 5 seconds, send a SIGTERM (killall beam.smp)
  to shutdown the node "cleanly"

* Start the node again

* Management will show 0 messages in all classic queues

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
