### PR TITLE
Introduce per-object policy matching events

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -203,6 +203,8 @@ start_cluster(Q) ->
                                         [{name, QName},
                                          {durable, Durable},
                                          {auto_delete, AutoDelete},
+                                         {exclusive, false},
+                                         {type, amqqueue:get_type(Q)},
                                          {arguments, Arguments},
                                          {user_who_performed_action,
                                           ActingUser}]),

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -118,6 +118,7 @@ create_stream(Q0, Node) ->
                                          {durable, true},
                                          {auto_delete, false},
                                          {arguments, Arguments},
+                                         {type, amqqueue:get_type(Q1)},
                                          {user_who_performed_action,
                                           ActingUser}]),
                     {new, Q};


### PR DESCRIPTION
## Proposed Changes

When policy changes, emit internal events for individual objects. This also helps
with observability and troubleshooting of policy changes.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

