### PR TITLE
fix hostname(1) calls on Solaris

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -69,7 +69,11 @@ node_enabled_plugins_file = $(call node_tmpdir,$(1))/enabled_plugins
 ifeq ($(PLATFORM),msys2)
 HOSTNAME := $(COMPUTERNAME)
 else
+ifeq ($(PLATFORM),solaris)
+HOSTNAME := $(shell hostname | sed 's@\..*@@')
+else
 HOSTNAME := $(shell hostname -s)
+endif
 endif
 
 RABBITMQ_NODENAME ?= rabbit@$(HOSTNAME)

--- a/deps/rabbit_common/mk/rabbitmq-tools.mk
+++ b/deps/rabbit_common/mk/rabbitmq-tools.mk
@@ -1,7 +1,11 @@
 ifeq ($(PLATFORM),msys2)
 HOSTNAME := $(COMPUTERNAME)
 else
+ifeq ($(PLATFORM),solaris)
+HOSTNAME := $(shell hostname | sed 's@\..*@@')
+else
 HOSTNAME := $(shell hostname -s)
+endif
 endif
 
 READY_DEPS = $(foreach DEP,\

--- a/scripts/rabbitmq-server-ha.ocf
+++ b/scripts/rabbitmq-server-ha.ocf
@@ -626,10 +626,19 @@ master_score() {
 
 # Return either FQDN or shortname, depends on the OCF_RESKEY_use_fqdn.
 get_hostname() {
+    local os=$(uname -s)
     if [ "${OCF_RESKEY_use_fqdn}" = 'false' ] ; then
-        echo "$(hostname -s)"
+        if [ "$os" == "SunOS" ]; then
+            echo "$(hostname | sed 's@\..*@@')"
+        else
+            echo "$(hostname -s)"
+        fi
     else
-        echo "$(hostname -f)"
+        if [ "$os" == "SunOS" ]; then
+            echo "$(hostname)"
+        else
+            echo "$(hostname -f)"
+        fi 
     fi
 }
 


### PR DESCRIPTION
## Proposed Changes

The hostname(1) command on Solaris does not support the '-s' and -f' flags. See https://docs.oracle.com/cd/E88353_01/html/E37839/hostname-1.html
As a result, the rabbitmq build produces several usage errors when the hostname command execution is attempted, but I am not sure if there's any impact.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories