### PR TITLE
Use Erlang 24 with JIT in Docker image

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -21,15 +21,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      # RabbitMQ master requires Erlang 23 (correct at Mar 2021)
+      # RabbitMQ master supports Erlang 24 (correct at June 2021)
       # Source of truth for released versions: https://www.rabbitmq.com/which-erlang.html
       #
       # For Elixir: https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
-      - name: Set up min required Erlang & Elixir
+      - name: Set up max supported Erlang & Elixir
         uses: erlef/setup-beam@v1.7
         with:
-          otp-version: '23.2'
-          elixir-version: '1.11.4'
+          otp-version: '24.0.2'
+          elixir-version: '1.12.1'
 
       - name: Build generic unix package
         run: |
@@ -37,8 +37,12 @@ jobs:
 
       - name: Build container image
         working-directory: packaging/docker-image
-        run: |
-          make dist IMAGE_TAG=${GITHUB_REF##*/} SKIP_PGP_VERIFY=true
+        run: >-
+          make dist
+          IMAGE_TAG=${GITHUB_REF##*/}
+          SKIP_PGP_VERIFY=true
+          OTP_VERSION=24.0.2
+          OTP_SHA256=4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18
 
       - name: Login to DockerHub
         working-directory: packaging/docker-image

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -1,6 +1,6 @@
 # The official Canonical Ubuntu Bionic image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN set -eux; \
 	apt-get update; \
@@ -50,6 +50,7 @@ RUN set -eux; \
 		ca-certificates \
 		dpkg-dev \
 		gcc \
+		g++ \
 		gnupg \
 		libncurses5-dev \
 		make \
@@ -127,6 +128,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -32,8 +32,8 @@ $(error Cannot determine version; please specify VERSION)
 endif
 endif
 
-OTP_VERSION ?= 23.2.4
-OTP_SHA256 ?= e72aa084907e0f34f932cf00caa33aba93147b0a7c9c35569d6bd1c402f532de
+OTP_VERSION ?= 24.0.2
+OTP_SHA256 ?= 4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18
 REPO ?= pivotalrabbitmq/rabbitmq
 SKIP_PGP_VERIFY ?= false
 PGP_KEYSERVER ?= pgpkeys.eu


### PR DESCRIPTION
GitHub action triggered by this PR created a new image:
```
> docker run -ti pivotalrabbitmq/rabbitmq:docker-image-erlang-24 erl
Erlang/OTP 24 [erts-12.0.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V12.0.2  (abort with ^G)
1>
```
As seen above, Erlang 24 and JIT is used.

Pair: @mkuratczyk 