### PR TITLE
Add bazel-test make target so that we can run tests in bazel quickly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ endif
 include rabbitmq-components.mk
 include erlang.mk
 include mk/github-actions.mk
+include mk/bazel.mk
 include mk/topic-branches.mk
 
 # --------------------------------------------------------------------

--- a/mk/bazel.mk
+++ b/mk/bazel.mk
@@ -1,16 +1,41 @@
-BAZEL ?= /usr/local/bin/bazel
+BAZELISK ?= /usr/local/bin/bazelisk
 ifeq (darwin,$(PLATFORM))
-$(BAZEL):
-	brew install bazel
+$(BAZELISK):
+	brew install bazelisk
 else
-	$(error Install bazel for your platform: https://docs.bazel.build/versions/4.1.0/install.html)
+	$(error Install bazelisk for your platform: https://github.com/bazelbuild/bazelisk)
 endif
 
-bazel-test: $(BAZEL)
+define USER_BAZELRC
+build --@bazel-erlang//:erlang_home=$(shell dirname $$(dirname $$(which erl)))
+build --@bazel-erlang//:erlang_version=$(shell erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)
+build --//:elixir_home=$(shell dirname $$(dirname $$(which iex)))/lib/elixir
+
+# rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS
+# sandbox (https://github.com/bazelbuild/bazel/issues/7448)
+# adding "--spawn_strategy=local" to the invocation is a workaround
+build --spawn_strategy=local
+
+build --incompatible_strict_action_env
+
+# run one test at a time on the local machine
+build --test_strategy=exclusive
+
+# don't re-run flakes automatically on the local machine
+build --flaky_test_attempts=1
+
+build:buildbuddy --remote_header=x-buildbuddy-api-key=YOUR_API_KEY
+endef
+
+export USER_BAZELRC
+user.bazelrc:
+	echo "$$USER_BAZELRC" > $@
+
+bazel-test: $(BAZELISK) | user.bazelrc
 ifeq ($(DEP),)
 	$(error DEP must be set to the dependency that this test is for, e.g. deps/rabbit)
 endif
 ifeq ($(SUITE),)
 	$(error SUITE must be set to the ct suite to run, e.g. queue_type if DEP=deps/rabbit)
 endif
-	$(BAZEL) test //deps/$(notdir $(DEP)):$(SUITE)_SUITE --config=ci
+	$(BAZELISK) test //deps/$(notdir $(DEP)):$(SUITE)_SUITE

--- a/mk/bazel.mk
+++ b/mk/bazel.mk
@@ -3,6 +3,7 @@ ifeq (darwin,$(PLATFORM))
 $(BAZELISK):
 	brew install bazelisk
 else
+$(BAZELISK):
 	$(error Install bazelisk for your platform: https://github.com/bazelbuild/bazelisk)
 endif
 

--- a/mk/bazel.mk
+++ b/mk/bazel.mk
@@ -1,0 +1,16 @@
+BAZEL ?= /usr/local/bin/bazel
+ifeq (darwin,$(PLATFORM))
+$(BAZEL):
+	brew install bazel
+else
+	$(error Install bazel for your platform: https://docs.bazel.build/versions/4.1.0/install.html)
+endif
+
+bazel-test: $(BAZEL)
+ifeq ($(DEP),)
+	$(error DEP must be set to the dependency that this test is for, e.g. deps/rabbit)
+endif
+ifeq ($(SUITE),)
+	$(error SUITE must be set to the ct suite to run, e.g. queue_type if DEP=deps/rabbit)
+endif
+	$(BAZEL) test //deps/$(notdir $(DEP)):$(SUITE)_SUITE --config=ci


### PR DESCRIPTION
How do we solve this one @pjk25?

```shell
    $ make bazel-test DEP=deps/rabbit SUITE=queue_type
    /usr/local/bin/bazel test //deps/rabbit:queue_type_SUITE --config=ci
    ERROR: Config value 'ci' is not defined in any .rc file
    make: *** [mk/bazel.mk:16: bazel-test] Error 2
```