### PR TITLE
Build OCI image for each supported Erlang major version

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -10,6 +10,7 @@ on:
       - Makefile
       - plugins.mk
       - rabbitmq-components.mk
+      - .github/workflows/oci.yaml
 env:
   GENERIC_UNIX_ARCHIVE: ${{ github.workspace }}/PACKAGES/rabbitmq-server-generic-unix-${{ github.sha }}.tar.xz
   RABBITMQ_VERSION: ${{ github.sha }}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -15,34 +15,38 @@ env:
   RABBITMQ_VERSION: ${{ github.sha }}
   VERSION: ${{ github.sha }}
 jobs:
-  # This job will build two docker images (one with minimum required OTP, one with maximum supported OTP).
+
+  # This job will build one docker image per supported Erlang major version.
   # Each image will have two tags (one containing the Git commit SHA, one containing the branch name).
   #
-  # For example, for Git commit SHA '1111aaa' and branch name 'main', the following four tags will be pushed to Dockerhub:
-  # * 1111aaa-otp-min (image 1)
-  # * main-otp-min (image 1)
-  # * 1111aaa-otp-max (image 2)
-  # * main-otp-max (image 2)
+  # For example, for Git commit SHA '1111aaa' and branch name 'main' and maximum supported Erlang major version '25',
+  # the following 3 images and 6 tags will be pushed to Dockerhub:
+  #
+  # * 1111aaa-otp-max (image OTP 25)
+  # * main-otp-max (image OTP 25)
+  # * 1111aaa-otp-max-1 (image OTP 24)
+  # * main-otp-max-1 (image OTP 24)
+  # * 1111aaa-otp-max-2 (image OTP 23)
+  # * main-otp-max-2 (image OTP 23)
+
   build-publish-dev:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            # Build two images:
-            # 1. with minimum required Erlang
-            # 2. with maximum supported Erlang
+            # Build image for every supported Erlang major version.
             # Source of truth for released versions: https://www.rabbitmq.com/which-erlang.html
             # For Elixir: https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
             # As of June 2021:
-            otp: ['23.2.1', '24.0.2']
+            otp: ['24.0.2', '23.2.1']
             include:
-            - otp: '23.2.1'
-              otp_sha256: e7034e2cfe50d7570ac8f70ea7ba69ea013f10863043e25132f0a5d3d0d8d3a7
-              elixir: '1.11.4'
-              image_tag_suffix: '-otp-min'
             - otp: '24.0.2'
               otp_sha256: 4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18
               elixir: '1.12.1'
               image_tag_suffix: '-otp-max'
+            - otp: '23.2.1'
+              otp_sha256: e7034e2cfe50d7570ac8f70ea7ba69ea013f10863043e25132f0a5d3d0d8d3a7
+              elixir: '1.11.4'
+              image_tag_suffix: '-otp-max-1'
     env:
       IMAGE_TAG_1: ${{ github.sha }}${{ matrix.image_tag_suffix }}
     steps:
@@ -75,8 +79,8 @@ jobs:
             --password '${{ secrets.DOCKERHUB_PASSWORD }}'
 
       # Push the same image with two different tags:
-      # 1. <git_commit_sha>-otp-[min|max]
-      # 2. <branch_name>-otp-[min|max]
+      # 1. <git_commit_sha>-otp-max[-1|-2]
+      # 2. <branch_name>-otp-max[-1|-2]
       - name: Push container image to DockerHub
         working-directory: packaging/docker-image
         env:

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -54,5 +54,4 @@ jobs:
       - name: Push container image to DockerHub
         working-directory: packaging/docker-image
         run: |
-          make push IMAGE_TAG=${GITHUB_SHA}
           make push IMAGE_TAG=${GITHUB_REF##*/}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -15,21 +15,45 @@ env:
   RABBITMQ_VERSION: ${{ github.sha }}
   VERSION: ${{ github.sha }}
 jobs:
+  # This job will build two docker images (one with minimum required OTP, one with maximum supported OTP).
+  # Each image will have two tags (one containing the Git commit SHA, one containing the branch name).
+  #
+  # For example, for Git commit SHA '1111aaa' and branch name 'main', the following four tags will be pushed to Dockerhub:
+  # * 1111aaa-otp-min (image 1)
+  # * main-otp-min (image 1)
+  # * 1111aaa-otp-max (image 2)
+  # * main-otp-max (image 2)
   build-publish-dev:
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            # Build two images:
+            # 1. with minimum required Erlang
+            # 2. with maximum supported Erlang
+            # Source of truth for released versions: https://www.rabbitmq.com/which-erlang.html
+            # For Elixir: https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
+            # As of June 2021:
+            otp: ['23.2.1', '24.0.2']
+            include:
+            - otp: '23.2.1'
+              otp_sha256: e7034e2cfe50d7570ac8f70ea7ba69ea013f10863043e25132f0a5d3d0d8d3a7
+              elixir: '1.11.4'
+              image_tag_suffix: '-otp-min'
+            - otp: '24.0.2'
+              otp_sha256: 4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18
+              elixir: '1.12.1'
+              image_tag_suffix: '-otp-max'
+    env:
+      IMAGE_TAG_1: ${{ github.sha }}${{ matrix.image_tag_suffix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      # RabbitMQ master supports Erlang 24 (correct at June 2021)
-      # Source of truth for released versions: https://www.rabbitmq.com/which-erlang.html
-      #
-      # For Elixir: https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
-      - name: Set up max supported Erlang & Elixir
+      - name: Set up Erlang & Elixir
         uses: erlef/setup-beam@v1.7
         with:
-          otp-version: '24.0.2'
-          elixir-version: '1.12.1'
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
 
       - name: Build generic unix package
         run: |
@@ -37,12 +61,11 @@ jobs:
 
       - name: Build container image
         working-directory: packaging/docker-image
-        run: >-
-          make dist
-          IMAGE_TAG=${GITHUB_REF##*/}
-          SKIP_PGP_VERIFY=true
-          OTP_VERSION=24.0.2
-          OTP_SHA256=4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18
+        env:
+          OTP_VERSION: ${{ matrix.otp }}
+          OTP_SHA256: ${{ matrix.otp_sha256 }}
+        run: |
+          make dist SKIP_PGP_VERIFY=true
 
       - name: Login to DockerHub
         working-directory: packaging/docker-image
@@ -51,7 +74,12 @@ jobs:
             --username '${{ secrets.DOCKERHUB_USERNAME }}' \
             --password '${{ secrets.DOCKERHUB_PASSWORD }}'
 
+      # Push the same image with two different tags:
+      # 1. <git_commit_sha>-otp-[min|max]
+      # 2. <branch_name>-otp-[min|max]
       - name: Push container image to DockerHub
         working-directory: packaging/docker-image
+        env:
+          IMAGE_TAG_SUFFIX: ${{ matrix.image_tag_suffix }}
         run: |
-          make push IMAGE_TAG=${GITHUB_REF##*/}
+          make push IMAGE_TAG_2=${GITHUB_REF##*/}${IMAGE_TAG_SUFFIX}

--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -39,6 +39,7 @@ SKIP_PGP_VERIFY ?= false
 PGP_KEYSERVER ?= pgpkeys.eu
 ALT1_PGP_KEYSERVER ?= keyserver.ubuntu.com
 ALT2_PGP_KEYSERVER ?= pgpkeys.uk
+IMAGE_TAG_1 ?= $(subst +,-,$(VERSION))
 
 all: dist
 
@@ -50,16 +51,14 @@ dist:
 	  --build-arg OTP_VERSION=$(OTP_VERSION) \
 	  --build-arg OTP_SHA256=$(OTP_SHA256) \
 	  --build-arg RABBITMQ_BUILD=rabbitmq_server-$(VERSION) \
-	  --tag $(REPO):$(subst +,-,$(VERSION)) \
+	  --tag $(REPO):$(IMAGE_TAG_1) \
 	  .
-ifdef IMAGE_TAG
-	docker tag $(REPO):$(subst +,-,$(VERSION)) $(REPO):$(IMAGE_TAG)
-endif
 
 push:
-	docker push $(REPO):$(subst +,-,$(VERSION))
-ifdef IMAGE_TAG
-	docker push $(REPO):$(IMAGE_TAG)
+	docker push $(REPO):$(IMAGE_TAG_1)
+ifdef IMAGE_TAG_2
+	docker tag $(REPO):$(IMAGE_TAG_1) $(REPO):$(IMAGE_TAG_2)
+	docker push $(REPO):$(IMAGE_TAG_2)
 endif
 
 clean:


### PR DESCRIPTION
As requested by @gerhard in https://github.com/rabbitmq/rabbitmq-server/pull/2777#issuecomment-866035696, auto-build OCI images for both Erlang 23 and 24.

Therefore, this job will create two images
1. for minimum required OTP
2. for maximum supported OTP

Each image will have two tags
1. git commit sha (i.e. the tip of the branch as requested by @michaelklishin)
2. branch name (this stable tag gets used for example in https://github.com/rabbitmq/cluster-operator/blob/a74ec732f31303c1e94f3ec30f3eb77961113c96/.github/workflows/pr.yml#L55).

For example, for Git commit SHA `1111aaa` and branch name `main`, the following two docker images and four tags will be pushed to DockerHub:
* `1111aaa-otp-min` (image 1)
* `main-otp-min` (image 1)
* `1111aaa-otp-max` (image 2)
* `main-otp-max` (image 2)

(While we could have used tag `main-otp-24.0.2` instead of `main-otp-max`, I prefer the latter option since we can use that stable tag when specifying the RabbitMQ image in pipelines or LREs.)

Needs to be backported to `v3.9.x` and `v3.8.x`.