### PR TITLE
Canonicalize a few more paths in the startup banner

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1086,7 +1086,7 @@ set_log_level(Level) ->
 
 -spec log_locations() -> [rabbit_prelaunch_logging:log_location()].
 log_locations() ->
-    [filename:absname(Path) || Path <- rabbit_prelaunch_logging:log_locations()].
+    rabbit_prelaunch_logging:log_locations().
 
 -spec config_locations() -> [rabbit_config:config_location()].
 config_locations() ->

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1086,7 +1086,7 @@ set_log_level(Level) ->
 
 -spec log_locations() -> [rabbit_prelaunch_logging:log_location()].
 log_locations() ->
-    rabbit_prelaunch_logging:log_locations().
+    [filename:absname(Path) || Path <- rabbit_prelaunch_logging:log_locations()].
 
 -spec config_locations() -> [rabbit_config:config_location()].
 config_locations() ->
@@ -1512,7 +1512,7 @@ motd() ->
 
 home_dir() ->
     case init:get_argument(home) of
-        {ok, [[Home]]} -> Home;
+        {ok, [[Home]]} -> filename:absname(Home);
         Other          -> Other
     end.
 

--- a/deps/rabbit_common/src/rabbit_nodes_common.erl
+++ b/deps/rabbit_common/src/rabbit_nodes_common.erl
@@ -141,7 +141,7 @@ verbose_erlang_distribution(false) ->
 current_node_details() ->
     [{"~nCurrent node details:~n * node name: ~w", [node()]},
      case init:get_argument(home) of
-         {ok, [[Home]]} -> {" * effective user's home directory: ~s", [Home]};
+         {ok, [[Home]]} -> {" * effective user's home directory: ~s", [filename:absname(Home)]};
          Other          -> {" * effective user has no home directory: ~p", [Other]}
      end,
      {" * Erlang cookie hash: ~s", [cookie_hash()]}].


### PR DESCRIPTION
This canonicalises a few more paths (effective user's home directory, log file locations) that are printed
and logged in the startup banner. The goal is to make sure the paths use consistent slashes
on Windows. Note that `filename:absname/1` [use *nix-style slashes and not backslashes](https://erlang.org/doc/man/filename.html).

References #3149.
