### PR TITLE
Deduplicate parsed list of plugin directories

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -285,10 +285,10 @@ find_cuttlefish_schemas([], AllSchemas) ->
     lists:sort(fun(A,B) -> A < B end, AllSchemas).
 
 list_apps(#{os_type := {win32, _}, plugins_path := PluginsPath}) ->
-    PluginsDirs = string:lexemes(PluginsPath, ";"),
+    PluginsDirs = lists:usort(string:lexemes(PluginsPath, ";")),
     list_apps1(PluginsDirs, []);
 list_apps(#{plugins_path := PluginsPath}) ->
-    PluginsDirs = string:lexemes(PluginsPath, ":"),
+    PluginsDirs = lists:usort(string:lexemes(PluginsPath, ":")),
     list_apps1(PluginsDirs, []).
 
 

--- a/deps/rabbit/src/rabbit_plugins.erl
+++ b/deps/rabbit/src/rabbit_plugins.erl
@@ -548,7 +548,7 @@ split_path(PathString) ->
                      {unix, _} -> ":";
                      {win32, _} -> ";"
                  end,
-    string:tokens(PathString, Delimiters).
+    lists:usort(string:tokens(PathString, Delimiters)).
 
 %% Search for files using glob in a given dir. Returns full filenames of those files.
 full_path_wildcard(Glob, Dir) ->


### PR DESCRIPTION
See #3155 for context. It is also possible that someone might
override the path with duplicate values.

Note that the list of directories will lose its original
ordering. That should be fine as we expect unique plugin
paths: it is not a "preference list" (ordering should
not matter).

Closes #3155
