### PR TITLE
Enable all plugins & ports in development container images

### DIFF
--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -253,6 +253,7 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+# EPMD AMQP-TLS AMQP ERLANG
 EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]
 
@@ -286,8 +287,24 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/rabbitmqadmin; \
 	apt-get update; apt-get install -y --no-install-recommends python3; rm -rf /var/lib/apt/lists/*; \
 	rabbitmqadmin --version
+# MANAGEMENT-TLS MANAGEMENT
 EXPOSE 15671 15672
 
 RUN rabbitmq-plugins enable --offline rabbitmq_prometheus && \
     rabbitmq-plugins is_enabled rabbitmq_prometheus --offline
-EXPOSE 15692
+# PROMETHEUS-TLS PROMETHEUS
+EXPOSE 15691 15692
+
+RUN rabbitmq-plugins enable --all
+# STREAM-TLS STREAM
+EXPOSE 5551 5552
+# MQTT-TLS MQTT
+EXPOSE 8883 1883
+# WEB-MQTT-TLS WEB-MQTT
+EXPOSE 15676 15675
+# STOMP-TLS STOMP
+EXPOSE 61614 61613
+# WEB-STOMP-TLS WEB-STOMP
+EXPOSE 15673 15674
+# EXAMPLES
+EXPOSE 15670


### PR DESCRIPTION
This is the best way of ensuring that everything works. RabbitMQ is not just the core components, it's all the plugins that ship with it.  While we don't expect anyone to enable all plugins at the same time (for example enabling all peer discovery plugins at the same time doesn't make sense), we need to be minimally confident that everything works. As we work on & QA various features in dev, this is the quickest way of doing just that.

For example, today we were testing some Stream features with @GSantomaggio and discovered that we needed to use a different image for it, `pivotalrabbitmq/rabbitmq-stream`, because in the default 3.9.x dev container image we don't enable the stream plugin by default. There is no reason why we would need a different container image to test a core feature, that ships part of RabbitMQ as a Tier 1 plugin. To be honest, I strongly believe that everyone be looking at these specific images (otp-max & otp-max-1) which bundle the majority of the RabbitMQ experience in a single artefact, including OpenSSL & Erlang.

While I would normally push this straight into the main branch, I'm doing it as a PR so that the following notice, and have the opportunity to comment on this standalone:
- @michaelklishin
- @GSantomaggio
- @Zerpet
- @MirahImage
- @ansd

As next steps, after all checks pass, can someone from the above list action the following please:
- merge into our main branch
- backport to v3.9.x
- deploy to lre-3-9

🙌
