### PR TITLE
Extract TLS informations that are delivered in PROXY protocol frame

### DIFF
--- a/deps/amqp_client/src/amqp_direct_connection.erl
+++ b/deps/amqp_client/src/amqp_direct_connection.erl
@@ -195,14 +195,14 @@ socket_adapter_info(Sock, Protocol) ->
 
 maybe_ssl_info(Sock) ->
     RealSocket = rabbit_net:unwrap_socket(Sock),
-    case rabbit_net:is_ssl(RealSocket) of
-        true  -> [{ssl, true}] ++ ssl_info(RealSocket) ++ ssl_cert_info(RealSocket);
-        false -> [{ssl, false}]
+    case rabbit_net:proxy_ssl_info(RealSocket, rabbit_net:maybe_get_proxy_socket(Sock)) of
+        nossl -> [{ssl, false}];
+        Info -> [{ssl, true}] ++ ssl_info(Info) ++ ssl_cert_info(RealSocket)
     end.
 
-ssl_info(Sock) ->
+ssl_info(Info) ->
     {Protocol, KeyExchange, Cipher, Hash} =
-        case rabbit_net:ssl_info(Sock) of
+        case Info of
             {ok, Infos} ->
                 {_, P} = lists:keyfind(protocol, 1, Infos),
                 #{cipher := C,

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -793,8 +793,8 @@ socket_info(Get, Select, #v1{sock = Sock}) ->
         {error, _} -> ''
     end.
 
-ssl_info(F, #v1{sock = Sock}) ->
-    case rabbit_net:ssl_info(Sock) of
+ssl_info(F, #v1{sock = Sock, proxy_socket = ProxySock}) ->
+    case rabbit_net:proxy_ssl_info(Sock, ProxySock) of
         nossl       -> '';
         {error, _}  -> '';
         {ok, Items} ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -82,7 +82,8 @@
          resource_alarm :: boolean(),
          send_file_oct ::
              atomics:atomics_ref(), % number of bytes sent with send_file (for metrics)
-         transport :: tcp | ssl}).
+         transport :: tcp | ssl,
+         proxy_socket :: undefined | ranch_proxy:proxy_socket()}).
 -record(configuration,
         {initial_credits :: integer(),
          credits_required_for_unblocking :: integer(),
@@ -221,7 +222,8 @@ init([KeepaliveSup,
                                frame_max = FrameMax,
                                resource_alarm = false,
                                send_file_oct = SendFileOct,
-                               transport = ConnTransport},
+                               transport = ConnTransport,
+                               proxy_socket = rabbit_net:maybe_get_proxy_socket(Sock)},
             State =
             #stream_connection_state{consumers = #{},
                                      blocked = false,
@@ -2726,8 +2728,8 @@ i(host, #stream_connection{host = Host}, _) ->
     Host;
 i(peer_host, #stream_connection{peer_host = PeerHost}, _) ->
     PeerHost;
-i(ssl, #stream_connection{socket = Socket}, _) ->
-    rabbit_net:is_ssl(Socket);
+i(ssl, #stream_connection{socket = Socket, proxy_socket = ProxySock}, _) ->
+    rabbit_net:proxy_ssl_info(Socket, ProxySock) /= nossl;
 i(peer_cert_subject, S, _) ->
     cert_info(fun rabbit_ssl:peer_cert_subject/1, S);
 i(peer_cert_issuer, S, _) ->
@@ -2793,8 +2795,8 @@ cert_info(F, #stream_connection{socket = Sock}) ->
             list_to_binary(F(Cert))
     end.
 
-ssl_info(F, #stream_connection{socket = Sock}) ->
-    case rabbit_net:ssl_info(Sock) of
+ssl_info(F, #stream_connection{socket = Sock, proxy_socket = ProxySock}) ->
+    case rabbit_net:proxy_ssl_info(Sock, ProxySock) of
         nossl ->
             '';
         {error, _} ->


### PR DESCRIPTION
## Proposed Changes

This adds extractor for TLS details that are provided in PROXY protocol payload. This makes connections that do use HAProxy to handle TLS (and have PROXY protocol enabled), show that they are encrypted and have data about protocol cipher that this connection used 
displayed in management ui.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

This extends already existing PROXY support with handling of TLS information that can be passed in it. This doesn't add passing information about client certificates, data that is provided that way, doesn't looks like is compatible with what rabbit is expecting, there is just not enough information in that.

This was sponsored by 84codes/CloudAMQP.
