### PR TITLE
Add missing application to Erlang LS config

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,6 +1,7 @@
 # otp_path: "/path/to/otp/lib/erlang"
 deps_dirs:
   - "deps/*"
+  - "deps/rabbit/apps/*"
 diagnostics:
   disabled: []
   enabled:


### PR DESCRIPTION
E.g. `./deps/rabbit/src/rabbit.erl` was reported by erlang_ls as having unresolved references.

Reason being that `rabbit_prelaunch` lives only in `deps/rabbit/apps/rabbit_prelaunch`,
and Erlang LS was not configured to find it there.