### PR TITLE
Use layer caching when building the oci

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -31,35 +31,34 @@ jobs:
   build-publish-dev:
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            # Build image for every supported Erlang major version.
-            # Source of truth for OTP versions (min & max): https://www.rabbitmq.com/which-erlang.html
-            otp:
-              - '23.2'
-              # Which is the latest OTP release for this major? 1/2
-              # https://github.com/erlang/otp/tags
-              - '24.0.3'
-            include:
-            - otp: '23.2'
-              # make -C packaging/docker-image find-otp-sha256 OTP_VERSION_MATCH=23.2
-              otp_sha256: 79f2233a960cc427607d52a7b7e9e5b08afba96a4d87ced4efb64e902b44160c
-              # Which is the min supported Elixir?
-              # https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
-              elixir: '1.10.4'
-              image_tag_suffix: '-otp-min'
-              # Which is the latest OTP release for this major? 2/2
-              # https://github.com/erlang/otp/tags
-            - otp: '24.0.3'
-              # make -C packaging/docker-image find-otp-sha256
-              otp_sha256: f46bdc3146ac0b54e0d20faa09129a78f4d880d85890acda557c1094662a1a42
-              # Which is the max supported Elixir?
-              # https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
-              # Which is the latest Elixir release?
-              # https://github.com/elixir-lang/elixir/tags
-              elixir: '1.12.2'
-              image_tag_suffix: '-otp-max'
-    env:
-      IMAGE_TAG_1: ${{ github.sha }}${{ matrix.image_tag_suffix }}
+      fail-fast: false
+      matrix:
+          # Build image for every supported Erlang major version.
+          # Source of truth for OTP versions (min & max): https://www.rabbitmq.com/which-erlang.html
+          otp:
+            - '23.2'
+            # Which is the latest OTP release for this major? 1/2
+            # https://github.com/erlang/otp/tags
+            - '24.0.3'
+          include:
+          - otp: '23.2'
+            # make -C packaging/docker-image find-otp-sha256 OTP_VERSION_MATCH=23.2
+            otp_sha256: 79f2233a960cc427607d52a7b7e9e5b08afba96a4d87ced4efb64e902b44160c
+            # Which is the min supported Elixir?
+            # https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
+            elixir: '1.10.4'
+            image_tag_suffix: '-otp-min'
+            # Which is the latest OTP release for this major? 2/2
+            # https://github.com/erlang/otp/tags
+          - otp: '24.0.3'
+            # make -C packaging/docker-image find-otp-sha256
+            otp_sha256: f46bdc3146ac0b54e0d20faa09129a78f4d880d85890acda557c1094662a1a42
+            # Which is the max supported Elixir?
+            # https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_cli/mix.exs#L14
+            # Which is the latest Elixir release?
+            # https://github.com/elixir-lang/elixir/tags
+            elixir: '1.12.2'
+            image_tag_suffix: '-otp-max'
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -72,29 +71,57 @@ jobs:
 
       - name: Build generic unix package
         run: |
-          make package-generic-unix PROJECT_VERSION=${GITHUB_SHA}
+          make package-generic-unix PROJECT_VERSION=${{ github.sha }}
 
-      - name: Build container image
-        working-directory: packaging/docker-image
-        env:
-          OTP_VERSION: ${{ matrix.otp }}
-          OTP_SHA256: ${{ matrix.otp_sha256 }}
-        run: |
-          make dist SKIP_PGP_VERIFY=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
-        working-directory: packaging/docker-image
-        run: |
-          docker login \
-            --username '${{ secrets.DOCKERHUB_USERNAME }}' \
-            --password '${{ secrets.DOCKERHUB_PASSWORD }}'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # Push the same image with two different tags:
-      # 1. <git_commit_sha>-otp-min[-max]
-      # 2. <branch_name>-otp-min[-max]
-      - name: Push container image to DockerHub
+      - name: Expand generic-unix-package
         working-directory: packaging/docker-image
-        env:
-          IMAGE_TAG_SUFFIX: ${{ matrix.image_tag_suffix }}
         run: |
-          make push IMAGE_TAG_2=${GITHUB_REF##*/}${IMAGE_TAG_SUFFIX}
+          xzcat ${GENERIC_UNIX_ARCHIVE} | tar xvf -
+
+      - name: Compute image tags
+        id: compute-tags
+        run: |
+          echo "::set-output name=TAG_1::${{ github.sha }}${{ matrix.image_tag_suffix }}"
+          echo "::set-output name=TAG_2::${GITHUB_REF##*/}${{ matrix.image_tag_suffix }}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: packaging/docker-image
+          load: true
+          tags: |
+            pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
+            pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}
+          build-args: |
+            SKIP_PGP_VERIFY=true
+            PGP_KEYSERVER=pgpkeys.eu
+            OTP_VERSION=${{ matrix.otp }}
+            OTP_SHA256=${{ matrix.otp_sha256 }}
+            RABBITMQ_BUILD=rabbitmq_server-${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: packaging/docker-image
-          load: true
+          push: true
           tags: |
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -80,9 +80,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.image_tag_suffix }}-buildx-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-${{ matrix.image_tag_suffix }}-buildx-
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
## Proposed Changes

This speeds up the workflow that produces OCI images on each commit by leveraging the caching options afforded by https://github.com/marketplace/actions/build-and-push-docker-images

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
