### PR TITLE
Add stream reader state timeouts

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -396,7 +396,9 @@ tuned(info, Msg, StateData) ->
                 end).
 
 state_timeout(State, Transport, Socket) ->
-    rabbit_log_connection:warning("Closing connection because of timeout in state '~s'.", [State]),
+    rabbit_log_connection:warning(
+      "Closing connection because of timeout in state '~s' likely due to lack of client action.",
+      [State]),
     close_immediately(Transport, Socket),
     stop.
 
@@ -1004,7 +1006,9 @@ close_sent(state_timeout, close, #statem_data{
                                     connection = #stream_connection{socket = Socket} = Connection,
                                     connection_state = State
                                    }) ->
-    rabbit_log_connection:warning("Closing connection because of timeout in state '~s'.", [?FUNCTION_NAME]),
+    rabbit_log_connection:warning(
+      "Closing connection because of timeout in state '~s' likely due to lack of client action.",
+      [?FUNCTION_NAME]),
     close(Transport, Socket, State),
     rabbit_networking:unregister_non_amqp_connection(self()),
     notify_connection_closed(Connection, State),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -147,9 +147,9 @@
          peer_cert_validity]).
 
 -ifdef(TEST).
--define(STATE_TIMEOUT, 500).
+-define(CONNECTION_NEGOTIATION_STEP_TIMEOUT, 500).
 -else.
--define(STATE_TIMEOUT, 10_000).
+-define(CONNECTION_NEGOTIATION_STEP_TIMEOUT, 10_000).
 -endif.
 
 %% client API
@@ -259,7 +259,7 @@ init([KeepaliveSup,
     end.
 
 tcp_connected(enter, _OldState, StateData) ->
-    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?STATE_TIMEOUT, close}};
+    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?CONNECTION_NEGOTIATION_STEP_TIMEOUT, close}};
 tcp_connected(state_timeout, close, #statem_data{
                                        transport = Transport,
                                        connection = #stream_connection{socket = Socket}
@@ -285,7 +285,7 @@ tcp_connected(info, Msg, StateData) ->
                 end).
 
 peer_properties_exchanged(enter, _OldState, StateData) ->
-    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?STATE_TIMEOUT, close}};
+    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?CONNECTION_NEGOTIATION_STEP_TIMEOUT, close}};
 peer_properties_exchanged(state_timeout, close, #statem_data{
                                                    transport = Transport,
                                                    connection = #stream_connection{socket = Socket}
@@ -311,7 +311,7 @@ peer_properties_exchanged(info, Msg, StateData) ->
                 end).
 
 authenticating(enter, _OldState, StateData) ->
-    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?STATE_TIMEOUT, close}};
+    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?CONNECTION_NEGOTIATION_STEP_TIMEOUT, close}};
 authenticating(state_timeout, close, #statem_data{
                                         transport = Transport,
                                         connection = #stream_connection{socket = Socket}
@@ -344,7 +344,7 @@ authenticating(info, Msg, StateData) ->
                 end).
 
 tuning(enter, _OldState, StateData) ->
-    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?STATE_TIMEOUT, close}};
+    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?CONNECTION_NEGOTIATION_STEP_TIMEOUT, close}};
 tuning(state_timeout, close, #statem_data{
                                 transport = Transport,
                                 connection = #stream_connection{socket = Socket}
@@ -374,7 +374,7 @@ tuning(info, Msg, StateData) ->
                 end).
 
 tuned(enter, _OldState, StateData) ->
-    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?STATE_TIMEOUT, close}};
+    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?CONNECTION_NEGOTIATION_STEP_TIMEOUT, close}};
 tuned(state_timeout, close, #statem_data{
                                transport = Transport,
                                connection = #stream_connection{socket = Socket}
@@ -1000,7 +1000,7 @@ open(cast, {force_event_refresh, Ref}, #statem_data{
     {keep_state, StatemData#statem_data{connection = Connection2}}.
 
 close_sent(enter, _OldState, StateData) ->
-    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?STATE_TIMEOUT, close}};
+    {next_state, ?FUNCTION_NAME, StateData, {state_timeout, ?CONNECTION_NEGOTIATION_STEP_TIMEOUT, close}};
 close_sent(state_timeout, close, #statem_data{
                                     transport = Transport,
                                     connection = #stream_connection{socket = Socket} = Connection,

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -68,13 +68,23 @@ init_per_group(single_node, Config) ->
     Config2 =
         rabbit_ct_helpers:set_config(Config1,
                                      {rabbitmq_ct_tls_verify, verify_none}),
-    rabbit_ct_helpers:run_setup_steps(Config2,
+    Config3 =
+        rabbit_ct_helpers:set_config(Config2,
+                                     {rabbitmq_stream, verify_none}),
+    rabbit_ct_helpers:run_setup_steps(Config3,
                                       [fun(StepConfig) ->
                                           rabbit_ct_helpers:merge_app_env(StepConfig,
                                                                           {rabbit,
                                                                            [{core_metrics_gc_interval,
                                                                              1000}]})
-                                       end]
+                                       end,
+                                       fun(StepConfig) ->
+                                          rabbit_ct_helpers:merge_app_env(StepConfig,
+                                                                          {rabbitmq_stream,
+                                                                           [{connection_negotiation_step_timeout,
+                                                                             500}]})
+                                       end
+                                      ]
                                       ++ rabbit_ct_broker_helpers:setup_steps());
 init_per_group(cluster = Group, Config) ->
     Config1 =

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -227,7 +227,7 @@ timeout_authenticating(Config) ->
     {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
     C0 = rabbit_stream_core:init(0),
     test_peer_properties(gen_tcp, S, C0),
-    SaslHandshakeFrame = rabbit_stream_core:frame({request, 1, sasl_handshake}),
+    _Frame = rabbit_stream_core:frame({request, 1, sasl_handshake}),
     ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
 
 timeout_close_sent(Config) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -39,8 +39,12 @@ groups() ->
        test_gc_consumers,
        test_gc_publishers,
        unauthenticated_client_rejected_tcp_connected,
+       timeout_tcp_connected,
        unauthenticated_client_rejected_peer_properties_exchanged,
-       unauthenticated_client_rejected_authenticating]},
+       timeout_peer_properties_exchanged,
+       unauthenticated_client_rejected_authenticating,
+       timeout_authenticating,
+       timeout_close_sent]},
      %% Run `test_global_counters` on its own so the global metrics are
      %% initialised to 0 for each testcase
      {single_node, [], [test_global_counters]},
@@ -189,12 +193,24 @@ unauthenticated_client_rejected_tcp_connected(Config) ->
     ?assertEqual(ok, gen_tcp:send(S, <<"invalid data">>)),
     ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
 
+timeout_tcp_connected(Config) ->
+    Port = get_stream_port(Config),
+    {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
+    ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
+
 unauthenticated_client_rejected_peer_properties_exchanged(Config) ->
     Port = get_stream_port(Config),
     {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
     C0 = rabbit_stream_core:init(0),
     test_peer_properties(gen_tcp, S, C0),
     ?assertEqual(ok, gen_tcp:send(S, <<"invalid data">>)),
+    ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
+
+timeout_peer_properties_exchanged(Config) ->
+    Port = get_stream_port(Config),
+    {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
+    C0 = rabbit_stream_core:init(0),
+    test_peer_properties(gen_tcp, S, C0),
     ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
 
 unauthenticated_client_rejected_authenticating(Config) ->
@@ -205,6 +221,31 @@ unauthenticated_client_rejected_authenticating(Config) ->
     SaslHandshakeFrame = rabbit_stream_core:frame({request, 1, sasl_handshake}),
     ?assertEqual(ok, gen_tcp:send(S, SaslHandshakeFrame)),
     ?awaitMatch({error, closed}, gen_tcp:send(S, <<"invalid data">>), ?WAIT).
+
+timeout_authenticating(Config) ->
+    Port = get_stream_port(Config),
+    {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
+    C0 = rabbit_stream_core:init(0),
+    test_peer_properties(gen_tcp, S, C0),
+    SaslHandshakeFrame = rabbit_stream_core:frame({request, 1, sasl_handshake}),
+    ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
+
+timeout_close_sent(Config) ->
+    Port = get_stream_port(Config),
+    {ok, S} = gen_tcp:connect("localhost", Port, [{active, false}, {mode, binary}]),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(gen_tcp, S, C0),
+    C2 = test_authenticate(gen_tcp, S, C1),
+    % Trigger rabbit_stream_reader to transition to state close_sent
+    NonExistentCommand = 999,
+    IOData = <<?REQUEST:1, NonExistentCommand:15, ?VERSION_1:16>>,
+    Size = iolist_size(IOData),
+    Frame = [<<Size:32>> | IOData],
+    ok = gen_tcp:send(S, Frame),
+    {{request, _CorrelationID, {close, ?RESPONSE_CODE_UNKNOWN_FRAME, <<"unknown frame">>}}, _Config}
+    = receive_commands(gen_tcp, S, C2),
+    % Now, rabbit_stream_reader is in state close_sent.
+    ?assertEqual(closed, wait_for_socket_close(gen_tcp, S, 1)).
 
 consumer_count(Config) ->
     ets_count(Config, ?TABLE_CONSUMER).


### PR DESCRIPTION
Add state timeouts.
If the client takes more than 10s for a single step in the authentication
protocol, make the server close the TCP connection.

Also close the TCP connection if the server times out in state
`close_sent`. That's the case when the client sends an invalid command
(after successful authentication), the server requests the client to
close the connection, but the client doesn't respond anymore.