### PR TITLE
Remove amqp_ssl:add_verify_fun_to_opts/2,3

### DIFF
--- a/deps/amqp_client/src/amqp_ssl.erl
+++ b/deps/amqp_client/src/amqp_ssl.erl
@@ -5,7 +5,6 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -export([maybe_enhance_ssl_options/1,
-         add_verify_fun_to_opts/2,
          verify_fun/3]).
 
 maybe_enhance_ssl_options(Params = #amqp_params_network{ssl_options = none}) ->
@@ -26,27 +25,16 @@ maybe_add_sni_0(false, Host, Options) ->
     % server_name_indication at all. If Host is a DNS host name,
     % we will specify server_name_indication via code
     maybe_add_sni_1(inet_parse:domain(Host), Host, Options);
-maybe_add_sni_0({server_name_indication, disable}, _Host, Options) ->
+maybe_add_sni_0({server_name_indication, _DisableOrSniHost}, _Host, Options) ->
     % NB: this is the case where the user explicitly disabled
-    % server_name_indication
-    Options;
-maybe_add_sni_0({server_name_indication, SniHost}, _Host, Options) ->
-    % NB: this is the case where the user explicitly specified
-    % an SNI host name. We may need to add verify_fun for OTP 19
-    maybe_add_verify_fun(lists:keymember(verify_fun, 1, Options), SniHost, Options).
+    % server_name_indication or explicitly specified an SNI host name.
+    Options.
 
 maybe_add_sni_1(false, _Host, Options) ->
     % NB: host is not a DNS host name, so nothing to add
     Options;
 maybe_add_sni_1(true, Host, Options) ->
-    Opts1 = [{server_name_indication, Host} | Options],
-    maybe_add_verify_fun(lists:keymember(verify_fun, 1, Opts1), Host, Opts1).
-
-maybe_add_verify_fun(true, _Host, Options) ->
-    % NB: verify_fun already present, don't add twice
-    Options;
-maybe_add_verify_fun(false, Host, Options) ->
-    add_verify_fun_to_opts(lists:keyfind(verify, 1, Options), Host, Options).
+    [{server_name_indication, Host} | Options].
 
 maybe_add_verify(Options) ->
     case lists:keymember(verify, 1, Options) of
@@ -58,19 +46,6 @@ maybe_add_verify(Options) ->
                     "Please see https://rabbitmq.com/ssl.html for more information.", [self()]),
             Options
     end.
-
-add_verify_fun_to_opts(Host, Options) ->
-    add_verify_fun_to_opts(false, Host, Options).
-
-add_verify_fun_to_opts({verify, verify_none}, _Host, Options) ->
-    % NB: this is the case where the user explicitly disabled
-    % certificate chain verification so there's not much sense
-    % in adding verify_fun
-    Options;
-add_verify_fun_to_opts(_, _Host, Options) ->
-    % NB: this is the case where the user either did not
-    % set the verify option or set it to verify_peer
-    Options.
 
 -type hostname() :: nonempty_string() | binary().
 

--- a/deps/amqp_client/test/unit_SUITE.erl
+++ b/deps/amqp_client/test/unit_SUITE.erl
@@ -139,18 +139,6 @@ amqp_uri_parsing(_Config) ->
     ],
     ?assertEqual(lists:usort(Exp1), lists:usort(TLSOpts1)),
 
-    {ok, #amqp_params_network{host = "host2", ssl_options = TLSOpts2}} =
-        amqp_uri:parse("amqps://host2/%2F?verify=verify_peer"
-                       "&server_name_indication=host2"
-                       "&cacertfile=/path/to/cacertfile.pem"
-                       "&certfile=/path/to/certfile.pem"),
-    Opts2 = [{certfile,  "/path/to/certfile.pem"},
-             {cacertfile,"/path/to/cacertfile.pem"},
-             {server_name_indication, "host2"},
-             {verify, verify_peer}],
-    Exp2 = amqp_ssl:add_verify_fun_to_opts("host2", Opts2),
-    ?assertEqual(lists:usort(Exp2), lists:usort(TLSOpts2)),
-
     {ok, #amqp_params_network{host = "host3", ssl_options = TLSOpts3}} =
         amqp_uri:parse("amqps://host3/%2f?verify=verify_peer"
                        "&fail_if_no_peer_cert=true"),
@@ -170,22 +158,6 @@ amqp_uri_parsing(_Config) ->
             {depth,     5},
             {server_name_indication,"host4"}],
     ?assertEqual(lists:usort(Exp4), lists:usort(TLSOpts4)),
-
-    {ok, #amqp_params_network{host = "host5", ssl_options = TLSOpts5}} =
-        amqp_uri:parse("amqps://host5/%2f?server_name_indication=foobar"
-                       "&verify=verify_peer"),
-    Opts5 = [{server_name_indication, "foobar"},
-             {verify, verify_peer}],
-    Exp5 = amqp_ssl:add_verify_fun_to_opts("foobar", Opts5),
-    ?assertEqual(lists:usort(Exp5), lists:usort(TLSOpts5)),
-
-    {ok, #amqp_params_network{host = "127.0.0.1", ssl_options = TLSOpts6}} =
-        amqp_uri:parse("amqps://127.0.0.1/%2f?server_name_indication=barbaz"
-                       "&verify=verify_peer"),
-    Opts6 = [{server_name_indication, "barbaz"},
-             {verify, verify_peer}],
-    Exp6 = amqp_ssl:add_verify_fun_to_opts("barbaz", Opts6),
-    ?assertEqual(lists:usort(Exp6), lists:usort(TLSOpts6)),
 
     {ok, #amqp_params_network{host = "host7", ssl_options = TLSOpts7}} =
         amqp_uri:parse("amqps://host7/%2f?server_name_indication=disable"),


### PR DESCRIPTION
## Proposed Changes

These functions have become no-op after d76234f. The `maybe_add_verify_fun/3` function has now become unreachable and was removed too.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Since `add_verify_fun_to_opts/2` was exported, this might be a breaking change, so we could deprecate it instead.

I noticed that `maybe_add_verify/1` has also become mostly a no-op after d76234f, except for logging a warning message. This function is reachable from 2 locations: `amqp_connection.start/2` and `amqp_uri.parse/2`. I believe this warning could be valuable in the former but not much in the latter, especially if we parse before connecting, which would log it twice.

This is my first time contributing to an Erlang project. Please let me know if these changes make any sense at all.