### PR TITLE
Mixed version testing in bazel

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -1,8 +1,8 @@
-name: Test
+name: Test Mixed Version Clusters
 on: push
 jobs:
-  test:
-    name: Test
+  test-mixed-versions:
+    name: Test (Mixed Version Cluster)
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
@@ -32,10 +32,10 @@ jobs:
       run: |
         bazelisk test //... \
           --config=rbe-${{ matrix.erlang_version }} \
-          --test_tag_filters=-exclusive,-aws,-mixed-version-cluster \
+          --test_tag_filters=mixed-version-cluster,-exclusive,-aws \
           --verbose_failures
-  test-exclusive:
-    name: Test (Exclusive Tests)
+  test-exclusive-mixed-versions:
+    name: Test (Exclusive Tests with Mixed Version Cluster)
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -75,7 +75,7 @@ jobs:
       run: |
         bazelisk test //... \
           --config=buildbuddy \
-          --test_tag_filters=exclusive,-aws,-mixed-version-cluster \
+          --test_tag_filters=exclusive,mixed-version-cluster,-aws \
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -73,9 +73,10 @@ jobs:
     #!   uses: mxschmitt/action-tmate@v3
     - name: RUN EXCLUSIVE TESTS
       run: |
-        bazelisk test //... \
+        MIXED_EXCLUSIVE_TESTS=$(bazel query 'attr(tags, "mixed-version-cluster", attr(tags, "exclusive", tests(//...)))')
+        bazelisk test $MIXED_EXCLUSIVE_TESTS \
           --config=buildbuddy \
-          --test_tag_filters=exclusive,mixed-version-cluster,-aws \
+          --test_tag_filters=-aws \
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
+        - "23"
         - "24"
     timeout-minutes: 120
     steps:
@@ -31,7 +32,7 @@ jobs:
       run: |
         bazelisk test //... \
           --config=rbe-${{ matrix.erlang_version }} \
-          --test_tag_filters=-exclusive,-aws \
+          --test_tag_filters=-exclusive,-aws,-mixed-version-cluster \
           --verbose_failures
   test-exclusive:
     name: Test (Exclusive Tests)
@@ -74,7 +75,40 @@ jobs:
       run: |
         bazelisk test //... \
           --config=buildbuddy \
-          --test_tag_filters=exclusive,-aws \
+          --test_tag_filters=exclusive,-aws,-mixed-version-cluster \
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
+          --verbose_failures
+  test-mixed-version-cluster:
+    name: Test
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        erlang_version:
+        - "23"
+        - "24"
+    timeout-minutes: 120
+    steps:
+    - name: CHECKOUT REPOSITORY
+      uses: actions/checkout@v2.3.4
+    - name: CONFIGURE BAZEL
+      run: |
+        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
+        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
+        cat << EOF >> user.bazelrc
+          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
+          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+
+          build:buildbuddy --build_metadata=ROLE=CI
+          build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
+          build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.erlang_version }}
+        EOF
+    #! - name: Setup tmate session
+    #!   uses: mxschmitt/action-tmate@v3
+    - name: RUN TESTS
+      run: |
+        bazelisk test //... \
+          --config=rbe-${{ matrix.erlang_version }} \
+          --test_tag_filters=mixed-version-cluster,-exclusive,-aws \
           --verbose_failures

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
   test-mixed-version-cluster:
-    name: Test
+    name: Test (Mixed Version Cluster)
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - "23"
         - "24"
     timeout-minutes: 120
     steps:

--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -5,7 +5,10 @@ rabbitmq_package_generic_unix(
     name = "broker-home",
     sbin = glob(["sbin/*"]),
     escript = glob(["escript/*"]),
-    plugins = glob(["plugins/*"]),
+    plugins = [
+        "//plugins:standard_plugins",
+        "//plugins:inet_tcp_proxy_ez",
+    ],
 )
 
 rabbitmq_run(

--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -1,0 +1,15 @@
+load("@//:rabbitmq_package_generic_unix.bzl", "rabbitmq_package_generic_unix")
+load("@//:rabbitmq_run.bzl", "rabbitmq_run")
+
+rabbitmq_package_generic_unix(
+    name = "broker-home",
+    sbin = glob(["sbin/*"]),
+    escript = glob(["escript/*"]),
+    plugins = glob(["plugins/*"]),
+)
+
+rabbitmq_run(
+    name = "rabbitmq-run",
+    home = ":broker-home",
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -89,9 +89,9 @@ EOF
 """
 
 http_archive(
-    name = "rabbitmq-server-generic-unix-3.8.17",
+    name = "rabbitmq-server-generic-unix-3.8.18",
     build_file = "@//:BUILD.package_generic_unix",
     patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-    strip_prefix = "rabbitmq_server-3.8.17",
-    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.17/rabbitmq-server-generic-unix-latest-toolchain-3.8.17.tar.xz"],
+    strip_prefix = "rabbitmq_server-3.8.18",
+    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.18/rabbitmq-server-generic-unix-3.8.18.tar.xz"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -56,5 +56,5 @@ http_archive(
     name = "rabbitmq-server-generic-unix-3.8.17",
     build_file = "@//:BUILD.package_generic_unix",
     strip_prefix = "rabbitmq_server-3.8.17",
-    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.17/rabbitmq-server-generic-unix-3.8.17.tar.xz"],
+    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.17/rabbitmq-server-generic-unix-latest-toolchain-3.8.17.tar.xz"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -51,3 +51,10 @@ git_repository(
 load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
 
 activemq_archive()
+
+http_archive(
+    name = "rabbitmq-server-generic-unix-3.8.17",
+    build_file = "@//:BUILD.package_generic_unix",
+    strip_prefix = "rabbitmq_server-3.8.17",
+    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.17/rabbitmq-server-generic-unix-3.8.17.tar.xz"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -17,6 +17,19 @@ load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
 buildbuddy(name = "buildbuddy_toolchain")
 
 http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
+    ],
+    sha256 = "038f1caa773a7e35b3663865ffb003169c6a71dc995e39bf4815792f385d837d",
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
+http_archive(
     name = "bazel-erlang",
     strip_prefix = "bazel-erlang-main",
     urls = ["https://github.com/rabbitmq/bazel-erlang/archive/main.zip"],
@@ -52,9 +65,33 @@ load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
 
 activemq_archive()
 
+ADD_PLUGINS_DIR_BUILD_FILE = """set -euo pipefail
+
+cat << EOF > plugins/BUILD.bazel
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+
+pkg_zip(
+    name = "inet_tcp_proxy_ez",
+    package_dir = "inet_tcp_proxy/ebin",
+    srcs = [
+        "@inet_tcp_proxy//:bazel_erlang_lib",
+    ],
+    package_file_name = "inet_tcp_proxy.ez",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "standard_plugins",
+    srcs = glob(["*.ez"]),
+    visibility = ["//visibility:public"],
+)
+EOF
+"""
+
 http_archive(
     name = "rabbitmq-server-generic-unix-3.8.17",
     build_file = "@//:BUILD.package_generic_unix",
+    patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
     strip_prefix = "rabbitmq_server-3.8.17",
     urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.17/rabbitmq-server-generic-unix-latest-toolchain-3.8.17.tar.xz"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -18,11 +18,11 @@ buildbuddy(name = "buildbuddy_toolchain")
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "038f1caa773a7e35b3663865ffb003169c6a71dc995e39bf4815792f385d837d",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
     ],
-    sha256 = "038f1caa773a7e35b3663865ffb003169c6a71dc995e39bf4815792f385d837d",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
 -compile(export_all).
 
@@ -247,15 +248,14 @@ quorum_queue_leadership_transfer(Config) ->
                    Config, Nodenames),
     case AllTheSame of
         true ->
-            rabbit_ct_helpers:await_condition(
-              fun () ->
-                      LocalLeaders = rabbit_ct_broker_helpers:rpc(
-                                       Config, A,
-                                       rabbit_amqqueue,
-                                       list_local_leaders,
-                                       []),
-                      length(LocalLeaders) =:= 0
-              end, 20000);
+            ?awaitMatch(
+               LocalLeaders when length(LocalLeaders) == 0,
+                                 rabbit_ct_broker_helpers:rpc(
+                                   Config, A,
+                                   rabbit_amqqueue,
+                                   list_local_leaders,
+                                   []),
+                                 20000);
         false ->
             ct:pal(
               ?LOW_IMPORTANCE,

--- a/deps/rabbit/test/quorum_queue_utils.erl
+++ b/deps/rabbit/test/quorum_queue_utils.erl
@@ -161,3 +161,9 @@ fifo_machines_use_same_version(Config, Nodenames)
               rabbit_fifo, version, []))
      || Nodename <- Nodenames],
     lists:all(fun(V) -> V =:= MachineAVersion end, OtherMachinesVersions).
+
+is_mixed_versions() ->
+    case {os:getenv("SECONDARY_UMBRELLA"), os:getenv("RABBITMQ_RUN_SECONDARY")} of
+        {false, false} -> false;
+        _ -> true
+    end.

--- a/deps/rabbit/test/quorum_queue_utils.erl
+++ b/deps/rabbit/test/quorum_queue_utils.erl
@@ -161,9 +161,3 @@ fifo_machines_use_same_version(Config, Nodenames)
               rabbit_fifo, version, []))
      || Nodename <- Nodenames],
     lists:all(fun(V) -> V =:= MachineAVersion end, OtherMachinesVersions).
-
-is_mixed_versions() ->
-    case {os:getenv("SECONDARY_UMBRELLA"), os:getenv("RABBITMQ_RUN_SECONDARY")} of
-        {false, false} -> false;
-        _ -> true
-    end.

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -118,7 +118,17 @@ init_per_suite(Config0) ->
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
+init_per_group(cluster_size_3_parallel = Group, Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "not mixed versions compatible"};
+        _ ->
+            init_per_group1(Group, Config)
+    end;
 init_per_group(Group, Config) ->
+    init_per_group1(Group, Config).
+
+init_per_group1(Group, Config) ->
     ClusterSize = case Group of
                       single_node -> 1;
                       single_node_parallel -> 1;

--- a/deps/rabbitmq_federation/test/queue_SUITE.erl
+++ b/deps/rabbitmq_federation/test/queue_SUITE.erl
@@ -117,10 +117,15 @@ init_per_group(cluster_size_1 = Group, Config) ->
       ]),
     init_per_group1(Group, Config1);
 init_per_group(cluster_size_2 = Group, Config) ->
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodes_count, 2}
-      ]),
-    init_per_group1(Group, Config1).
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "not mixed versions compatible"};
+        _ ->
+            Config1 = rabbit_ct_helpers:set_config(Config, [
+                {rmq_nodes_count, 2}
+            ]),
+            init_per_group1(Group, Config1)
+    end.
 
 init_per_group1(Group, Config) ->
     SetupFederation = case Group of

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -91,6 +91,10 @@ end_per_group(_, Config) ->
     Steps = Teardown0 ++ Teardown1,
     rabbit_ct_helpers:run_teardown_steps(Config, Steps).
 
+init_per_testcase(Testcase, Config)
+        when Testcase == is_quorum_critical_test
+            orelse Testcase == is_mirror_sync_critical_test ->
+    {skip, "not mixed versions compatible"};
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 

--- a/deps/rabbitmq_management_agent/test/rabbit_mgmt_gc_SUITE.erl
+++ b/deps/rabbitmq_management_agent/test/rabbit_mgmt_gc_SUITE.erl
@@ -78,13 +78,20 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(quorum_queue_stats = Testcase, Config) ->
-    case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
-        ok ->
-            rabbit_ct_helpers:testcase_started(Config, Testcase),
-            rabbit_ct_helpers:run_steps(
-              Config, rabbit_ct_client_helpers:setup_steps());
-        Skip ->
-            Skip
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "not mixed versions compatible"};
+        _ ->
+            case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
+                ok ->
+                    rabbit_ct_helpers:testcase_started(Config, Testcase),
+                    rabbit_ct_helpers:run_steps(
+                    Config, rabbit_ct_client_helpers:setup_steps());
+                {skip, _} = Skip ->
+                    Skip;
+                Other ->
+                    {skip, Other}
+            end
     end;
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -5,7 +5,7 @@ load(
     "erlang_lib",
     "test_erlang_lib",
 )
-load("@bazel-erlang//:ct_sharded.bzl", "ct_suite")
+load("@bazel-erlang//:ct_sharded.bzl", "ct_suite", "ct_suite_variant")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 
@@ -112,6 +112,8 @@ def rabbitmq_integration_suite(
         tags = [],
         data = [],
         erlc_opts = [],
+        additional_hdrs = [],
+        additional_srcs = [],
         test_env = {},
         tools = [],
         deps = [],
@@ -122,6 +124,8 @@ def rabbitmq_integration_suite(
         suite_name = name,
         tags = tags,
         erlc_opts = RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
+        additional_hdrs = additional_hdrs,
+        additional_srcs = additional_srcs,
         data = [
             "@rabbitmq_ct_helpers//tools/tls-certs:Makefile",
             "@rabbitmq_ct_helpers//tools/tls-certs:openssl.cnf.in",
@@ -150,11 +154,10 @@ def rabbitmq_integration_suite(
         **kwargs
     )
 
-    ct_suite(
-        name = "{}-mixed".format(name),
+    ct_suite_variant(
+        name = name + "-mixed",
         suite_name = name,
         tags = tags + ["mixed-version-cluster"],
-        erlc_opts = RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
         data = [
             "@rabbitmq_ct_helpers//tools/tls-certs:Makefile",
             "@rabbitmq_ct_helpers//tools/tls-certs:openssl.cnf.in",

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -108,6 +108,8 @@ def broker_for_integration_suites():
 
 def rabbitmq_integration_suite(
         package,
+        name = None,
+        tags = [],
         data = [],
         erlc_opts = [],
         test_env = {},
@@ -116,6 +118,9 @@ def rabbitmq_integration_suite(
         runtime_deps = [],
         **kwargs):
     ct_suite(
+        name = name,
+        suite_name = name,
+        tags = tags,
         erlc_opts = RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
         data = [
             "@rabbitmq_ct_helpers//tools/tls-certs:Makefile",

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -188,7 +188,7 @@ def rabbitmq_integration_suite(
         **kwargs
     )
 
-    return kwargs["name"]
+    return name
 
 def assert_suites(suite_names, suite_files):
     for f in suite_files:

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -169,11 +169,11 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.8.17/rabbitmq-run",
+            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.8.18/rabbitmq-run",
         }.items() + test_env.items()),
         tools = [
             ":rabbitmq-for-tests-run",
-            "@rabbitmq-server-generic-unix-3.8.17//:rabbitmq-run",
+            "@rabbitmq-server-generic-unix-3.8.18//:rabbitmq-run",
         ] + tools,
         runtime_deps = [
             "//deps/rabbitmq_cli:elixir_as_bazel_erlang_lib",

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -149,6 +149,42 @@ def rabbitmq_integration_suite(
         ] + deps,
         **kwargs
     )
+
+    ct_suite(
+        name = "{}-mixed".format(name),
+        suite_name = name,
+        tags = tags + ["mixed-version-cluster"],
+        erlc_opts = RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
+        data = [
+            "@rabbitmq_ct_helpers//tools/tls-certs:Makefile",
+            "@rabbitmq_ct_helpers//tools/tls-certs:openssl.cnf.in",
+        ] + data,
+        test_env = dict({
+            "SKIP_MAKE_TEST_DIST": "true",
+            "RABBITMQ_FEATURE_FLAGS": "",
+            "RABBITMQ_RUN": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/rabbitmq-for-tests-run".format(package),
+            "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
+            "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
+            "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
+            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.8.17/rabbitmq-run",
+        }.items() + test_env.items()),
+        tools = [
+            ":rabbitmq-for-tests-run",
+            "@rabbitmq-server-generic-unix-3.8.17//:rabbitmq-run",
+        ] + tools,
+        runtime_deps = [
+            "//deps/rabbitmq_cli:elixir_as_bazel_erlang_lib",
+            "//deps/rabbitmq_cli:rabbitmqctl",
+            "@rabbitmq_ct_client_helpers//:bazel_erlang_lib",
+        ] + runtime_deps,
+        deps = [
+            "//deps/amqp_client:bazel_erlang_lib",
+            "//deps/rabbit_common:bazel_erlang_lib",
+            "@rabbitmq_ct_helpers//:bazel_erlang_lib",
+        ] + deps,
+        **kwargs
+    )
+
     return kwargs["name"]
 
 def assert_suites(suite_names, suite_files):

--- a/rabbitmq_home.bzl
+++ b/rabbitmq_home.bzl
@@ -6,7 +6,6 @@ RabbitmqHomeInfo = provider(
         "sbin": "Files making up the sbin dir",
         "escript": "Files making up the escript dir",
         "plugins": "Files making up the plugins dir",
-        "erlang_version": "Version of the Erlang compiler used",
     },
 )
 
@@ -118,7 +117,6 @@ def _impl(ctx):
             sbin = scripts,
             escript = escripts,
             plugins = plugins,
-            erlang_version = erlang_versions[0],
         ),
         DefaultInfo(
             files = depset(scripts + escripts + plugins),
@@ -141,7 +139,6 @@ rabbitmq_home = rule(
             allow_files = True,
         ),
         "_rabbitmqctl_escript": attr.label(default = "//deps/rabbitmq_cli:rabbitmqctl"),
-        "_erlang_version": attr.label(default = "@bazel-erlang//:erlang_version"),
         "plugins": attr.label_list(),
     },
 )

--- a/rabbitmq_package_generic_unix.bzl
+++ b/rabbitmq_package_generic_unix.bzl
@@ -1,0 +1,26 @@
+load("@//:rabbitmq_home.bzl", "RabbitmqHomeInfo")
+
+def _impl(ctx):
+    scripts = ctx.files.sbin
+    escripts = ctx.files.escript
+    plugins = ctx.files.plugins
+
+    return [
+        RabbitmqHomeInfo(
+            sbin = scripts,
+            escript = escripts,
+            plugins = plugins,
+        ),
+        DefaultInfo(
+            files = depset(scripts + escripts + plugins),
+        ),
+    ]
+
+rabbitmq_package_generic_unix = rule(
+    implementation = _impl,
+    attrs = {
+        "sbin": attr.label_list(allow_files = True),
+        "escript": attr.label_list(allow_files = True),
+        "plugins": attr.label_list(allow_files = True),
+    },
+)

--- a/rabbitmqctl.bzl
+++ b/rabbitmqctl.bzl
@@ -6,9 +6,6 @@ def _impl(ctx):
 
     rabbitmq_home = ctx.attr.home[RabbitmqHomeInfo]
 
-    if rabbitmq_home.erlang_version != erlang_version:
-        fail("Mismatched erlang versions", erlang_version, rabbitmq_home.erlang_version)
-
     script = """
     exec ./{home}/sbin/{cmd} $@
     """.format(

--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# https://stackoverflow.com/a/4774063
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+if [ -z ${TEST_SRCDIR+x} ]; then
+BASE_DIR=$PWD
+else
+BASE_DIR=$TEST_SRCDIR/$TEST_WORKSPACE
+fi
 
 if [ $1 = "-C" ]; then
     cd $2
@@ -32,13 +35,13 @@ for arg in "$@"; do
     esac
 done
 
-DEFAULT_PLUGINS_DIR=${SCRIPTPATH}/{RABBITMQ_HOME}/plugins
+DEFAULT_PLUGINS_DIR=${BASE_DIR}/{RABBITMQ_HOME}/plugins
 if [ ! -z ${EXTRA_PLUGINS_DIR+x} ]; then
     DEFAULT_PLUGINS_DIR=${DEFAULT_PLUGINS_DIR}:${EXTRA_PLUGINS_DIR}
 fi
 
 TEST_TMPDIR=${TEST_TMPDIR:=${TMPDIR}/rabbitmq-test-instances}
-RABBITMQ_SCRIPTS_DIR=${SCRIPTPATH}/{RABBITMQ_HOME}/sbin
+RABBITMQ_SCRIPTS_DIR=${BASE_DIR}/{RABBITMQ_HOME}/sbin
 RABBITMQ_PLUGINS=${RABBITMQ_SCRIPTS_DIR}/rabbitmq-plugins
 RABBITMQ_SERVER=${RABBITMQ_SCRIPTS_DIR}/rabbitmq-server
 RABBITMQCTL=${RABBITMQ_SCRIPTS_DIR}/rabbitmqzctl
@@ -161,12 +164,12 @@ case $CMD in
             while ps -p "$pid" >/dev/null 2>&1; do sleep 1; done
         ;;
     set-resource-alarm)
-        ERL_LIBS="{ERL_LIBS}" \
+        ERL_LIBS="${BASE_DIR}/{ERL_LIBS}" \
            ${RABBITMQ_SCRIPTS_DIR}/rabbitmqctl -n ${RABBITMQ_NODENAME} \
             eval "rabbit_alarm:set_alarm({{resource_limit, ${SOURCE}, node()}, []})."
         ;;
     clear-resource-alarm)
-        ERL_LIBS="{ERL_LIBS}" \
+        ERL_LIBS="${BASE_DIR}/{ERL_LIBS}" \
             ${RABBITMQ_SCRIPTS_DIR}/rabbitmqctl -n ${RABBITMQ_NODENAME} \
             eval "rabbit_alarm:clear_alarm({resource_limit, ${SOURCE}, node()})."
         ;;


### PR DESCRIPTION
## Proposed Changes

Adds the mechanisms and a new github actions workflow to perform mixed version testing with bazel. Unlike the gnu make mechanism, this fetches a prior release of rabbit rather than building the secondary from source.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] CI

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

In its current form, this will block the release pipeline in cases where mixed version tests fail. That has not been historically the case.
