### PR TITLE
Validate amqp0.9.1 queue name length in management UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@
 /plugins.lock
 /sbin/
 /sbin.lock
+erl_crash.dump
 .envrc
 *.plt
 *.lock

--- a/deps/rabbit/src/rabbit_parameter_validation.erl
+++ b/deps/rabbit/src/rabbit_parameter_validation.erl
@@ -7,7 +7,8 @@
 
 -module(rabbit_parameter_validation).
 
--export([number/2, integer/2, binary/2, boolean/2, list/2, regex/2, proplist/3, enum/1]).
+-export([number/2, integer/2, binary/2, amqp091_queue_name/2,
+        boolean/2, list/2, regex/2, proplist/3, enum/1]).
 
 number(_Name, Term) when is_number(Term) ->
     ok;
@@ -26,6 +27,16 @@ binary(_Name, Term) when is_binary(Term) ->
 
 binary(Name, Term) ->
     {error, "~s should be binary, actually was ~p", [Name, Term]}.
+
+amqp091_queue_name(Name, S) when is_binary(S) ->
+    case size(S) of
+        Len when Len =< 255 -> ok;
+        _                   -> {error, "~s should be less than 255 bytes, actually was ~p", [Name, size(S)]}
+    end;
+
+amqp091_queue_name(Name, Term) ->
+    {error, "~s should be binary, actually was ~p", [Name, Term]}.
+
 
 boolean(_Name, Term) when is_boolean(Term) ->
     ok;

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -152,7 +152,7 @@ amqp091_dest_validation(_Def, User) ->
     [{<<"dest-uri">>,        validate_uri_fun(User), mandatory},
      {<<"dest-exchange">>,   fun rabbit_parameter_validation:binary/2,optional},
      {<<"dest-exchange-key">>,fun rabbit_parameter_validation:binary/2,optional},
-     {<<"dest-queue">>,      fun rabbit_parameter_validation:binary/2,optional},
+     {<<"dest-queue">>,      fun rabbit_parameter_validation:amqp091_queue_name/2,optional},
      {<<"dest-queue-args">>, fun validate_queue_args/2, optional},
      {<<"add-forward-headers">>, fun rabbit_parameter_validation:boolean/2,optional},
      {<<"add-timestamp-header">>, fun rabbit_parameter_validation:boolean/2,optional},

--- a/deps/rabbitmq_shovel_management/test/http_SUITE.erl
+++ b/deps/rabbitmq_shovel_management/test/http_SUITE.erl
@@ -166,6 +166,27 @@ shovels(Config) ->
                            'dest-queue' => <<"test2">>}}, ?CREATED)
      || V <- ["%2f", "v"]],
 
+     [http_put(Config, "/parameters/shovel/" ++ V ++ "/my-dynamic",
+              #{value => #{'src-protocol' => <<"amqp091">>,
+                           'src-uri'    => <<"amqp://">>,
+                           'src-queue'  => <<"test">>,
+                           'dest-protocol' => <<"amqp091">>,
+                           'dest-uri'   => <<"amqp://">>,
+                           'dest-queue' => list_to_binary(
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+                                           "test2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq")}},
+               ?BAD_REQUEST)
+     || V <- ["%2f", "v"]],
+
     ?assertMatch([?StaticPattern, ?Dynamic1Pattern, ?Dynamic2Pattern],
 		 http_get(Config, "/shovels",     "guest", "guest", ?OK)),
     ?assertMatch([?Dynamic1Pattern],


### PR DESCRIPTION
## Proposed Changes

Validate AMQP 0.9.1 queue name length when creating queue directly in Management UI on Queues tab or indirectly when moving messages to the new queue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (potentially :man_shrugging:)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I wasn't sure what to do here for the sake of consistency (and given the fact that unicode eats bytes) - either drop  limit in the frames completely or make Management UI validate it. Luckily shovel plugin has this separate module for 0.9.1 shovels and queue creation in Management UI goes via 0.9.1 framing too. So the new validation is scoped to 0.9.1.
