### PR TITLE
Use `skopeo` instead of pulling an image just to get its digest

### DIFF
--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -12,15 +12,17 @@ jobs:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.3.4
     - name: UPDATE RBE IMAGE SHA
+      env:
+        IMAGE: pivotalrabbitmq/rabbitmq-server-buildenv
+        TAG: linux-erlang-git-master
       run: |
         # buildbuddy caches the container image, so we must use a specific sha to ensure
         # the latest is used
-        IMAGE=pivotalrabbitmq/rabbitmq-server-buildenv:linux-erlang-git-master
-        docker pull ${IMAGE}
-        PINNED_IMAGE="$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE)"
-        npm install @bazel/buildozer
+        DIGEST="$(skopeo inspect --format '{{.Digest}}' docker://${IMAGE}:${TAG})"
+        echo "Will use ${IMAGE}@${DIGEST}"
+        npm install --silent @bazel/buildozer
         npx buildozer \
-          "dict_set exec_properties container-image:docker://${PINNED_IMAGE}" \
+          "dict_set exec_properties container-image:docker://${IMAGE}@${DIGEST}" \
           //:erlang_git_platform
     - name: CONFIGURE BAZEL
       run: |


### PR DESCRIPTION
As per @binarin's suggestion in #3215 