### PR TITLE
Fix CLI list_stream_publishers usage output

### DIFF
--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamPublishersCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamPublishersCommand.erl
@@ -84,7 +84,7 @@ usage_additional() ->
     Prefix = <<" must be one of ">>,
     InfoItems =
         'Elixir.Enum':join(
-            lists:usort(?CONSUMER_INFO_ITEMS), <<", ">>),
+            lists:usort(?PUBLISHER_INFO_ITEMS), <<", ">>),
     [{<<"<column>">>, <<Prefix/binary, InfoItems/binary>>}].
 
 usage_doc_guides() ->


### PR DESCRIPTION
Before:
```zsh
> ./sbin/rabbitmqctl list_stream_publishers --help

Arguments and Options

<column>
	 must be one of connection_pid, credits, messages_consumed, offset, offset_lag, properties, stream, subscription_id
```

After:
```zsh
> ./sbin/rabbitmqctl list_stream_publishers --help

Usage

Arguments and Options

<column>
	 must be one of connection_pid, messages_confirmed, messages_errored, messages_published, publisher_id, reference, stream
```