### PR TITLE
Fix broken link of stream docs in CLI

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/doc_guide.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/doc_guide.ex
@@ -58,7 +58,7 @@ defmodule RabbitMQ.CLI.Core.DocGuide do
   Macros.defguide("plugins")
   Macros.defguide("queues")
   Macros.defguide("quorum_queues")
-  Macros.defguide("stream_queues", domain: "next.rabbitmq.com")
+  Macros.defguide("streams")
   Macros.defguide("runtime_tuning", path_segment: "runtime")
   Macros.defguide("tls", path_segment: "ssl")
   Macros.defguide("troubleshooting")

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/add_replica_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/add_replica_command.ex
@@ -48,7 +48,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.AddReplicaCommand do
 
   def usage_doc_guides() do
     [
-      DocGuide.stream_queues()
+      DocGuide.streams()
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/delete_replica_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/delete_replica_command.ex
@@ -49,7 +49,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.DeleteReplicaCommand do
 
   def usage_doc_guides() do
     [
-      DocGuide.stream_queues()
+      DocGuide.streams()
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/set_stream_retention_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/set_stream_retention_policy_command.ex
@@ -40,7 +40,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.SetStreamRetentionPolicyCommand do
 
   def usage_doc_guides() do
     [
-      DocGuide.stream_queues()
+      DocGuide.streams()
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/stream_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/stream_status_command.ex
@@ -58,7 +58,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
 
   def usage_doc_guides() do
     [
-      DocGuide.stream_queues()
+      DocGuide.streams()
     ]
   end
 


### PR DESCRIPTION
Before this commit:

```zsh
> ./sbin/rabbitmq-diagnostics stream_status --help
...
Relevant Doc Guides
 * https://next.rabbitmq.com/stream-queues.html
```
After this commit:

```zsh
> ./sbin/rabbitmq-diagnostics stream_status --help
...
Relevant Doc Guides
 * https://rabbitmq.com/streams.html
```
Needs to be backported to `v3.9.x`.