### PR TITLE
Adjust initial gen_server_call_timeout

### DIFF
--- a/deps/amqp_client/src/amqp_util.erl
+++ b/deps/amqp_client/src/amqp_util.erl
@@ -9,7 +9,7 @@ call_timeout() ->
         undefined ->
             Timeout = rabbit_misc:get_env(amqp_client,
                                           gen_server_call_timeout,
-                                          60000),
+                                          safe_call_timeout(60000)),
             put(gen_server_call_timeout, Timeout),
             Timeout;
         Timeout ->


### PR DESCRIPTION
## Proposed Changes

Preventing `amqp_connection:start/2` from logging a warning when we use default values.

The default for `connection_timeout` [is already `60000`](https://github.com/rabbitmq/rabbitmq-server/blob/e09fb7d8a8e3700d023945a4a4345340e9fe32f1/deps/amqp_client/include/amqp_client.hrl#L24). When we don't explicitly set it to a lower value, `amqp_connection:maybe_update_call_timeout/2` adjusts it to `70000` and logs a warning message (See #2660), which may appear unexpected, especially for users upgrading to 3.8.10+ with no config changes.

This change addresses that problem by pre-adjusting it to `70000`, making it safe by default and ensuring our default values don't conflict with each other.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

An alternative approach to this would be reducing the original `connection_timeout` default to `50000` for example, but that could potentially be a change of bigger impact, since `60000` has been the default since 1905e30e67b0f6e9a9e347be8088786241dcf5eb. Please let me know if this is a saner approach and I can make the changes.