### PR TITLE
Fix typo in ensure_safe_call_timeout/2

### DIFF
--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -405,7 +405,7 @@ ensure_safe_call_timeout(#amqp_params_direct{}, CallTimeout) ->
         {ongoing_change_to, NetTicktime} ->
             maybe_update_call_timeout(tick_or_direct_timeout(NetTicktime * 1000),
                 CallTimeout);
-        ignore ->
+        ignored ->
             maybe_update_call_timeout(?DIRECT_OPERATION_TIMEOUT, CallTimeout)
     end.
 


### PR DESCRIPTION
## Proposed Changes

Matching on `ignored` instead of `ignore`, as described in [the documentation](https://erlang.org/doc/man/net_kernel.html#get_net_ticktime-0) of `net_kernel:get_net_ticktime/0`. Thus making that last clause reachable.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I have not added a regression test for it. Let me know if it is required and I can give it a try.