### PR TITLE
Update auth name

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -86,7 +86,7 @@ it will translate into the following configuration (in the [advanced RabbitMQ co
 [
   %% ...
   %% backend configuration
-  {rabbitmq_auth_backend_oauth2, [
+  {rabbit_auth_backend_oauth2, [
     {resource_server_id, <<"my_rabbit_server">>},
     %% UAA signing key configuration
     {key_config, [
@@ -110,7 +110,7 @@ If a symmetric key is used, the configuration will look like this:
 
 ```erlang
 [
-  {rabbitmq_auth_backend_oauth2, [
+  {rabbit_auth_backend_oauth2, [
     {resource_server_id, <<"my_rabbit_server">>},
     {key_config, [
       {signing_keys, #{
@@ -128,7 +128,7 @@ In that case, the configuration will look like this:
 
 ```erlang
 [
-  {rabbitmq_auth_backend_oauth2, [
+  {rabbit_auth_backend_oauth2, [
     {resource_server_id, <<"my_rabbit_server">>},
     {key_config, [
       {jwks_url, <<"https://my-jwt-issuer/jwks.json">>}
@@ -197,7 +197,7 @@ By default the plugin will look for the `scope` key in the token, you can config
 
 ```erlang
 [
-  {rabbitmq_auth_backend_oauth2, [
+  {rabbit_auth_backend_oauth2, [
     {resource_server_id, <<"my_rabbit_server">>},
     {extra_scopes_source, <<"my_custom_scope_key">>},
     ...


### PR DESCRIPTION
In the examples given, the auth plugin is referred to as `rabbitmq_auth_backend_oauth2` which is incorrect. This is the name of the plugin, and what must be set in the `enabled_plugins` file. 

The name is correctly set in the demo files.

## Proposed Changes

Fix minor issue in the documentation that I spent too long to admit debugging.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
