### PR TITLE
Handle 'absent' return value

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -129,7 +129,9 @@ create_stream(Q0, Node) ->
                      [rabbit_misc:rs(QName), node(), Error]}
             end;
         {existing, Q} ->
-            {existing, Q}
+            {existing, Q};
+        {absent, Q, Reason} ->
+            {absent, Q, Reason}
     end.
 
 -spec delete(amqqueue:amqqueue(), boolean(),


### PR DESCRIPTION
`absent` is one of the three valid return values from `rabbit_amqqueue:internal_declare/2` and the only one not handled.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

