### PR TITLE
Add rebar3_hex plugin reference to rebar3.config generated by erlang.mk

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -5645,6 +5645,7 @@ $(call comma_list,$(foreach d,$(DEPS),\
 		{$(call dep_name,$d)$(comma)"$(call dep_repo,$d)"},\
 		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma)"$(call dep_commit,$d)"}})))
 ]}.
+{plugins, [rebar3_hex]}.
 {erl_opts, $(call compat_erlc_opts_to_list,$(ERLC_OPTS))}.
 endef
 


### PR DESCRIPTION
This allows erlang.mk hex publish target to progress beyond `===> Command hex not found` error