### PR TITLE
DO NOT MERGE Per-queue delivers for old classic queues

### DIFF
--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -1079,6 +1079,8 @@ entry_to_segment(RelSeq, {Pub, Del, Ack}, Initial) ->
                {no_del, no_ack} ->
                    Initial;
                _ ->
+                   %% @todo This might create issues when we don't deliver (and don't ack)!!
+                   %% @todo We need to always write 2 binaries when we ack and it wasn't acked before.
                    Binary = <<?REL_SEQ_ONLY_PREFIX:?REL_SEQ_ONLY_PREFIX_BITS,
                               RelSeq:?REL_SEQ_BITS>>,
                    case {Del, Ack} of
@@ -1215,11 +1217,11 @@ segment_plus_journal1(undefined, {?PUB, del, no_ack} = Obj) ->
 segment_plus_journal1(undefined, {?PUB, del, ack}) ->
     {undefined, 0};
 
-segment_plus_journal1({?PUB = Pub, no_del, no_ack}, {no_pub, del, no_ack}) ->
+segment_plus_journal1({?PUB = Pub, no_del, no_ack}, {no_pub, _del, no_ack}) ->
     {{Pub, del, no_ack}, 0};
-segment_plus_journal1({?PUB, no_del, no_ack},       {no_pub, del, ack}) ->
+segment_plus_journal1({?PUB, no_del, no_ack},       {no_pub, _del, ack}) ->
     {undefined, -1};
-segment_plus_journal1({?PUB, del, no_ack},          {no_pub, no_del, ack}) ->
+segment_plus_journal1({?PUB, del, no_ack},          {no_pub, _no_del, ack}) ->
     {undefined, -1}.
 
 %% Remove from the journal entries for a segment, items that are

--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -843,9 +843,9 @@ action_to_entry(RelSeq, Action, JEntries) ->
              end};
         ({Pub,    no_del, no_ack}) when Action == del ->
             {set, {Pub,    del, no_ack}};
-        ({no_pub,    del, no_ack}) when Action == ack ->
+        ({no_pub,    _del, no_ack}) when Action == ack ->
             {set, {no_pub, del,    ack}};
-        ({?PUB,      del, no_ack}) when Action == ack ->
+        ({?PUB,      _del, no_ack}) when Action == ack ->
             {reset, none}
     end.
 
@@ -1084,7 +1084,7 @@ entry_to_segment(RelSeq, {Pub, Del, Ack}, Initial) ->
                    Binary = <<?REL_SEQ_ONLY_PREFIX:?REL_SEQ_ONLY_PREFIX_BITS,
                               RelSeq:?REL_SEQ_BITS>>,
                    case {Del, Ack} of
-                       {del, ack} -> [[Binary, Binary] | Initial];
+                       {_del, ack} -> [[Binary, Binary] | Initial];
                        _          -> [Binary | Initial]
                    end
            end,

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -1433,10 +1433,11 @@ queue_index_publish(SeqIds, Persistent, Qi) ->
     ok = rabbit_msg_store:client_delete_and_terminate(MSCState),
     {A, B}.
 
+%% @todo Check for Delivered intentionally removed since it's now per-queue not per-message.
 verify_read_with_published(_Delivered, _Persistent, [], _) ->
     ok;
 verify_read_with_published(Delivered, Persistent,
-                           [{MsgId, SeqId, _Props, Persistent, Delivered}|Read],
+                           [{MsgId, SeqId, _Props, Persistent, _IgnoreDelivered}|Read],
                            [{SeqId, MsgId}|Published]) ->
     verify_read_with_published(Delivered, Persistent, Read, Published);
 verify_read_with_published(_Delivered, _Persistent, _Read, _Published) ->


### PR DESCRIPTION
This is a change that comes from the modern index work and proves beneficial for the old index and could provide a boost in a 3.9 patch release. Context: https://github.com/rabbitmq/rabbitmq-server/pull/3029#issuecomment-889859401

It's very WIP at the time of opening and the PR is only opened for the sake of tracking the work. Because August will be slow there might not be too much progress at first. Lots of code removal/simplification remains to be done and so the performance boost might increase further.

## Types of Changes

Non-breaking performance improvement.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
