### PR TITLE
Make sure 'rabbitmq-upgrade {drain, revive}' do not produce scary log messages

### DIFF
--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -74,17 +74,17 @@ drain() ->
 
 -spec do_drain() -> ok.
 do_drain() ->
-    rabbit_log:alert("This node is being put into maintenance (drain) mode"),
+    rabbit_log:warning("This node is being put into maintenance (drain) mode"),
     mark_as_being_drained(),
     rabbit_log:info("Marked this node as undergoing maintenance"),
     suspend_all_client_listeners(),
-    rabbit_log:alert("Suspended all listeners and will no longer accept client connections"),
+    rabbit_log:warning("Suspended all listeners and will no longer accept client connections"),
     {ok, NConnections} = close_all_client_connections(),
     %% allow plugins to react e.g. by closing their protocol connections
     rabbit_event:notify(maintenance_connections_closed, #{
         reason => <<"node is being put into maintenance">>
     }),
-    rabbit_log:alert("Closed ~b local client connections", [NConnections]),
+    rabbit_log:warning("Closed ~b local client connections", [NConnections]),
 
     TransferCandidates = primary_replica_transfer_candidate_nodes(),
     %% Note: only QQ leadership is transferred because it is a reasonably quick thing to do a lot of queues
@@ -96,7 +96,7 @@ do_drain() ->
     rabbit_event:notify(maintenance_draining, #{
         reason => <<"node is being put into maintenance">>
     }),
-    rabbit_log:alert("Node is ready to be shut down for maintenance or upgrade"),
+    rabbit_log:info("Node is ready to be shut down for maintenance or upgrade"),
 
     ok.
 
@@ -111,11 +111,11 @@ revive() ->
 
 -spec do_revive() -> ok.
 do_revive() ->
-    rabbit_log:alert("This node is being revived from maintenance (drain) mode"),
+    rabbit_log:info("This node is being revived from maintenance (drain) mode"),
     revive_local_quorum_queue_replicas(),
-    rabbit_log:alert("Resumed all listeners and will accept client connections again"),
+    rabbit_log:info("Resumed all listeners and will accept client connections again"),
     resume_all_client_listeners(),
-    rabbit_log:alert("Resumed all listeners and will accept client connections again"),
+    rabbit_log:info("Resumed all listeners and will accept client connections again"),
     unmark_as_being_drained(),
     rabbit_log:info("Marked this node as back from maintenance and ready to serve clients"),
 


### PR DESCRIPTION
"scary" here means log messages that show up as "errors". Warnings
and info messages make more sense.

Per discussion with @mkuratczyk.