### PR TITLE
Make test/development related makefile vars lazy

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -67,12 +67,12 @@ node_enabled_plugins_file = $(call node_tmpdir,$(1))/enabled_plugins
 
 # Broker startup variables for the test environment.
 ifeq ($(PLATFORM),msys2)
-HOSTNAME := $(COMPUTERNAME)
+HOSTNAME = $(COMPUTERNAME)
 else
 ifeq ($(PLATFORM),solaris)
-HOSTNAME := $(shell hostname | sed 's@\..*@@')
+HOSTNAME = $(shell hostname | sed 's@\..*@@')
 else
-HOSTNAME := $(shell hostname -s)
+HOSTNAME = $(shell hostname -s)
 endif
 endif
 
@@ -265,8 +265,8 @@ endif
 endif
 
 run-broker run-tls-broker: RABBITMQ_CONFIG_FILE := $(basename $(TEST_CONFIG_FILE))
-run-broker:     config := $(test_rabbitmq_config)
-run-tls-broker: config := $(test_rabbitmq_config_with_tls)
+run-broker:     config = $(test_rabbitmq_config)
+run-tls-broker: config = $(test_rabbitmq_config_with_tls)
 run-tls-broker: $(TEST_TLS_CERTS_DIR)
 
 run-broker run-tls-broker: node-tmpdir $(DIST_TARGET) $(TEST_CONFIG_FILE)

--- a/deps/rabbit_common/mk/rabbitmq-tools.mk
+++ b/deps/rabbit_common/mk/rabbitmq-tools.mk
@@ -1,10 +1,10 @@
 ifeq ($(PLATFORM),msys2)
-HOSTNAME := $(COMPUTERNAME)
+HOSTNAME = $(COMPUTERNAME)
 else
 ifeq ($(PLATFORM),solaris)
-HOSTNAME := $(shell hostname | sed 's@\..*@@')
+HOSTNAME = $(shell hostname | sed 's@\..*@@')
 else
-HOSTNAME := $(shell hostname -s)
+HOSTNAME = $(shell hostname -s)
 endif
 endif
 

--- a/mk/bazel.mk
+++ b/mk/bazel.mk
@@ -28,7 +28,7 @@ build --flaky_test_attempts=1
 build:buildbuddy --remote_header=x-buildbuddy-api-key=YOUR_API_KEY
 endef
 
-export USER_BAZELRC
+user.bazelrc: export USER_BAZELRC
 user.bazelrc:
 	echo "$$USER_BAZELRC" > $@
 


### PR DESCRIPTION
## Proposed Changes

Running `make` in a fully hermetic enviornment was producing spurious error messages about missing `hostname` and `which` executables. Turns out some dev/test related variables in makefiles were too eagerly evaluated.

Performance of those `shell` calls is not very important, as they are caled just a few times during script runtime anyway (there is even a hack to make these lazy, but evaluating only once - but it's hardly worth it).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
