### PR TITLE
Logging: Fix crash when Epoch-based timestamps are used with JSON

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_json_fmt.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_json_fmt.erl
@@ -44,10 +44,14 @@ format_meta(Meta, Config) ->
     maps:fold(
       fun
           (time, Timestamp, Acc) ->
-              FormattedTime = unicode:characters_to_binary(
-                                rabbit_logger_fmt_helpers:format_time(
-                                  Timestamp, Config)),
-              Acc#{time => FormattedTime};
+              FormattedTime0 = rabbit_logger_fmt_helpers:format_time(
+                                 Timestamp, Config),
+              FormattedTime1 = case is_number(FormattedTime0) of
+                                   true  -> FormattedTime0;
+                                   false -> unicode:characters_to_binary(
+                                              FormattedTime0)
+                               end,
+              Acc#{time => FormattedTime1};
           (domain = Key, Components, Acc) ->
               Term = unicode:characters_to_binary(
                        string:join(

--- a/deps/rabbit/test/logging_SUITE.erl
+++ b/deps/rabbit/test/logging_SUITE.erl
@@ -35,6 +35,7 @@
          logging_as_multi_line_works/1,
          formatting_as_json_configured_in_env_works/1,
          formatting_as_json_configured_in_config_works/1,
+         formatting_as_json_using_epoch_secs_timestamps_works/1,
          renaming_json_fields_works/1,
          removing_specific_json_fields_works/1,
          removing_non_mentionned_json_fields_works/1,
@@ -76,6 +77,7 @@ groups() ->
        logging_as_multi_line_works,
        formatting_as_json_configured_in_env_works,
        formatting_as_json_configured_in_config_works,
+       formatting_as_json_using_epoch_secs_timestamps_works,
        renaming_json_fields_works,
        removing_specific_json_fields_works,
        removing_non_mentionned_json_fields_works,
@@ -597,6 +599,15 @@ formatting_as_json_configured_in_config_works(Config) ->
     ok = application:set_env(
            rabbit, log,
            [{file, [{formatter, {rabbit_logger_json_fmt, #{}}}]}],
+           [{persistent, true}]),
+    formatting_as_json_works(Config, Context).
+
+formatting_as_json_using_epoch_secs_timestamps_works(Config) ->
+    Context = default_context(Config),
+    ok = application:set_env(
+           rabbit, log,
+           [{file, [{formatter, {rabbit_logger_json_fmt,
+                                 #{time_format => {epoch, secs, int}}}}]}],
            [{persistent, true}]),
     formatting_as_json_works(Config, Context).
 


### PR DESCRIPTION
The code was passing a number (the timestamp) to unicode:characters_to_binary/1 which expects an iolist to convert to UTF-8.

We now verify if we have a number before calling that function. If this is a number (integer or float), we keep it as is because JSON supports that type.