### PR TITLE
Logging: Always represent Epoch-based timestamps as integers

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
@@ -22,7 +22,7 @@ format_time1(Timestamp, {rfc3339, Sep, Offset}) ->
                {time_designator, Sep}],
     calendar:system_time_to_rfc3339(Timestamp, Options);
 format_time1(Timestamp, {epoch, secs, int}) ->
-    Timestamp / 1000000;
+    Timestamp div 1000000;
 format_time1(Timestamp, {epoch, usecs, int}) ->
     Timestamp;
 format_time1(Timestamp, {epoch, secs, binary}) ->


### PR DESCRIPTION
Before this change, seconds were represented as floats.