### PR TITLE
Add support to override `default_{user,pass,vhost}` and the Erlang cookie from the environment

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -56,8 +56,8 @@ do_setup(#{nodename := Node,
     %% Override the Erlang cookie if one was set in the environment.
     case maps:get(erlang_cookie, Origins, default) of
         environment ->
-            ?LOG_DEBUG(
-               "Override Erlang cookie using the one set in the environment",
+            ?LOG_WARNING(
+               "Overriding Erlang cookie using the value set in the environment",
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
             Cookie = maps:get(erlang_cookie, Config),
             ?assert(is_atom(Cookie)),

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -1,5 +1,6 @@
 -module(rabbit_prelaunch_dist).
 
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/logger.hrl").
 
 -include_lib("rabbit_common/include/logging.hrl").
@@ -33,7 +34,9 @@ setup(#{nodename := Node, nodename_type := NameType} = Context) ->
     end,
     ok.
 
-do_setup(#{nodename := Node, nodename_type := NameType}) ->
+do_setup(#{nodename := Node,
+           nodename_type := NameType,
+           var_origins := Origins} = Config) ->
     ?LOG_DEBUG(
        "Starting Erlang distribution",
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
@@ -47,6 +50,19 @@ do_setup(#{nodename := Node, nodename_type := NameType}) ->
             ok;
         _ ->
             {ok, _} = net_kernel:start([Node, NameType]),
+            ok
+    end,
+
+    %% Override the Erlang cookie if one was set in the environment.
+    case maps:get(erlang_cookie, Origins, default) of
+        environment ->
+            ?LOG_DEBUG(
+               "Override Erlang cookie using the one set in the environment",
+               #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
+            Cookie = maps:get(erlang_cookie, Config),
+            ?assert(is_atom(Cookie)),
+            true = erlang:set_cookie(node(), Cookie);
+        _ ->
             ok
     end,
     ok.

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -7,6 +7,7 @@
 
 -module(rabbit).
 
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/logger.hrl").
 -include_lib("rabbit_common/include/logging.hrl").
 
@@ -1047,10 +1048,10 @@ maybe_insert_default_data() ->
     end.
 
 insert_default_data() ->
-    {ok, DefaultUser} = application:get_env(default_user),
-    {ok, DefaultPass} = application:get_env(default_pass),
+    DefaultUser = get_default_data_param(default_user),
+    DefaultPass = get_default_data_param(default_pass),
     {ok, DefaultTags} = application:get_env(default_user_tags),
-    {ok, DefaultVHost} = application:get_env(default_vhost),
+    DefaultVHost = get_default_data_param(default_vhost),
     {ok, [DefaultConfigurePerm, DefaultWritePerm, DefaultReadPerm]} =
         application:get_env(default_permissions),
 
@@ -1076,6 +1077,18 @@ insert_default_data() ->
                                                       DefaultReadPermBin,
                                                       ?INTERNAL_USER),
     ok.
+
+get_default_data_param(Param) ->
+    #{var_origins := Origins} = Context = rabbit_prelaunch:get_context(),
+    case maps:get(Param, Origins, default) of
+        environment ->
+            Value = maps:get(Param, Context),
+            ?assert(is_binary(Value)),
+            Value;
+        default ->
+            {ok, Value} = application:get_env(Param),
+            Value
+    end.
 
 %%---------------------------------------------------------------------------
 %% logging

--- a/deps/rabbit_common/src/rabbit_env.erl
+++ b/deps/rabbit_common/src/rabbit_env.erl
@@ -51,9 +51,13 @@
          "RABBITMQ_CONFIG_FILE",
          "RABBITMQ_CONFIG_FILES",
          "RABBITMQ_DBG",
+         "RABBITMQ_DEFAULT_PASS",
+         "RABBITMQ_DEFAULT_USER",
+         "RABBITMQ_DEFAULT_VHOST",
          "RABBITMQ_DIST_PORT",
          "RABBITMQ_ENABLED_PLUGINS",
          "RABBITMQ_ENABLED_PLUGINS_FILE",
+         "RABBITMQ_ERLANG_COOKIE",
          "RABBITMQ_FEATURE_FLAGS",
          "RABBITMQ_FEATURE_FLAGS_FILE",
          "RABBITMQ_HOME",
@@ -152,6 +156,10 @@ get_context_after_reloading_env(Context) ->
              fun plugins_expand_dir/1,
              fun enabled_plugins_file/1,
              fun enabled_plugins/1,
+             fun default_vhost/1,
+             fun default_user/1,
+             fun default_pass/1,
+             fun erlang_cookie/1,
              fun maybe_stop_dist_for_remote_query/1,
              fun amqp_ipaddr/1,
              fun amqp_tcp_port/1,
@@ -1437,6 +1445,62 @@ motd_file_from_node(#{from_remote_node := Remote} = Context) ->
             update_context(Context, motd_file, undefined, default);
         File ->
             update_context(Context, motd_file, File, remote_node)
+    end.
+
+%% -------------------------------------------------------------------
+%%
+%% RABBITMQ_DEFAULT_VHOST
+%%   Override the default virtual host.
+%%   Default: unset (i.e. <<"/">>)
+%%
+%% RABBITMQ_DEFAULT_USER
+%%   Override the default username.
+%%   Default: unset (i.e. <<"guest">>).
+%%
+%% RABBITMQ_MOTD_FILE
+%%   Override the default user's password.
+%%   Default: unset (i.e. <<"guest">>).
+
+default_vhost(Context) ->
+    case get_prefixed_env_var("RABBITMQ_DEFAULT_VHOST") of
+        false ->
+            update_context(Context, default_vhost, undefined, default);
+        Value ->
+            VHost = list_to_binary(Value),
+            update_context(Context, default_vhost, VHost, environment)
+    end.
+
+default_user(Context) ->
+    case get_prefixed_env_var("RABBITMQ_DEFAULT_USER") of
+        false ->
+            update_context(Context, default_user, undefined, default);
+        Value ->
+            Username = list_to_binary(Value),
+            update_context(Context, default_user, Username, environment)
+    end.
+
+default_pass(Context) ->
+    case get_prefixed_env_var("RABBITMQ_DEFAULT_PASS") of
+        false ->
+            update_context(Context, default_pass, undefined, default);
+        Value ->
+            Password = list_to_binary(Value),
+            update_context(Context, default_pass, Password, environment)
+    end.
+
+%% -------------------------------------------------------------------
+%%
+%% RABBITMQ_ERLANG_COOKIE
+%%   Override the on-disk Erlang cookie.
+%%   Default: unset (i.e. defaults to the content of ~/.erlang.cookie)
+
+erlang_cookie(Context) ->
+    case get_prefixed_env_var("RABBITMQ_ERLANG_COOKIE") of
+        false ->
+            update_context(Context, erlang_cookie, undefined, default);
+        Value ->
+            Cookie = list_to_atom(Value),
+            update_context(Context, erlang_cookie, Cookie, environment)
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit_common/test/rabbit_env_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_env_SUITE.erl
@@ -28,9 +28,13 @@
          check_RABBITMQ_ADVANCED_CONFIG_FILE/1,
          check_RABBITMQ_CONFIG_FILE/1,
          check_RABBITMQ_CONFIG_FILES/1,
+         check_RABBITMQ_DEFAULT_PASS/1,
+         check_RABBITMQ_DEFAULT_USER/1,
+         check_RABBITMQ_DEFAULT_VHOST/1,
          check_RABBITMQ_DIST_PORT/1,
          check_RABBITMQ_ENABLED_PLUGINS/1,
          check_RABBITMQ_ENABLED_PLUGINS_FILE/1,
+         check_RABBITMQ_ERLANG_COOKIE/1,
          check_RABBITMQ_FEATURE_FLAGS_FILE/1,
          check_RABBITMQ_KEEP_PID_FILE_ON_EXIT/1,
          check_RABBITMQ_LOG/1,
@@ -69,9 +73,13 @@ all() ->
      check_RABBITMQ_ADVANCED_CONFIG_FILE,
      check_RABBITMQ_CONFIG_FILE,
      check_RABBITMQ_CONFIG_FILES,
+     check_RABBITMQ_DEFAULT_PASS,
+     check_RABBITMQ_DEFAULT_USER,
+     check_RABBITMQ_DEFAULT_VHOST,
      check_RABBITMQ_DIST_PORT,
      check_RABBITMQ_ENABLED_PLUGINS,
      check_RABBITMQ_ENABLED_PLUGINS_FILE,
+     check_RABBITMQ_ERLANG_COOKIE,
      check_RABBITMQ_FEATURE_FLAGS_FILE,
      check_RABBITMQ_KEEP_PID_FILE_ON_EXIT,
      check_RABBITMQ_LOG,
@@ -167,8 +175,12 @@ check_default_values(_) ->
       amqp_ipaddr => default,
       amqp_tcp_port => default,
       conf_env_file => default,
+      default_user => default,
+      default_pass => default,
+      default_vhost => default,
       enabled_plugins => default,
       enabled_plugins_file => default,
+      erlang_cookie => default,
       erlang_dist_tcp_port => default,
       feature_flags_file => default,
       forced_feature_flags_on_init => RFFOrigin,
@@ -207,8 +219,12 @@ check_default_values(_) ->
          data_dir => "/var/lib/rabbitmq",
          dbg_mods => [],
          dbg_output => stdout,
+         default_user => undefined,
+         default_pass => undefined,
+         default_vhost => undefined,
          enabled_plugins => undefined,
          enabled_plugins_file => "/etc/rabbitmq/enabled_plugins",
+         erlang_cookie => undefined,
          erlang_dist_tcp_port => 25672,
          feature_flags_file =>
            "/var/lib/rabbitmq/mnesia/" ++ NodeS ++ "-feature_flags",
@@ -256,8 +272,12 @@ check_default_values(_) ->
          data_dir => "%APPDATA%/RabbitMQ",
          dbg_mods => [],
          dbg_output => stdout,
+         default_user => undefined,
+         default_pass => undefined,
+         default_vhost => undefined,
          enabled_plugins => undefined,
          enabled_plugins_file => "%APPDATA%/RabbitMQ/enabled_plugins",
+         erlang_cookie => undefined,
          erlang_dist_tcp_port => 25672,
          feature_flags_file =>
            "%APPDATA%/RabbitMQ/db/" ++ NodeS ++ "-feature_flags",
@@ -380,8 +400,12 @@ check_values_from_reachable_remote_node(Config) ->
           amqp_ipaddr => default,
           amqp_tcp_port => default,
           conf_env_file => default,
+          default_user => default,
+          default_pass => default,
+          default_vhost => default,
           enabled_plugins => default,
           enabled_plugins_file => remote_node,
+          erlang_cookie => default,
           erlang_dist_tcp_port => default,
           feature_flags_file => remote_node,
           forced_feature_flags_on_init => RFFOrigin,
@@ -420,8 +444,12 @@ check_values_from_reachable_remote_node(Config) ->
              data_dir => "/var/lib/rabbitmq",
              dbg_mods => [],
              dbg_output => stdout,
+             default_user => undefined,
+             default_pass => undefined,
+             default_vhost => undefined,
              enabled_plugins => undefined,
              enabled_plugins_file => EnabledPluginsFile,
+             erlang_cookie => undefined,
              erlang_dist_tcp_port => 25672,
              feature_flags_file => FeatureFlagsFile,
              forced_feature_flags_on_init => RFFValue,
@@ -497,8 +525,12 @@ check_values_from_offline_remote_node(_) ->
       amqp_ipaddr => default,
       amqp_tcp_port => default,
       conf_env_file => default,
+      default_user => default,
+      default_pass => default,
+      default_vhost => default,
       enabled_plugins => default,
       enabled_plugins_file => default,
+      erlang_cookie => default,
       erlang_dist_tcp_port => default,
       feature_flags_file => default,
       forced_feature_flags_on_init => RFFOrigin,
@@ -537,8 +569,12 @@ check_values_from_offline_remote_node(_) ->
          data_dir => "/var/lib/rabbitmq",
          dbg_mods => [],
          dbg_output => stdout,
+         default_user => undefined,
+         default_pass => undefined,
+         default_vhost => undefined,
          enabled_plugins => undefined,
          enabled_plugins_file => undefined,
+         erlang_cookie => undefined,
          erlang_dist_tcp_port => 25672,
          feature_flags_file => undefined,
          forced_feature_flags_on_init => RFFValue,
@@ -735,6 +771,24 @@ check_RABBITMQ_CONFIG_FILES(_) ->
                             Value1, Value1,
                             Value2, Value2).
 
+check_RABBITMQ_DEFAULT_PASS(_) ->
+    Value1 = random_string(),
+    check_variable("RABBITMQ_DEFAULT_PASS",
+                   default_pass,
+                   Value1, list_to_binary(Value1)).
+
+check_RABBITMQ_DEFAULT_USER(_) ->
+    Value1 = random_string(),
+    check_variable("RABBITMQ_DEFAULT_USER",
+                   default_user,
+                   Value1, list_to_binary(Value1)).
+
+check_RABBITMQ_DEFAULT_VHOST(_) ->
+    Value1 = random_string(),
+    check_variable("RABBITMQ_DEFAULT_VHOST",
+                   default_vhost,
+                   Value1, list_to_binary(Value1)).
+
 check_RABBITMQ_DIST_PORT(_) ->
     Value1 = random_int(),
     Value2 = random_int(),
@@ -766,6 +820,12 @@ check_RABBITMQ_ENABLED_PLUGINS_FILE(_) ->
                             '_',
                             Value1, Value1,
                             Value2, Value2).
+
+check_RABBITMQ_ERLANG_COOKIE(_) ->
+    Value1 = random_atom(),
+    check_variable("RABBITMQ_ERLANG_COOKIE",
+                   erlang_cookie,
+                   atom_to_list(Value1), Value1).
 
 check_RABBITMQ_FEATURE_FLAGS_FILE(_) ->
     Value1 = random_string(),


### PR DESCRIPTION
Historically, the Docker image allowed the user to override the default user/password and vhost as well as the Erlang cookie from environment variables among other things. After some discussion in https://github.com/docker-library/rabbitmq/issues/506#issuecomment-887786516, support for environment variables specific to the Docker image was removed in docker-library/rabbitmq#467.

Several users were impacted by this removal (see docker-library/rabbitmq#508). After some more discussion, it was decided to re-introduce some variables directly into RabbitMQ itself. The following variables are added by this patch:
* `$RABBITMQ_DEFAULT_USER` (overrides `default_user`)
* `$RABBITMQ_DEFAULT_PASS` (overrides `default_pass`)
* `$RABBITMQ_DEFAULT_VHOST` (overrides `default_vhost`)
* `$RABBITMQ_ERLANG_COOKIE` (overrides the Erlang cookie file content)

Fixes docker-library/rabbitmq#508