### PR TITLE
Set terminal titlebar to the node name & RabbitMQ version

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_boot_state.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_boot_state.erl
@@ -19,7 +19,7 @@
          has_reached/1,
          has_reached_and_is_active/1]).
 
--define(PT_KEY_BOOT_STATE,    {?MODULE, boot_state}).
+-define(PT_KEY_BOOT_STATE, {?MODULE, boot_state}).
 
 -type boot_state() :: stopped |
                       booting |

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_boot_state_sup.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_boot_state_sup.erl
@@ -18,13 +18,17 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    SystemdSpec = #{id => rabbit_boot_state_systemd,
+    SystemdSpec = #{id => systemd,
                     start => {rabbit_boot_state_systemd, start_link, []},
                     restart => transient},
+    XtermTitlebarSpec = #{id => xterm_titlebar,
+                          start => {rabbit_boot_state_xterm_titlebar,
+                                    start_link, []},
+                          restart => transient},
     {ok, {#{strategy => one_for_one,
             intensity => 1,
             period => 5},
-          [SystemdSpec]}}.
+          [SystemdSpec, XtermTitlebarSpec]}}.
 
 -spec notify_boot_state_listeners(rabbit_boot_state:boot_state()) -> ok.
 notify_boot_state_listeners(BootState) ->

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_boot_state_xterm_titlebar.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_boot_state_xterm_titlebar.erl
@@ -1,0 +1,99 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @doc
+%% This module updates the titlebar of an Xterm-compatible terminal emulator
+%% to show some details of the running RabbitMQ node. It is useful for
+%% developers when running multiple RabbitMQ node in multiple terminal
+%% windows.
+-module(rabbit_boot_state_xterm_titlebar).
+
+-behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
+
+-include_lib("rabbit_common/include/logging.hrl").
+
+-export([start_link/0]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         terminate/2,
+         code_change/3]).
+
+-record(?MODULE, {raw_stdio_port}).
+
+-define(LOG_PREFIX, "Boot state/xterm: ").
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    %% We assume that if the OS is Unix, then the terminal emulator must be
+    %% compatible with Xterm escape sequences.
+    RunsOnUnix = case os:type() of
+                     {unix, _} -> true;
+                     _         -> false
+                 end,
+    %% We don't know if the output is a terminal (we don't have access to
+    %% isatty(3)). Let's assume that if input is enabled, we are talking to a
+    %% terminal.
+    AcceptsInput = case init:get_argument(noinput) of
+                       {ok, _} -> false;
+                       error   -> true
+                   end,
+    case RunsOnUnix andalso AcceptsInput of
+        true ->
+            RawStdio = erlang:open_port({fd, 0, 1}, [out]),
+            State = #?MODULE{raw_stdio_port = RawStdio},
+            {ok, State};
+        false ->
+            ignore
+    end.
+
+handle_call(_Request, _From, State) ->
+    {noreply, State}.
+
+handle_cast({notify_boot_state, BootState}, State) ->
+    _ = set_xterm_titlebar(State, BootState),
+    {noreply, State}.
+
+terminate(normal, #?MODULE{raw_stdio_port = RawStdio}) ->
+    erlang:port_close(RawStdio),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Private
+
+set_xterm_titlebar(#?MODULE{raw_stdio_port = RawStdio}, BootState) ->
+    Title = format_title(BootState),
+    Binary = unicode:characters_to_binary(Title),
+    %% Read the "Operating System Controls" section in the Xterm Control
+    %% Sequences documentation:
+    %% https://www.xfree86.org/current/ctlseqs.html
+    erlang:port_command(RawStdio, ["\033]2;", Binary, "\007"]).
+
+format_title(BootState) ->
+    %% We use rabbitmq_prelaunch's version here because `rabbit` may not be
+    %% loaded yet.
+    %% FIXME: Move product info to prelaunch and use it here?
+    {ok, Vsn} = application:get_key(rabbitmq_prelaunch, vsn),
+    BootStateSuffix = case BootState of
+                          ready -> "";
+                          _     -> io_lib:format(": ~ts", [BootState])
+                      end,
+    case node() of
+        nonode@nohost ->
+            rabbit_misc:format(
+              "RabbitMQ ~ts~ts", [Vsn, BootStateSuffix]);
+        Node ->
+            rabbit_misc:format(
+              "~s — RabbitMQ ~ts~ts", [Node, Vsn, BootStateSuffix])
+    end.


### PR DESCRIPTION
With this change and if the RabbitMQ node is running on Unix and accepts input, the titlebar of an Xterm-compatible terminal emulator will show a few details about the running node. Specifically, it will indicate the name of the node and the version of RabbitMQ.

This is a change I have locally in the Khepri branch for quite some time. Time to extract it from that branch and see if it can help other people!

![2021-08-19T13:09:27+02:00](https://user-images.githubusercontent.com/159804/130060332-bb54929c-a11e-4278-8bd7-398f93d4c2a9.png)