### PR TITLE
Adding retries to AWS API calls

### DIFF
--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -43,6 +43,9 @@
 
 -define(METADATA_TOKEN, "X-aws-ec2-metadata-token").
 
+-define(LINEAR_BACK_OFF_MILLIS, 500).
+-define(MAX_RETRIES, 5).
+
 -type access_key() :: nonempty_string().
 -type secret_access_key() :: nonempty_string().
 -type expiration() :: calendar:datetime() | undefined.

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -555,10 +555,10 @@ api_get_request_with_retries(Service, Path, Retries, WaitTimeBetweenRetries) ->
     {ok, {_Headers, Payload}} -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
                                  {ok, Payload};
     {error, {credentials, _}} -> {error, credentials};
-    {error, Message, _}       -> case Retries of
-                                   0 -> {error, Message};
-                                   _ -> rabbit_log:warning("Error occurred ~s~nWill retry AWS request, remaining retries: ~b", [Message, Retries]),
-                                        timer:sleep(WaitTimeBetweenRetries),
-                                        api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries)
+    {error, Message, _}       -> case Retries > 0 of
+                                   true ->  rabbit_log:warning("Error occurred ~s~nWill retry AWS request, remaining retries: ~b", [Message, Retries]),
+                                            timer:sleep(WaitTimeBetweenRetries),
+                                            api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries);
+                                   false -> {error, Message}
                                  end
   end.

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -549,16 +549,16 @@ api_get_request(Service, Path) ->
   -spec api_get_request_with_retries(string(), path(), integer(), integer()) -> result().
   %% @doc Invoke an API call to an AWS service with retries.
   %% @end
+api_get_request_with_retries(_, _, 0, _) ->
+  rabbit_log:warning("Request to AWS service has failed after ~b retries.", [?MAX_RETRIES]),
+  {error, "AWS service is unavailable."};
 api_get_request_with_retries(Service, Path, Retries, WaitTimeBetweenRetries) ->
   ensure_credentials_valid(),
   case get(Service, Path) of
     {ok, {_Headers, Payload}} -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
                                  {ok, Payload};
     {error, {credentials, _}} -> {error, credentials};
-    {error, Message, _}       -> case Retries > 0 of
-                                   true ->  rabbit_log:warning("Error occurred ~s~nWill retry AWS request, remaining retries: ~b", [Message, Retries]),
-                                            timer:sleep(WaitTimeBetweenRetries),
-                                            api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries);
-                                   false -> {error, Message}
-                                 end
+    {error, Message, _}       -> rabbit_log:warning("Error occurred ~s~nWill retry AWS request, remaining retries: ~b", [Message, Retries]),
+                                 timer:sleep(WaitTimeBetweenRetries),
+                                 api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries)
   end.

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -543,10 +543,22 @@ ensure_credentials_valid() ->
 %% @end
 api_get_request(Service, Path) ->
   rabbit_log:debug("Invoking AWS request {Service: ~p; Path: ~p}...", [Service, Path]),
+  api_get_request_with_retries(Service, Path, ?MAX_RETRIES, ?LINEAR_BACK_OFF_MILLIS).
+
+
+  -spec api_get_request_with_retries(string(), path(), integer(), integer()) -> result().
+  %% @doc Invoke an API call to an AWS service with retries.
+  %% @end
+api_get_request_with_retries(Service, Path, Retries, WaitTimeBetweenRetries) ->
   ensure_credentials_valid(),
   case get(Service, Path) of
     {ok, {_Headers, Payload}} -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
                                  {ok, Payload};
     {error, {credentials, _}} -> {error, credentials};
-    {error, Message, _}       -> {error, Message}
+    {error, Message, _}       -> case Retries of
+                                   0 -> {error, Message};
+                                   _ -> rabbit_log:warning("Error occurred ~s~nWill retry AWS request, remaining retries: ~b", [Message, Retries]),
+                                        timer:sleep(WaitTimeBetweenRetries),
+                                        api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries)
+                                 end
   end.

--- a/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
+++ b/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
@@ -491,7 +491,7 @@ api_get_request_test_() ->
           rabbitmq_aws:set_credentials(State),
           Result = rabbitmq_aws:api_get_request_with_retries("AWS", "API", 3, 1),
           ok = gen_server:stop(Pid),
-          ?assertEqual({error, "invalid input"}, Result),
+          ?assertEqual({error, "AWS service is unavailable"}, Result),
           meck:validate(httpc)
         end
       },


### PR DESCRIPTION
## Proposed Changes

This PR addresses the issues related to transient errors while querying AWS APIs. Retries have been added to AWS API calls with a sleep time in between the calls to make sure whatever the error code returned by AWS is not transient. Credential errors are not retried.

The motivation behind this PR is unlock failures during peer discovery due to timed out AWS calls. The retries on the AWS calls would reduce the possibility of a node not releasing the discovery lock after successfully joining a cluster.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ x ] I have read the `CONTRIBUTING.md` document
- [ x ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ x ] All tests pass locally with my changes
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added necessary documentation (if appropriate)
- [ x ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
