### PR TITLE
Correctly import virtual host metadata

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -481,11 +481,13 @@ add_policy(VHost, Param, Username) ->
 -spec add_vhost(map(), rabbit_types:username()) -> ok.
 
 add_vhost(VHost, ActingUser) ->
-    VHostName = maps:get(name, VHost, undefined),
-    VHostTrace = maps:get(tracing, VHost, undefined),
-    VHostDefinition = maps:get(definition, VHost, undefined),
-    VHostTags = maps:get(tags, VHost, undefined),
-    rabbit_vhost:put_vhost(VHostName, VHostDefinition, VHostTags, VHostTrace, ActingUser).
+    Name             = maps:get(name, VHost, undefined),
+    IsTracingEnabled = maps:get(tracing, VHost, undefined),
+    Metadata         = rabbit_data_coercion:atomize_keys(maps:get(metadata, VHost, #{})),
+    Description      = maps:get(description, VHost, maps:get(description, Metadata, <<"">>)),
+    Tags             = maps:get(tags, VHost, maps:get(tags, Metadata, [])),
+
+    rabbit_vhost:put_vhost(Name, Description, Tags, IsTracingEnabled, ActingUser).
 
 add_permission(Permission, ActingUser) ->
     rabbit_auth_backend_internal:set_permissions(maps:get(user,      Permission, undefined),

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -45,7 +45,8 @@ groups() ->
                                import_case12,
                                import_case13,
                                import_case14,
-                               import_case15
+                               import_case15,
+                               import_case16
                               ]},
         
         {boot_time_import_using_classic_source, [], [
@@ -206,6 +207,28 @@ import_case13(Config) ->
 import_case14(Config) -> import_file_case(Config, "case14").
 %% contains a user with tags as a list
 import_case15(Config) -> import_file_case(Config, "case15").
+%% contains a virtual host with tags
+import_case16(Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, virtual_host_metadata) of
+        ok ->
+            import_file_case(Config, "case16"),
+            VHost = <<"tagged">>,
+            VHostIsImported =
+            fun () ->
+                    case vhost_lookup(Config, VHost) of
+                        {error, {no_such_vhosts, _}} -> false;
+                        _       -> true
+                    end
+            end,
+            rabbit_ct_helpers:await_condition(VHostIsImported, 20000),
+            VHostRec = vhost_lookup(Config, VHost),
+            ?assertEqual(<<"A case16 description">>, vhost:get_description(VHostRec)),
+            ?assertEqual([multi_dc_replication,ab,cde], vhost:get_tags(VHostRec)),
+
+            ok;
+        Skip ->
+            Skip
+    end.
 
 export_import_round_trip_case1(Config) ->
     %% case 6 has runtime parameters that do not depend on any plugins
@@ -338,3 +361,6 @@ run_invalid_import_case(Path) ->
 
 queue_lookup(Config, VHost, Name) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup, [rabbit_misc:r(VHost, queue, Name)]).
+
+vhost_lookup(Config, VHost) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_vhost, lookup, [VHost]).

--- a/deps/rabbit/test/definition_import_SUITE_data/case16.json
+++ b/deps/rabbit/test/definition_import_SUITE_data/case16.json
@@ -1,0 +1,58 @@
+{
+  "bindings": [],
+  "exchanges": [],
+  "global_parameters": [
+    {
+      "name": "cluster_name",
+      "value": "rabbitmq@localhost"
+    }
+  ],
+  "parameters": [],
+  "permissions": [
+    {
+      "configure": ".*",
+      "read": ".*",
+      "user": "guest",
+      "vhost": "/",
+      "write": ".*"
+    }
+  ],
+  "policies": [],
+  "queues": [],
+  "rabbit_version": "3.9.1",
+  "rabbitmq_version": "3.9.1",
+  "topic_permissions": [],
+  "users": [
+    {
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "limits": {},
+      "name": "guest",
+      "password_hash": "wS4AT3B4Z5RpWlFn1FA30osf2C75D7WA3gem591ACDZ6saO6",
+      "tags": [
+        "administrator"
+      ]
+    }
+  ],
+  "vhosts": [
+    {
+      "limits": [],
+      "metadata": {
+        "description": "Default virtual host",
+        "tags": []
+      },
+      "name": "/"
+    },
+    {
+      "limits": [],
+      "metadata": {
+        "description": "A case16 description",
+        "tags": [
+          "multi_dc_replication",
+          "ab",
+          "cde"
+        ]
+      },
+      "name": "tagged"
+    }
+  ]
+}


### PR DESCRIPTION
## Proposed Changes

With this change virtual hosts with metadata are imported correctly (tags and description are not lost).

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
