### PR TITLE
Logging: Add `single_line` flag support to $RABBITMQ_LOG

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -111,11 +111,14 @@ main_handler_config(Context) ->
     #{filter_default => log,
       formatter => default_formatter(Context)}.
 
-default_formatter(#{log_levels := #{json := true}}) ->
-    {rabbit_logger_json_fmt, #{}};
+default_formatter(#{log_levels := #{json := true}} = Context) ->
+    SingleLine = format_msgs_as_single_lines(Context),
+    {rabbit_logger_json_fmt, #{single_line => SingleLine}};
 default_formatter(Context) ->
     Color = use_colored_logging(Context),
-    {rabbit_logger_text_fmt, #{use_colors => Color}}.
+    SingleLine = format_msgs_as_single_lines(Context),
+    {rabbit_logger_text_fmt, #{use_colors => Color,
+                               single_line => SingleLine}}.
 
 default_console_formatter(Context) ->
     default_formatter(Context).
@@ -141,6 +144,11 @@ use_colored_logging(#{log_levels := #{color := true},
                       output_supports_colors := true}) ->
     true;
 use_colored_logging(_) ->
+    false.
+
+format_msgs_as_single_lines(#{log_levels := #{single_line := true}}) ->
+    true;
+format_msgs_as_single_lines(_) ->
     false.
 
 enable_quick_dbg(#{dbg_mods := []}) ->

--- a/deps/rabbit/src/rabbit_prelaunch_logging.erl
+++ b/deps/rabbit/src/rabbit_prelaunch_logging.erl
@@ -1094,7 +1094,7 @@ apply_log_levels_from_env(LogConfig, #{log_levels := LogLevels})
     maps:fold(
       fun
           (_, Value, LC) when is_boolean(Value) ->
-              %% Ignore the '+color' and '+json' flags.
+              %% Ignore flags such as '+color' and '+json'.
               LC;
           (global, Level, #{global := GlobalConfig} = LC) ->
               GlobalConfig1 = GlobalConfig#{level => Level},

--- a/deps/rabbit_common/src/rabbit_env.erl
+++ b/deps/rabbit_common/src/rabbit_env.erl
@@ -657,6 +657,12 @@ parse_log_levels([CategoryValue | Rest], Result) ->
         ["-json"] ->
             Result1 = Result#{json => false},
             parse_log_levels(Rest, Result1);
+        ["+single_line"] ->
+            Result1 = Result#{single_line => true},
+            parse_log_levels(Rest, Result1);
+        ["-single_line"] ->
+            Result1 = Result#{single_line => false},
+            parse_log_levels(Rest, Result1);
         [CategoryOrLevel] ->
             case parse_level(CategoryOrLevel) of
                 undefined ->


### PR DESCRIPTION
A user could already enable single-line logging (the `single_line` option of `logger_formatter` or RabbitMQ internal formatters) from the configuration file. For example:

```
log.console.formatter.single_line = on
```

With this patch, the option can be enabled from the `$RABBITMQ_LOG` environment variable as well:

```
make run-broker RABBITMQ_LOG=+single_line
```