### PR TITLE
Make run-broker: set default node name to rabbit@localhost

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -76,7 +76,7 @@ HOSTNAME = $(shell hostname -s)
 endif
 endif
 
-RABBITMQ_NODENAME ?= rabbit@$(HOSTNAME)
+RABBITMQ_NODENAME ?= rabbit@localhost
 RABBITMQ_NODENAME_FOR_PATHS ?= $(RABBITMQ_NODENAME)
 NODE_TMPDIR ?= $(call node_tmpdir,$(RABBITMQ_NODENAME_FOR_PATHS))
 


### PR DESCRIPTION
This way code_reload via lsp works for everybody, regardless of actual hostnames

