### PR TITLE
rabbitmq_cli: Fix `maintenance_mode_status` feature flag name in testsuite

### DIFF
--- a/deps/rabbitmq_cli/test/upgrade/drain_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/drain_command_test.exs
@@ -23,7 +23,7 @@ defmodule DrainCommandTest do
   end
 
   setup context do
-    enable_feature_flag(:maintenance_mode)
+    enable_feature_flag(:maintenance_mode_status)
 
     {:ok, opts: %{
         node: get_rabbit_hostname(),

--- a/deps/rabbitmq_cli/test/upgrade/revive_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/revive_command_test.exs
@@ -23,7 +23,7 @@ defmodule ReviveCommandTest do
   end
 
   setup context do
-    enable_feature_flag(:maintenance_mode)
+    enable_feature_flag(:maintenance_mode_status)
 
     {:ok, opts: %{
         node: get_rabbit_hostname(),


### PR DESCRIPTION
This didn't really affect the testsuite because all feature flags are enabled earlier if I understand correctly.