### PR TITLE
Update Github Actions workflow triggering to include bazel build

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -12,6 +12,11 @@ on:
       - Makefile
       - plugins.mk
       - rabbitmq-components.mk
+      - .bazelrc
+      - .bazelversion
+      - BUILD.*
+      - '*.bzl'
+      - '*.bazel'
       - .github/workflows/test-mixed-versions.yaml
 jobs:
   test-mixed-versions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,11 @@ on:
       - Makefile
       - plugins.mk
       - rabbitmq-components.mk
+      - .bazelrc
+      - .bazelversion
+      - BUILD.*
+      - '*.bzl'
+      - '*.bazel'
       - .github/workflows/test.yaml
 jobs:
   test:


### PR DESCRIPTION
Github Actions Test and Test Mixed Versions workflows should trigger when bazel files change.

(opened as a PR for convenience of backporting).