### PR TITLE
Add debug utilities to Docker image

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -7,7 +7,6 @@ on:
       - v3.8.x
     paths:
       - 'deps/**'
-      - 'packaging/**'
       - 'scripts/**'
       - Makefile
       - plugins.mk

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,6 @@ on:
   push:
     paths:
       - 'deps/**'
-      - 'packaging/**'
       - 'scripts/**'
       - Makefile
       - plugins.mk

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -286,7 +286,7 @@ RUN set -eux; \
 	fi; \
 	[ -s /usr/local/bin/rabbitmqadmin ]; \
 	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apt-get update; apt-get install -y --no-install-recommends python3; rm -rf /var/lib/apt/lists/*; \
+	apt-get update; apt-get install -y --no-install-recommends python3 dstat sysstat htop nmon tmux neovim; rm -rf /var/lib/apt/lists/*; \
 	rabbitmqadmin --version
 # MANAGEMENT-TLS MANAGEMENT
 EXPOSE 15671 15672


### PR DESCRIPTION
We need these to debug various rabbitmq-related issues. Ephemeral debug containers are not enabled on GKE Autopilot (not sure if GKE enables this alpha feature at all), so we are doing this instead.

```
 error: ephemeral containers are disabled for this cluster (error from server: "the server could not find the requested resource").
```

Pair @Gsantomaggio

---

Backport to v3.9.x & v3.8.x if build passes