### PR TITLE
Fix mixed version testing for 3.7/3.8

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -18,7 +18,6 @@ on:
       - '*.bzl'
       - '*.bazel'
       - .github/workflows/test-mixed-versions.yaml
-  workflow_dispatch:
 jobs:
   test-mixed-versions:
     name: Test (Mixed Version Cluster)

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -18,6 +18,7 @@ on:
       - '*.bzl'
       - '*.bazel'
       - .github/workflows/test-mixed-versions.yaml
+  workflow_dispatch:
 jobs:
   test-mixed-versions:
     name: Test (Mixed Version Cluster)

--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -1,27 +1,23 @@
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@//:rabbitmq_package_generic_unix.bzl", "rabbitmq_package_generic_unix")
 load("@//:rabbitmq_run.bzl", "rabbitmq_run", "rabbitmq_run_command")
 load("@//:rabbitmqctl.bzl", "rabbitmqctl")
 
-# The 3.7 package has a slightly different layout, and rabbit.ez
-# need be created for compatibility
-pkg_zip(
-    name = "rabbit",
-    package_dir = "rabbit/ebin",
-    srcs = glob(["ebin/*"]),
-    package_file_name = "plugins/rabbit.ez",
-    visibility = ["//visibility:public"],
-)
-
 rabbitmq_package_generic_unix(
     name = "broker-home",
-    sbin = glob(["sbin/*"]),
-    escript = glob(["escript/*"]),
-    plugins = [
-        "//:rabbit",
-        "//plugins:standard_plugins",
-        "//plugins:inet_tcp_proxy_ez",
-    ],
+    additional_files =
+        glob(
+            [
+                "ebin/*",
+                "priv/**/*",
+                "sbin/*",
+                "escript/*",
+            ],
+            exclude = ["sbin/rabbitmqctl"],
+        ) + [
+            "//plugins:standard_plugins",
+            "//plugins:inet_tcp_proxy_ez",
+        ],
+    rabbitmqctl = "sbin/rabbitmqctl",
 )
 
 rabbitmq_run(
@@ -39,7 +35,6 @@ rabbitmq_run_command(
 rabbitmqctl(
     name = "rabbitmqctl",
     home = ":broker-home",
-    # visibility = ["//visibility:public"],
 )
 
 rabbitmqctl(

--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -1,12 +1,24 @@
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@//:rabbitmq_package_generic_unix.bzl", "rabbitmq_package_generic_unix")
 load("@//:rabbitmq_run.bzl", "rabbitmq_run", "rabbitmq_run_command")
 load("@//:rabbitmqctl.bzl", "rabbitmqctl")
+
+# The 3.7 package has a slightly different layout, and rabbit.ez
+# need be created for compatibility
+pkg_zip(
+    name = "rabbit",
+    package_dir = "rabbit/ebin",
+    srcs = glob(["ebin/*"]),
+    package_file_name = "plugins/rabbit.ez",
+    visibility = ["//visibility:public"],
+)
 
 rabbitmq_package_generic_unix(
     name = "broker-home",
     sbin = glob(["sbin/*"]),
     escript = glob(["escript/*"]),
     plugins = [
+        "//:rabbit",
         "//plugins:standard_plugins",
         "//plugins:inet_tcp_proxy_ez",
     ],

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -66,13 +66,6 @@ load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
 
 activemq_archive()
 
-# The 3.7 package has a slightly different layout, and rabbit.ez
-# needs to be created for compatibility
-CREATE_RABBIT_EZ = """set -euo pipefail
-
-zip -r plugins/rabbit.ez ebin/* priv/*
-"""
-
 ADD_PLUGINS_DIR_BUILD_FILE = """set -euo pipefail
 
 cat << EOF > plugins/BUILD.bazel
@@ -100,7 +93,6 @@ http_archive(
     name = "rabbitmq-server-generic-unix-3.7.28",
     build_file = "@//:BUILD.package_generic_unix",
     patch_cmds = [
-        CREATE_RABBIT_EZ, # <- for 3.7 only
         ADD_PLUGINS_DIR_BUILD_FILE,
     ],
     sha256 = "8cc45ef421323b407eda3fa82975fffd81d9a46235f6314e16855caedacd02cc",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -46,7 +46,7 @@ rabbitmq_external_deps(rabbitmq_workspace = "@")
 
 git_repository(
     name = "rabbitmq_ct_helpers",
-    branch = "v3.8.x",
+    branch = "master",
     remote = "https://github.com/rabbitmq/rabbitmq-ct-helpers.git",
     repo_mapping = {
         "@rabbitmq-server": "@",
@@ -55,7 +55,7 @@ git_repository(
 
 git_repository(
     name = "rabbitmq_ct_client_helpers",
-    branch = "v3.8.x",
+    branch = "master",
     remote = "https://github.com/rabbitmq/rabbitmq-ct-client-helpers.git",
     repo_mapping = {
         "@rabbitmq-server": "@",

--- a/deps/rabbit/test/rabbitmq_queues_cli_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbitmq_queues_cli_integration_SUITE.erl
@@ -49,9 +49,12 @@ init_per_group(tests, Config0) ->
     case rabbit_ct_broker_helpers:enable_feature_flag(Config2, quorum_queue) of
         ok ->
             Config2;
-        Skip ->
+        {skip, _} = Skip ->
             end_per_group(tests, Config2),
-            Skip
+            Skip;
+        Other ->
+            end_per_group(tests, Config2),
+            {skip, Other}
     end.
 
 end_per_group(tests, Config) ->

--- a/deps/rabbitmq_management/test/clustering_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_SUITE.erl
@@ -76,15 +76,21 @@ merge_app_env(Config) ->
                                            {detailed, [{10, 5}]}] }]}).
 
 init_per_suite(Config) ->
-    rabbit_ct_helpers:log_environment(),
-    inets:start(),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-                                                    {rmq_nodename_suffix, ?MODULE},
-                                                    {rmq_nodes_count, 2}
-                                                   ]),
-    Config2 = merge_app_env(Config1),
-    rabbit_ct_helpers:run_setup_steps(Config2,
-                                      rabbit_ct_broker_helpers:setup_steps()).
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            %% skip due to the pg/pg2 cross cluster incompatibility
+            {skip, "not mixed versions compatible"};
+        _ ->
+            rabbit_ct_helpers:log_environment(),
+            inets:start(),
+            Config1 = rabbit_ct_helpers:set_config(Config, [
+                                                            {rmq_nodename_suffix, ?MODULE},
+                                                            {rmq_nodes_count, 2}
+                                                           ]),
+            Config2 = merge_app_env(Config1),
+            rabbit_ct_helpers:run_setup_steps(Config2,
+                                              rabbit_ct_broker_helpers:setup_steps())
+    end.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,

--- a/deps/rabbitmq_management/test/clustering_prop_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_prop_SUITE.erl
@@ -54,15 +54,21 @@ merge_app_env(Config) ->
                                            {detailed, [{605, 5}]}] }]}).
 
 init_per_suite(Config) ->
-    rabbit_ct_helpers:log_environment(),
-    inets:start(),
-    Config1 = rabbit_ct_helpers:set_config(Config, [
-                                                    {rmq_nodename_suffix, ?MODULE},
-                                                    {rmq_nodes_count, 3}
-                                                   ]),
-    Config2 = merge_app_env(Config1),
-    rabbit_ct_helpers:run_setup_steps(Config2,
-                                      rabbit_ct_broker_helpers:setup_steps()).
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            %% skip due to the pg/pg2 cross cluster incompatibility
+            {skip, "not mixed versions compatible"};
+        _ ->
+            rabbit_ct_helpers:log_environment(),
+            inets:start(),
+            Config1 = rabbit_ct_helpers:set_config(Config, [
+                                                            {rmq_nodename_suffix, ?MODULE},
+                                                            {rmq_nodes_count, 3}
+                                                           ]),
+            Config2 = merge_app_env(Config1),
+            rabbit_ct_helpers:run_setup_steps(Config2,
+                                              rabbit_ct_broker_helpers:setup_steps())
+    end.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,

--- a/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
+++ b/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
@@ -41,7 +41,11 @@ init_per_suite(Config) ->
         {rmq_nodename_suffix, ?MODULE},
         {rmq_nodes_count,     2}
       ]),
-    rabbit_ct_helpers:run_setup_steps(Config1,
+    Config2 = rabbit_ct_helpers:merge_app_env(Config1,
+      {rabbit, [
+          {log, [{file, [{level, debug}]},
+                 {console, [{level, debug}]}]}]}),
+    rabbit_ct_helpers:run_setup_steps(Config2,
       rabbit_ct_broker_helpers:setup_steps() ++
       rabbit_ct_client_helpers:setup_steps()).
 

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -42,7 +42,7 @@ RABBITMQ_DIALYZER_OPTS = [
     "-Wunmatched_returns",
 ]
 
-APP_VERSION = "3.9.0"
+APP_VERSION = "3.8"
 
 LABELS_WITH_TEST_VERSIONS = [
     "//deps/amqp10_common:bazel_erlang_lib",

--- a/rabbitmq_home.bzl
+++ b/rabbitmq_home.bzl
@@ -3,9 +3,7 @@ load("@bazel-erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "flat_deps", "path
 RabbitmqHomeInfo = provider(
     doc = "An assembled RABBITMQ_HOME dir",
     fields = {
-        "sbin": "Files making up the sbin dir",
-        "escript": "Files making up the escript dir",
-        "plugins": "Files making up the plugins dir",
+        "rabbitmqctl": "rabbitmqctl script from the sbin directory",
     },
 )
 
@@ -112,11 +110,16 @@ def _impl(ctx):
 
     plugins = _flatten([_plugins_dir_links(ctx, plugin) for plugin in plugins])
 
+    rabbitmqctl = None
+    for script in scripts:
+        if script.basename == "rabbitmqctl":
+            rabbitmqctl = script
+    if rabbitmqctl == None:
+        fail("could not find rabbitmqct among", scripts)
+
     return [
         RabbitmqHomeInfo(
-            sbin = scripts,
-            escript = escripts,
-            plugins = plugins,
+            rabbitmqctl = rabbitmqctl,
         ),
         DefaultInfo(
             files = depset(scripts + escripts + plugins),
@@ -146,7 +149,7 @@ def _dirname(p):
     return p.rpartition("/")[0]
 
 def rabbitmq_home_short_path(rabbitmq_home):
-    short_path = rabbitmq_home[RabbitmqHomeInfo].sbin[0].short_path
+    short_path = rabbitmq_home[RabbitmqHomeInfo].rabbitmqctl.short_path
     if rabbitmq_home.label.workspace_root != "":
         short_path = path_join(rabbitmq_home.label.workspace_root, short_path)
     return _dirname(_dirname(short_path))

--- a/rabbitmq_package_generic_unix.bzl
+++ b/rabbitmq_package_generic_unix.bzl
@@ -1,26 +1,19 @@
 load("@//:rabbitmq_home.bzl", "RabbitmqHomeInfo")
 
 def _impl(ctx):
-    scripts = ctx.files.sbin
-    escripts = ctx.files.escript
-    plugins = ctx.files.plugins
-
     return [
         RabbitmqHomeInfo(
-            sbin = scripts,
-            escript = escripts,
-            plugins = plugins,
+            rabbitmqctl = ctx.file.rabbitmqctl,
         ),
         DefaultInfo(
-            files = depset(scripts + escripts + plugins),
+            files = depset(ctx.files.rabbitmqctl + ctx.files.additional_files),
         ),
     ]
 
 rabbitmq_package_generic_unix = rule(
     implementation = _impl,
     attrs = {
-        "sbin": attr.label_list(allow_files = True),
-        "escript": attr.label_list(allow_files = True),
-        "plugins": attr.label_list(allow_files = True),
+        "rabbitmqctl": attr.label(allow_single_file = True),
+        "additional_files": attr.label_list(allow_files = True),
     },
 )

--- a/rabbitmq_run.bzl
+++ b/rabbitmq_run.bzl
@@ -6,6 +6,7 @@ load(":rabbitmq_home.bzl", "RabbitmqHomeInfo", "rabbitmq_home_short_path")
 def _impl(ctx):
     rabbitmq_home_path = rabbitmq_home_short_path(ctx.attr.home)
 
+    # the rabbitmq-run.sh template only allows a single erl_libs currently
     erl_libs = [path_join(rabbitmq_home_path, "plugins")]
 
     ctx.actions.expand_template(


### PR DESCRIPTION
The `v3.8.x` branch of https://github.com/rabbitmq/rabbitmq-ct-helpers and https://github.com/rabbitmq/rabbitmq-ct-helpers was out of date such that the mixed version tests never actually used 3.7 code. This adopts master of https://github.com/rabbitmq/rabbitmq-ct-helpers and fixes the resulting breakage, so that we should be able to avoid this scenario again.