### PR TITLE
Make prometheus plugin output customizable

### DIFF
--- a/deps/rabbitmq_prometheus/README.md
+++ b/deps/rabbitmq_prometheus/README.md
@@ -85,6 +85,20 @@ To go back to aggregated metrics on-the-fly, run the following command:
 rabbitmqctl eval 'application:set_env(rabbitmq_prometheus, return_per_object_metrics, false).'
 ```
 
+## Selective querying of per-object metrics
+
+As mentioned in the previous section, returning a lot of per-object metrics is quite computationally expensive process. One of the reasons is that `/metrics/per-object` returns every possible metric for every possible object - even if having them makes no sense in the day-to-day monitoring activity.
+
+That's why there is an additional endpoint that always return per-object metrics and allows one to explicitly query only the things that are relevant - `/metrics/detailed`. By default it doesn't return anything at all, but it's possible to specify required metric groups and virtual host filters in the GET-parameters. Scraping `/metrics/detailed?vhost=vhost-1&vhost=vhost-2&family=queue_coarse_metrics&family=queue_consumer_count`. will only return requested metrics (and not, for example, channel metrics that include erlang PID in labels). 
+
+This endpoint supports the following parameters:
+
+* Zero or more `family` - only the requested metric families will be returned. The full list is documented in [metrics-detailed](metrics-detailed.md).
+* Zero or more `vhost` - if it's given, queue related metrics (`queue_coarse_metrics`, `queue_consumer_count` and `queue_metrics`) will be returned only for given vhost(s).
+
+The returned metrics use different prefix `rabbitmq_detailed_` (instead of plain `rabbitmq_` used by other  endpoints), so that endpoint can be used simultaneously with `/metrics`, and existing dashboards won't be affected.
+
+Here are the performance gains you can expect from using this endpoint. On a test system with 10k queues/10k consumer/10k producers, `/metrics/per-object` took a bit over 2 minutes. Querying `/metrics/detailed?family=queue_coarse_metrics&family=queue_consumer_count` provides just enough metrics to see how many messages sit in every queue and how much consumers each of these queues have. And it takes only 2 seconds, a significant improvement over indiscriminate `/metrics/per-object`.
 
 ## Contributing
 

--- a/deps/rabbitmq_prometheus/metrics-detailed.md
+++ b/deps/rabbitmq_prometheus/metrics-detailed.md
@@ -1,0 +1,238 @@
+## Configurable RabbitMQ metric groups
+
+Those are metrics than can be explicitly requested via `/metrics/detailed` endpoint. 
+
+### Generic metrics
+
+These are some generic metrics, which do not refer to any specific
+queue/connection/etc. 
+
+#### Connection/channel/queue churn
+
+Group `connection_churn_metrics`:
+
+| Metric                                     | Description                                      |
+|--------------------------------------------|--------------------------------------------------|
+| rabbitmq_detailed_connections_opened_total | Total number of connections opened               |
+| rabbitmq_detailed_connections_closed_total | Total number of connections closed or terminated |
+| rabbitmq_detailed_channels_opened_total    | Total number of channels opened                  |
+| rabbitmq_detailed_channels_closed_total    | Total number of channels closed                  |
+| rabbitmq_detailed_queues_declared_total    | Total number of queues declared                  |
+| rabbitmq_detailed_queues_created_total     | Total number of queues created                   |
+| rabbitmq_detailed_queues_deleted_total     | Total number of queues deleted                   |
+
+
+#### Erlang VM/Disk IO via RabbitMQ
+
+Group `node_coarse_metrics`:
+
+| Metric                                                    | Description                                                           |
+|-----------------------------------------------------------|-----------------------------------------------------------------------|
+| rabbitmq_detailed_process_open_fds                        | Open file descriptors                                                 |
+| rabbitmq_detailed_process_open_tcp_sockets                | Open TCP sockets                                                      |
+| rabbitmq_detailed_process_resident_memory_bytes           | Memory used in bytes                                                  |
+| rabbitmq_detailed_disk_space_available_bytes              | Disk space available in bytes                                         |
+| rabbitmq_detailed_erlang_processes_used                   | Erlang processes used                                                 |
+| rabbitmq_detailed_erlang_gc_runs_total                    | Total number of Erlang garbage collector runs                         |
+| rabbitmq_detailed_erlang_gc_reclaimed_bytes_total         | Total number of bytes of memory reclaimed by Erlang garbage collector |
+| rabbitmq_detailed_erlang_scheduler_context_switches_total | Total number of Erlang scheduler context switches                     |
+
+Group `node_metrics`:
+
+| Metric                                             | Description                            |
+|----------------------------------------------------|----------------------------------------|
+| rabbitmq_detailed_process_max_fds                  | Open file descriptors limit            |
+| rabbitmq_detailed_process_max_tcp_sockets          | Open TCP sockets limit                 |
+| rabbitmq_detailed_resident_memory_limit_bytes      | Memory high watermark in bytes         |
+| rabbitmq_detailed_disk_space_available_limit_bytes | Free disk space low watermark in bytes |
+| rabbitmq_detailed_erlang_processes_limit           | Erlang processes limit                 |
+| rabbitmq_detailed_erlang_scheduler_run_queue       | Erlang scheduler run queue             |
+| rabbitmq_detailed_erlang_net_ticktime_seconds      | Inter-node heartbeat interval          |
+| rabbitmq_detailed_erlang_uptime_seconds            | Node uptime                            |
+
+
+Group `node_persister_metrics`:
+
+| Metric                                                | Description                                          |
+|-------------------------------------------------------|------------------------------------------------------|
+| rabbitmq_detailed_io_read_ops_total                   | Total number of I/O read operations                  |
+| rabbitmq_detailed_io_read_bytes_total                 | Total number of I/O bytes read                       |
+| rabbitmq_detailed_io_write_ops_total                  | Total number of I/O write operations                 |
+| rabbitmq_detailed_io_write_bytes_total                | Total number of I/O bytes written                    |
+| rabbitmq_detailed_io_sync_ops_total                   | Total number of I/O sync operations                  |
+| rabbitmq_detailed_io_seek_ops_total                   | Total number of I/O seek operations                  |
+| rabbitmq_detailed_io_open_attempt_ops_total           | Total number of file open attempts                   |
+| rabbitmq_detailed_io_reopen_ops_total                 | Total number of times files have been reopened       |
+| rabbitmq_detailed_schema_db_ram_tx_total              | Total number of Schema DB memory transactions        |
+| rabbitmq_detailed_schema_db_disk_tx_total             | Total number of Schema DB disk transactions          |
+| rabbitmq_detailed_msg_store_read_total                | Total number of Message Store read operations        |
+| rabbitmq_detailed_msg_store_write_total               | Total number of Message Store write operations       |
+| rabbitmq_detailed_queue_index_read_ops_total          | Total number of Queue Index read operations          |
+| rabbitmq_detailed_queue_index_write_ops_total         | Total number of Queue Index write operations         |
+| rabbitmq_detailed_queue_index_journal_write_ops_total | Total number of Queue Index Journal write operations |
+| rabbitmq_detailed_io_read_time_seconds_total          | Total I/O read time                                  |
+| rabbitmq_detailed_io_write_time_seconds_total         | Total I/O write time                                 |
+| rabbitmq_detailed_io_sync_time_seconds_total          | Total I/O sync time                                  |
+| rabbitmq_detailed_io_seek_time_seconds_total          | Total I/O seek time                                  |
+| rabbitmq_detailed_io_open_attempt_time_seconds_total  | Total file open attempts time                        |
+
+
+#### Raft metrics
+
+Group `ra_metrics`:
+
+| Metric                                              | Description                                |
+|-----------------------------------------------------|--------------------------------------------|
+| rabbitmq_detailed_raft_term_total                   | Current Raft term number                   |
+| rabbitmq_detailed_raft_log_snapshot_index           | Raft log snapshot index                    |
+| rabbitmq_detailed_raft_log_last_applied_index       | Raft log last applied index                |
+| rabbitmq_detailed_raft_log_commit_index             | Raft log commit index                      |
+| rabbitmq_detailed_raft_log_last_written_index       | Raft log last written index                |
+| rabbitmq_detailed_raft_entry_commit_latency_seconds | Time taken for a log entry to be committed |
+
+#### Auth metrics
+
+Group `auth_attempt_metrics`:
+
+| Metric                                          | Description                                        |
+|-------------------------------------------------|----------------------------------------------------|
+| rabbitmq_detailed_auth_attempts_total           | Total number of authorization attempts             |
+| rabbitmq_detailed_auth_attempts_succeeded_total | Total number of successful authentication attempts |
+| rabbitmq_detailed_auth_attempts_failed_total    | Total number of failed authentication attempts     |
+
+
+Group `auth_attempt_detailed_metrics` (when aggregated, it produces the same numbers as `auth_attempt_metrics` - so it's mutually exclusive with it in the aggregation mode):
+
+| Metric                                                   | Description                                                        |
+|----------------------------------------------------------|--------------------------------------------------------------------|
+| rabbitmq_detailed_auth_attempts_detailed_total           | Total number of authorization attempts with source info            |
+| rabbitmq_detailed_auth_attempts_detailed_succeeded_total | Total number of successful authorization attempts with source info |
+| rabbitmq_detailed_auth_attempts_detailed_failed_total    | Total number of failed authorization attempts with source info     |
+
+
+### Queue metrics
+
+Each of metrics in this group refers to a single queue in its label. Amount of data and performance totally depends on the number of queues.
+
+They are listed from least expensive to collect to the most expensive.
+
+#### Queue coarse metrics
+
+Group `queue_coarse_metrics`:
+
+| Metric                                           | Description                                                  |
+|--------------------------------------------------|--------------------------------------------------------------|
+| rabbitmq_detailed_queue_messages_ready           | Messages ready to be delivered to consumers                  |
+| rabbitmq_detailed_queue_messages_unacked         | Messages delivered to consumers but not yet acknowledged     |
+| rabbitmq_detailed_queue_messages                 | Sum of ready and unacknowledged messages - total queue depth |
+| rabbitmq_detailed_queue_process_reductions_total | Total number of queue process reductions                     |
+
+#### Per-queue consumer count
+
+Group `queue_consumer_count`. This is a strict subset of `queue_metrics` which contains only a single metric (if both `queue_consumer_count` and `queue_metrics` are requested, the former will be automatically skipped):
+
+| Metric                            | Description          |
+|-----------------------------------|----------------------|
+| rabbitmq_detailed_queue_consumers | Consumers on a queue |
+
+This is one of the more telling metrics, and having it separately allows to skip some expensive operations for extracting/exposing the other metrics from the same datasource.
+
+#### Detailed queue metrics
+
+Group `queue_metrics` contains all the metrics for every queue, and can be relatively expensive to produce:
+
+| Metric                                            | Description                                                |
+|---------------------------------------------------|------------------------------------------------------------|
+| rabbitmq_detailed_queue_consumers                 | Consumers on a queue                                       |
+| rabbitmq_detailed_queue_consumer_capacity         | Consumer capacity                                          |
+| rabbitmq_detailed_queue_consumer_utilisation      | Same as consumer capacity                                  |
+| rabbitmq_detailed_queue_process_memory_bytes      | Memory in bytes used by the Erlang queue process           |
+| rabbitmq_detailed_queue_messages_ram              | Ready and unacknowledged messages stored in memory         |
+| rabbitmq_detailed_queue_messages_ram_bytes        | Size of ready and unacknowledged messages stored in memory |
+| rabbitmq_detailed_queue_messages_ready_ram        | Ready messages stored in memory                            |
+| rabbitmq_detailed_queue_messages_unacked_ram      | Unacknowledged messages stored in memory                   |
+| rabbitmq_detailed_queue_messages_persistent       | Persistent messages                                        |
+| rabbitmq_detailed_queue_messages_persistent_bytes | Size in bytes of persistent messages                       |
+| rabbitmq_detailed_queue_messages_bytes            | Size in bytes of ready and unacknowledged messages         |
+| rabbitmq_detailed_queue_messages_ready_bytes      | Size in bytes of ready messages                            |
+| rabbitmq_detailed_queue_messages_unacked_bytes    | Size in bytes of all unacknowledged messages               |
+| rabbitmq_detailed_queue_messages_paged_out        | Messages paged out to disk                                 |
+| rabbitmq_detailed_queue_messages_paged_out_bytes  | Size in bytes of messages paged out to disk                |
+| rabbitmq_detailed_queue_disk_reads_total          | Total number of times queue read messages from disk        |
+| rabbitmq_detailed_queue_disk_writes_total         | Total number of times queue wrote messages to disk         |
+
+Tests show that performance difference between it and `queue_consumer_count` is approximately 8 times. E.g. on a test broker with 10k queues/producers/consumers, scrape time was ~8 second and ~1 respectively. So while it's expensive, it's not prohibitively so - especially compared to other metrics from per-connection/channel groups.
+
+### Connection/channel metrics
+
+All of those include Erlang PID in their label, which is rarely useful when ingested into Prometheus. And they are most expensive to produce, the most resources are spent by `/metrics/per-object` on these.
+
+#### Connection metrics
+
+Group `connection_coarse_metrics`:
+
+| Metric                                                | Description                                    |
+|-------------------------------------------------------|------------------------------------------------|
+| rabbitmq_detailed_connection_incoming_bytes_total     | Total number of bytes received on a connection |
+| rabbitmq_detailed_connection_outgoing_bytes_total     | Total number of bytes sent on a connection     |
+| rabbitmq_detailed_connection_process_reductions_total | Total number of connection process reductions  |
+
+Group `connection_metrics`:
+
+| Metric                                              | Description                                          |
+|-----------------------------------------------------|------------------------------------------------------|
+| rabbitmq_detailed_connection_incoming_packets_total | Total number of packets received on a connection     |
+| rabbitmq_detailed_connection_outgoing_packets_total | Total number of packets sent on a connection         |
+| rabbitmq_detailed_connection_pending_packets        | Number of packets waiting to be sent on a connection |
+| rabbitmq_detailed_connection_channels               | Channels on a connection                             |
+
+#### General channel metrics
+
+Group `channel_metrics`:
+
+| Metric                                         | Description                                                           |
+|------------------------------------------------|-----------------------------------------------------------------------|
+| rabbitmq_detailed_channel_consumers            | Consumers on a channel                                                |
+| rabbitmq_detailed_channel_messages_unacked     | Delivered but not yet acknowledged messages                           |
+| rabbitmq_detailed_channel_messages_unconfirmed | Published but not yet confirmed messages                              |
+| rabbitmq_detailed_channel_messages_uncommitted | Messages received in a transaction but not yet committed              |
+| rabbitmq_detailed_channel_acks_uncommitted     | Message acknowledgements in a transaction not yet committed           |
+| rabbitmq_detailed_consumer_prefetch            | Limit of unacknowledged messages for each consumer                    |
+| rabbitmq_detailed_channel_prefetch             | Total limit of unacknowledged messages for all consumers on a channel |
+
+
+Group `channel_process_metrics`:
+
+| Metric                                             | Description                                |
+|----------------------------------------------------|--------------------------------------------|
+| rabbitmq_detailed_channel_process_reductions_total | Total number of channel process reductions |
+
+
+#### Channel metrics with queue/exchange breakdowns
+
+Group `channel_exchange_metrics`:
+
+| Metric                                                       | Description                                                                                                  |
+|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| rabbitmq_detailed_channel_messages_published_total           | Total number of messages published into an exchange on a channel                                             |
+| rabbitmq_detailed_channel_messages_confirmed_total           | Total number of messages published into an exchange and confirmed on the channel                             |
+| rabbitmq_detailed_channel_messages_unroutable_returned_total | Total number of messages published as mandatory into an exchange and returned to the publisher as unroutable |
+| rabbitmq_detailed_channel_messages_unroutable_dropped_total  | Total number of messages published as non-mandatory into an exchange and dropped as unroutable               |
+
+Group `channel_queue_metrics`:
+
+| Metric                                                 | Description                                                                       |
+|--------------------------------------------------------|-----------------------------------------------------------------------------------|
+| rabbitmq_detailed_channel_get_ack_total                | Total number of messages fetched with basic.get in manual acknowledgement mode    |
+| rabbitmq_detailed_channel_get_total                    | Total number of messages fetched with basic.get in automatic acknowledgement mode |
+| rabbitmq_detailed_channel_messages_delivered_ack_total | Total number of messages delivered to consumers in manual acknowledgement mode    |
+| rabbitmq_detailed_channel_messages_delivered_total     | Total number of messages delivered to consumers in automatic acknowledgement mode |
+| rabbitmq_detailed_channel_messages_redelivered_total   | Total number of messages redelivered to consumers                                 |
+| rabbitmq_detailed_channel_messages_acked_total         | Total number of messages acknowledged by consumers                                |
+| rabbitmq_detailed_channel_get_empty_total              | Total number of times basic.get operations fetched no message                     |
+
+Group `channel_queue_exchange_metrics`:
+
+| Metric                                           | Description                                  |
+|--------------------------------------------------|----------------------------------------------|
+| rabbitmq_detailed_queue_messages_published_total | Total number of messages published to queues |

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
@@ -27,6 +27,9 @@ build_dispatcher() ->
         prometheus_rabbitmq_core_metrics_collector,
         prometheus_rabbitmq_global_metrics_collector
         ]),
+    prometheus_registry:register_collectors('detailed', [
+        prometheus_rabbitmq_core_metrics_collector
+        ]),
     rabbit_prometheus_handler:setup(),
     cowboy_router:compile([{'_', dispatcher()}]).
 

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
@@ -32,7 +32,8 @@ is_authorized(ReqData, Context) ->
 
 setup() ->
     setup_metrics(telemetry_registry()),
-    setup_metrics('per-object').
+    setup_metrics('per-object'),
+    setup_metrics('detailed').
 
 setup_metrics(Registry) ->
     ScrapeDuration = [{name, ?SCRAPE_DURATION},
@@ -67,6 +68,7 @@ gen_response(<<"GET">>, Request) ->
         false ->
           cowboy_req:reply(404, #{}, <<"Unknown Registry">>, Request);
         Registry ->
+            put_filtering_options_into_process_dictionary(Request),
             gen_metrics_response(Registry, Request)
     end;
 gen_response(_, Request) ->
@@ -146,4 +148,43 @@ encode_format(ContentType, Encoding, Scrape, Registry) ->
 encode_format_("gzip", Scrape) ->
     zlib:gzip(Scrape);
 encode_format_("identity", Scrape) ->
-    Scrape.
+     Scrape.
+
+%% It's not easy to pass this information in a pure way (it'll require changing prometheus.erl)
+put_filtering_options_into_process_dictionary(Request) ->
+    #{vhost := VHosts, family := Families} = cowboy_req:match_qs([{vhost, [], undefined}, {family, [], undefined}], Request),
+    case parse_vhosts(VHosts) of
+        Vs when is_list(Vs) ->
+            put(prometheus_vhost_filter, Vs);
+        _ -> ok
+    end,
+    case parse_metric_families(Families) of
+        Fs when is_list(Fs) ->
+            put(prometheus_mf_filter, Fs);
+        _ -> ok
+    end,
+    ok.
+
+parse_vhosts(N) when is_binary(N) ->
+    parse_vhosts([N]);
+parse_vhosts(L) when is_list(L) ->
+    [ VHostName || VHostName <- L, rabbit_vhost:exists(VHostName)];
+parse_vhosts(_) ->
+    false.
+
+parse_metric_families(N) when is_binary(N) ->
+    parse_metric_families([N]);
+parse_metric_families([]) ->
+    [];
+parse_metric_families([B|Bs]) ->
+    %% binary_to_existing_atom() should be enough, as it's used for filtering things out.
+    %% Getting a full list of supported metrics would be harder.
+    %% NB But on the other hand, it's nice to have validation. Implement it?
+    case catch erlang:binary_to_existing_atom(B) of
+        A when is_atom(A) ->
+            [A|parse_metric_families(Bs)];
+        _ ->
+            parse_metric_families(Bs)
+    end;
+parse_metric_families(_) ->
+    false.


### PR DESCRIPTION
## Proposed Changes

Prometheus plugin always exposes all possible metrics (even in aggregated mode, where the output is smaller, but the same amount of data still needs to be processed), and this can be problematic when there is a large number of connections/channels/queues.

For existing endpoints this change allows to disable some metric families altogether or filter out some vhosts (but this is optional, and without configuration change everything is 100% backwards compatible). This can greatly reduce the amount of data exposed, while still providing enough details for a proper monitoring.

And then there is a new endpoint where the same customizations can be applied on the fly, in case more information is needed, or with different level of details.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
