### PR TITLE
Add counters on detail pages

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/channel.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/channel.ejs
@@ -74,7 +74,7 @@
 </div>
 
 <div class="section">
-  <h2>Consumers</h2>
+  <h2 class="updatable" >Consumers (<%=(channel.consumer_details.length)%>) </h2>
   <div class="hider updatable">
 <%= format('consumers', {'mode': 'channel', 'consumers': channel.consumer_details}) %>
   </div>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
@@ -76,7 +76,7 @@
 </div>
 
 <div class="section">
-  <h2>Channels</h2>
+  <h2 class="updatable" >Channels (<%=(channels.length)%>) </h2>
   <div class="hider updatable">
     <%= format('channels-list', {'channels': channels, 'mode': 'connection'}) %>
   </div>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -130,7 +130,7 @@
       </tr>
       <% if(queue.consumers) { %>
       <tr>
-        <th>Consumers></th>
+        <th>Consumers</th>
         <td><%= fmt_string(queue.consumers) %></td>
       </tr>
       <% } else if(queue.hasOwnProperty('consumer_details')) { %>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -130,7 +130,7 @@
       </tr>
       <% if(queue.consumers) { %>
       <tr>
-        <th>Consumers%></th>
+        <th>Consumers></th>
         <td><%= fmt_string(queue.consumers) %></td>
       </tr>
       <% } else if(queue.hasOwnProperty('consumer_details')) { %>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -130,7 +130,7 @@
       </tr>
       <% if(queue.consumers) { %>
       <tr>
-        <th>Consumers</th>
+        <th>Consumers%></th>
         <td><%= fmt_string(queue.consumers) %></td>
       </tr>
       <% } else if(queue.hasOwnProperty('consumer_details')) { %>
@@ -273,7 +273,7 @@
 
 <% if(!disable_stats) { %>
 <div class="section-hidden">
-  <h2>Consumers</h2>
+  <h2 class="updatable">Consumers (<%=(queue.consumer_details.length)%>) </h2>
   <div class="hider updatable">
 <%= format('consumers', {'mode': 'queue', 'consumers': queue.consumer_details}) %>
   </div>
@@ -281,7 +281,7 @@
 <% } %>
 
 <div class="section-hidden">
-  <h2>Bindings</h2>
+  <h2 class="updatable">Bindings (<%=(bindings.length)%>) </h2>
   <div class="hider">
     <div class="bindings-wrapper">
       <%= format('bindings', {'mode': 'queue', 'bindings': bindings}) %>

--- a/deps/rabbitmq_stream_management/priv/www/js/stream.js
+++ b/deps/rabbitmq_stream_management/priv/www/js/stream.js
@@ -20,7 +20,7 @@ dispatcher_add(function(sammy) {
         if (is_stream(queue)) {
             var publishers = extraContent['extra_stream_publishers'];
             if (publishers !== undefined) {
-                return '<div class="section-hidden"><h2>Stream publishers</h2><div class="hider updatable">' +
+                return '<div class="section-hidden"><h2 class="updatable">Stream publishers (' + Object.keys(publishers).length +')</h2><div class="hider updatable">' +
                     format('streamPublishersList', {'publishers': publishers, 'mode': 'queue'}) +
                     '</div></div>';
             } else {

--- a/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
+++ b/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
@@ -116,14 +116,14 @@
 <% } %>
 
 <div class="section">
-  <h2>Publishers</h2>
+  <h2 class="updatable">Publishers (<%=(publishers.length)%>) </h2>
   <div class="hider updatable">
     <%= format('streamPublishersList', {'publishers': publishers, 'mode' : 'connection'}) %>
   </div>
 </div>
 
 <div class="section">
-  <h2>Consumers</h2>
+  <h2 class="updatable" >Consumers (<%=(consumers.length)%>)</h2>
   <div class="hider updatable">
     <%= format('streamConsumersList', {'consumers': consumers}) %>
   </div>


### PR DESCRIPTION
closes https://github.com/rabbitmq/rabbitmq-server/issues/3416

## Proposed Changes
Add counters on detail pages


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

@acogoluegnes for the `stream.js` I could not use the `.ejs` script to count the items. 
I used the standard [java script way](https://github.com/rabbitmq/rabbitmq-server/commit/346adc86affcddc4ad1cafc08b5d4eae9ad593e0#diff-eba28b2bb081ee23702f857e578c8108f6c4ecc937604a6424f18d3403d7c4ffR23) 

an example
![Screen Shot 2021-09-14 at 17 23 32](https://user-images.githubusercontent.com/386987/133286416-72411de0-6c2a-4bc6-87ab-eaa3fa62f726.png)
