### PR TITLE
Use the deterministic compiler flag for elixir/rabbitmq_cli

### DIFF
--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -85,6 +85,7 @@ def _impl(ctx):
         fi
 
         export DEPS_DIR={mix_deps_dir}
+        export ERL_COMPILER_OPTIONS=deterministic
         mix local.hex --force
         mix local.rebar --force
         mix make_all

--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -78,6 +78,7 @@ def _impl(ctx):
         fi
 
         export DEPS_DIR={mix_deps_dir}
+        export ERL_COMPILER_OPTIONS=deterministic
         mix local.hex --force
         mix local.rebar --force
         mix make_deps


### PR DESCRIPTION
## Proposed Changes

Passes the `+deterministic` flag to the erlang compiler during elixir compilation. We already use the flag for the rest of the code, so this brings things more in sync.

Note that this only applies to the Bazel build at this point, Make/Erlang.mk are unaffected.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I intend to address the Make/Erlang.mk side of this in another PR.
