### PR TITLE
Use the +deterministic compiler flag when building with Make

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-build.mk
+++ b/deps/rabbit_common/mk/rabbitmq-build.mk
@@ -18,6 +18,8 @@ ifneq ($(filter-out rabbit_common amqp_client,$(PROJECT)),)
 RMQ_ERLC_OPTS += -pa $(DEPS_DIR)/rabbitmq_cli/_build/dev/lib/rabbitmqctl/ebin
 endif
 
+RMQ_ERLC_OPTS += +deterministic
+
 # Push our compilation options to both the normal and test ERLC_OPTS.
 ERLC_OPTS += $(RMQ_ERLC_OPTS)
 TEST_ERLC_OPTS += $(RMQ_ERLC_OPTS)

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -13,7 +13,7 @@ VERBOSE_TEST ?= true
 MAX_CASES ?= 1
 
 MIX_TEST_OPTS ?= ""
-MIX_TEST = mix test --max-cases=$(MAX_CASES)
+MIX_TEST = ERL_COMPILER_OPTIONS=deterministic mix test --max-cases=$(MAX_CASES)
 
 ifneq ("",$(MIX_TEST_OPTS))
 MIX_TEST := $(MIX_TEST) $(MIX_TEST_OPTS)
@@ -106,9 +106,9 @@ rabbitmqctl_srcs := mix.exs \
 # ones).
 $(ACTUAL_ESCRIPTS): $(rabbitmqctl_srcs)
 	$(gen_verbose) if test -d ../.hex; then \
-		echo y | mix make_all_in_src_archive; \
+		echo y | ERL_COMPILER_OPTIONS=deterministic mix make_all_in_src_archive; \
 	else \
-		echo y | mix make_all; \
+		echo y | ERL_COMPILER_OPTIONS=deterministic mix make_all; \
 	fi
 
 $(LINKED_ESCRIPTS):

--- a/release-notes/3.9.7.md
+++ b/release-notes/3.9.7.md
@@ -1,0 +1,46 @@
+RabbitMQ `3.9.7` is a maintenance release in the `3.9.x` release series.
+
+Please refer to the **Upgrading to 3.9** section from [v3.9.0 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.0) if upgrading from a version prior to 3.9.0.
+
+This release requires at least Erlang 23.2, and supports the latest Erlang 24 version, 24.0.5 at the time of release. [RabbitMQ and Erlang/OTP Compatibility Matrix](https://www.rabbitmq.com/which-erlang.html) has more details on Erlang version requirements for RabbitMQ.
+
+
+
+## Changes Worth Mentioning
+
+Release notes are kept under [rabbitmq-server/release-notes](https://github.com/rabbitmq/rabbitmq-server/tree/v3.9.x/release-notes).
+Contributors are encouraged to update them together with their changes. This helps with release automation and a more consistent release schedule.
+
+### All Components
+
+  * All bytecode is now compiled using the `+deterministic` compiler flag. This should eliminate the capture of some irrelevant build environment attributes in produced artifacts, improve consistency between builds, and reduce the file level diff between release artifacts.
+
+    GitHub issue: [#3442](https://github.com/rabbitmq/rabbitmq-server/pull/3442)
+
+### Core Server
+
+#### Bug Fixes
+
+* ...
+
+### Stream Plugin
+
+#### Bug Fixes
+
+ * ...
+
+### Management Plugin
+
+#### Enhancements
+
+  * ...
+
+
+## Dependency Upgrades
+
+ * ...
+
+
+## Source Code Archives
+
+To obtain source code of the entire distribution, please download the archive named `rabbitmq-server-3.9.7.tar.xz` instead of the source tarball produced by GitHub.


### PR DESCRIPTION
## Proposed Changes

This matches changes on the bazel side of the build to compile with the `deterministic` option to reduce the variation in built files.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

See #3440 & c73ece267ef5b6bbc609e124b7c05f3ff03892fa
