### PR TITLE
Split the feature_flags_SUITE into two parts for CI/Bazel

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -437,6 +437,19 @@ suites = [
         size = "large",
         flaky = True,
         shard_count = 5,
+        runtime_deps = [
+            "//deps/rabbit/test/feature_flags_SUITE_data/my_plugin:bazel_erlang_lib",
+        ],
+    ),
+    rabbitmq_integration_suite(
+        PACKAGE,
+        name = "feature_flags_with_unpriveleged_user_SUITE",
+        size = "large",
+        additional_beam = [
+            ":feature_flags_SUITE_beam_files",
+        ],
+        flaky = True,
+        shard_count = 2,
         # The enabling_* tests chmod files and then expect writes to be blocked.
         # This probably doesn't work because we are root in the remote docker image.
         tags = ["exclusive"],

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -61,14 +61,12 @@ groups() ->
      {enabling_on_single_node, [],
       [
        enable_feature_flag_in_a_healthy_situation,
-       enable_unsupported_feature_flag_in_a_healthy_situation,
-       enable_feature_flag_when_ff_file_is_unwritable
+       enable_unsupported_feature_flag_in_a_healthy_situation
       ]},
      {enabling_in_cluster, [],
       [
        enable_feature_flag_in_a_healthy_situation,
        enable_unsupported_feature_flag_in_a_healthy_situation,
-       enable_feature_flag_when_ff_file_is_unwritable,
        enable_feature_flag_with_a_network_partition,
        mark_feature_flag_as_enabled_with_a_network_partition
       ]},

--- a/deps/rabbit/test/feature_flags_with_unpriveleged_user_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_with_unpriveleged_user_SUITE.erl
@@ -1,0 +1,74 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2018-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(feature_flags_with_unpriveleged_user_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([suite/0,
+         all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2,
+
+         enable_feature_flag_when_ff_file_is_unwritable/1
+        ]).
+
+suite() ->
+    [{timetrap, {minutes, 15}}].
+
+all() ->
+    [
+     {group, enabling_on_single_node},
+     {group, enabling_in_cluster}
+    ].
+
+groups() ->
+    [
+     {enabling_on_single_node, [],
+      [
+       enable_feature_flag_when_ff_file_is_unwritable
+      ]},
+     {enabling_in_cluster, [],
+      [
+       enable_feature_flag_when_ff_file_is_unwritable
+      ]}
+    ].
+
+%% This suite exists to allow running a portion of the feature_flags_SUITE
+%% under separate conditions in ci
+
+init_per_suite(Config) ->
+    feature_flags_SUITE:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    feature_flags_SUITE:end_per_suite(Config).
+
+
+init_per_group(Group, Config) ->
+    feature_flags_SUITE:init_per_group(Group, Config).
+
+end_per_group(Group, Config) ->
+    feature_flags_SUITE:end_per_group(Group, Config).
+
+init_per_testcase(Testcase, Config) ->
+    feature_flags_SUITE:init_per_testcase(Testcase, Config).
+
+end_per_testcase(Testcase, Config) ->
+    feature_flags_SUITE:end_per_testcase(Testcase, Config).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+enable_feature_flag_when_ff_file_is_unwritable(Config) ->
+    feature_flags_SUITE:enable_feature_flag_when_ff_file_is_unwritable(Config).


### PR DESCRIPTION
Two testcases in the original suite fail if the test is run as the root user. Currently under remote execution with bazel this is the only working option. There is a workaround in place (executing the feature_flags_SUITE on the Github Actions worker rather than on BuildBuddy), but the entire suite when run that way takes around 12 minutes. This splits the suite so that the minimal set of cases is executed using the slower workaround.