### PR TITLE
Quorum Queue consumer cancellation fixes

### DIFF
--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -386,6 +386,16 @@ return_auto_checked_out_test(_) ->
                 Effects),
     ok.
 
+cancelled_checkout_empty_queue_test(_) ->
+    Cid = {<<"cid">>, self()},
+    {State1, _} = check_auto(Cid, 2, test_init(test)),
+    % cancelled checkout should clear out service_queue also, else we'd get a
+    % build up of these
+    {State2, _, _} = apply(meta(3), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
+    ?assertEqual(0, map_size(State2#rabbit_fifo.consumers)),
+    ?assertEqual(0, priority_queue:len(State2#rabbit_fifo.service_queue)),
+    ok.
+
 cancelled_checkout_out_test(_) ->
     Cid = {<<"cid">>, self()},
     {State00, [_, _]} = enq(1, 1, first, test_init(test)),
@@ -395,6 +405,7 @@ cancelled_checkout_out_test(_) ->
     {State2, _, _} = apply(meta(3), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
     ?assertEqual(1, lqueue:len(State2#rabbit_fifo.messages)),
     ?assertEqual(0, lqueue:len(State2#rabbit_fifo.returns)),
+    ?assertEqual(0, priority_queue:len(State2#rabbit_fifo.service_queue)),
 
     {State3, {dequeue, empty}} =
         apply(meta(3), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State2),

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -391,9 +391,11 @@ cancelled_checkout_empty_queue_test(_) ->
     {State1, _} = check_auto(Cid, 2, test_init(test)),
     % cancelled checkout should clear out service_queue also, else we'd get a
     % build up of these
-    {State2, _, _} = apply(meta(3), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
+    {State2, _, Effects} = apply(meta(3), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
     ?assertEqual(0, map_size(State2#rabbit_fifo.consumers)),
     ?assertEqual(0, priority_queue:len(State2#rabbit_fifo.service_queue)),
+    ct:pal("Effs: ~p", [Effects]),
+    ?ASSERT_EFF({release_cursor, _, _}, Effects),
     ok.
 
 cancelled_checkout_out_test(_) ->


### PR DESCRIPTION
Fixes #3445 

If the queue is empty when a consumer is cancelled it would leave the
consumer id inside the service queue. If an application subscribes/unsubscibes
in a loop from an empty queue this would cause the service queue to never be
cleared up.

NB: whenever we make a change to how the quorum queue state machien is
calculated we need to consider how this effects determinism as during an
upgrade different members may calculate a different service queue state.
In this case it should be ok as they will eventually converge on the same
state once all "dead" consumer ids have been removed from the queue.

QQ: emit release cursors after consumer cancel, `purge_nodes`, `garbage_collection` and
`update_config` commands to ensure that repeated use of these commands
against an empty queue will not grow the log excessively.

