### PR TITLE
Stream coordinator: monitor task processes

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -634,7 +634,7 @@ run_action(Action, StreamId, #{node := _Node,
                              ActionFun(),
                              unlink(Coordinator)
                      end),
-    Effects = [],
+    Effects = [{monitor, process, aux, Pid}],
     Actions = Actions0#{Pid => {StreamId, Action, Args}},
     {no_reply, Aux#aux{actions = Actions}, Log, Effects}.
 


### PR DESCRIPTION
So that they are cleaned up from the stream coordinator aux state
when they finish instead of growing indefinitely.
