### PR TITLE
Use 3.8.22 in 3.8/3.9 mixed version testing

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -89,9 +89,9 @@ EOF
 """
 
 http_archive(
-    name = "rabbitmq-server-generic-unix-3.8.18",
+    name = "rabbitmq-server-generic-unix-3.8.22",
     build_file = "@//:BUILD.package_generic_unix",
     patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-    strip_prefix = "rabbitmq_server-3.8.18",
-    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.18/rabbitmq-server-generic-unix-3.8.18.tar.xz"],
+    strip_prefix = "rabbitmq_server-3.8.22",
+    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.22/rabbitmq-server-generic-unix-3.8.22.tar.xz"],
 )

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -171,11 +171,11 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.8.18/rabbitmq-run",
+            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.8.22/rabbitmq-run",
         }.items() + test_env.items()),
         tools = [
             ":rabbitmq-for-tests-run",
-            "@rabbitmq-server-generic-unix-3.8.18//:rabbitmq-run",
+            "@rabbitmq-server-generic-unix-3.8.22//:rabbitmq-run",
         ] + tools,
         runtime_deps = [
             "//deps/rabbitmq_cli:elixir_as_bazel_erlang_lib",


### PR DESCRIPTION
Updates the patch version of 3.8 used when testing mixed version clusters