### PR TITLE
Use rabbitmq_ct_helpers to allocate prometheus port

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -45,7 +45,7 @@ rabbitmq_external_deps(rabbitmq_workspace = "@")
 
 git_repository(
     name = "rabbitmq_ct_helpers",
-    commit = "9a848f06e432262ab30e6124e52564714662f47b",
+    commit = "f709a6f6a2345d3ab5076469cb8d8e42e89b2b59",
     remote = "https://github.com/rabbitmq/rabbitmq-ct-helpers.git",
     repo_mapping = {
         "@rabbitmq-server": "@",


### PR DESCRIPTION
## Proposed Changes

This test always used standard 15692 before, which were causing
conflicts with e.g. local `make run-broker`. After this commit, the port is allocated using the same mechanism as for all other ports of a test instance.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

