### PR TITLE
Use a pinned version of rabbitmq-ct-[client-]helpers

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -45,7 +45,7 @@ rabbitmq_external_deps(rabbitmq_workspace = "@")
 
 git_repository(
     name = "rabbitmq_ct_helpers",
-    branch = "master",
+    commit = "9a848f06e432262ab30e6124e52564714662f47b",
     remote = "https://github.com/rabbitmq/rabbitmq-ct-helpers.git",
     repo_mapping = {
         "@rabbitmq-server": "@",
@@ -54,7 +54,7 @@ git_repository(
 
 git_repository(
     name = "rabbitmq_ct_client_helpers",
-    branch = "master",
+    commit = "51ed1e59d725816cd82a3bd6211c043d385f180e",
     remote = "https://github.com/rabbitmq/rabbitmq-ct-client-helpers.git",
     repo_mapping = {
         "@rabbitmq-server": "@",


### PR DESCRIPTION
When these changes, it can break builds asynchronously and present difficult to diagnose errors

Automation to update the pinned version automatically, so that the dep does not fall behind is ready, but needs to be pushed directly to master to be tested due to Github actions scheduling rules