### PR TITLE
Handle no-context delivery in web stomp

### DIFF
--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -827,7 +827,7 @@ send_delivery(Delivery = #'basic.deliver'{consumer_tag = ConsumerTag},
     NewState.
 
 notify_received(undefined) ->
-  %% no notification for quorum queues
+  %% no notification for quorum queues and streams
   ok;
 notify_received(DeliveryCtx) ->
   %% notification for flow control

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -183,6 +183,15 @@ websocket_info({Delivery = #'basic.deliver'{},
                                                      DeliveryCtx,
                                                      ProcState0),
     {ok, State#state{ proc_state = ProcState }};
+websocket_info({Delivery = #'basic.deliver'{},
+               #amqp_msg{props = Props, payload = Payload}},
+               State=#state{ proc_state = ProcState0 }) ->
+    ProcState = rabbit_stomp_processor:send_delivery(Delivery,
+                                                     Props,
+                                                     Payload,
+                                                     undefined,
+                                                     ProcState0),
+    {ok, State#state{ proc_state = ProcState }};
 websocket_info(#'basic.cancel'{consumer_tag = Ctag},
                State=#state{ proc_state = ProcState0 }) ->
     case rabbit_stomp_processor:cancel_consumer(Ctag, ProcState0) of


### PR DESCRIPTION
To support messages from streams, which do not have a
context (for credit flow).

References rabbitmq/rabbitmq-stomp#138

Fixes #3508