### PR TITLE
Support for advertising different hostname for TLS stream connections

### DIFF
--- a/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
+++ b/deps/rabbitmq_stream/priv/schema/rabbitmq_stream.schema
@@ -193,6 +193,15 @@ fun(Conf) ->
     list_to_binary(cuttlefish:conf_get("stream.advertised_host", Conf))
 end}.
 
+{mapping, "stream.advertised_tls_host", "rabbitmq_stream.advertised_tls_host", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_stream.advertised_tls_host",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("stream.advertised_tls_host", Conf))
+end}.
+
 {mapping, "stream.advertised_port", "rabbitmq_stream.advertised_port", [
     {datatype, integer}
 ]}.

--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -20,6 +20,7 @@
 
 -export([start/2,
          host/0,
+         tls_host/0,
          port/0,
          tls_port/0,
          kill_connection/1]).
@@ -43,6 +44,15 @@ start(_Type, _Args) ->
     rabbit_global_counters:init([{protocol, stream},
                                  {queue_type, ?STREAM_QUEUE_TYPE}]),
     rabbit_stream_sup:start_link().
+
+tls_host() ->
+    case application:get_env(rabbitmq_stream, advertised_tls_host, undefined)
+    of
+        undefined ->
+            hostname_from_node();
+        Host ->
+            rabbit_data_coercion:to_binary(Host)
+    end.
 
 host() ->
     case application:get_env(rabbitmq_stream, advertised_host, undefined)

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1374,7 +1374,13 @@ handle_frame_pre_auth(Transport,
                                                      VirtualHost,
                                                      {socket, S},
                                                      #{}),
-            AdvertisedHost = rabbit_stream:host(),
+            AdvertisedHost =
+                case TransportLayer of
+                    tcp ->
+                        rabbit_stream:host();
+                    ssl ->
+                        rabbit_stream:tls_host()
+                end,
             AdvertisedPort =
                 case TransportLayer of
                     tcp ->

--- a/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
+++ b/deps/rabbitmq_stream/test/config_schema_SUITE_data/rabbitmq_stream.snippets
@@ -54,9 +54,11 @@
   [rabbitmq_stream]},
   {advertised_host_port,
       "stream.advertised_host = some-host
+       stream.advertised_tls_host = some-other-host
        stream.advertised_port = 5556
        stream.advertised_tls_port = 5553",
       [{rabbitmq_stream,[{advertised_host, <<"some-host">>},
+                          {advertised_tls_host, <<"some-other-host">>},
                          	{advertised_port, 5556},
                          	{advertised_tls_port, 5553}]}],
       [rabbitmq_stream]},


### PR DESCRIPTION
## Proposed Changes

Feel free to shot this one down, but this PR allow plain stream connections over one (internal) IP, and TLS stream connections over another (eg. public) IP. Without this patch a cluster can only support access over one or the other IP, not both (unless --load-balancer is used of course).

Even better would be support for multiple listeners, with different advertised_host/port per listener, but this was faster to implement..

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
