### PR TITLE
Reuse list of nodes in peer discovery plugins that use Erlang global locks

### DIFF
--- a/deps/rabbitmq_peer_discovery_aws/test/unit_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_aws/test/unit_SUITE.erl
@@ -75,23 +75,26 @@ registration_support(_Config) ->
 
 lock_single_node(_Config) ->
   LocalNode = node(),
-  meck:expect(rabbit_peer_discovery_aws, list_nodes, 0, {ok, {[LocalNode], disc}}),
+  Nodes = [LocalNode],
+  meck:expect(rabbit_peer_discovery_aws, list_nodes, 0, {ok, {Nodes, disc}}),
 
-  {ok, LockId} = rabbit_peer_discovery_aws:lock(LocalNode),
-  ?assertEqual(ok, rabbit_peer_discovery_aws:unlock(LockId)).
+  {ok, {LockId, Nodes}} = rabbit_peer_discovery_aws:lock(LocalNode),
+  ?assertEqual(ok, rabbit_peer_discovery_aws:unlock({LockId, Nodes})).
 
 lock_multiple_nodes(_Config) ->
   application:set_env(rabbit, cluster_formation, [{internal_lock_retries, 2}]),
   LocalNode = node(),
   OtherNode = other@host,
-  meck:expect(rabbit_peer_discovery_aws, list_nodes, 0, {ok, {[OtherNode, LocalNode], disc}}),
+  Nodes = [OtherNode, LocalNode],
+  meck:expect(rabbit_peer_discovery_aws, list_nodes, 0, {ok, {Nodes, disc}}),
 
-  {ok, {LockResourceId, OtherNode}} = rabbit_peer_discovery_aws:lock(OtherNode),
+  {ok, {{LockResourceId, OtherNode}, Nodes}} = rabbit_peer_discovery_aws:lock(OtherNode),
   ?assertEqual({error, "Acquiring lock taking too long, bailing out after 2 retries"},
                rabbit_peer_discovery_aws:lock(LocalNode)),
-  ?assertEqual(ok, rabbitmq_peer_discovery_aws:unlock({LockResourceId, OtherNode})),
-  ?assertEqual({ok, {LockResourceId, LocalNode}}, rabbit_peer_discovery_aws:lock(LocalNode)),
-  ?assertEqual(ok, rabbitmq_peer_discovery_aws:unlock({LockResourceId, LocalNode})).
+  ?assertEqual(ok, rabbitmq_peer_discovery_aws:unlock({{LockResourceId, OtherNode}, Nodes})),
+
+  ?assertEqual({ok, {{LockResourceId, LocalNode}, Nodes}}, rabbit_peer_discovery_aws:lock(LocalNode)),
+  ?assertEqual(ok, rabbitmq_peer_discovery_aws:unlock({{LockResourceId, LocalNode}, Nodes})).
 
 lock_local_node_not_discovered(_Config) ->
   meck:expect(rabbit_peer_discovery_aws, list_nodes, 0, {ok, {[n1@host, n2@host], disc}} ),

--- a/deps/rabbitmq_peer_discovery_k8s/src/rabbit_peer_discovery_k8s.erl
+++ b/deps/rabbitmq_peer_discovery_k8s/src/rabbit_peer_discovery_k8s.erl
@@ -68,7 +68,8 @@ register() ->
 unregister() ->
     ok.
 
--spec lock(Node :: node()) -> {ok, {ResourceId :: string(), LockRequesterId :: node()}} | {error, Reason :: string()}.
+-spec lock(Node :: node()) -> {ok, {{ResourceId :: string(), LockRequesterId :: node()}, Nodes :: [node()]}} |
+                              {error, Reason :: string()}.
 
 lock(Node) ->
   %% call list_nodes/0 externally such that meck can mock the function
@@ -81,7 +82,7 @@ lock(Node) ->
           Retries = rabbit_nodes:lock_retries(),
           case global:set_lock(LockId, Nodes, Retries) of
             true ->
-              {ok, LockId};
+              {ok, {LockId, Nodes}};
             false ->
               {error, io_lib:format("Acquiring lock taking too long, bailing out after ~b retries", [Retries])}
           end;
@@ -95,16 +96,12 @@ lock(Node) ->
       Error
   end.
 
--spec unlock({ResourceId :: string(), LockRequesterId :: node()}) -> ok | {error, Reason :: string()}.
+-spec unlock({{ResourceId :: string(), LockRequesterId :: node()}, Nodes :: [node()]}) ->
+    ok | {error, Reason :: string()}.
 
-unlock(LockId) ->
-  case ?MODULE:list_nodes() of
-    {ok, {Nodes, disc}} ->
-      global:del_lock(LockId, Nodes),
-      ok;
-    {error, _} = Error ->
-      Error
-  end.
+unlock({LockId, Nodes}) ->
+    global:del_lock(LockId, Nodes),
+    ok.
 
 %%
 %% Implementation


### PR DESCRIPTION
## Proposed Changes

AWS, Kubernetes and Classic peer discovery plugins use list_nodes and
Erlang global:set_lock to create a mutex lock. To unlock, these plugins
get the latest list with list_nodes and call global:del_lock.

However, if list_nodes within unlock fails, RabbitMQ will throw an
uncaught exception and the lock will not be released until the node
holding the lock is restarted. This prevents new nodes from joining the
cluster.

This failure can be avoided by passing the list of nodes from lock to
unlock. If a node goes away (and comes back) between the lock and unlock
calls, del_lock could still successfully remove the lock. Similarly, if
a new node starts up between the lock and unlock calls, del_lock
wouldn't need to inform the new node.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
