### PR TITLE
Emit identity info in prometheus /metrics/detailed endpoint

### DIFF
--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -515,14 +515,15 @@ parse_response(Body) ->
                 || L = [C|_] <- Lines, C /= $#
               ],
     lists:foldl(fun ({Metric, Label, Value}, MetricMap) ->
-                        case string:prefix(atom_to_list(Metric), "telemetry") of
-                            nomatch ->
+                        case re:run(atom_to_list(Metric), "^(telemetry|rabbitmq_identity_info|rabbitmq_build_info)", [{capture, none}]) of
+                            match ->
+                                MetricMap;
+                            _ ->
                                 OldLabelMap = maps:get(Metric, MetricMap, #{}),
                                 OldValues = maps:get(Label, OldLabelMap, []),
                                 NewValues = [Value|OldValues],
                                 NewLabelMap = maps:put(Label, NewValues, OldLabelMap),
-                                maps:put(Metric, NewLabelMap, MetricMap);
-                            _ -> MetricMap
+                                maps:put(Metric, NewLabelMap, MetricMap)
                         end
                 end, #{}, Metrics).
 


### PR DESCRIPTION
## Proposed Changes

This is needed to make filtering metrics on a cluster name possible (as is the case with other pre-defined dashboards, like RabbitMQ-Overview)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
