### PR TITLE
fix: list exchanges in current virtual host in topic permissions

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/dispatcher.js
+++ b/deps/rabbitmq_management/priv/www/js/dispatcher.js
@@ -190,12 +190,15 @@ dispatcher_add(function(sammy) {
                      'permissions': '/permissions'}, 'users');
     sammy.get('#/users/:id', function() {
         var vhosts = JSON.parse(sync_get('/vhosts'));
-            render({'user': '/users/' + esc(this.params['id']),
+        const current_vhost = get_pref('vhost');
+        let index_vhost = vhosts.findIndex(v => v.name === current_vhost);
+        index_vhost = index_vhost === -1 ? 0 : index_vhost;
+        render({'user': '/users/' + esc(this.params['id']),
                     'permissions': '/users/' + esc(this.params['id']) + '/permissions',
                     'topic_permissions': '/users/' + esc(this.params['id']) + '/topic-permissions',
                     'vhosts': '/vhosts/',
-                    'exchanges': '/exchanges/' + esc(vhosts[0].name)}, 'user',
-                   '#/users');
+                    'exchanges': '/exchanges/' + esc(vhosts[index_vhost].name)},
+           'user','#/users');
         });
     sammy.put('#/users-add', function() {
             res = sync_put(this, '/users/:username');


### PR DESCRIPTION
## Proposed Changes

This PR fixes a client-side bug in rabbitmq-management-ui.
If you define a custom topic exchange on a virtual host and want to set topic permission, you cannot select it from the drop-down list.
Because the 'first' vhost it's hardcoded.

Closes #2609.


## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2609)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
