### PR TITLE
Use inter-node TLS conf to enable Osiris TLS replication

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
@@ -30,6 +30,7 @@ xref(
     additional_libs = [
         "@ranch//:bazel_erlang_lib",
         "@systemd//:bazel_erlang_lib",
+        "@osiris//:bazel_erlang_lib",
     ],
     tags = ["xref"],
 )


### PR DESCRIPTION
Depends on rabbitmq/osiris#57.

This PR uses the inter-node TLS configuration to configure stream replication over TLS for the Osiris application. Both strategies covered in the [inter-node TLS guide](https://rabbitmq.com/clustering-ssl.html) are supported.