### PR TITLE
Fix memory leak when using mandatory flag in CQs

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -301,9 +301,9 @@ settlement_action(Type, QRef, MsgSeqs, Acc) ->
 deliver(Qs0, #delivery{flow = Flow,
                        msg_seq_no = MsgNo,
                        message = #basic_message{exchange_name = _Ex},
-                       confirm = _Confirm} = Delivery) ->
+                       confirm = Confirm} = Delivery) ->
     %% TODO: record master and slaves for confirm processing
-    {MPids, SPids, Qs, Actions} = qpids(Qs0, MsgNo),
+    {MPids, SPids, Qs, Actions} = qpids(Qs0, Confirm, MsgNo),
     QPids = MPids ++ SPids,
     case Flow of
         %% Here we are tracking messages sent by the rabbit_channel
@@ -363,7 +363,7 @@ purge(Q) when ?is_amqqueue(Q) ->
     QPid = amqqueue:get_pid(Q),
     delegate:invoke(QPid, {gen_server2, call, [purge, infinity]}).
 
-qpids(Qs, MsgNo) ->
+qpids(Qs, Confirm, MsgNo) ->
     lists:foldl(
       fun ({Q, S0}, {MPidAcc, SPidAcc, Qs0, Actions0}) ->
               QPid = amqqueue:get_pid(Q),
@@ -371,14 +371,14 @@ qpids(Qs, MsgNo) ->
               QRef = amqqueue:get_name(Q),
               Actions = [{monitor, QPid, QRef}
                          | [{monitor, P, QRef} || P <- SPids]] ++ Actions0,
-              %% confirm record only if MsgNo isn't undefined
+              %% confirm record only if necessary
               S = case S0 of
                       #?STATE{unconfirmed = U0} ->
                           Rec = [QPid | SPids],
-                          U = case MsgNo of
-                                  undefined ->
+                          U = case Confirm of
+                                  false ->
                                       U0;
-                                  _ ->
+                                  true ->
                                       U0#{MsgNo => #msg_status{pending = Rec}}
                               end,
                           S0#?STATE{pid = QPid,

--- a/release-notes/3.9.8.md
+++ b/release-notes/3.9.8.md
@@ -1,0 +1,36 @@
+RabbitMQ `3.9.8` is a maintenance release in the `3.9.x` release series.
+
+Please refer to the **Upgrading to 3.9** section from [v3.9.0 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.0) if upgrading from a version prior to 3.9.0.
+
+This release requires at least Erlang 23.2, and supports the latest Erlang 24 version, 24.1.2 at the time of release. [RabbitMQ and Erlang/OTP Compatibility Matrix](https://www.rabbitmq.com/which-erlang.html) has more details on Erlang version requirements for RabbitMQ.
+
+
+
+## Changes Worth Mentioning
+
+Release notes are kept under [rabbitmq-server/release-notes](https://github.com/rabbitmq/rabbitmq-server/tree/v3.9.x/release-notes).
+Contributors are encouraged to update them together with their changes. This helps with release automation and a more consistent release schedule.
+
+### Core Server
+
+#### Enhancements
+
+ * ...
+
+
+#### Bug Fixes
+
+* When the mandatory flag was used when publishing to classic queues,
+  but publisher confirms were not, channels memory usage would grow indefinitely.
+
+   GitHub issue: [#3560](https://github.com/rabbitmq/rabbitmq-server/issues/3560)
+
+
+## Dependency Upgrades
+
+ * ...
+
+
+## Source Code Archives
+
+To obtain source code of the entire distribution, please download the archive named `rabbitmq-server-3.9.8.tar.xz` instead of the source tarball produced by GitHub.


### PR DESCRIPTION
## Proposed Changes

When the mandatory flag is used for publishing the channel would keep a lot of state in memory as if it was waiting for confirms, even though publisher confirms were not used. This affects v3.9.x and above and seems to have been introduced by the `rabbit_queue_type` refactoring.

I have confirmed via PerfTest that the problem is fixed. Example command to reproduce:

```
make run ARGS="--producers 1 --consumers 1 --flag mandatory --flag persistent --auto-delete false --qos 10 --queue 'q'"
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
