### PR TITLE
Handling of `stream_not_found` return value when init a stream client

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2174,6 +2174,11 @@ deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{ex
                     ok
             end,
             State;
+        {error, {stream_not_found, Resource}} ->
+            rabbit_misc:protocol_error(
+              resource_error,
+              "Stream not found for ~s",
+              [rabbit_misc:rs(Resource)]);
         {error, {coordinator_unavailable, Resource}} ->
             rabbit_misc:protocol_error(
               resource_error,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -652,6 +652,8 @@ init(Q) when ?is_amqqueue(Q) ->
                                 leader = Leader,
                                 writer_id = WriterId,
                                 soft_limit = SoftLimit}};
+        {ok, stream_not_found, _} ->
+            {error, stream_not_found};
         {error, coordinator_unavailable} = E ->
             rabbit_log:warning("Failed to start stream client ~p: coordinator unavailable",
                                [rabbit_misc:rs(QName)]),


### PR DESCRIPTION
This error probably shouldn't happen if the system is correct, however `stream_not_found` is a valid return value for the functions called - it comes from `register_listener`. Not handling it causes a case_clause (and long stacktrace) that is sent to the client as an internal error, instead of a known protocol error. Seen while debugging another issue.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

