### PR TITLE
Log response body of failed AWS requests 

### DIFF
--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -546,19 +546,24 @@ api_get_request(Service, Path) ->
   api_get_request_with_retries(Service, Path, ?MAX_RETRIES, ?LINEAR_BACK_OFF_MILLIS).
 
 
-  -spec api_get_request_with_retries(string(), path(), integer(), integer()) -> result().
-  %% @doc Invoke an API call to an AWS service with retries.
-  %% @end
+-spec api_get_request_with_retries(string(), path(), integer(), integer()) -> result().
+%% @doc Invoke an API call to an AWS service with retries.
+%% @end
 api_get_request_with_retries(_, _, 0, _) ->
   rabbit_log:warning("Request to AWS service has failed after ~b retries", [?MAX_RETRIES]),
   {error, "AWS service is unavailable"};
 api_get_request_with_retries(Service, Path, Retries, WaitTimeBetweenRetries) ->
   ensure_credentials_valid(),
   case get(Service, Path) of
-    {ok, {_Headers, Payload}} -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
-                                 {ok, Payload};
-    {error, {credentials, _}} -> {error, credentials};
-    {error, Message, _}       -> rabbit_log:warning("Error occurred ~s~nWill retry AWS request, remaining retries: ~b", [Message, Retries]),
-                                 timer:sleep(WaitTimeBetweenRetries),
-                                 api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries)
+    {ok, {_Headers, Payload}}  -> rabbit_log:debug("AWS request: ~s~nResponse: ~p", [Path, Payload]),
+                                  {ok, Payload};
+    {error, {credentials, _}}  -> {error, credentials};
+    {error, Message, Response} -> rabbit_log:warning("Error occurred: ~s", [Message]),
+                                  case Response of
+                                      {_, Payload} -> rabbit_log:warning("Failed AWS request: ~s~nResponse: ~p", [Path, Payload]);
+                                      _            -> ok
+                                  end,
+                                  rabbit_log:warning("Will retry AWS request, remaining retries: ~b", [Retries]),
+                                  timer:sleep(WaitTimeBetweenRetries),
+                                  api_get_request_with_retries(Service, Path, Retries - 1, WaitTimeBetweenRetries)
   end.

--- a/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
+++ b/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
@@ -485,7 +485,7 @@ api_get_request_test_() ->
                          secret_access_key = "ExpiredAccessKey",
                          region = "us-east-1",
                          expiration = {{3016, 4, 1}, {12, 0, 0}}},
-          meck:expect(httpc, request, 4, {error, "invalid input"}),
+          meck:expect(httpc, request, 4, {error, "network error"}),
           {ok, Pid} = rabbitmq_aws:start_link(),
           rabbitmq_aws:set_region("us-east-1"),
           rabbitmq_aws:set_credentials(State),
@@ -501,7 +501,11 @@ api_get_request_test_() ->
                          secret_access_key = "ExpiredAccessKey",
                          region = "us-east-1",
                          expiration = {{3016, 4, 1}, {12, 0, 0}}},
-          meck:expect(httpc, request, 4, meck:seq([{error, "invalid input"}, {ok, {{"HTTP/1.0", 200, "OK"}, [{"content-type", "application/json"}], "{\"data\": \"value\"}"}}])),
+          meck:expect(httpc, request, 4, meck:seq([
+              {error, "network error"},
+              {ok, {{"HTTP/1.0", 500, "OK"}, [{"content-type", "application/json"}], "{\"error\": \"server error\"}"}},
+              {ok, {{"HTTP/1.0", 200, "OK"}, [{"content-type", "application/json"}], "{\"data\": \"value\"}"}}
+          ])),
           {ok, Pid} = rabbitmq_aws:start_link(),
           rabbitmq_aws:set_region("us-east-1"),
           rabbitmq_aws:set_credentials(State),


### PR DESCRIPTION
## Proposed Changes

Currently, RabbitMQ only logs a simple error message when AWS API calls fail. This can be insufficient for debugging. This PR adds more logs for failed AWS request.

Here is an example error message after the change:
```
2021-10-08 22:17:09.233583+00:00 [warn] <0.2885.0> Error occurred: Forbidden
--
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0> Failed AWS request: /?Action=DescribeInstances&InstanceId.3=i-0e0a1ffe033f786ed&InstanceId.4=i-0d41f71f51082f61b&InstanceId.5=i-059087f7877037020&Version=2015-10-01
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0> Response: [{"Response",
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0>             [{"Errors",
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0>               [{"Error",
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0>                 [{"Code","UnauthorizedOperation"},
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0>                  {"Message",
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0>                   "You are not authorized to perform this operation."}]}]},
2021-10-08 22:17:09.233639+00:00 [warn] <0.2885.0>              {"RequestID","8b108075-b2f6-49b9-b0ba-12057748b4a4"}]}]
2021-10-08 22:17:09.233739+00:00 [warn] <0.2885.0> Will retry AWS request, remaining retries: 5
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
