### PR TITLE
Fix an Erlang monitor leak when queue churn is high

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -817,8 +817,10 @@ handle_info({'DOWN', _MRef, process, QPid, Reason},
             State1 = State0#ch{queue_states = QState1},
             State = handle_queue_actions(Actions, State1),
             noreply_coalesce(State);
-        {eol, QRef} ->
-            State1 = handle_consuming_queue_down_or_eol(QRef, State0),
+        {eol, QState1, QRef} ->
+            State1 = handle_consuming_queue_down_or_eol(QRef, State0#ch{
+                queue_states = QState1
+            }),
             {ConfirmMXs, UC1} =
                 rabbit_confirms:remove_queue(QRef, State1#ch.unconfirmed),
             %% Deleted queue is a special case.
@@ -827,7 +829,7 @@ handle_info({'DOWN', _MRef, process, QPid, Reason},
                                      State1#ch{unconfirmed = UC1}),
             erase_queue_stats(QRef),
             noreply_coalesce(
-              State2#ch{queue_states = rabbit_queue_type:remove(QRef, QStates0)})
+              State2#ch{queue_states = rabbit_queue_type:remove(QRef, State2#ch.queue_states)})
     end;
 
 handle_info({'EXIT', _Pid, Reason}, State) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -398,7 +398,7 @@ handle_down(Pid, Info, #?STATE{monitor_registry = Reg0} = State0) ->
                 {ok, State, Actions} ->
                     {ok, State#?STATE{monitor_registry = Reg}, Actions};
                 eol ->
-                    {eol, QRef};
+                    {eol, State0#?STATE{monitor_registry = Reg}, QRef};
                 Err ->
                     Err
             end;


### PR DESCRIPTION
Hi,

This fixes the Pid leak in the consumer registry from #3558 when a queue is deleted. 

Related: #3558


## Types of Changes


- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
