### PR TITLE
Prometheus plugin: fix TLS port handling

### DIFF
--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -62,52 +62,53 @@
     [{datatype, integer}]}.
 {mapping, "prometheus.ssl.ip", "rabbitmq_prometheus.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
-{mapping, "prometheus.ssl.certfile", "rabbitmq_prometheus.ssl_config.certfile",
+
+{mapping, "prometheus.ssl.certfile", "rabbitmq_prometheus.ssl_config.ssl_opts.certfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
-{mapping, "prometheus.ssl.keyfile", "rabbitmq_prometheus.ssl_config.keyfile",
+{mapping, "prometheus.ssl.keyfile", "rabbitmq_prometheus.ssl_config.ssl_opts.keyfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
-{mapping, "prometheus.ssl.cacertfile", "rabbitmq_prometheus.ssl_config.cacertfile",
+{mapping, "prometheus.ssl.cacertfile", "rabbitmq_prometheus.ssl_config.ssl_opts.cacertfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
-{mapping, "prometheus.ssl.password", "rabbitmq_prometheus.ssl_config.password",
+{mapping, "prometheus.ssl.password", "rabbitmq_prometheus.ssl_config.ssl_opts.password",
     [{datatype, string}]}.
 
-{mapping, "prometheus.ssl.verify", "rabbitmq_prometheus.ssl_config.verify", [
+{mapping, "prometheus.ssl.verify", "rabbitmq_prometheus.ssl_config.ssl_opts.verify", [
     {datatype, {enum, [verify_peer, verify_none]}}]}.
 
-{mapping, "prometheus.ssl.fail_if_no_peer_cert", "rabbitmq_prometheus.ssl_config.fail_if_no_peer_cert", [
+{mapping, "prometheus.ssl.fail_if_no_peer_cert", "rabbitmq_prometheus.ssl_config.ssl_opts.fail_if_no_peer_cert", [
     {datatype, {enum, [true, false]}}]}.
 
-{mapping, "prometheus.ssl.honor_cipher_order", "rabbitmq_prometheus.ssl_config.honor_cipher_order",
+{mapping, "prometheus.ssl.honor_cipher_order", "rabbitmq_prometheus.ssl_config.ssl_opts.honor_cipher_order",
     [{datatype, {enum, [true, false]}}]}.
 
-{mapping, "prometheus.ssl.honor_ecc_order", "rabbitmq_prometheus.ssl_config.honor_ecc_order",
+{mapping, "prometheus.ssl.honor_ecc_order", "rabbitmq_prometheus.ssl_config.ssl_opts.honor_ecc_order",
     [{datatype, {enum, [true, false]}}]}.
 
-{mapping, "prometheus.ssl.reuse_sessions", "rabbitmq_prometheus.ssl_config.reuse_sessions",
+{mapping, "prometheus.ssl.reuse_sessions", "rabbitmq_prometheus.ssl_config.ssl_opts.reuse_sessions",
     [{datatype, {enum, [true, false]}}]}.
 
-{mapping, "prometheus.ssl.secure_renegotiate", "rabbitmq_prometheus.ssl_config.secure_renegotiate",
+{mapping, "prometheus.ssl.secure_renegotiate", "rabbitmq_prometheus.ssl_config.ssl_opts.secure_renegotiate",
     [{datatype, {enum, [true, false]}}]}.
 
-{mapping, "prometheus.ssl.client_renegotiation", "rabbitmq_prometheus.ssl_config.client_renegotiation",
+{mapping, "prometheus.ssl.client_renegotiation", "rabbitmq_prometheus.ssl_config.ssl_opts.client_renegotiation",
     [{datatype, {enum, [true, false]}}]}.
 
-{mapping, "prometheus.ssl.depth", "rabbitmq_prometheus.ssl_config.depth",
+{mapping, "prometheus.ssl.depth", "rabbitmq_prometheus.ssl_config.ssl_opts.depth",
     [{datatype, integer}, {validators, ["byte"]}]}.
 
-{mapping, "prometheus.ssl.versions.$version", "rabbitmq_prometheus.ssl_config.versions",
+{mapping, "prometheus.ssl.versions.$version", "rabbitmq_prometheus.ssl_config.ssl_opts.versions",
     [{datatype, atom}]}.
 
-{translation, "rabbitmq_prometheus.ssl_config.versions",
+{translation, "rabbitmq_prometheus.ssl_config.ssl_opts.versions",
 fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("prometheus.ssl.versions", Conf),
     [V || {_, V} <- Settings]
 end}.
 
-{mapping, "prometheus.ssl.ciphers.$cipher", "rabbitmq_prometheus.ssl_config.ciphers",
+{mapping, "prometheus.ssl.ciphers.$cipher", "rabbitmq_prometheus.ssl_config.ssl_opts.ciphers",
     [{datatype, string}]}.
 
-{translation, "rabbitmq_prometheus.ssl_config.ciphers",
+{translation, "rabbitmq_prometheus.ssl_config.ssl_opts.ciphers",
 fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("prometheus.ssl.ciphers", Conf),
     lists:reverse([V || {_, V} <- Settings])

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_app.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_app.erl
@@ -74,14 +74,7 @@ has_configured_listener(Key) ->
     end.
 
 get_tls_listener() ->
-    {ok, Listener0} = application:get_env(rabbitmq_prometheus, ssl_config),
-     case proplists:get_value(cowboy_opts, Listener0) of
-        undefined ->
-             [{ssl, true}, {ssl_opts, Listener0}];
-        CowboyOpts ->
-            Listener1 = lists:keydelete(cowboy_opts, 1, Listener0),
-            [{ssl, true}, {ssl_opts, Listener1}, {cowboy_opts, CowboyOpts}]
-     end.
+    [{ssl, true} | application:get_env(rabbitmq_prometheus, ssl_config, [])].
 
 get_tcp_listener() ->
     application:get_env(rabbitmq_prometheus, tcp_config, []).
@@ -111,8 +104,9 @@ ensure_port_and_protocol(tcp, Protocol, Listener) ->
     do_ensure_port_and_protocol(?DEFAULT_PORT, Protocol, Listener).
 
 do_ensure_port_and_protocol(Port, Protocol, Listener) ->
-    %% include default port if it's not provided in the config
-    %% as Cowboy won't start if the port is missing
+    %% Include default port if it's not provided in the config
+    %% as Cowboy won't start if the port is missing.
+    %% Protocol is displayed in mgmt UI and CLI output.
     M0 = maps:from_list(Listener),
     M1 = maps:merge(#{port => Port, protocol => Protocol}, M0),
     {ok, maps:to_list(M1)}.

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -144,12 +144,14 @@
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691},
-                                        {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-                                        {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
-                                        {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
-                                        {verify, verify_none},
-                                        {fail_if_no_peer_cert, false}
-                                       ]}
+                                        {ssl_opts, [
+                                          {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+                                          {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+                                          {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+                                          {verify, verify_none},
+                                          {fail_if_no_peer_cert, false}
+                                        ]}
+                                    ]}
                           ]}],
     [rabbitmq_prometheus]},
 
@@ -184,31 +186,33 @@
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691},
-                                        {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-                                        {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
-                                        {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+                                        {ssl_opts, [
+                                          {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+                                          {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+                                          {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
 
-                                        {verify, verify_peer},
-                                        {fail_if_no_peer_cert, false},
+                                          {verify, verify_peer},
+                                          {fail_if_no_peer_cert, false},
 
-                                        {honor_cipher_order,   true},
-                                        {honor_ecc_order,      true},
-                                        {client_renegotiation, false},
-                                        {secure_renegotiate,   true},
+                                          {honor_cipher_order,   true},
+                                          {honor_ecc_order,      true},
+                                          {client_renegotiation, false},
+                                          {secure_renegotiate,   true},
 
-                                        {versions,['tlsv1.2','tlsv1.1']},
-                                        {ciphers, [
-                                          "ECDHE-ECDSA-AES256-GCM-SHA384",
-                                          "ECDHE-RSA-AES256-GCM-SHA384",
-                                          "ECDHE-ECDSA-AES256-SHA384",
-                                          "ECDHE-RSA-AES256-SHA384",
-                                          "ECDH-ECDSA-AES256-GCM-SHA384",
-                                          "ECDH-RSA-AES256-GCM-SHA384",
-                                          "ECDH-ECDSA-AES256-SHA384",
-                                          "ECDH-RSA-AES256-SHA384",
-                                          "DHE-RSA-AES256-GCM-SHA384"
-                                          ]}
-                                       ]}
+                                          {versions,['tlsv1.2','tlsv1.1']},
+                                          {ciphers, [
+                                            "ECDHE-ECDSA-AES256-GCM-SHA384",
+                                            "ECDHE-RSA-AES256-GCM-SHA384",
+                                            "ECDHE-ECDSA-AES256-SHA384",
+                                            "ECDHE-RSA-AES256-SHA384",
+                                            "ECDH-ECDSA-AES256-GCM-SHA384",
+                                            "ECDH-RSA-AES256-GCM-SHA384",
+                                            "ECDH-ECDSA-AES256-SHA384",
+                                            "ECDH-RSA-AES256-SHA384",
+                                            "DHE-RSA-AES256-GCM-SHA384"
+                                            ]}
+                                         ]}
+                                      ]}
                           ]}],
     [rabbitmq_prometheus]},
 


### PR DESCRIPTION
## Proposed Changes

Fixes #2975

All ssl options were stored in the same proplist, and the code was then trying to determine whether an option actually belongs to ranch ssl options or not.

Some keys landed in the wrong place, like it did happen in #2975 - different ports were mentioned in listener config (default at
top-level, and non-default in `ssl_opts`). Then `ranch` and `rabbitmq_web_dispatch` were treating this situation differently.

This change just moves all ranch ssl opts into proper place using schema, removing any need for guessing in code.

This is breaking change when advanced config format was used to configure prometheus plugin SSL listener.

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
