### PR TITLE
Fix RabbitMQ Streams protocol documentation

### DIFF
--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -227,7 +227,7 @@ DeclarePublisherRequest => Key Version CorrelationId PublisherId [PublisherRefer
   PublisherReference => string // max 256 characters
   Stream => string
 
-DeclarePublisherResponse => Key Version CorrelationId ResponseCode PublisherId
+DeclarePublisherResponse => Key Version CorrelationId ResponseCode
   Key => uint16 // 1
   Version => uint16
   CorrelationId => uint32
@@ -491,12 +491,14 @@ SaslHandshakeRequest => Key Version CorrelationId Mechanism
   Key => uint16 // 18
   Version => uint16
   CorrelationId => uint32
+  Mechanism => string
 
-SaslHandshakeResponse => Key Version CorrelationId ResponseCode [Mechanism]
+SaslHandshakeResponse => Key Version CorrelationId ResponseCode [Mechanisms]
   Key => uint16 // 18
   Version => uint16
   CorrelationId => uint32
   ResponseCode => uint16
+  Mechanisms => [Mechanism]
   Mechanism => string
 ```
 


### PR DESCRIPTION
1. Response for publisher declaration request does not contain
   publisher id.

2. Add mechanism entry to the details of SASL handshake request.

3. SASL handshake response contains list of mechanisms, not just single
   mechanism.
