### PR TITLE
Turn down logging from queue rebalancing

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -511,11 +511,11 @@ maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
                     {not_migrated, update_not_migrated_queue(N, Queue, Queues, ByNode)};
                 _ ->
                     [{Length, Destination} | _] = sort_by_number_of_queues(Candidates, ByNode),
-                    rabbit_log:warning("Migrating queue ~p from node ~p with ~p queues to node ~p with ~p queues",
+                    rabbit_log:info("Migrating queue ~p from node ~p with ~p queues to node ~p with ~p queues",
                                        [Name, N, length(All), Destination, Length]),
                     case Module:transfer_leadership(Q, Destination) of
                         {migrated, NewNode} ->
-                            rabbit_log:warning("Queue ~p migrated to ~p", [Name, NewNode]),
+                            rabbit_log:info("Queue ~p migrated to ~p", [Name, NewNode]),
                             {migrated, update_migrated_queue(Destination, N, Queue, Queues, ByNode)};
                         {not_migrated, Reason} ->
                             rabbit_log:warning("Error migrating queue ~p: ~p", [Name, Reason]),
@@ -527,7 +527,7 @@ maybe_migrate(ByNode, MaxQueuesDesired, [N | Nodes]) ->
                                "Do nothing", [N, length(All)]),
             maybe_migrate(ByNode, MaxQueuesDesired, Nodes);
         All ->
-            rabbit_log:warning("Node ~p only contains ~p queues, do nothing",
+            rabbit_log:debug("Node ~p only contains ~p queues, do nothing",
                                [N, length(All)]),
             maybe_migrate(ByNode, MaxQueuesDesired, Nodes)
     end.


### PR DESCRIPTION
With many queues, rebalancing can log hundreds of lines at warning/info
level, even though nothing exciting happened. I think we can tune that
down - if there is nothing to do - that's a debug level,
if things go well - that's info, not a warning.

I labeled it for backporting to 3.8 and 3.9 but feel free to change that.