### PR TITLE
Comment-out code_reload

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -20,6 +20,6 @@ include_dirs:
 # macros:
 #   - name: DEFINED_WITH_VALUE
 #     value: 42
-code_reload:
-  node: rabbit@localhost
+# code_reload:
+#  node: rabbit@localhost
 plt_path: .rabbitmq_server_release.plt


### PR DESCRIPTION
If RabbitMQ is not running, `erlang_ls` returns `nodedown` which is shown in your text editor console.