### PR TITLE
Tweak more erlang_ls settings

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,14 +1,17 @@
+# vim: ft=yaml
+# https://erlang-ls.github.io/configuration/
 # otp_path: "/path/to/otp/lib/erlang"
 deps_dirs:
   - "deps/*"
   - "deps/rabbit/apps/*"
 diagnostics:
-  disabled: []
+  # disabled:
+  #   - bound_var_in_pattern
   enabled:
     - crossref
     - dialyzer
-    - elvis
     - compiler
+    # - elvis
 include_dirs:
   - "deps"
   - "deps/*/include"


### PR DESCRIPTION
As suggested in #3647:

* Add commented-out section to disable bound_var_in_pattern should someone like to disable that.
* Comment-out `elvis` as that is not yet a standard used by the team.

cc @kjnilsson @mkuratczyk