### PR TITLE
Expose pending enqueues in quorum queue overview

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -589,7 +589,7 @@ handle_ra_event(Leader, {machine, leader_change}, State0) ->
     %% we need to update leader
     %% and resend any pending commands
     State = resend_all_pending(State0#state{leader = Leader}),
-    {ok, State, []};
+    {ok, cancel_timer(State), []};
 handle_ra_event(_From, {rejected, {not_leader, undefined, _Seq}}, State0) ->
     % TODO: how should these be handled? re-sent on timer or try random
     {ok, State0, []};


### PR DESCRIPTION
Expose pending enqueues in overview output to allow
debugging of situation where messages may be stuck.

Also cancel rabbit_fifo_client timer after message resend to avoid
resending them again when the timer triggers.