### PR TITLE
Adopt the new buildbuddy remote execution url

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,15 +2,15 @@ build --incompatible_strict_action_env
 build --local_test_jobs=1
 
 build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
-build:buildbuddy --bes_backend=grpcs://cloud.buildbuddy.io
-build:buildbuddy --remote_cache=grpcs://cloud.buildbuddy.io
+build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
+build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_timeout=1200
 build:buildbuddy --grpc_keepalive_time=30s
 build:buildbuddy --build_metadata=REPO_URL=https://github.com/rabbitmq/rabbitmq-server.git
 
 build:rbe --config=buildbuddy
 
-build:rbe --remote_executor=grpcs://cloud.buildbuddy.io
+build:rbe --remote_executor=grpcs://remote.buildbuddy.io
 
 build:rbe --crosstool_top=@buildbuddy_toolchain//:toolchain
 build:rbe --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -19,11 +19,8 @@ jobs:
       uses: actions/checkout@v2.4.0
     - name: CONFIGURE BAZEL
       run: |
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${CACHE_NAME}
@@ -48,11 +45,8 @@ jobs:
       uses: actions/checkout@v2.4.0
     - name: CONFIGURE BAZEL
       run: |
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${CACHE_NAME}

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -29,11 +29,8 @@ jobs:
         wait-interval: 30 # seconds
     - name: CONFIGURE BAZEL
       run: |
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -26,11 +26,8 @@ jobs:
           //:erlang_git_platform
     - name: CONFIGURE BAZEL
       run: |
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -37,11 +37,8 @@ jobs:
       uses: actions/checkout@v2.4.0
     - name: CONFIGURE BAZEL
       run: |
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
@@ -76,11 +73,8 @@ jobs:
       run: |
         ERLANG_HOME="$(dirname $(dirname $(which erl)))"
         ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,11 +29,8 @@ jobs:
       uses: actions/checkout@v2.4.0
     - name: CONFIGURE BAZEL
       run: |
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
@@ -70,11 +67,8 @@ jobs:
       run: |
         ERLANG_HOME="$(dirname $(dirname $(which erl)))"
         ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
-        echo "${{ secrets.BUILDBUDDY_CERT }}" > buildbuddy-cert.pem
-        echo "${{ secrets.BUILDBUDDY_KEY }}" > buildbuddy-key.pem
         cat << EOF >> user.bazelrc
-          build:buildbuddy --tls_client_certificate=buildbuddy-cert.pem
-          build:buildbuddy --tls_client_key=buildbuddy-key.pem
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE


### PR DESCRIPTION
Buildbuddy reached out and expects it should be more reliable