### PR TITLE
Update link in comment

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_app.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap_app.erl
@@ -10,7 +10,8 @@
 -behaviour(application).
 -export([start/2, stop/1]).
 
-%% Dummy supervisor to get this application behaviour working
+%% Dummy supervisor - see Ulf Wiger's comment at
+%% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
 -behaviour(supervisor).
 -export([create_ldap_pool/0, init/1]).
 

--- a/deps/rabbitmq_auth_mechanism_ssl/src/rabbit_auth_mechanism_ssl_app.erl
+++ b/deps/rabbitmq_auth_mechanism_ssl/src/rabbit_auth_mechanism_ssl_app.erl
@@ -11,7 +11,7 @@
 -export([start/2, stop/1]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
-%% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
+%% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
 
 -behaviour(supervisor).
 -export([init/1]).

--- a/deps/rabbitmq_federation/src/rabbit_federation_app.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_app.erl
@@ -13,7 +13,7 @@
 -export([start/2, stop/1]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
-%% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
+%% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
 
 %% All of our actual server processes are supervised by
 %% rabbit_federation_sup, which is started by a rabbit_boot_step

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
@@ -17,7 +17,7 @@
 ]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
-%% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
+%% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
 -behaviour(supervisor).
 -export([init/1]).
 

--- a/deps/rabbitmq_web_mqtt_examples/src/rabbit_web_mqtt_examples_app.erl
+++ b/deps/rabbitmq_web_mqtt_examples/src/rabbit_web_mqtt_examples_app.erl
@@ -11,7 +11,7 @@
 -export([start/2,stop/1]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
-%% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
+%% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
 -behaviour(supervisor).
 -export([init/1]).
 

--- a/deps/rabbitmq_web_stomp_examples/src/rabbit_web_stomp_examples_app.erl
+++ b/deps/rabbitmq_web_stomp_examples/src/rabbit_web_stomp_examples_app.erl
@@ -11,7 +11,7 @@
 -export([start/2,stop/1]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
-%% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
+%% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
 -behaviour(supervisor).
 -export([init/1]).
 


### PR DESCRIPTION
It is a useful comment, so update all the links to the correct place on the internet:
http://erlang.org/pipermail/erlang-questions/2010-April/050508.html

I'm updating rabbitmq-email to use the new boot steps and while investigating how other plugins do it I came across this stale link (https://github.com/gotthardp/rabbitmq-email/pull/46)