### PR TITLE
Increase some buildbuddy rbe timeouts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,7 +5,8 @@ build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
 build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_timeout=1200
-build:buildbuddy --grpc_keepalive_time=30s
+build:buildbuddy --grpc_keepalive_time=360s
+build:buildbuddy --grpc_keepalive_timeout=360s
 build:buildbuddy --build_metadata=REPO_URL=https://github.com/rabbitmq/rabbitmq-server.git
 
 build:rbe --config=buildbuddy


### PR DESCRIPTION
We have some timeouts in CI between the GitHub Actions worker and BuildBuddy. This should help.