### PR TITLE
Avoid slow mnesia transaction on QQ init

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -7,6 +7,7 @@
 
 -module(rabbit_amqqueue).
 
+-export([store_queue_ram_dirty/1]).
 -export([warn_file_limit/0]).
 -export([recover/1, stop/1, start/1, declare/6, declare/7,
          delete_immediately/1, delete_exclusive/2, delete/4, purge/1,
@@ -329,6 +330,9 @@ store_queue(Q) when not ?amqqueue_is_durable(Q) ->
 
 store_queue_ram(Q) ->
     ok = mnesia:write(rabbit_queue, rabbit_queue_decorator:set(Q), write).
+
+store_queue_ram_dirty(Q) ->
+    ok = mnesia:dirty_write(rabbit_queue, rabbit_queue_decorator:set(Q)).
 
 -spec update_decorators(name()) -> 'ok'.
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -569,7 +569,8 @@ recover(_Vhost, Queues) ->
          %% present in the rabbit_queue table and not just in
          %% rabbit_durable_queue
          %% So many code paths are dependent on this.
-         {ok, Q} = rabbit_amqqueue:ensure_rabbit_queue_record_is_initialized(Q0),
+         ok = rabbit_amqqueue:store_queue_ram_dirty(Q0),
+         Q = Q0,
          case Res of
              ok ->
                  {[Q | R0], F0};


### PR DESCRIPTION
As we only need to make sure the rabbit_queues table is populated
use a dirty write function that only does this instead. This could potentially
half recovery times for many QQ scenarios.
