### PR TITLE
Use externailzed rbe config in bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,38 +14,25 @@ build:rbe --config=buildbuddy
 
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io
 
-build:rbe --crosstool_top=@buildbuddy_toolchain//:toolchain
-build:rbe --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain
-build:rbe --javabase=@buildbuddy_toolchain//:javabase_jdk8
-build:rbe --host_javabase=@buildbuddy_toolchain//:javabase_jdk8
-build:rbe --java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
-build:rbe --host_java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
+build:rbe --host_javabase=@rbe_default//java:jdk
+build:rbe --javabase=@rbe_default//java:jdk
+build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --crosstool_top=@rbe_default//cc:toolchain
+build:rbe --extra_toolchains=@rbe_default//config:cc-toolchain
+build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
+build:rbe --host_platform=@rbe_default//config:platform
+build:rbe --platforms=@rbe_default//config:platform
+build:rbe --extra_execution_platforms=@rbe_default//config:platform
+
+build:rbe --@bazel-erlang//:erlang_version=24
 build:rbe --@bazel-erlang//:erlang_home=/usr/lib/erlang
 build:rbe --//:elixir_home=/usr/local
 
 build:rbe --spawn_strategy=remote
 build:rbe --test_strategy=""
-build:rbe --jobs=50
-
-build:rbe-23 --config=rbe
-build:rbe-23 --host_platform=//:erlang_23_platform
-build:rbe-23 --platforms=//:erlang_23_platform
-build:rbe-23 --extra_execution_platforms=//:erlang_23_platform
-build:rbe-23 --@bazel-erlang//:erlang_version=23
-
-build:rbe-24 --config=rbe
-build:rbe-24 --host_platform=//:erlang_24_platform
-build:rbe-24 --platforms=//:erlang_24_platform
-build:rbe-24 --extra_execution_platforms=//:erlang_24_platform
-build:rbe-24 --@bazel-erlang//:erlang_version=24
-
-build:rbe-git --config=rbe
-build:rbe-git --host_platform=//:erlang_git_platform
-build:rbe-git --platforms=//:erlang_git_platform
-build:rbe-git --extra_execution_platforms=//:erlang_git_platform
-build:rbe-git --@bazel-erlang//:erlang_home=/usr/local/lib/erlang
-build:rbe-git --@bazel-erlang//:erlang_version=25
+build:rbe --jobs=100
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -6,29 +6,41 @@ on:
         description: 'A bazel label representing the test target'
         required: true
         default: '//deps/rabbit:rabbit_stream_queue_SUITE'
-env:
-  ERLANG_MAJOR: "24"
-  CACHE_NAME: ci-bazel-cache-analysis
 jobs:
   run-a:
     name: Run A
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        erlang_version:
+        - "24"
+        include:
+        - erlang_version: "24"
+          rbe_default_branch: linux-erlang-24.1
+          cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
+    - name: SELECT ERLANG VERSION
+      run: |
+        sudo npm install --global --silent @bazel/buildozer
+        echo "$(cat WORKSPACE.bazel | npx buildozer 'set branch "${{ matrix.rbe_default_branch }}"' -:rbe_default)" > WORKSPACE.bazel
+        git diff
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
           build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
-          build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${CACHE_NAME}
+          build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.cache_name }}
+
+          build:rbe --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
         EOF
     - name: RUN TESTS
       run: |
         bazelisk test ${{ github.event.inputs.target }} \
-          --config=rbe-${ERLANG_MAJOR} \
+          --config=rbe \
           --execution_log_binary_file=/tmp/exec.log
     - name: SAVE EXECUTION LOG BINARY
       uses: actions/upload-artifact@v2-preview
@@ -39,22 +51,37 @@ jobs:
     name: Run B
     needs: run-a
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        erlang_version:
+        - "24"
+        include:
+        - erlang_version: "24"
+          rbe_default_branch: linux-erlang-24.1
+          cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
+    - name: SELECT ERLANG VERSION
+      run: |
+        sudo npm install --global --silent @bazel/buildozer
+        echo "$(cat WORKSPACE.bazel | npx buildozer 'set branch "${{ matrix.rbe_default_branch }}"' -:rbe_default)" > WORKSPACE.bazel
+        git diff
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
           build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
 
           build:buildbuddy --build_metadata=ROLE=CI
-          build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${CACHE_NAME}
+          build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.cache_name }}
+
+          build:rbe --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
         EOF
     - name: RUN TESTS
       run: |
         bazelisk test ${{ github.event.inputs.target }} \
-          --config=rbe-${ERLANG_MAJOR} \
+          --config=rbe \
           --execution_log_binary_file=/tmp/exec.log
     - name: SAVE EXECUTION LOG BINARY
       uses: actions/upload-artifact@v2-preview

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -16,6 +16,7 @@ jobs:
         include:
         - image_tag_suffix: otp-max
           erlang_version: "24"
+          rbe_default_branch: linux-erlang-24.1
     timeout-minutes: 45
     steps:
     - name: CHECKOUT REPOSITORY
@@ -27,6 +28,11 @@ jobs:
         check-name: build-publish-dev (${{ matrix.image_tag_suffix }})
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30 # seconds
+    - name: SELECT ERLANG VERSION
+      run: |
+        sudo npm install --global --silent @bazel/buildozer
+        echo "$(cat WORKSPACE.bazel | npx buildozer 'set branch "${{ matrix.rbe_default_branch }}"' -:rbe_default)" > WORKSPACE.bazel
+        git diff
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -35,6 +41,8 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-aws-${{ matrix.erlang_version }}
+
+          build:rbe --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
@@ -42,7 +50,7 @@ jobs:
       run: |
         branch_or_tag="${GITHUB_REF##*/}"
         bazelisk test //deps/rabbitmq_peer_discovery_aws:integration_SUITE \
-          --config=rbe-${{ matrix.erlang_version }} \
+          --config=rbe \
           --test_tag_filters=aws \
           --build_tests_only \
           --test_env AWS_ACCESS_KEY_ID=${{ secrets.CONCOURSE_AWS_ACCESS_KEY_ID }} \

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -32,6 +32,19 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-erlang-git
+
+          build:rbe-git --crosstool_top=@buildbuddy_toolchain//:toolchain
+          build:rbe-git --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain
+          build:rbe-git --javabase=@buildbuddy_toolchain//:javabase_jdk8
+          build:rbe-git --host_javabase=@buildbuddy_toolchain//:javabase_jdk8
+          build:rbe-git --java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
+          build:rbe-git --host_java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
+
+          build:rbe-git --host_platform=//:erlang_git_platform
+          build:rbe-git --platforms=//:erlang_git_platform
+          build:rbe-git --extra_execution_platforms=//:erlang_git_platform
+          build:rbe-git --@bazel-erlang//:erlang_home=/usr/local/lib/erlang
+          build:rbe-git --@bazel-erlang//:erlang_version=25
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -31,10 +31,20 @@ jobs:
         erlang_version:
         - "23"
         - "24"
+        include:
+        - erlang_version: "23"
+          rbe_default_branch: linux-erlang-23.3
+        - erlang_version: "24"
+          rbe_default_branch: linux-erlang-24.1
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
+    - name: SELECT ERLANG VERSION
+      run: |
+        sudo npm install --global --silent @bazel/buildozer
+        echo "$(cat WORKSPACE.bazel | npx buildozer 'set branch "${{ matrix.rbe_default_branch }}"' -:rbe_default)" > WORKSPACE.bazel
+        git diff
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -43,13 +53,15 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.erlang_version }}
+
+          build:rbe --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
     - name: RUN TESTS
       run: |
         bazelisk test //... \
-          --config=rbe-${{ matrix.erlang_version }} \
+          --config=rbe \
           --test_tag_filters=mixed-version-cluster,-exclusive,-aws \
           --verbose_failures
   test-exclusive-mixed-versions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,10 +23,20 @@ jobs:
         erlang_version:
         - "23"
         - "24"
+        include:
+        - erlang_version: "23"
+          rbe_default_branch: linux-erlang-23.3
+        - erlang_version: "24"
+          rbe_default_branch: linux-erlang-24.1
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
+    - name: SELECT ERLANG VERSION
+      run: |
+        sudo npm install --global --silent @bazel/buildozer
+        echo "$(cat WORKSPACE.bazel | npx buildozer 'set branch "${{ matrix.rbe_default_branch }}"' -:rbe_default)" > WORKSPACE.bazel
+        git diff
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -35,6 +45,8 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.erlang_version }}
+
+          build:rbe --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
         EOF
 
         bazelisk info release
@@ -43,7 +55,7 @@ jobs:
     - name: RUN TESTS
       run: |
         bazelisk test //... \
-          --config=rbe-${{ matrix.erlang_version }} \
+          --config=rbe \
           --test_tag_filters=-exclusive,-aws,-mixed-version-cluster \
           --verbose_failures
   test-exclusive:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,34 +19,6 @@ elixir_home(
 )
 
 platform(
-    name = "erlang_23_platform",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-        "@bazel_tools//tools/cpp:clang",
-    ],
-    exec_properties = {
-        "OSFamily": "Linux",
-        # linux-erlang-23.3
-        "container-image": "docker://pivotalrabbitmq/rabbitmq-server-buildenv@sha256:5de95518e8d5f3724839ad46e450b80d89cb0e7e546872a63b7ce4fd482a696e",
-    },
-)
-
-platform(
-    name = "erlang_24_platform",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-        "@bazel_tools//tools/cpp:clang",
-    ],
-    exec_properties = {
-        "OSFamily": "Linux",
-        # linux-erlang-24.0
-        "container-image": "docker://pivotalrabbitmq/rabbitmq-server-buildenv@sha256:52a81330352656180952e9c3f09e510a529cc0ed4fd6bc3b480ad313f2ddc3ae",
-    },
-)
-
-platform(
     name = "erlang_git_platform",
     constraint_values = [
         "@platforms//os:linux",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -14,7 +14,16 @@ buildbuddy_deps()
 
 load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
 
-buildbuddy(name = "buildbuddy_toolchain")
+buildbuddy(
+    name = "buildbuddy_toolchain",
+    llvm = True,
+)
+
+git_repository(
+    name = "rbe_default",
+    branch = "linux-erlang-24.1",
+    remote = "https://github.com/rabbitmq/rbe-erlang-platform.git",
+)
 
 http_archive(
     name = "rules_pkg",


### PR DESCRIPTION
This moves from the embedded `erlang_23_platform` and `erlang_24_platform` used for Bazel remote execution to more complete platform definitions generated with https://github.com/bazelbuild/bazel-toolchains. These configs are based 

This serves 2 purposes:
1. Provide a properly configured C compiler (clang) so that nifs can be compiled (if present)
2. Relieve some of our other projects from an artificial dependency on this repo

Note: The `erlang_git_platform` platform definition remains embedded for now, as it's updated just in time for use in the GitHub Actions workflow that tests against the Erlang master branch. For now externalizing that definition is more trouble that it's worth.