### PR TITLE
Set core_started before running postlaunch phase

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -913,8 +913,8 @@ start(normal, []) ->
         ?LOG_DEBUG("== Boot steps =="),
 
         ok = rabbit_boot_steps:run_boot_steps([rabbit | Plugins]),
-        run_postlaunch_phase(Plugins),
         rabbit_boot_state:set(core_started),
+        run_postlaunch_phase(Plugins),
         {ok, SupPid}
     catch
         throw:{error, _} = Error ->


### PR DESCRIPTION
Since the postlaunch phase is async there is a slight chance that rabbit_direct connections will not see core_started if attempted during postlaunch.

I have confirmed this fixes the startup issue found while bringing `gotthardp/rabbitmq-email` up-to-date:

https://github.com/gotthardp/rabbitmq-email/pull/46

I'll be doing more testing using the above changes before setting this PR to ready.

Also, I suspect this change will fix the following message seen in a customer's log files during RabbitMQ's boot sequence (version 3.8.8):

```
2021-11-07 15:52:13.525 [error] <0.20653.0> ** Generic server <0.20653.0> terminating
** Last message in was {tcp,#Port<0.75>,<<16,40,0,4,77,81,84,84,4,194,0,0,0,0,0,14,115,118,99,46,99,100,99,112,117,98,46,112,114,100,0,10,115,102,51,50,104,120,113,36,83,77>>}
** When Server state == {state,#Port<0.75>,"10.10.128.3:1883 -> 10.10.128.33:1883",true,undefined,false,running,{none,none},<0.20652.0>,false,none,{proc_state,#Port<0.75>,#{},{undefined,undefined},{0,nil},{0,nil},undefined,1,undefined,undefined,undefined,{undefined,undefined},undefined,<<"amq.topic">>,{amqp_adapter_info,{0,0,0,0,0,65535,2570,32801},1883,{0,0,0,0,0,65535,2570,32771},1883,<<"10.10.128.3:1883 -> 10.10.128.33:1883">>,{'MQTT',"N/A"},[{channels,1},{channel_max,1},{frame_max,0},{client_properties,[{<<"product">>,longstr,<<"MQTT client">>}]},{ssl,false}]},none,undefined,undefined,#Fun<rabbit_mqtt_processor.0.70426639>,{0,0,0,0,0,65535,2570,32771},#Fun<rabbit_mqtt_util.4.100928214>,#Fun<rabbit_mqtt_util.5.100928214>,undefined},undefined,{state,fine,60000,undefined}}
** Reason for termination == 
** {{case_clause,{error,broker_not_found_on_node}},[{rabbit_mqtt_processor,process_login,4,[{file,"src/rabbit_mqtt_processor.erl"},{line,552}]},{rabbit_mqtt_processor,process_request,3,[{file,"src/rabbit_mqtt_processor.erl"},{line,129}]},{rabbit_mqtt_processor,process_frame,2,[{file,"src/rabbit_mqtt_processor.erl"},{line,69}]},{rabbit_mqtt_reader,process_received_bytes,2,[{file,"src/rabbit_mqtt_reader.erl"},{line,303}]},{gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1067}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}
2021-11-07 15:52:13.525 [info] <0.20653.0> [{initial_call,{rabbit_mqtt_reader,init,['Argument__1']}},{pid,<0.20653.0>},{registered_name,[]},{error_info,{exit,{{case_clause,{error,broker_not_found_on_node}},[{rabbit_mqtt_processor,process_login,4,[{file,"src/rabbit_mqtt_processor.erl"},{line,552}]},{rabbit_mqtt_processor,process_request,3,[{file,"src/rabbit_mqtt_processor.erl"},{line,129}]},{rabbit_mqtt_processor,process_frame,2,[{file,"src/rabbit_mqtt_processor.erl"},{line,69}]},{rabbit_mqtt_reader,process_received_bytes,2,[{file,"src/rabbit_mqtt_reader.erl"},{line,303}]},{gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1067}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]},[{gen_server2,terminate,3,[{file,"src/gen_server2.erl"},{line,1183}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}},{ancestors,[<0.20651.0>,<0.20381.0>,<0.20380.0>,<0.20379.0>,rabbit_mqtt_sup,<0.20349.0>]},{message_queue_len,0},{messages,[]},{links,[<0.20651.0>,#Port<0.75>]},{dictionary,[{guid_secure,{{1,'rabbit@iot-plz-rcvr01',#Ref<0.3344525485.2251030531.16317>},0}},{gen_server_call_timeout,60000},{rand_seed,{#{jump => #Fun<rand.3.47293030>,max => 288230376151711743,next => #Fun<rand.5.47293030>,type => exsplus},[123122518957753202|237093961954278786]}}]},{trap_exit,true},{status,running},{heap_size,1598},{stack_size,28},{reductions,7693}], []
2021-11-07 15:52:13.525 [error] <0.20653.0> CRASH REPORT Process <0.20653.0> with 0 neighbours exited with reason: no case clause matching {error,broker_not_found_on_node} in rabbit_mqtt_processor:process_login/4 line 552 in gen_server2:terminate/3 line 1183
```