### PR TITLE
Add --remote_download_toplevel to the bazel config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,7 @@ build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_timeout=1200
 build:buildbuddy --grpc_keepalive_time=360s
 build:buildbuddy --grpc_keepalive_timeout=360s
+build:buildbuddy --remote_download_toplevel
 build:buildbuddy --build_metadata=REPO_URL=https://github.com/rabbitmq/rabbitmq-server.git
 
 build:rbe --config=buildbuddy


### PR DESCRIPTION
Based on the testing and advice from BuildBuddy:

Network limitations/flakiness in GitHub actions can be mitigated by
reducing the number of artifacts that get downloaded. Since we only
use bazel for testing currently, we don't actually care about the
artifacts, so there is no downside to the flag.

If this isn't enough, we can try the --remote_download_minimal flag,
which limits the amount of downloads even further.