### PR TITLE
Generate the rabbitmqadmin cli under bazel

### DIFF
--- a/deps/rabbitmq_management/BUILD.bazel
+++ b/deps/rabbitmq_management/BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel-erlang//:xref.bzl", "xref")
 load("@bazel-erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
+    "APP_VERSION",
     "RABBITMQ_DIALYZER_OPTS",
     "assert_suites",
     "broker_for_integration_suites",
@@ -54,12 +55,23 @@ RUNTIME_DEPS = [
     "@cowlib//:bazel_erlang_lib",
 ]
 
+genrule(
+    name = "rabbitmqadmin",
+    srcs = ["bin/rabbitmqadmin"],
+    outs = ["priv/www/cli/rabbitmqadmin"],
+    cmd = """set -euxo pipefail
+
+sed 's/%%VSN%%/{}/' $< > $@
+""".format(APP_VERSION),
+)
+
 rabbitmq_lib(
     app_description = APP_DESCRIPTION,
     app_env = APP_ENV,
     app_module = APP_MODULE,
     app_name = APP_NAME,
     extra_apps = EXTRA_APPS,
+    extra_priv = [":rabbitmqadmin"],
     first_srcs = FIRST_SRCS,
     runtime_deps = RUNTIME_DEPS,
     deps = DEPS,

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -49,6 +49,7 @@ def rabbitmq_lib(
         erlc_opts = RABBITMQ_ERLC_OPTS,
         test_erlc_opts = RABBITMQ_TEST_ERLC_OPTS,
         first_srcs = [],
+        extra_priv = [],
         build_deps = [],
         deps = [],
         runtime_deps = []):
@@ -60,6 +61,7 @@ def rabbitmq_lib(
         app_registered = app_registered,
         app_env = app_env,
         extra_apps = extra_apps,
+        extra_priv = extra_priv,
         erlc_opts = erlc_opts,
         first_srcs = first_srcs,
         build_deps = build_deps,
@@ -75,6 +77,7 @@ def rabbitmq_lib(
         app_registered = app_registered,
         app_env = app_env,
         extra_apps = extra_apps,
+        extra_priv = extra_priv,
         erlc_opts = test_erlc_opts,
         first_srcs = first_srcs,
         build_deps = with_test_versions(build_deps),


### PR DESCRIPTION
There was a rule for generating `priv/www/cli/rabbitmqadmin` under make, but it had been missed up until now with bazel