### PR TITLE
Fix description of "deliver" command in RabbitMQ Streams protocol documentation

### DIFF
--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -327,17 +327,21 @@ Subscribe => Key Version CorrelationId SubscriptionId Stream OffsetSpecification
 ```
 Deliver => Key Version SubscriptionId OsirisChunk
   Key => uint16 // 0x0008
-  Version => uint32
+  Version => uint16
   SubscriptionId => uint8
   OsirisChunk => MagicVersion NumEntries NumRecords Epoch ChunkFirstOffset ChunkCrc DataLength Messages
   MagicVersion => int8
+  ChunkType => int8 // 0: user, 1: tracking delta, 2: tracking snapshot
   NumEntries => uint16
   NumRecords => uint32
+  Timestamp => int64 // in milliseconds, since epoch
   Epoch => uint64
   ChunkFirstOffset => uint64
   ChunkCrc => int32
   DataLength => uint32
-  Messages => [Message] // no int32 for the size for this array
+  TrailerLength => uint32
+  Reserved => unit32 // unused 4 bytes
+  Messages => [Message] // no int32 for the size for this array; the size is defined by NumEntries field above
   Message => EntryTypeAndSize
   Data => bytes
 ```


### PR DESCRIPTION
Add missing fields - chunk type, timestamp, trailer length and reserved.
The fields are added after looking at

- https://github.com/rabbitmq/rabbitmq-stream-java-client/blob/3fd348d2250c6b9a55d9c0a968d63fe04f46e4b6/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java#L267
- https://github.com/qweeze/rstream/blob/master/rstream/schema.py#L376

Change type of "version" field - it shall be uint16 like in other
commands.
