### PR TITLE
Use --remote_download_minimal and Actions Cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_timeout=1200
 build:buildbuddy --grpc_keepalive_time=360s
 build:buildbuddy --grpc_keepalive_timeout=360s
-build:buildbuddy --remote_download_toplevel
+build:buildbuddy --remote_download_minimal
 build:buildbuddy --build_metadata=REPO_URL=https://github.com/rabbitmq/rabbitmq-server.git
 
 build:rbe --config=buildbuddy

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -32,6 +32,11 @@ jobs:
         check-name: build-publish-dev (${{ matrix.image_tag_suffix }})
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 30 # seconds
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -40,6 +45,9 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-aws-${{ matrix.erlang_version }}
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -24,6 +24,11 @@ jobs:
         npx buildozer \
           "dict_set exec_properties container-image:docker://${IMAGE}@${DIGEST}" \
           //:erlang_git_platform
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -32,6 +37,9 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-erlang-git
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
 
           build:rbe-git --crosstool_top=@buildbuddy_toolchain//:toolchain
           build:rbe-git --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-erlang-git:
     name: Test (Erlang Git Master)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   test-mixed-versions:
     name: Test (Mixed Version Cluster)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +55,7 @@ jobs:
           --verbose_failures
   test-exclusive-mixed-versions:
     name: Test (Exclusive Tests with Mixed Version Cluster)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         erlang_version:

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -35,6 +35,11 @@ jobs:
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -43,6 +48,9 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.erlang_version }}
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
@@ -70,6 +78,11 @@ jobs:
       with:
         otp-version: ${{ matrix.erlang_version }}
         elixir-version: 1.11.4
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache
     - name: CONFIGURE BAZEL
       run: |
         ERLANG_HOME="$(dirname $(dirname $(which erl)))"
@@ -80,6 +93,9 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-exclusive-${{ matrix.erlang_version }}
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
 
           build --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
           build --@bazel-erlang//:erlang_home=${ERLANG_HOME}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,7 @@ jobs:
           --verbose_failures
   test-exclusive:
     name: Test (Exclusive Tests)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         erlang_version:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,11 @@ jobs:
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v2.4.0
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache
     - name: CONFIGURE BAZEL
       run: |
         cat << EOF >> user.bazelrc
@@ -35,6 +40,9 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-${{ matrix.erlang_version }}
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
         EOF
 
         bazelisk info release
@@ -64,6 +72,11 @@ jobs:
       with:
         otp-version: ${{ matrix.erlang_version }}
         elixir-version: 1.11.4
+    - name: MOUNT BAZEL CACHE
+      uses: actions/cache@v1
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache
     - name: CONFIGURE BAZEL
       run: |
         ERLANG_HOME="$(dirname $(dirname $(which erl)))"
@@ -74,6 +87,9 @@ jobs:
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
           build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-exclusive-${{ matrix.erlang_version }}
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
 
           build --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
           build --@bazel-erlang//:erlang_home=${ERLANG_HOME}


### PR DESCRIPTION
We are still seeing many network flakes from GitHub Actions. Attempting to further reduce them with:
- use `--remote_download_minimal` instead of `--remote_download_toplevel`
- use the GitHub Actions `cache` action