### PR TITLE
Fixup the "Failed to symlink private_log directory." error in bazel

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -607,8 +607,11 @@ get_selection(Config) ->
 
 
 symlink_priv_dir(Config) ->
-    case os:type() of
-        {win32, _} ->
+    case {os:type(), ?config(rabbitmq_run_cmd, Config)} of
+        {{win32, _}, _} ->
+            Config;
+        {_, Cmd} when Cmd =/= undefined ->
+            %% skip if bazel
             Config;
         _ ->
             SrcDir = ?config(current_srcdir, Config),


### PR DESCRIPTION
While it doesn't cause any tests to fail, it's confusing to see it in the logs