### PR TITLE
Distribution listener settings support in rabbitmq.conf

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1803,6 +1803,37 @@ end}.
     {validators, ["non_zero_positive_integer"]}
 ]}.
 
+{mapping, "distribution.listener.port_range.min", "kernel.inet_dist_listen_min", [
+    {datatype, [integer]},
+    {validators, ["non_zero_positive_integer"]}
+]}.
+
+{mapping, "distribution.listener.port_range.max", "kernel.inet_dist_listen_max", [
+    {datatype, [integer]},
+    {validators, ["non_zero_positive_integer"]}
+]}.
+
+{mapping, "distribution.listener.interface", "kernel.inet_dist_use_interface", [
+    {datatype, [string]},
+    {validators, ["is_ip"]}
+]}.
+
+{translation, "kernel.inet_dist_use_interface",
+    fun(Conf) ->
+            case cuttlefish:conf_get("distribution.listener.interface", Conf, undefined) of
+                undefined ->
+                    cuttlefish:unset();
+                Value when is_list(Value) ->
+                    case inet:parse_address(Value) of
+                        {ok, Parsed} -> Parsed;
+                        {error, _}   -> cuttlefish:invalid("should be a valid IP address")
+                    end;
+                _ ->
+                    cuttlefish:invalid("should be a valid IP address")
+            end
+    end
+}.
+
 % ==========================
 % sysmon_handler section
 % ==========================
@@ -2104,7 +2135,7 @@ fun(File) ->
     end
 end}.
 
-{validator, "is_ip", "string is a valid IP address",
+{validator, "is_ip", "value should be a valid IP address",
 fun(IpStr) ->
     Res = inet:parse_address(IpStr),
     element(1, Res) == ok

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -72,6 +72,28 @@ ssl_options.fail_if_no_peer_cert = true",
  {num_acceptors,
   "num_acceptors.ssl = 1",[{rabbit,[{num_ssl_acceptors,1}]}],[]},
 
+ {distribution_listener,
+ "distribution.listener.interface = 192.168.0.1
+  distribution.listener.port_range.min = 25679
+  distribution.listener.port_range.max = 25679",
+ [{kernel, [
+    {inet_dist_listen_min, 25679},
+    {inet_dist_listen_max, 25679},
+    {inet_dist_use_interface, {192,168,0,1}}
+   ]}],
+ []},
+
+ {distribution_listener_ipv6,
+ "distribution.listener.interface = ::1
+  distribution.listener.port_range.min = 25679
+  distribution.listener.port_range.max = 25679",
+ [{kernel, [
+    {inet_dist_listen_min, 25679},
+    {inet_dist_listen_max, 25679},
+    {inet_dist_use_interface, {0,0,0,0,0,0,0,1}}
+   ]}],
+ []},
+
  {socket_writer_gc_threshold,
   "socket_writer.gc_threshold = 999666111", [{rabbit, [{writer_gc_threshold, 999666111}]}],[]},
 


### PR DESCRIPTION
 * `distribution.listener.interface`
 * `distribution.listener.port_range.min`
 * `distribution.listener.port_range.max`

A `rabbitmq.conf` that can be used for manual testing:

``` ini
distribution.listener.port_range.min = 25679
distribution.listener.port_range.max = 25679
distribution.listener.interface = 127.0.0.1
```

Then:

```
rabbitmq-diagnostics listeners
```

```
rabbitmqctl eval 'application:get_all_env(kernel).'
```

Closes #3739.
