### PR TITLE
Fix rabbitmq.conf translation rule for OAuth2 signing keys

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -49,7 +49,7 @@
 
 %% A map of signing keys
 %%
-%% {signing_keys, #{<<"id1">> => <<"value1">>,<<"id2">> => <<"value2">>}}
+%% {signing_keys, #{<<"id1">> => {pem, <<"value1">>}, <<"id2">> => {pem, <<"value2">>}}}
 %% validator doesn't work
 
 {mapping,
@@ -73,7 +73,7 @@
         end,
     SigningKeys =
         lists:map(fun({Id, Path}) ->
-                    {list_to_binary(lists:last(Id)), TryReadingFileFun(Path)}
+                    {list_to_binary(lists:last(Id)), {pem, TryReadingFileFun(Path)}}
                   end, Settings),
     maps:from_list(SigningKeys)
  end}.

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -13,8 +13,8 @@
             {default_key, <<"id1">>},
             {signing_keys,
                 #{
-                    <<"id1">> => <<"I'm not a certificate">>,
-                    <<"id2">> => <<"I'm not a certificate">>
+                    <<"id1">> => {pem, <<"I'm not a certificate">>},
+                    <<"id2">> => {pem, <<"I'm not a certificate">>}
                 }
             }
             ]


### PR DESCRIPTION
The structure of the signing_keys map should be `<<"id">> => {pem, <<"key">>}`. Previously it was mapped directly as `<<"id">> => <<"key">>` which caused a `case_clause` error.