### PR TITLE
Add systemd hardening parameters in rabbitmq-server.service.example

### DIFF
--- a/deps/rabbit/docs/rabbitmq-server.service.example
+++ b/deps/rabbit/docs/rabbitmq-server.service.example
@@ -5,6 +5,19 @@ After=network.target epmd@0.0.0.0.socket
 Wants=network.target epmd@0.0.0.0.socket
 
 [Service]
+# Note: You *may* wish to uncomment the following lines to apply systemd
+# hardening effort to RabbitMQ, to prevent your system from being illegally 
+# modified by undiscovered vulnerabilities in RabbitMQ.
+# ProtectSystem=full
+# ProtectHome=true
+# PrivateDevices=true
+# ProtectHostname=true
+# ProtectClock=true
+# ProtectKernelTunables=true
+# ProtectKernelModules=true
+# ProtectKernelLogs=true
+# ProtectControlGroups=true
+# RestrictRealtime=true
 Type=notify
 User=rabbitmq
 Group=rabbitmq


### PR DESCRIPTION
## Proposed Changes

systemd offers various options to harden services. These options offer mitigations for rabbitmq-server.

To see details please visit https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

