### PR TITLE
Add optional metrics for vhost and exchange count

### DIFF
--- a/deps/rabbitmq_prometheus/metrics-detailed.md
+++ b/deps/rabbitmq_prometheus/metrics-detailed.md
@@ -236,3 +236,33 @@ Group `channel_queue_exchange_metrics`:
 | Metric                                           | Description                                  |
 |--------------------------------------------------|----------------------------------------------|
 | rabbitmq_detailed_queue_messages_published_total | Total number of messages published to queues |
+
+### Virtual hosts and exchange metrics
+
+These can make sense in some scenarios, e.g. when vhost/exchanges are
+created using self-service automation. They are also a bit different
+from the rest of the metrics, as they not exactly per-node metrics,
+but cluster wide. So any aggregations of these values accross multiple
+nodes make no sense.
+
+Group `vhost_status`:
+
+| Metric                         | Description                      |
+|--------------------------------|----------------------------------|
+| rabbitmq_detailed_vhost_status | Whether a given vhost is running |
+
+Group `exchange_names`:
+
+| Metric                          | Description                                                                                              |
+|---------------------------------|----------------------------------------------------------------------------------------------------------|
+| rabbitmq_detailed_exchange_name | Enumerates exchanges without any additional info (cheaper than `exchange_bindings`, cluster-wide number) |
+
+Group `exchange_bindings`:
+
+| Metric                              | Description                                                            |
+|-------------------------------------|------------------------------------------------------------------------|
+| rabbitmq_detailed_exchange_bindings | Number of bindings for an exchange (WARNING: it's cluster-wide number) |
+
+
+
+

--- a/deps/rabbitmq_prometheus/metrics-detailed.md
+++ b/deps/rabbitmq_prometheus/metrics-detailed.md
@@ -246,21 +246,21 @@ These metrics **must not** be aggregated across cluster nodes.
 
 Group `vhost_status`:
 
-| Metric                         | Description                      |
-|--------------------------------|----------------------------------|
-| rabbitmq_detailed_vhost_status | Whether a given vhost is running |
+| Metric                        | Description                      |
+|-------------------------------|----------------------------------|
+| rabbitmq_cluster_vhost_status | Whether a given vhost is running |
 
 Group `exchange_names`:
 
-| Metric                          | Description                                                                                              |
-|---------------------------------|----------------------------------------------------------------------------------------------------------|
-| rabbitmq_detailed_exchange_name | Enumerates exchanges without any additional info. This value is cluster-wide. A cheaper alternative to `exchange_bindings` |
+| Metric                         | Description                                                                                                                |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| rabbitmq_cluster_exchange_name | Enumerates exchanges without any additional info. This value is cluster-wide. A cheaper alternative to `exchange_bindings` |
 
 Group `exchange_bindings`:
 
-| Metric                              | Description                                                            |
-|-------------------------------------|------------------------------------------------------------------------|
-| rabbitmq_detailed_exchange_bindings | Number of bindings for an exchange. This value is cluster-wide. |
+| Metric                             | Description                                                     |
+|------------------------------------|-----------------------------------------------------------------|
+| rabbitmq_cluster_exchange_bindings | Number of bindings for an exchange. This value is cluster-wide. |
 
 
 

--- a/deps/rabbitmq_prometheus/metrics-detailed.md
+++ b/deps/rabbitmq_prometheus/metrics-detailed.md
@@ -239,11 +239,10 @@ Group `channel_queue_exchange_metrics`:
 
 ### Virtual hosts and exchange metrics
 
-These can make sense in some scenarios, e.g. when vhost/exchanges are
-created using self-service automation. They are also a bit different
-from the rest of the metrics, as they not exactly per-node metrics,
-but cluster wide. So any aggregations of these values accross multiple
-nodes make no sense.
+These additional metrics can be useful when virtual hosts or exchanges are
+created on a shared cluster in a self-service way. They are different
+from the rest of the metrics: they are cluster-wide and not node-local.
+These metrics **must not** be aggregated across cluster nodes.
 
 Group `vhost_status`:
 

--- a/deps/rabbitmq_prometheus/metrics-detailed.md
+++ b/deps/rabbitmq_prometheus/metrics-detailed.md
@@ -254,13 +254,13 @@ Group `exchange_names`:
 
 | Metric                          | Description                                                                                              |
 |---------------------------------|----------------------------------------------------------------------------------------------------------|
-| rabbitmq_detailed_exchange_name | Enumerates exchanges without any additional info (cheaper than `exchange_bindings`, cluster-wide number) |
+| rabbitmq_detailed_exchange_name | Enumerates exchanges without any additional info. This value is cluster-wide. A cheaper alternative to `exchange_bindings` |
 
 Group `exchange_bindings`:
 
 | Metric                              | Description                                                            |
 |-------------------------------------|------------------------------------------------------------------------|
-| rabbitmq_detailed_exchange_bindings | Number of bindings for an exchange (WARNING: it's cluster-wide number) |
+| rabbitmq_detailed_exchange_bindings | Number of bindings for an exchange. This value is cluster-wide. |
 
 
 

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -501,7 +501,7 @@ detailed_metrics_no_families_enabled_by_default(Config) ->
 
 vhost_status_metric(Config) ->
     {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?family=vhost_status", [], 200),
-    Expected = #{rabbitmq_detailed_vhost_status =>
+    Expected = #{rabbitmq_cluster_vhost_status =>
                      #{#{vhost => "vhost-1"} => [1],
                        #{vhost => "vhost-2"} => [1],
                        #{vhost => "/"} => [1]}},
@@ -511,7 +511,7 @@ vhost_status_metric(Config) ->
 exchange_bindings_metric(Config) ->
     {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?family=exchange_bindings", [], 200),
 
-    Bindings = map_get(rabbitmq_detailed_exchange_bindings, parse_response(Body1)),
+    Bindings = map_get(rabbitmq_cluster_exchange_bindings, parse_response(Body1)),
     ?assertEqual([11], map_get(#{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-topic-exchange",type=>"topic"}, Bindings)),
     ?assertEqual([1],  map_get(#{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-direct-exchange",type=>"direct"}, Bindings)),
     ok.
@@ -526,7 +526,7 @@ exchange_names_metric(Config) ->
                   (_, _) ->
                       true
               end,
-              map_get(rabbitmq_detailed_exchange_name, parse_response(Body1))),
+              map_get(rabbitmq_cluster_exchange_name, parse_response(Body1))),
 
     ?assertEqual(#{ #{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-topic-exchange",type=>"topic"} => [1],
                     #{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-direct-exchange",type=>"direct"} => [1],

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -54,7 +54,10 @@ groups() ->
                                      queue_consumer_count_all_vhosts_per_object_test,
                                      queue_coarse_metrics_per_object_test,
                                      queue_metrics_per_object_test,
-                                     queue_consumer_count_and_queue_metrics_mutually_exclusive_test
+                                     queue_consumer_count_and_queue_metrics_mutually_exclusive_test,
+                                     vhost_status_metric,
+                                     exchange_bindings_metric,
+                                     exchange_names_metric
         ]}
     ].
 
@@ -120,6 +123,14 @@ init_per_group(detailed_metrics, Config0) ->
                                      amqp_channel:cast(Ch,
                                                        #'basic.publish'{routing_key = QName},
                                                        #amqp_msg{payload = <<"msg">>})
+                             end, lists:seq(1, MsgNum) ),
+              ExDirect = <<QName/binary, "-direct-exchange">>,
+              #'exchange.declare_ok'{} = amqp_channel:call(Ch, #'exchange.declare'{exchange = ExDirect}),
+              ExTopic = <<QName/binary, "-topic-exchange">>,
+              #'exchange.declare_ok'{} = amqp_channel:call(Ch, #'exchange.declare'{exchange = ExTopic, type = <<"topic">>}),
+              #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{queue = QName, exchange = ExDirect, routing_key = QName}),
+              lists:foreach( fun (Idx) ->
+                                     #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{queue = QName, exchange = ExTopic, routing_key = integer_to_binary(Idx)})
                              end, lists:seq(1, MsgNum) )
       end)()
      || {VHost, Ch, MsgNum} <- [{<<"/">>, DefaultCh, 3}, {<<"vhost-1">>, VHost1Ch, 7}, {<<"vhost-2">>, VHost2Ch, 11}],
@@ -487,6 +498,51 @@ detailed_metrics_no_families_enabled_by_default(Config) ->
     {_, Body} = http_get_with_pal(Config, "/metrics/detailed", [], 200),
     ?assertEqual(#{}, parse_response(Body)),
     ok.
+
+vhost_status_metric(Config) ->
+    {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?family=vhost_status", [], 200),
+    Expected = #{rabbitmq_detailed_vhost_status =>
+                     #{#{vhost => "vhost-1"} => [1],
+                       #{vhost => "vhost-2"} => [1],
+                       #{vhost => "/"} => [1]}},
+    ?assertEqual(Expected, parse_response(Body1)),
+    ok.
+
+exchange_bindings_metric(Config) ->
+    {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?family=exchange_bindings", [], 200),
+
+    Bindings = map_get(rabbitmq_detailed_exchange_bindings, parse_response(Body1)),
+    ?assertEqual([11], map_get(#{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-topic-exchange",type=>"topic"}, Bindings)),
+    ?assertEqual([1],  map_get(#{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-direct-exchange",type=>"direct"}, Bindings)),
+    ok.
+
+exchange_names_metric(Config) ->
+    {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?family=exchange_names", [], 200),
+
+    Names = maps:filter(
+              fun
+                  (#{exchange := [$a, $m, $q|_]}, _) ->
+                      false;
+                  (_, _) ->
+                      true
+              end,
+              map_get(rabbitmq_detailed_exchange_name, parse_response(Body1))),
+
+    ?assertEqual(#{ #{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-topic-exchange",type=>"topic"} => [1],
+                    #{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-messages-direct-exchange",type=>"direct"} => [1],
+                    #{vhost=>"vhost-1",exchange=>"vhost-1-queue-with-messages-topic-exchange",type=>"topic"} => [1],
+                    #{vhost=>"vhost-1",exchange=>"vhost-1-queue-with-messages-direct-exchange",type=>"direct"} => [1],
+                    #{vhost=>"/",exchange=>"default-queue-with-messages-topic-exchange",type=>"topic"} => [1],
+                    #{vhost=>"/",exchange=>"default-queue-with-messages-direct-exchange",type=>"direct"} => [1],
+                    #{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-consumer-topic-exchange",type=>"topic"} => [1],
+                    #{vhost=>"vhost-2",exchange=>"vhost-2-queue-with-consumer-direct-exchange",type=>"direct"} => [1],
+                    #{vhost=>"vhost-1",exchange=>"vhost-1-queue-with-consumer-topic-exchange",type=>"topic"} => [1],
+                    #{vhost=>"vhost-1",exchange=>"vhost-1-queue-with-consumer-direct-exchange",type=>"direct"} => [1],
+                    #{vhost=>"/",exchange=>"default-queue-with-consumer-topic-exchange",type=>"topic"} => [1],
+                    #{vhost=>"/",exchange=>"default-queue-with-consumer-direct-exchange",type=>"direct"} => [1]
+                  }, Names),
+    ok.
+
 
 http_get(Config, ReqHeaders, CodeExp) ->
     Path = proplists:get_value(prometheus_path, Config, "/metrics"),


### PR DESCRIPTION
## Proposed Changes

This adds optional prometheus metrics for getting numbers/lists of vhosts and exchanges.

These can make sense in some scenarios, e.g. when vhost/exchanges are created using self-service automation.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
