### PR TITLE
To stop collect_statistics when rabbitmq_management_agent has been disabled

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_db_handler.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_db_handler.erl
@@ -93,7 +93,15 @@ handle_info(_Info, State) ->
     {ok, State}.
 
 terminate(_Arg, _State) ->
+    ensure_statistics_disabled(),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+ensure_statistics_disabled() ->
+    %% Reset the default values, see Makefile
+    _ = rabbit_log:info("Management plugin: to stop collect_statistics."),
+    application:set_env(rabbit, collect_statistics, none),
+    application:set_env(rabbit, collect_statistics_interval, 5000),
+    ok = rabbit:force_event_refresh(erlang:make_ref()).


### PR DESCRIPTION
After stopping the 'rabbitmq_management', these statistics tables are still being refreshed.


