### PR TITLE
tcp_listener: avoid logging listener arguments on shutdown

### DIFF
--- a/deps/rabbit/src/tcp_listener.erl
+++ b/deps/rabbit/src/tcp_listener.erl
@@ -114,5 +114,10 @@ deobfuscate_state(#state{on_startup = OnStartup, on_shutdown = OnShutdown} = Sta
 
 ensure_credential_obfuscation_secret() ->
     ok = credentials_obfuscation:refresh_config(),
-    CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
-    ok = credentials_obfuscation:set_secret(CookieBin).
+    case credentials_obfuscation:secret() of
+        '$pending-secret' ->
+            CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
+            ok = credentials_obfuscation:set_secret(CookieBin);
+        _Other ->
+            ok
+    end.

--- a/deps/rabbit/src/tcp_listener.erl
+++ b/deps/rabbit/src/tcp_listener.erl
@@ -63,12 +63,20 @@ start_link(IPAddress, Port,
 
 %%--------------------------------------------------------------------
 
-init({IPAddress, Port, {M,F,A} = OnStartup, OnShutdown, Label}) ->
+init({IPAddress, Port, {M, F, A} = OnStartup, OnShutdown, Label}) ->
+    ensure_credential_obfuscation_secret(),
+
     process_flag(trap_exit, true),
     logger:info("started ~s on ~s:~p", [Label, rabbit_misc:ntoab(IPAddress), Port]),
     apply(M, F, A ++ [IPAddress, Port]),
-    {ok, #state{on_startup = OnStartup, on_shutdown = OnShutdown,
-                label = Label, ip=IPAddress, port=Port}}.
+    State0 = #state{
+        on_startup = OnStartup,
+        on_shutdown = OnShutdown,
+        label = Label,
+        ip = IPAddress,
+        port = Port
+    },
+    {ok, obfuscate_state(State0)}.
 
 handle_call(_Request, _From, State) ->
     {noreply, State}.
@@ -79,9 +87,32 @@ handle_cast(_Msg, State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
-terminate(_Reason, #state{on_shutdown = {M,F,A}, label=Label, ip=IPAddress, port=Port}) ->
+terminate(_Reason, #state{label = Label, ip = IPAddress, port = Port} = State0) ->
+    #state{on_shutdown = {M, F, A}} = deobfuscate_state(State0),
     logger:info("stopped ~s on ~s:~p", [Label, rabbit_misc:ntoab(IPAddress), Port]),
-    apply(M, F, A ++ [IPAddress, Port]).
+    try
+        apply(M, F, A ++ [IPAddress, Port])
+    catch _:Error ->
+        logger:error("Failed to stop listener ~s on ~s:~p: ~p",
+                     [Label, rabbit_misc:ntoab(IPAddress), Port, Error])
+    end.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+obfuscate_state(#state{on_startup = OnStartup, on_shutdown = OnShutdown} = State) ->
+    State#state{
+        on_startup  = credentials_obfuscation:encrypt(term_to_binary(OnStartup)),
+        on_shutdown = credentials_obfuscation:encrypt(term_to_binary(OnShutdown))
+    }.
+
+deobfuscate_state(#state{on_startup = OnStartup, on_shutdown = OnShutdown} = State) ->
+    State#state{
+        on_startup  = binary_to_term(credentials_obfuscation:decrypt(OnStartup)),
+        on_shutdown = binary_to_term(credentials_obfuscation:decrypt(OnShutdown))
+    }.
+
+ensure_credential_obfuscation_secret() ->
+    ok = credentials_obfuscation:refresh_config(),
+    CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
+    ok = credentials_obfuscation:set_secret(CookieBin).

--- a/deps/rabbit/src/tcp_listener.erl
+++ b/deps/rabbit/src/tcp_listener.erl
@@ -89,7 +89,7 @@ terminate(_Reason, #state{on_shutdown = OnShutdown, label = Label, ip = IPAddres
     try
         OnShutdown(IPAddress, Port)
     catch _:Error ->
-        logger:error("Failed to stop listener ~s on ~s:~p: ~p",
+        logger:error("Failed to stop ~s on ~s:~p: ~p",
                      [Label, rabbit_misc:ntoab(IPAddress), Port, Error])
     end.
 


### PR DESCRIPTION
Even if exception occurs.

While at it, encrypt memory-stored arguments that might contain sensitive values.

Closes #3803.
