### PR TITLE
Introduce a new CLI tool (scope), rabbitmq-tanzu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,8 @@ SCRIPTS = rabbitmq-defaults \
 	  rabbitmq-diagnostics \
 	  rabbitmq-queues \
 	  rabbitmq-upgrade \
-	  rabbitmq-streams
+	  rabbitmq-streams \
+		rabbitmq-tanzu
 
 AUTOCOMPLETE_SCRIPTS = bash_autocomplete.sh zsh_autocomplete.sh
 
@@ -434,6 +435,7 @@ WINDOWS_SCRIPTS = rabbitmq-defaults.bat \
 		  rabbitmq-service.bat \
 		  rabbitmq-upgrade.bat \
 		  rabbitmq-streams.bat \
+			rabbitmq-tanzu.bat \
 		  rabbitmqctl.bat
 
 UNIX_TO_DOS ?= todos

--- a/deps/rabbit/docs/rabbitmq-diagnostics.8
+++ b/deps/rabbit/docs/rabbitmq-diagnostics.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd June 19, 2021
 .Dt RABBITMQ-DIAGNOSTICS 8

--- a/deps/rabbit/docs/rabbitmq-echopid.8
+++ b/deps/rabbit/docs/rabbitmq-echopid.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd September 28, 2019
 .Dt RABBITMQ-ECHOPID.BAT 8

--- a/deps/rabbit/docs/rabbitmq-env.conf.5
+++ b/deps/rabbit/docs/rabbitmq-env.conf.5
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd September 28, 2019
 .Dt RABBITMQ-ENV.CONF 5

--- a/deps/rabbit/docs/rabbitmq-plugins.8
+++ b/deps/rabbit/docs/rabbitmq-plugins.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd September 28, 2019
 .Dt RABBITMQ-PLUGINS 8

--- a/deps/rabbit/docs/rabbitmq-queues.8
+++ b/deps/rabbit/docs/rabbitmq-queues.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd June 19, 2021
 .Dt RABBITMQ-QUEUES 8

--- a/deps/rabbit/docs/rabbitmq-server.8
+++ b/deps/rabbit/docs/rabbitmq-server.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd September 28, 2019
 .Dt RABBITMQ-SERVER 8

--- a/deps/rabbit/docs/rabbitmq-service.8
+++ b/deps/rabbit/docs/rabbitmq-service.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd September 28, 2019
 .Dt RABBITMQ-SERVICE.BAT 8

--- a/deps/rabbit/docs/rabbitmq-upgrade.8
+++ b/deps/rabbit/docs/rabbitmq-upgrade.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd June 19, 2021
 .Dt RABBITMQ-UPGRADE 8

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -1,9 +1,9 @@
 .\" vim:ft=nroff:
-.\" This Source Code Form is subject to the terms of the Mozilla Public 
+.\" This Source Code Form is subject to the terms of the Mozilla Public
 .\" License, v. 2.0. If a copy of the MPL was not distributed with this
 .\" file, You can obtain one at https://mozilla.org/MPL/2.0/.
 .\"
-.\" Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+.\" Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 .\"
 .Dd June 19, 2021
 .Dt RABBITMQCTL 8

--- a/deps/rabbit/scripts/rabbitmq-tanzu
+++ b/deps/rabbit/scripts/rabbitmq-tanzu
@@ -1,0 +1,23 @@
+#!/bin/sh
+##  This Source Code Form is subject to the terms of the Mozilla Public
+##  License, v. 2.0. If a copy of the MPL was not distributed with this
+##  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+##  Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+##
+
+# Exit immediately if a pipeline, which may consist of a single simple command,
+# a list, or a compound command returns a non-zero status
+set -e
+
+# Each variable or function that is created or modified is given the export
+# attribute and marked for export to the environment of subsequent commands.
+set -a
+
+# shellcheck source=/dev/null
+#
+# TODO: when shellcheck adds support for relative paths, change to
+# shellcheck source=./rabbitmq-env
+. "${0%/*}"/rabbitmq-env
+
+run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-tanzu "$@"

--- a/deps/rabbit/scripts/rabbitmq-tanzu.bat
+++ b/deps/rabbit/scripts/rabbitmq-tanzu.bat
@@ -1,0 +1,56 @@
+@echo off
+REM  This Source Code Form is subject to the terms of the Mozilla Public
+REM  License, v. 2.0. If a copy of the MPL was not distributed with this
+REM  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+REM
+REM  Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+REM
+
+REM Scopes the variables to the current batch file
+setlocal
+
+rem Preserve values that might contain exclamation marks before
+rem enabling delayed expansion
+set TDP0=%~dp0
+set STAR=%*
+setlocal enabledelayedexpansion
+
+REM Get default settings with user overrides for (RABBITMQ_)<var_name>
+REM Non-empty defaults should be set in rabbitmq-env
+call "%TDP0%\rabbitmq-env.bat" %~n0
+
+if not exist "!ERLANG_HOME!\bin\erl.exe" (
+    echo.
+    echo ******************************
+    echo ERLANG_HOME not set correctly.
+    echo ******************************
+    echo.
+    echo Please either set ERLANG_HOME to point to your Erlang installation or place the
+    echo RabbitMQ server distribution in the Erlang lib folder.
+    echo.
+    exit /B 1
+)
+
+REM Disable erl_crash.dump by default for control scripts.
+if not defined ERL_CRASH_DUMP_SECONDS (
+    set ERL_CRASH_DUMP_SECONDS=0
+)
+
+"!ERLANG_HOME!\bin\erl.exe" +B ^
+-boot !CLEAN_BOOT_FILE! ^
+-noinput -noshell -hidden -smp enable ^
+!RABBITMQ_CTL_ERL_ARGS! ^
+-kernel inet_dist_listen_min !RABBITMQ_CTL_DIST_PORT_MIN! ^
+-kernel inet_dist_listen_max !RABBITMQ_CTL_DIST_PORT_MAX! ^
+-run escript start ^
+-escript main rabbitmqctl_escript ^
+-extra "%RABBITMQ_HOME%\escript\rabbitmq-tanzu" !STAR!
+
+if ERRORLEVEL 1 (
+    exit /B %ERRORLEVEL%
+)
+
+EXIT /B 0
+
+endlocal
+endlocal

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -47,7 +47,8 @@ LINKED_ESCRIPTS = escript/rabbitmq-plugins \
 		  escript/rabbitmq-diagnostics \
 		  escript/rabbitmq-queues \
 		  escript/rabbitmq-streams \
-                  escript/rabbitmq-upgrade
+			escript/rabbitmq-tanzu \
+      escript/rabbitmq-upgrade
 ESCRIPTS = $(ACTUAL_ESCRIPTS) $(LINKED_ESCRIPTS)
 
 # Record the build and link dependency: the target files are linked to
@@ -56,8 +57,9 @@ rabbitmq-plugins = escript/rabbitmqctl
 rabbitmq-diagnostics = escript/rabbitmqctl
 rabbitmq-queues = escript/rabbitmqctl
 rabbitmq-streams = escript/rabbitmqctl
+rabbitmq-tanzu = escript/rabbitmqctl
 rabbitmq-upgrade = escript/rabbitmqctl
-escript/rabbitmq-plugins escript/rabbitmq-diagnostics escript/rabbitmq-queues escript/rabbitmq-streams escript/rabbitmq-upgrade: escript/rabbitmqctl
+escript/rabbitmq-plugins escript/rabbitmq-diagnostics escript/rabbitmq-queues escript/rabbitmq-streams escript/rabbitmq-tanzu escript/rabbitmq-upgrade: escript/rabbitmqctl
 
 # We use hardlinks or symlinks in the `escript` directory and
 # install's PREFIX when a single escript can have several names (eg.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -14,7 +14,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def scopes(), do: [:ctl, :diagnostics, :plugins, :queues, :upgrade]
+  def scopes(), do: [:ctl, :diagnostics, :plugins, :queues, :tanzu, :upgrade]
   def switches(), do: [list_commands: :boolean]
 
   def distribution(_), do: :none

--- a/deps/rabbitmq_cli/test/ctl/clear_global_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_global_parameter_command_test.exs
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 
 
 defmodule ClearGlobalParameterCommandTest do
@@ -15,7 +15,7 @@ defmodule ClearGlobalParameterCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    
+
     :ok
   end
 

--- a/deps/rabbitmq_cli/test/ctl/clear_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_policy_command_test.exs
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 
 
 defmodule ClearPolicyCommandTest do
@@ -17,7 +17,7 @@ defmodule ClearPolicyCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    
+
     add_vhost @vhost
 
     enable_federation_plugin()

--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-//  Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+//  Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 //
 
 package com.rabbitmq.mqtt.test;
@@ -705,7 +705,7 @@ public class MqttTest implements MqttCallback {
 
         // let last will propagate after disconnection
         waitForTestDelay();
-        
+
         client2.connect(client2_opts);
         client2.setCallback(this);
         client2.subscribe(retainedTopic, 1);

--- a/deps/rabbitmq_peer_discovery_etcd/test/config_schema_SUITE_data/rabbitmq_peer_discovery_etcd.snippets
+++ b/deps/rabbitmq_peer_discovery_etcd/test/config_schema_SUITE_data/rabbitmq_peer_discovery_etcd.snippets
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 [
@@ -20,7 +20,7 @@
             ]}
         ], [rabbitmq_peer_discovery_etcd]
     },
-    
+
     {etcd_discovery_mechanism_shortcut,
         "cluster_formation.peer_discovery_backend = etcd
          cluster_formation.etcd.host = etcd.eng.megacorp.local", [
@@ -34,7 +34,7 @@
             ]}
         ], [rabbitmq_peer_discovery_etcd]
     },
-    
+
     %% etcd hostname
     {etcd_host, "cluster_formation.etcd.host = etcd.eng.megacorp.local", [
             {rabbit, [

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/rabbitmq_peer_discovery_k8s.snippets
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/rabbitmq_peer_discovery_k8s.snippets
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 [
@@ -19,7 +19,7 @@
           ]}
       ], [rabbitmq_peer_discovery_k8s]
   },
-  
+
   {k8s_discovery_mechanism_as_alias1,
       "cluster_formation.peer_discovery_backend = k8s
        cluster_formation.k8s.host = k8s.eng.megacorp.local", [
@@ -33,7 +33,7 @@
           ]}
       ], [rabbitmq_peer_discovery_k8s]
   },
-  
+
   {k8s_discovery_mechanism_as_alias2,
       "cluster_formation.peer_discovery_backend = kubernetes
        cluster_formation.k8s.host = k8s.eng.megacorp.local", [
@@ -47,7 +47,7 @@
           ]}
       ], [rabbitmq_peer_discovery_k8s]
   },
-  
+
   {k8s_host, "cluster_formation.k8s.host = k8s.eng.megacorp.local", [
           {rabbit, [
               {cluster_formation, [

--- a/dist.bzl
+++ b/dist.bzl
@@ -168,6 +168,7 @@ def _versioned_rabbitmq_home_impl(ctx):
         "rabbitmq-plugins",
         "rabbitmq-queues",
         "rabbitmq-streams",
+        "rabbitmq-tanzu",
         "rabbitmq-upgrade",
         "rabbitmqctl",
     ]

--- a/rabbitmq_home.bzl
+++ b/rabbitmq_home.bzl
@@ -95,6 +95,7 @@ def _impl(ctx):
         "rabbitmq-plugins",
         "rabbitmq-queues",
         "rabbitmq-streams",
+        "rabbitmq-tanzu",
         "rabbitmq-upgrade",
         "rabbitmqctl",
     ]


### PR DESCRIPTION
For Tanzu (commercial) plugins to attach their commands to instead of
polluting rabbitmqctl.

Pair: @pjk25
