### PR TITLE
Create configuration nested record in stream consumer record

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1802,25 +1802,20 @@ handle_frame_post_auth(Transport,
                                               osiris_log:next_offset(Log)]),
                             ConsumerCounters =
                                 atomics:new(2, [{signed, false}]),
+                            ConsumerConfiguration =
+                                #consumer_configuration{member_pid =
+                                                            LocalMemberPid,
+                                                        subscription_id =
+                                                            SubscriptionId,
+                                                        socket = Socket,
+                                                        stream = Stream,
+                                                        offset = OffsetSpec,
+                                                        counters =
+                                                            ConsumerCounters,
+                                                        properties =
+                                                            Properties},
                             ConsumerState =
-                                #consumer{configuration =
-                                              #consumer_configuration{member_pid
-                                                                          =
-                                                                          LocalMemberPid,
-                                                                      subscription_id
-                                                                          =
-                                                                          SubscriptionId,
-                                                                      socket =
-                                                                          Socket,
-                                                                      stream =
-                                                                          Stream,
-                                                                      offset =
-                                                                          OffsetSpec,
-                                                                      counters =
-                                                                          ConsumerCounters,
-                                                                      properties
-                                                                          =
-                                                                          Properties},
+                                #consumer{configuration = ConsumerConfiguration,
                                           log = Log,
                                           credit = Credit},
 

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -30,9 +30,7 @@
 -define(WAIT, 5000).
 
 all() ->
-    [{group, single_node},
-     {group, single_node_1},
-     {group, cluster}].
+    [{group, single_node}, {group, single_node_1}, {group, cluster}].
 
 groups() ->
     [{single_node, [],
@@ -64,7 +62,8 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
-init_per_group(Group, Config) when Group == single_node orelse Group == single_node_1 ->
+init_per_group(Group, Config)
+    when Group == single_node orelse Group == single_node_1 ->
     Config1 =
         rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, false}]),
     Config2 =


### PR DESCRIPTION
Only a couple of fields of the stream consumer record change
very frequently (credits and Osiris log reference), so this commit
introduces a nested record in the main consumer record that
contains the immutable fields. This potentially avoids producing
a lot of garbage, especially when the consumer state contains
several properties (consumer name, or single active consumer information
in the future).

Fixes #3841