### PR TITLE
Get 'writer_gc_threshold' from the environment variables

### DIFF
--- a/deps/rabbit_common/src/rabbit_writer.erl
+++ b/deps/rabbit_common/src/rabbit_writer.erl
@@ -151,13 +151,15 @@ start_link(Sock, Channel, FrameMax, Protocol, ReaderPid, Identity) ->
 
 start(Sock, Channel, FrameMax, Protocol, ReaderPid, Identity,
       ReaderWantsStats) ->
+    GCThreshold = application:get_env(rabbit, writer_gc_threshold, ?DEFAULT_GC_THRESHOLD),     
     start(Sock, Channel, FrameMax, Protocol, ReaderPid, Identity,
-          ReaderWantsStats, ?DEFAULT_GC_THRESHOLD).
+          ReaderWantsStats, GCThreshold).
 
 start_link(Sock, Channel, FrameMax, Protocol, ReaderPid, Identity,
            ReaderWantsStats) ->
+    GCThreshold = application:get_env(rabbit, writer_gc_threshold, ?DEFAULT_GC_THRESHOLD),     
     start_link(Sock, Channel, FrameMax, Protocol, ReaderPid, Identity,
-               ReaderWantsStats, ?DEFAULT_GC_THRESHOLD).
+               ReaderWantsStats, GCThreshold).
 
 start(Sock, Channel, FrameMax, Protocol, ReaderPid, Identity,
       ReaderWantsStats, GCThreshold) ->


### PR DESCRIPTION


Get 'writer_gc_threshold' from the environment variables to support configurable.


