### PR TITLE
Revisit policy merging for boolean keys

### DIFF
--- a/deps/rabbit/src/rabbit_policies.erl
+++ b/deps/rabbit/src/rabbit_policies.erl
@@ -176,4 +176,6 @@ merge_policy_value(<<"max-length-bytes">>, Val, OpVal) -> min(Val, OpVal);
 merge_policy_value(<<"max-in-memory-length">>, Val, OpVal) -> min(Val, OpVal);
 merge_policy_value(<<"max-in-memory-bytes">>, Val, OpVal) -> min(Val, OpVal);
 merge_policy_value(<<"expires">>, Val, OpVal)          -> min(Val, OpVal);
-merge_policy_value(<<"delivery-limit">>, Val, OpVal)   -> min(Val, OpVal).
+merge_policy_value(<<"delivery-limit">>, Val, OpVal)   -> min(Val, OpVal);
+%% use operator policy value for booleans
+merge_policy_value(_Key, Val, OpVal) when is_boolean(Val) andalso is_boolean(OpVal) -> OpVal.

--- a/deps/rabbit/test/unit_operator_policy_SUITE.erl
+++ b/deps/rabbit/test/unit_operator_policy_SUITE.erl
@@ -21,7 +21,8 @@ all() ->
 groups() ->
     [
       {parallel_tests, [parallel], [
-          merge_operator_policy_definitions
+          merge_operator_policy_definitions,
+          conflict_resolution_for_booleans
         ]}
     ].
 
@@ -102,6 +103,54 @@ merge_operator_policy_definitions(_Config) ->
                     [{definition, [
                       {<<"message-ttl">>, 3000}
                     ]}])
-    ),
+    ).
 
-    passed.
+
+  conflict_resolution_for_booleans(_Config) ->
+    ?assertEqual(
+      [
+        {<<"remote-dc-replicate">>, true}
+      ],
+      rabbit_policy:merge_operator_definitions(
+         #{definition => #{
+           <<"remote-dc-replicate">> => true
+         }},
+         [{definition, [
+           {<<"remote-dc-replicate">>, true}
+         ]}])),
+
+    ?assertEqual(
+      [
+        {<<"remote-dc-replicate">>, false}
+      ],
+      rabbit_policy:merge_operator_definitions(
+        #{definition => #{
+          <<"remote-dc-replicate">> => false
+        }},
+        [{definition, [
+          {<<"remote-dc-replicate">>, false}
+        ]}])),
+
+    ?assertEqual(
+      [
+        {<<"remote-dc-replicate">>, true}
+      ],
+      rabbit_policy:merge_operator_definitions(
+        #{definition => #{
+          <<"remote-dc-replicate">> => false
+        }},
+        [{definition, [
+          {<<"remote-dc-replicate">>, true}
+        ]}])),
+
+    ?assertEqual(
+      [
+        {<<"remote-dc-replicate">>, false}
+      ],
+      rabbit_policy:merge_operator_definitions(
+        #{definition => #{
+          <<"remote-dc-replicate">> => true
+        }},
+        [{definition, [
+          {<<"remote-dc-replicate">>, false}
+        ]}])).


### PR DESCRIPTION
## Proposed Changes

For booleans, we can prefer the operator policy value
unconditionally, without any safety implications.

Per discussion with @binarin @pjk25

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

