### PR TITLE
OAuth 2 plugin improvements

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -139,6 +139,42 @@ In that case, the configuration will look like this:
 
 NOTE: `jwks_url` takes precedence over `signing_keys` if both are provided.
 
+### Variables Configurable in rabbitmq.conf
+
+| Key                                      | Documentation     
+|------------------------------------------|-----------
+| `auth_oauth2.resource_server_id`         | The Resource Server ID. Please see below for more details
+| `auth_oauth2.additional_scopes_key`      | Configure the plugin to also look in other fields (maps to `additional_rabbitmq_scopes` in the old format)
+| `auth_oauth2.default_key`                | ID of the default signing key
+| `auth_oauth2.signing_keys`               | Paths to signing key files
+| `auth_oauth2.jwks_url`                   | The URL of key server. According to the JWT Specification key server URL must be https.
+| `auth_oauth2.https.cacertfile`           | Path to a file containing PEM-encoded CA certificates. The CA certificates are used during key server authentication
+| `auth_oauth2.https.depth`                | Maximum number of non-self-issued intermediate certificates that can follow the peer certificate in a valid certification path. Default is 10. Please see: https://www.erlang.org/doc/man/ssl.html#type-allowed_cert_chain_length for more details
+| `auth_oauth2.https.peer_verification`    | Identify if the verification should be performed towards key server. Available values: `verify_none`, `verify_peer`. Default is `verify_none`. It is recommended to configure `verify_peer`
+| `auth_oauth2.algorithms`                 | Restrict the usable algorithms
+
+For example:
+
+Configure with key files
+```
+auth_oauth2.resource_server_id = new_resource_server_id
+auth_oauth2.additional_scopes_key = my_custom_scope_key
+auth_oauth2.default_key = id1
+auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
+auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem
+auth_oauth2.algorithms.1 = HS256
+auth_oauth2.algorithms.2 = RS256
+```
+Configure with key server
+```
+auth_oauth2.resource_server_id = new_resource_server_id
+auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
+auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+auth_oauth2.https.peer_verification = verify_peer
+auth_oauth2.https.depth = 5
+auth_oauth2.algorithms.1 = HS256
+auth_oauth2.algorithms.2 = RS256
+```
 ### Resource Server ID and Scope Prefixes
 
 OAuth 2.0 (and thus UAA-provided) tokens use scopes to communicate what set of permissions particular

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -176,7 +176,7 @@ auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
 auth_oauth2.https.peer_verification = verify_peer
 auth_oauth2.https.depth = 5
 auth_oauth2.https.fail_if_no_peer_cert = true
-auth_oauth2.https.wildcard = true
+auth_oauth2.https.hostname_verification = wildcard
 auth_oauth2.algorithms.1 = HS256
 auth_oauth2.algorithms.2 = RS256
 ```

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -151,7 +151,9 @@ NOTE: `jwks_url` takes precedence over `signing_keys` if both are provided.
 | `auth_oauth2.https.cacertfile`           | Path to a file containing PEM-encoded CA certificates. The CA certificates are used during key server authentication
 | `auth_oauth2.https.depth`                | Maximum number of non-self-issued intermediate certificates that can follow the peer certificate in a valid certification path. Default is 10. Please see: https://www.erlang.org/doc/man/ssl.html#type-allowed_cert_chain_length for more details
 | `auth_oauth2.https.peer_verification`    | Identify if the verification should be performed towards key server. Available values: `verify_none`, `verify_peer`. Default is `verify_none`. It is recommended to configure `verify_peer`
-| `auth_oauth2.https.wildcard`             | Enable wildcard-aware hostname verification for key server. Available values: `true`, `false`. Default is `false`.
+| `auth_oauth2.https.fail_if_no_peer_cert` | Used together with `auth_oauth2.https.peer_verification = verify_peer`. If set to `true`, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to `false`, it fails only if the client sends an invalid certificate (an empty certificate is considered valid). Default is `false`.
+| `auth_oauth2.https.hostname_verification`| Enable wildcard-aware hostname verification for key server. Available values: `wildcard`, `none`. Default is `none`.
+| `auth_oauth2.https.crl_check`            | Enable certificate check against the CA’s Certificate Revocation List (CRL). Available values: `true`, `false`, `peer`, `best_effort`. Default is `false`. Please refer: https://www.erlang.org/doc/man/ssl.html#type-crl_check for more details
 | `auth_oauth2.algorithms`                 | Restrict the usable algorithms
 
 For example:
@@ -173,6 +175,7 @@ auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
 auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
 auth_oauth2.https.peer_verification = verify_peer
 auth_oauth2.https.depth = 5
+auth_oauth2.https.fail_if_no_peer_cert = true
 auth_oauth2.https.wildcard = true
 auth_oauth2.algorithms.1 = HS256
 auth_oauth2.algorithms.2 = RS256

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -151,6 +151,7 @@ NOTE: `jwks_url` takes precedence over `signing_keys` if both are provided.
 | `auth_oauth2.https.cacertfile`           | Path to a file containing PEM-encoded CA certificates. The CA certificates are used during key server authentication
 | `auth_oauth2.https.depth`                | Maximum number of non-self-issued intermediate certificates that can follow the peer certificate in a valid certification path. Default is 10. Please see: https://www.erlang.org/doc/man/ssl.html#type-allowed_cert_chain_length for more details
 | `auth_oauth2.https.peer_verification`    | Identify if the verification should be performed towards key server. Available values: `verify_none`, `verify_peer`. Default is `verify_none`. It is recommended to configure `verify_peer`
+| `auth_oauth2.https.wildcard`             | Enable wildcard-aware hostname verification for key server. Available values: `true`, `false`. Default is `false`.
 | `auth_oauth2.algorithms`                 | Restrict the usable algorithms
 
 For example:
@@ -172,6 +173,7 @@ auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
 auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
 auth_oauth2.https.peer_verification = verify_peer
 auth_oauth2.https.depth = 5
+auth_oauth2.https.wildcard = true
 auth_oauth2.algorithms.1 = HS256
 auth_oauth2.algorithms.2 = RS256
 ```

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -143,18 +143,17 @@ NOTE: `jwks_url` takes precedence over `signing_keys` if both are provided.
 
 | Key                                      | Documentation     
 |------------------------------------------|-----------
-| `auth_oauth2.resource_server_id`         | The Resource Server ID. Please see below for more details
-| `auth_oauth2.additional_scopes_key`      | Configure the plugin to also look in other fields (maps to `additional_rabbitmq_scopes` in the old format)
-| `auth_oauth2.default_key`                | ID of the default signing key
-| `auth_oauth2.signing_keys`               | Paths to signing key files
-| `auth_oauth2.jwks_url`                   | The URL of key server. According to the JWT Specification key server URL must be https.
-| `auth_oauth2.https.cacertfile`           | Path to a file containing PEM-encoded CA certificates. The CA certificates are used during key server authentication
-| `auth_oauth2.https.depth`                | Maximum number of non-self-issued intermediate certificates that can follow the peer certificate in a valid certification path. Default is 10. Please see: https://www.erlang.org/doc/man/ssl.html#type-allowed_cert_chain_length for more details
-| `auth_oauth2.https.peer_verification`    | Identify if the verification should be performed towards key server. Available values: `verify_none`, `verify_peer`. Default is `verify_none`. It is recommended to configure `verify_peer`
-| `auth_oauth2.https.fail_if_no_peer_cert` | Used together with `auth_oauth2.https.peer_verification = verify_peer`. If set to `true`, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to `false`, it fails only if the client sends an invalid certificate (an empty certificate is considered valid). Default is `false`.
+| `auth_oauth2.resource_server_id`         | [The Resource Server ID](#resource-server-id-and-scope-prefixes)
+| `auth_oauth2.additional_scopes_key`      | Configure the plugin to also look in other fields (maps to `additional_rabbitmq_scopes` in the old format).
+| `auth_oauth2.default_key`                | ID of the default signing key.
+| `auth_oauth2.signing_keys`               | Paths to signing key files.
+| `auth_oauth2.jwks_url`                   | The URL of key server. According to the [JWT Specification](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2) key server URL must be https.
+| `auth_oauth2.https.cacertfile`           | Path to a file containing PEM-encoded CA certificates. The CA certificates are used during key server [peer verification](https://rabbitmq.com/ssl.html#peer-verification).
+| `auth_oauth2.https.depth`                | The maximum number of non-self-issued intermediate certificates that may follow the peer certificate in a valid [certification path](https://rabbitmq.com/ssl.html#peer-verification-depth). Default is 10.
+| `auth_oauth2.https.peer_verification`    | Should [peer verification](https://rabbitmq.com/ssl.html#peer-verification) be enabled. Available values: `verify_none`, `verify_peer`. Default is `verify_none`. It is recommended to configure `verify_peer`. Peer verification requires a certain amount of setup and is more secure.
+| `auth_oauth2.https.fail_if_no_peer_cert` | Used together with `auth_oauth2.https.peer_verification = verify_peer`. When set to `true`, TLS connection will be rejected if client fails to provide a certificate. Default is `false`.
 | `auth_oauth2.https.hostname_verification`| Enable wildcard-aware hostname verification for key server. Available values: `wildcard`, `none`. Default is `none`.
-| `auth_oauth2.https.crl_check`            | Enable certificate check against the CA’s Certificate Revocation List (CRL). Available values: `true`, `false`, `peer`, `best_effort`. Default is `false`. Please refer: https://www.erlang.org/doc/man/ssl.html#type-crl_check for more details
-| `auth_oauth2.algorithms`                 | Restrict the usable algorithms
+| `auth_oauth2.algorithms`                 | Restrict [the usable algorithms](https://github.com/potatosalad/erlang-jose#algorithm-support).
 
 For example:
 

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -77,3 +77,32 @@
                   end, Settings),
     maps:from_list(SigningKeys)
  end}.
+
+{mapping,
+ "auth_oauth2.jwks_url",
+ "rabbitmq_auth_backend_oauth2.key_config.jwks_url",
+ [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
+
+{mapping,
+ "auth_oauth2.strict",
+ "rabbitmq_auth_backend_oauth2.key_config.strict",
+ [{datatype, {enum, [true, false]}}]}.
+
+{mapping,
+ "auth_oauth2.cacertfile",
+ "rabbitmq_auth_backend_oauth2.key_config.cacertfile",
+ [{datatype, file}, {validators, ["file_accessible"]}]}.
+
+{validator, "https_uri", "invalid https uri",
+ fun(Uri) -> string:nth_lexeme(Uri, 1, "://") == "https" end}.
+
+{mapping,
+ "auth_oauth2.algorithms.$algorithm",
+ "rabbitmq_auth_backend_oauth2.key_config.algorithms",
+ [{datatype, string}]}.
+
+{translation, "rabbitmq_auth_backend_oauth2.key_config.algorithms",
+ fun(Conf) ->
+     Settings = cuttlefish_variable:filter_by_prefix("auth_oauth2.algorithms", Conf),
+     [list_to_binary(V) || {_, V} <- Settings]
+ end}.

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -84,12 +84,12 @@
  [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
 
 {mapping,
- "auth_oauth2.strict",
- "rabbitmq_auth_backend_oauth2.key_config.strict",
- [{datatype, {enum, [true, false]}}]}.
+ "auth_oauth2.https.peer_verification",
+ "rabbitmq_auth_backend_oauth2.key_config.peer_verification",
+ [{datatype, {enum, [verify_peer, verify_none]}}]}.
 
 {mapping,
- "auth_oauth2.cacertfile",
+ "auth_oauth2.https.cacertfile",
  "rabbitmq_auth_backend_oauth2.key_config.cacertfile",
  [{datatype, file}, {validators, ["file_accessible"]}]}.
 

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -93,7 +93,12 @@
  "rabbitmq_auth_backend_oauth2.key_config.cacertfile",
  [{datatype, file}, {validators, ["file_accessible"]}]}.
 
-{validator, "https_uri", "invalid https uri",
+{mapping,
+ "auth_oauth2.https.depth",
+ "rabbitmq_auth_backend_oauth2.key_config.depth",
+ [{datatype, integer}]}.
+
+{validator, "https_uri", "According to the JWT Specification, Key Server URL must be https.",
  fun(Uri) -> string:nth_lexeme(Uri, 1, "://") == "https" end}.
 
 {mapping,

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -99,8 +99,18 @@
  [{datatype, integer}]}.
 
 {mapping,
- "auth_oauth2.https.wildcard",
- "rabbitmq_auth_backend_oauth2.key_config.wildcard",
+ "auth_oauth2.https.hostname_verification",
+ "rabbitmq_auth_backend_oauth2.key_config.hostname_verification",
+ [{datatype, {enum, [wildcard, none]}}]}.
+
+{mapping,
+ "auth_oauth2.https.crl_check",
+ "rabbitmq_auth_backend_oauth2.key_config.crl_check",
+ [{datatype, {enum, [true, false, peer, best_effort]}}]}.
+
+{mapping,
+ "auth_oauth2.https.fail_if_no_peer_cert",
+ "rabbitmq_auth_backend_oauth2.key_config.fail_if_no_peer_cert",
  [{datatype, {enum, [true, false]}}]}.
 
 {validator, "https_uri", "According to the JWT Specification, Key Server URL must be https.",

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -98,6 +98,11 @@
  "rabbitmq_auth_backend_oauth2.key_config.depth",
  [{datatype, integer}]}.
 
+{mapping,
+ "auth_oauth2.https.wildcard",
+ "rabbitmq_auth_backend_oauth2.key_config.wildcard",
+ [{datatype, {enum, [true, false]}}]}.
+
 {validator, "https_uri", "According to the JWT Specification, Key Server URL must be https.",
  fun(Uri) -> string:nth_lexeme(Uri, 1, "://") == "https" end}.
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
@@ -3,7 +3,7 @@
 
 -spec get(string() | binary()) -> {ok, term()} | {error, term()}.
 get(JwksUrl) ->
-    httpc:request(get, {JwksUrl, []}, [{ssl, ssl_options()}], []).
+    httpc:request(get, {JwksUrl, []}, [{ssl, ssl_options()}, {timeout, 60000}], []).
 
 -spec ssl_options() -> list().
 ssl_options() ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
@@ -1,0 +1,27 @@
+-module(uaa_jwks).
+-export([get/1]).
+
+-spec get(string() | binary()) -> {ok, term()} | {error, term()}.
+get(JwksUrl) ->
+    httpc:request(get, {JwksUrl, []}, [{ssl, ssl_options()}], []).
+
+-spec ssl_options() -> list().
+ssl_options() ->
+    UaaEnv = application:get_env(rabbitmq_auth_backend_oauth2, key_config, []),
+    PeerVerification = proplists:get_value(peer_verification, UaaEnv, verify_none),
+    CaCertFile = proplists:get_value(cacertfile, UaaEnv),
+    Depth = proplists:get_value(depth, UaaEnv, 10),
+    FailIfNoPeerCert = proplists:get_value(fail_if_no_peer_cert, UaaEnv, false),
+    CrlCheck = proplists:get_value(crl_check, UaaEnv, false),
+    SslOpts0 = [{verify, PeerVerification},
+                {cacertfile, CaCertFile},
+                {depth, Depth},
+                {fail_if_no_peer_cert, FailIfNoPeerCert},
+                {crl_check, CrlCheck},
+                {crl_cache, {ssl_crl_cache, {internal, [{http, 10000}]}}}],
+    case proplists:get_value(hostname_verification, UaaEnv, none) of
+        wildcard ->
+            [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | SslOpts0];
+        none ->
+            SslOpts0
+    end.

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
@@ -71,14 +71,10 @@ update_jwks_signing_keys() ->
 -spec fetch_keys(binary() | list()) -> {ok, term()} | {error, term()}.
 fetch_keys(JwksUrl) ->
     UaaEnv = application:get_env(?APP, key_config, []),
-    case proplists:get_value(strict, UaaEnv, true) of
-        false ->
-            httpc:request(JwksUrl);
-        true ->
-            CaCertFile = proplists:get_value(cacertfile, UaaEnv),
-            SslOpts = [{verify, verify_peer}, {cacertfile, CaCertFile}, {fail_if_no_peer_cert, true}],
-            httpc:request(get, {JwksUrl, []}, [{ssl, SslOpts}], [])
-    end.
+    PeerVerification = proplists:get_value(peer_verification, UaaEnv, verify_peer),
+    CaCertFile = proplists:get_value(cacertfile, UaaEnv),
+    SslOpts = [{verify, PeerVerification}, {cacertfile, CaCertFile}],
+    httpc:request(get, {JwksUrl, []}, [{ssl, SslOpts}], []).
 
 -spec decode_and_verify(binary()) -> {boolean(), map()} | {error, term()}.
 decode_and_verify(Token) ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
@@ -73,7 +73,8 @@ fetch_keys(JwksUrl) ->
     UaaEnv = application:get_env(?APP, key_config, []),
     PeerVerification = proplists:get_value(peer_verification, UaaEnv, verify_none),
     CaCertFile = proplists:get_value(cacertfile, UaaEnv),
-    SslOpts = [{verify, PeerVerification}, {cacertfile, CaCertFile}],
+    Depth = proplists:get_value(depth, UaaEnv, 10),
+    SslOpts = [{verify, PeerVerification}, {cacertfile, CaCertFile}, {depth, Depth}],
     httpc:request(get, {JwksUrl, []}, [{ssl, SslOpts}], []).
 
 -spec decode_and_verify(binary()) -> {boolean(), map()} | {error, term()}.

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
@@ -71,7 +71,7 @@ update_jwks_signing_keys() ->
 -spec fetch_keys(binary() | list()) -> {ok, term()} | {error, term()}.
 fetch_keys(JwksUrl) ->
     UaaEnv = application:get_env(?APP, key_config, []),
-    PeerVerification = proplists:get_value(peer_verification, UaaEnv, verify_peer),
+    PeerVerification = proplists:get_value(peer_verification, UaaEnv, verify_none),
     CaCertFile = proplists:get_value(cacertfile, UaaEnv),
     SslOpts = [{verify, PeerVerification}, {cacertfile, CaCertFile}],
     httpc:request(get, {JwksUrl, []}, [{ssl, SslOpts}], []).

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -9,7 +9,9 @@
         auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
         auth_oauth2.https.peer_verification = verify_none
         auth_oauth2.https.depth = 5
-        auth_oauth2.https.wildcard = true
+        auth_oauth2.https.fail_if_no_peer_cert = false
+        auth_oauth2.https.hostname_verification = wildcard
+        auth_oauth2.https.crl_check = true
         auth_oauth2.algorithms.1 = HS256
         auth_oauth2.algorithms.2 = RS256",
         [
@@ -28,7 +30,9 @@
             {cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"},
             {peer_verification, verify_none},
             {depth, 5},
-            {wildcard, true},
+            {fail_if_no_peer_cert, false},
+            {hostname_verification, wildcard},
+            {crl_check, true},
             {algorithms, [<<"HS256">>, <<"RS256">>]}
             ]
             }

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -4,7 +4,12 @@
         auth_oauth2.additional_scopes_key = my_custom_scope_key
         auth_oauth2.default_key = id1
         auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
-        auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem",
+        auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem
+        auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
+        auth_oauth2.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+        auth_oauth2.strict = false
+        auth_oauth2.algorithms.1 = HS256
+        auth_oauth2.algorithms.2 = RS256",
         [
         {rabbitmq_auth_backend_oauth2, [
             {resource_server_id,<<"new_resource_server_id">>},
@@ -16,7 +21,11 @@
                     <<"id1">> => {pem, <<"I'm not a certificate">>},
                     <<"id2">> => {pem, <<"I'm not a certificate">>}
                 }
-            }
+            },
+            {jwks_url, "https://my-jwt-issuer/jwks.json"},
+            {cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"},
+            {strict, false},
+            {algorithms, [<<"HS256">>, <<"RS256">>]}
             ]
             }
         ]}

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -9,6 +9,7 @@
         auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
         auth_oauth2.https.peer_verification = verify_none
         auth_oauth2.https.depth = 5
+        auth_oauth2.https.wildcard = true
         auth_oauth2.algorithms.1 = HS256
         auth_oauth2.algorithms.2 = RS256",
         [
@@ -27,6 +28,7 @@
             {cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"},
             {peer_verification, verify_none},
             {depth, 5},
+            {wildcard, true},
             {algorithms, [<<"HS256">>, <<"RS256">>]}
             ]
             }

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -8,6 +8,7 @@
         auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
         auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
         auth_oauth2.https.peer_verification = verify_none
+        auth_oauth2.https.depth = 5
         auth_oauth2.algorithms.1 = HS256
         auth_oauth2.algorithms.2 = RS256",
         [
@@ -25,6 +26,7 @@
             {jwks_url, "https://my-jwt-issuer/jwks.json"},
             {cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"},
             {peer_verification, verify_none},
+            {depth, 5},
             {algorithms, [<<"HS256">>, <<"RS256">>]}
             ]
             }

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -6,8 +6,8 @@
         auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
         auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem
         auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
-        auth_oauth2.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
-        auth_oauth2.strict = false
+        auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+        auth_oauth2.https.peer_verification = verify_none
         auth_oauth2.algorithms.1 = HS256
         auth_oauth2.algorithms.2 = RS256",
         [
@@ -24,7 +24,7 @@
             },
             {jwks_url, "https://my-jwt-issuer/jwks.json"},
             {cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"},
-            {strict, false},
+            {peer_verification, verify_none},
             {algorithms, [<<"HS256">>, <<"RS256">>]}
             ]
             }

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -194,6 +194,7 @@ start_jwks_server(Config) ->
     StrictJwksUrl = "https://localhost:" ++ integer_to_list(JwksServerPort) ++ "/jwks",
 
     ok = application:set_env(jwks_http, keys, [Jwk]),
+    {ok, _} = application:ensure_all_started(ssl),
     {ok, _} = application:ensure_all_started(cowboy),
     CertsDir = ?config(rmq_certsdir, Config),
     ok = jwks_http_app:start(JwksServerPort, CertsDir),

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -362,7 +362,7 @@ test_successful_token_refresh(Config) ->
     Conn     = open_unmanaged_connection(Config, 0, <<"vhost1">>, <<"username">>, Token),
     {ok, Ch} = amqp_connection:open_channel(Conn),
 
-    {_Algo, Token2} = generate_valid_token(Config, [<<"rabbitmq.configure:vhost1/*">>,
+    {_Algo2, Token2} = generate_valid_token(Config, [<<"rabbitmq.configure:vhost1/*">>,
                                                     <<"rabbitmq.write:vhost1/*">>,
                                                     <<"rabbitmq.read:vhost1/*">>]),
     ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration)),
@@ -423,7 +423,7 @@ test_failed_token_refresh_case1(Config) ->
     #'queue.declare_ok'{queue = _} =
         amqp_channel:call(Ch, #'queue.declare'{exclusive = true}),
 
-    {_Algo, Token2} = generate_expired_token(Config, [<<"rabbitmq.configure:vhost4/*">>,
+    {_Algo2, Token2} = generate_expired_token(Config, [<<"rabbitmq.configure:vhost4/*">>,
                                                       <<"rabbitmq.write:vhost4/*">>,
                                                       <<"rabbitmq.read:vhost4/*">>]),
     %% the error is communicated asynchronously via a connection-level error

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -23,7 +23,7 @@ all() ->
      {group, happy_path},
      {group, unhappy_path},
      {group, unvalidated_jwks_server},
-     {group, non_strict_mode}
+     {group, no_peer_verification}
     ].
 
 groups() ->
@@ -49,7 +49,7 @@ groups() ->
                          test_failed_token_refresh_case2
                         ]},
      {unvalidated_jwks_server, [], [test_failed_connection_with_unvalidated_jwks_server]},
-     {non_strict_mode, [], [{group, happy_path}, {group, unhappy_path}]}
+     {no_peer_verification, [], [{group, happy_path}, {group, unhappy_path}]}
     ].
 
 %%
@@ -75,9 +75,9 @@ end_per_suite(Config) ->
         fun stop_jwks_server/1
       ] ++ rabbit_ct_broker_helpers:teardown_steps()).
 
-init_per_group(non_strict_mode, Config) ->
+init_per_group(no_peer_verification, Config) ->
     add_vhosts(Config),
-    KeyConfig = rabbit_ct_helpers:set_config(?config(key_config, Config), [{jwks_url, ?config(non_strict_jwks_url, Config)}, {strict, false}]),
+    KeyConfig = rabbit_ct_helpers:set_config(?config(key_config, Config), [{jwks_url, ?config(non_strict_jwks_url, Config)}, {peer_verification, verify_none}]),
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_auth_backend_oauth2, key_config, KeyConfig]),
     rabbit_ct_helpers:set_config(Config, {key_config, KeyConfig});
 
@@ -85,9 +85,9 @@ init_per_group(_Group, Config) ->
     add_vhosts(Config),
     Config.
 
-end_per_group(non_strict_mode, Config) ->
+end_per_group(no_peer_verification, Config) ->
     delete_vhosts(Config),
-    KeyConfig = rabbit_ct_helpers:set_config(?config(key_config, Config), [{jwks_url, ?config(strict_jwks_url, Config)}, {strict, true}]),
+    KeyConfig = rabbit_ct_helpers:set_config(?config(key_config, Config), [{jwks_url, ?config(strict_jwks_url, Config)}, {peer_verification, verify_peer}]),
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_auth_backend_oauth2, key_config, KeyConfig]),
     rabbit_ct_helpers:set_config(Config, {key_config, KeyConfig});
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -198,6 +198,7 @@ start_jwks_server(Config) ->
     CertsDir = ?config(rmq_certsdir, Config),
     ok = jwks_http_app:start(JwksServerPort, CertsDir),
     KeyConfig = [{jwks_url, StrictJwksUrl},
+                 {peer_verification, verify_peer},
                  {cacertfile, filename:join([CertsDir, "testca", "cacert.pem"])}],
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
                                       [rabbitmq_auth_backend_oauth2, key_config, KeyConfig]),

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_http_app.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_http_app.erl
@@ -1,8 +1,8 @@
 -module(jwks_http_app).
 
--export([start/1, stop/0]).
+-export([start/2, stop/0]).
 
-start(Port) ->
+start(Port, CertsDir) ->
     Dispatch =
         cowboy_router:compile(
           [
@@ -11,8 +11,10 @@ start(Port) ->
                  ]}
           ]
          ),
-    {ok, _} = cowboy:start_clear(jwks_http_listener,
-                      [{port, Port}],
+    {ok, _} = cowboy:start_tls(jwks_http_listener,
+                      [{port, Port},
+                       {certfile, filename:join([CertsDir, "server", "cert.pem"])},
+                       {keyfile, filename:join([CertsDir, "server", "key.pem"])}],
                       #{env => #{dispatch => Dispatch}}),
     ok.
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
@@ -73,7 +73,7 @@ expired_token_with_scopes(Scopes) ->
     token_with_scopes_and_expiration(Scopes, os:system_time(seconds) - 10).
 
 fixture_token_with_scopes(Scopes) ->
-    token_with_scopes_and_expiration(Scopes, os:system_time(seconds) + 10).
+    token_with_scopes_and_expiration(Scopes, os:system_time(seconds) + 30).
 
 token_with_scopes_and_expiration(Scopes, Expiration) ->
     %% expiration is a timestamp with precision in seconds


### PR DESCRIPTION
Hi,

We implemented some changes to the Oauth plugin which affect how RabbitMQ fetches the JWKey Sets from a remote host, restrict the list of valid algorithms in the token, and some improvements to the config file. 

These changes are the following:

- Currently, when the keys are fetched from a remote service, the certificate of the remote is not validated. For this we implemented the configuration options:
    - auth_oauth2.https.peer_verification = verify_peer
    - auth_oauth2.https.cacertfile = /usr/local/etc/ca-certificates/cert.pem
    - auth_oauth2.https.depth = 10
- Added configuration option in the ini style config for a jwks URL. 
  - auth_oauth2.jwks_url = https://URL
  - According to the JWK spec the URL must be HTTPS, so we added validation for that. 
- The list of algorithms usable by the tokens is restrictable. 
  - We wanted to enforce certain algorithms (ie, symmetric keys should not be used), therefore we implemented a configuration option, for example:
    - auth_oauth2.algorithms.0 = HS256
    - auth_oauth2.algorithms.1 = RS256
- Changes the HTTPC timeout to 60 seconds. 
- Updated README and tests. 

Care was taken to keep the current behaviour, however for example this caused that verify_none needs to be the default for the key fetching.

This PR was created as part of a security audit made on behalf of [LKAB](https://www.lkab.com/).