### PR TITLE
CLI: make node_health_check a no-op

### DIFF
--- a/deps/rabbit/src/rabbit_health_check.erl
+++ b/deps/rabbit/src/rabbit_health_check.erl
@@ -4,17 +4,17 @@
 %%
 %% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 %%
+
+%% This health check module is deprecated. DO NOT USE.
+%% See https://www.rabbitmq.com/monitoring.html#health-checks for modern alternatives.
 -module(rabbit_health_check).
 
-%% External API
 -export([node/1, node/2]).
-
-%% Internal API
 -export([local/0]).
 
-%%----------------------------------------------------------------------------
-%% External functions
-%%----------------------------------------------------------------------------
+%%
+%% API
+%%
 
 node(Node) ->
     %% same default as in CLI
@@ -28,54 +28,6 @@ node(Node, Timeout) ->
 -spec local() -> ok | {error_string, string()}.
 
 local() ->
-    rabbit_log:warning("rabbitmqctl node_health_check and its HTTP API counterpart are DEPRECATED. "
-                       "See https://www.rabbitmq.com/monitoring.html#health-checks for replacement options."),
-    run_checks([list_channels, list_queues, alarms, rabbit_node_monitor]).
-
-%%----------------------------------------------------------------------------
-%% Internal functions
-%%----------------------------------------------------------------------------
-run_checks([]) ->
-    ok;
-run_checks([C|Cs]) ->
-    case node_health_check(C) of
-        ok ->
-            run_checks(Cs);
-        Error ->
-            Error
-    end.
-
-node_health_check(list_channels) ->
-    case rabbit_channel:info_local([pid]) of
-        L when is_list(L) ->
-            ok
-    end;
-
-node_health_check(list_queues) ->
-    health_check_queues(rabbit_vhost:list_names());
-
-node_health_check(rabbit_node_monitor) ->
-    case rabbit_node_monitor:partitions() of
-        [] ->
-            ok;
-        L when is_list(L), length(L) > 0 ->
-            ErrorMsg = io_lib:format("cluster partition in effect: ~p", [L]),
-            {error_string, ErrorMsg}
-    end;
-
-node_health_check(alarms) ->
-    case proplists:get_value(alarms, rabbit:status()) of
-        [] ->
-            ok;
-        Alarms ->
-            ErrorMsg = io_lib:format("resource alarm(s) in effect:~p", [Alarms]),
-            {error_string, ErrorMsg}
-    end.
-
-health_check_queues([]) ->
-    ok;
-health_check_queues([VHost|RestVHosts]) ->
-    case rabbit_amqqueue:info_local(VHost) of
-        L when is_list(L) ->
-            health_check_queues(RestVHosts)
-    end.
+    rabbit_log:warning("rabbitmqctl node_health_check and its HTTP API counterpart are DEPRECATED and no longer perform any checks. "
+                       "See https://www.rabbitmq.com/monitoring.html#health-checks for modern alternatives"),
+    ok.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -26,37 +26,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
   end
 
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([], %{node: node_name, timeout: timeout}) do
-    case :rabbit_misc.rpc_call(node_name, :rabbit_health_check, :node, [node_name, timeout]) do
-      :ok ->
-        :ok
-
-      true ->
-        :ok
-
-      {:badrpc, _} = err ->
-        err
-
-      {:error_string, error_message} ->
-        {:healthcheck_failed, error_message}
-
-      {:node_is_ko, error_message, _exit_code} ->
-        {:healthcheck_failed, error_message}
-
-      other ->
-        other
-    end
+  def run([], _opts) do
+    :ok
   end
 
   def output(:ok, _) do
-    {:ok, "Health check passed"}
-  end
-
-  def output({:healthcheck_failed, message}, _) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software(),
-     "Error: health check failed. Message: #{message}"}
+    {:ok, "This command is a no-op. See https://www.rabbitmq.com/monitoring.html#health-checks for modern alternatives"}
   end
 
   use RabbitMQ.CLI.DefaultOutput
@@ -71,17 +47,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
 
   def help_section(), do: :deprecated
   def description() do
-    "DEPRECATED. Performs intrusive, opinionated health checks on a fully booted node. " <>
-    "See https://www.rabbitmq.com/monitoring.html#health-checks instead"
+    "DEPRECATED. Does not perform any checks (is a no-op). " <>
+    "See https://www.rabbitmq.com/monitoring.html#health-checks for modern alternatives"
   end
 
-  def banner(_, %{node: node_name, timeout: timeout}) do
+  def banner(_, _) do
     [
-      "This command is DEPRECATED and will be removed in a future version.",
-      "It performs intrusive, opinionated health checks and requires a fully booted node.",
-      "Use one of the options covered in https://www.rabbitmq.com/monitoring.html#health-checks instead.",
-      "Timeout: #{trunc(timeout / 1000)} seconds ...",
-      "Checking health of node #{node_name} ..."
+      "This command has been DEPRECATED since 2019 and no longer has any effect.",
+      "Use one of the options covered in https://www.rabbitmq.com/monitoring.html#health-checks instead."
     ]
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/node_health_check_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/node_health_check_command_test.exs
@@ -11,20 +11,8 @@ defmodule NodeHealthCheckCommandTest do
 
   @command RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand
 
-  setup_all do
-    RabbitMQ.CLI.Core.Distribution.start()
-
-    reset_vm_memory_high_watermark()
-
-    on_exit([], fn ->
-      reset_vm_memory_high_watermark()
-    end)
-
-    :ok
-  end
-
   setup do
-    {:ok, opts: %{node: get_rabbit_hostname(), timeout: 20000}}
+    {:ok, opts: %{timeout: 20000}}
   end
 
   test "validate: with extra arguments returns an arg count error", context do
@@ -35,31 +23,7 @@ defmodule NodeHealthCheckCommandTest do
     assert @command.validate([], []) == :ok
   end
 
-  test "validate: with a named, active node argument succeeds", context do
-    assert @command.validate([], context[:opts]) == :ok
-  end
-
-  test "run: request to a named, active node succeeds", context do
-    assert @command.run([], context[:opts])
-  end
-
-  test "run: request to a named, active node with an alarm in effect fails", context do
-    set_vm_memory_high_watermark(0.0000000000001)
-    # give VM memory monitor check some time to kick in
-    :timer.sleep(1500)
-    {:healthcheck_failed, _message} = @command.run([], context[:opts])
-
-    reset_vm_memory_high_watermark()
-    :timer.sleep(1500)
-    assert @command.run([], context[:opts]) == :ok
-  end
-
-  test "run: request to a non-existent node returns a badrpc" do
-    assert match?({:badrpc, _}, @command.run([], %{node: :jake@thedog, timeout: 200}))
-  end
-
   test "banner", context do
-    assert @command.banner([], context[:opts]) |> Enum.join("\n") =~ ~r/Checking health/
-    assert @command.banner([], context[:opts]) |> Enum.join("\n") =~ ~r/#{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) |> Enum.join("\n") =~ ~r/This command has been DEPRECATED since 2019 and no longer has any effect/
   end
 end


### PR DESCRIPTION
## Proposed Changes

This legacy health check has been [deprecated since 2019](https://www.rabbitmq.com/monitoring.html#deprecations) with a group of [alternatives available](https://www.rabbitmq.com/monitoring.html#health-checks).

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Closes #3892.
