### PR TITLE
Khepri integration: handle shutdown errors when importing definitions

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -269,8 +269,8 @@ apply_defs(Map, ActingUser, SuccessFun) when is_function(SuccessFun) ->
 
         SuccessFun(),
         ok
-    catch {error, E} -> {error, E};
-          exit:E     -> {error, E}
+    catch {error, E} -> {error, format(E)};
+          exit:E     -> {error, format(E)}
     end.
 
 -spec apply_defs(Map :: #{atom() => any()},
@@ -418,6 +418,10 @@ format({no_such_vhost, VHost}) ->
                          [VHost]));
 format({vhost_limit_exceeded, ErrMsg}) ->
     rabbit_data_coercion:to_binary(ErrMsg);
+format({shutdown, _} = Error) ->
+    rabbit_log:debug("Metadata store is unavailable: ~p", [Error]),
+    rabbit_data_coercion:to_binary(
+      rabbit_misc:format("Metadata store is unavailable. Please try again.", []));
 format(E) ->
     rabbit_data_coercion:to_binary(rabbit_misc:format("~p", [E])).
 


### PR DESCRIPTION
After talking with @dumbbell, we both think that the best option is to ask the user to retry.

The ra leader can go down while importing definitions, and there is no much we can do. It is better to warn the user and ask him to retry. It could be a temporary flake or a sign that something is wrong in the system. 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #3859)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

