### PR TITLE
Fix log level when halting the VM

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -500,7 +500,7 @@ stop_and_halt() ->
         %% init:stop() will be called regardless of any errors.
         try
             AppsLeft = [ A || {A, _, _} <- application:which_applications() ],
-            ?LOG_ERROR(
+            ?LOG_INFO(
                 lists:flatten(
                   ["Halting Erlang VM with the following applications:~n",
                    ["    ~p~n" || _ <- AppsLeft]]),


### PR DESCRIPTION
When switching from lager to logger a mistake was made and
the list of applications remaining when the node stops was
made to log at error level instead of info.

https://github.com/rabbitmq/rabbitmq-server/commit/cdcf602749a#diff-5d9f448b943b2c77af7822440fc8df8af02bf2001d1c51a484413f69cad37a62L473-R486

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
