### PR TITLE
Prevent creating unnamed policy when loading definition

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -464,11 +464,9 @@ add_policy(Param, Username) ->
 
 add_policy(VHost, Param, Username) ->
     Key   = maps:get(name,  Param, undefined),
-    case Key == undefined of
-      true ->
-        rabbit_misc:protocol_error(
-          command_invalid, "invalid policy name '~s'", [Key]);
-      false -> ok
+    case Key of
+      undefined -> exit("policy name not defined");
+      _ -> ok
     end,
     case rabbit_policy:set(
            VHost, Key, maps:get(pattern, Param, undefined),

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -464,6 +464,12 @@ add_policy(Param, Username) ->
 
 add_policy(VHost, Param, Username) ->
     Key   = maps:get(name,  Param, undefined),
+    case Key == undefined of
+      true ->
+        rabbit_misc:protocol_error(
+          command_invalid, "invalid policy name '~s'", [Key]);
+      false -> ok
+    end,
     case rabbit_policy:set(
            VHost, Key, maps:get(pattern, Param, undefined),
            case maps:get(definition, Param, undefined) of

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -46,7 +46,8 @@ groups() ->
                                import_case13,
                                import_case14,
                                import_case15,
-                               import_case16
+                               import_case16,
+                               import_case17
                               ]},
         
         {boot_time_import_using_classic_source, [], [
@@ -235,6 +236,8 @@ import_case16(Config) ->
         %% skip the test in mixed version mode
         {skip, "Should not run in mixed version environments"}
     end.
+
+import_case17(Config) -> import_invalid_file_case(Config, "failing_case17").
 
 export_import_round_trip_case1(Config) ->
     case rabbit_ct_helpers:is_mixed_versions() of

--- a/deps/rabbit/test/definition_import_SUITE_data/failing_case17.json
+++ b/deps/rabbit/test/definition_import_SUITE_data/failing_case17.json
@@ -1,0 +1,19 @@
+{
+  "vhosts": [
+    {
+      "name": "\/"
+    }
+  ],
+  "policies": [
+    {
+      "vhost": "\/",
+      "pattern": "^project-nd-ns-",
+      "apply-to": "queues",
+      "definition": {
+        "expires": 120000,
+        "max-length": 10000
+      },
+      "priority": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Proposed Changes

Fixes #971
Prevent creating unnamed policy when loading definition

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
