### PR TITLE
Add a feature flags controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@
 !/deps/rabbitmq_cli/
 !/deps/rabbitmq_codegen/
 !/deps/rabbitmq_consistent_hash_exchange/
+!/deps/rabbitmq_ct_helpers/
+!/deps/rabbitmq_ct_client_helpers/
 !/deps/rabbitmq_event_exchange/
 !/deps/rabbitmq_federation/
 !/deps/rabbitmq_federation_management/

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -432,10 +432,15 @@ suites = [
         name = "feature_flags_SUITE",
         size = "large",
         flaky = True,
-        shard_count = 5,
+        shard_count = 9,
         runtime_deps = [
             "//deps/rabbit/test/feature_flags_SUITE_data/my_plugin:erlang_app",
         ],
+    ),
+    rabbitmq_integration_suite(
+        PACKAGE,
+        name = "feature_flags_v2_SUITE",
+        size = "large",
     ),
     rabbitmq_integration_suite(
         PACKAGE,

--- a/deps/rabbit/include/feature_flags.hrl
+++ b/deps/rabbit/include/feature_flags.hrl
@@ -1,0 +1,13 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-record(ffcommand, {
+          name :: rabbit_feature_flags:feature_name(),
+          props :: rabbit_feature_flags:feature_props_extended(),
+          command :: enable | post_enable,
+          extra :: #{nodes := [node()]}
+         }).

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -851,6 +851,12 @@ start(normal, []) ->
         log_motd(),
         {ok, SupPid} = rabbit_sup:start_link(),
 
+        %% When we load plugins later in this function, we refresh feature
+        %% flags. If `feature_flags_v2' is enabled, `rabbit_ff_controller'
+        %% will be used. We start it now because we can't wait for boot steps
+        %% to do this (feature flags are refreshed before boot steps run).
+        ok = rabbit_sup:start_child(rabbit_ff_controller),
+
         %% Compatibility with older RabbitMQ versions + required by
         %% rabbit_node_monitor:notify_node_up/0:
         %%

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -87,6 +87,12 @@
       migration_fun => {?MODULE, direct_exchange_routing_v2_migration}
      }}).
 
+-rabbit_feature_flag(
+    {feature_flags_v2,
+     #{desc          => "Feature flags subsystem V2",
+       stability     => stable
+     }}).
+
 classic_mirrored_queue_version_migration(_FeatureName, _FeatureProps, _Enable) ->
     ok.
 

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -7,21 +7,17 @@
 
 -module(rabbit_core_ff).
 
--export([classic_mirrored_queue_version_migration/3,
-         quorum_queue_migration/3,
-         stream_queue_migration/3,
+-export([quorum_queue_migration/3,
          implicit_default_bindings_migration/3,
          virtual_host_metadata_migration/3,
          maintenance_mode_status_migration/3,
          user_limits_migration/3,
-         stream_single_active_consumer_migration/3,
          direct_exchange_routing_v2_migration/3]).
 
 -rabbit_feature_flag(
    {classic_mirrored_queue_version,
     #{desc          => "Support setting version for classic mirrored queues",
-      stability     => stable,
-      migration_fun => {?MODULE, classic_mirrored_queue_version_migration}
+      stability     => stable
      }}).
 
 -rabbit_feature_flag(
@@ -37,8 +33,7 @@
     #{desc          => "Support queues of type `stream`",
       doc_url       => "https://www.rabbitmq.com/stream.html",
       stability     => stable,
-      depends_on    => [quorum_queue],
-      migration_fun => {?MODULE, stream_queue_migration}
+      depends_on    => [quorum_queue]
      }}).
 
 -rabbit_feature_flag(
@@ -75,8 +70,7 @@
     #{desc          => "Single active consumer for streams",
       doc_url       => "https://www.rabbitmq.com/stream.html",
       stability     => stable,
-      depends_on    => [stream_queue],
-      migration_fun => {?MODULE, stream_single_active_consumer_migration}
+      depends_on    => [stream_queue]
      }}).
 
 -rabbit_feature_flag(
@@ -92,9 +86,6 @@
      #{desc          => "Feature flags subsystem V2",
        stability     => stable
      }}).
-
-classic_mirrored_queue_version_migration(_FeatureName, _FeatureProps, _Enable) ->
-    ok.
 
 %% -------------------------------------------------------------------
 %% Quorum queues.
@@ -114,9 +105,6 @@ quorum_queue_migration(_FeatureName, _FeatureProps, is_enabled) ->
     Fields = amqqueue:fields(amqqueue_v2),
     mnesia:table_info(rabbit_queue, attributes) =:= Fields andalso
     mnesia:table_info(rabbit_durable_queue, attributes) =:= Fields.
-
-stream_queue_migration(_FeatureName, _FeatureProps, _Enable) ->
-    ok.
 
 migrate_to_amqqueue_with_type(FeatureName, [Table | Rest], Fields) ->
     rabbit_log_feature_flags:info(
@@ -213,15 +201,6 @@ user_limits_migration(_FeatureName, _FeatureProps, enable) ->
     end;
 user_limits_migration(_FeatureName, _FeatureProps, is_enabled) ->
     mnesia:table_info(rabbit_user, attributes) =:= internal_user:fields(internal_user_v2).
-
-%% -------------------------------------------------------------------
-%% Stream single active consumer.
-%% -------------------------------------------------------------------
-
-stream_single_active_consumer_migration(_FeatureName, _FeatureProps, enable) ->
-    ok;
-stream_single_active_consumer_migration(_FeatureName, _FeatureProps, is_enabled) ->
-    undefined.
 
 %% -------------------------------------------------------------------
 %% Direct exchange routing v2.

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -1,0 +1,1152 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @author The RabbitMQ team
+%% @copyright 2022 VMware, Inc. or its affiliates.
+%%
+%% @doc
+%% The feature flag controller is responsible for synchronization and managing
+%% concurrency when feature flag states are changed.
+%%
+%% It makes sure only one node can enable feature flags or synchronize its
+%% feature flag states with other nodes at a time. If another node wants to
+%% enable a feature flag or if it joins a cluster and needs to synchronize its
+%% feature flag states, it will wait for the current task to finish.
+%%
+%% The feature flag controller is used as soon as the `feature_flags_v2'
+%% feature flag is enabled.
+%%
+%% Compared to the initial subsystem, it also introduces a new migration
+%% function signature; See {@link rabbit_feature_flags:migration_fun_v2()}.
+
+-module(rabbit_ff_controller).
+-behaviour(gen_statem).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include_lib("rabbit_common/include/logging.hrl").
+
+-include("feature_flags.hrl").
+
+-export([is_supported/1, is_supported/2,
+         enable/1,
+         check_node_compatibility/1,
+         sync_cluster/0,
+         refresh_after_app_load/0]).
+
+%% Internal use only.
+-export([start/0,
+         start_link/0,
+         rpc_call/5,
+         all_nodes/0,
+         running_nodes/0]).
+
+%% gen_statem callbacks.
+-export([callback_mode/0,
+         init/1,
+         terminate/3,
+         code_change/4,
+
+         standing_by/3,
+         waiting_for_end_of_controller_task/3,
+         updating_feature_flag_states/3]).
+
+-record(?MODULE, {from,
+                  notify = #{}}).
+
+-define(LOCAL_NAME, ?MODULE).
+-define(GLOBAL_NAME, {?MODULE, global}).
+
+%% Default timeout for operations on remote nodes.
+-define(TIMEOUT, 60000).
+
+start() ->
+    gen_statem:start({local, ?LOCAL_NAME}, ?MODULE, none, []).
+
+start_link() ->
+    gen_statem:start_link({local, ?LOCAL_NAME}, ?MODULE, none, []).
+
+is_supported(FeatureNames) ->
+    is_supported(FeatureNames, ?TIMEOUT).
+
+is_supported(FeatureName, Timeout) when is_atom(FeatureName) ->
+    is_supported([FeatureName], Timeout);
+is_supported(FeatureNames, Timeout) when is_list(FeatureNames) ->
+    Nodes = running_nodes(),
+    case collect_inventory_on_nodes(Nodes, Timeout) of
+        {ok, Inventory} ->
+            lists:all(
+              fun(FeatureName) ->
+                      is_known_and_supported(Inventory, FeatureName)
+              end,
+              FeatureNames);
+        _Error ->
+            false
+    end.
+
+enable(FeatureName) when is_atom(FeatureName) ->
+    enable([FeatureName]);
+enable(FeatureNames) when is_list(FeatureNames) ->
+    ?LOG_DEBUG(
+       "Feature flags: REQUEST TO ENABLE: ~p",
+       [FeatureNames],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    gen_statem:call(?LOCAL_NAME, {enable, FeatureNames}).
+
+check_node_compatibility(RemoteNode) ->
+    ThisNode = node(),
+    ?LOG_DEBUG(
+       "Feature flags: CHECKING COMPATIBILITY between nodes `~s` and `~s`",
+       [ThisNode, RemoteNode],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    %% We don't go through the controller process to check nodes compatibility
+    %% because this function is used while `rabbit' is stopped usually.
+    %%
+    %% There is no benefit in starting a controller just for this check
+    %% because it would not guaranty that the compatibility remains true after
+    %% this function finishes and before the node starts and synchronizes
+    %% feature flags.
+    check_node_compatibility_task(ThisNode, RemoteNode).
+
+sync_cluster() ->
+    ?LOG_DEBUG(
+       "Feature flags: SYNCING FEATURE FLAGS in cluster...",
+       [],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    case erlang:whereis(?LOCAL_NAME) of
+        Pid when is_pid(Pid) ->
+            %% The function is called while `rabbit' is running.
+            gen_statem:call(?LOCAL_NAME, sync_cluster);
+        undefined ->
+            %% The function is called while `rabbit' is stopped. We need to
+            %% start a one-off controller, again to make sure concurrent
+            %% changes are blocked.
+            {ok, Pid} = start_link(),
+            Ret = gen_statem:call(Pid, sync_cluster),
+            gen_statem:stop(Pid),
+            Ret
+    end.
+
+refresh_after_app_load() ->
+    ?LOG_DEBUG(
+       "Feature flags: REFRESHING after applications load...",
+       [],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    gen_statem:call(?LOCAL_NAME, refresh_after_app_load).
+
+%% --------------------------------------------------------------------
+%% gen_statem callbacks.
+%% --------------------------------------------------------------------
+
+callback_mode() ->
+    state_functions.
+
+init(_Args) ->
+    {ok, standing_by, none}.
+
+standing_by(
+  {call, From} = EventType, EventContent, none)
+  when EventContent =/= notify_when_done ->
+    ?LOG_DEBUG(
+       "Feature flags: registering controller globally before "
+       "proceeding with task: ~p",
+       [EventContent],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+
+    %% The first step is to register this process globally (it is already
+    %% registered locally). The purpose is to make sure this one takes full
+    %% control on feature flag changes among other controllers.
+    %%
+    %% This is useful for situations where a new node joins the cluster while
+    %% a feature flag is being enabled. In this case, when that new node joins
+    %% and its controller wants to synchronize feature flags, it will block
+    %% and wait for this one to finish.
+    case register_globally() of
+        yes ->
+            %% We would register the process globally. Therefore we can
+            %% proceed with enabling/syncing feature flags.
+            ?LOG_DEBUG(
+               "Feature flags: controller globally registered; can proceed "
+               "with task",
+               [],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+
+            Data = #?MODULE{from = From},
+            {next_state, updating_feature_flag_states, Data,
+             [{next_event, internal, EventContent}]};
+
+        no ->
+            %% Another controller is globally registered. We ask that global
+            %% controller to notify us when it is done, and we wait for its
+            %% response.
+            ?LOG_DEBUG(
+               "Feature flags: controller NOT globally registered; need to "
+               "wait for the current global controller's task to finish",
+               [],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+
+            RequestId = notify_me_when_done(),
+            {next_state, waiting_for_end_of_controller_task, RequestId,
+             [{next_event, EventType, EventContent}]}
+    end;
+standing_by(
+  {call, From}, notify_when_done, none) ->
+    %% This state is entered when a globally-registered controller finished
+    %% its task but had unhandled `notify_when_done` requests in its inbox. We
+    %% just need to notify the caller that it can proceed.
+    notify_waiting_controller(From),
+    {keep_state_and_data, []}.
+
+waiting_for_end_of_controller_task(
+  {call, _From}, _EventContent, _RequestId) ->
+    {keep_state_and_data, [postpone]};
+waiting_for_end_of_controller_task(
+  info, Msg, RequestId) ->
+    case gen_statem:check_response(Msg, RequestId) of
+        {reply, done} ->
+            ?LOG_DEBUG(
+               "Feature flags: current global controller's task finished; "
+               "trying to take next turn",
+               [],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {next_state, standing_by, none, []};
+        {error, Reason} ->
+            ?LOG_DEBUG(
+               "Feature flags: error while waiting for current global "
+               "controller's task: ~0p; trying to take next turn",
+               [Reason],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {next_state, standing_by, none, []};
+        no_reply ->
+            ?LOG_DEBUG(
+               "Feature flags: unknown message while waiting for current "
+               "global controller's task: ~0p; still waiting",
+               [Msg],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            keep_state_and_data
+    end.
+
+updating_feature_flag_states(
+  internal, Task, #?MODULE{from = From} = Data) ->
+    Reply = proceed_with_task(Task),
+
+    ?LOG_DEBUG(
+       "Feature flags: unregistering controller globally",
+       [],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    unregister_globally(),
+    notify_waiting_controllers(Data),
+    {next_state, standing_by, none, [{reply, From, Reply}]};
+updating_feature_flag_states(
+  {call, From}, notify_when_done, #?MODULE{notify = Notify} = Data) ->
+    Notify1 = Notify#{From => true},
+    Data1 = Data#?MODULE{notify = Notify1},
+    {keep_state, Data1}.
+
+proceed_with_task({enable, FeatureNames}) ->
+    enable_task(FeatureNames);
+proceed_with_task(sync_cluster) ->
+    sync_cluster_task();
+proceed_with_task(refresh_after_app_load) ->
+    refresh_after_app_load_task().
+
+terminate(_Reason, _State, _Data) ->
+    ok.
+
+code_change(_OldVsn, OldState, OldData, _Extra) ->
+    {ok, OldState, OldData}.
+
+%% --------------------------------------------------------------------
+%% Global name registration.
+%% --------------------------------------------------------------------
+
+register_globally() ->
+    ?LOG_DEBUG(
+       "Feature flags: [global sync] @ ~s",
+       [node()],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    ok = global:sync(),
+    ?LOG_DEBUG(
+       "Feature flags: [global register] @ ~s",
+       [node()],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    global:register_name(?GLOBAL_NAME, self()).
+
+unregister_globally() ->
+    ?LOG_DEBUG(
+       "Feature flags: [global unregister] @ ~s",
+       [node()],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    _ = global:unregister_name(?GLOBAL_NAME),
+    ok.
+
+notify_me_when_done() ->
+    gen_statem:send_request({global, ?GLOBAL_NAME}, notify_when_done).
+
+notify_waiting_controllers(#?MODULE{notify = Notify}) ->
+    maps:fold(
+      fun(From, true, Acc) ->
+              notify_waiting_controller(From),
+              Acc
+      end, ok, Notify).
+
+notify_waiting_controller({ControlerPid, _} = From) ->
+    ControlerNode = node(ControlerPid),
+    ?LOG_DEBUG(
+       "Feature flags: controller's task finished; notify waiting controller "
+       "on node ~p",
+       [ControlerNode],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    gen_statem:reply(From, done).
+
+%% --------------------------------------------------------------------
+%% Code to check compatibility between nodes.
+%% --------------------------------------------------------------------
+
+-spec check_node_compatibility_task(Node, Node) -> Ret when
+      Node :: node(),
+      Ret :: ok | {error, Reason},
+      Reason :: incompatible_feature_flags.
+
+check_node_compatibility_task(NodeA, NodeB) ->
+    ?LOG_NOTICE(
+       "Feature flags: checking nodes `~s` and `~s` compatibility...",
+       [NodeA, NodeB],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    NodesA = list_nodes_clustered_with(NodeA),
+    NodesB = list_nodes_clustered_with(NodeB),
+    AreCompatible = case collect_inventory_on_nodes(NodesA) of
+                        {ok, InventoryA} ->
+                            ?LOG_DEBUG(
+                               "Feature flags: inventory of node `~s`:~n~p",
+                               [NodeA, InventoryA],
+                               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                            case collect_inventory_on_nodes(NodesB) of
+                                {ok, InventoryB} ->
+                                    ?LOG_DEBUG(
+                                       "Feature flags: inventory of node "
+                                       "`~s`:~n~p",
+                                       [NodeB, InventoryB],
+                                       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                                    are_compatible(InventoryA, InventoryB);
+                                _ ->
+                                    false
+                            end;
+                        _ ->
+                            false
+                    end,
+    case AreCompatible of
+        true ->
+            ?LOG_NOTICE(
+               "Feature flags: nodes `~s` and `~s` are compatible",
+               [NodeA, NodeB],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            ok;
+        false ->
+            ?LOG_WARNING(
+               "Feature flags: nodes `~s` and `~s` are incompatible",
+               [NodeA, NodeB],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {error, incompatible_feature_flags}
+    end.
+
+-spec list_nodes_clustered_with(Node) -> [Node] when
+      Node :: node().
+
+list_nodes_clustered_with(Node) ->
+    %% If Mnesia is stopped on the given node, it will return an empty list.
+    %% In this case, only consider that stopped node.
+    case rpc_call(Node, ?MODULE, running_nodes, [], ?TIMEOUT) of
+        []   -> [Node];
+        List -> List
+    end.
+
+-spec are_compatible(Inventory, Inventory) -> AreCompatible when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      AreCompatible :: boolean().
+
+are_compatible(InventoryA, InventoryB) ->
+    check_one_way_compatibility(InventoryA, InventoryB)
+    andalso
+    check_one_way_compatibility(InventoryB, InventoryA).
+
+-spec check_one_way_compatibility(Inventory, Inventory) -> AreCompatible when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      AreCompatible :: boolean().
+
+check_one_way_compatibility(InventoryA, InventoryB) ->
+    %% This function checks the compatibility in one way, "inventory A" is
+    %% compatible with "inventory B". This is true if all feature flags
+    %% enabled in "inventory B" are supported by "inventory A".
+    %%
+    %% They don't need to be enabled on both side: the feature flags states
+    %% will be synchronized by `sync_cluster()'.
+    FeatureNames = list_feature_flags_enabled_somewhere(InventoryB, true),
+    lists:all(
+      fun(FeatureName) ->
+              #{feature_flags := #{FeatureName := FeatureFlag}} = InventoryB,
+              not is_known(InventoryA, FeatureFlag)
+              orelse
+              is_known_and_supported(InventoryA, FeatureName)
+      end, FeatureNames).
+
+%% --------------------------------------------------------------------
+%% Code to enable and sync feature flags.
+%% --------------------------------------------------------------------
+
+-spec enable_task(FeatureNames) -> Ret when
+      FeatureNames :: [rabbit_feature_flags:feature_name()],
+      Ret :: ok | {error, Reason},
+      Reason :: term().
+
+enable_task(FeatureNames) ->
+    %% We take a snapshot of clustered nodes, including stopped nodes, at the
+    %% beginning of the process and use that list at all time.
+    %%
+    %% If there are some missing, unreachable or stopped nodes, we abort the
+    %% task and refuse to enable the feature flag(s). This is to make sure
+    %% that if there is a network partition, the other side of the partition
+    %% doesn't "rejoin" the cluster with some feature flags enabled behind the
+    %% scene.
+    %%
+    %% TODO: Should we remove the requirement above and call `sync_cluster()'
+    %% when a network partition is repaired?
+    %%
+    %% If a node tries to join the cluster during the task, it will block
+    %% because it will want to synchronize its feature flags state with the
+    %% cluster. For that to happen, this controller `enable' task needs to
+    %% finish before the synchronization task starts.
+    %%
+    %% If a node stops during the task, this will trigger an RPC error at some
+    %% point and the task will abort. That's ok because migration functions
+    %% are supposed to be idempotent.
+    AllNodes = all_nodes(),
+    RunningNodes = running_nodes(),
+    case RunningNodes of
+        AllNodes ->
+            ?LOG_DEBUG(
+               "Feature flags: nodes where the feature flags will be "
+               "enabled: ~p~n"
+               "Feature flags: new nodes joining the cluster in between "
+               "will wait and synchronize their feature flag states after.",
+               [AllNodes],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+
+            %% Likewise, we take a snapshot of the feature flags states on all
+            %% running nodes right from the beginning. This is what we use
+            %% during the entire task to determine if feature flags are
+            %% supported, enabled somewhere, etc.
+            case collect_inventory_on_nodes(AllNodes) of
+                {ok, Inventory} -> enable_many(Inventory, FeatureNames);
+                Error           -> Error
+            end;
+        _ ->
+            ?LOG_ERROR(
+               "Feature flags: refuse to enable feature flags while "
+               "clustered nodes are missing, stopped or unreachable: ~p",
+               [AllNodes -- RunningNodes]),
+            {error, missing_clustered_nodes}
+    end.
+
+-spec sync_cluster_task() -> Ret when
+      Ret :: ok | {error, Reason},
+      Reason :: term().
+
+sync_cluster_task() ->
+    %% We assume that a feature flag can only be enabled, not disabled.
+    %% Therefore this synchronization searches for feature flags enabled on
+    %% some nodes but not all, and make sure they are enabled everywhere.
+    %%
+    %% This happens when a node joins a cluster and that node has a different
+    %% set of enabled feature flags.
+    %%
+    %% FIXME: `enable_task()' requires that all nodes in the cluster run to
+    %% enable anything. Should we require the same here? On one hand, this
+    %% would make sure a feature flag isn't enabled while there is a network
+    %% partition. On the other hand, this would require that all nodes are
+    %% running before we can expand the cluster...
+    Nodes = running_nodes(),
+    ?LOG_DEBUG(
+       "Feature flags: synchronizing feature flags on nodes: ~p",
+       [Nodes],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+
+    case collect_inventory_on_nodes(Nodes) of
+        {ok, Inventory} ->
+            FeatureNames = list_feature_flags_enabled_somewhere(
+                             Inventory, false),
+            enable_many(Inventory, FeatureNames);
+        Error ->
+            Error
+    end.
+
+-spec refresh_after_app_load_task() -> Ret when
+      Ret :: ok | {error, Reason},
+      Reason :: term().
+
+refresh_after_app_load_task() ->
+    case rabbit_ff_registry_factory:initialize_registry() of
+        ok    -> sync_cluster_task();
+        Error -> Error
+    end.
+
+-spec enable_many(Inventory, FeatureNames) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureNames :: [rabbit_feature_flags:feature_name()],
+      Ret :: ok | {error, Reason},
+      Reason :: term().
+
+enable_many(#{states_per_node := _} = Inventory, [FeatureName | Rest]) ->
+    case enable_if_supported(Inventory, FeatureName) of
+        ok    -> enable_many(Inventory, Rest);
+        Error -> Error
+    end;
+enable_many(_Inventory, []) ->
+    ok.
+
+-spec enable_if_supported(Inventory, FeatureName) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: ok | {error, Reason},
+      Reason :: term().
+
+enable_if_supported(#{states_per_node := _} = Inventory, FeatureName) ->
+    case is_known_and_supported(Inventory, FeatureName) of
+        true ->
+            ?LOG_DEBUG(
+               "Feature flags: `~s`: supported; continuing",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            case lock_registry_and_enable(Inventory, FeatureName) of
+                {ok, _Inventory} -> ok;
+                Error            -> Error
+            end;
+        false ->
+            ?LOG_DEBUG(
+               "Feature flags: `~s`: unsupported; aborting",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {error, unsupported}
+    end.
+
+-spec lock_registry_and_enable(Inventory, FeatureName) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: {ok, Inventory} | {error, Reason},
+      Reason :: term().
+
+lock_registry_and_enable(#{states_per_node := _} = Inventory, FeatureName) ->
+    %% We acquire a lock before making any change to the registry. This is not
+    %% used by the controller (because it is already using a globally
+    %% registered name to prevent concurrent runs). But this is used in
+    %% `rabbit_feature_flags:is_enabled()' to block while the state is
+    %% `state_changing'.
+    ?LOG_DEBUG(
+       "Feature flags: acquiring registry state change lock",
+       [],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    rabbit_ff_registry_factory:acquire_state_change_lock(),
+
+    Ret = enable_with_registry_locked(Inventory, FeatureName),
+
+    ?LOG_DEBUG(
+       "Feature flags: releasing registry state change lock",
+       [],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    rabbit_ff_registry_factory:release_state_change_lock(),
+    Ret.
+
+-spec enable_with_registry_locked(Inventory, FeatureName) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: {ok, Inventory} | {error, Reason},
+      Reason :: term().
+
+enable_with_registry_locked(
+  #{states_per_node := _} = Inventory, FeatureName) ->
+    %% We verify if the feature flag needs to be enabled somewhere. This may
+    %% have changed since the beginning, not because another controller
+    %% enabled it (this is not possible because only one can run at a given
+    %% time), but because this feature flag was already enabled as a
+    %% consequence (for instance, it's a dependency of another feature flag we
+    %% processed).
+    Nodes = list_nodes_where_feature_flag_is_disabled(Inventory, FeatureName),
+    case Nodes of
+        [] ->
+            ?LOG_DEBUG(
+               "Feature flags: `~s`: already enabled; skipping",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {ok, Inventory};
+        _ ->
+            ?LOG_NOTICE(
+               "Feature flags: attempt to enable `~s`...",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+
+            case update_feature_state_and_enable(Inventory, FeatureName) of
+                {ok, _Inventory} = Ok ->
+                    ?LOG_NOTICE(
+                       "Feature flags: `~s` enabled",
+                       [FeatureName],
+                       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                    Ok;
+                Error ->
+                    ?LOG_ERROR(
+                       "Feature flags: failed to enable `~s`: ~p",
+                       [FeatureName, Error],
+                       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+                    Error
+            end
+    end.
+
+-spec update_feature_state_and_enable(Inventory, FeatureName) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: {ok, Inventory} | {error, Reason},
+      Reason :: term().
+
+update_feature_state_and_enable(
+  #{states_per_node := _} = Inventory, FeatureName) ->
+    %% The feature flag is marked as `state_changing' on all running nodes who
+    %% know it, including those where it's already enabled. The idea is that
+    %% the feature flag is between two states on some nodes and the code
+    %% running on the nodes where the feature flag enabled shouldn't assume
+    %% all nodes in the cluster are in the same situation.
+    Nodes = list_nodes_who_know_the_feature_flag(Inventory, FeatureName),
+
+    %% We only consider nodes where the feature flag is disabled. The
+    %% migration function is only executed on those nodes. I.e. we don't run
+    %% it again where it has already been executed.
+    NodesWhereDisabled = list_nodes_where_feature_flag_is_disabled(
+                           Inventory, FeatureName),
+
+    Ret1 = mark_as_enabled_on_nodes(
+             Nodes, Inventory, FeatureName, state_changing),
+    case Ret1 of
+        %% We ignore the returned updated inventory because we don't need or
+        %% even want to remember the `state_changing' state. This is only used
+        %% for external queries of the registry.
+        {ok, _Inventory0} ->
+            case do_enable(Inventory, FeatureName, NodesWhereDisabled) of
+                {ok, Inventory1} ->
+                    Ret2 = mark_as_enabled_on_nodes(
+                      Nodes, Inventory1, FeatureName, true),
+                    case Ret2 of
+                        {ok, Inventory2} ->
+                            post_enable(
+                              Inventory2, FeatureName, NodesWhereDisabled),
+                            Ret2;
+                        Error ->
+                            _ = mark_as_enabled_on_nodes(
+                                  Nodes, Inventory, FeatureName, false),
+                            Error
+                    end;
+                Error ->
+                    _ = mark_as_enabled_on_nodes(
+                          Nodes, Inventory, FeatureName, false),
+                    Error
+            end;
+        Error ->
+            _ = mark_as_enabled_on_nodes(
+                  Nodes, Inventory, FeatureName, false),
+            Error
+    end.
+
+-spec do_enable(Inventory, FeatureName, Nodes) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Nodes :: [node()],
+      Ret :: {ok, Inventory} | {error, Reason},
+      Reason :: term().
+
+do_enable(#{states_per_node := _} = Inventory, FeatureName, Nodes) ->
+    %% After dependencies are enabled, we need to remember the updated
+    %% inventory. This is useful later to skip feature flags enabled earlier
+    %% in the process. For instance because a feature flag is dependency of
+    %% several other feature flags.
+    case enable_dependencies(Inventory, FeatureName) of
+        {ok, Inventory1} ->
+            Extra = #{nodes => Nodes},
+            Rets = run_migration_fun(
+                     Nodes, FeatureName, enable, Extra, infinity),
+            maps:fold(
+              fun
+                  (_Node, ok, {ok, _} = Ret) -> Ret;
+                  (_Node, Error, {ok, _})    -> Error;
+                  (_Node, _, Error)          -> Error
+              end, {ok, Inventory1}, Rets);
+        Error ->
+            Error
+    end.
+
+-spec post_enable(Inventory, FeatureName, Nodes) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Nodes :: [node()],
+      Ret :: ok.
+
+post_enable(#{states_per_node := _}, FeatureName, Nodes) ->
+    case rabbit_feature_flags:uses_migration_fun_v2(FeatureName) of
+        true ->
+            Extra = #{nodes => Nodes},
+            _ = run_migration_fun(
+                  Nodes, FeatureName, post_enable, Extra, infinity),
+            ok;
+        false ->
+            ok
+    end.
+
+%% --------------------------------------------------------------------
+%% Cluster relationship and inventory.
+%% --------------------------------------------------------------------
+
+-ifndef(TEST).
+all_nodes() ->
+    lists:usort([node() | mnesia:system_info(db_nodes)]).
+
+running_nodes() ->
+    lists:usort([node() | mnesia:system_info(running_db_nodes)]).
+-else.
+all_nodes() ->
+    RemoteNodes = case rabbit_feature_flags:get_overriden_nodes() of
+                      undefined -> mnesia:system_info(db_nodes);
+                      Nodes     -> Nodes
+                  end,
+    lists:usort([node() | RemoteNodes]).
+
+running_nodes() ->
+    RemoteNodes = case rabbit_feature_flags:get_overriden_running_nodes() of
+                      undefined -> mnesia:system_info(running_db_nodes);
+                      Nodes     -> Nodes
+                  end,
+    lists:usort([node() | RemoteNodes]).
+-endif.
+
+collect_inventory_on_nodes(Nodes) ->
+    collect_inventory_on_nodes(Nodes, ?TIMEOUT).
+
+-spec collect_inventory_on_nodes(Nodes, Timeout) -> Ret when
+      Nodes :: [node()],
+      Timeout :: timeout(),
+      Ret :: {ok, Inventory} | {error, Reason},
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      Reason :: term().
+
+collect_inventory_on_nodes(Nodes, Timeout) ->
+    ?LOG_DEBUG(
+       "Feature flags: collecting inventory on nodes: ~p",
+       [Nodes],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    Inventory0 = #{feature_flags => #{},
+                   applications_per_node => #{},
+                   states_per_node => #{}},
+    Rets = rpc_calls(Nodes, rabbit_ff_registry, inventory, [], Timeout),
+    maps:fold(
+      fun
+          (Node,
+           #{feature_flags := FeatureFlags1,
+             applications := ScannedApps,
+             states := FeatureStates},
+           {ok, #{feature_flags := FeatureFlags,
+                  applications_per_node := ScannedAppsPerNode,
+                  states_per_node := StatesPerNode} = Inventory}) ->
+            FeatureFlags2 = maps:merge(FeatureFlags, FeatureFlags1),
+            ScannedAppsPerNode1 = ScannedAppsPerNode#{Node => ScannedApps},
+            StatesPerNode1 = StatesPerNode#{Node => FeatureStates},
+            Inventory1 = Inventory#{
+                           feature_flags => FeatureFlags2,
+                           applications_per_node => ScannedAppsPerNode1,
+                           states_per_node => StatesPerNode1},
+            {ok, Inventory1};
+          (_Node, #{}, Error) ->
+              Error;
+          (_Node, Error, {ok, #{}}) ->
+              Error;
+          (_Node, _Error, Error) ->
+              Error
+      end, {ok, Inventory0}, Rets).
+
+-spec list_feature_flags_enabled_somewhere(Inventory, HandleStateChanging) ->
+    Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      HandleStateChanging :: boolean(),
+      Ret :: [FeatureName],
+      FeatureName :: rabbit_feature_flags:feature_name().
+
+list_feature_flags_enabled_somewhere(
+  #{states_per_node := StatesPerNode},
+  HandleStateChanging) ->
+    %% We want to collect feature flags which are enabled on at least one
+    %% node.
+    MergedStates = maps:fold(
+                     fun(_Node, FeatureStates, Acc1) ->
+                             maps:fold(
+                               fun
+                                   (FeatureName, true, Acc2) ->
+                                       Acc2#{FeatureName => true};
+                                   (_FeatureName, false, Acc2) ->
+                                       Acc2;
+                                   (FeatureName, state_changing, Acc2)
+                                     when HandleStateChanging ->
+                                       Acc2#{FeatureName => true}
+                               end, Acc1, FeatureStates)
+                     end, #{}, StatesPerNode),
+    lists:sort(maps:keys(MergedStates)).
+
+-spec list_nodes_who_know_the_feature_flag(Inventory, FeatureName) ->
+    Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: [node()].
+
+list_nodes_who_know_the_feature_flag(
+  #{states_per_node := StatesPerNode},
+  FeatureName) ->
+    Nodes = lists:sort(
+              maps:keys(
+                maps:filter(
+                  fun(_Node, FeatureStates) ->
+                          maps:is_key(FeatureName, FeatureStates)
+                  end, StatesPerNode))),
+    this_node_first(Nodes).
+
+-spec list_nodes_where_feature_flag_is_disabled(Inventory, FeatureName) ->
+    Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: [node()].
+
+list_nodes_where_feature_flag_is_disabled(
+  #{states_per_node := StatesPerNode},
+  FeatureName) ->
+    Nodes = lists:sort(
+              maps:keys(
+                maps:filter(
+                  fun(_Node, FeatureStates) ->
+                          case FeatureStates of
+                              %% The feature flag is known on this node, run
+                              %% the migration function only if it is
+                              %% disabled.
+                              #{FeatureName := Enabled} -> not Enabled;
+
+
+                              %% The feature flags is unknown on this node,
+                              %% don't run the migration function.
+                              _ -> false
+                          end
+                  end, StatesPerNode))),
+    this_node_first(Nodes).
+
+this_node_first(Nodes) ->
+    ThisNode = node(),
+    case lists:member(ThisNode, Nodes) of
+        true  -> [ThisNode | Nodes -- [ThisNode]];
+        false -> Nodes
+    end.
+
+-spec rpc_call(Node, Module, Function, Args, Timeout) -> Ret when
+      Node :: node(),
+      Module :: module(),
+      Function :: atom(),
+      Args :: [term()],
+      Timeout :: timeout(),
+      Ret :: term() | {error, term()}.
+
+rpc_call(Node, Module, Function, Args, Timeout) ->
+    case rpc:call(Node, Module, Function, Args, Timeout) of
+        {badrpc, {'EXIT',
+                  {undef,
+                   [{rabbit_feature_flags, Function, Args, []}
+                    | _]}}} ->
+            %% If rabbit_feature_flags:Function() is undefined
+            %% on the remote node, we consider it to be a 3.7.x
+            %% pre-feature-flags node.
+            %%
+            %% Theoretically, it could be an older version (3.6.x and
+            %% older). But the RabbitMQ version consistency check
+            %% (rabbit_misc:version_minor_equivalent/2) called from
+            %% rabbit_mnesia:check_rabbit_consistency/2 already blocked
+            %% this situation from happening before we reach this point.
+            ?LOG_DEBUG(
+               "Feature flags: ~s:~s~p unavailable on node `~s`: "
+               "assuming it is a RabbitMQ 3.7.x pre-feature-flags node",
+               [?MODULE, Function, Args, Node],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {error, pre_feature_flags_rabbitmq};
+        {badrpc, Reason} = Error ->
+            ?LOG_ERROR(
+               "Feature flags: error while running:~n"
+               "Feature flags:   ~s:~s~p~n"
+               "Feature flags: on node `~s`:~n"
+               "Feature flags:   ~p",
+               [?MODULE, Function, Args, Node, Reason],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            {error, Error};
+        Ret ->
+            Ret
+    end.
+
+-spec rpc_calls(Nodes, Module, Function, Args, Timeout) -> Rets when
+      Nodes :: [node()],
+      Module :: module(),
+      Function :: atom(),
+      Args :: [term()],
+      Timeout :: timeout(),
+      Rets :: #{node() => term()}.
+
+rpc_calls(Nodes, Module, Function, Args, Timeout) when is_list(Nodes) ->
+    Parent = self(),
+    CallRef = {Module, Function, Args},
+    Runners = [{Node,
+                spawn_monitor(
+                  fun() ->
+                          Ret = rpc_call(
+                                  Node, Module, Function, Args, Timeout),
+                          Parent ! {internal_rpc_call, Node, CallRef, Ret}
+                  end)}
+               || Node <- Nodes],
+    Rets = [receive
+                {internal_rpc_call, Node, CallRef, Ret} ->
+                    %% After we got the return value for that node, we still
+                    %% need to consume the `DOWN' message emitted once the
+                    %% spawn process exited.
+                    receive
+                        {'DOWN', MRef, process, Pid, Reason} ->
+                            ?assertEqual(normal, Reason)
+                    end,
+                    {Node, Ret};
+                {'DOWN', MRef, process, Pid, Reason} ->
+                    {Node, {error, {'DOWN', Reason}}}
+            end
+            || {Node, {Pid, MRef}} <- Runners],
+    maps:from_list(Rets).
+
+%% --------------------------------------------------------------------
+%% Feature flag support queries.
+%% --------------------------------------------------------------------
+
+-spec is_known(Inventory, FeatureFlag) -> IsKnown when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureFlag :: rabbit_feature_flags:feature_props_extended(),
+      IsKnown :: boolean().
+
+is_known(
+  #{applications_per_node := ScannedAppsPerNode},
+  #{provided_by := App} = _FeatureFlag) ->
+    maps:fold(
+      fun
+          (_Node, ScannedApps, false) -> lists:member(App, ScannedApps);
+          (_Node, _ScannedApps, true) -> true
+      end, false, ScannedAppsPerNode).
+
+-spec is_known_and_supported(Inventory, FeatureName) ->
+    IsKnownAndSupported when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      IsKnownAndSupported :: boolean().
+
+is_known_and_supported(
+  #{feature_flags := FeatureFlags,
+    applications_per_node := ScannedAppsPerNode,
+    states_per_node := StatesPerNode},
+  FeatureName)
+  when is_map_key(FeatureName, FeatureFlags) ->
+    %% A feature flag is considered supported by a node if:
+    %%   - the node knows the feature flag, or
+    %%   - the node does not have the application providing it.
+    %%
+    %% Therefore, we first need to look up the application providing this
+    %% feature flag.
+    #{FeatureName := #{provided_by := App}} = FeatureFlags,
+
+    maps:fold(
+      fun
+          (Node, FeatureStates, true) ->
+              case FeatureStates of
+                  #{FeatureName := _} ->
+                      %% The node knows about the feature flag.
+                      true;
+                  _ ->
+                      %% The node doesn't know about the feature flag, so does
+                      %% it have the application providing it loaded?
+                      #{Node := ScannedApps} = ScannedAppsPerNode,
+                      not lists:member(App, ScannedApps)
+              end;
+          (_Node, _FeatureStates, false) ->
+              false
+      end, true, StatesPerNode);
+is_known_and_supported(_Inventory, _FeatureName) ->
+    %% None of the nodes know about this feature flag at all.
+    false.
+
+%% --------------------------------------------------------------------
+%% Feature flag state changes.
+%% --------------------------------------------------------------------
+
+-spec mark_as_enabled_on_nodes(Nodes, Inventory, FeatureName, IsEnabled) ->
+    Ret when
+      Nodes :: [node()],
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      IsEnabled :: rabbit_feature_flags:feature_state(),
+      Ret :: {ok, Inventory} | {error, Reason},
+      Reason :: term().
+
+mark_as_enabled_on_nodes(
+  Nodes,
+  #{states_per_node := StatesPerNode} = Inventory,
+  FeatureName, IsEnabled) ->
+    ?LOG_DEBUG(
+       "Feature flags: `~s`: mark as enabled=~p on nodes ~p",
+       [FeatureName, IsEnabled, Nodes],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    Rets = rpc_calls(
+             Nodes, rabbit_feature_flags, mark_as_enabled_locally,
+             [FeatureName, IsEnabled], ?TIMEOUT),
+    Ret = maps:fold(
+            fun
+                (Node, ok, {ok, StatesPerNode1}) ->
+                    FeatureStates1 = maps:get(Node, StatesPerNode1),
+                    FeatureStates2 = FeatureStates1#{
+                                       FeatureName => IsEnabled},
+                    StatesPerNode2 = StatesPerNode1#{
+                                       Node => FeatureStates2},
+                    {ok, StatesPerNode2};
+                (_Node, ok, Error) ->
+                    Error;
+                (_Node, Error, {ok, _StatesPerNode1}) ->
+                    Error;
+                (_Node, _Error, Error) ->
+                    Error
+            end, {ok, StatesPerNode}, Rets),
+    case Ret of
+        {ok, StatesPerNode3} ->
+            Inventory1 = Inventory#{states_per_node => StatesPerNode3},
+            {ok, Inventory1};
+        Error ->
+            Error
+    end.
+
+%% --------------------------------------------------------------------
+%% Feature flag dependencies handling.
+%% --------------------------------------------------------------------
+
+-spec enable_dependencies(Inventory, FeatureName) -> Ret when
+      Inventory :: rabbit_feature_flags:cluster_inventory(),
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Ret :: {ok, Inventory} | {error, Reason},
+      Reason :: term().
+
+enable_dependencies(
+  #{feature_flags := FeatureFlags} = Inventory, FeatureName) ->
+    #{FeatureName := FeatureProps} = FeatureFlags,
+    DependsOn = maps:get(depends_on, FeatureProps, []),
+    case DependsOn of
+        [] ->
+            {ok, Inventory};
+        _ ->
+            ?LOG_DEBUG(
+               "Feature flags: `~s`: enable dependencies: ~p",
+               [FeatureName, DependsOn],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            enable_dependencies1(Inventory, DependsOn)
+    end.
+
+enable_dependencies1(
+  #{states_per_node := _} = Inventory, [FeatureName | Rest]) ->
+    case enable_with_registry_locked(Inventory, FeatureName) of
+        {ok, Inventory1} -> enable_dependencies1(Inventory1, Rest);
+        Error            -> Error
+    end;
+enable_dependencies1(
+  #{states_per_node := _} = Inventory, []) ->
+    {ok, Inventory}.
+
+%% --------------------------------------------------------------------
+%% Migration function.
+%% --------------------------------------------------------------------
+
+-spec run_migration_fun(Nodes, FeatureName, Command, Extra, Timeout) ->
+    Rets when
+      Nodes :: [node()],
+      FeatureName :: rabbit_feature_flags:feature_name(),
+      Command :: atom(),
+      Extra :: map(),
+      Timeout :: timeout(),
+      Rets :: #{node() => term()}.
+
+run_migration_fun(Nodes, FeatureName, Command, Extra, Timeout) ->
+    FeatureProps = rabbit_ff_registry:get(FeatureName),
+    case maps:get(migration_fun, FeatureProps, none) of
+        {MigrationMod, MigrationFun}
+          when is_atom(MigrationMod) andalso is_atom(MigrationFun) ->
+            UsesMFv2 = rabbit_feature_flags:uses_migration_fun_v2(
+                         MigrationMod, MigrationFun),
+            case UsesMFv2 of
+                true ->
+                    %% The migration fun API v2 is of the form:
+                    %%   MigrationMod:MigrationFun(#ffcommand{...}).
+                    %%
+                    %% Also, the function is executed on all nodes in
+                    %% parallel.
+                    FFCommand = #ffcommand{
+                                   name = FeatureName,
+                                   props = FeatureProps,
+                                   command = Command,
+                                   extra = Extra},
+                    run_migration_fun_v2(
+                      Nodes, MigrationMod, MigrationFun, FFCommand, Timeout);
+                false ->
+                    %% The migration fun API v1 is of the form:
+                    %%   MigrationMod:MigrationFun(
+                    %%     FeatureName, FeatureProps, Command).
+                    %%
+                    %% Also, the function is executed once on the calling node
+                    %% only.
+                    Ret = rabbit_feature_flags:run_migration_fun(
+                            FeatureName, FeatureProps, Command),
+                    #{node() => Ret}
+            end;
+        none ->
+            #{};
+        Invalid ->
+            ?LOG_ERROR(
+               "Feature flags: `~s`: invalid migration function: ~p",
+               [FeatureName, Invalid],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+            #{node() => {error, {invalid_migration_fun, Invalid}}}
+    end.
+
+-spec run_migration_fun_v2(Nodes, MigrationMod, MigrationFun, FFCommand,
+                           Timeout) -> Rets when
+      Nodes :: [node()],
+      MigrationMod :: module(),
+      MigrationFun :: atom(),
+      FFCommand :: rabbit_feature_flags:ffcommand(),
+      Timeout :: timeout(),
+      Rets :: #{node() => term}.
+
+run_migration_fun_v2(
+  Nodes, MigrationMod, MigrationFun,
+  #ffcommand{name = FeatureName} = FFCommand,
+  Timeout) ->
+    ?LOG_DEBUG(
+       "Feature flags: `~s`: run migration function (v2) ~s:~s~n"
+       "Feature flags:   with command=~p~n"
+       "Feature flags:   on nodes ~p",
+       [FeatureName, MigrationMod, MigrationFun, FFCommand, Nodes],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    Rets = rpc_calls(
+             Nodes, MigrationMod, MigrationFun, [FFCommand], Timeout),
+    ?LOG_DEBUG(
+       "Feature flags: `~s`: migration function (v2) ~s:~s returned:~n"
+       "Feature flags:   ~p",
+       [FeatureName, MigrationMod, MigrationFun, Rets],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    Rets.

--- a/deps/rabbit/src/rabbit_ff_registry.erl
+++ b/deps/rabbit/src/rabbit_ff_registry.erl
@@ -26,7 +26,8 @@
          is_supported/1,
          is_enabled/1,
          is_registry_initialized/0,
-         is_registry_written_to_disk/0]).
+         is_registry_written_to_disk/0,
+         inventory/0]).
 
 -ifdef(TEST).
 -on_load(on_load/0).
@@ -44,7 +45,7 @@
 %% @returns the properties of the specified feature flag.
 
 get(FeatureName) ->
-    rabbit_feature_flags:initialize_registry(),
+    rabbit_ff_registry_factory:initialize_registry(),
     %% Initially, is_registry_initialized/0 always returns `false`
     %% and this ?MODULE:get(FeatureName) is always called. The case
     %% statement is here to please Dialyzer.
@@ -65,7 +66,7 @@ get(FeatureName) ->
 %% @returns A map of selected feature flags.
 
 list(Which) ->
-    rabbit_feature_flags:initialize_registry(),
+    rabbit_ff_registry_factory:initialize_registry(),
     %% See get/1 for an explanation of the case statement below.
     case is_registry_initialized() of
         false -> ?MODULE:list(Which);
@@ -82,7 +83,7 @@ list(Which) ->
 %% @returns A map of feature flag states.
 
 states() ->
-    rabbit_feature_flags:initialize_registry(),
+    rabbit_ff_registry_factory:initialize_registry(),
     %% See get/1 for an explanation of the case statement below.
     case is_registry_initialized() of
         false -> ?MODULE:states();
@@ -101,7 +102,7 @@ states() ->
 %%   otherwise.
 
 is_supported(FeatureName) ->
-    rabbit_feature_flags:initialize_registry(),
+    rabbit_ff_registry_factory:initialize_registry(),
     %% See get/1 for an explanation of the case statement below.
     case is_registry_initialized() of
         false -> ?MODULE:is_supported(FeatureName);
@@ -120,7 +121,7 @@ is_supported(FeatureName) ->
 %%   its state is transient, or `false' otherwise.
 
 is_enabled(FeatureName) ->
-    rabbit_feature_flags:initialize_registry(),
+    rabbit_ff_registry_factory:initialize_registry(),
     %% See get/1 for an explanation of the case statement below.
     case is_registry_initialized() of
         false -> ?MODULE:is_enabled(FeatureName);
@@ -157,6 +158,13 @@ is_registry_initialized() ->
 
 is_registry_written_to_disk() ->
     always_return_true().
+
+-spec inventory() -> rabbit_feature_flags:inventory().
+
+inventory() ->
+    #{applications => [],
+      feature_flags => #{},
+      states => #{}}.
 
 always_return_true() ->
     %% This function is here to trick Dialyzer. We want some functions

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -1,0 +1,631 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_ff_registry_factory).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([initialize_registry/0,
+         initialize_registry/1,
+         initialize_registry/3,
+         acquire_state_change_lock/0,
+         release_state_change_lock/0]).
+
+-ifdef(TEST).
+-export([registry_loading_lock/0]).
+-endif.
+
+-define(FF_STATE_CHANGE_LOCK, {feature_flags_state_change, self()}).
+-define(FF_REGISTRY_LOADING_LOCK, {feature_flags_registry_loading, self()}).
+
+-type registry_vsn() :: term().
+
+acquire_state_change_lock() ->
+    global:set_lock(?FF_STATE_CHANGE_LOCK).
+
+release_state_change_lock() ->
+    global:del_lock(?FF_STATE_CHANGE_LOCK).
+
+-spec initialize_registry() -> ok | {error, any()} | no_return().
+%% @private
+%% @doc
+%% Initializes or reinitializes the registry.
+%%
+%% The registry is an Erlang module recompiled at runtime to hold the
+%% state of all supported feature flags.
+%%
+%% That Erlang module is called {@link rabbit_ff_registry}. The initial
+%% source code of this module simply calls this function so it is
+%% replaced by a proper registry.
+%%
+%% Once replaced, the registry contains the map of all supported feature
+%% flags and their state. This is makes it very efficient to query a
+%% feature flag state or property.
+%%
+%% The registry is local to all RabbitMQ nodes.
+
+initialize_registry() ->
+    initialize_registry(#{}).
+
+-spec initialize_registry(rabbit_feature_flags:feature_flags()) ->
+    ok | {error, any()} | no_return().
+%% @private
+%% @doc
+%% Initializes or reinitializes the registry.
+%%
+%% See {@link initialize_registry/0} for a description of the registry.
+%%
+%% This function takes a map of new supported feature flags (so their
+%% name and extended properties) to add to the existing known feature
+%% flags.
+
+initialize_registry(NewSupportedFeatureFlags) ->
+    %% The first step is to get the feature flag states: if this is the
+    %% first time we initialize it, we read the list from disk (the
+    %% `feature_flags` file). Otherwise we query the existing registry
+    %% before it is replaced.
+    RegistryInitialized = rabbit_ff_registry:is_registry_initialized(),
+    FeatureStates =
+    case RegistryInitialized of
+        true ->
+            rabbit_ff_registry:states();
+        false ->
+            EnabledFeatureNames =
+            rabbit_feature_flags:read_enabled_feature_flags_list(),
+            rabbit_feature_flags:enabled_feature_flags_to_feature_states(
+              EnabledFeatureNames)
+    end,
+
+    %% We also record if the feature flags state was correctly written
+    %% to disk. Currently we don't use this information, but in the
+    %% future, we might want to retry the write if it failed so far.
+    %%
+    %% TODO: Retry to write the feature flags state if the first try
+    %% failed.
+    WrittenToDisk = case RegistryInitialized of
+                        true ->
+                            rabbit_ff_registry:is_registry_written_to_disk();
+                        false ->
+                            true
+                    end,
+    initialize_registry(NewSupportedFeatureFlags,
+                        FeatureStates,
+                        WrittenToDisk).
+
+-spec initialize_registry(rabbit_feature_flags:feature_flags(),
+                          rabbit_feature_flags:feature_states(),
+                          boolean()) ->
+    ok | {error, any()} | no_return().
+%% @private
+%% @doc
+%% Initializes or reinitializes the registry.
+%%
+%% See {@link initialize_registry/0} for a description of the registry.
+%%
+%% This function takes a map of new supported feature flags (so their
+%% name and extended properties) to add to the existing known feature
+%% flags, a map of the new feature flag states (whether they are
+%% enabled, disabled or `state_changing'), and a flag to indicate if the
+%% feature flag states was recorded to disk.
+%%
+%% The latter is used to block callers asking if a feature flag is
+%% enabled or disabled while its state is changing.
+
+initialize_registry(NewSupportedFeatureFlags,
+                    NewFeatureStates,
+                    WrittenToDisk) ->
+    Ret = maybe_initialize_registry(NewSupportedFeatureFlags,
+                                    NewFeatureStates,
+                                    WrittenToDisk),
+    case Ret of
+        ok      -> ok;
+        restart -> initialize_registry(NewSupportedFeatureFlags,
+                                       NewFeatureStates,
+                                       WrittenToDisk);
+        Error   -> Error
+    end.
+
+-spec maybe_initialize_registry(rabbit_feature_flags:feature_flags(),
+                                rabbit_feature_flags:feature_states(),
+                                boolean()) ->
+    ok | restart | {error, any()} | no_return().
+
+maybe_initialize_registry(NewSupportedFeatureFlags,
+                          NewFeatureStates,
+                          WrittenToDisk) ->
+    %% We save the version of the current registry before computing
+    %% the new one. This is used when we do the actual reload: if the
+    %% current registry was reloaded in the meantime, we need to restart
+    %% the computation to make sure we don't loose data.
+    RegistryVsn = registry_vsn(),
+
+    %% We take the feature flags already registered.
+    RegistryInitialized = rabbit_ff_registry:is_registry_initialized(),
+    KnownFeatureFlags1 = case RegistryInitialized of
+                             true  -> rabbit_ff_registry:list(all);
+                             false -> #{}
+                         end,
+
+    %% Query the list (it's a map to be exact) of known
+    %% supported feature flags. That list comes from the
+    %% `-rabbitmq_feature_flag().` module attributes exposed by all
+    %% currently loaded Erlang modules.
+    {ScannedApps, KnownFeatureFlags2} =
+    rabbit_feature_flags:query_supported_feature_flags(),
+
+    %% We merge the feature flags we already knew about
+    %% (KnownFeatureFlags1), those found in the loaded applications
+    %% (KnownFeatureFlags2) and those specified in arguments
+    %% (NewSupportedFeatureFlags). The latter come from remote nodes
+    %% usually: for example, they can come from plugins loaded on remote
+    %% node but the plugins are missing locally. In this case, we
+    %% consider those feature flags supported because there is no code
+    %% locally which would cause issues.
+    %%
+    %% It means that the list of feature flags only grows. we don't try
+    %% to clean it at some point because we want to remember about the
+    %% feature flags we saw (and their state). It should be fine because
+    %% that list should remain small.
+    KnownFeatureFlags = maps:merge(KnownFeatureFlags1,
+                                   KnownFeatureFlags2),
+    AllFeatureFlags = maps:merge(KnownFeatureFlags,
+                                 NewSupportedFeatureFlags),
+
+    %% Next we want to update the feature states, based on the new
+    %% states passed as arguments.
+    FeatureStates0 = case RegistryInitialized of
+                         true ->
+                             maps:merge(rabbit_ff_registry:states(),
+                                        NewFeatureStates);
+                         false ->
+                             NewFeatureStates
+                     end,
+    FeatureStates = maps:map(
+                      fun(FeatureName, _FeatureProps) ->
+                              case FeatureStates0 of
+                                  #{FeatureName := FeatureState} ->
+                                      FeatureState;
+                                  _ ->
+                                      false
+                              end
+                      end, AllFeatureFlags),
+
+    %% The feature flags inventory is used by rabbit_ff_controller to query
+    %% feature flags atomically. The inventory also contains the list of
+    %% scanned applications: this is used to determine if an application is
+    %% known by this node or not, and decide if a missing feature flag is
+    %% unknown or unsupported.
+    Inventory = #{applications => ScannedApps,
+                  feature_flags => KnownFeatureFlags2,
+                  states => FeatureStates},
+
+    Proceed = does_registry_need_refresh(AllFeatureFlags,
+                                         FeatureStates,
+                                         WrittenToDisk),
+
+    case Proceed of
+        true ->
+            rabbit_log_feature_flags:debug(
+              "Feature flags: (re)initialize registry (~p)",
+              [self()]),
+            T0 = erlang:timestamp(),
+            Ret = do_initialize_registry(RegistryVsn,
+                                         AllFeatureFlags,
+                                         FeatureStates,
+                                         Inventory,
+                                         WrittenToDisk),
+            T1 = erlang:timestamp(),
+            rabbit_log_feature_flags:debug(
+              "Feature flags: time to regen registry: ~p µs",
+              [timer:now_diff(T1, T0)]),
+            Ret;
+        false ->
+            rabbit_log_feature_flags:debug(
+              "Feature flags: registry already up-to-date, skipping init"),
+            ok
+    end.
+
+-spec does_registry_need_refresh(rabbit_feature_flags:feature_flags(),
+                                 rabbit_feature_flags:feature_states(),
+                                 boolean()) ->
+    boolean().
+
+does_registry_need_refresh(AllFeatureFlags,
+                           FeatureStates,
+                           WrittenToDisk) ->
+    case rabbit_ff_registry:is_registry_initialized() of
+        true ->
+            %% Before proceeding with the actual
+            %% (re)initialization, let's see if there are any
+            %% changes.
+            CurrentAllFeatureFlags = rabbit_ff_registry:list(all),
+            CurrentFeatureStates = rabbit_ff_registry:states(),
+            CurrentWrittenToDisk =
+            rabbit_ff_registry:is_registry_written_to_disk(),
+
+            if
+                AllFeatureFlags =/= CurrentAllFeatureFlags ->
+                    rabbit_log_feature_flags:debug(
+                      "Feature flags: registry refresh needed: "
+                      "yes, list of feature flags differs"),
+                    true;
+                FeatureStates =/= CurrentFeatureStates ->
+                    rabbit_log_feature_flags:debug(
+                      "Feature flags: registry refresh needed: "
+                      "yes, feature flag states differ"),
+                    true;
+                WrittenToDisk =/= CurrentWrittenToDisk ->
+                    rabbit_log_feature_flags:debug(
+                      "Feature flags: registry refresh needed: "
+                      "yes, \"written to disk\" state changed"),
+                    true;
+                true ->
+                    rabbit_log_feature_flags:debug(
+                      "Feature flags: registry refresh needed: no"),
+                    false
+            end;
+        false ->
+            rabbit_log_feature_flags:debug(
+              "Feature flags: registry refresh needed: "
+              "yes, first-time initialization"),
+            true
+    end.
+
+-spec do_initialize_registry(registry_vsn(),
+                             rabbit_feature_flags:feature_flags(),
+                             rabbit_feature_flags:feature_states(),
+                             rabbit_feature_flags:inventory(),
+                             boolean()) ->
+    ok | restart | {error, any()} | no_return().
+%% @private
+
+do_initialize_registry(RegistryVsn,
+                       AllFeatureFlags,
+                       FeatureStates,
+                       #{applications := ScannedApps} = Inventory,
+                       WrittenToDisk) ->
+    %% We log the state of those feature flags.
+    rabbit_log_feature_flags:debug(
+      "Feature flags: list of feature flags found:~n" ++
+      lists:flatten(
+        [rabbit_misc:format(
+           "Feature flags:   [~s] ~s~n",
+           [case maps:get(FeatureName, FeatureStates, false) of
+                true           -> "x";
+                state_changing -> "~~";
+                false          -> " "
+            end,
+            FeatureName])
+         || FeatureName <- lists:sort(maps:keys(AllFeatureFlags))] ++
+        [rabbit_misc:format(
+           "Feature flags: scanned applications: ~p~n"
+           "Feature flags: feature flag states written to disk: ~s",
+           [ScannedApps,
+            case WrittenToDisk of
+                true  -> "yes";
+                false -> "no"
+            end])])
+     ),
+
+    %% We request the registry to be regenerated and reloaded with the
+    %% new state.
+    regen_registry_mod(RegistryVsn,
+                       AllFeatureFlags,
+                       FeatureStates,
+                       Inventory,
+                       WrittenToDisk).
+
+-spec regen_registry_mod(
+        RegistryVsn, AllFeatureFlags, FeatureStates, Inventory,
+        WrittenToDisk) -> Ret when
+      RegistryVsn :: registry_vsn(),
+      AllFeatureFlags :: rabbit_feature_flags:feature_flags(),
+      FeatureStates :: rabbit_feature_flags:feature_states(),
+      Inventory :: rabbit_feature_flags:inventory(),
+      WrittenToDisk :: boolean(),
+      Ret :: ok | restart | {error, any()} | no_return().
+%% @private
+
+regen_registry_mod(RegistryVsn,
+                   AllFeatureFlags,
+                   FeatureStates,
+                   Inventory,
+                   WrittenToDisk) ->
+    %% Here, we recreate the source code of the `rabbit_ff_registry`
+    %% module from scratch.
+    %%
+    %% IMPORTANT: We want both modules to have the exact same public
+    %% API in order to simplify the life of developers and their tools
+    %% (Dialyzer, completion, and so on).
+
+    %% -module(rabbit_ff_registry).
+    ModuleAttr = erl_syntax:attribute(
+                   erl_syntax:atom(module),
+                   [erl_syntax:atom(rabbit_ff_registry)]),
+    ModuleForm = erl_syntax:revert(ModuleAttr),
+    %% -export([...]).
+    ExportAttr = erl_syntax:attribute(
+                   erl_syntax:atom(export),
+                   [erl_syntax:list(
+                      [erl_syntax:arity_qualifier(
+                         erl_syntax:atom(F),
+                         erl_syntax:integer(A))
+                       || {F, A} <- [{get, 1},
+                                     {list, 1},
+                                     {states, 0},
+                                     {is_supported, 1},
+                                     {is_enabled, 1},
+                                     {is_registry_initialized, 0},
+                                     {is_registry_written_to_disk, 0},
+                                     {inventory, 0}]]
+                     )
+                   ]
+                  ),
+    ExportForm = erl_syntax:revert(ExportAttr),
+    %% get(_) -> ...
+    GetClauses = [erl_syntax:clause(
+                    [erl_syntax:atom(FeatureName)],
+                    [],
+                    [erl_syntax:abstract(maps:get(FeatureName,
+                                                  AllFeatureFlags))])
+                     || FeatureName <- maps:keys(AllFeatureFlags)
+                    ],
+    GetUnknownClause = erl_syntax:clause(
+                         [erl_syntax:variable("_")],
+                         [],
+                         [erl_syntax:atom(undefined)]),
+    GetFun = erl_syntax:function(
+               erl_syntax:atom(get),
+               GetClauses ++ [GetUnknownClause]),
+    GetFunForm = erl_syntax:revert(GetFun),
+    %% list(_) -> ...
+    ListAllBody = erl_syntax:abstract(AllFeatureFlags),
+    ListAllClause = erl_syntax:clause([erl_syntax:atom(all)],
+                                      [],
+                                      [ListAllBody]),
+    EnabledFeatureFlags = maps:filter(
+                            fun(FeatureName, _) ->
+                                    maps:is_key(FeatureName,
+                                                FeatureStates)
+                                    andalso
+                                    maps:get(FeatureName, FeatureStates)
+                                    =:=
+                                    true
+                            end, AllFeatureFlags),
+    ListEnabledBody = erl_syntax:abstract(EnabledFeatureFlags),
+    ListEnabledClause = erl_syntax:clause(
+                          [erl_syntax:atom(enabled)],
+                          [],
+                          [ListEnabledBody]),
+    DisabledFeatureFlags = maps:filter(
+                            fun(FeatureName, _) ->
+                                    not maps:is_key(FeatureName,
+                                                    FeatureStates)
+                                    orelse
+                                    maps:get(FeatureName, FeatureStates)
+                                    =:=
+                                    false
+                            end, AllFeatureFlags),
+    ListDisabledBody = erl_syntax:abstract(DisabledFeatureFlags),
+    ListDisabledClause = erl_syntax:clause(
+                          [erl_syntax:atom(disabled)],
+                          [],
+                          [ListDisabledBody]),
+    StateChangingFeatureFlags = maps:filter(
+                                  fun(FeatureName, _) ->
+                                          maps:is_key(FeatureName,
+                                                      FeatureStates)
+                                          andalso
+                                          maps:get(FeatureName, FeatureStates)
+                                          =:=
+                                          state_changing
+                                  end, AllFeatureFlags),
+    ListStateChangingBody = erl_syntax:abstract(StateChangingFeatureFlags),
+    ListStateChangingClause = erl_syntax:clause(
+                                [erl_syntax:atom(state_changing)],
+                                [],
+                                [ListStateChangingBody]),
+    ListFun = erl_syntax:function(
+                erl_syntax:atom(list),
+                [ListAllClause,
+                 ListEnabledClause,
+                 ListDisabledClause,
+                 ListStateChangingClause]),
+    ListFunForm = erl_syntax:revert(ListFun),
+    %% states() -> ...
+    StatesBody = erl_syntax:abstract(FeatureStates),
+    StatesClause = erl_syntax:clause([], [], [StatesBody]),
+    StatesFun = erl_syntax:function(
+                  erl_syntax:atom(states),
+                  [StatesClause]),
+    StatesFunForm = erl_syntax:revert(StatesFun),
+    %% is_supported(_) -> ...
+    IsSupportedClauses = [erl_syntax:clause(
+                            [erl_syntax:atom(FeatureName)],
+                            [],
+                            [erl_syntax:atom(true)])
+                          || FeatureName <- maps:keys(AllFeatureFlags)
+                         ],
+    NotSupportedClause = erl_syntax:clause(
+                           [erl_syntax:variable("_")],
+                           [],
+                           [erl_syntax:atom(false)]),
+    IsSupportedFun = erl_syntax:function(
+                       erl_syntax:atom(is_supported),
+                       IsSupportedClauses ++ [NotSupportedClause]),
+    IsSupportedFunForm = erl_syntax:revert(IsSupportedFun),
+    %% is_enabled(_) -> ...
+    IsEnabledClauses = [erl_syntax:clause(
+                          [erl_syntax:atom(FeatureName)],
+                          [],
+                          [case maps:is_key(FeatureName, FeatureStates) of
+                               true ->
+                                   erl_syntax:atom(
+                                     maps:get(FeatureName, FeatureStates));
+                               false ->
+                                   erl_syntax:atom(false)
+                           end])
+                        || FeatureName <- maps:keys(AllFeatureFlags)
+                       ],
+    NotEnabledClause = erl_syntax:clause(
+                         [erl_syntax:variable("_")],
+                         [],
+                         [erl_syntax:atom(false)]),
+    IsEnabledFun = erl_syntax:function(
+                     erl_syntax:atom(is_enabled),
+                     IsEnabledClauses ++ [NotEnabledClause]),
+    IsEnabledFunForm = erl_syntax:revert(IsEnabledFun),
+    %% is_registry_initialized() -> ...
+    IsInitializedClauses = [erl_syntax:clause(
+                              [],
+                              [],
+                              [erl_syntax:atom(true)])
+                           ],
+    IsInitializedFun = erl_syntax:function(
+                         erl_syntax:atom(is_registry_initialized),
+                         IsInitializedClauses),
+    IsInitializedFunForm = erl_syntax:revert(IsInitializedFun),
+    %% is_registry_written_to_disk() -> ...
+    IsWrittenToDiskClauses = [erl_syntax:clause(
+                                [],
+                                [],
+                                [erl_syntax:atom(WrittenToDisk)])
+                             ],
+    IsWrittenToDiskFun = erl_syntax:function(
+                           erl_syntax:atom(is_registry_written_to_disk),
+                           IsWrittenToDiskClauses),
+    IsWrittenToDiskFunForm = erl_syntax:revert(IsWrittenToDiskFun),
+    %% inventory() -> ...
+    InventoryBody = erl_syntax:abstract(Inventory),
+    InventoryClause = erl_syntax:clause([], [], [InventoryBody]),
+    InventoryFun = erl_syntax:function(
+                     erl_syntax:atom(inventory),
+                     [InventoryClause]),
+    InventoryFunForm = erl_syntax:revert(InventoryFun),
+    %% Compilation!
+    Forms = [ModuleForm,
+             ExportForm,
+             GetFunForm,
+             ListFunForm,
+             StatesFunForm,
+             IsSupportedFunForm,
+             IsEnabledFunForm,
+             IsInitializedFunForm,
+             IsWrittenToDiskFunForm,
+             InventoryFunForm],
+    maybe_log_registry_source_code(Forms),
+    CompileOpts = [return_errors,
+                   return_warnings],
+    case compile:forms(Forms, CompileOpts) of
+        {ok, Mod, Bin, _} ->
+            load_registry_mod(RegistryVsn, Mod, Bin);
+        {error, Errors, Warnings} ->
+            rabbit_log_feature_flags:error(
+              "Feature flags: registry compilation failure:~n"
+              "Errors: ~p~n"
+              "Warnings: ~p",
+              [Errors, Warnings]),
+            {error, {compilation_failure, Errors, Warnings}};
+        error ->
+            rabbit_log_feature_flags:error(
+              "Feature flags: registry compilation failure",
+              []),
+            {error, {compilation_failure, [], []}}
+    end.
+
+maybe_log_registry_source_code(Forms) ->
+    case rabbit_prelaunch:get_context() of
+        #{log_feature_flags_registry := true} ->
+            rabbit_log_feature_flags:debug(
+              "== FEATURE FLAGS REGISTRY ==~n"
+              "~s~n"
+              "== END ==~n",
+              [erl_prettypr:format(erl_syntax:form_list(Forms))]),
+            ok;
+        _ ->
+            ok
+    end.
+
+-ifdef(TEST).
+registry_loading_lock() -> ?FF_REGISTRY_LOADING_LOCK.
+-endif.
+
+-spec load_registry_mod(registry_vsn(), module(), binary()) ->
+    ok | restart | no_return().
+%% @private
+
+load_registry_mod(RegistryVsn, Mod, Bin) ->
+    rabbit_log_feature_flags:debug(
+      "Feature flags: registry module ready, loading it (~p)...",
+      [self()]),
+    FakeFilename = "Compiled and loaded by " ?MODULE_STRING,
+    %% Time to load the new registry, replacing the old one. We use a
+    %% lock here to synchronize concurrent reloads.
+    global:set_lock(?FF_REGISTRY_LOADING_LOCK, [node()]),
+    rabbit_log_feature_flags:debug(
+      "Feature flags: acquired lock before reloading registry module (~p)",
+     [self()]),
+    %% We want to make sure that the old registry (not the one being
+    %% currently in use) is purged by the code server. It means no
+    %% process lingers on that old code.
+    %%
+    %% We use code:soft_purge() for that (meaning no process is killed)
+    %% and we wait in an infinite loop for that to succeed.
+    ok = purge_old_registry(Mod),
+    %% Now we can replace the currently loaded registry by the new one.
+    %% The code server takes care of marking the current registry as old
+    %% and load the new module in an atomic operation.
+    %%
+    %% Therefore there is no chance of a window where there is no
+    %% registry module available, causing the one on disk to be
+    %% reloaded.
+    Ret = case registry_vsn() of
+              RegistryVsn -> code:load_binary(Mod, FakeFilename, Bin);
+              OtherVsn    -> {error, {restart, RegistryVsn, OtherVsn}}
+          end,
+    rabbit_log_feature_flags:debug(
+      "Feature flags: releasing lock after reloading registry module (~p)",
+     [self()]),
+    global:del_lock(?FF_REGISTRY_LOADING_LOCK, [node()]),
+    case Ret of
+        {module, _} ->
+            rabbit_log_feature_flags:debug(
+              "Feature flags: registry module loaded (vsn: ~p -> ~p)",
+              [RegistryVsn, registry_vsn()]),
+            ok;
+        {error, {restart, Expected, Current}} ->
+            rabbit_log_feature_flags:error(
+              "Feature flags: another registry module was loaded in the "
+              "meantime (expected old vsn: ~p, current vsn: ~p); "
+              "restarting the regen",
+              [Expected, Current]),
+            restart;
+        {error, Reason} ->
+            rabbit_log_feature_flags:error(
+              "Feature flags: failed to load registry module: ~p",
+              [Reason]),
+            throw({feature_flag_registry_reload_failure, Reason})
+    end.
+
+-spec registry_vsn() -> registry_vsn().
+%% @private
+
+registry_vsn() ->
+    Attrs = rabbit_ff_registry:module_info(attributes),
+    proplists:get_value(vsn, Attrs, undefined).
+
+purge_old_registry(Mod) ->
+    case code:is_loaded(Mod) of
+        {file, _} -> do_purge_old_registry(Mod);
+        false     -> ok
+    end.
+
+do_purge_old_registry(Mod) ->
+    case code:soft_purge(Mod) of
+        true  -> ok;
+        false -> do_purge_old_registry(Mod)
+    end.

--- a/deps/rabbit/src/rabbit_prelaunch_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_prelaunch_feature_flags.erl
@@ -22,7 +22,7 @@ setup(#{feature_flags_file := FFFile}) ->
             ?LOG_DEBUG(
                "Initializing feature flags registry", [],
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
-            case rabbit_feature_flags:initialize_registry() of
+            case rabbit_ff_registry_factory:initialize_registry() of
                 ok ->
                     ok;
                 {error, Reason} ->

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -1,0 +1,1540 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(feature_flags_v2_SUITE).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("rabbit_common/include/logging.hrl").
+
+-include("feature_flags.hrl").
+
+-export([suite/0,
+         all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2,
+
+         mf_count_runs/3,
+         mf_wait_and_count_runs/3,
+         mf_wait_and_count_runs_v2/1,
+         mf_wait_and_count_runs_in_post_enable/1,
+
+         enable_unknown_feature_flag_on_a_single_node/1,
+         enable_supported_feature_flag_on_a_single_node/1,
+         enable_unknown_feature_flag_in_a_3node_cluster/1,
+         enable_supported_feature_flag_in_a_3node_cluster/1,
+         enable_partially_supported_feature_flag_in_a_3node_cluster/1,
+         enable_unsupported_feature_flag_in_a_3node_cluster/1,
+         enable_feature_flag_in_cluster_and_add_member_after/1,
+         enable_feature_flag_in_cluster_and_add_member_concurrently_mfv1/1,
+         enable_feature_flag_in_cluster_and_add_member_concurrently_mfv2/1,
+         enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv1/1,
+         enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv2/1,
+         enable_feature_flag_with_post_enable/1
+        ]).
+
+suite() ->
+    [{timetrap, {minutes, 1}}].
+
+all() ->
+    [
+     {group, feature_flags_v1},
+     {group, feature_flags_v2}
+    ].
+
+groups() ->
+    Groups =
+    [
+     {cluster_size_1, [parallel],
+      [
+       enable_unknown_feature_flag_on_a_single_node,
+       enable_supported_feature_flag_on_a_single_node
+      ]},
+     {cluster_size_3, [parallel],
+      [
+       enable_unknown_feature_flag_in_a_3node_cluster,
+       enable_supported_feature_flag_in_a_3node_cluster,
+       enable_partially_supported_feature_flag_in_a_3node_cluster,
+       enable_unsupported_feature_flag_in_a_3node_cluster,
+       enable_feature_flag_in_cluster_and_add_member_after,
+       enable_feature_flag_in_cluster_and_add_member_concurrently_mfv1,
+       enable_feature_flag_in_cluster_and_add_member_concurrently_mfv2,
+       enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv1,
+       enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv2,
+       enable_feature_flag_with_post_enable
+      ]}
+    ],
+    [
+     {feature_flags_v1, [], Groups},
+     {feature_flags_v2, [], Groups}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    logger:set_primary_config(level, debug),
+    rabbit_ct_helpers:run_steps(
+      Config,
+      [fun rabbit_ct_helpers:redirect_logger_to_ct_logs/1]).
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(feature_flags_v1, Config) ->
+    rabbit_ct_helpers:set_config(Config, {enable_feature_flags_v2, false});
+init_per_group(feature_flags_v2, Config) ->
+    rabbit_ct_helpers:set_config(Config, {enable_feature_flags_v2, true});
+init_per_group(cluster_size_1, Config) ->
+    rabbit_ct_helpers:set_config(Config, {nodes_count, 1});
+init_per_group(cluster_size_3, Config) ->
+    rabbit_ct_helpers:set_config(Config, {nodes_count, 3});
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:run_steps(
+      Config,
+      [fun(Cfg) -> start_slave_nodes(Cfg, Testcase) end]).
+
+end_per_testcase(_Testcase, Config) ->
+    rabbit_ct_helpers:run_steps(
+      Config,
+      [fun stop_slave_nodes/1]).
+
+start_slave_nodes(Config, Testcase) ->
+    NodesCount = ?config(nodes_count, Config),
+    ct:pal("Starting ~b slave node(s):", [NodesCount]),
+    Parent = self(),
+    Starters = [spawn_link(
+                  fun() ->
+                          start_slave_node(Parent, Config, Testcase, N)
+                  end)
+                || N <- lists:seq(1, NodesCount)],
+    Nodes = lists:sort(
+              [receive
+                   {node, Starter, Node} -> Node
+               end || Starter <- Starters]),
+    ct:pal("Started ~b slave node(s): ~p", [NodesCount, Nodes]),
+    rabbit_ct_helpers:set_config(Config, {nodes, Nodes}).
+
+start_slave_node(Parent, Config, Testcase, N) ->
+    Prefix = case ?config(enable_feature_flags_v2, Config) of
+                 false -> "ffv1";
+                 true  -> "ffv2"
+             end,
+    Name = list_to_atom(
+             rabbit_misc:format("~s-~s-~b", [Prefix, Testcase, N])),
+    ct:pal("- Starting slave node `~s@...`", [Name]),
+    {ok, Node} = slave:start(net_adm:localhost(), Name),
+    ct:pal("- Slave node `~s` started", [Node]),
+
+    TestCodePath = filename:dirname(code:which(?MODULE)),
+    true = rpc:call(Node, code, add_path, [TestCodePath]),
+    ok = run_on_node(Node, fun setup_slave_node/1, [Config]),
+    ct:pal("- Slave node `~s` configured", [Node]),
+    Parent ! {node, self(), Node}.
+
+stop_slave_nodes(Config) ->
+    Nodes = ?config(nodes, Config),
+    ct:pal("Stopping ~b slave nodes:", [length(Nodes)]),
+    lists:foreach(fun stop_slave_node/1, Nodes),
+    rabbit_ct_helpers:delete_config(Config, nodes).
+
+stop_slave_node(Node) ->
+    ct:pal("- Stopping slave node `~s`...", [Node]),
+    ok = slave:stop(Node).
+
+connect_nodes([FirstNode | OtherNodes] = Nodes) ->
+    lists:foreach(
+      fun(Node) -> pong = rpc:call(Node, net_adm, ping, [FirstNode]) end,
+      OtherNodes),
+    Cluster = lists:sort(
+                [FirstNode | rpc:call(FirstNode, erlang, nodes, [])]),
+    ?assert(lists:all(fun(Node) -> lists:member(Node, Cluster) end, Nodes)).
+
+run_on_node(Node, Fun) ->
+    run_on_node(Node, Fun, []).
+
+run_on_node(Node, Fun, Args) ->
+    rpc:call(Node, erlang, apply, [Fun, Args]).
+
+%% -------------------------------------------------------------------
+%% Slave node configuration.
+%% -------------------------------------------------------------------
+
+setup_slave_node(Config) ->
+    ok = setup_logger(),
+    ok = setup_feature_flags_file(Config),
+    ok = start_controller(),
+    ok = maybe_enable_feature_flags_v2(Config),
+    ok.
+
+setup_logger() ->
+    logger:set_primary_config(level, debug),
+    ok.
+
+setup_feature_flags_file(Config) ->
+    %% The `feature_flags_file' is set to a specific location in the test log
+    %% directory.
+    FeatureFlagsFile = filename:join(
+                         ?config(priv_dir, Config),
+                         rabbit_misc:format("feature_flags-~s", [node()])),
+    ?LOG_INFO("Setting `feature_flags_file to \"~ts\"", [FeatureFlagsFile]),
+    case application:load(rabbit) of
+        ok                           -> ok;
+        {error, {already_loaded, _}} -> ok
+    end,
+    ok = application:set_env(rabbit, feature_flags_file, FeatureFlagsFile),
+    ok.
+
+start_controller() ->
+    ?LOG_INFO("Starting feature flags controller"),
+    {ok, Pid} = rabbit_ff_controller:start(),
+    ?LOG_INFO("Feature flags controller: ~p", [Pid]),
+    ok.
+
+maybe_enable_feature_flags_v2(Config) ->
+    EnableFFv2 = ?config(enable_feature_flags_v2, Config),
+    case EnableFFv2 of
+        true  -> ok = rabbit_feature_flags:enable(feature_flags_v2);
+        false -> ok
+    end,
+    IsEnabled = rabbit_feature_flags:is_enabled(feature_flags_v2),
+    ?LOG_INFO("`feature_flags_v2` enabled: ~s", [IsEnabled]),
+    ?assertEqual(EnableFFv2, IsEnabled),
+    ok.
+
+override_running_nodes(Nodes) when is_list(Nodes) ->
+    ct:pal("Overring (running) remote nodes for ~p", [Nodes]),
+    _ = [begin
+             ok = rpc:call(
+                    Node, rabbit_feature_flags, override_nodes,
+                    [Nodes]),
+             ?assertEqual(
+                Nodes,
+                lists:sort(
+                  [Node |
+                   rpc:call(Node, rabbit_feature_flags, remote_nodes, [])])),
+             ?assertEqual(
+                Nodes,
+                rpc:call(Node, rabbit_ff_controller, all_nodes, [])),
+
+             ok = rpc:call(
+                    Node, rabbit_feature_flags, override_running_nodes,
+                    [Nodes]),
+             ?assertEqual(
+                Nodes,
+                lists:sort(
+                  [Node |
+                   rpc:call(
+                     Node, rabbit_feature_flags, running_remote_nodes, [])])),
+             ?assertEqual(
+                Nodes,
+                rpc:call(Node, rabbit_ff_controller, running_nodes, []))
+         end
+         || Node <- Nodes],
+    ok.
+
+inject_on_nodes(Nodes, FeatureFlags) ->
+    ct:pal(
+      "Injecting feature flags on nodes~n"
+      "  Nodes:         ~p~n"
+      "  Feature flags: ~p~n",
+     [FeatureFlags, Nodes]),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:inject_test_feature_flags(
+                        FeatureFlags)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ok.
+
+%% -------------------------------------------------------------------
+%% Migration functions.
+%% -------------------------------------------------------------------
+
+-define(PT_MIGRATION_FUN_RUNS, {?MODULE, migration_fun_runs}).
+
+bump_runs() ->
+    Count = persistent_term:get(?PT_MIGRATION_FUN_RUNS, 0),
+    persistent_term:put(?PT_MIGRATION_FUN_RUNS, Count + 1),
+    ok.
+
+mf_count_runs(_FeatureName, _FeatureProps, enable) ->
+    bump_runs(),
+    ok.
+
+mf_wait_and_count_runs(_FeatureName, _FeatureProps, enable) ->
+    Peer = get_peer_proc(),
+    Peer ! {node(), self(), waiting},
+    ?LOG_NOTICE("Migration function: waiting for signal from ~p...", [Peer]),
+    receive proceed -> ok end,
+    ?LOG_NOTICE("Migration function: unblocked!", []),
+    bump_runs(),
+    ok.
+
+mf_wait_and_count_runs_v2(#ffcommand{command = enable}) ->
+    Peer = get_peer_proc(),
+    Peer ! {node(), self(), waiting},
+    ?LOG_NOTICE("Migration function: waiting for signal from ~p...", [Peer]),
+    receive proceed -> ok end,
+    ?LOG_NOTICE("Migration function: unblocked!", []),
+    bump_runs(),
+    ok;
+mf_wait_and_count_runs_v2(_) ->
+    ok.
+
+mf_wait_and_count_runs_in_post_enable(#ffcommand{command = post_enable}) ->
+    Peer = get_peer_proc(),
+    Peer ! {node(), self(), waiting},
+    ?LOG_NOTICE("Migration function: waiting for signal from ~p...", [Peer]),
+    receive proceed -> ok end,
+    ?LOG_NOTICE("Migration function: unblocked!", []),
+    bump_runs(),
+    ok;
+mf_wait_and_count_runs_in_post_enable(_) ->
+    ok.
+
+-define(PT_PEER_PROC, {?MODULE, peer_proc}).
+
+record_peer_proc(Peer) ->
+    ?LOG_ALERT("Recording peer=~p", [Peer]),
+    persistent_term:put(?PT_PEER_PROC, Peer).
+
+get_peer_proc() ->
+    persistent_term:get(?PT_PEER_PROC).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+enable_unknown_feature_flag_on_a_single_node(Config) ->
+    [Node] = ?config(nodes, Config),
+    ok = run_on_node(
+           Node, fun enable_unknown_feature_flag_on_a_single_node/0).
+
+enable_unknown_feature_flag_on_a_single_node() ->
+    FeatureName = ?FUNCTION_NAME,
+    ?assertNot(rabbit_feature_flags:is_supported(FeatureName)),
+    ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+
+    %% The node doesn't know about the feature flag and thus rejects the
+    %% request.
+    ?assertEqual(
+       {error, unsupported}, rabbit_feature_flags:enable(FeatureName)),
+    ?assertNot(rabbit_feature_flags:is_supported(FeatureName)),
+    ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+    ok.
+
+enable_supported_feature_flag_on_a_single_node(Config) ->
+    [Node] = ?config(nodes, Config),
+    ok = run_on_node(
+           Node, fun enable_supported_feature_flag_on_a_single_node/0).
+
+enable_supported_feature_flag_on_a_single_node() ->
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName => #{provided_by => ?MODULE,
+                                      stability => stable}},
+    ?assertEqual(
+       ok, rabbit_feature_flags:inject_test_feature_flags(FeatureFlags)),
+    ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+    ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+
+    ?assertEqual(ok, rabbit_feature_flags:enable(FeatureName)),
+    ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+    ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+    ok.
+
+enable_unknown_feature_flag_in_a_3node_cluster(Config) ->
+    Nodes = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes(Nodes),
+
+    FeatureName = ?FUNCTION_NAME,
+
+    ct:pal(
+      "Checking the feature flag is unsupported and disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    %% No nodes know about the feature flag and thus all reject the request.
+    ct:pal("Trying to enable the feature flag on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(
+                      {error, unsupported},
+                      rabbit_feature_flags:enable(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ct:pal(
+      "Checking the feature flag is still unsupported and disabled on all "
+      "nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ok.
+
+enable_supported_feature_flag_in_a_3node_cluster(Config) ->
+    Nodes = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes(Nodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName => #{provided_by => ?MODULE,
+                                      stability => stable}},
+    inject_on_nodes(Nodes, FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    %% The first call enables the feature flag, the following calls are
+    %% idempotent and do nothing.
+    ct:pal("Enabling the feature flag on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(ok, rabbit_feature_flags:enable(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ct:pal("Checking the feature flag is supported and enabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ok.
+
+enable_partially_supported_feature_flag_in_a_3node_cluster(Config) ->
+    [FirstNode | OtherNodes] = Nodes = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes(Nodes),
+    UsingFFv1 = not ?config(enable_feature_flags_v2, Config),
+
+    %% This time, we inject the feature flag on a single node only. The other
+    %% nodes don't know about it.
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName => #{provided_by => ?MODULE,
+                                      stability => stable}},
+    inject_on_nodes([FirstNode], FeatureFlags),
+
+    case UsingFFv1 of
+        true ->
+            %% With `feature_flags_v1', the code would have shared the new
+            %% feature flags with remote nodes, so let's run that here. In the
+            %% end, the testcase is similar to
+            %% `enable_supported_feature_flag_in_a_3node_cluster'.
+            ct:pal("Refreshing feature flags after app load"),
+            ok = run_on_node(
+                   FirstNode,
+                   fun() ->
+                           ?assertEqual(
+                              ok,
+                              rabbit_feature_flags:
+                              share_new_feature_flags_after_app_load(
+                                FeatureFlags, infinity)),
+                           ok
+                   end,
+                   []);
+        false ->
+            ok
+    end,
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    %% The first call enables the feature flag, the following calls are
+    %% idempotent and do nothing.
+    ct:pal("Enabling the feature flag on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:enable(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ct:pal(
+      "Checking the feature flag is supported on all nodes and enabled on "
+      "all nodes (v1) or the node knowing it only (v2)"),
+    ok = run_on_node(
+           FirstNode,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           []),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   case UsingFFv1 of
+                       true ->
+                           ?assert(
+                              rabbit_feature_flags:is_supported(FeatureName)),
+                           ?assert(
+                              rabbit_feature_flags:is_enabled(FeatureName));
+                       false ->
+                           ?assert(
+                              rabbit_feature_flags:is_supported(FeatureName)),
+                           ?assertNot(
+                              rabbit_feature_flags:is_enabled(FeatureName))
+                   end,
+                   ok
+           end,
+           [])
+         || Node <- OtherNodes],
+    ok.
+
+enable_unsupported_feature_flag_in_a_3node_cluster(Config) ->
+    [FirstNode | _OtherNodes] = Nodes = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes(Nodes),
+
+    %% We inject the feature flag on a single node only. We tell it is
+    %% provided by `rabbit' which was already loaded and scanned while
+    %% configuring the node. This way, we ensure the feature flag is
+    %% considered supported by the node where is was injected, but
+    %% unsupported by other nodes.
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName => #{provided_by => rabbit,
+                                      stability => stable}},
+    inject_on_nodes([FirstNode], FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is unsupported and disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    %% The feature flag is unsupported, thus all reject the request.
+    ct:pal("Enabling the feature flag on all nodes (denied)"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(
+                      {error, unsupported},
+                      rabbit_feature_flags:enable(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ct:pal("Checking the feature flag is still disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ok.
+
+enable_feature_flag_in_cluster_and_add_member_after(Config) ->
+    AllNodes = [NewNode | [FirstNode | _] = Nodes] = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes([NewNode]),
+    override_running_nodes(Nodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => ?MODULE,
+                       stability => stable,
+                       migration_fun => {?MODULE, mf_count_runs}}},
+    inject_on_nodes(AllNodes, FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+
+    ct:pal("Enabling the feature flag in the cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(ok, rabbit_feature_flags:enable(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ct:pal("Checking the feature flag is enabled in the initial cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ct:pal("Checking the feature flag is still disabled on the new node"),
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           []),
+
+    %% Check compatibility between NewNodes and Nodes.
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:check_node_compatibility(
+                        FirstNode)),
+                   ok
+           end, []),
+
+    %% Add node to cluster and synchronize feature flags.
+    connect_nodes(AllNodes),
+    override_running_nodes(AllNodes),
+    ct:pal(
+      "Synchronizing feature flags in the expanded cluster~n"
+      "~n"
+      "NOTE: Error messages about crashed migration functions can be "
+      "ignored for feature~n"
+      "      flags other than `~s`~n"
+      "      because they assume they run inside RabbitMQ.",
+      [FeatureName]),
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:sync_feature_flags_with_cluster(
+                        Nodes, true)),
+                   ok
+           end, []),
+
+    ct:pal("Checking the feature flag is enabled in the expanded cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   %% With both feature flags v1 and v2, the migration
+                   %% function is executed on the node where `enable()' was
+                   %% called, and then on the node joining the cluster.
+                   Count = case Node of
+                               FirstNode -> 1;
+                               NewNode   -> 1;
+                               _         -> 0
+                           end,
+                   ?assertEqual(
+                      Count,
+                      persistent_term:get(?PT_MIGRATION_FUN_RUNS, 0)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    ok.
+
+enable_feature_flag_in_cluster_and_add_member_concurrently_mfv1(Config) ->
+    AllNodes = [NewNode | [FirstNode | _] = Nodes] = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes([NewNode]),
+    override_running_nodes(Nodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => ?MODULE,
+                       stability => stable,
+                       migration_fun => {?MODULE, mf_wait_and_count_runs}}},
+    inject_on_nodes(AllNodes, FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+
+    ct:pal(
+      "Enabling the feature flag in the cluster (in a separate process)"),
+    Peer = self(),
+    Enabler = spawn_link(
+                fun() ->
+                        ok =
+                        run_on_node(
+                          FirstNode,
+                          fun() ->
+                                  %% The migration function uses the `Peer'
+                                  %% PID (the process executing the testcase)
+                                  %% to notify its own PID and wait for a
+                                  %% signal from `Peer' to proceed and finish
+                                  %% the migration.
+                                  record_peer_proc(Peer),
+                                  ?assertEqual(
+                                     ok,
+                                     rabbit_feature_flags:enable(
+                                       FeatureName)),
+                                  ok
+                          end,
+                          [])
+                end),
+
+    %% By waiting for the message from one of the migration function
+    %% instances, we make sure the feature flags controller on `FirstNode' is
+    %% blocked and waits for a message from this process. Therefore, we are
+    %% sure the feature flag is in the `state_changing' state and we can try
+    %% to add a new node and sync its feature flags.
+    FirstNodeMigFunPid = receive
+                             {FirstNode, MigFunPid1, waiting} -> MigFunPid1
+                         end,
+
+    %% Check compatibility between NewNodes and Nodes. This doesn't block.
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:check_node_compatibility(
+                        FirstNode)),
+                   ok
+           end, []),
+
+    %% Add node to cluster and synchronize feature flags. The synchronization
+    %% blocks.
+    connect_nodes(AllNodes),
+    override_running_nodes(AllNodes),
+    ct:pal(
+      "Synchronizing feature flags in the expanded cluster (in a separate "
+      "process)~n"
+      "~n"
+      "NOTE: Error messages about crashed migration functions can be "
+      "ignored for feature~n"
+      "      flags other than `~s`~n"
+      "      because they assume they run inside RabbitMQ.",
+      [FeatureName]),
+    Syncer = spawn_link(
+               fun() ->
+                       ok =
+                       run_on_node(
+                         NewNode,
+                         fun() ->
+                                 record_peer_proc(Peer),
+                                 ?assertEqual(
+                                    ok,
+                                    rabbit_feature_flags:
+                                    sync_feature_flags_with_cluster(
+                                      Nodes, true)),
+                                 ok
+                         end, [])
+               end),
+
+    ct:pal(
+      "Checking the feature flag state is changing in the initial cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(
+                      state_changing,
+                      rabbit_feature_flags:is_enabled(
+                        FeatureName, non_blocking)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    ct:pal("Checking the feature flag is still disabled on the new node"),
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           []),
+
+    %% Unblock the migration functions on `Nodes'.
+    UsingFFv1 = not ?config(enable_feature_flags_v2, Config),
+    EnablerMRef = erlang:monitor(process, Enabler),
+    SyncerMRef = erlang:monitor(process, Syncer),
+    unlink(Enabler),
+    unlink(Syncer),
+    ExpectedNodes = case UsingFFv1 of
+                        true ->
+                            %% With v1, the migration function runs on a
+                            %% single node in the cluster only in this
+                            %% scenario.
+                            %%
+                            %% The reason is that the new node joined during
+                            %% the migration and the feature flag was marked
+                            %% as enabled there as well, even though the
+                            %% migration function possibly didn't know about
+                            %% it. This is one of the problems
+                            %% `feature_flags_v2' fixes.
+                            [FirstNode];
+                        false ->
+                            %% With v2 but still using the old migration
+                            %% function API (taking 3 arguments), the
+                            %% migration function is executed on the node
+                            %% where `enable()' was called, and then on the
+                            %% node joining the cluster, thanks to the
+                            %% synchronization.
+                            [FirstNode, NewNode]
+                    end,
+
+    %% Unblock the migration function for which we already consumed the
+    %% `waiting' notification.
+    FirstMigratedNode = node(FirstNodeMigFunPid),
+    ?assertEqual(FirstNode, FirstMigratedNode),
+    ct:pal(
+      "Unblocking first node (~p @ ~s)",
+      [FirstNodeMigFunPid, FirstMigratedNode]),
+    FirstNodeMigFunPid ! proceed,
+
+    %% Unblock the rest and collect the node names of all migration functions
+    %% which ran.
+    ct:pal("Unblocking other nodes, including the joining one"),
+    OtherMigratedNodes = [receive
+                              {Node, MigFunPid2, waiting} ->
+                                  MigFunPid2 ! proceed,
+                                  Node 
+                          end || Node <- ExpectedNodes -- [FirstMigratedNode]],
+    MigratedNodes = [FirstMigratedNode | OtherMigratedNodes],
+    ?assertEqual(lists:sort(ExpectedNodes), lists:sort(MigratedNodes)),
+
+    ct:pal("Waiting for spawned processes to terminate"),
+    receive
+        {'DOWN', EnablerMRef, process, Enabler, EnablerReason} ->
+            ?assertEqual(normal, EnablerReason)
+    end,
+    receive
+        {'DOWN', SyncerMRef, process, Syncer, SyncerReason} ->
+            ?assertEqual(normal, SyncerReason)
+    end,
+
+    ct:pal("Checking the feature flag is enabled in the expanded cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assert(
+                      not lists:member(Node, MigratedNodes) orelse
+                      1 =:= persistent_term:get(?PT_MIGRATION_FUN_RUNS, 0)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    ok.
+
+enable_feature_flag_in_cluster_and_add_member_concurrently_mfv2(Config) ->
+    AllNodes = [NewNode | [FirstNode | _] = Nodes] = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes([NewNode]),
+    override_running_nodes(Nodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => ?MODULE,
+                       stability => stable,
+                       migration_fun => {?MODULE,
+                                         mf_wait_and_count_runs_v2}}},
+    inject_on_nodes(AllNodes, FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+
+    ct:pal(
+      "Enabling the feature flag in the cluster (in a separate process)"),
+    Peer = self(),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   %% The migration function uses the `Peer' PID (the process
+                   %% executing the testcase) to notify its own PID and wait
+                   %% for a signal from `Peer' to proceed and finish the
+                   %% migration.
+                   record_peer_proc(Peer),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    Enabler = spawn_link(
+                fun() ->
+                        ok =
+                        run_on_node(
+                          FirstNode,
+                          fun() ->
+                                  ?assertEqual(
+                                     ok,
+                                     rabbit_feature_flags:enable(
+                                       FeatureName)),
+                                  ok
+                          end,
+                          [])
+                end),
+
+    %% By waiting for the message from one of the migration function
+    %% instances, we make sure the feature flags controller on `FirstNode' is
+    %% blocked and waits for a message from this process. Therefore, we are
+    %% sure the feature flag is in the `state_changing' state and we can try
+    %% to add a new node and sync its feature flags.
+    FirstNodeMigFunPid = receive
+                             {_Node, MigFunPid1, waiting} -> MigFunPid1
+                         end,
+
+    %% Check compatibility between NewNodes and Nodes. This doesn't block.
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:check_node_compatibility(
+                        FirstNode)),
+                   ok
+           end, []),
+
+    %% Add node to cluster and synchronize feature flags. The synchronization
+    %% blocks.
+    connect_nodes(AllNodes),
+    override_running_nodes(AllNodes),
+    ct:pal(
+      "Synchronizing feature flags in the expanded cluster (in a separate "
+      "process)~n"
+      "~n"
+      "NOTE: Error messages about crashed migration functions can be "
+      "ignored for feature~n"
+      "      flags other than `~s`~n"
+      "      because they assume they run inside RabbitMQ.",
+      [FeatureName]),
+    Syncer = spawn_link(
+               fun() ->
+                       ok =
+                       run_on_node(
+                         NewNode,
+                         fun() ->
+                                 ?assertEqual(
+                                    ok,
+                                    rabbit_feature_flags:
+                                    sync_feature_flags_with_cluster(
+                                      Nodes, true)),
+                                 ok
+                         end, [])
+               end),
+
+    ct:pal(
+      "Checking the feature flag state is changing in the initial cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assertEqual(
+                      state_changing,
+                      rabbit_feature_flags:is_enabled(
+                        FeatureName, non_blocking)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    ct:pal("Checking the feature flag is still disabled on the new node"),
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           []),
+
+    %% Unblock the migration functions on `Nodes'.
+    EnablerMRef = erlang:monitor(process, Enabler),
+    SyncerMRef = erlang:monitor(process, Syncer),
+    unlink(Enabler),
+    unlink(Syncer),
+
+    %% The migration function runs on all clustered nodes with v2, including
+    %% the one joining the cluster, thanks to the synchronization.
+    %%
+    %% When this testcase runs with feature flags v1, the feature flag we want
+    %% to enable uses the migration function API v2: this implicitly enables
+    %% `feature_flags_v2'. As part of the synchronization, the node still on
+    %% feature flags v1 will try to sync `feature_flags_v2' specificaly first.
+    %% After that, the controller-based sync proceeds.
+    ExpectedNodes = Nodes ++ [NewNode],
+
+    %% Unblock the migration function for which we already consumed the
+    %% `waiting' notification.
+    FirstMigratedNode = node(FirstNodeMigFunPid),
+    ct:pal(
+      "Unblocking first node (~p @ ~s)",
+      [FirstNodeMigFunPid, FirstMigratedNode]),
+    FirstNodeMigFunPid ! proceed,
+
+    %% Unblock the rest and collect the node names of all migration functions
+    %% which ran.
+    ct:pal("Unblocking other nodes, including the joining one"),
+    OtherMigratedNodes = [receive
+                              {Node, MigFunPid2, waiting} ->
+                                  MigFunPid2 ! proceed,
+                                  Node
+                          end || Node <- ExpectedNodes -- [FirstMigratedNode]],
+    MigratedNodes = [FirstMigratedNode | OtherMigratedNodes],
+    ?assertEqual(lists:sort(ExpectedNodes), lists:sort(MigratedNodes)),
+
+    ct:pal("Waiting for spawned processes to terminate"),
+    receive
+        {'DOWN', EnablerMRef, process, Enabler, EnablerReason} ->
+            ?assertEqual(normal, EnablerReason)
+    end,
+    receive
+        {'DOWN', SyncerMRef, process, Syncer, SyncerReason} ->
+            ?assertEqual(normal, SyncerReason)
+    end,
+
+    ct:pal("Checking the feature flag is enabled in the expanded cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assertEqual(
+                      1,
+                      persistent_term:get(?PT_MIGRATION_FUN_RUNS, 0)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    ok.
+
+enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv1(Config) ->
+    AllNodes = [LeavingNode | [FirstNode | _] = Nodes] = ?config(
+                                                            nodes, Config),
+    connect_nodes(AllNodes),
+    override_running_nodes(AllNodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => ?MODULE,
+                       stability => stable,
+                       migration_fun => {?MODULE, mf_wait_and_count_runs}}},
+    inject_on_nodes(AllNodes, FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+
+    UsingFFv1 = not ?config(enable_feature_flags_v2, Config),
+    ExpectedRet = case UsingFFv1 of
+                      true  -> ok;
+                      false -> {error, {badrpc, nodedown}}
+                  end,
+    ct:pal(
+      "Enabling the feature flag in the cluster (in a separate process)"),
+    Peer = self(),
+    Enabler = spawn_link(
+                fun() ->
+                        ok =
+                        run_on_node(
+                          FirstNode,
+                          fun() ->
+                                  %% The migration function uses the `Peer'
+                                  %% PID (the process executing the testcase)
+                                  %% to notify its own PID and wait for a
+                                  %% signal from `Peer' to proceed and finish
+                                  %% the migration.
+                                  record_peer_proc(Peer),
+                                  ?assertEqual(
+                                     ExpectedRet,
+                                     rabbit_feature_flags:enable(
+                                       FeatureName)),
+                                  ok
+                          end,
+                          [])
+                end),
+
+    %% By waiting for the message from one of the migration function
+    %% instances, we make sure the feature flags controller on `FirstNode' is
+    %% blocked and waits for a message from this process. Therefore, we are
+    %% sure the feature flag is in the `state_changing' state and we can try
+    %% to add a new node and sync its feature flags.
+    FirstNodeMigFunPid = receive
+                             {_Node, MigFunPid1, waiting} -> MigFunPid1
+                         end,
+
+    %% Remove node from cluster.
+    stop_slave_node(LeavingNode),
+    override_running_nodes(Nodes),
+
+    %% Unblock the migration functions on `Nodes'.
+    EnablerMRef = erlang:monitor(process, Enabler),
+    unlink(Enabler),
+
+    %% Unblock the migration function for which we already consumed the
+    %% `waiting' notification.
+    FirstMigratedNode = node(FirstNodeMigFunPid),
+    ct:pal(
+      "Unblocking first node (~p @ ~s)",
+      [FirstNodeMigFunPid, FirstMigratedNode]),
+    FirstNodeMigFunPid ! proceed,
+
+    ct:pal("Waiting for spawned processes to terminate"),
+    receive
+        {'DOWN', EnablerMRef, process, Enabler, EnablerReason} ->
+            ?assertEqual(normal, EnablerReason)
+    end,
+
+    ct:pal(
+      "Checking the feature flag is enabled (v1) or disabled (v2) in the "
+      "cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   case UsingFFv1 of
+                       true ->
+                           ?assert(
+                              rabbit_feature_flags:is_enabled(FeatureName));
+                       false ->
+                           ?assertNot(
+                              rabbit_feature_flags:is_enabled(FeatureName))
+                   end,
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ok.
+
+enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv2(Config) ->
+    AllNodes = [LeavingNode | [FirstNode | _] = Nodes] = ?config(
+                                                            nodes, Config),
+    connect_nodes(AllNodes),
+    override_running_nodes(AllNodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => ?MODULE,
+                       stability => stable,
+                       migration_fun => {?MODULE,
+                                         mf_wait_and_count_runs_v2}}},
+    inject_on_nodes(AllNodes, FeatureFlags),
+
+    UsingFFv1 = not ?config(enable_feature_flags_v2, Config),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+
+    ct:pal(
+      "Enabling the feature flag in the cluster (in a separate process)"),
+    Peer = self(),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   %% The migration function uses the `Peer' PID (the process
+                   %% executing the testcase) to notify its own PID and wait
+                   %% for a signal from `Peer' to proceed and finish the
+                   %% migration.
+                   record_peer_proc(Peer),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    Enabler = spawn_link(
+                fun() ->
+                        ok =
+                        run_on_node(
+                          FirstNode,
+                          fun() ->
+                                  ?assertEqual(
+                                     {error, {badrpc, nodedown}},
+                                     rabbit_feature_flags:enable(
+                                       FeatureName)),
+                                  ok
+                          end,
+                          [])
+                end),
+
+    %% By waiting for the message from one of the migration function
+    %% instances, we make sure the feature flags controller on `FirstNode' is
+    %% blocked and waits for a message from this process. Therefore, we are
+    %% sure the feature flag is in the `state_changing' state and we can try
+    %% to add a new node and sync its feature flags.
+    FirstNodeMigFunPid = receive
+                             {FirstNode, MigFunPid1, waiting} -> MigFunPid1
+                         end,
+
+    %% Remove node from cluster.
+    stop_slave_node(LeavingNode),
+    override_running_nodes(Nodes),
+
+    %% Unblock the migration functions on `Nodes'.
+    EnablerMRef = erlang:monitor(process, Enabler),
+    unlink(Enabler),
+
+    %% The migration function runs on all clustered nodes with v2.
+    %%
+    %% When this testcase runs with feature flags v1, the feature flag we want
+    %% to enable uses the migration function API v2: this implicitly enables
+    %% `feature_flags_v2'. As part of the synchronization, the node still on
+    %% feature flags v1 will try to sync `feature_flags_v2' specificaly first.
+    %% After that, the controller-based sync proceeds.
+    ExpectedNodes = Nodes,
+
+    %% Unblock the migration function for which we already consumed the
+    %% `waiting' notification.
+    FirstMigratedNode = node(FirstNodeMigFunPid),
+    ?assertEqual(FirstNode, FirstMigratedNode),
+    ct:pal(
+      "Unblocking first node (~p @ ~s)",
+      [FirstNodeMigFunPid, FirstMigratedNode]),
+    FirstNodeMigFunPid ! proceed,
+
+    %% Unblock the rest and collect the node names of all migration functions
+    %% which ran.
+    ct:pal("Unblocking other nodes"),
+    OtherMigratedNodes = [receive
+                              {Node, MigFunPid2, waiting} ->
+                                  MigFunPid2 ! proceed,
+                                  Node
+                          end || Node <- ExpectedNodes -- [FirstMigratedNode]],
+    MigratedNodes = [FirstMigratedNode | OtherMigratedNodes],
+    ?assertEqual(lists:sort(ExpectedNodes), lists:sort(MigratedNodes)),
+
+    ct:pal("Waiting for spawned processes to terminate"),
+    receive
+        {'DOWN', EnablerMRef, process, Enabler, EnablerReason} ->
+            ?assertEqual(normal, EnablerReason)
+    end,
+
+    ct:pal(
+      "Checking the feature flag is enabled (v1) or disabled (v2) in the "
+      "cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   case UsingFFv1 of
+                       true ->
+                           ?assertNot(
+                              rabbit_feature_flags:is_enabled(FeatureName));
+                       false ->
+                           ?assertNot(
+                              rabbit_feature_flags:is_enabled(FeatureName))
+                   end,
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+    ok.
+
+enable_feature_flag_with_post_enable(Config) ->
+    AllNodes = [NewNode | [FirstNode | _] = Nodes] = ?config(nodes, Config),
+    connect_nodes(Nodes),
+    override_running_nodes([NewNode]),
+    override_running_nodes(Nodes),
+
+    FeatureName = ?FUNCTION_NAME,
+    FeatureFlags = #{FeatureName =>
+                     #{provided_by => ?MODULE,
+                       stability => stable,
+                       migration_fun =>
+                       {?MODULE,
+                        mf_wait_and_count_runs_in_post_enable}}},
+    inject_on_nodes(AllNodes, FeatureFlags),
+
+    ct:pal(
+      "Checking the feature flag is supported but disabled on all nodes"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_supported(FeatureName)),
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+
+    ct:pal(
+      "Enabling the feature flag in the cluster (in a separate process)"),
+    Peer = self(),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   %% The migration function uses the `Peer' PID (the process
+                   %% executing the testcase) to notify its own PID and wait
+                   %% for a signal from `Peer' to proceed and finish the
+                   %% migration.
+                   record_peer_proc(Peer),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    Enabler = spawn_link(
+                fun() ->
+                        ok =
+                        run_on_node(
+                          FirstNode,
+                          fun() ->
+                                  ?assertEqual(
+                                     ok,
+                                     rabbit_feature_flags:enable(
+                                       FeatureName)),
+                                  ok
+                          end,
+                          [])
+                end),
+
+    %% By waiting for the message from one of the migration function
+    %% instances, we make sure the feature flags controller on `FirstNode' is
+    %% blocked and waits for a message from this process. Therefore, we are
+    %% sure the feature flag is in the `state_changing' state and we can try
+    %% to add a new node and sync its feature flags.
+    FirstNodeMigFunPid = receive
+                             {_Node, MigFunPid1, waiting} -> MigFunPid1
+                         end,
+
+    %% Check compatibility between NewNodes and Nodes. This doesn't block.
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertEqual(
+                      ok,
+                      rabbit_feature_flags:check_node_compatibility(
+                        FirstNode)),
+                   ok
+           end, []),
+
+    %% Add node to cluster and synchronize feature flags. The synchronization
+    %% blocks.
+    connect_nodes(AllNodes),
+    override_running_nodes(AllNodes),
+    ct:pal(
+      "Synchronizing feature flags in the expanded cluster (in a separate "
+      "process)~n"
+      "~n"
+      "NOTE: Error messages about crashed migration functions can be "
+      "ignored for feature~n"
+      "      flags other than `~s`~n"
+      "      because they assume they run inside RabbitMQ.",
+      [FeatureName]),
+    Syncer = spawn_link(
+               fun() ->
+                       ok =
+                       run_on_node(
+                         NewNode,
+                         fun() ->
+                                 ?assertEqual(
+                                    ok,
+                                    rabbit_feature_flags:
+                                    sync_feature_flags_with_cluster(
+                                      Nodes, true)),
+                                 ok
+                         end, [])
+               end),
+
+    ct:pal(
+      "Checking the feature flag is enabled in the initial cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(
+                      rabbit_feature_flags:is_enabled(
+                        FeatureName, non_blocking)),
+                   ok
+           end,
+           [])
+         || Node <- Nodes],
+
+    ct:pal("Checking the feature flag is still disabled on the new node"),
+    ok = run_on_node(
+           NewNode,
+           fun() ->
+                   ?assertNot(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ok
+           end,
+           []),
+
+    %% Unblock the migration functions on `Nodes'.
+    EnablerMRef = erlang:monitor(process, Enabler),
+    SyncerMRef = erlang:monitor(process, Syncer),
+    unlink(Enabler),
+    unlink(Syncer),
+
+    %% The migration function runs on all clustered nodes with v2, including
+    %% the one joining the cluster, thanks to the synchronization.
+    %%
+    %% When this testcase runs with feature flags v1, the feature flag we want
+    %% to enable uses the migration function API v2: this implicitly enables
+    %% `feature_flags_v2'. As part of the synchronization, the node still on
+    %% feature flags v1 will try to sync `feature_flags_v2' specificaly first.
+    %% After that, the controller-based sync proceeds.
+    ExpectedNodes = Nodes ++ [NewNode],
+
+    %% Unblock the migration function for which we already consumed the
+    %% `waiting' notification.
+    FirstMigratedNode = node(FirstNodeMigFunPid),
+    ct:pal(
+      "Unblocking first node (~p @ ~s)",
+      [FirstNodeMigFunPid, FirstMigratedNode]),
+    FirstNodeMigFunPid ! proceed,
+
+    %% Unblock the rest and collect the node names of all migration functions
+    %% which ran.
+    ct:pal("Unblocking other nodes, including the joining one"),
+    OtherMigratedNodes = [receive
+                              {Node, MigFunPid2, waiting} ->
+                                  MigFunPid2 ! proceed,
+                                  Node
+                          end || Node <- ExpectedNodes -- [FirstMigratedNode]],
+    MigratedNodes = [FirstMigratedNode | OtherMigratedNodes],
+    ?assertEqual(lists:sort(ExpectedNodes), lists:sort(MigratedNodes)),
+
+    ct:pal("Waiting for spawned processes to terminate"),
+    receive
+        {'DOWN', EnablerMRef, process, Enabler, EnablerReason} ->
+            ?assertEqual(normal, EnablerReason)
+    end,
+    receive
+        {'DOWN', SyncerMRef, process, Syncer, SyncerReason} ->
+            ?assertEqual(normal, SyncerReason)
+    end,
+
+    ct:pal("Checking the feature flag is enabled in the expanded cluster"),
+    _ = [ok =
+         run_on_node(
+           Node,
+           fun() ->
+                   ?assert(rabbit_feature_flags:is_enabled(FeatureName)),
+                   ?assertEqual(
+                      1,
+                      persistent_term:get(?PT_MIGRATION_FUN_RUNS, 0)),
+                   ok
+           end,
+           [])
+         || Node <- AllNodes],
+    ok.

--- a/deps/rabbit/test/feature_flags_with_unpriveleged_user_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_with_unpriveleged_user_SUITE.erl
@@ -53,7 +53,6 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     feature_flags_SUITE:end_per_suite(Config).
 
-
 init_per_group(enabling_in_cluster, Config) ->
     case rabbit_ct_helpers:is_mixed_versions() of
         true ->

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -52,6 +52,7 @@
 -export([dict_cons/3, orddict_cons/3, maps_cons/3, gb_trees_cons/3]).
 -export([gb_trees_fold/3, gb_trees_foreach/2]).
 -export([all_module_attributes/1,
+         rabbitmq_related_apps/0,
          rabbitmq_related_module_attributes/1,
          module_attributes_from_apps/2,
          build_acyclic_graph/3]).

--- a/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
@@ -23,7 +23,8 @@ defmodule EnableFeatureFlagCommandTest do
         provided_by: :EnableFeatureFlagCommandTest,
         stability: :stable}}
     :ok = :rabbit_misc.rpc_call(
-      node, :rabbit_feature_flags, :initialize_registry, [new_feature_flags])
+      node, :rabbit_feature_flags, :inject_test_feature_flags,
+      [new_feature_flags])
 
     {
       :ok,

--- a/deps/rabbitmq_cli/test/ctl/list_feature_flags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_feature_flags_command_test.exs
@@ -28,7 +28,8 @@ defmodule ListFeatureFlagsCommandTest do
         provided_by: :ListFeatureFlagsCommandTest,
         stability: :stable}}
     :ok = :rabbit_misc.rpc_call(
-      node, :rabbit_feature_flags, :initialize_registry, [new_feature_flags])
+      node, :rabbit_feature_flags, :inject_test_feature_flags,
+      [new_feature_flags])
     :ok = :rabbit_misc.rpc_call(
       node, :rabbit_feature_flags, :enable_all, [])
 

--- a/deps/rabbitmq_ct_helpers/src/cth_log_redirect_any_domains.erl
+++ b/deps/rabbitmq_ct_helpers/src/cth_log_redirect_any_domains.erl
@@ -1,0 +1,23 @@
+-module(cth_log_redirect_any_domains).
+
+-export([log/2]).
+
+-define(BACKEND_MODULE, cth_log_redirect).
+
+%% Reversed behavior compared to `cth_log_redirect': log events with an
+%% unknown domain are sent to the `cth_log_redirect' server, others are
+%% dropped (as they are already handled by `cth_log_redirect').
+log(#{msg:={report,_Msg},meta:=#{domain:=[otp,sasl]}},_Config) ->
+    ok;
+log(#{meta:=#{domain:=[otp]}},_Config) ->
+    ok;
+log(#{meta:=#{domain:=_}}=Log,Config) ->
+    do_log(add_log_category(Log,error_logger),Config);
+log(_Log,_Config) ->
+    ok.
+
+add_log_category(#{meta:=Meta}=Log,Category) ->
+    Log#{meta=>Meta#{?BACKEND_MODULE=>#{category=>Category}}}.
+
+do_log(Log,Config) ->
+    gen_server:call(?BACKEND_MODULE,{log,Log,Config}).


### PR DESCRIPTION
This gen_statem-based process is responsible for handling concurrency when feature flags are enabled and synchronized when a cluster is expanded.

This clarifies and stabilizes the behavior of the feature flag subsystem w.r.t. situations where e.g. a feature flag migration function takes time to update data and a new node joins a cluster and synchronizes its feature flag states with the cluster. There was a chance that the feature flag was marked as enabled on the joining node, even though the migration function didn't take care of that node.

With this new feature flags controller, enabling or synchronizing feature flags blocks and delays any concurrent operations which try to modify feature flags states too.

This change also clarifies where and when the migration function is called: it is called at least once on each node who knows the feature flag and when the state goes from "disabled" to "enabled" on that node.

Note that even if the feature flag is being enabled on a subset of the nodes (because other nodes already have it enabled), it is marked as "state_changing" everywhere during the migration. This is to prevent that a node where it is enabled assumes it is enabled on all nodes who know the feature flag.

There is a new feature as well: just after a feature flag is enabled, the migration function is called a second time for any post-enable actions. The feature flag is marked as enabled between these "enable" and "post-enable" steps. The success or failure of this "post-enable" run does not affect the state of the feature flag (i.e. it is ignored).

A new migration function API is introduced to allow more advanced things. The new API is:

```erlang
my_migration_function(
  #ffcommand{name = ...,
             props = ...,
             command = enable | post_enable,
             extra = #{...}})
```

The record is defined in `include/feature_flags.hrl`. Here is the meaning of each field:

* `name` and `props` are the equivalent of the `FeatureName` and `FeatureProps` arguments of the previous migration function API.

* `command` is basically the same as the previous `Arg` arguments.

* `extra` is map containing context-specific information. For instance, it contains the list of nodes where the feature flag state changes.

This whole new behavior is behind a new feature flag called `feature_flags_v2`. If a feature flag uses the new migration function API, `feature_flags_v2` will be automatically enabled.

If many feature flags are enabled at once (like when a fresh RabbitMQ node is started for the first time), `feature_flags_v2` will be enabled first if it is in the list.

Fixes #3939.