### PR TITLE
Disable +deterministic in compilation_mode dbg under bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,13 @@ exports_files([
     "scripts/bazel/rabbitmq-run.sh",
 ])
 
+config_setting(
+    name = "debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
 # This allows us to
 # `bazel build //my/target \
 #    --//:elixir_home=/path/to/elixir/installation`

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ load("elixir_home.bzl", "elixir_home")
 load(":rabbitmq_home.bzl", "rabbitmq_home")
 load(":rabbitmq_run.bzl", "rabbitmq_run", "rabbitmq_run_command")
 load(":rabbitmqctl.bzl", "rabbitmqctl")
-load(":rabbitmq.bzl", "ALL_PLUGINS", "APP_VERSION")
+load(":rabbitmq.bzl", "APP_VERSION", "all_plugins")
 load(":dist.bzl", "collect_licenses", "versioned_rabbitmq_home")
 
 exports_files([
@@ -42,7 +42,7 @@ plt(
 
 rabbitmq_home(
     name = "broker-home",
-    plugins = ALL_PLUGINS,
+    plugins = all_plugins(rabbitmq_workspace = ""),
 )
 
 rabbitmq_home(
@@ -71,7 +71,6 @@ rabbitmq_run(
 
 # Allow us to `bazel run broker`
 # for the equivalent of `make run-broker`
-# (though it as of yet includes no plugins)
 rabbitmq_run_command(
     name = "broker",
     rabbitmq_run = ":rabbitmq-run",
@@ -97,7 +96,7 @@ rabbitmqctl(
 
 shell(
     name = "repl",
-    deps = ALL_PLUGINS,
+    deps = all_plugins(rabbitmq_workspace = ""),
 )
 
 collect_licenses(
@@ -109,12 +108,12 @@ collect_licenses(
             "LICENSE.txt",
         ],
     ),
-    deps = ALL_PLUGINS,
+    deps = all_plugins(rabbitmq_workspace = ""),
 )
 
 versioned_rabbitmq_home(
     name = "dist-home",
-    plugins = ALL_PLUGINS,
+    plugins = all_plugins(rabbitmq_workspace = ""),
 )
 
 pkg_tar(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -59,7 +59,7 @@ rules_pkg_dependencies()
 
 git_repository(
     name = "bazel-erlang",
-    commit = "050faedb2a3422a60d6b98678c714ed1a61ec71d",
+    commit = "d62a13548b3d1e5bd2830f42e3f3933ae17db3cb",
     remote = "https://github.com/rabbitmq/bazel-erlang.git",
 )
 

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -192,20 +192,14 @@ FIRST_SRCS = [
     "src/rabbit_queue_master_locator.erl",
 ]
 
-EXTRA_ERLC_OPTS = [
-    "-DINSTR_MOD=gm",
-]
-
 rabbitmq_lib(
     app_description = "RabbitMQ",
     app_env = _APP_ENV,
     app_module = APP_MODULE,
     app_name = "rabbit",
     app_registered = APP_REGISTERED,
-    erlc_opts = RABBITMQ_ERLC_OPTS + EXTRA_ERLC_OPTS,
     extra_apps = EXTRA_APPS,
     first_srcs = FIRST_SRCS,
-    test_erlc_opts = RABBITMQ_TEST_ERLC_OPTS + EXTRA_ERLC_OPTS,
     runtime_deps = RUNTIME_DEPS,
     deps = DEPS,
 )

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -9,10 +9,18 @@ load("@bazel-erlang//:ct_sharded.bzl", "ct_suite", "ct_suite_variant")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 
-RABBITMQ_ERLC_OPTS = DEFAULT_ERLC_OPTS
+def without(item, elements):
+    c = list(elements)
+    c.remove(item)
+    return c
+
+RABBITMQ_ERLC_OPTS = DEFAULT_ERLC_OPTS + [
+    "-DINSTR_MOD=gm",
+]
 
 RABBITMQ_TEST_ERLC_OPTS = DEFAULT_TEST_ERLC_OPTS + [
     "+nowarn_export_all",
+    "-DINSTR_MOD=gm",
 ]
 
 RABBITMQ_DIALYZER_OPTS = [
@@ -85,8 +93,6 @@ def rabbitmq_lib(
         app_registered = [],
         app_env = "[]",
         extra_apps = [],
-        erlc_opts = RABBITMQ_ERLC_OPTS,
-        test_erlc_opts = RABBITMQ_TEST_ERLC_OPTS,
         first_srcs = [],
         extra_priv = [],
         build_deps = [],
@@ -101,7 +107,10 @@ def rabbitmq_lib(
         app_env = app_env,
         extra_apps = extra_apps,
         extra_priv = extra_priv,
-        erlc_opts = erlc_opts,
+        erlc_opts = select({
+            "//:debug_build": without("+deterministic", RABBITMQ_ERLC_OPTS),
+            "//conditions:default": RABBITMQ_ERLC_OPTS,
+        }),
         first_srcs = first_srcs,
         build_deps = build_deps,
         deps = deps,
@@ -117,7 +126,10 @@ def rabbitmq_lib(
         app_env = app_env,
         extra_apps = extra_apps,
         extra_priv = extra_priv,
-        erlc_opts = test_erlc_opts,
+        erlc_opts = select({
+            "//:debug_build": without("+deterministic", RABBITMQ_TEST_ERLC_OPTS),
+            "//conditions:default": RABBITMQ_TEST_ERLC_OPTS,
+        }),
         first_srcs = first_srcs,
         build_deps = with_test_versions(build_deps),
         deps = with_test_versions(deps),
@@ -167,7 +179,10 @@ def rabbitmq_integration_suite(
         name = name,
         suite_name = name,
         tags = tags,
-        erlc_opts = RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
+        erlc_opts = select({
+            "//:debug_build": without("+deterministic", RABBITMQ_TEST_ERLC_OPTS + erlc_opts),
+            "//conditions:default": RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
+        }),
         additional_hdrs = additional_hdrs,
         additional_srcs = additional_srcs,
         data = data,


### PR DESCRIPTION
This allows compiling and reloading code from the erlang shell when running the broker with `bazel run -c dbg broker`