### PR TITLE
Distribution listener IP address is hardcoded in listener metadata

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -365,7 +365,12 @@ record_distribution_listener() ->
     {Name, Host} = rabbit_nodes:parts(node()),
     case erl_epmd:port_please(list_to_atom(Name), Host, infinity) of
         {port, Port, _Version} ->
-            tcp_listener_started(clustering, [], {0,0,0,0,0,0,0,0}, Port);
+            IPAddress =
+                case application:get_env(kernel, inet_dist_use_interface) of
+                    {ok, IP} -> IP;
+                    _ -> {0,0,0,0,0,0,0,0}
+                end,
+            tcp_listener_started(clustering, [], IPAddress, Port);
         noport ->
             throw({error, no_epmd_port})
     end.


### PR DESCRIPTION
For security reasons, it is recommended not to listen on the all zero ip address.

Add an item to the advanced configuration file:

``` erl
{kernel, [{inet_dist_use_interface, {8193,291,0,0,0,0,0,1}}]}
```

Use the netstat command to check the IP address of the distribution port(25672):

```
netstat -anp | grep 25672
tcp6       0      0 2001:123::1:25672       :::*                    LISTEN      2075/beam.smp
```

However, `rabbitmqctl status` shows:

```
Interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication
```

After modification, it shows:

```
Interface: [2001:123::1], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication
```
