### PR TITLE
Limit the version of rebar3_hex to v6

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -5645,7 +5645,7 @@ $(call comma_list,$(foreach d,$(DEPS),\
 		{$(call dep_name,$d)$(comma)"$(call dep_repo,$d)"},\
 		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma)"$(call dep_commit,$d)"}})))
 ]}.
-{plugins, [rebar3_hex]}.
+{plugins, [{rebar3_hex, "~> 6.11"}]}.
 {erl_opts, $(call compat_erlc_opts_to_list,$(ERLC_OPTS))}.
 endef
 


### PR DESCRIPTION
rebar3_hex v7 introduces changes that break pipelines - https://github.com/rabbitmq/hexpm-cli/issues/3

It would be better to drop hexpm-cli and use the hex publishing support present in newer versions of erlang.mk