### PR TITLE
Rename "bazel-erlang" to "rules_erlang"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,7 +18,7 @@ build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
-build:rbe --@bazel-erlang//:erlang_home=/usr/lib/erlang
+build:rbe --@rules_erlang//:erlang_home=/usr/lib/erlang
 build:rbe --//:elixir_home=/usr/local
 
 build:rbe --spawn_strategy=remote
@@ -37,7 +37,7 @@ build:rbe-23 --host_platform=@rbe_23//config:platform
 build:rbe-23 --platforms=@rbe_23//config:platform
 build:rbe-23 --extra_execution_platforms=@rbe_23//config:platform
 
-build:rbe-23 --@bazel-erlang//:erlang_version=23
+build:rbe-23 --@rules_erlang//:erlang_version=23
 
 build:rbe-24 --config=rbe
 build:rbe-24 --host_javabase=@rbe_24//java:jdk
@@ -49,7 +49,7 @@ build:rbe-24 --host_platform=@rbe_24//config:platform
 build:rbe-24 --platforms=@rbe_24//config:platform
 build:rbe-24 --extra_execution_platforms=@rbe_24//config:platform
 
-build:rbe-24 --@bazel-erlang//:erlang_version=24
+build:rbe-24 --@rules_erlang//:erlang_version=24
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -51,8 +51,8 @@ jobs:
           build:rbe-git --host_platform=//:erlang_git_platform
           build:rbe-git --platforms=//:erlang_git_platform
           build:rbe-git --extra_execution_platforms=//:erlang_git_platform
-          build:rbe-git --@bazel-erlang//:erlang_home=/usr/local/lib/erlang
-          build:rbe-git --@bazel-erlang//:erlang_version=25
+          build:rbe-git --@rules_erlang//:erlang_home=/usr/local/lib/erlang
+          build:rbe-git --@rules_erlang//:erlang_version=25
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -98,8 +98,8 @@ jobs:
           build:buildbuddy --color=yes
           build:buildbuddy --disk_cache=
 
-          build --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
-          build --@bazel-erlang//:erlang_home=${ERLANG_HOME}
+          build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
+          build --@rules_erlang//:erlang_home=${ERLANG_HOME}
           build --//:elixir_home=${ELIXIR_HOME}
         EOF
     #! - name: Setup tmate session

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,8 +93,8 @@ jobs:
           build:buildbuddy --color=yes
           build:buildbuddy --disk_cache=
 
-          build --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
-          build --@bazel-erlang//:erlang_home=${ERLANG_HOME}
+          build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
+          build --@rules_erlang//:erlang_home=${ERLANG_HOME}
           build --//:elixir_home=${ELIXIR_HOME}
         EOF
     #! - name: Setup tmate session

--- a/.github/workflows/update-rules_erlang.yaml
+++ b/.github/workflows/update-rules_erlang.yaml
@@ -1,11 +1,11 @@
-name: Update bazel-erlang
+name: Update rules_erlang
 on:
   schedule:
   - cron: '0 3 * * *'
   workflow_dispatch:
 jobs:
-  update-bazel-erlang:
-    name: Update bazel-erlang
+  update-rules_erlang:
+    name: Update rules_erlang
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -13,21 +13,21 @@ jobs:
       uses: actions/checkout@v2.4.0
       with:
         path: rabbitmq-server
-    - name: CHECKOUT bazel-erlang
+    - name: CHECKOUT rules_erlang
       uses: actions/checkout@v2.4.0
       with:
-        repository: rabbitmq/bazel-erlang
-        path: bazel-erlang
+        repository: rabbitmq/rules_erlang
+        path: rules_erlang
     - name: DETERMINE LATEST COMMIT
       id: find-commit
-      working-directory: bazel-erlang
+      working-directory: rules_erlang
       run: |
         echo "::set-output name=SHA::$(git rev-parse HEAD)"
-    - name: UPDATE bazel-erlang COMMIT
+    - name: UPDATE rules_erlang COMMIT
       working-directory: rabbitmq-server
       run: |
         sudo npm install --global --silent @bazel/buildozer
-        echo "$(cat WORKSPACE.bazel | npx buildozer 'set commit "${{ steps.find-commit.outputs.SHA }}"' -:bazel-erlang)" > WORKSPACE.bazel
+        echo "$(cat WORKSPACE.bazel | npx buildozer 'set commit "${{ steps.find-commit.outputs.SHA }}"' -:rules_erlang)" > WORKSPACE.bazel
         git diff
     - name: CREATE PULL REQUEST
       uses: peter-evans/create-pull-request@v3
@@ -36,10 +36,10 @@ jobs:
         committer: GitHub <noreply@github.com>
         author: GitHub <noreply@github.com>
         path: rabbitmq-server
-        title: Adopt latest bazel-erlang
+        title: Adopt latest rules_erlang
         commit-message: |
-          Adopt latest bazel-erlang
+          Adopt latest rules_erlang
 
-          - bazel-erlang@${{ steps.find-commit.outputs.SHA }}
-        branch: bump-bazel-erlang
+          - rules_erlang@${{ steps.find-commit.outputs.SHA }}
+        branch: bump-rules_erlang
         delete-branch: true

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -9,7 +9,7 @@ RabbitMQ, Tier1 plugins included, is a large codebase. The developer experience 
 
 More importantly, RabbitMQ's test suite is large and takes hours if run on a single machine. Bazel allows tests to be run in parallel on a large number of remote workers if needed, and furthermore uses cached test results when branches of the codebase remain unchanged.
 
-Bazel does not provide built in Erlang or Elixir support, nor is there an available library of bazel rules. Therefore, we have defined our own rules in https://github.com/rabbitmq/bazel-erlang. Elixir compilation is handled as a special case within this repository. To use these rules, the location of your Erlang and Elixir installations must be indicated to the build (see below).
+Bazel does not provide built in Erlang or Elixir support, nor is there an available library of bazel rules. Therefore, we have defined our own rules in `https://github.com/rabbitmq/rules_erlang.git`. Elixir compilation is handled as a special case within this repository. To use these rules, the location of your Erlang and Elixir installations must be indicated to the build (see below).
 
 While most of work for running tests happens in Bazel, the suite still makes use of some external tools for commands, notably gnu `make` and `openssl`. Ideally we could bring all of these tools under bazel, so that the only tool needed would be `bazel` or `bazelisk`, but that will take some time.
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@bazel-erlang//:dialyze.bzl", "plt")
-load("@bazel-erlang//:shell.bzl", "shell")
+load("@rules_erlang//:dialyze.bzl", "plt")
+load("@rules_erlang//:shell.bzl", "shell")
 load("elixir_home.bzl", "elixir_home")
 load(":rabbitmq_home.bzl", "rabbitmq_home")
 load(":rabbitmq_run.bzl", "rabbitmq_run", "rabbitmq_run_command")

--- a/BUILD.inet_tcp_proxy
+++ b/BUILD.inet_tcp_proxy
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlang_lib")
 
 erlang_lib(
     app_name = "inet_tcp_proxy_dist",

--- a/BUILD.ranch
+++ b/BUILD.ranch
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "app_file", "bazel_erlang_lib", "erlc",
+load("@rules_erlang//:bazel_erlang_lib.bzl", "app_file", "bazel_erlang_lib", "erlc",
 "DEFAULT_ERLC_OPTS")
 
 FIRST_SRCS = [

--- a/BUILD.trust_store_http
+++ b/BUILD.trust_store_http
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlang_lib")
 
 erlang_lib(
     app_name = "trust_store_http",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -58,12 +58,12 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
 git_repository(
-    name = "bazel-erlang",
+    name = "rules_erlang",
     commit = "d62a13548b3d1e5bd2830f42e3f3933ae17db3cb",
-    remote = "https://github.com/rabbitmq/bazel-erlang.git",
+    remote = "https://github.com/rabbitmq/rules_erlang.git",
 )
 
-load("@bazel-erlang//:bazel_erlang.bzl", "bazel_erlang_deps")
+load("@rules_erlang//:bazel_erlang.bzl", "bazel_erlang_deps")
 
 bazel_erlang_deps()
 

--- a/deps/amqp10_client/BUILD.bazel
+++ b/deps/amqp10_client/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/amqp10_common/BUILD.bazel
+++ b/deps/amqp10_common/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
-    "@bazel-erlang//:bazel_erlang_lib.bzl",
+    "@rules_erlang//:bazel_erlang_lib.bzl",
     "app_file",
     "bazel_erlang_lib",
     "erlc",
 )
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "APP_VERSION",

--- a/deps/amqp_client/BUILD.bazel
+++ b/deps/amqp_client/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load("//:rabbitmq.bzl", "APP_VERSION", "rabbitmq_lib", "rabbitmq_suite")
 
 APP_NAME = "rabbitmq_prelaunch"

--- a/deps/rabbit/test/feature_flags_SUITE_data/my_plugin/BUILD.bazel
+++ b/deps/rabbit/test/feature_flags_SUITE_data/my_plugin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlang_lib")
 
 DEPS = [
     "//deps/rabbit_common:bazel_erlang_lib",

--- a/deps/rabbit_common/BUILD.bazel
+++ b/deps/rabbit_common/BUILD.bazel
@@ -1,11 +1,11 @@
 load(
-    "@bazel-erlang//:bazel_erlang_lib.bzl",
+    "@rules_erlang//:bazel_erlang_lib.bzl",
     "app_file",
     "bazel_erlang_lib",
     "erlc",
 )
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "APP_VERSION",

--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_auth_backend_cache/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_cache/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_auth_backend_http/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_http/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_auth_backend_ldap/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_ldap/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_auth_mechanism_ssl/BUILD.bazel
+++ b/deps/rabbitmq_auth_mechanism_ssl/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_aws/BUILD.bazel
+++ b/deps/rabbitmq_aws/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:eunit.bzl", "eunit")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:eunit.bzl", "eunit")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("//:rabbitmq.bzl", "RABBITMQ_TEST_ERLC_OPTS", "rabbitmq_lib")
 
 APP_NAME = "rabbitmq_aws"

--- a/deps/rabbitmq_cli/elixir.bzl
+++ b/deps/rabbitmq_cli/elixir.bzl
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "path_join")
+load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "path_join")
 load("//:elixir_home.bzl", "ElixirHomeProvider")
 
 def _impl(ctx):
@@ -38,8 +38,8 @@ def _impl(ctx):
 elixir = rule(
     implementation = _impl,
     attrs = {
-        "_erlang_version": attr.label(default = "@bazel-erlang//:erlang_version"),
-        "_erlang_home": attr.label(default = "@bazel-erlang//:erlang_home"),
+        "_erlang_version": attr.label(default = "@rules_erlang//:erlang_version"),
+        "_erlang_home": attr.label(default = "@rules_erlang//:erlang_home"),
         "_elixir_home": attr.label(default = "//:elixir_home"),
     },
 )

--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
+load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
 load(
-    "@bazel-erlang//:bazel_erlang_lib.bzl",
+    "@rules_erlang//:bazel_erlang_lib.bzl",
     "BEGINS_WITH_FUN",
     "ErlangLibInfo",
     "QUERY_ERL_VERSION",
@@ -155,8 +155,8 @@ rabbitmqctl = rule(
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [ErlangLibInfo]),
-        "_erlang_version": attr.label(default = "@bazel-erlang//:erlang_version"),
-        "_erlang_home": attr.label(default = "@bazel-erlang//:erlang_home"),
+        "_erlang_version": attr.label(default = "@rules_erlang//:erlang_version"),
+        "_erlang_home": attr.label(default = "@rules_erlang//:erlang_home"),
         "_elixir_home": attr.label(default = "//:elixir_home"),
     },
     executable = True,

--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "BEGINS_WITH_FUN", "ErlangLibInfo", "QUERY_ERL_VERSION", "path_join")
-load("@bazel-erlang//:ct.bzl", "code_paths")
+load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "BEGINS_WITH_FUN", "ErlangLibInfo", "QUERY_ERL_VERSION", "path_join")
+load("@rules_erlang//:ct.bzl", "code_paths")
 load("//:elixir_home.bzl", "ElixirHomeProvider")
 load(":rabbitmqctl.bzl", "MIX_DEPS_DIR")
 
@@ -143,8 +143,8 @@ rabbitmqctl_test = rule(
             executable = True,
             cfg = "target",
         ),
-        "_erlang_version": attr.label(default = "@bazel-erlang//:erlang_version"),
-        "_erlang_home": attr.label(default = "@bazel-erlang//:erlang_home"),
+        "_erlang_version": attr.label(default = "@rules_erlang//:erlang_version"),
+        "_erlang_home": attr.label(default = "@rules_erlang//:erlang_home"),
         "_elixir_home": attr.label(default = "//:elixir_home"),
     },
     test = True,

--- a/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
+++ b/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_ct_client_helpers/BUILD.bazel
+++ b/deps/rabbitmq_ct_client_helpers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlang_lib")
 
 erlang_lib(
     app_name = "rabbitmq_ct_client_helpers",

--- a/deps/rabbitmq_ct_client_helpers/WORKSPACE.bazel
+++ b/deps/rabbitmq_ct_client_helpers/WORKSPACE.bazel
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel-erlang",
+    name = "rules_erlang",
     sha256 = "422a9222522216f59a01703a13f578c601d6bddf5617bee8da3c43e3b299fc4e",
     strip_prefix = "bazel-erlang-1.1.0",
-    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/refs/tags/1.1.0.zip"],
+    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/1.1.0.zip"],
 )
 
 http_archive(

--- a/deps/rabbitmq_ct_helpers/BUILD.bazel
+++ b/deps/rabbitmq_ct_helpers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlang_lib")
 
 erlang_lib(
     app_name = "rabbitmq_ct_helpers",

--- a/deps/rabbitmq_ct_helpers/WORKSPACE.bazel
+++ b/deps/rabbitmq_ct_helpers/WORKSPACE.bazel
@@ -1,10 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel-erlang",
+    name = "rules_erlang",
     sha256 = "422a9222522216f59a01703a13f578c601d6bddf5617bee8da3c43e3b299fc4e",
     strip_prefix = "bazel-erlang-1.1.0",
-    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/refs/tags/1.1.0.zip"],
+    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/1.1.0.zip"],
 )
 
 http_archive(

--- a/deps/rabbitmq_event_exchange/BUILD.bazel
+++ b/deps/rabbitmq_event_exchange/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_federation/BUILD.bazel
+++ b/deps/rabbitmq_federation/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_federation_management/BUILD.bazel
+++ b/deps/rabbitmq_federation_management/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_jms_topic_exchange/BUILD.bazel
+++ b/deps/rabbitmq_jms_topic_exchange/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_management/BUILD.bazel
+++ b/deps/rabbitmq_management/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "APP_VERSION",

--- a/deps/rabbitmq_management_agent/BUILD.bazel
+++ b/deps/rabbitmq_management_agent/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_peer_discovery_aws/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_aws/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_peer_discovery_common/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_common/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_peer_discovery_consul/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_consul/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_peer_discovery_etcd/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_etcd/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_peer_discovery_k8s/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_k8s/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_prometheus/BUILD.bazel
+++ b/deps/rabbitmq_prometheus/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_random_exchange/BUILD.bazel
+++ b/deps/rabbitmq_random_exchange/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_recent_history_exchange/BUILD.bazel
+++ b/deps/rabbitmq_recent_history_exchange/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_sharding/BUILD.bazel
+++ b/deps/rabbitmq_sharding/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_shovel/BUILD.bazel
+++ b/deps/rabbitmq_shovel/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbitmq_shovel_management/BUILD.bazel
+++ b/deps/rabbitmq_shovel_management/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbitmq_stomp/BUILD.bazel
+++ b/deps/rabbitmq_stomp/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_stream/BUILD.bazel
+++ b/deps/rabbitmq_stream/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_stream_common/BUILD.bazel
+++ b/deps/rabbitmq_stream_common/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_stream_management/BUILD.bazel
+++ b/deps/rabbitmq_stream_management/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbitmq_top/BUILD.bazel
+++ b/deps/rabbitmq_top/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_tracing/BUILD.bazel
+++ b/deps/rabbitmq_tracing/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_trust_store/BUILD.bazel
+++ b/deps/rabbitmq_trust_store/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbitmq_web_dispatch/BUILD.bazel
+++ b/deps/rabbitmq_web_dispatch/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(

--- a/deps/rabbitmq_web_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_web_mqtt/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_web_mqtt_examples/BUILD.bazel
+++ b/deps/rabbitmq_web_mqtt_examples/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_web_stomp/BUILD.bazel
+++ b/deps/rabbitmq_web_stomp/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlc")
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "erlc")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/deps/rabbitmq_web_stomp_examples/BUILD.bazel
+++ b/deps/rabbitmq_web_stomp_examples/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",

--- a/dist.bzl
+++ b/dist.bzl
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangHomeProvider")
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "flat_deps", "path_join")
-load("@bazel-erlang//:ct.bzl", "additional_file_dest_relative_path")
+load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "flat_deps", "path_join")
+load("@rules_erlang//:ct.bzl", "additional_file_dest_relative_path")
 load(
     ":rabbitmq_home.bzl",
     "RABBITMQ_HOME_ATTRS",
@@ -195,6 +195,6 @@ def _versioned_rabbitmq_home_impl(ctx):
 versioned_rabbitmq_home = rule(
     implementation = _versioned_rabbitmq_home_impl,
     attrs = dict(RABBITMQ_HOME_ATTRS.items() + {
-        "_erlang_home": attr.label(default = "@bazel-erlang//:erlang_home"),
+        "_erlang_home": attr.label(default = "@rules_erlang//:erlang_home"),
     }.items()),
 )

--- a/mk/bazel.mk
+++ b/mk/bazel.mk
@@ -8,8 +8,8 @@ $(BAZELISK):
 endif
 
 define USER_BAZELRC
-build --@bazel-erlang//:erlang_home=$(shell dirname $$(dirname $$(which erl)))
-build --@bazel-erlang//:erlang_version=$(shell erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)
+build --@rules_erlang//:erlang_home=$(shell dirname $$(dirname $$(which erl)))
+build --@rules_erlang//:erlang_version=$(shell erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell)
 build --//:elixir_home=$(shell dirname $$(dirname $$(which iex)))/lib/elixir
 
 # rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -1,11 +1,11 @@
 load(
-    "@bazel-erlang//:bazel_erlang_lib.bzl",
+    "@rules_erlang//:bazel_erlang_lib.bzl",
     "DEFAULT_ERLC_OPTS",
     "DEFAULT_TEST_ERLC_OPTS",
     "erlang_lib",
     "test_erlang_lib",
 )
-load("@bazel-erlang//:ct_sharded.bzl", "ct_suite", "ct_suite_variant")
+load("@rules_erlang//:ct_sharded.bzl", "ct_suite", "ct_suite_variant")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
 

--- a/rabbitmq_home.bzl
+++ b/rabbitmq_home.bzl
@@ -1,5 +1,5 @@
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "flat_deps", "path_join")
-load("@bazel-erlang//:ct.bzl", "additional_file_dest_relative_path")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "ErlangLibInfo", "flat_deps", "path_join")
+load("@rules_erlang//:ct.bzl", "additional_file_dest_relative_path")
 
 RabbitmqHomeInfo = provider(
     doc = "An assembled RABBITMQ_HOME dir",

--- a/rabbitmq_run.bzl
+++ b/rabbitmq_run.bzl
@@ -1,6 +1,6 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
-load("@bazel-erlang//:bazel_erlang_lib.bzl", "path_join")
-load("@bazel-erlang//:ct.bzl", "sanitize_sname")
+load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
+load("@rules_erlang//:bazel_erlang_lib.bzl", "path_join")
+load("@rules_erlang//:ct.bzl", "sanitize_sname")
 load(":rabbitmq_home.bzl", "RabbitmqHomeInfo", "rabbitmq_home_short_path")
 
 def _impl(ctx):
@@ -32,7 +32,7 @@ rabbitmq_run = rule(
             default = Label("//:scripts/bazel/rabbitmq-run.sh"),
             allow_single_file = True,
         ),
-        "_erlang_home": attr.label(default = "@bazel-erlang//:erlang_home"),
+        "_erlang_home": attr.label(default = "@rules_erlang//:erlang_home"),
         "home": attr.label(providers = [RabbitmqHomeInfo]),
     },
     executable = True,

--- a/rabbitmqctl.bzl
+++ b/rabbitmqctl.bzl
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangVersionProvider")
+load("@rules_erlang//:erlang_home.bzl", "ErlangVersionProvider")
 load(":rabbitmq_home.bzl", "RabbitmqHomeInfo", "rabbitmq_home_short_path")
 
 def _impl(ctx):
@@ -25,7 +25,7 @@ def _impl(ctx):
 rabbitmqctl = rule(
     implementation = _impl,
     attrs = {
-        "_erlang_version": attr.label(default = "@bazel-erlang//:erlang_version"),
+        "_erlang_version": attr.label(default = "@rules_erlang//:erlang_version"),
         "home": attr.label(providers = [RabbitmqHomeInfo]),
     },
     executable = True,

--- a/release-notes/3.9.0.md
+++ b/release-notes/3.9.0.md
@@ -149,7 +149,7 @@ consistent release schedule.
 
 * Continuous integration of open source RabbitMQ has switched to Bazel, GitHub Actions and [BuildBuddy](https://buildbuddy.io), resulting in much faster and incremental test runs.
 
-  [Bazel support for Erlang](https://github.com/rabbitmq/bazel-erlang) is a new project open sourced by the RabbitMQ Core team as a result.
+  [Bazel support for Erlang](https://github.com/rabbitmq/rules_erlang) is a new project open sourced by the RabbitMQ Core team as a result.
 
 * Process group membership now uses `pg`.
 

--- a/tools/erlang_ls.bzl
+++ b/tools/erlang_ls.bzl
@@ -1,4 +1,4 @@
-load("@bazel-erlang//:erlang_home.bzl", "ErlangHomeProvider")
+load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider")
 
 def _impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name)
@@ -33,6 +33,6 @@ plt_path: bazel-bin/deps/rabbit/.base_plt.plt
 erlang_ls_config = rule(
     implementation = _impl,
     attrs = {
-        "_erlang_home": attr.label(default = "@bazel-erlang//:erlang_home"),
+        "_erlang_home": attr.label(default = "@rules_erlang//:erlang_home"),
     },
 )

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -1,5 +1,5 @@
-build --@bazel-erlang//:erlang_home=/Users/rabbitmq/kerl/24.0
-build --@bazel-erlang//:erlang_version=24.0
+build --@rules_erlang//:erlang_home=/Users/rabbitmq/kerl/24.0
+build --@rules_erlang//:erlang_version=24.0
 build --//:elixir_home=/Users/rabbitmq/.kiex/elixirs/elixir-1.12.0/lib/elixir
 
 # rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -1,8 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
-load("@bazel-erlang//:github.bzl", "github_bazel_erlang_lib")
-load("@bazel-erlang//:hex_archive.bzl", "hex_archive")
-load("@bazel-erlang//:hex_pm.bzl", "hex_pm_bazel_erlang_lib")
+load("@rules_erlang//:github.bzl", "github_bazel_erlang_lib")
+load("@rules_erlang//:hex_archive.bzl", "hex_archive")
+load("@rules_erlang//:hex_pm.bzl", "hex_pm_bazel_erlang_lib")
 load("//:rabbitmq.bzl", "APP_VERSION")
 
 def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
@@ -87,7 +87,7 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
         name = "emqttc",
         urls = ["https://github.com/rabbitmq/emqttc/archive/remove-logging.zip"],
         strip_prefix = "emqttc-remove-logging",
-        build_file_content = """load("@bazel-erlang//:bazel_erlang_lib.bzl", "erlang_lib")
+        build_file_content = """load("@rules_erlang//:bazel_erlang_lib.bzl", "erlang_lib")
 
 erlang_lib(
     app_name = "emqttc",


### PR DESCRIPTION
In light of the repository rename, we should do the same here.

@pjk25 may have already started on this.

My guess is that these changes depend on some or all of the changes in this branch:

https://github.com/rabbitmq/rules_erlang/tree/v2

https://github.com/rabbitmq/rules_erlang/pull/19