### PR TITLE
'rabbit_stream_coordinator:select_leader' runs with wrong comparison

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1528,9 +1528,9 @@ find_leader(Members) ->
     end.
 
 select_leader(Offsets) ->
-    [{Node, _} | _] = lists:sort(fun({_, {Ao, E}}, {_, {Bo, E}}) ->
+    [{Node, _} | _] = lists:sort(fun({_, {E, Ao}}, {_, {E, Bo}}) ->
                                          Ao >= Bo;
-                                    ({_, {_, Ae}}, {_, {_, Be}}) ->
+                                    ({_, {Ae, _}}, {_, {Be, _}}) ->
                                          Ae >= Be;
                                     ({_, empty}, _) ->
                                          false;


### PR DESCRIPTION
The input parameter 'Offsets' consists of candidates which is a tuple {node, tail}, and the tail is made of {epoch, offset}.
While the 'select_leader' think the tail is made of {offset, epoch}. 

Suppose there are two candidates:
[{node1,{1,100}},{node2,{2,99}}] 

It selects node1 as the leader instead of node2 with larger epoch.

