### PR TITLE
'rabbit_stream_coordinator:select_leader' runs with wrong comparison

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1527,16 +1527,16 @@ find_leader(Members) ->
             {undefined, Replicas}
     end.
 
-select_leader(Offsets) ->
-    [{Node, _} | _] = lists:sort(fun({_, {Ao, E}}, {_, {Bo, E}}) ->
+select_leader(EpochOffsets) ->
+    [{Node, _} | _] = lists:sort(fun({_, {E, Ao}}, {_, {E, Bo}}) ->
                                          Ao >= Bo;
-                                    ({_, {_, Ae}}, {_, {_, Be}}) ->
+                                    ({_, {Ae, _}}, {_, {Be, _}}) ->
                                          Ae >= Be;
                                     ({_, empty}, _) ->
                                          false;
                                     (_, {_, empty}) ->
                                          true
-                                 end, Offsets),
+                                 end, EpochOffsets),
     Node.
 
 maybe_sleep({{nodedown, _}, _}) ->

--- a/deps/rabbit/src/rabbit_stream_coordinator.hrl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.hrl
@@ -11,7 +11,7 @@
                     atom() => term()}.
 -type monitor_role() :: member | listener.
 -type queue_ref() :: rabbit_types:r(queue).
--type tail() :: {osiris:offset(), osiris:epoch()} | empty.
+-type tail() :: {osiris:epoch(), osiris:offset()} | empty.
 
 -record(member,
         {state = {down, 0} :: {down, osiris:epoch()}


### PR DESCRIPTION
The input parameter 'Offsets' consists of candidates which is a tuple {node, tail}, and the tail is made of {epoch, offset}.
While the 'select_leader' think the tail is made of {offset, epoch}.

Suppose there are two candidates:
[{node1,{1,100}},{node2,{2,99}}]

It selects node1 as the leader instead of node2 with larger epoch.

