### PR TITLE
Replace one use of filelib:is_regular/1

### DIFF
--- a/deps/rabbit/src/rabbit_config.erl
+++ b/deps/rabbit/src/rabbit_config.erl
@@ -35,7 +35,7 @@ get_advanced_config() ->
 -spec config_files() -> [config_location()].
 config_files() ->
     ConfFiles = [filename:absname(File) || File <- get_confs(),
-                                           filelib:is_regular(File)],
+                                           rabbit_misc:is_regular_file(File)],
     AdvancedFiles = case get_advanced_config() of
                         none -> [];
                         FileName -> [filename:absname(FileName)]

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -81,6 +81,7 @@
 -export([get_gc_info/1]).
 -export([group_proplists_by/2]).
 -export([raw_read_file/1]).
+-export([is_regular_file/1]).
 
 %% Horrible macro to use in guards
 -define(IS_BENIGN_EXIT(R),
@@ -1419,6 +1420,16 @@ raw_read_file(File) ->
         end
     catch
         error:{badmatch, Error} -> Error
+    end.
+
+-spec is_regular_file(Name) -> boolean() when
+      Name :: file:filename_all().
+is_regular_file(Name) ->
+    % Note: this works around the win32 file leak in file:read_file/1
+    % https://github.com/erlang/otp/issues/5527
+    case file:read_file_info(Name, [raw]) of
+        {ok, #file_info{type=regular}} -> true;
+        _ -> false
     end.
 
 %% -------------------------------------------------------------------------


### PR DESCRIPTION
This specific case is called multiple times by the Prometheus plugin. It eventually calls `file:read_file_info/1` which leaks on Windows

See #3936

Discovered via the following trace while RabbitMQ was running:

```
code:add_patha("C:\\Users\\bakkenl\\development\\massemanet\\redbug\\_build\\default\\lib\\redbug\\ebin").
redbug:start("file:read_file_info/1->return,stack",[{msgs,100},{time,60000}]).
```

Output:

```
% 09:12:40 <0.858.0>(rabbit_mgmt_external_stats)
% file:read_file_info("c:/Users/bakkenl/development/lukebakken/rabbitmq/users/win32-memory-leak-UE-wxXerJl8/rabbitmq.conf")
%   filelib:do_is_regular/2 
%   rabbit_config:'-config_files/0-lc$^0/1-0-'/1 
%   rabbit_config:config_files/0 
%   rabbit_mgmt_external_stats:i/2 
%   rabbit_mgmt_external_stats:infos/3 
%   rabbit_mgmt_external_stats:emit_update/1 
%   rabbit_mgmt_external_stats:handle_info/2 
%   gen_server:try_dispatch/4 
%   gen_server:handle_msg/6 
%   proc_lib:init_p_do_apply/3 
%   unknown function    
                        
% 09:12:40 <0.858.0>(rabbit_mgmt_external_stats)
% file:read_file_info/1 -> {ok,{file_info,277,regular,read_write,
                                   {{2022,1,10},{15,47,21}},
                                   {{2021,12,23},{6,46,12}},
                                   {{2021,12,23},{6,46,12}},
                                   33206,1,3,0,0,0,0}}
```

In one minute that's the only call to `file:read_file_info/1`. I double-checked `file:read_file` as well.