### PR TITLE
Delete obsolete 'unacked_message_q' entries when queue leader replica restarts

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -167,7 +167,7 @@
              queue_states,
              tick_timer,
              publishing_mode = false :: boolean(),
-             obsolete_deliver_tags = []
+             obsolete_delivery_tags = []
             }).
 
 -define(QUEUE, lqueue).
@@ -1340,9 +1340,9 @@ handle_method(#'basic.nack'{delivery_tag = DeliveryTag,
 handle_method(#'basic.ack'{delivery_tag = DeliveryTag,
                            multiple     = Multiple},
               _, State = #ch{unacked_message_q = UAMQ, tx = Tx,
-                             obsolete_deliver_tags = ODTags}) ->
+                             obsolete_delivery_tags = ODTags}) ->
     {Acked, Remaining, ODTags1} = collect_acks(UAMQ, DeliveryTag, Multiple, ODTags),
-    State1 = State#ch{unacked_message_q = Remaining, obsolete_deliver_tags = ODTags1},
+    State1 = State#ch{unacked_message_q = Remaining, obsolete_delivery_tags = ODTags1},
     {noreply, case Tx of
                   none         -> {State2, Actions} = ack(Acked, State1),
                                   handle_queue_actions(Actions, State2);
@@ -1877,7 +1877,7 @@ handle_consuming_queue_down_or_eol(QName,
               end
       end, State#ch{queue_consumers = maps:remove(QName, QCons),
             unacked_message_q = UAMQ1,
-            obsolete_deliver_tags = ObsoleteDeliverTags}, ConsumerTags).
+            obsolete_delivery_tags = ObsoleteDeliverTags}, ConsumerTags).
 
 %% [0] There is a slight danger here that if a queue is deleted and
 %% then recreated again the reconsume will succeed even though it was
@@ -1968,9 +1968,9 @@ basic_return(#basic_message{exchange_name = ExchangeName,
            Content).
 
 reject(DeliveryTag, Requeue, Multiple,
-       State = #ch{unacked_message_q = UAMQ, tx = Tx, obsolete_deliver_tags = ODTags}) ->
+       State = #ch{unacked_message_q = UAMQ, tx = Tx, obsolete_delivery_tags = ODTags}) ->
     {Acked, Remaining, ODTags1} = collect_acks(UAMQ, DeliveryTag, Multiple, ODTags),
-    State1 = State#ch{unacked_message_q = Remaining, obsolete_deliver_tags = ODTags1},
+    State1 = State#ch{unacked_message_q = Remaining, obsolete_delivery_tags = ODTags1},
     {noreply, case Tx of
                   none ->
                       {State2, Actions} = internal_reject(Requeue, Acked, State1#ch.limiter, State1),


### PR DESCRIPTION
If the client acks very slowly and the qpid restarts abnormally, the following may happen:

2022-01-17 10:01:43.828503+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2192 record_sent]unacked_message_q num:10
2022-01-17 10:01:43.828591+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,1, <<"msg_test_ctag_0">>, 1642384899892, {resource,<<"/">>,queue, <<"q12">>}, 0}
2022-01-17 10:01:43.828696+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,2, <<"msg_test_ctag_0">>, 1642384899894, {resource,<<"/">>,queue, <<"q12">>}, 1}
2022-01-17 10:01:43.828777+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,3, <<"msg_test_ctag_0">>, 1642384899896, {resource,<<"/">>,queue, <<"q12">>}, 2}
2022-01-17 10:01:43.828850+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,4, <<"msg_test_ctag_0">>, 1642384899897, {resource,<<"/">>,queue, <<"q12">>}, 3}
2022-01-17 10:01:43.828922+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,5, <<"msg_test_ctag_0">>, 1642384899899, {resource,<<"/">>,queue, <<"q12">>}, 4}
2022-01-17 10:01:43.828997+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,6, <<"msg_test_ctag_0">>, 1642384903822, {resource,<<"/">>,queue, <<"q12">>}, 0}
2022-01-17 10:01:43.829066+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,7, <<"msg_test_ctag_0">>, 1642384903824, {resource,<<"/">>,queue, <<"q12">>}, 1}
2022-01-17 10:01:43.829134+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,8, <<"msg_test_ctag_0">>, 1642384903825, {resource,<<"/">>,queue, <<"q12">>}, 2}
2022-01-17 10:01:43.829202+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,9, <<"msg_test_ctag_0">>, 1642384903827, {resource,<<"/">>,queue, <<"q12">>}, 3}
2022-01-17 10:01:43.829273+08:00 [info] <0.1693.0> [DBG]["rabbit_channel.erl":2193 record_sent]{pending_ack,10, <<"msg_test_ctag_0">>, 1642384903828, {resource,<<"/">>,queue, <<"q12">>}, 4}

The old deliver_tag-ack_tag pairs are {1,0},{2,1},{3,2},{4,3},{5,4},
The new deliver_tag-ack_tag pairs are {6,0},{7,1},{8,2},{9,3},{10,4}.

These two sets of pairs have overlapping ack_tags. When the client answers the old deliver_tags, it collects ack_tags and sends them to new QPID.
The new QPID will mistakenly assume that expected acknowledgement has been received.


