### PR TITLE
Content hashing support for definition import

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -154,10 +154,10 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "definitions.checksum.use_checksum", "rabbit.definitions.use_checksum", [
+{mapping, "definitions.hashing.use_hashing", "rabbit.definitions.use_hashing", [
     {datatype, {enum, [true, false]}}]}.
 
-{mapping, "definitions.checksum.checksum_algorithm", "rabbit.definitions.checksum_algorithm", [
+{mapping, "definitions.hashing.algorithm", "rabbit.definitions.hashing_algorithm", [
     {datatype, {enum, [sha, sha224, sha256, sha384, sha512]}}]}.
 
 %% Load definitions from a remote URL over HTTPS. See

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -154,6 +154,12 @@ fun(Conf) ->
     end
 end}.
 
+{mapping, "definitions.checksum.use_checksum", "rabbit.definitions.use_checksum", [
+    {datatype, {enum, [true, false]}}]}.
+
+{mapping, "definitions.checksum.checksum_algorithm", "rabbit.definitions.checksum_algorithm", [
+    {datatype, {enum, [sha, sha224, sha256, sha384, sha512]}}]}.
+
 %% Load definitions from a remote URL over HTTPS. See
 %% https://www.rabbitmq.com/management.html#load-definitions
 {mapping, "definitions.https.url", "rabbit.definitions.url",

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -154,7 +154,7 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "definitions.hashing.use_hashing", "rabbit.definitions.use_hashing", [
+{mapping, "definitions.skip_if_unchanged", "rabbit.definitions.skip_if_unchanged", [
     {datatype, {enum, [true, false]}}]}.
 
 {mapping, "definitions.hashing.algorithm", "rabbit.definitions.hashing_algorithm", [

--- a/deps/rabbit/src/rabbit_definitions_hashing.erl
+++ b/deps/rabbit/src/rabbit_definitions_hashing.erl
@@ -1,0 +1,62 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+-module(rabbit_definitions_hashing).
+
+-include("rabbit.hrl").
+
+-import(rabbit_misc, [pget/2, pget/3]).
+
+-export([
+    hashing_algorithm/0,
+    hash/1,
+    hash/2,
+    stored_hash/0,
+    store_hash/1,
+    store_hash/2
+]).
+
+-define(DEFAULT_HASHING_ALGORITHM, sha256).
+-define(GLOBAL_RUNTIME_PARAMETER_KEY, definitions_hash).
+
+%%
+%% API
+%%
+
+-spec hashing_algorithm() -> {ok, crypto:sha1() | crypto:sha2()}.
+hashing_algorithm() ->
+    case application:get_env(rabbit, definitions) of
+        undefined   -> undefined;
+        {ok, none}  -> undefined;
+        {ok, []}    -> undefined;
+        {ok, Proplist} ->
+            pget(hashing_algorithm, Proplist, ?DEFAULT_HASHING_ALGORITHM)
+    end.
+
+-spec hash(Value :: term()) -> binary().
+hash(Value) ->
+    crypto:hash(hashing_algorithm(), Value).
+
+-spec hash(Algo :: crypto:sha1() | crypto:sha2(), Value :: term()) -> binary().
+hash(Algo, Value) ->
+    crypto:hash(Algo, term_to_binary(Value)).
+
+-spec stored_hash() -> binary() | undefined.
+stored_hash() ->
+    case rabbit_runtime_parameters:lookup_global(?GLOBAL_RUNTIME_PARAMETER_KEY) of
+        not_found -> undefined;
+        undefined -> undefined;
+        Proplist  -> pget(value, Proplist)
+    end.
+
+-spec store_hash(Value :: term()) -> ok.
+store_hash(Value0) ->
+    store_hash(Value0, ?INTERNAL_USER).
+
+-spec store_hash(Value :: term(), Username :: rabbit_types:username()) -> ok.
+store_hash(Value0, Username) ->
+    Value = rabbit_data_coercion:to_binary(Value0),
+    rabbit_runtime_parameters:set_global(?GLOBAL_RUNTIME_PARAMETER_KEY, Value, Username).

--- a/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
@@ -14,6 +14,7 @@
     load/1,
     %% classic arguments specific to this source
     load/2,
+    load_with_hashing/3,
     location/0
 ]).
 
@@ -55,6 +56,14 @@ load(Proplist) when is_list(Proplist) ->
 
 load(IsDir, Path) ->
     load_from_local_path(IsDir, Path).
+
+load_with_hashing(Defs, undefined = _Hash, _Algo) when is_list(Defs) ->
+    load(Defs);
+load_with_hashing(Defs, PreviousHash, Algo) ->
+    case rabbit_definitions_hashing:hash(Algo, Defs) of
+        PreviousHash -> ok;
+        _            -> load(Defs)
+    end.
 
 location() ->
     case location_from_classic_option() of

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -418,7 +418,7 @@ global_info_keys() -> [name, value].
 
 lookup_component(Component) ->
     case rabbit_registry:lookup_module(
-           runtime_parameter, list_to_atom(binary_to_list(Component))) of
+           runtime_parameter, rabbit_data_coercion:to_atom(Component)) of
         {error, not_found} -> {errors,
                                [{"component ~s not found", [Component]}]};
         {ok, Module}       -> {ok, Module}

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -46,6 +46,7 @@
 -export([atom_to_binary/1, parse_bool/1, parse_int/1]).
 -export([pid_to_string/1, string_to_pid/1,
          pid_change_node/2, node_to_fake_pid/1]).
+-export([hexify/1]).
 -export([version_compare/2, version_compare/3]).
 -export([version_minor_equivalent/2, strict_version_minor_equivalent/2]).
 -export([dict_cons/3, orddict_cons/3, maps_cons/3, gb_trees_cons/3]).
@@ -775,6 +776,14 @@ atom_to_binary(A) ->
 pid_to_string(Pid) when is_pid(Pid) ->
     {Node, Cre, Id, Ser} = decompose_pid(Pid),
     format("<~s.~B.~B.~B>", [Node, Cre, Id, Ser]).
+
+-spec hexify(binary() | atom() | list()) -> binary().
+hexify(Bin) when is_binary(Bin) ->
+    iolist_to_binary([io_lib:format("~2.16.0B", [V]) || <<V:8>> <= Bin]);
+hexify(Bin) when is_list(Bin) ->
+    hexify(binary_to_list(Bin));
+hexify(Bin) when is_atom(Bin) ->
+    hexify(atom_to_binary(Bin)).
 
 %% inverse of above
 string_to_pid(Str) ->


### PR DESCRIPTION
## Proposed Changes

This Introduces definition hashing during import 
as an opt-in feature. The goal is to avoid re-importing the definition
from the definition file/directory/source if we know the content
has not changed. Since this feature won't be appropriate for
every environment (sometimes unconditional reimporting is expected),
the feature is opt-in.

This is still a WIP.


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Per discussion with @mkuratczyk.