### PR TITLE
Make it possible to skip definition import if imported contents have not changed

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -148,7 +148,7 @@ fun(Conf) ->
         http             -> rabbit_definitions_import_https;
         %% accept both rabbitmq_ and rabbit_ (typical core module prefix)
         rabbitmq_definitions_import_local_filesystem -> rabbit_definitions_import_local_filesystem;
-        rabbitmq_definitions_import_local_filesystem -> rabbit_definitions_import_https;
+        rabbitmq_definitions_import_http             -> rabbit_definitions_import_https;
         %% any other value is used as is
         Module           -> Module
     end

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -154,10 +154,10 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "definitions.checksum.use_checksum", "rabbit.definitions.use_checksum", [
+{mapping, "definitions.hashing.use_hashing", "rabbit.definitions.use_hashing", [
     {datatype, {enum, [true, false]}}]}.
 
-{mapping, "definitions.checksum.checksum_algorithm", "rabbit.definitions.checksum_algorithm", [
+{mapping, "definitions.hashing.algorithm", "rabbit.definitions.hashing_algorithm", [
     {datatype, {enum, [sha, sha224, sha256, sha384, sha512]}}]}.
 
 %% Load definitions from a remote URL over HTTPS. See

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -154,6 +154,12 @@ fun(Conf) ->
     end
 end}.
 
+{mapping, "definitions.checksum.use_checksum", "rabbit.definitions.use_checksum", [
+    {datatype, {enum, [true, false]}}]}.
+
+{mapping, "definitions.checksum.checksum_algorithm", "rabbit.definitions.checksum_algorithm", [
+    {datatype, {enum, [sha, sha224, sha256, sha384, sha512]}}]}.
+
 %% Load definitions from a remote URL over HTTPS. See
 %% https://www.rabbitmq.com/management.html#load-definitions
 {mapping, "definitions.https.url", "rabbit.definitions.url",

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -154,7 +154,7 @@ fun(Conf) ->
     end
 end}.
 
-{mapping, "definitions.hashing.use_hashing", "rabbit.definitions.use_hashing", [
+{mapping, "definitions.skip_if_unchanged", "rabbit.definitions.skip_if_unchanged", [
     {datatype, {enum, [true, false]}}]}.
 
 {mapping, "definitions.hashing.algorithm", "rabbit.definitions.hashing_algorithm", [

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -237,13 +237,13 @@ maybe_load_definitions_from_local_filesystem(App, Key) ->
                 true ->
                     rabbit_log:debug("Will use module ~s to import definitions (if definition file/directory has changed)", [Mod]),
                     CurrentHash = rabbit_definitions_hashing:stored_global_hash(),
-                    rabbit_log:info("Previously stored hash value of imported definitions: ~s...", [rabbit_misc:hexify(CurrentHash)]),
+                    rabbit_log:debug("Previously stored hash value of imported definitions: ~s...", [binary:part(rabbit_misc:hexify(CurrentHash), 0, 12)]),
                     Algo = rabbit_definitions_hashing:hashing_algorithm(),
                     case Mod:load_with_hashing(IsDir, Path, CurrentHash, Algo) of
                         CurrentHash ->
                             rabbit_log:info("Hash value of imported definitions matches current contents");
                         UpdatedHash ->
-                            rabbit_log:debug("Hash value of imported definitions has changed to ~p", [rabbit_misc:hexify(CurrentHash)]),
+                            rabbit_log:debug("Hash value of imported definitions has changed to ~s", [binary:part(rabbit_misc:hexify(CurrentHash), 0, 12)]),
                             rabbit_definitions_hashing:store_global_hash(UpdatedHash)
                     end
             end
@@ -267,13 +267,13 @@ maybe_load_definitions_from_pluggable_source(App, Key) ->
                         true ->
                             rabbit_log:debug("Will use module ~s to import definitions (if definition file/directory/source has changed)", [Mod]),
                             CurrentHash = rabbit_definitions_hashing:stored_global_hash(),
-                            rabbit_log:info("Previously stored hash value of imported definitions: ~s...", [rabbit_misc:hexify(CurrentHash)]),
+                            rabbit_log:debug("Previously stored hash value of imported definitions: ~s...", [binary:part(rabbit_misc:hexify(CurrentHash), 0, 12)]),
                             Algo = rabbit_definitions_hashing:hashing_algorithm(),
                             case Mod:load_with_hashing(Proplist, CurrentHash, Algo) of
                                 CurrentHash ->
                                     rabbit_log:info("Hash value of imported definitions matches current contents");
                                 UpdatedHash ->
-                                    rabbit_log:debug("Hash value of imported definitions has changed to ~s...", [rabbit_misc:hexify(CurrentHash)]),
+                                    rabbit_log:debug("Hash value of imported definitions has changed to ~s...", [binary:part(rabbit_misc:hexify(CurrentHash), 0, 12)]),
                                     rabbit_definitions_hashing:store_global_hash(UpdatedHash)
                             end
                     end

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -258,15 +258,15 @@ maybe_load_definitions_from_local_filesystem(App, Key) ->
                     rabbit_log:debug("Will use module ~s to import definitions", [Mod]),
                     Mod:load(IsDir, Path);
                 true ->
-                    rabbit_log:debug("Will use module ~s to import definitions (if definition file/directory has changed)", [Mod]),
+                    Algo = rabbit_definitions_hashing:hashing_algorithm(),
+                    rabbit_log:debug("Will use module ~s to import definitions (if definition file/directory has changed, hashing algo: ~s)", [Mod, Algo]),
                     CurrentHash = rabbit_definitions_hashing:stored_global_hash(),
                     rabbit_log:debug("Previously stored hash value of imported definitions: ~s...", [binary:part(rabbit_misc:hexify(CurrentHash), 0, 12)]),
-                    Algo = rabbit_definitions_hashing:hashing_algorithm(),
                     case Mod:load_with_hashing(IsDir, Path, CurrentHash, Algo) of
                         CurrentHash ->
                             rabbit_log:info("Hash value of imported definitions matches current contents");
                         UpdatedHash ->
-                            rabbit_log:debug("Hash value of imported definitions has changed to ~s", [binary:part(rabbit_misc:hexify(CurrentHash), 0, 12)]),
+                            rabbit_log:debug("Hash value of imported definitions has changed to ~s", [binary:part(rabbit_misc:hexify(UpdatedHash), 0, 12)]),
                             rabbit_definitions_hashing:store_global_hash(UpdatedHash)
                     end
             end

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -368,9 +368,10 @@ should_skip_if_unchanged() ->
 apply_defs(Map, ActingUser) ->
     apply_defs(Map, ActingUser, fun () -> ok end).
 
+-type vhost_or_success_fun() :: vhost:name() | fun(() -> 'ok').
 -spec apply_defs(Map :: #{atom() => any()},
                  ActingUser :: rabbit_types:username(),
-                 (VHost :: vhost:name() | SuccessFun :: fun(() -> 'ok'))) -> 'ok' | {error, term()}.
+                 VHostOrSuccessFun :: vhost_or_success_fun()) -> 'ok' | {error, term()}.
 
 apply_defs(Map, ActingUser, VHost) when is_binary(VHost) ->
     apply_defs(Map, ActingUser, fun () -> ok end, VHost);

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -368,11 +368,12 @@ should_skip_if_unchanged() ->
 apply_defs(Map, ActingUser) ->
     apply_defs(Map, ActingUser, fun () -> ok end).
 
--spec apply_defs(Map :: #{atom() => any()}, ActingUser :: rabbit_types:username(),
-                SuccessFun :: fun(() -> 'ok')) -> 'ok'  | {error, term()};
-                (Map :: #{atom() => any()}, ActingUser :: rabbit_types:username(),
-                VHost :: vhost:name()) -> 'ok'  | {error, term()}.
+-spec apply_defs(Map :: #{atom() => any()},
+                 ActingUser :: rabbit_types:username(),
+                 (VHost :: vhost:name() | SuccessFun :: fun(() -> 'ok'))) -> 'ok' | {error, term()}.
 
+apply_defs(Map, ActingUser, VHost) when is_binary(VHost) ->
+    apply_defs(Map, ActingUser, fun () -> ok end, VHost);
 apply_defs(Map, ActingUser, SuccessFun) when is_function(SuccessFun) ->
     Version = maps:get(rabbitmq_version, Map, maps:get(rabbit_version, Map, undefined)),
     try
@@ -417,7 +418,7 @@ apply_defs(Map, ActingUser, SuccessFun) when is_function(SuccessFun) ->
                 SuccessFun :: fun(() -> 'ok'),
                 VHost :: vhost:name()) -> 'ok' | {error, term()}.
 
-apply_defs(Map, ActingUser, SuccessFun, VHost) when is_binary(VHost) ->
+apply_defs(Map, ActingUser, SuccessFun, VHost) when is_function(SuccessFun); is_binary(VHost) ->
     rabbit_log:info("Asked to import definitions for a virtual host. Virtual host: ~p, acting user: ~p",
                     [VHost, ActingUser]),
     try

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -118,10 +118,10 @@ import_parsed_with_hashing(Body0) when is_map(Body0) ->
             Algo         = rabbit_definitions_hashing:hashing_algorithm(),
             case rabbit_definitions_hashing:hash(Algo, Body) of
                 PreviousHash ->
-                    rabbit_log:debug("Submitted definition content hash matches the stored one: ~p", [rabbit_misc:hexify(PreviousHash)]),
+                    rabbit_log:info("Submitted definition content hash matches the stored one: ~s", [binary:part(rabbit_misc:hexify(PreviousHash), 0, 12)]),
                     ok;
                 Other        ->
-                    rabbit_log:debug("Submitted definition content hash: ~p, stored one: ~p", [
+                    rabbit_log:debug("Submitted definition content hash: ~s, stored one: ~s", [
                         binary:part(rabbit_misc:hexify(PreviousHash), 0, 10),
                         binary:part(rabbit_misc:hexify(Other), 0, 10)
                     ]),
@@ -146,10 +146,10 @@ import_parsed_with_hashing(Body0, VHost) ->
             Algo         = rabbit_definitions_hashing:hashing_algorithm(),
             case rabbit_definitions_hashing:hash(Algo, Body) of
                 PreviousHash ->
-                    rabbit_log:debug("Submitted definition content hash matches the stored one: ~p", [rabbit_misc:hexify(PreviousHash)]),
+                    rabbit_log:info("Submitted definition content hash matches the stored one: ~s", [binary:part(rabbit_misc:hexify(PreviousHash), 0, 12)]),
                     ok;
                 Other        ->
-                    rabbit_log:debug("Submitted definition content hash: ~p, stored one: ~p", [
+                    rabbit_log:debug("Submitted definition content hash: ~s, stored one: ~s", [
                         binary:part(rabbit_misc:hexify(PreviousHash), 0, 10),
                         binary:part(rabbit_misc:hexify(Other), 0, 10)
                     ]),

--- a/deps/rabbit/src/rabbit_definitions_hashing.erl
+++ b/deps/rabbit/src/rabbit_definitions_hashing.erl
@@ -1,0 +1,62 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+-module(rabbit_definitions_hashing).
+
+-include("rabbit.hrl").
+
+-import(rabbit_misc, [pget/2, pget/3]).
+
+-export([
+    hashing_algorithm/0,
+    hash/1,
+    hash/2,
+    stored_hash/0,
+    store_hash/1,
+    store_hash/2
+]).
+
+-define(DEFAULT_HASHING_ALGORITHM, sha256).
+-define(GLOBAL_RUNTIME_PARAMETER_KEY, definitions_hash).
+
+%%
+%% API
+%%
+
+-spec hashing_algorithm() -> {ok, crypto:sha1() | crypto:sha2()}.
+hashing_algorithm() ->
+    case application:get_env(rabbit, definitions) of
+        undefined   -> undefined;
+        {ok, none}  -> undefined;
+        {ok, []}    -> undefined;
+        {ok, Proplist} ->
+            pget(hashing_algorithm, Proplist, ?DEFAULT_HASHING_ALGORITHM)
+    end.
+
+-spec hash(Value :: term()) -> binary().
+hash(Value) ->
+    crypto:hash(hashing_algorithm(), Value).
+
+-spec hash(Algo :: crypto:sha1() | crypto:sha2(), Value :: term()) -> binary().
+hash(Algo, Value) ->
+    crypto:hash(Algo, term_to_binary(Value)).
+
+-spec stored_hash() -> binary() | undefined.
+stored_hash() ->
+    case rabbit_runtime_parameters:lookup_global(?GLOBAL_RUNTIME_PARAMETER_KEY) of
+        not_found -> undefined;
+        undefined -> undefined;
+        Proplist  -> pget(value, Proplist)
+    end.
+
+-spec store_hash(Value :: term()) -> ok.
+store_hash(Value0) ->
+    store_hash(Value0, ?INTERNAL_USER).
+
+-spec store_hash(Value :: term(), Username :: rabbit_types:username()) -> ok.
+store_hash(Value0, Username) ->
+    Value = rabbit_data_coercion:to_binary(Value0),
+    rabbit_runtime_parameters:set_global(?GLOBAL_RUNTIME_PARAMETER_KEY, Value, Username).

--- a/deps/rabbit/src/rabbit_definitions_hashing.erl
+++ b/deps/rabbit/src/rabbit_definitions_hashing.erl
@@ -4,6 +4,17 @@
 %%
 %% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
+
+%% This module is responsible for definition content hashing. Content hashing
+%% makes it possible for the user to opt into skipping definition import if
+%% file/source content has not changed.
+%%
+%% See also
+%%
+%%  * rabbit.schema (core Cuttlefish schema mapping file)
+%%  * rabbit_definitions
+%%  * rabbit_definitions_import_local_filesystem
+%%  * rabbit_definitions_import_http
 -module(rabbit_definitions_hashing).
 
 -behaviour(rabbit_runtime_parameter).

--- a/deps/rabbit/src/rabbit_definitions_hashing.erl
+++ b/deps/rabbit/src/rabbit_definitions_hashing.erl
@@ -73,7 +73,7 @@ notify_clear(_VHost, ?RUNTIME_PARAMETER_COMPONENT, _Name, _ActingUser) ->
 
 
 
--spec hashing_algorithm() -> {ok, crypto:sha1() | crypto:sha2()}.
+-spec hashing_algorithm() -> crypto:sha1() | crypto:sha2() | undefined.
 hashing_algorithm() ->
     case application:get_env(rabbit, definitions) of
         undefined   -> undefined;
@@ -87,7 +87,9 @@ hashing_algorithm() ->
 hash(Value) ->
     crypto:hash(hashing_algorithm(), Value).
 
--spec hash(Algo :: crypto:sha1() | crypto:sha2(), Value :: term()) -> binary().
+-spec hash(Algo :: crypto:sha1() | crypto:sha2() | undefined, Value :: term()) -> binary().
+hash(undefined, Value) ->
+    hash(?DEFAULT_HASHING_ALGORITHM, Value);
 hash(Algo, Value) ->
     crypto:hash(Algo, term_to_binary(Value)).
 
@@ -95,7 +97,6 @@ hash(Algo, Value) ->
 stored_global_hash() ->
     case rabbit_runtime_parameters:lookup_global(?GLOBAL_RUNTIME_PARAMETER_KEY) of
         not_found -> undefined;
-        undefined -> undefined;
         Proplist  -> pget(value, Proplist)
     end.
 
@@ -103,7 +104,6 @@ stored_global_hash() ->
 stored_vhost_specific_hash(VHostName) ->
     case rabbit_runtime_parameters:lookup(VHostName, ?RUNTIME_PARAMETER_COMPONENT, ?PARAMETER_NAME) of
         not_found -> undefined;
-        undefined -> undefined;
         Proplist  -> pget(value, Proplist)
     end.
 

--- a/deps/rabbit/src/rabbit_definitions_hashing.erl
+++ b/deps/rabbit/src/rabbit_definitions_hashing.erl
@@ -8,7 +8,7 @@
 
 -behaviour(rabbit_runtime_parameter).
 
--include("rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -import(rabbit_misc, [pget/2, pget/3]).
 

--- a/deps/rabbit/src/rabbit_definitions_hashing.erl
+++ b/deps/rabbit/src/rabbit_definitions_hashing.erl
@@ -109,6 +109,7 @@ stored_vhost_specific_hash(VHostName) ->
 
 -spec store_global_hash(Value :: term()) -> ok.
 store_global_hash(Value) ->
+    rabbit_log:debug("Storing global imported definitions content hash, hex value: ~s", [rabbit_misc:hexify(Value)]),
     store_global_hash(Value, ?INTERNAL_USER).
 
 -spec store_global_hash(Value0 :: term(), Username :: rabbit_types:username()) -> ok.

--- a/deps/rabbit/src/rabbit_definitions_import_https.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_https.erl
@@ -2,9 +2,17 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
+%% This module is responsible for loading definition from an HTTPS endpoint.
+%%
+%% See also
+%%
+%%  * rabbit.schema (core Cuttlefish schema mapping file)
+%%  * rabbit_definitions
+%%  * rabbit_definitions_import_local_filesystem
+%%  * rabbit_definitions_hashing
 -module(rabbit_definitions_import_https).
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -38,7 +46,6 @@ is_enabled() ->
     end.
 
 load(Proplist) ->
-    rabbit_log:debug("Definitions proprties: ~p", [Proplist]),
     URL = pget(url, Proplist),
     TLSOptions0 = [
         %% avoids a peer verification warning emitted by default if no certificate chain and peer verification

--- a/deps/rabbit/src/rabbit_definitions_import_https.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_https.erl
@@ -46,7 +46,7 @@ is_enabled() ->
             end
     end.
 
--spec load(Proplist :: list()) -> ok | {error, term()}.
+-spec load(Proplist :: list() | map()) -> ok | {error, term()}.
 load(Proplist) ->
     URL = pget(url, Proplist),
     rabbit_log:info("Applying definitions from a remote URL"),

--- a/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
@@ -14,6 +14,7 @@
     load/1,
     %% classic arguments specific to this source
     load/2,
+    load_with_hashing/3,
     location/0
 ]).
 
@@ -55,6 +56,14 @@ load(Proplist) when is_list(Proplist) ->
 
 load(IsDir, Path) ->
     load_from_local_path(IsDir, Path).
+
+load_with_hashing(Defs, undefined = _Hash, _Algo) when is_list(Defs) ->
+    load(Defs);
+load_with_hashing(Defs, PreviousHash, Algo) ->
+    case rabbit_definitions_hashing:hash(Algo, Defs) of
+        PreviousHash -> ok;
+        _            -> load(Defs)
+    end.
 
 location() ->
     case location_from_classic_option() of

--- a/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
@@ -45,6 +45,7 @@
 is_enabled() ->
     is_enabled_via_classic_option() or is_enabled_via_modern_option().
 
+-spec load(Proplist :: list() | map()) -> ok | {error, term()}.
 load(Proplist) when is_list(Proplist) ->
     case pget(local_path, Proplist, undefined) of
         undefined -> {error, "local definition file path is not configured: local_path is not set"};
@@ -69,6 +70,7 @@ load(Proplist) when is_list(Proplist) ->
 load(Map) when is_map(Map) ->
     load(maps:to_list(Map)).
 
+-spec load(IsDir :: boolean(), Path :: file:name_all()) -> ok | {error, term()}.
 load(IsDir, Path) when is_boolean(IsDir) ->
     load_from_local_path(IsDir, Path).
 
@@ -105,6 +107,7 @@ location() ->
         Value     -> Value
     end.
 
+-spec load_from_local_path(IsDir :: boolean(), Path :: file:name_all()) -> ok | {error, term()}.
 load_from_local_path(true, Dir) ->
     rabbit_log:info("Applying definitions from directory ~s", [Dir]),
     load_from_files(file:list_dir(Dir), Dir);

--- a/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
@@ -172,8 +172,8 @@ compiled_definitions_from_local_path(true = _IsDir, Dir) ->
     end;
 compiled_definitions_from_local_path(false = _IsDir, Path) ->
     case read_file_contents(Path) of
-        Body       -> [Body];
-        {error, _} -> []
+        {error, _} -> [];
+        Body       -> [Body]
     end.
 
 -spec read_file_contents(Path :: file:name_all()) -> binary() | {error, any()}.

--- a/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
+++ b/deps/rabbit/src/rabbit_definitions_import_local_filesystem.erl
@@ -2,9 +2,18 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
+%% This module is responsible for loading definition from a local filesystem
+%% (a JSON file or a conf.d-style directory of files).
+%%
+%% See also
+%%
+%%  * rabbit.schema (core Cuttlefish schema mapping file)
+%%  * rabbit_definitions
+%%  * rabbit_definitions_import_http
+%%  * rabbit_definitions_hashing
 -module(rabbit_definitions_import_local_filesystem).
 -include_lib("rabbit_common/include/rabbit.hrl").
 

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -418,7 +418,7 @@ global_info_keys() -> [name, value].
 
 lookup_component(Component) ->
     case rabbit_registry:lookup_module(
-           runtime_parameter, list_to_atom(binary_to_list(Component))) of
+           runtime_parameter, rabbit_data_coercion:to_atom(Component)) of
         {error, not_found} -> {errors,
                                [{"component ~s not found", [Component]}]};
         {ok, Module}       -> {ok, Module}

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(definition_import_SUITE).

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -20,6 +20,7 @@ all() ->
      %% uses rabbit.definitions with import_backend set to local_filesystem
      {group, boot_time_import_using_modern_local_filesystem_source},
      {group, boot_time_import_using_public_https_source},
+     {group, skip_if_unchanged},
      {group, roundtrip},
      {group, import_on_a_running_node}
     ].
@@ -67,6 +68,12 @@ groups() ->
         {roundtrip, [], [
             export_import_round_trip_case1,
             export_import_round_trip_case2
+        ]},
+
+        {skip_if_unchanged, [], [
+            %% these all must import the same definition file
+            import_on_a_booting_node_using_skip_if_unchanged,
+            import_case5
         ]}
     ].
 
@@ -104,6 +111,22 @@ init_per_group(boot_time_import_using_modern_local_filesystem_source = Group, Co
           {definitions, [
               {import_backend, rabbit_definitions_import_local_filesystem},
               {local_path,     CasePath}
+          ]}
+      ]}),
+    rabbit_ct_helpers:run_setup_steps(Config2, rabbit_ct_broker_helpers:setup_steps());
+%% same as the classic source semantically, uses skip_if_unchanged
+init_per_group(skip_if_unchanged = Group, Config) ->
+    CasePath = filename:join(?config(data_dir, Config), "case5.json"),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Group},
+        {rmq_nodes_count, 1}
+      ]),
+    Config2 = rabbit_ct_helpers:merge_app_env(Config1,
+      {rabbit, [
+          {definitions, [
+              {import_backend,    rabbit_definitions_import_local_filesystem},
+              {local_path,        CasePath},
+              {skip_if_unchanged, true}
           ]}
       ]}),
     rabbit_ct_helpers:run_setup_steps(Config2, rabbit_ct_broker_helpers:setup_steps());
@@ -320,6 +343,15 @@ import_on_a_booting_node_using_modern_local_filesystem_source(Config) ->
 import_on_a_booting_node_using_public_https_source(Config) ->
     VHost = <<"bunny_testbed">>,
     %% verify that virtual host eventually starts
+    case rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_vhost, await_running_on_all_nodes, [VHost, 3000]) of
+        ok -> ok;
+        {error, timeout} -> ct:fail("virtual host ~p was not imported on boot", [VHost])
+    end.
+
+import_on_a_booting_node_using_skip_if_unchanged(Config) ->
+    %% see case5.json
+    VHost = <<"vhost2">>,
+    %% verify that vhost2 eventually starts
     case rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_vhost, await_running_on_all_nodes, [VHost, 3000]) of
         ok -> ok;
         {error, timeout} -> ct:fail("virtual host ~p was not imported on boot", [VHost])

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -781,9 +781,9 @@ pid_to_string(Pid) when is_pid(Pid) ->
 hexify(Bin) when is_binary(Bin) ->
     iolist_to_binary([io_lib:format("~2.16.0B", [V]) || <<V:8>> <= Bin]);
 hexify(Bin) when is_list(Bin) ->
-    hexify(binary_to_list(Bin));
+    hexify(erlang:binary_to_list(Bin));
 hexify(Bin) when is_atom(Bin) ->
-    hexify(atom_to_binary(Bin)).
+    hexify(erlang:atom_to_binary(Bin)).
 
 %% inverse of above
 string_to_pid(Str) ->

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -46,6 +46,7 @@
 -export([atom_to_binary/1, parse_bool/1, parse_int/1]).
 -export([pid_to_string/1, string_to_pid/1,
          pid_change_node/2, node_to_fake_pid/1]).
+-export([hexify/1]).
 -export([version_compare/2, version_compare/3]).
 -export([version_minor_equivalent/2, strict_version_minor_equivalent/2]).
 -export([dict_cons/3, orddict_cons/3, maps_cons/3, gb_trees_cons/3]).
@@ -775,6 +776,14 @@ atom_to_binary(A) ->
 pid_to_string(Pid) when is_pid(Pid) ->
     {Node, Cre, Id, Ser} = decompose_pid(Pid),
     format("<~s.~B.~B.~B>", [Node, Cre, Id, Ser]).
+
+-spec hexify(binary() | atom() | list()) -> binary().
+hexify(Bin) when is_binary(Bin) ->
+    iolist_to_binary([io_lib:format("~2.16.0B", [V]) || <<V:8>> <= Bin]);
+hexify(Bin) when is_list(Bin) ->
+    hexify(binary_to_list(Bin));
+hexify(Bin) when is_atom(Bin) ->
+    hexify(atom_to_binary(Bin)).
 
 %% inverse of above
 string_to_pid(Str) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
@@ -36,7 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([], %{node: node_name, format: format, skip_if_unchanged: skip?, timeout: timeout}) do
+  def run([], %{node: node_name, format: format, timeout: timeout}) do
     case IO.read(:stdio, :all) do
       :eof -> {:error, :not_enough_args}
       bin  ->
@@ -44,6 +44,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
           {:error, error} ->
             {:error, ExitCodes.exit_dataerr(), "Failed to deserialise input (format: #{human_friendly_format(format)}) (error: #{inspect(error)})"}
           {:ok, map} ->
+            skip? = Map.get(map, :skip_if_unchanged, false)
             fun = case skip? do
               true  -> :import_parsed_with_hashing
               false -> :import_parsed
@@ -52,7 +53,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
         end
     end
   end
-  def run([path], %{node: node_name, format: format, skip_if_unchanged: skip?, timeout: timeout}) do
+  def run([path], %{node: node_name, format: format, timeout: timeout}) do
     abs_path = Path.absname(path)
 
     case File.read(abs_path) do
@@ -63,6 +64,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
           {:error, error} ->
             {:error, ExitCodes.exit_dataerr(), "Failed to deserialise input (format: #{human_friendly_format(format)}) (error: #{inspect(error)})"}
           {:ok, map} ->
+            skip? = Map.get(map, :skip_if_unchanged, false)
             fun = case skip? do
               true  -> :import_parsed_with_hashing
               false -> :import_parsed

--- a/deps/rabbitmq_cli/test/ctl/import_definitions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/import_definitions_command_test.exs
@@ -27,7 +27,7 @@ defmodule ImportDefinitionsCommandTest do
 
   test "merge_defaults: defaults to JSON for format" do
     assert @command.merge_defaults([valid_file_path()], %{}) ==
-             {[valid_file_path()], %{format: "json"}}
+             {[valid_file_path()], %{format: "json", skip_if_unchanged: false}}
   end
 
   test "merge_defaults: defaults to --silent if target is stdout" do
@@ -36,14 +36,14 @@ defmodule ImportDefinitionsCommandTest do
 
   test "merge_defaults: format is case insensitive" do
     assert @command.merge_defaults([valid_file_path()], %{format: "JSON"}) ==
-             {[valid_file_path()], %{format: "json"}}
+             {[valid_file_path()], %{format: "json", skip_if_unchanged: false}}
     assert @command.merge_defaults([valid_file_path()], %{format: "Erlang"}) ==
-             {[valid_file_path()], %{format: "erlang"}}
+             {[valid_file_path()], %{format: "erlang", skip_if_unchanged: false}}
   end
 
   test "merge_defaults: format can be overridden" do
     assert @command.merge_defaults([valid_file_path()], %{format: "erlang"}) ==
-             {[valid_file_path()], %{format: "erlang"}}
+             {[valid_file_path()], %{format: "erlang", skip_if_unchanged: false}}
   end
 
   test "validate: accepts a file path argument", context do
@@ -77,6 +77,14 @@ defmodule ImportDefinitionsCommandTest do
   @tag format: "json"
   test "run: imports definitions from a file", context do
     assert :ok == @command.run([valid_file_path()], context[:opts])
+
+    # clean up the state we've modified
+    clear_parameter("/", "federation-upstream", "up-1")
+  end
+
+  @tag format: "json"
+  test "run: imports definitions from a file when --skip-if-unchanged is provided", context do
+    assert :ok == @command.run([valid_file_path()], Map.merge(context[:opts], %{skip_if_unchanged: true}))
 
     # clean up the state we've modified
     clear_parameter("/", "federation-upstream", "up-1")


### PR DESCRIPTION
This Introduces definition hashing during import
as an opt-in feature. The goal is to avoid re-importing the definition
from the definition file/directory/source if we know the content
has not changed. Since this feature won't be appropriate for
every environment (sometimes unconditional reimporting is expected),
the feature is opt-in.

Some example configuration files. Import a single file:

``` ini
log.file.level = debug
log.console.level = debug

definitions.skip_if_unchanged = true
definitions.hashing.algorithm = sha256

definitions.import_backend = local_filesystem
definitions.local.path = /path/to/definitions/defs.json
```

Import a directory of files:

``` ini
log.file.level = debug
log.console.level = debug

definitions.skip_if_unchanged = true
definitions.hashing.algorithm = sha256

definitions.import_backend = local_filesystem
definitions.local.path = /path/to/definitions/conf.d/
```

Import from an HTTPS URL:

``` ini
log.file.level = debug
log.console.level = debug

definitions.skip_if_unchanged = true
definitions.hashing.algorithm = sha256

definitions.import_backend = https
definitions.https.url = https://gist.githubusercontent.com/michaelklishin/e73b0114728d9391425d0644304f264a/raw/f15642771f099c60b6fa93f75d46a4246bb47c45/upstream.definitions.json

# definitions.tls.verify     = verify_peer
# definitions.tls.fail_if_no_peer_cert = true
#
# definitions.tls.cacertfile = /path/to/tls-gen.git/basic/result/ca_certificate.pem
# definitions.tls.certfile   = /path/to/tls-gen.git/basic/result/server_certificate.pem
# definitions.tls.keyfile    = /path/to/tls-gen.git/basic/result/server_key.pem

definitions.tls.versions.1 = tlsv1.2
definitions.tls.log_level   = error

definitions.tls.secure_renegotiate = true

definitions.tls.ciphers.1  = ECDHE-ECDSA-AES256-GCM-SHA384
definitions.tls.ciphers.2  = ECDHE-RSA-AES256-GCM-SHA384
definitions.tls.ciphers.3  = ECDH-ECDSA-AES256-GCM-SHA384
definitions.tls.ciphers.4  = ECDH-RSA-AES256-GCM-SHA384
definitions.tls.ciphers.5  = DHE-RSA-AES256-GCM-SHA384
definitions.tls.ciphers.6  = DHE-DSS-AES256-GCM-SHA384
definitions.tls.ciphers.7  = ECDHE-ECDSA-AES128-GCM-SHA256
definitions.tls.ciphers.8  = ECDHE-RSA-AES128-GCM-SHA256
definitions.tls.ciphers.9  = ECDH-ECDSA-AES128-GCM-SHA256
definitions.tls.ciphers.10 = ECDH-RSA-AES128-GCM-SHA256
definitions.tls.ciphers.11 = DHE-RSA-AES128-GCM-SHA256
definitions.tls.ciphers.12 = DHE-DSS-AES128-GCM-SHA256

```