### PR TITLE
Update buildbuddy toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,8 +14,6 @@ build:rbe --config=buildbuddy
 
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io
 
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 build:rbe --@rules_erlang//:erlang_home=/usr/lib/erlang
@@ -26,10 +24,6 @@ build:rbe --test_strategy=""
 build:rbe --jobs=100
 
 build:rbe-23 --config=rbe
-build:rbe-23 --host_javabase=@rbe_23//java:jdk
-build:rbe-23 --javabase=@rbe_23//java:jdk
-build:rbe-23 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe-23 --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
 build:rbe-23 --crosstool_top=@rbe_23//cc:toolchain
 build:rbe-23 --extra_toolchains=@rbe_23//config:cc-toolchain
 
@@ -40,8 +34,6 @@ build:rbe-23 --extra_execution_platforms=@rbe_23//config:platform
 build:rbe-23 --@rules_erlang//:erlang_version=23
 
 build:rbe-24 --config=rbe
-build:rbe-24 --host_javabase=@rbe_24//java:jdk
-build:rbe-24 --javabase=@rbe_24//java:jdk
 build:rbe-24 --crosstool_top=@rbe_24//cc:toolchain
 build:rbe-24 --extra_toolchains=@rbe_24//config:cc-toolchain
 

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -43,10 +43,6 @@ jobs:
 
           build:rbe-git --crosstool_top=@buildbuddy_toolchain//:toolchain
           build:rbe-git --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain
-          build:rbe-git --javabase=@buildbuddy_toolchain//:javabase_jdk8
-          build:rbe-git --host_javabase=@buildbuddy_toolchain//:javabase_jdk8
-          build:rbe-git --java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
-          build:rbe-git --host_java_toolchain=@buildbuddy_toolchain//:toolchain_jdk8
 
           build:rbe-git --host_platform=//:erlang_git_platform
           build:rbe-git --platforms=//:erlang_git_platform

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -16,9 +16,9 @@ rules_pkg_dependencies()
 
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "48546946879b1fd2dcba327ba15776c822f2ce9a9ef1077be9bf3ecadcc1564a",
-    strip_prefix = "buildbuddy-toolchain-b2f5e7e3b126c6d7cf243227147478c0959bfc95",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/b2f5e7e3b126c6d7cf243227147478c0959bfc95.zip"],
+    sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
+    strip_prefix = "buildbuddy-toolchain-829c8a574f706de5c96c54ca310f139f4acda7dd",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/829c8a574f706de5c96c54ca310f139f4acda7dd.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")


### PR DESCRIPTION
Updates the buildbuddy_toolchain bazel lib to the version in its readme and remove some build args that are deprecated in bazel 5