### PR TITLE
Fix performance regression when stream_queue feature is not enabled

### DIFF
--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -32,6 +32,7 @@
          credit/5,
          dequeue/5,
          fold_state/3,
+         find_name_from_pid/2,
          is_policy_applicable/2,
          is_server_named_allowed/1,
          notify_decorators/1
@@ -273,6 +274,11 @@ info(Q, Items) ->
 
 fold_state(Fun, Acc, #?STATE{ctxs = Ctxs}) ->
     maps:fold(Fun, Acc, Ctxs).
+
+%% slight hack to help provide backwards compatibility in the channel
+%% better than scanning the entire queue state
+find_name_from_pid(Pid, #?STATE{monitor_registry = Mons}) ->
+    maps:get(Pid, Mons, undefined).
 
 state_info(#ctx{state = S,
                 module = Mod}) ->


### PR DESCRIPTION
If the quorum_queue and stream_queue features are not enabled the
classic queues will use the old message format for confirms.

This causes the channel to scan its entire queue type state
map to find the queue name corresponding to the pid. Particularly
when using large ratio fan-outs (1:600) this could cause very poor
performance.

Luckily we can use the queue type's `monitor_registery` to get exactly the
information we need quickly which is what this change implements.

See https://groups.google.com/g/rabbitmq-users/c/1dwZTdhvUWk

perftest command used for testing:

```
perftest \
    --id regres8_3kb_1P_FANOUT_600excl_5m \
    --producers 1 \
    --consumers 600 \
    --size 3000 \
    --time 30 \
    --queue-pattern regres8_3kb_1P_FANOUT_600excl_5m-%d \
    --queue-pattern-from 1 \
    --queue-pattern-to 600 \
    --type fanout \
    --exclusive true \
    --heartbeat-sender-threads 30 \
    --producer-random-start-delay 10 \
    --confirm-timeout 120 \
    --qos 500 \
    --confirm 200 \
    --producer-channel-count 1 \
    --consumer-channel-count 1 \
    --flag false \
    --producer-schedule-threads 100 \
    --consumers-thread-pools  100 \
    --shutdown-timeout 60 \
    --auto-delete true
```

AC: 

1. start broker without any feature flags enabled. e.g. `gmake run-broker PLUGINS="rabbitmq_management" RABBITMQ_FEATURE_FLAGS=`

2. test throughput of above command on master and compare to this branch.