### PR TITLE
Use rules_erlang 2.1.0

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -59,9 +59,9 @@ rules_pkg_dependencies()
 
 http_archive(
     name = "rules_erlang",
-    sha256 = "7fd0564918537eb72294d17f5f8dc663907b16d712773b1c006e83194746a1c0",
-    strip_prefix = "rules_erlang-2.0.0",
-    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/2.0.0.zip"],
+    sha256 = "d4c95e77a4fae33c70a13ebab032a00e55cca7429c44b3ce062fa6ae64662e4c",
+    strip_prefix = "rules_erlang-2.1.0",
+    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/2.1.0.zip"],
 )
 
 load("@rules_erlang//:rules_erlang.bzl", "rules_erlang_dependencies")


### PR DESCRIPTION
Adopts the latest rules_erlang, which contains windows related fixes