### PR TITLE
Remove lines that do not apply to modern Erlang

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -13,9 +13,6 @@
 
 -ignore_xref({rabbit_direct, force_event_refresh, 1}).
 -ignore_xref({rabbit_networking, force_connection_event_refresh, 1}).
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
 
 -behaviour(application).
 


### PR DESCRIPTION
as all releases require at least Erlang/OTP 22+