### PR TITLE
Oauth2 plugin configuration additional_scopes_key is not converted to the correct Erlang App Config

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -19,17 +19,17 @@
  fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.resource_server_id", Conf))
  end}.
 
-%% Configure the plugin to also look in other fields using additional_scopes_key (maps to additional_rabbitmq_scopes in the old format)
+%% Configure the plugin to also look in other fields using additional_scopes_key (maps to extra_scopes_source in the old format)
 %%
 %% {additional_rabbitmq_scopes, <<"my_custom_scope_key">>},
 
 {mapping,
  "auth_oauth2.additional_scopes_key",
- "rabbitmq_auth_backend_oauth2.additional_rabbitmq_scopes",
+ "rabbitmq_auth_backend_oauth2.extra_scopes_source",
  [{datatype, string}]}.
 
 {translation,
- "rabbitmq_auth_backend_oauth2.additional_rabbitmq_scopes",
+ "rabbitmq_auth_backend_oauth2.extra_scopes_source",
  fun(Conf) ->
     list_to_binary(cuttlefish:conf_get("auth_oauth2.additional_scopes_key", Conf))
  end}.

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -17,7 +17,7 @@
         [
         {rabbitmq_auth_backend_oauth2, [
             {resource_server_id,<<"new_resource_server_id">>},
-            {additional_rabbitmq_scopes, <<"my_custom_scope_key">>},
+            {extra_scopes_source, <<"my_custom_scope_key">>},
             {key_config, [
             {default_key, <<"id1">>},
             {signing_keys,


### PR DESCRIPTION
## Proposed Changes

Hi,

When the config mapping file was created the config key "auth_oauth2.additional_scopes_key" was mapped to "additional_rabbitmq_scopes", instead of "extra_scopes_source". 

"additional_rabbitmq_scopes" is not used anywhere in the plugin, and the description provided fits "extra_scopes_source".


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it


