### PR TITLE
Allocate less memory when invoking lqueue functions

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -494,6 +494,13 @@ suites = [
             "@syslog//:erlang_app",
         ],
     ),
+    rabbitmq_suite(
+        name = "lqueue_SUITE",
+        size = "small",
+        deps = [
+            "@proper//:erlang_app",
+        ],
+    ),
     rabbitmq_integration_suite(
         PACKAGE,
         name = "maintenance_mode_SUITE",

--- a/deps/rabbit/src/lqueue.erl
+++ b/deps/rabbit/src/lqueue.erl
@@ -7,6 +7,8 @@
 
 -module(lqueue).
 
+-compile({no_auto_import,[get/1]}).
+
 %% Most functions in lqueue were copied from OTP's queue module
 %% and amended to maintain the length of the queue.
 %% lqueue implements a subset of Erlang's queue module.
@@ -18,7 +20,7 @@
 %% Original style API
 -export([in/2, in_r/2, out/1, out_r/1]).
 %% Less garbage style API
--export([peek/1, peek_r/1, drop/1]).
+-export([get/1, get_r/1, peek/1, peek_r/1, drop/1]).
 %% Higher level API
 -export([join/2, fold/3]).
 
@@ -197,6 +199,55 @@ out_r({L, {In, Out}})
   when is_integer(L), L >= 0, is_list(In), is_list(Out) ->
     out_r({L, In, Out});
 out_r(Q) ->
+    erlang:error(badarg, [Q]).
+
+%%--------------------------------------------------------------------------
+%% Less garbage style API.
+
+%% Return the first element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec get(Q :: ?MODULE(Item)) -> Item.
+get({0, [], []} = Q) ->
+    erlang:error(empty, [Q]);
+get({L, R, F})
+  when is_integer(L), L > 0, is_list(R), is_list(F) ->
+    get(R, F);
+%% accept deprecated state
+get({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    get({L, R, F});
+get(Q) ->
+    erlang:error(badarg, [Q]).
+
+-spec get(list(), list()) -> term().
+get(R, [H|_])
+  when is_list(R) ->
+    H;
+get([H], []) ->
+    H;
+get([_|R], []) -> % malformed queue -> O(len(Q))
+    lists:last(R).
+
+%% Return the last element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec get_r(Q :: ?MODULE(Item)) -> Item.
+get_r({0, [], []} = Q) ->
+    erlang:error(empty, [Q]);
+get_r({L, [H|_], F})
+  when is_integer(L), L > 0, is_list(F) ->
+    H;
+get_r({1, [], [H]}) ->
+    H;
+get_r({L, [], [_|F]}) % malformed queue -> O(len(Q))
+  when is_integer(L), L > 0 ->
+    lists:last(F);
+%% accept deprecated state
+get_r({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    get_r({L, R, F});
+get_r(Q) ->
     erlang:error(badarg, [Q]).
 
 %% Return the first element in the queue

--- a/deps/rabbit/src/lqueue.erl
+++ b/deps/rabbit/src/lqueue.erl
@@ -7,96 +7,333 @@
 
 -module(lqueue).
 
-%% lqueue implements a subset of Erlang's queue module. lqueues
-%% maintain their own length, so lqueue:len/1
+%% Most functions in lqueue were copied from OTP's queue module
+%% and amended to maintain the length of the queue.
+%% lqueue implements a subset of Erlang's queue module.
+%% lqueues maintain their own length, so lqueue:len/1
 %% is an O(1) operation, in contrast with queue:len/1 which is O(n).
 
--export([new/0, is_empty/1, len/1, in/2, in_r/2, out/1, out_r/1, join/2,
-         foldl/3, foldr/3, from_list/1, drop/1, to_list/1, peek/1, peek_r/1]).
-
--define(QUEUE, queue).
+%% Creation, inspection and conversion
+-export([new/0, is_empty/1, len/1, to_list/1, from_list/1]).
+%% Original style API
+-export([in/2, in_r/2, out/1, out_r/1]).
+%% Less garbage style API
+-export([peek/1, peek_r/1, drop/1]).
+%% Higher level API
+-export([join/2, fold/3]).
 
 -export_type([
               ?MODULE/0,
               ?MODULE/1
              ]).
 
--opaque ?MODULE() :: ?MODULE(_).
--opaque ?MODULE(T) :: {non_neg_integer(), queue:queue(T)}.
--type value()     :: any().
--type result(T)    :: 'empty' | {'value', T}.
+%%--------------------------------------------------------------------------
+%% Efficient implementation of double ended fifo queues
+%%
+%% Queue representation
+%%
+%% {Length,RearList,FrontList}
+%%
+%% The first element in the queue is at the head of the FrontList
+%% The last element in the queue is at the head of the RearList,
+%% that is; the RearList is reversed.
 
--spec new() -> ?MODULE(_).
+%% For backwards compatibility, lqueue functions accept old state, but return only new state.
+%% Compared to the deprecated state, the new state creates less garbage per queue operation:
+%% 4 = erts_debug:size({0, [], []}).
+%% 6 = erts_debug:size({0, {[], []}}).
+-define(STATE(T),{
+                Length :: non_neg_integer(),
+                Rear :: list(T), Front :: list(T)
+               }).
+-define(DEPRECATED_STATE(T),{
+                           Length :: non_neg_integer(),
+                           %% queue:queue(T)}
+                           {Rear :: list(T), Front :: list(T)}
+                          }).
+-type ?MODULE() :: ?MODULE(_).
+-opaque ?MODULE(T) :: ?STATE(T) | ?DEPRECATED_STATE(T).
 
-new() -> {0, ?QUEUE:new()}.
+%% Creation, inspection and conversion
 
--spec drop(?MODULE(T)) -> ?MODULE(T).
+%% O(1)
+-spec new() -> ?MODULE().
+new() -> {0, [], []}.
 
-drop({L, Q}) -> {L - 1, ?QUEUE:drop(Q)}.
+%% O(1)
+-spec is_empty(Q :: ?MODULE()) -> boolean().
+is_empty({0, [], []}) ->
+    true;
+is_empty({L, R, F})
+  when is_integer(L), L > 0, is_list(R), is_list(F) ->
+    false;
+%% accept deprecated state
+is_empty({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    is_empty({L, R, F});
+is_empty(Q) ->
+    erlang:error(badarg, [Q]).
 
--spec is_empty(?MODULE(_)) -> boolean().
+%% O(1)
+-spec len(Q :: ?MODULE()) -> non_neg_integer().
+len({L, R, F})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    L;
+%% accept deprecated state
+len({L, _Q})
+  when is_integer(L), L >= 0 ->
+    L;
+len(Q) ->
+    erlang:error(badarg, [Q]).
 
-is_empty({0, _Q}) -> true;
-is_empty(_)       -> false.
+%% O(len(Q))
+-spec to_list(Q :: ?MODULE(Item)) -> list(Item).
+to_list({L, R, F})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    F ++ lists:reverse(R, []);
+%% accept deprecated state
+to_list({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    to_list({L, R, F});
+to_list(Q) ->
+    erlang:error(badarg, [Q]).
 
--spec in(T, ?MODULE(T)) -> ?MODULE(T).
+%% Create queue from list
+%%
+%% O(length(L))
+-spec from_list(L :: list(Item)) -> ?MODULE(Item).
+from_list(L)
+  when is_list(L) ->
+    f2r(length(L), L);
+from_list(L) ->
+    erlang:error(badarg, [L]).
 
-in(V, {L, Q}) -> {L+1, ?QUEUE:in(V, Q)}.
+%%--------------------------------------------------------------------------
+%% Original style API
 
--spec in_r(value(), ?MODULE(T)) -> ?MODULE(T).
+%% Append to tail/rear
+%% Put at least one element in each list, if it is cheap
+%%
+%% O(1)
+-spec in(Item, Q1 :: ?MODULE(Item)) -> Q2 :: ?MODULE(Item).
+in(X, {1, [_] = In, []}) ->
+    {2, [X], In};
+in(X, {L, In, Out})
+  when is_integer(L), L >= 0, is_list(In), is_list(Out) ->
+    {L + 1, [X|In], Out};
+%% accept deprecated state
+in(X, {L, {In, Out}})
+  when is_integer(L), L >= 0, is_list(In), is_list(Out) ->
+    in(X, {L, In, Out});
+in(X, Q) ->
+    erlang:error(badarg, [X, Q]).
 
-in_r(V, {L, Q}) -> {L+1, ?QUEUE:in_r(V, Q)}.
+%% Prepend to head/front
+%% Put at least one element in each list, if it is cheap
+%%
+%% O(1)
+-spec in_r(Item, Q1 :: ?MODULE(Item)) -> Q2 :: ?MODULE(Item).
+in_r(X, {1, [], [_] = F}) ->
+    {2, F, [X]};
+in_r(X, {L, R, F})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    {L + 1, R, [X|F]};
+%% accept deprecated state
+in_r(X, {L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    in_r(X, {L, R, F});
+in_r(X, Q) ->
+    erlang:error(badarg, [X, Q]).
 
--spec out(?MODULE(T)) -> {result(T), ?MODULE(T)}.
+%% Take from head/front
+%%
+%% O(1) amortized, O(len(Q)) worst case
+-spec out(Q1 :: ?MODULE(Item)) ->
+    {{value, Item}, Q2 :: ?MODULE(Item)} |
+    {empty, Q1 :: ?MODULE(Item)}.
+out({0, [], []} = Q) ->
+    {empty, Q};
+out({1, [V], []}) ->
+    {{value, V}, {0, [], []}};
+out({L, [Y|In], []})
+  when is_integer(L), L > 0 ->
+    [V|Out] = lists:reverse(In, []),
+    {{value, V}, {L - 1, [Y], Out}};
+out({L, In, [V]})
+  when is_integer(L), L > 0, is_list(In) ->
+    {{value, V}, r2f(L - 1, In)};
+out({L, In, [V|Out]})
+  when is_integer(L), L > 0, is_list(In) ->
+    {{value, V}, {L - 1, In, Out}};
+%% accept deprecated state
+out({L, {In, Out}})
+  when is_integer(L), L >= 0, is_list(In), is_list(Out) ->
+    out({L, In, Out});
+out(Q) ->
+    erlang:error(badarg, [Q]).
 
-out({0, _Q} = Q) -> {empty, Q};
-out({L,  Q})     -> {Result, Q1} = ?QUEUE:out(Q),
-                    {Result, {L-1, Q1}}.
+%% Take from tail/rear
+%%
+%% O(1) amortized, O(len(Q)) worst case
+-spec out_r(Q1 :: ?MODULE(Item)) ->
+    {{value, Item}, Q2 :: ?MODULE(Item)} |
+    {empty, Q1 :: ?MODULE(Item)}.
+out_r({0, [], []} = Q) ->
+    {empty, Q};
+out_r({1, [], [V]}) ->
+    {{value, V}, {0, [], []}};
+out_r({L, [], [Y|Out]})
+  when is_integer(L), L > 0 ->
+    [V|In] = lists:reverse(Out, []),
+    {{value, V}, {L - 1, In, [Y]}};
+out_r({L, [V], Out})
+  when is_integer(L), L > 0, is_list(Out) ->
+    {{value, V}, f2r(L - 1, Out)};
+out_r({L, [V|In], Out})
+  when is_integer(L), L > 0, is_list(Out) ->
+    {{value, V}, {L - 1, In, Out}};
+%% accept deprecated state
+out_r({L, {In, Out}})
+  when is_integer(L), L >= 0, is_list(In), is_list(Out) ->
+    out_r({L, In, Out});
+out_r(Q) ->
+    erlang:error(badarg, [Q]).
 
--spec out_r(?MODULE(T)) -> {result(T), ?MODULE(T)}.
+%% Return the first element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec peek(Q :: ?MODULE(Item)) -> empty | {value, Item}.
+peek({0, [], []}) ->
+    empty;
+peek({L, R, [H|_]})
+  when is_integer(L), L > 0, is_list(R) ->
+    {value, H};
+peek({1, [H], []}) ->
+    {value, H};
+peek({L, [_|R], []}) % malformed queue -> O(len(Q))
+  when is_integer(L), L > 0 ->
+    {value, lists:last(R)};
+%% accept deprecated state
+peek({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    peek({L, R, F});
+peek(Q) ->
+    erlang:error(badarg, [Q]).
 
-out_r({0, _Q} = Q) -> {empty, Q};
-out_r({L,  Q})     -> {Result, Q1} = ?QUEUE:out_r(Q),
-                      {Result, {L-1, Q1}}.
+%% Return the last element in the queue
+%%
+%% O(1) since the queue is supposed to be well formed
+-spec peek_r(Q :: ?MODULE(Item)) -> empty | {value, Item}.
+peek_r({0, [], []}) ->
+    empty;
+peek_r({L, [H|_], F})
+  when is_integer(L), L > 0, is_list(F) ->
+    {value,H};
+peek_r({1, [], [H]}) ->
+    {value, H};
+peek_r({L, [], [_|R]}) % malformed queue -> O(len(Q))
+  when is_integer(L), L > 0 ->
+    {value, lists:last(R)};
+%% accept deprecated state
+peek_r({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    peek_r({L, R, F});
+peek_r(Q) ->
+    erlang:error(badarg, [Q]).
 
--spec join(?MODULE(A), ?MODULE(B)) -> ?MODULE(A | B).
+%% Remove the first element and return resulting queue
+%%
+%% O(1) amortized
+-spec drop(Q1 :: ?MODULE(Item)) -> Q2 :: ?MODULE(Item).
+drop({0, [], []} = Q) ->
+    erlang:error(empty, [Q]);
+drop({1, [_], []}) ->
+    {0, [], []};
+drop({L, [Y|R], []})
+  when is_integer(L), L > 0 ->
+    [_|F] = lists:reverse(R, []),
+    {L - 1, [Y], F};
+drop({L, R, [_]})
+  when is_integer(L), L > 0, is_list(R) ->
+    r2f(L - 1, R);
+drop({L, R, [_|F]})
+  when is_integer(L), L > 0, is_list(R) ->
+    {L - 1, R, F};
+%% accept deprecated state
+drop({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    drop({L, R, F});
+drop(Q) ->
+    erlang:error(badarg, [Q]).
 
-join({L1, Q1}, {L2, Q2}) -> {L1 + L2, ?QUEUE:join(Q1, Q2)}.
+%% Join two queues
+%%
+%% Q2 empty: O(1)
+%% else:     O(len(Q1))
+-spec join(Q1 :: ?MODULE(Item), Q2 :: ?MODULE(Item)) -> Q3 :: ?MODULE(Item).
+join({L, R, F} = Q, {0, [], []})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    Q;
+join({0, [], []}, {L, R, F} = Q)
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    Q;
+join({L1, R1, F1}, {L2, R2, F2})
+  when is_integer(L1), L1 >= 0, is_list(R1), is_list(F1),
+       is_integer(L2), L2 >= 0, is_list(R2), is_list(F2) ->
+    {L1 + L2, R2, F1 ++ lists:reverse(R1, F2)};
+%% accept deprecated state
+join({L, {R, F}}, Q)
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    join({L, R, F}, Q);
+join(Q, {L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
+    join(Q, {L, R, F});
+join(Q1, Q2) ->
+    erlang:error(badarg, [Q1,Q2]).
 
--spec to_list(?MODULE(T)) -> [T].
+%% Fold a function over a queue, in queue order.
+%%
+%% O(len(Q))
+-spec fold(Fun, Acc0, Q :: ?MODULE(Item)) -> Acc1 when
+      Fun :: fun((Item, AccIn) -> AccOut),
+                 Acc0 :: term(),
+                 Acc1 :: term(),
+                 AccIn :: term(),
+                 AccOut :: term().
+fold(Fun, Acc0, {L, R, F})
+  when is_integer(L), L >= 0, is_function(Fun, 2), is_list(R), is_list(F) ->
+    Acc1 = lists:foldl(Fun, Acc0, F),
+    lists:foldr(Fun, Acc1, R);
+%% accept deprecated state
+fold(Fun, Acc0, {L, {R, F}})
+  when is_integer(L), L >= 0, is_function(Fun, 2), is_list(R), is_list(F) ->
+    fold(Fun, Acc0, {L, R, F});
+fold(Fun, Acc0, Q) ->
+    erlang:error(badarg, [Fun, Acc0, Q]).
 
-to_list({_L, Q}) -> ?QUEUE:to_list(Q).
+%%--------------------------------------------------------------------------
+%% Internal workers
 
--spec from_list([T]) -> ?MODULE(T).
+-compile({inline, [r2f/2, f2r/2]}).
 
-from_list(L) -> {length(L), ?QUEUE:from_list(L)}.
+%% Move half of elements from R to F, if there are at least three
+r2f(0, []) ->
+    {0, [], []};
+r2f(1, [_] = R) ->
+    {1, [], R};
+r2f(2, [X, Y]) ->
+    {2, [X], [Y]};
+r2f(Len, List) ->
+    {FF, RR} = lists:split(Len div 2 + 1, List),
+    {Len, FF, lists:reverse(RR, [])}.
 
--spec foldl(fun ((T, B) -> B), B, ?MODULE(T)) -> B.
-
-foldl(Fun, Init, Q) ->
-    case out(Q) of
-        {empty, _Q}      -> Init;
-        {{value, V}, Q1} -> foldl(Fun, Fun(V, Init), Q1)
-    end.
-
--spec foldr(fun ((T, B) -> B), B, ?MODULE(T)) -> B.
-
-foldr(Fun, Init, Q) ->
-    case out_r(Q) of
-        {empty, _Q}      -> Init;
-        {{value, V}, Q1} -> foldr(Fun, Fun(V, Init), Q1)
-    end.
-
--spec len(?MODULE(_)) -> non_neg_integer().
-
-len({L, _}) -> L.
-
--spec peek(?MODULE(T)) -> result(T).
-
-peek({ 0, _Q}) -> empty;
-peek({_L,  Q}) -> ?QUEUE:peek(Q).
-
--spec peek_r(?MODULE(T)) -> result(T).
-
-peek_r({ 0, _Q}) -> empty;
-peek_r({_L,  Q}) -> ?QUEUE:peek_r(Q).
+%% Move half of elements from F to R, if there are enough
+f2r(0, []) ->
+    {0, [], []};
+f2r(1, [_] = F) ->
+    {1, F, []};
+f2r(2, [X, Y]) ->
+    {2, [Y], [X]};
+f2r(Len, List) ->
+    {FF, RR} = lists:split(Len div 2 + 1, List),
+    {Len, lists:reverse(RR, []), FF}.

--- a/deps/rabbit/src/lqueue.erl
+++ b/deps/rabbit/src/lqueue.erl
@@ -84,8 +84,8 @@ len({L, R, F})
   when is_integer(L), L >= 0, is_list(R), is_list(F) ->
     L;
 %% accept deprecated state
-len({L, _Q})
-  when is_integer(L), L >= 0 ->
+len({L, {R, F}})
+  when is_integer(L), L >= 0, is_list(R), is_list(F) ->
     L;
 len(Q) ->
     erlang:error(badarg, [Q]).

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1718,7 +1718,7 @@ handle_method(#'tx.commit'{}, _, #ch{tx = none}) ->
 
 handle_method(#'tx.commit'{}, _, State = #ch{tx      = {Deliveries, Acks},
                                              limiter = Limiter}) ->
-    State1 = queue_fold(fun deliver_to_queues/2, State, Deliveries),
+    State1 = ?QUEUE:fold(fun deliver_to_queues/2, State, Deliveries),
     Rev = fun (X) -> lists:reverse(lists:sort(X)) end,
     {State2, Actions2} =
         lists:foldl(fun ({ack,     A}, {Acc, Actions}) ->
@@ -2842,12 +2842,6 @@ get_operation_timeout_and_deadline() ->
     Timeout = ?CHANNEL_OPERATION_TIMEOUT,
     Deadline =  now_millis() + Timeout,
     {Timeout, Deadline}.
-
-queue_fold(Fun, Acc, Queue) ->
-    case ?QUEUE:out(Queue) of
-        {empty, _Queue}      -> Acc;
-        {{value, Item}, Queue1} -> queue_fold(Fun, Fun(Item, Acc), Queue1)
-    end.
 
 evaluate_consumer_timeout(State0 = #ch{cfg = #conf{channel = Channel,
                                                    consumer_timeout = Timeout},

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2847,16 +2847,16 @@ evaluate_consumer_timeout(State0 = #ch{cfg = #conf{channel = Channel,
                                                    consumer_timeout = Timeout},
                                        unacked_message_q = UAMQ}) ->
     Now = os:system_time(millisecond),
-    case ?QUEUE:peek(UAMQ) of
-        {value, #pending_ack{delivery_tag = ConsumerTag,
-                             delivered_at = Time}}
+    case ?QUEUE:get(UAMQ, empty) of
+        #pending_ack{delivery_tag = ConsumerTag,
+                     delivered_at = Time}
           when is_integer(Timeout)
                andalso Time < Now - Timeout ->
             rabbit_log_channel:warning("Consumer ~s on channel ~w has timed out "
                                        "waiting for delivery acknowledgement. Timeout used: ~p ms. "
                                        "This timeout value can be configured, see consumers doc guide to learn more",
                                        [rabbit_data_coercion:to_binary(ConsumerTag),
-                                       Channel, Timeout]),
+                                        Channel, Timeout]),
             Ex = rabbit_misc:amqp_error(precondition_failed,
                                         "delivery acknowledgement on channel ~w timed out. "
                                         "Timeout value used: ~p ms. "

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1705,10 +1705,7 @@ take_next_msg(#?MODULE{returns = Returns,
                        prefix_msgs = {NumR, R, NumP, P}} = State) ->
     %% use peek rather than out there as the most likely case is an empty
     %% queue
-    case lqueue:peek(Returns) of
-        {value, NextMsg} ->
-            {NextMsg,
-             State#?MODULE{returns = lqueue:drop(Returns)}};
+    case lqueue:get(Returns, empty) of
         empty when P == [] ->
             case lqueue:out(Messages0) of
                 {empty, _} ->
@@ -1726,7 +1723,10 @@ take_next_msg(#?MODULE{returns = Returns,
                 Header ->
                     {{'$prefix_msg', Header},
                      State#?MODULE{prefix_msgs = {NumR, R, NumP-1, Rem}}}
-            end
+            end;
+        NextMsg ->
+            {NextMsg,
+             State#?MODULE{returns = lqueue:drop(Returns)}}
     end.
 
 delivery_effect({CTag, CPid}, [], InMemMsgs) ->

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1484,15 +1484,12 @@ get_qs_head(Qs) ->
             end, undefined, Qs).
 
 get_q_head(Q) ->
-    get_collection_head(Q, fun ?QUEUE:is_empty/1, fun ?QUEUE:peek/1).
+    ?QUEUE:get(Q, undefined).
 
 get_pa_head(PA) ->
-    get_collection_head(PA, fun gb_trees:is_empty/1, fun gb_trees:smallest/1).
-
-get_collection_head(Col, IsEmpty, GetVal) ->
-    case IsEmpty(Col) of
+    case gb_trees:is_empty(PA) of
         false ->
-            {_, MsgStatus} = GetVal(Col),
+            {_, MsgStatus} = gb_trees:smallest(PA),
             MsgStatus;
         true  -> undefined
     end.
@@ -2842,9 +2839,9 @@ msg_from_pending_ack(SeqId, State) ->
     end.
 
 beta_limit(Q) ->
-    case ?QUEUE:peek(Q) of
-        {value, #msg_status { seq_id = SeqId }} -> SeqId;
-        empty                                   -> undefined
+    case ?QUEUE:get(Q, empty) of
+        #msg_status { seq_id = SeqId } -> SeqId;
+        empty -> undefined
     end.
 
 delta_limit(?BLANK_DELTA_PATTERN(_))              -> undefined;

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -2122,10 +2122,10 @@ fetch_by_predicate(Pred, Fun, FetchAcc,
 %% For the meaning of Fun and FetchAcc arguments see
 %% fetch_by_predicate/4 above.
 process_queue_entries(Q, Fun, FetchAcc, State = #vqstate{ next_deliver_seq_id = NextDeliverSeqId }) ->
-    ?QUEUE:foldl(fun (MsgStatus, Acc) ->
-                         process_queue_entries1(MsgStatus, Fun, Acc)
-                 end,
-                 {NextDeliverSeqId, FetchAcc, State}, Q).
+    ?QUEUE:fold(fun (MsgStatus, Acc) ->
+                        process_queue_entries1(MsgStatus, Fun, Acc)
+                end,
+                {NextDeliverSeqId, FetchAcc, State}, Q).
 
 process_queue_entries1(
   #msg_status { seq_id = SeqId } = MsgStatus,
@@ -2227,8 +2227,8 @@ purge_betas_and_deltas(DelsAndAcksFun, State = #vqstate { mode = Mode }) ->
 remove_queue_entries(Q, DelsAndAcksFun,
                      State = #vqstate{next_deliver_seq_id = NextDeliverSeqId0, msg_store_clients = MSCState}) ->
     {MsgIdsByStore, NextDeliverSeqId, Acks, State1} =
-        ?QUEUE:foldl(fun remove_queue_entries1/2,
-                     {maps:new(), NextDeliverSeqId0, [], State}, Q),
+        ?QUEUE:fold(fun remove_queue_entries1/2,
+                    {maps:new(), NextDeliverSeqId0, [], State}, Q),
     remove_vhost_msgs_by_id(MsgIdsByStore, MSCState),
     DelsAndAcksFun(NextDeliverSeqId, Acks, State1).
 

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -3319,8 +3319,8 @@ push_betas_to_deltas(Generator, LimitFun, Q, PushState) ->
         true ->
             {Q, PushState};
         false ->
-            {value, #msg_status { seq_id = MinSeqId }} = ?QUEUE:peek(Q),
-            {value, #msg_status { seq_id = MaxSeqId }} = ?QUEUE:peek_r(Q),
+            #msg_status { seq_id = MinSeqId } = ?QUEUE:get(Q),
+            #msg_status { seq_id = MaxSeqId } = ?QUEUE:get_r(Q),
             Limit = LimitFun(MinSeqId),
             case MaxSeqId < Limit of
                 true  -> {Q, PushState};

--- a/deps/rabbit/test/lqueue_SUITE.erl
+++ b/deps/rabbit/test/lqueue_SUITE.erl
@@ -1,0 +1,584 @@
+-module(lqueue_SUITE).
+
+-export([suite/0, all/0, groups/0,
+         init_per_suite/1, end_per_suite/1,
+         init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2
+        ]).
+
+-export([do/1, to_list/1, io_test/1, op_test/1, error/1, oops/1,
+         prop_from_list_to_list/1, prop_from_list_length/1,
+         prop_in_out/1, prop_join_fold/1, prop_fifo/1, prop_r/1,
+         deprecated_state/1, out_r_worst_case/1]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+suite() ->
+    [{timetrap,{minutes,1}}].
+
+all() ->
+    [{group, tests}].
+
+groups() ->
+    [{tests, [parallel],
+      [
+       %% copied from OTP's queue module
+       do,
+       to_list,
+       io_test,
+       op_test,
+       error,
+       oops,
+       %% property tests
+       prop_from_list_to_list,
+       prop_from_list_length,
+       prop_in_out,
+       prop_join_fold,
+       prop_fifo,
+       prop_r,
+       %% test old state to new state conversion
+       deprecated_state,
+       %% tests involving lists:reverse/2
+       out_r_worst_case
+      ]
+     }].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+do(Config) when is_list(Config) ->
+    L = [{in, 1},
+         {in, 2},
+         {out, {value, 1}},
+         {in, 3},
+         {out, {value, 2}},
+         {out, {value, 3}},
+         {out, empty}
+        ],
+
+    E = lqueue:new(),
+    [] = lqueue:to_list(E),
+    Q = do_queue(E, L),
+    true = lqueue:is_empty(Q),
+    0 = lqueue:len(Q),
+    ok.
+
+do_queue(Q, []) ->
+    Q;
+do_queue(Q, [E | Rest]) ->
+    do_queue(do_queue_1(E, Q), Rest).
+
+do_queue_1({in, E}, Q) ->
+    lqueue:in(E, Q);
+do_queue_1({out, E}, Q) ->
+    case lqueue:out(Q) of
+        {E, Q1} ->
+            Q1;
+        Other ->
+            ct:fail({"out failed", E, Q, Other})
+    end.
+
+%% OTP-2701
+to_list(Config) when is_list(Config) ->
+    E = lqueue:new(),
+    Q = do_queue(E, [{in, 1},
+                     {in, 2},
+                     {in, 3},
+                     {out, {value, 1}},
+                     {in, 4},
+                     {in, 5}]),
+    4 = lqueue:len(Q),
+    case lqueue:to_list(Q) of
+        [2,3,4,5] ->
+            ok;
+        Other1 ->
+            ct:fail(Other1)
+    end,
+    ok.
+
+
+%% Test input and output.
+io_test(Config) when is_list(Config) ->
+    E = lqueue:new(),
+    do_io_test(E),
+    ok.
+
+do_io_test(E) ->
+    [4,3,5] =
+	io([in,in,out,out,out,in_r,in_r,in], E, 1),
+    [5,3,4] =
+	io([in_r,in_r,out_r,out_r,out_r,in,in,in_r], E, 1),
+    %%
+    [] =
+	io([in,in,out,in,in,out,out,in,out,out], E, 1),
+    [] =
+	io([in_r,in_r,out_r,in_r,in_r,out_r,out_r,in_r,out_r,out_r],
+	   E, 1),
+    %%
+    [5,6] =
+	io([in,in,in,out,out,in,in,in,out,out], E, 1),
+    [6,5] =
+	io([in_r,in_r,in_r,out_r,out_r,in_r,in_r,in_r,out_r,out_r],
+	   E, 1),
+    %%
+    [5] =
+	io([in,out,out,in,out,in,out,in,out,in], E, 1),
+    [5] =
+	io([in_r,out_r,out_r,in_r,out_r,in_r,out_r,in_r,out_r,in_r],
+	   E, 1),
+    %%
+    [] =
+	io([in,out,in,in,out,out,in,in,in,out,out,out],
+	   E, 1),
+    [] =
+	io([in_r,out_r,in_r,in_r,out_r,out_r,in_r,in_r,in_r,out_r,out_r,out_r],
+	   E, 1),
+    %%
+    [3] =	io([in,in,in,in_r,out,out,out], E, 1),
+    [3] =	io([in_r,in_r,in_r,in,out_r,out_r,out_r], E, 1),
+    %%
+    [3] =
+	io([in,peek,peek_r,drop,in_r,peek,peek_r,in,peek,peek_r,drop], E, 1),
+    %% Malformed queues UGLY-GUTS-ALL-OVER-THE-PLACE
+    [2,1] = io([peek], {2,[1,2],[]}, 1),
+    [1,2] = io([peek_r], {2,[],[1,2]}, 1),
+    %%
+    ok.
+
+%% Perform a list of operations to a queue.
+%% Keep a reference queue on the side; just a list.
+%% Compare the read values between the queues.
+%% Return the resulting queue as a list.
+%% Inserted values are increments of the previously inserted.
+io(Ops, Q, X) ->
+    io(Ops, Q, lqueue:to_list(Q), X).
+
+io([out | Tail], Q, [], X) ->
+    {empty, Q1} = lqueue:out(Q),
+    io(Tail, Q1, [], X);
+io([out | Tail], Q, [H | T], X) ->
+    {{value,H}, Q1} = lqueue:out(Q),
+    io(Tail, Q1, T, X);
+io([out_r | Tail], Q, [], X) ->
+    {empty, Q1} = lqueue:out_r(Q),
+    io(Tail, Q1, [], X);
+io([out_r | Tail], Q, QQ, X) ->
+    {{value,H}, Q1} = lqueue:out_r(Q),
+    [H | T] = lists:reverse(QQ),
+    io(Tail, Q1, lists:reverse(T), X);
+io([in_r | Tail], Q, QQ, X) ->
+    io(Tail, lqueue:in_r(X,Q), [X|QQ], X+1);
+io([in | Tail], Q, QQ, X) ->
+    io(Tail, lqueue:in(X,Q), QQ++[X], X+1);
+io([peek | Tail], Q, [], X) ->
+    empty = lqueue:peek(Q),
+    io(Tail, Q, [], X);
+io([peek | Tail], Q, [H|_]=Q0, X) ->
+    {value,H} = lqueue:peek(Q),
+    io(Tail, Q, Q0, X);
+io([peek_r | Tail], Q, [], X) ->
+    empty = lqueue:peek_r(Q),
+    io(Tail, Q, [], X);
+io([peek_r | Tail], Q, Q0, X) ->
+    E = lists:last(Q0),
+    {value,E} = lqueue:peek_r(Q),
+    io(Tail, Q, Q0, X);
+io([drop | Tail], Q, [], X) ->
+    try lqueue:drop(Q) of
+        V ->
+            ct:fail({?MODULE,?LINE,V})
+    catch
+        error:empty ->
+            io(Tail, Q, [], X)
+    end;
+io([drop | Tail], Q, [_ | T], X) ->
+    Q1 = lqueue:drop(Q),
+    io(Tail, Q1, T, X);
+io([], Q, QQ, _X) ->
+    QQ = lqueue:to_list(Q),
+    Length = length(QQ),
+    Length = lqueue:len(Q),
+    QQ.
+
+%% Test operations on whole queues.
+op_test(Config) when is_list(Config) ->
+    do_op_test(fun id/1),
+    ok.
+
+do_op_test(F) ->
+    Len = 50,
+    Len2 = 2*Len,
+    L1 = lists:seq(1, Len),
+    L2 = lists:seq(Len+1, Len2),
+    L3 = L1++L2,
+    Q0 = F(lqueue:new()),
+    [] = lqueue:to_list(Q0),
+    Q0 = F(lqueue:from_list([])),
+    Q1 = F(lqueue:from_list(L1)),
+    Q2 = F(lqueue:from_list(L2)),
+    Q3 = F(lqueue:from_list(L3)),
+    Len = lqueue:len(Q1),
+    Len = lqueue:len(Q2),
+    Len2 = lqueue:len(Q3),
+    L1 = lqueue:to_list(Q1),
+    L2 = lqueue:to_list(Q2),
+    L3 = lqueue:to_list(Q3),
+    Q3b = lqueue:join(Q0, lqueue:join(lqueue:join(Q1, Q2), Q0)),
+    L3 = lqueue:to_list(Q3b),
+
+    FoldQ = lqueue:from_list(L1),
+    FoldExp1 = lists:sum(L1),
+    FoldAct1 = lqueue:fold(fun(X,A) -> X+A end, 0, FoldQ),
+    FoldExp1 = FoldAct1,
+    FoldExp2 = [X*X || X <- L1],
+    FoldAct2 = lqueue:fold(fun(X,A) -> [X*X|A] end, [], FoldQ),
+    FoldExp2 = lists:reverse(FoldAct2),
+    ok.
+
+%% Test queue errors.
+error(Config) when is_list(Config) ->
+    do_error(fun id/1, illegal_queue),
+    do_error(fun id/1, {[],illegal_queue}),
+    do_error(fun id/1, {illegal_queue,[17]}),
+    do_error(fun id/1, {-1, [],[]}),
+    do_error(fun id/1, {illegal_length, [],[]}),
+    do_error(fun id/1, {0, [],illegal_queue}),
+    do_error(fun id/1, {-1, {[],[]}}),
+    ok.
+
+trycatch(F, Args) ->
+    trycatch(lqueue, F, Args).
+
+trycatch(M, F, Args) ->
+    try apply(M, F, Args) of
+        V ->
+            ct:fail("expected error, got ~p", [V])
+    catch
+        C:R -> {C,R}
+    end.
+
+do_error(F, IQ) ->
+    io:format("Illegal Queue: ~p~n", [IQ]),
+    {error,badarg} = trycatch(in, [1, IQ]),
+    {error,badarg} = trycatch(out, [IQ]),
+    {error,badarg} = trycatch(drop, [IQ]),
+    {error,badarg} = trycatch(in_r ,[1, IQ]),
+    {error,badarg} = trycatch(out_r ,[IQ]),
+    {error,badarg} = trycatch(to_list ,[IQ]),
+    {error,badarg} = trycatch(from_list, [no_list]),
+    {error,badarg} = trycatch(is_empty, [IQ]),
+    {error,badarg} = trycatch(len, [IQ]),
+    {error,badarg} = trycatch(fold, [fun(_,_) -> ok end,0,IQ]),
+    {error,badarg} = trycatch(join, [F(lqueue:new()), IQ]),
+    {error,badarg} = trycatch(join, [IQ, F(lqueue:new())]),
+    {error,badarg} = trycatch(peek, [IQ]),
+    {error,badarg} = trycatch(peek_r, [IQ]),
+    ok.
+
+id(X) ->
+    X.
+
+%% Test queue errors.
+oops(Config) when is_list(Config) ->
+    N = 3142,
+    Optab = optab(),
+    Seed0 = rand:seed(exsplus, {1,2,4}),
+    {Is,Seed} = random_list(N, tuple_size(Optab), Seed0, []),
+    io:format("~p ", [Is]),
+    QA = lqueue:new(),
+    QB = {[]},
+    emul([QA], [QB], Seed, [element(I, Optab) || I <- Is]).
+
+optab() ->
+    {{new,[],        q,     fun ()     -> {[]} end},
+     {is_empty,[q],  v,     fun (Q) ->
+                                    case Q of
+                                        {[]} -> true;
+                                        _    -> false
+                                    end end},
+     {len,[q],       v,     fun ({L})   -> length(L) end},
+     {to_list,[q],   v,     fun ({L})   -> L end},
+     {from_list,[l], q,     fun (L)     -> {L} end},
+     {in,[t,q],      q,     fun (X,{L}) -> {L++[X]} end},
+     {in_r,[t,q],    q,     fun (X,{L}) -> {[X|L]} end},
+     {out,[q],       {v,q}, fun ({L}=Q) ->
+                                    case L of
+                                        []    -> {empty,Q};
+                                        [X|T] -> {{value,X},{T}}
+                                    end
+                            end},
+     {out_r,[q],     {v,q}, fun ({L}=Q) ->
+                                    case L of
+                                        []    -> {empty,Q};
+                                        _ ->
+                                            [X|R] = lists:reverse(L),
+                                            T = lists:reverse(R),
+                                            {{value,X},{T}}
+                                    end
+                            end},
+     {peek,[q],      v,     fun ({[]})    -> empty;
+                                ({[H|_]}) -> {value,H}
+                            end},
+     {peek_r,[q],    v,     fun ({[]})    -> empty;
+                                ({L})     -> {value,lists:last(L)}
+                            end},
+     {drop,[q],      q,     fun ({[]})    -> erlang:error(empty);
+                                ({[_|T]}) -> {T}
+                            end},
+     {join,[q,q],    q,     fun ({L1}, {L2}) -> {L1++L2} end}
+    }.
+
+emul(_, _, _, []) ->
+    ok;
+emul(QsA0, QsB0, Seed0, [{Op,Ts,S,Fun}|Ops]) ->
+    {AsA,Seed} = args(Ts, QsA0, Seed0, []),
+    {AsB,Seed} = args(Ts, QsB0, Seed0, []),
+    io:format("~n% ~w % ~p ", [Op,AsA]),
+    io:format("% ~p :", [AsB]),
+    XX = call({lqueue,Op}, AsA),
+    YY = call(Fun, AsB),
+    case {XX,YY} of
+        {{value,X},{value,Y}} ->
+            {[Qa|_]=QsA,[{Lb}|_]=QsB} = chk(QsA0, QsB0, S, X, Y),
+            case lqueue:to_list(Qa) of
+                Lb ->
+                    io:format("|~p| ", [Lb]),
+                    emul(QsA, QsB, Seed, Ops);
+                La ->
+                    throw({to_list,[XX,YY,Op,AsA,AsB,La,Lb]})
+            end;
+        {Exception,Exception} ->
+            io:format("!~p! ", [Exception]),
+            emul(QsA0, QsB0, Seed, Ops);
+        _ ->
+            throw({diff,[XX,YY,Op,AsA,AsB]})
+    end.
+
+args([], _, Seed, R) ->
+    {lists:reverse(R),Seed};
+args([q|Ts], [Q|Qs]=Qss, Seed, R) ->
+    args(Ts, if Qs =:= [] -> Qss; true -> Qs end, Seed, [Q|R]);
+args([l|Ts], Qs, Seed0, R) ->
+    {N,Seed1} = rand:uniform_s(17, Seed0),
+    {L,Seed} = random_list(N, 4711, Seed1, []),
+    args(Ts, Qs, Seed, [L|R]);
+args([t|Ts], Qs, Seed0, R) ->
+    {T,Seed} = rand:uniform_s(4711, Seed0),
+    args(Ts, Qs, Seed, [T|R]);
+args([n|Ts], Qs, Seed0, R) ->
+    {N,Seed} = rand:uniform_s(17, Seed0),
+    args(Ts, Qs, Seed, [N|R]).
+
+random_list(0, _, Seed, R) ->
+    {R,Seed};
+random_list(N, M, Seed0, R) ->
+    {X,Seed} = rand:uniform_s(M, Seed0),
+    random_list(N-1, M, Seed, [X|R]).
+
+call(Func, As) ->
+    try case Func of
+            {M,F} -> apply(M, F, As);
+            _     -> apply(Func, As)
+        end of
+        V ->
+            {value,V}
+    catch
+        Class:Reason ->
+            {Class,Reason}
+    end.
+
+chk(QsA, QsB, v, X, X) ->
+    io:format("<~p> ", [X]),
+    {QsA,QsB};
+chk(_, _, v, X, Y) ->
+    throw({diff,v,[X,Y]});
+chk(QsA, QsB, q, Qa, {Lb}=Qb) ->
+    case lqueue:to_list(Qa) of
+        Lb ->
+            io:format("|~p| ", [Lb]),
+            {[Qa|QsA],[Qb|QsB]};
+        La ->
+            throw({diff,q,[Qa,La,Lb]})
+    end;
+chk(QsA, QsB, T, X, Y)
+  when tuple_size(T) =:= tuple_size(X), tuple_size(T) =:= tuple_size(Y) ->
+    io:format("{"),
+    try
+        chk_tuple(QsA, QsB, T, X, Y, 1)
+    after
+        io:format("}")
+    end;
+chk(_, _, T, X, Y)
+  when is_tuple(T), is_tuple(X), is_tuple(Y) ->
+    throw({diff,T,[X,Y]}).
+
+chk_tuple(QsA, QsB, T, _, _, N) when N > tuple_size(T) ->
+    {QsA,QsB};
+chk_tuple(QsA0, QsB0, T, X, Y, N) ->
+    {QsA,QsB} = chk(QsA0, QsB0, element(N, T), element(N, X), element(N, Y)),
+    chk_tuple(QsA, QsB, T, X, Y, N+1).
+
+prop_from_list_to_list(_Config) ->
+    run_proper(fun() ->
+                       ?FORALL(List, list(),
+                               begin
+                                   equals(List,
+                                          lqueue:to_list(lqueue:from_list(List)))
+                               end)
+               end).
+
+prop_from_list_length(_Config) ->
+    run_proper(fun() ->
+                       ?FORALL(List, list(),
+                               begin
+                                   Q = lqueue:from_list(List),
+                                   equals(length(List), lqueue:len(Q))
+                               end)
+               end).
+
+prop_in_out(_Config) ->
+    run_proper(fun() ->
+                       ?FORALL({Ins0, Outs0},
+                               {
+                                resize(10_000, list(oneof([in, in_r]))),
+                                resize(10_000, list(oneof([out, out_r, drop])))
+                               },
+                               begin
+                                   Ins0Len = length(Ins0),
+                                   Outs0Len = length(Outs0),
+                                   Min = min(Ins0Len, Outs0Len),
+                                   %% Make Ins and Outs have same length
+                                   Ins = lists:nthtail(Ins0Len - Min, Ins0),
+                                   Outs = lists:nthtail(Outs0Len - Min, Outs0),
+                                   {Queue0, Min} = lists:foldl(
+                                                     fun(Op, {Q0, Len}) ->
+                                                             ?assertEqual(Len, lqueue:len(Q0)),
+                                                             Q = lqueue:Op(a, Q0),
+                                                             {Q, Len + 1}
+                                                     end, {lqueue:new(), 0}, Ins),
+                                   {Queue, 0} = lists:foldl(
+                                                  fun (Op, {Q0, Len}) ->
+                                                          ?assertEqual(Len, lqueue:len(Q0)),
+                                                          Q = case Op of
+                                                                  out ->
+                                                                      {{value, a}, Q1} = lqueue:out(Q0),
+                                                                      Q1;
+                                                                  out_r ->
+                                                                      {{value, a}, Q1} = lqueue:out_r(Q0),
+                                                                      Q1;
+                                                                  drop ->
+                                                                      lqueue:drop(Q0)
+                                                              end,
+                                                          {Q, Len-1}
+                                                  end, {Queue0, Min}, Outs),
+                                   lqueue:is_empty(Queue)
+                               end)
+               end).
+
+prop_join_fold(_Config) ->
+    run_proper(fun() ->
+                       ?FORALL({L1, L2}, {list(), list()},
+                               begin
+                                   L = L1 ++ L2,
+                                   Q = lqueue:join(
+                                         lqueue:from_list(L1),
+                                         lqueue:from_list(L2)
+                                        ),
+                                   ?assertEqual(length(L), lqueue:len(Q)),
+                                   It = lqueue:fold(fun(Elem, I) ->
+                                                            ?assertEqual(lists:nth(I, L), Elem),
+                                                            I + 1
+                                                    end, 1, Q),
+                                   equals(length(L), It - 1)
+                               end)
+               end).
+
+prop_fifo(_Config) ->
+    run_proper(fun() ->
+                       ?FORALL(List, list(),
+                               begin
+                                   Queue0 = lists:foldl(fun(E, Q0) ->
+                                                                lqueue:in(E, Q0)
+                                                        end, lqueue:new(), List),
+                                   ?assertEqual(length(List), lqueue:len(Queue0)),
+                                   Queue = lists:foldl(fun(E, Q0) ->
+                                                               {value, E} = lqueue:peek(Q0),
+                                                               {{value, E}, Q} = lqueue:out(Q0),
+                                                               ?assertMatch(Q, lqueue:drop(Q0)),
+                                                               Q
+                                                       end, Queue0, List),
+                                   ?assertEqual(empty, lqueue:peek(Queue)),
+                                   ?assertMatch({empty, Queue}, lqueue:out(Queue)),
+                                   ?assertError(empty, lqueue:drop(Queue)),
+                                   lqueue:is_empty(Queue)
+                               end)
+               end).
+
+prop_r(_Config) ->
+    run_proper(fun() ->
+                       ?FORALL(List, list(),
+                               begin
+                                   Queue0 = lists:foldl(fun(E, Q0) ->
+                                                                lqueue:in_r(E, Q0)
+                                                        end, lqueue:new(), List),
+                                   ?assertEqual(length(List), lqueue:len(Queue0)),
+                                   Queue = lists:foldl(fun(E, Q0) ->
+                                                               {value, E} = lqueue:peek_r(Q0),
+                                                               {{value, E}, Q} = lqueue:out_r(Q0),
+                                                               Q
+                                                       end, Queue0, List),
+                                   ?assertEqual(empty, lqueue:peek_r(Queue)),
+                                   ?assertMatch({empty, Queue}, lqueue:out_r(Queue)),
+                                   lqueue:is_empty(Queue)
+                               end)
+               end).
+
+run_proper(Fun) ->
+    ?assert(proper:counterexample(
+              Fun(),
+              [{numtests, 100},
+               {on_output, fun(".", _) -> ok; % don't print the '.'s on new lines
+                              (F, A) -> ct:pal(?LOW_IMPORTANCE, F, A)
+                           end}])).
+
+%% Test that functions accept deprecated state.
+deprecated_state(_Config) ->
+    OldState = {4, {[d,c], [a,b]}},
+    ?assertNot(lqueue:is_empty(OldState)),
+    ?assertEqual(4, lqueue:len(OldState)),
+    ?assertEqual([a,b,c,d], lqueue:to_list(OldState)),
+    ?assertEqual({value, a}, lqueue:peek(OldState)),
+    ?assertEqual({value, d}, lqueue:peek_r(OldState)),
+    ?assertEqual(4, lqueue:fold(fun(E, N) when is_atom(E) -> N+1 end, 0, OldState)),
+    %% convert to new state
+    ?assertEqual({5, [e,d,c], [a,b]}, lqueue:in(e, OldState)),
+    ?assertEqual({5, [d,c], [e,a,b]}, lqueue:in_r(e, OldState)),
+    ?assertEqual({{value, a}, {3, [d,c], [b]}}, lqueue:out(OldState)),
+    ?assertEqual({3, [d,c], [b]}, lqueue:drop(OldState)),
+    ?assertEqual({{value, d}, {3, [c], [a,b]}}, lqueue:out_r(OldState)),
+    ?assertEqual({5, [e], [a,b,c,d]}, lqueue:join(OldState, {1, {[e], []}})).
+
+out_r_worst_case(_Config) ->
+    Q0 = lqueue:in(a, lqueue:new()),
+    Q1 = lqueue:in_r(b, lqueue:new()),
+    Q2 = lqueue:join(Q0, Q1),
+    %% calls lists:reverse/2 internally
+    {{value, b}, Q3} = lqueue:out_r(Q2),
+    ?assertEqual(1, lqueue:len(Q3)).


### PR DESCRIPTION
Allocate 2 bytes less per `lqueue` operation by changing the `lqueue` state.

Old `lqueue` state:
```
6 = erts_debug:size({0, {[], []}}).
```

New `lqueue` state:
```
4 = erts_debug:size({0, [], []}).
```

This results in less garbage collection when `lqueue` functions are called many thousand times per second (as it is the case with quorum queues).

Before the change:
![page-faults-master](https://user-images.githubusercontent.com/12648310/152574303-289a261e-e8d3-4e63-983a-416af7bb3c54.svg)

Searching for `rabbit_fifo:take_next_msg` matches 1.5% of all page faults.

After the change:
![page-faults-lqueue](https://user-images.githubusercontent.com/12648310/152574326-e59041e2-3b61-4cd1-9120-1886e298ad34.svg)

Searching for `rabbit_fifo:take_next_msg` matches 1.0% of all page faults.

The flame graph was created by running the server:
```
RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+JPperf true +S 1" make run-broker TEST_TMPDIR="$HOME/scratch/rabbit" RABBITMQ_CONFIG_FILE="$HOME/scratch/advanced.config"
```
with following `advanced.config`:
```
[
  {rabbit, [{credit_flow_default_credit, {3200, 1600}},
            {quorum_commands_soft_limit, 256}]}
].
```
starting perf-test:
```
~/workspace/rabbitmq-perf-test$ ./target/rabbitmq-perf-test-2.17.0-SNAPSHOT/bin/runjava com.rabbitmq.perf.PerfTest -x 1 -y 1 -ad false -f persistent -qa "x-queue-type=quorum" -u q1
```
and recording the page faults:
```
sudo perf record -e page-faults -p $(cat $HOME/scratch/rabbit/rabbit@ubuntu/rabbit@ubuntu.pid) -g -- sleep 90
```

Function `lqueue:get/2` is added mainly for https://github.com/rabbitmq/rabbitmq-server/blob/aee6563d619f555a0b469e6a088a4b58e4c89d36/deps/rabbit/src/rabbit_fifo.erl#L1891-L1898 on branch https://github.com/rabbitmq/rabbitmq-server/tree/quorum-queues-v2 where we need to peek the queue for expired messages.

Disadvantage of this PR is that some functions are copied from Erlang OTP's `queue` module.