### PR TITLE
rabbitmqadmin: use port 15671 for SSL in help text

### DIFF
--- a/deps/rabbitmq_management/bin/rabbitmqadmin
+++ b/deps/rabbitmq_management/bin/rabbitmqadmin
@@ -265,7 +265,7 @@ def config_usage():
 
   [host_ssl]
   hostname = otherhost
-  port = 15672
+  port = 15671
   username = guest
   password = guest
   ssl = True
@@ -365,7 +365,7 @@ def make_parser():
         help="connect to host HOST",
         metavar="HOST")
     add("-P", "--port", dest="port",
-        help="connect to port PORT",
+        help="connect to port PORT (use 15671 for SSL)",
         metavar="PORT")
     add("--path-prefix", dest="path_prefix",
         help="use specific URI path prefix for the RabbitMQ HTTP API. /api and operation path will be appended to it. (default: blank string)")


### PR DESCRIPTION
Most users run HTTPS on 15671 instead of 15672. Improve the help text to
guide them to the right port setting.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it