### PR TITLE
Add option to choose payload encoding when manually publishing a message in the Management UI

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1064,7 +1064,6 @@ function publish_msg(params0) {
 
 function publish_msg0(params) {
     var path = fill_path_template('/exchanges/:vhost/:name/publish', params);
-    params['payload_encoding'] = 'string';
     params['properties'] = {};
     params['properties']['delivery_mode'] = parseInt(params['delivery_mode']);
     if (params['headers'] != '')

--- a/deps/rabbitmq_management/priv/www/js/tmpl/publish.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/publish.ejs
@@ -60,6 +60,15 @@
           <th><label>Payload:</label></th>
           <td><textarea name="payload"></textarea></td>
         </tr>
+        <tr>
+          <th><label>Payload encoding:</label></th>
+          <td>
+            <select name="payload_encoding">
+              <option value="string" selected>String (default)</option>
+              <option value="base64">Base64</option>
+            </select>
+          </td>
+        </tr>
       </table>
       <input type="submit" value="Publish message" />
     </form>


### PR DESCRIPTION
Hello everyone!

## Proposed Changes

This PR adds a new option to the form to manually publish messages in the Management UI to select the payload encoding in order to allow publishing non-string messages from the UI. 

![payload-encoding](https://user-images.githubusercontent.com/852259/153896337-9d45a012-916b-426b-87ce-3f8dd159cd71.png)

The HTTP API already supports publishing binary messages by encoding them in base64, but this feature is not exposed to the frontend. This change just adds a new field to the message publishing form (both on the `Exchanges` and `Queues` pages) to let the user select their preferred encoding.

This change is particularly useful if the messages you are working with have a non-text encoding like, in my case, ProtoBuf.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
