### PR TITLE
Add quorum_queue_prop_SUITE

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -657,6 +657,14 @@ rabbitmq_integration_suite(
     shard_count = 6,
 )
 
+rabbitmq_integration_suite(
+    name = "quorum_queue_prop_SUITE",
+    size = "large",
+    deps = [
+        "@proper//:erlang_app",
+    ],
+)
+
 rabbitmq_suite(
     name = "rabbit_confirms_SUITE",
     size = "small",

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2175,6 +2175,16 @@ deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{ex
                     ok
             end,
             State;
+        %% When sending to QQs we may get an error when the process shuts
+        %% down or gets killed. In that case we retry. We can retry safely
+        %% because we are sending to a single queue in this function clause.
+        %%
+        %% We do not need to worry about infinite loops because this
+        %% is only sent when the process exits.
+        {error, {shutdown, _}} ->
+            deliver_to_queues({Delivery, [QName]}, State0);
+        {error, {killed, _}} ->
+            deliver_to_queues({Delivery, [QName]}, State0);
         {error, {stream_not_found, Resource}} ->
             rabbit_misc:protocol_error(
               resource_error,

--- a/deps/rabbit/test/quorum_queue_prop_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_prop_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
--module(classic_queue_prop_SUITE).
+-module(quorum_queue_prop_SUITE).
 -compile(export_all).
 
 -define(NUM_TESTS, 500).
@@ -20,10 +20,9 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("proper/include/proper.hrl").
 
--record(cq, {
+-record(qq, {
     amq = undefined :: amqqueue:amqqueue(),
     name :: atom(),
-    version :: 1 | 2,
 
     %% We have one queue per way of publishing messages (such as channels).
     %% We can only confirm the publish order on a per-channel level because
@@ -73,18 +72,13 @@
 %% Common Test.
 
 all() ->
-    [{group, classic_queue_tests}, {group, classic_queue_regressions}].
+    [{group, quorum_queue_tests}].
 
 groups() ->
-    [{classic_queue_tests, [], [
-%        manual%,
-        classic_queue_v1,
-        classic_queue_v2
-     ]},
-     {classic_queue_regressions, [], [
-        reg_v1_full_recover_only_journal
-     ]}
-    ].
+    [{quorum_queue_tests, [], [
+%        manual
+        quorum_queue
+    ]}].
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -93,17 +87,13 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
-init_per_group(Group, Config) ->
+init_per_group(Group = quorum_queue_tests, Config) ->
     Config1 = rabbit_ct_helpers:set_config(Config, [
         {rmq_nodename_suffix, Group},
         {rmq_nodes_count, 1},
-        {erlang_node_config, [{rabbit, [
-            %% We make sure the server can handle fast-paced forced queue crashes
-            %% for the purpose of the tests.
-            {amqqueue_max_restart_intensity, {1000000, 1}},
-            %% We reduce the segment_entry_count values to make using multiple segments more likely.
-            {queue_index_segment_entry_count, 512},
-            {classic_queue_index_v2_segment_entry_count, 512}
+        {erlang_node_config, [{ra, [
+            %% We want Ra to stay alive when we kill a lot of Ra systems.
+            {ra_systems_sup_intensity, {1000000, 1}}
         ]}]}
       ]),
     Config2 = rabbit_ct_helpers:run_steps(Config1,
@@ -118,33 +108,33 @@ init_per_group(Group, Config) ->
         erlang, system_flag, [backtrace_depth, 16]),
     Config2.
 
-end_per_group(_, Config) ->
+end_per_group(quorum_queue_tests, Config) ->
     rabbit_ct_helpers:run_steps(Config,
       rabbit_ct_client_helpers:teardown_steps() ++
       rabbit_ct_broker_helpers:teardown_steps()).
 
 %% $ make -C deps/rabbit test-build
 %% $ erl -pa deps/rabbit/test
-%% > classic_queue_prop_SUITE:instrs_to_manual([[{init,...},...]]).
+%% > quorum_queue_prop_SUITE:instrs_to_manual([[{init,...},...]]).
 %% Paste into do_manual/1.
 %% Enable manual as the only test in groups/0.
-%% $ make -C deps/rabbit ct-classic_queue_prop
+%% $ make -C deps/rabbit ct-quorum_queue_prop
 instrs_to_manual([Instrs]) ->
     io:format("~ndo_manual(Config) ->~n~n"),
     lists:foreach(fun
-        ({init, CQ}) ->
-            #cq{name=Name, version=Version} = CQ,
-            io:format("    St0 = #cq{name=~0p, version=~0p,~n"
+        ({init, QQ}) ->
+            #qq{name=Name} = QQ,
+            io:format("    St0 = #qq{name=~0p,~n"
                       "              config=minimal_config(Config)},~n~n",
-                      [Name, Version]);
+                      [Name]);
         ({set, {var,Var}, {call, ?MODULE, cmd_setup_queue, _}}) ->
             Res = "Res" ++ integer_to_list(Var),
             PrevSt = "St" ++ integer_to_list(Var - 1),
             St = "St" ++ integer_to_list(Var),
-            io:format("    ~ts = cmd_setup_queue(~ts),~n"
-                      "    ~ts = ~ts#cq{amq=~ts},~n~n",
+            io:format("    ~s = cmd_setup_queue(~s),~n"
+                      "    ~s = ~s#qq{amq=~s},~n~n",
                       [Res, PrevSt, St, PrevSt, Res]);
-        ({set, {var,Var}, {call, ?MODULE, Cmd, [#cq{}|Args]}}) ->
+        ({set, {var,Var}, {call, ?MODULE, Cmd, [#qq{}|Args]}}) ->
             Res = "Res" ++ integer_to_list(Var),
             PrevSt = "St" ++ integer_to_list(Var - 1),
             St = "St" ++ integer_to_list(Var),
@@ -152,9 +142,9 @@ instrs_to_manual([Instrs]) ->
                                     {var,V} -> "Res" ++ integer_to_list(V);
                                     _ -> io_lib:format("~0p", [A])
                                 end] || A <- Args],
-            io:format("    ~ts = ~ts(~ts~ts),~n"
-                      "    true = postcondition(~ts, {call, undefined, ~ts, [~ts~ts]}, ~ts),~n"
-                      "    ~ts = next_state(~ts, ~ts, {call, undefined, ~ts, [~ts~ts]}),~n~n",
+            io:format("    ~s = ~s(~s~s),~n"
+                      "    true = postcondition(~s, {call, undefined, ~s, [~s~s]}, ~s),~n"
+                      "    ~s = next_state(~s, ~s, {call, undefined, ~s, [~s~s]}),~n~n",
                       [Res, Cmd, PrevSt, ExtraArgs,
                        PrevSt, Cmd, PrevSt, ExtraArgs, Res,
                        St, PrevSt, Res, Cmd, PrevSt, ExtraArgs]);
@@ -169,9 +159,9 @@ instrs_to_manual([Instrs]) ->
                 "" -> "";
                 ", " ++ ExtraArgs0 -> ExtraArgs0
             end,
-            io:format("    ~ts = ~ts(~ts),~n"
-                      "    true = postcondition(~ts, {call, undefined, ~ts, [~ts]}, ~ts),~n"
-                      "    ~ts = next_state(~ts, ~ts, {call, undefined, ~ts, [~ts]}),~n~n",
+            io:format("    ~s = ~s(~s),~n"
+                      "    true = postcondition(~s, {call, undefined, ~s, [~s]}, ~s),~n"
+                      "    ~s = next_state(~s, ~s, {call, undefined, ~s, [~s]}),~n~n",
                       [Res, Cmd, ExtraArgs,
                        PrevSt, Cmd, ExtraArgs, Res,
                        St, PrevSt, Res, Cmd, ExtraArgs])
@@ -191,24 +181,48 @@ manual(Config) ->
 %% - Add some timer:sleep(1) or longer between commands if delays are necessary.
 %% - If a shrunk set of commands isn't good enough, the original might.
 %% - Removing some steps can help understand the sequence of events leading to the problem.
+%do_manual(Config) ->
+%    Config =:= Config.
 do_manual(Config) ->
-    Config =:= Config.
 
-classic_queue_v1(Config) ->
+    St0 = #qq{name=prop_quorum_queue,
+              config=minimal_config(Config)},
+
+    Res1 = cmd_setup_queue(St0),
+    St1 = St0#qq{amq=Res1},
+
+    do_manual_loop(St1).
+
+do_manual_loop(St1) ->
+
+    Res2 = cmd_restart_vhost_clean(St1),
+    true = postcondition(St1, {call, undefined, cmd_restart_vhost_clean, [St1]}, Res2),
+    St2 = next_state(St1, Res2, {call, undefined, cmd_restart_vhost_clean, [St1]}),
+
+    Res3 = cmd_publish_msg(St2, 6, 2, false, undefined),
+    true = postcondition(St2, {call, undefined, cmd_publish_msg, [St2, 6, 2, false, undefined]}, Res3),
+    St3 = next_state(St2, Res3, {call, undefined, cmd_publish_msg, [St2, 6, 2, false, undefined]}),
+
+    Res4 = cmd_basic_get_msg(St3),
+    true = postcondition(St3, {call, undefined, cmd_basic_get_msg, [St3]}, Res4),
+    St4 = next_state(St3, Res4, {call, undefined, cmd_basic_get_msg, [St3]}),
+
+    Res5 = cmd_publish_msg(St4, 12, 1, true, undefined),
+    true = postcondition(St4, {call, undefined, cmd_publish_msg, [St4, 12, 1, true, undefined]}, Res5),
+    St5 = next_state(St4, Res5, {call, undefined, cmd_publish_msg, [St4, 12, 1, true, undefined]}),
+
+    Res6 = cmd_basic_get_msg(St5),
+    true = postcondition(St5, {call, undefined, cmd_basic_get_msg, [St5]}, Res6),
+    St6 = next_state(St5, Res6, {call, undefined, cmd_basic_get_msg, [St5]}),
+
+    do_manual_loop(St6).
+
+quorum_queue(Config) ->
     true = rabbit_ct_broker_helpers:rpc(Config, 0,
-        ?MODULE, do_classic_queue_v1, [Config]).
+        ?MODULE, do_quorum_queue, [Config]).
 
-do_classic_queue_v1(Config) ->
-    true = proper:quickcheck(prop_classic_queue_v1(Config),
-                             [{on_output, on_output_fun()},
-                              {numtests, ?NUM_TESTS}]).
-
-classic_queue_v2(Config) ->
-    true = rabbit_ct_broker_helpers:rpc(Config, 0,
-        ?MODULE, do_classic_queue_v2, [Config]).
-
-do_classic_queue_v2(Config) ->
-    true = proper:quickcheck(prop_classic_queue_v2(Config),
+do_quorum_queue(Config) ->
+    true = proper:quickcheck(prop_quorum_queue(Config),
                              [{on_output, on_output_fun()},
                               {numtests, ?NUM_TESTS}]).
 
@@ -216,32 +230,28 @@ on_output_fun() ->
     fun (".", _) -> ok; % don't print the '.'s on new lines
         ("!", _) -> ok;
         ("~n", _) -> ok; % don't print empty lines; CT adds many to logs already
-        ("~w~n", A) -> logger:error("~tp~n", [A]); % make sure this gets sent to the terminal, it's important
+        ("~w~n", A) -> logger:error("~p~n", [A]); % make sure this gets sent to the terminal, it's important
         (F, A) -> io:format(F, A)
     end.
 
 %% Properties.
 
-prop_classic_queue_v1(Config) ->
+prop_quorum_queue(Config) ->
     {ok, LimiterPid} = rabbit_limiter:start_link(no_id),
-    InitialState = #cq{name=?FUNCTION_NAME, version=1,
-                       config=minimal_config(Config), limiter=LimiterPid},
-    prop_common(InitialState).
-
-prop_classic_queue_v2(Config) ->
-    {ok, LimiterPid} = rabbit_limiter:start_link(no_id),
-    InitialState = #cq{name=?FUNCTION_NAME, version=2,
+    InitialState = #qq{name=?FUNCTION_NAME,
                        config=minimal_config(Config), limiter=LimiterPid},
     prop_common(InitialState).
 
 prop_common(InitialState) ->
     ?FORALL(Commands, commands(?MODULE, InitialState),
-        ?TRAPEXIT(begin
+        ?TRAPEXIT(try
             {History, State, Result} = run_commands(?MODULE, Commands),
             cmd_teardown_queue(State),
-            ?WHENFAIL(logger:error("History: ~tp~nState: ~tp~nResult: ~tp",
+            ?WHENFAIL(logger:error("History: ~p~nState: ~p~nResult: ~p",
                                    [History, State, Result]),
                       aggregate(command_names(Commands), Result =:= ok))
+        catch C:E:S ->
+            logger:error("Crash: ~p:~p ~p", [C, E, S])
         end)
     ).
 
@@ -255,14 +265,14 @@ minimal_config(Config) ->
 
 %% Commands.
 
-command(St = #cq{amq=undefined}) ->
+command(St = #qq{amq=undefined}) ->
     {call, ?MODULE, cmd_setup_queue, [St]};
 command(St) ->
     ChannelCmds = case has_channels(St) of
         false -> [];
         true -> [
             {100, {call, ?MODULE, cmd_channel_confirm_mode, [channel(St)]}},
-            {100, {call, ?MODULE, cmd_channel_close, [channel(St)]}},
+%            {100, {call, ?MODULE, cmd_channel_close, [channel(St)]}},
             {900, {call, ?MODULE, cmd_channel_publish, [St, channel(St), integer(0, 1024*1024), integer(1, 2), boolean(), expiration()]}},
             {200, {call, ?MODULE, cmd_channel_publish_many, [St, channel(St), integer(2, 512), integer(0, 1024*1024), integer(1, 2), boolean(), expiration()]}},
             {900, {call, ?MODULE, cmd_channel_wait_for_confirms, [channel(St)]}},
@@ -281,10 +291,6 @@ command(St) ->
         %% These restart the vhost or the queue.
         {100, {call, ?MODULE, cmd_restart_vhost_clean, [St]}},
         {100, {call, ?MODULE, cmd_restart_queue_dirty, [St]}},
-        %% These change internal configuration.
-        { 10, {call, ?MODULE, cmd_set_v2_check_crc32, [boolean()]}},
-        %% These set policies.
-        { 50, {call, ?MODULE, cmd_set_version, [oneof([1, 2])]}},
         %% These are direct operations using internal functions.
         { 50, {call, ?MODULE, cmd_publish_msg, [St, integer(0, 1024*1024), integer(1, 2), boolean(), expiration()]}},
         { 50, {call, ?MODULE, cmd_basic_get_msg, [St]}},
@@ -300,17 +306,17 @@ expiration() ->
         integer(0, 100) %% Up to 0.1s to make it more likely to trigger dropping messages.
     ]).
 
-has_channels(#cq{channels=Channels}) ->
+has_channels(#qq{channels=Channels}) ->
     map_size(Channels) > 0.
 
-channel(#cq{channels=Channels}) ->
+channel(#qq{channels=Channels}) ->
     elements(maps:keys(Channels)).
 
 %% Next state.
 
 next_state(St, AMQ, {call, _, cmd_setup_queue, _}) ->
-    St#cq{amq=AMQ};
-next_state(St=#cq{q=Q0, confirmed=Confirmed, uncertain=Uncertain0, channels=Channels0}, AMQ, {call, _, cmd_restart_vhost_clean, _}) ->
+    St#qq{amq=AMQ};
+next_state(St=#qq{q=Q0, confirmed=Confirmed, uncertain=Uncertain0, channels=Channels0}, AMQ, {call, _, cmd_restart_vhost_clean, _}) ->
     %% Consider all consumers canceled when the vhost restarts.
     Channels = maps:map(fun (_, ChInfo) -> ChInfo#{consumer => none} end, Channels0),
     %% The status of persistent messages that were published before the vhost restart
@@ -323,8 +329,8 @@ next_state(St=#cq{q=Q0, confirmed=Confirmed, uncertain=Uncertain0, channels=Chan
         ChQUncertain = [Msg || Msg <- ChQL, not lists:member(Msg, Confirmed)],
         {ChQUncertain ++ UncertainAcc, QAcc#{Ch => queue:from_list(ChQConfirmed)}}
     end, {Uncertain0, #{}}, Q0),
-    St#cq{amq=AMQ, q=Q, restarted=true, uncertain=Uncertain, channels=Channels};
-next_state(St=#cq{q=Q0, confirmed=Confirmed, uncertain=Uncertain0}, AMQ, {call, _, cmd_restart_queue_dirty, _}) ->
+    St#qq{amq=AMQ, q=Q, restarted=true, uncertain=Uncertain, channels=Channels};
+next_state(St=#qq{q=Q0, confirmed=Confirmed, uncertain=Uncertain0}, AMQ, {call, _, cmd_restart_queue_dirty, _}) ->
     %% The status of persistent messages that were published before the queue crash
     %% is uncertain, unless the channel is in confirms mode and confirms
     %% were received.
@@ -337,17 +343,13 @@ next_state(St=#cq{q=Q0, confirmed=Confirmed, uncertain=Uncertain0}, AMQ, {call, 
         ChQUncertain = [Msg || Msg <- ChQL, not lists:member(Msg, Confirmed)],
         {ChQUncertain ++ UncertainAcc, QAcc#{Ch => queue:from_list(ChQConfirmed)}}
     end, {Uncertain0, #{}}, Q0),
-    St#cq{amq=AMQ, q=Q, restarted=true, crashed=true, uncertain=Uncertain};
-next_state(St, _, {call, _, cmd_set_v2_check_crc32, _}) ->
-    St;
-next_state(St, _, {call, _, cmd_set_version, [Version]}) ->
-    St#cq{version=Version};
-next_state(St=#cq{q=Q}, Msg, {call, _, cmd_publish_msg, _}) ->
+    St#qq{amq=AMQ, q=Q, restarted=true, crashed=true, uncertain=Uncertain};
+next_state(St=#qq{q=Q}, Msg, {call, _, cmd_publish_msg, _}) ->
     IntQ = maps:get(internal, Q, queue:new()),
-    St#cq{q=Q#{internal => queue:in(Msg, IntQ)}};
+    St#qq{q=Q#{internal => queue:in(Msg, IntQ)}};
 next_state(St, empty, {call, _, cmd_basic_get_msg, _}) ->
     St;
-next_state(St=#cq{q=Q, received=Received}, Msg, {call, _, cmd_basic_get_msg, _}) ->
+next_state(St=#qq{q=Q, received=Received}, Msg, {call, _, cmd_basic_get_msg, _}) ->
     %% When there are multiple active consumers we may receive
     %% messages out of order because the commands are not running
     %% in the same order as the messages sent to channels.
@@ -359,8 +361,8 @@ next_state(St=#cq{q=Q, received=Received}, Msg, {call, _, cmd_basic_get_msg, _})
     %%
     %% For all these reasons we remove messages regardless of where
     %% they are in the queue.
-    St#cq{q=delete_message(Q, Msg), received=[Msg|Received]};
-next_state(St=#cq{q=Q, uncertain=Uncertain0}, _, {call, _, cmd_purge, _}) ->
+    St#qq{q=delete_message(Q, Msg), received=[Msg|Received]};
+next_state(St=#qq{q=Q, uncertain=Uncertain0}, _, {call, _, cmd_purge, _}) ->
     %% The status of messages that were published before a purge
     %% is uncertain in the same way as for a vhost restart or a
     %% queue crash, because the purge command does not go through
@@ -369,32 +371,32 @@ next_state(St=#cq{q=Q, uncertain=Uncertain0}, _, {call, _, cmd_purge, _}) ->
     Uncertain = maps:fold(fun(_, ChQ, Acc) ->
         queue:to_list(ChQ) ++ Acc
     end, Uncertain0, Q),
-    St#cq{q=#{}, restarted=true, uncertain=Uncertain};
-next_state(St=#cq{channels=Channels}, Ch, {call, _, cmd_channel_open, _}) ->
-    St#cq{channels=Channels#{Ch => #{consumer => none, confirms => false}}};
-next_state(St=#cq{channels=Channels}, _, {call, _, cmd_channel_close, [Ch]}) ->
-    St#cq{channels=maps:remove(Ch, Channels)};
-next_state(St=#cq{q=Q, unconfirmed=Unconfirmed, channels=Channels}, _, {call, _, cmd_channel_confirm_mode, [Ch]}) ->
+    St#qq{q=#{}, restarted=true, uncertain=Uncertain};
+next_state(St=#qq{channels=Channels}, Ch, {call, _, cmd_channel_open, _}) ->
+    St#qq{channels=Channels#{Ch => #{consumer => none, confirms => false}}};
+next_state(St=#qq{channels=Channels}, _, {call, _, cmd_channel_close, [Ch]}) ->
+    St#qq{channels=maps:remove(Ch, Channels)};
+next_state(St=#qq{q=Q, unconfirmed=Unconfirmed, channels=Channels}, _, {call, _, cmd_channel_confirm_mode, [Ch]}) ->
     %% All persistent messages sent before we enabled confirm mode will not be
     %% confirmed retroactively. We therefore need to keep track of them to avoid
     %% marking them as confirmed later on.
     ChQ = maps:get(Ch, Q, queue:new()),
     Persistent = [Msg || Msg = #amqp_msg{props=#'P_basic'{delivery_mode=2}} <- queue:to_list(ChQ)],
     ChInfo = maps:get(Ch, Channels),
-    St#cq{unconfirmed=Persistent ++ Unconfirmed,
+    St#qq{unconfirmed=Persistent ++ Unconfirmed,
           channels=Channels#{Ch => ChInfo#{confirms => true}}};
-next_state(St=#cq{q=Q}, Msg, {call, _, cmd_channel_publish, [_, Ch|_]}) ->
+next_state(St=#qq{q=Q}, Msg, {call, _, cmd_channel_publish, [_, Ch|_]}) ->
     ChQ = maps:get(Ch, Q, queue:new()),
-    St#cq{q=Q#{Ch => queue:in(Msg, ChQ)}};
-next_state(St=#cq{q=Q}, Msgs0, {call, _, cmd_channel_publish_many, [_, Ch|_]}) ->
+    St#qq{q=Q#{Ch => queue:in(Msg, ChQ)}};
+next_state(St=#qq{q=Q}, Msgs0, {call, _, cmd_channel_publish_many, [_, Ch|_]}) ->
     %% We handle {var,_} specially here but it would work for cmd_channel_publish as well.
     Msgs = case is_list(Msgs0) of
         true -> Msgs0;
         false -> [Msgs0]
     end,
     ChQ = maps:get(Ch, Q, queue:new()),
-    St#cq{q=Q#{Ch => queue:from_list(queue:to_list(ChQ) ++ Msgs)}};
-next_state(St=#cq{q=Q, confirmed=Confirmed, unconfirmed=Unconfirmed}, _, {call, _, cmd_channel_wait_for_confirms, [Ch]}) ->
+    St#qq{q=Q#{Ch => queue:from_list(queue:to_list(ChQ) ++ Msgs)}};
+next_state(St=#qq{q=Q, confirmed=Confirmed, unconfirmed=Unconfirmed}, _, {call, _, cmd_channel_wait_for_confirms, [Ch]}) ->
     %% All messages sent on the channel were confirmed. We move them
     %% to the list of confirmed messages. We might end up with
     %% duplicates in the confirmed list because we might wait
@@ -404,10 +406,10 @@ next_state(St=#cq{q=Q, confirmed=Confirmed, unconfirmed=Unconfirmed}, _, {call, 
     ChQ = maps:get(Ch, Q, queue:new()),
     %% We only keep persistent messages. Messages in Confirmed are always persistent.
     Persistent = [Msg || Msg = #amqp_msg{props=#'P_basic'{delivery_mode=2}} <- queue:to_list(ChQ), not lists:member(Msg, Unconfirmed)],
-    St#cq{confirmed=Persistent ++ Confirmed};
+    St#qq{confirmed=Persistent ++ Confirmed};
 next_state(St, empty, {call, _, cmd_channel_basic_get, _}) ->
     St;
-next_state(St=#cq{q=Q, received=Received}, Msg, {call, _, cmd_channel_basic_get, _}) ->
+next_state(St=#qq{q=Q, received=Received}, Msg, {call, _, cmd_channel_basic_get, _}) ->
     %% When there are multiple active consumers we may receive
     %% messages out of order because the commands are not running
     %% in the same order as the messages sent to channels.
@@ -419,16 +421,16 @@ next_state(St=#cq{q=Q, received=Received}, Msg, {call, _, cmd_channel_basic_get,
     %%
     %% For all these reasons we remove messages regardless of where
     %% they are in the queue.
-    St#cq{q=delete_message(Q, Msg), received=[Msg|Received]};
-next_state(St=#cq{channels=Channels}, Tag, {call, _, cmd_channel_consume, [_, Ch]}) ->
+    St#qq{q=delete_message(Q, Msg), received=[Msg|Received]};
+next_state(St=#qq{channels=Channels}, Tag, {call, _, cmd_channel_consume, [_, Ch]}) ->
     ChInfo = maps:get(Ch, Channels),
-    St#cq{consumers=true, channels=Channels#{Ch => ChInfo#{consumer => Tag}}};
-next_state(St=#cq{channels=Channels}, _, {call, _, cmd_channel_cancel, [_, Ch]}) ->
+    St#qq{consumers=true, channels=Channels#{Ch => ChInfo#{consumer => Tag}}};
+next_state(St=#qq{channels=Channels}, _, {call, _, cmd_channel_cancel, [_, Ch]}) ->
     ChInfo = maps:get(Ch, Channels),
-    St#cq{channels=Channels#{Ch => ChInfo#{consumer => none}}};
+    St#qq{channels=Channels#{Ch => ChInfo#{consumer => none}}};
 next_state(St, none, {call, _, cmd_channel_receive_and_ack, _}) ->
     St;
-next_state(St=#cq{q=Q, acked=Acked}, Msg, {call, _, cmd_channel_receive_and_ack, _}) ->
+next_state(St=#qq{q=Q, acked=Acked}, Msg, {call, _, cmd_channel_receive_and_ack, _}) ->
     %% When there are multiple active consumers we may receive
     %% messages out of order because the commands are not running
     %% in the same order as the messages sent to channels.
@@ -440,33 +442,39 @@ next_state(St=#cq{q=Q, acked=Acked}, Msg, {call, _, cmd_channel_receive_and_ack,
     %%
     %% We do not need to add the message to both acked and received
     %% because we always check acked even when crashes occurred.
-    St#cq{q=delete_message(Q, Msg), acked=[Msg|Acked]};
+    St#qq{q=delete_message(Q, Msg), acked=[Msg|Acked]};
 next_state(St, _, {call, _, cmd_channel_receive_and_requeue, _}) ->
     St;
-next_state(St=#cq{q=Q, acked=Acked}, Msg, {call, _, cmd_channel_receive_and_discard, _}) ->
+next_state(St=#qq{q=Q, acked=Acked}, Msg, {call, _, cmd_channel_receive_and_discard, _}) ->
     %% Rejecting without requeing ends up acking the message
     %% (and possibly dead-lettering) so we handle it the same
     %% as normal acks.
-    St#cq{q=delete_message(Q, Msg), acked=[Msg|Acked]};
-next_state(St=#cq{q=Q, acked=Acked}, Msgs0, {call, _, cmd_channel_receive_many_and_ack_ooo, _}) ->
+    St#qq{q=delete_message(Q, Msg), acked=[Msg|Acked]};
+next_state(St=#qq{q=Q, acked=Acked}, Msgs0, {call, _, cmd_channel_receive_many_and_ack_ooo, _}) ->
     %% We handle {var,_} specially here but it would work for cmd_channel_receive_and_ack as well.
     Msgs = case is_list(Msgs0) of
         true -> Msgs0;
         false -> [Msgs0]
     end,
-    St#cq{q=lists:foldl(fun(Msg, QF) -> delete_message(QF, Msg) end, Q, Msgs), acked=Msgs ++ Acked};
+    St#qq{q=lists:foldl(fun(Msg, QF) -> delete_message(QF, Msg) end, Q, Msgs), acked=Msgs ++ Acked};
 next_state(St, _, {call, _, cmd_channel_receive_many_and_requeue_ooo, _}) ->
     St;
-next_state(St=#cq{q=Q, acked=Acked}, Msgs0, {call, _, cmd_channel_receive_many_and_discard_ooo, _}) ->
+next_state(St=#qq{q=Q, acked=Acked}, Msgs0, {call, _, cmd_channel_receive_many_and_discard_ooo, _}) ->
     %% We handle {var,_} specially here but it would work for cmd_channel_receive_and_discard as well.
     Msgs = case is_list(Msgs0) of
         true -> Msgs0;
         false -> [Msgs0]
     end,
-    St#cq{q=lists:foldl(fun(Msg, QF) -> delete_message(QF, Msg) end, Q, Msgs), acked=Msgs ++ Acked}.
+    St#qq{q=lists:foldl(fun(Msg, QF) -> delete_message(QF, Msg) end, Q, Msgs), acked=Msgs ++ Acked}.
 
 %% We remove at most one message anywhere in the queue.
-delete_message(Qs0, Msg) ->
+delete_message(Qs0, Msg0) ->
+    Msg = try element(1, Msg0) of
+        amqp_msg -> msg_without_headers(Msg0);
+        _ -> Msg0
+    catch _:_ ->
+        Msg0
+    end,
     {Qs, _} = maps:fold(fun
         (Ch, ChQ, {Qs1, true}) ->
             {Qs1#{Ch => ChQ}, true};
@@ -488,29 +496,29 @@ delete_message(Qs0, Msg) ->
 
 %% Preconditions.
 %%
-%% We cannot rely on the data found in #cq.q here because when we are
-%% in a symbolic context we cannot remove the messages from #cq.q
+%% We cannot rely on the data found in #qq.q here because when we are
+%% in a symbolic context we cannot remove the messages from #qq.q
 %% (since we are always getting a new {var,integer()}).
 
-precondition(#cq{amq=AMQ}, {call, _, cmd_restart_vhost_clean, _}) ->
+precondition(#qq{amq=AMQ}, {call, _, cmd_restart_vhost_clean, _}) ->
     AMQ =/= undefined;
-precondition(#cq{amq=AMQ}, {call, _, cmd_restart_queue_dirty, _}) ->
+precondition(#qq{amq=AMQ}, {call, _, cmd_restart_queue_dirty, _}) ->
     AMQ =/= undefined;
-precondition(#cq{channels=Channels}, {call, _, cmd_channel_confirm_mode, [Ch]}) ->
+precondition(#qq{channels=Channels}, {call, _, cmd_channel_confirm_mode, [Ch]}) ->
     %% Only enabled confirms if they were not already enabled.
     %% Otherwise it is a no-op so not a big problem but this
     %% reduces the quality of the test runs.
     maps:get(confirms, maps:get(Ch, Channels)) =:= false;
-precondition(#cq{channels=Channels}, {call, _, cmd_channel_wait_for_confirms, [Ch]}) ->
+precondition(#qq{channels=Channels}, {call, _, cmd_channel_wait_for_confirms, [Ch]}) ->
     %% Only wait for confirms when they were enabled.
     maps:get(confirms, maps:get(Ch, Channels)) =:= true;
-precondition(#cq{channels=Channels}, {call, _, Cmd, [_, Ch]}) when
+precondition(#qq{channels=Channels}, {call, _, Cmd, [_, Ch]}) when
         %% Using both consume and basic_get is non-deterministic.
         Cmd =:= cmd_channel_basic_get;
         %% Don't consume if we are already consuming on this channel.
         Cmd =:= cmd_channel_consume ->
     maps:get(consumer, maps:get(Ch, Channels)) =:= none;
-precondition(#cq{channels=Channels}, {call, _, Cmd, [_, Ch|_]}) when
+precondition(#qq{channels=Channels}, {call, _, Cmd, [_, Ch|_]}) when
         %% Only cancel/receive when we are already consuming on this channel.
         Cmd =:= cmd_channel_cancel; Cmd =:= cmd_channel_receive_and_ack;
         Cmd =:= cmd_channel_receive_and_requeue; Cmd =:= cmd_channel_receive_and_discard;
@@ -525,10 +533,6 @@ precondition(_, _) ->
 postcondition(_, {call, _, Cmd, _}, Q) when
         Cmd =:= cmd_setup_queue; Cmd =:= cmd_restart_vhost_clean; Cmd =:= cmd_restart_queue_dirty ->
     element(1, Q) =:= amqqueue;
-postcondition(_, {call, _, cmd_set_v2_check_crc32, _}, Res) ->
-    Res =:= ok;
-postcondition(#cq{amq=AMQ}, {call, _, cmd_set_version, [Version]}, _) ->
-    do_check_queue_version(AMQ, Version) =:= ok;
 postcondition(_, {call, _, cmd_publish_msg, _}, Msg) ->
     is_record(Msg, amqp_msg);
 postcondition(_, {call, _, cmd_purge, _}, Res) ->
@@ -553,27 +557,12 @@ postcondition(_, {call, _, cmd_channel_consume, _}, _) ->
     true;
 postcondition(_, {call, _, cmd_channel_cancel, _}, _) ->
     true;
-postcondition(St, {call, _, Cmd, Args}, empty) when
+postcondition(_, {call, _, Cmd, _}, empty) when
         Cmd =:= cmd_basic_get_msg; Cmd =:= cmd_channel_basic_get ->
-    Ch = case Cmd of
-        cmd_basic_get_msg -> internal;
-        cmd_channel_basic_get -> lists:nth(2, Args)
-    end,
-    %% We may get 'empty' if there are/were consumers and the messages are
-    %% in transit.
-    has_consumers(St) orelse
-    %% Due to the asynchronous nature of publishing it may be
-    %% possible to have published a message but an immediate basic.get
-    %% on a separate channel cannot retrieve it. In that case we accept
-    %% an empty return value only if the channel we are calling
-    %% basic.get on has no messages published and not consumed.
-    not queue_has_channel(St, Ch) orelse
-    %% When messages can expire they will never be removed from the
-    %% property state because we cannot know whether the message
-    %% will be received later on (it was in transit when it expired).
-    %% Therefore we accept an empty response if all messages
-    %% sent via this particular channel have an expiration.
-    queue_part_all_expired(St, Ch);
+    %% Some command have a lower priority in QQs so it is not
+    %% possible to accurately describe whether a basic.get will
+    %% return results or which results it would return.
+    true;
 postcondition(St, {call, _, Cmd, _}, Msg) when
         Cmd =:= cmd_basic_get_msg; Cmd =:= cmd_channel_basic_get ->
     %% When there are active consumers we may receive
@@ -627,13 +616,14 @@ postcondition(St, {call, _, Cmd, _}, Msgs) when
 
 %% This function returns 'true' when there was a consumer at some point
 %% even if consumers were recently cancelled or closed.
-has_consumers(#cq{consumers=Consumers}) ->
+has_consumers(#qq{consumers=Consumers}) ->
     Consumers.
 
-queue_has_channel(#cq{q=Q}, Ch) ->
+queue_has_channel(#qq{q=Q}, Ch) ->
     maps:is_key(Ch, Q).
 
-queue_head_has_msg(#cq{q=Qs}, Msg) ->
+queue_head_has_msg(#qq{q=Qs}, Msg0) ->
+    Msg = msg_without_headers(Msg0),
     maps:fold(fun
         (_, _, true) ->
             true;
@@ -656,7 +646,8 @@ queue_head_has_msg(#cq{q=Qs}, Msg) ->
             Res =:= true
     end, false, Qs).
 
-queue_has_msg(#cq{q=Qs}, Msg) ->
+queue_has_msg(#qq{q=Qs}, Msg0) ->
+    Msg = msg_without_headers(Msg0),
     maps:fold(fun
         (_, _, true) ->
             true;
@@ -664,7 +655,7 @@ queue_has_msg(#cq{q=Qs}, Msg) ->
             queue:member(Msg, ChQ)
     end, false, Qs).
 
-queue_part_all_expired(#cq{q=Qs}, Key) ->
+queue_part_all_expired(#qq{q=Qs}, Key) ->
     queue_all(fun(#amqp_msg{props=#'P_basic'{expiration=Expiration}}) ->
         Expiration =/= undefined
     end, maps:get(Key, Qs)).
@@ -674,13 +665,15 @@ queue_part_all_expired(#cq{q=Qs}, Key) ->
 %% vhost was restarting at the same time. Unfortunately the
 %% current implementation means that we cannot detect
 %% "receive, ack, receive again" errors after a restart.
-restarted_and_previously_acked(#cq{restarted=Restarted, acked=Acked}, Msg) ->
+restarted_and_previously_acked(#qq{restarted=Restarted, acked=Acked}, Msg0) ->
+    Msg = msg_without_headers(Msg0),
     Restarted andalso lists:member(Msg, Acked).
 
 %% Some messages may have been published but lost during the
 %% restart (without publisher confirms). Messages we are
 %% uncertain about are kept in a separate list after restart.
-restarted_and_uncertain_publish_status(#cq{uncertain=Uncertain}, Msg) ->
+restarted_and_uncertain_publish_status(#qq{uncertain=Uncertain}, Msg0) ->
+    Msg = msg_without_headers(Msg0),
     lists:member(Msg, Uncertain).
 
 %% We may receive messages that were previously received
@@ -690,32 +683,34 @@ restarted_and_uncertain_publish_status(#cq{uncertain=Uncertain}, Msg) ->
 %% "receive, ack, receive again" errors after a crash
 %% (because that's something we have to accept when
 %% crashes occur).
-crashed_and_previously_received(#cq{crashed=Crashed, received=Received}, Msg) ->
+crashed_and_previously_received(#qq{crashed=Crashed, received=Received}, Msg0) ->
+    Msg = msg_without_headers(Msg0),
     Crashed andalso lists:member(Msg, Received).
+
+%% We remove headers when checking for messages because quorum queues
+%% implement x-delivery-count and we cannot do a simple lists:member/2
+%% of the message when messages get resent and this value is increased.
+msg_without_headers(Msg=#amqp_msg{props=Props}) ->
+    Msg#amqp_msg{props=Props#'P_basic'{headers=undefined}}.
 
 %% Helpers.
 
-cmd_setup_queue(St=#cq{name=Name, version=Version}) ->
+cmd_setup_queue(St=#qq{name=Name}) ->
     ?DEBUG("~0p", [St]),
     IsDurable = true, %% We want to be able to restart the queue process.
     IsAutoDelete = false,
-    %% We cannot use args to set the version as the arguments override
-    %% the policies and we also want to test policy changes.
-    cmd_set_version(Version),
     Args = [
-%        {<<"x-queue-version">>, long, Version}
+        {<<"x-queue-type">>, longstr, <<"quorum">>}
     ],
     QName = rabbit_misc:r(<<"/">>, queue, iolist_to_binary([atom_to_binary(Name, utf8), $_,
                                                             integer_to_binary(erlang:unique_integer([positive]))])),
     {new, AMQ} = rabbit_amqqueue:declare(QName, IsDurable, IsAutoDelete, Args, none, <<"acting-user">>),
-    %% We check that the queue was creating with the right version.
-    ok = do_check_queue_version(AMQ, Version),
     AMQ.
 
-cmd_teardown_queue(St=#cq{amq=undefined}) ->
+cmd_teardown_queue(St=#qq{amq=undefined}) ->
     ?DEBUG("~0p", [St]),
     ok;
-cmd_teardown_queue(St=#cq{amq=AMQ, channels=Channels}) ->
+cmd_teardown_queue(St=#qq{amq=AMQ, channels=Channels}) ->
     ?DEBUG("~0p", [St]),
     %% We must close all channels since we will not be using them anymore.
     %% Otherwise we end up wasting resources and may hit per-(direct)-connection limits.
@@ -725,13 +720,18 @@ cmd_teardown_queue(St=#cq{amq=AMQ, channels=Channels}) ->
         || Ch <- maps:keys(Channels)],
     %% Then we can delete the queue.
     rabbit_amqqueue:delete(AMQ, false, false, <<"acting-user">>),
-    rabbit_policy:delete(<<"/">>, <<"queue-version-policy">>, <<"acting-user">>),
+    rabbit_policy:delete(<<"/">>, <<"queue-mode-version-policy">>, <<"acting-user">>),
     ok.
 
-cmd_restart_vhost_clean(St=#cq{amq=AMQ0}) ->
+cmd_restart_vhost_clean(St=#qq{amq=AMQ0}) ->
     ?DEBUG("~0p", [St]),
+%    Pid = whereis(element(1,rabbit_amqqueue:pid_of(AMQ0))),
+%    dbg:tracer(process, {fun (Msg, _) -> file:write_file("/tmp/out.txt", io_lib:format("~p~n", [Msg]), [append]) end, ok}),
+%    dbg:p(Pid, [m, p, s, r]),
+%    timer:sleep(1000),
     rabbit_amqqueue:stop(<<"/">>),
     {Recovered, []} = rabbit_amqqueue:recover(<<"/">>),
+    %% @todo This one doesn't do anything for quorum.
     rabbit_amqqueue:start(Recovered),
     %% We must lookup the new AMQ value because the state has changed,
     %% notably the pid of the queue process is now different.
@@ -739,57 +739,72 @@ cmd_restart_vhost_clean(St=#cq{amq=AMQ0}) ->
     %% We cannot use the AMQ found in Recovered directly because it is
     %% in 'stopped' state. We have to look up the most recent value.
     {ok, AMQ} = rabbit_amqqueue:lookup(amqqueue:get_name(AMQ0)),
-    AMQ.
+    Pid2 = whereis(element(1,rabbit_amqqueue:pid_of(AMQ0))),
+    do_wait_leader_ra_server(Pid2),
+%    dbg:p(Pid2, [m, p, s, r]),
+%    logger:error("cmd_restart_vhost_clean: ~p -> ~p", [Pid, Pid2]),
+    AMQ. %% @todo This doesn't change. We don't need to return it.
 
-cmd_restart_queue_dirty(St=#cq{amq=AMQ}) ->
+cmd_restart_queue_dirty(St=#qq{amq=AMQ}) ->
     ?DEBUG("~0p", [St]),
-    Pid = rabbit_amqqueue:pid_of(AMQ),
-    exit(Pid, kill),
-    %% We must lookup the new AMQ value because the state has changed,
-    %% notably the pid of the queue process is now different.
-    Res = do_wait_updated_amqqueue(amqqueue:get_name(AMQ), Pid),
+    Pid = whereis(element(1, rabbit_amqqueue:pid_of(AMQ))),
+    [{_, SystemSup, supervisor, _}] = [Child || Child={quorum_queues, _, _, _} <- supervisor:which_children(ra_systems_sup)],
+    AllPidsToKill = [SystemSup] ++ lists:flatten(do_get_all_system_pids(SystemSup)),
+    _ = [sys:suspend(P) || P <- AllPidsToKill],
+    _ = [exit(P, kill) || P <- AllPidsToKill],
+    do_wait_stopped_ra_server(Pid),
+    do_wait_started_ra_server_sup_sup(),
+    ok = ra:restart_server(quorum_queues, rabbit_amqqueue:pid_of(AMQ)),
+    %% We must wait for the new ra_server_proc to restart before
+    %% we can issue certain commands, like dirty restarts.
+    Pid2 = do_wait_restarted_ra_server(rabbit_amqqueue:pid_of(AMQ)),
+    do_wait_leader_ra_server(Pid2),
     %% We make the channels drop the pending confirms because
     %% they will be lost due to the crash.
-    #cq{channels=Channels} = St,
+    #qq{channels=Channels} = St,
     _ = [
         amqp_channel:wait_for_confirms(Ch, {1, second})
     || {Ch, #{confirms := true}} <- maps:to_list(Channels)],
-    Res.
+    AMQ. %% @todo This doesn't change. We don't need to return it.
 
-do_wait_updated_amqqueue(Name, Pid) ->
+do_get_all_system_pids(Sup) ->
+    [case Child of
+        {_, Pid, worker, _} -> Pid;
+        {_, Pid, supervisor, _} -> [Pid] ++ do_get_all_system_pids(Pid)
+    end || Child <- supervisor:which_children(Sup)].
+
+do_wait_stopped_ra_server(Pid) ->
     timer:sleep(1),
-    {ok, AMQ} = rabbit_amqqueue:lookup(Name),
-    case rabbit_amqqueue:pid_of(AMQ) of
-        Pid ->
-            do_wait_updated_amqqueue(Name, Pid);
-        _ ->
-            AMQ
+    case is_process_alive(Pid) of
+        true -> do_wait_stopped_ra_server(Pid);
+        false -> ok
     end.
 
-cmd_set_v2_check_crc32(Value) ->
-    application:set_env(rabbit, classic_queue_store_v2_check_crc32, Value).
-
-cmd_set_version(Version) ->
-    ?DEBUG("~0p ~0p", [Version]),
-    rabbit_policy:set(<<"/">>, <<"queue-version-policy">>, <<".*">>,
-        [{<<"queue-version">>, Version}],
-        0, <<"queues">>, <<"acting-user">>).
-
-%% We loop until the queue has switched version.
-do_check_queue_version(AMQ, Version) ->
-    do_check_queue_version(AMQ, Version, 1000).
-
-do_check_queue_version(_, _, 0) ->
-    error;
-do_check_queue_version(AMQ, Version, N) ->
+do_wait_started_ra_server_sup_sup() ->
     timer:sleep(1),
-    [{backing_queue_status, Status}] = rabbit_amqqueue:info(AMQ, [backing_queue_status]),
-    case proplists:get_value(version, Status) of
-        Version -> ok;
-        _ -> do_check_queue_version(AMQ, Version, N - 1)
+    case whereis(ra_server_sup_sup) of
+        undefined -> do_wait_started_ra_server_sup_sup();
+        _ -> ok
     end.
 
-cmd_publish_msg(St=#cq{amq=AMQ}, PayloadSize, DeliveryMode, Mandatory, Expiration) ->
+do_wait_restarted_ra_server(Name) ->
+    timer:sleep(1),
+    case whereis(element(1, Name)) of
+        undefined ->
+            do_wait_restarted_ra_server(Name);
+        RestartedPid ->
+            RestartedPid
+    end.
+
+do_wait_leader_ra_server(Pid) ->
+    case ra_server_proc:ping(Pid, 1000) of
+        {pong, leader} ->
+            ok;
+        {pong, follower} ->
+            do_wait_leader_ra_server(Pid)
+    end.
+
+cmd_publish_msg(St=#qq{amq=AMQ}, PayloadSize, DeliveryMode, Mandatory, Expiration) ->
     ?DEBUG("~0p ~0p ~0p ~0p ~0p", [St, PayloadSize, DeliveryMode, Mandatory, Expiration]),
     Payload = do_rand_payload(PayloadSize),
     Msg = rabbit_basic:message(rabbit_misc:r(<<>>, exchange, <<>>),
@@ -802,7 +817,7 @@ cmd_publish_msg(St=#cq{amq=AMQ}, PayloadSize, DeliveryMode, Mandatory, Expiratio
     {MsgProps, MsgPayload} = rabbit_basic_common:from_content(Msg#basic_message.content),
     #amqp_msg{props=MsgProps, payload=MsgPayload}.
 
-cmd_basic_get_msg(St=#cq{amq=AMQ, limiter=LimiterPid}) ->
+cmd_basic_get_msg(St=#qq{amq=AMQ, limiter=LimiterPid}) ->
     ?DEBUG("~0p", [St]),
     %% The second argument means that we will not be sending an ack message.
     Res = rabbit_amqqueue:basic_get(AMQ, true, LimiterPid,
@@ -816,14 +831,17 @@ cmd_basic_get_msg(St=#cq{amq=AMQ, limiter=LimiterPid}) ->
             #amqp_msg{props=MsgProps, payload=MsgPayload}
     end.
 
-cmd_purge(St=#cq{amq=AMQ}) ->
+cmd_purge(St=#qq{amq=AMQ}) ->
     ?DEBUG("~0p", [St]),
     rabbit_amqqueue:purge(AMQ).
 
-cmd_channel_open(St=#cq{config=Config}) ->
+cmd_channel_open(St=#qq{config=Config}) ->
     ?DEBUG("~0p", [St]),
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
-    rabbit_ct_client_helpers:open_channel(Config, Server).
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    rpc:call(node(Ch), dbg, tracer, [process, {fun (Msg, _) -> file:write_file("/tmp/out.txt", io_lib:format("~p~n", [Msg]), [append]) end, ok}]),
+    rpc:call(node(Ch), dbg, p, [Ch, [m, p, s, r]]),
+    Ch.
 
 cmd_channel_confirm_mode(Ch) ->
     ?DEBUG("~0p", [Ch]),
@@ -839,7 +857,7 @@ cmd_channel_close(Ch) ->
     %% So instead we close directly.
     amqp_channel:close(Ch).
 
-cmd_channel_publish(St=#cq{amq=AMQ}, Ch, PayloadSize, DeliveryMode, Mandatory, Expiration) ->
+cmd_channel_publish(St=#qq{amq=AMQ}, Ch, PayloadSize, DeliveryMode, Mandatory, Expiration) ->
     ?DEBUG("~0p ~0p ~0p ~0p ~0p ~0p", [St, Ch, PayloadSize, DeliveryMode, Mandatory, Expiration]),
     #resource{name = Name} = amqqueue:get_name(AMQ),
     Payload = do_rand_payload(PayloadSize),
@@ -860,7 +878,7 @@ cmd_channel_wait_for_confirms(Ch) ->
     ?DEBUG("~0p", [Ch]),
     amqp_channel:wait_for_confirms(Ch, {1, second}).
 
-cmd_channel_basic_get(St=#cq{amq=AMQ}, Ch) ->
+cmd_channel_basic_get(St=#qq{amq=AMQ}, Ch) ->
     ?DEBUG("~0p ~0p", [St, Ch]),
     #resource{name = Name} = amqqueue:get_name(AMQ),
     case amqp_channel:call(Ch, #'basic.get'{queue = Name, no_ack = true}) of
@@ -870,7 +888,7 @@ cmd_channel_basic_get(St=#cq{amq=AMQ}, Ch) ->
             Msg
     end.
 
-cmd_channel_consume(St=#cq{amq=AMQ}, Ch) ->
+cmd_channel_consume(St=#qq{amq=AMQ}, Ch) ->
     ?DEBUG("~0p ~0p", [St, Ch]),
     %% We register ourselves as a default consumer to avoid race conditions
     %% when we try to cancel the channel after the server has already canceled
@@ -885,7 +903,7 @@ cmd_channel_consume(St=#cq{amq=AMQ}, Ch) ->
     receive #'basic.consume_ok'{consumer_tag = Tag} -> ok end,
     Tag.
 
-cmd_channel_cancel(St=#cq{channels=Channels}, Ch) ->
+cmd_channel_cancel(St=#qq{channels=Channels}, Ch) ->
     ?DEBUG("~0p ~0p", [St, Ch]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     #'basic.cancel_ok'{} =
@@ -894,7 +912,7 @@ cmd_channel_cancel(St=#cq{channels=Channels}, Ch) ->
     %% We have to requeue the messages in transit to preserve ordering.
     do_receive_requeue_all(Ch, Tag).
 
-cmd_channel_receive_and_ack(St=#cq{channels=Channels}, Ch) ->
+cmd_channel_receive_and_ack(St=#qq{channels=Channels}, Ch) ->
     ?DEBUG("~0p ~0p", [St, Ch]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     receive
@@ -906,7 +924,7 @@ cmd_channel_receive_and_ack(St=#cq{channels=Channels}, Ch) ->
         none
     end.
 
-cmd_channel_receive_and_requeue(St=#cq{channels=Channels}, Ch) ->
+cmd_channel_receive_and_requeue(St=#qq{channels=Channels}, Ch) ->
     ?DEBUG("~0p ~0p", [St, Ch]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     receive
@@ -918,7 +936,7 @@ cmd_channel_receive_and_requeue(St=#cq{channels=Channels}, Ch) ->
         none
     end.
 
-cmd_channel_receive_and_discard(St=#cq{channels=Channels}, Ch) ->
+cmd_channel_receive_and_discard(St=#qq{channels=Channels}, Ch) ->
     ?DEBUG("~0p ~0p", [St, Ch]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     receive
@@ -930,7 +948,7 @@ cmd_channel_receive_and_discard(St=#cq{channels=Channels}, Ch) ->
         none
     end.
 
-cmd_channel_receive_many_and_ack_ooo(St=#cq{channels=Channels}, Ch, Num) ->
+cmd_channel_receive_many_and_ack_ooo(St=#qq{channels=Channels}, Ch, Num) ->
     ?DEBUG("~0p ~0p ~0p", [St, Ch, Num]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     do_cmd_channel_receive_many_and_ack_ooo_loop(Tag, Ch, Num, [], []).
@@ -948,7 +966,7 @@ do_cmd_channel_receive_many_and_ack_ooo_loop(Tag, Ch, Num, TagAcc, MsgAcc) ->
         do_cmd_channel_receive_many_and_ack_ooo_loop(Tag, Ch, 0, TagAcc, MsgAcc)
     end.
 
-cmd_channel_receive_many_and_requeue_ooo(St=#cq{channels=Channels}, Ch, Num) ->
+cmd_channel_receive_many_and_requeue_ooo(St=#qq{channels=Channels}, Ch, Num) ->
     ?DEBUG("~0p ~0p ~0p", [St, Ch, Num]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     do_cmd_channel_receive_many_and_requeue_ooo_loop(Tag, Ch, Num, [], []).
@@ -966,7 +984,7 @@ do_cmd_channel_receive_many_and_requeue_ooo_loop(Tag, Ch, Num, TagAcc, MsgAcc) -
         do_cmd_channel_receive_many_and_requeue_ooo_loop(Tag, Ch, 0, TagAcc, MsgAcc)
     end.
 
-cmd_channel_receive_many_and_discard_ooo(St=#cq{channels=Channels}, Ch, Num) ->
+cmd_channel_receive_many_and_discard_ooo(St=#qq{channels=Channels}, Ch, Num) ->
     ?DEBUG("~0p ~0p ~0p", [St, Ch, Num]),
     #{consumer := Tag} = maps:get(Ch, Channels),
     do_cmd_channel_receive_many_and_discard_ooo_loop(Tag, Ch, Num, [], []).
@@ -1090,38 +1108,3 @@ queue_fold(Fun, Acc0, {R, F}) when is_function(Fun, 2), is_list(R), is_list(F) -
     lists:foldr(Fun, Acc1, R);
 queue_fold(Fun, Acc0, Q) ->
     erlang:error(badarg, [Fun, Acc0, Q]).
-
-%% Regression tests.
-%%
-%% These tests are hard to reproduce by running the test suite normally
-%% because they require a very specific sequence of events.
-
-reg_v1_full_recover_only_journal(Config) ->
-    true = rabbit_ct_broker_helpers:rpc(Config, 0,
-        ?MODULE, do_reg_v1_full_recover_only_journal, [Config]).
-
-do_reg_v1_full_recover_only_journal(Config) ->
-
-    St0 = #cq{name=prop_classic_queue_v1, version=1,
-              config=minimal_config(Config)},
-
-    Res1 = cmd_setup_queue(St0),
-    St3 = St0#cq{amq=Res1},
-
-    Res4 = cmd_channel_open(St3),
-    true = postcondition(St3, {call, undefined, cmd_channel_open, [St3]}, Res4),
-    St7 = next_state(St3, Res4, {call, undefined, cmd_channel_open, [St3]}),
-
-    Res8 = cmd_restart_queue_dirty(St7),
-    true = postcondition(St7, {call, undefined, cmd_restart_queue_dirty, [St7]}, Res8),
-    St11 = next_state(St7, Res8, {call, undefined, cmd_restart_queue_dirty, [St7]}),
-
-    Res12 = cmd_channel_publish_many(St11, Res4, 117, 4541, 2, true, undefined),
-    true = postcondition(St11, {call, undefined, cmd_channel_publish_many, [St11, Res4, 117, 4541, 2, true, undefined]}, Res12),
-    St14 = next_state(St11, Res12, {call, undefined, cmd_channel_publish_many, [St11, Res4, 117, 4541, 2, true, undefined]}),
-
-    Res15 = cmd_restart_vhost_clean(St14),
-    true = postcondition(St14, {call, undefined, cmd_restart_vhost_clean, [St14]}, Res15),
-    _ = next_state(St14, Res15, {call, undefined, cmd_restart_vhost_clean, [St14]}),
-
-    true.


### PR DESCRIPTION
This adds a property suite for QQs that is ported over from the property suite I wrote for CQs.

This PR includes or contributed to 3 fixes: a clause was removed in `rabbit_fifo_client` that caused some commands to be dropped after a `ra` leader restarted and became leader again (merged in 3.10); and two new case clauses to deal with the `ra` process being restarted or killed (in this PR).