### PR TITLE
Adjust test to avoid race condition and flake

### DIFF
--- a/deps/amqp_client/test/system_SUITE.erl
+++ b/deps/amqp_client/test/system_SUITE.erl
@@ -1486,8 +1486,8 @@ command_invalid_over_channel(Config) ->
 %% command_invalid - this only applies to the network case
 command_invalid_over_channel0(Config) ->
     {ok, Connection} = new_connection(Config),
-    gen_server:cast(Connection, {method, #'basic.ack'{}, none, noflow}),
     MonitorRef = erlang:monitor(process, Connection),
+    gen_server:cast(Connection, {method, #'basic.ack'{}, none, noflow}),
     assert_down_with_error(MonitorRef, command_invalid).
 
 %% -------------------------------------------------------------------


### PR DESCRIPTION
The monitor might as well be created before performing the action that causes the monitored process to shut down. Some flakes appear to be because the process is already down by the time we call monitor.