### PR TITLE
[DONT MERGE] Add quorum queues support for MQTT

### DIFF
--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -42,7 +42,7 @@ end}.
 {mapping, "mqtt.allow_anonymous", "rabbitmq_mqtt.allow_anonymous",
     [{datatype, {enum, [true, false]}}]}.
 
-%% If you have multiple chosts, specify the one to which the
+%% If you have multiple vhosts, specify the one to which the
 %% adapter connects.
 %%
 %% {vhost, <<"/">>},
@@ -256,4 +256,16 @@ fun(Conf) ->
     LingerOn = cuttlefish:conf_get("mqtt.tcp_listen_options.linger.on", Conf, false),
     LingerTimeout = cuttlefish:conf_get("mqtt.tcp_listen_options.linger.timeout", Conf, 0),
     {LingerOn, LingerTimeout}
+end}.
+
+%% Queue data type can be classic or quorum
+%%
+%%
+%% {queue_type, <<"classic">>},
+
+{mapping, "mqtt.queue_type", "rabbitmq_mqtt.queue_type", [{datatype, string}]}.
+
+{translation, "rabbitmq_mqtt.queue_type",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("mqtt.queue_type", Conf))
 end}.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -123,11 +123,15 @@ handle_cast({close_connection, Reason},
 handle_cast(Msg, State) ->
     {stop, {mqtt_unexpected_cast, Msg}, State}.
 
+handle_info({#'basic.deliver'{}, #amqp_msg{}} = Delivery,
+    State) ->
+    %% receiving a message from a quorum queue
+    %% no delivery context
+    handle_info(erlang:insert_element(3, Delivery, undefined), State);
 handle_info({#'basic.deliver'{}, #amqp_msg{}, _DeliveryCtx} = Delivery,
             State = #state{ proc_state = ProcState }) ->
     callback_reply(State, rabbit_mqtt_processor:amqp_callback(Delivery,
                                                               ProcState));
-
 handle_info(#'basic.ack'{} = Ack, State = #state{ proc_state = ProcState }) ->
     callback_reply(State, rabbit_mqtt_processor:amqp_callback(Ack, ProcState));
 


### PR DESCRIPTION
Add Quorum queues support for MQTT.

How to test:
```
make run-broker RABBITMQ_CONFIG_FILE=myfile.conf PLUGINS='rabbitmq_mqtt rabbitmq_management'
```

where `myfile.conf` is:
```
mqtt.queue_type = quorum
```

python client recv:
```python
import paho.mqtt.client as mqtt


def on_connect(client, userdata, flags, rc):
    print("Connected with result code " + str(rc))
    client.subscribe("paho/temperature", qos=1)


def on_message(client, userdata, msg):
    print(msg.topic + " " + str(msg.payload))


def on_disconnect(client, userdata, rc):
    print("Disconnected: " + str(rc))


client = mqtt.Client(client_id="myclient", clean_session=False)
client.on_connect = on_connect
client.on_message = on_message
client.on_disconnect = on_disconnect

client.connect("localhost", 1883, 60)
client.loop_forever()
```

send:
```python
import datetime
import paho.mqtt.client as mqtt
import time
def on_connect(client, userdata, flags, rc):
    print("Connected with result code " + str(rc))

client = mqtt.Client()
client.on_connect = on_connect

client.connect("localhost", 1883, 60)
for i in range(110):
    client.publish("paho/temperature", "temperature {}".format(datetime.datetime.now()), qos=1)
    time.sleep(1)

client.loop_forever()
```

Problem
---
when we set `clean_session=True` with `qos = 1`:
```python
client = mqtt.Client(client_id="clean", clean_session=True)
```

We set `auto-delete` flag for classi queue, see this (old) conversation:
https://github.com/rabbitmq/rabbitmq-mqtt/issues/37

Quorum queues don't support `auto-delete` flag and we get this error:
```
2022-02-24 12:04:10.694754+01:00 [error] <0.1033.0>     reason: {{shutdown,
2022-02-24 12:04:10.694754+01:00 [error] <0.1033.0>                  {server_initiated_close,406,
2022-02-24 12:04:10.694754+01:00 [error] <0.1033.0>                      <<"PRECONDITION_FAILED - invalid property 'auto-delete' for queue 'mqtt-subscription-myclientqos1' in vhost '/'">>}},
2022-02-24 12:04:10.694754+01:00 [error] <0.1033.0>              {gen_server,call,
2022-02-24 12:04:10.694754+01:00 [error] <0.1033.0>                  [<0.1046.0>,
```


There are few possibile solutions:
 1- leave it in this way and document that is not possible use `quorum` and `qos=1` and `clean_session=True` 
 2- when there is `qos=1` and `clean_session=True` use always classic queues

Per conversation with @michaelklishin   we could queue during the startup up (In my personal opinion i see it a bit dangerous). I'd like to avoid it if possible. 
But  I am open to hearing your opinion





