### PR TITLE
Additional dialyzer warning fixes

### DIFF
--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -57,7 +57,7 @@ plt(
 
 dialyze(
     size = "medium",
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,

--- a/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
@@ -51,7 +51,7 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,

--- a/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
+++ b/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
@@ -41,10 +41,9 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
-    warnings_as_errors = False,
 )
 
 broker_for_integration_suites()

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
@@ -54,7 +54,7 @@ init() ->
                                                  {type, ordered_set}]),
     mnesia:add_table_copy(?HASH_RING_STATE_TABLE, node(), ram_copies),
     rabbit_table:wait([?HASH_RING_STATE_TABLE]),
-    recover(),
+    _ = recover(),
     ok.
 
 info(_X) -> [].

--- a/deps/rabbitmq_federation/BUILD.bazel
+++ b/deps/rabbitmq_federation/BUILD.bazel
@@ -50,7 +50,7 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,

--- a/deps/rabbitmq_management_agent/BUILD.bazel
+++ b/deps/rabbitmq_management_agent/BUILD.bazel
@@ -67,7 +67,7 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -79,7 +79,7 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,

--- a/deps/rabbitmq_shovel/BUILD.bazel
+++ b/deps/rabbitmq_shovel/BUILD.bazel
@@ -69,10 +69,9 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
-    warnings_as_errors = False,
 )
 
 rabbitmq_home(

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_status.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_status.erl
@@ -77,7 +77,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, State) ->
-    rabbit_misc:stop_timer(State, #state.timer),
+    _ = rabbit_misc:stop_timer(State, #state.timer),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/deps/rabbitmq_stomp/BUILD.bazel
+++ b/deps/rabbitmq_stomp/BUILD.bazel
@@ -72,7 +72,7 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,

--- a/deps/rabbitmq_stream/BUILD.bazel
+++ b/deps/rabbitmq_stream/BUILD.bazel
@@ -63,7 +63,7 @@ plt(
 )
 
 dialyze(
-    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_behaviours"],
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
     tags = ["dialyze"],
     warnings_as_errors = False,


### PR DESCRIPTION
Currently loading of the rabbitmq_cli defined behaviors compiled with Elixir does not work, so we ignore the callback definitions contained therein