### PR TITLE
Support `all-with-x` in `x-match` binding argument for headers exchange

### DIFF
--- a/deps/rabbit/src/rabbit_exchange_type_headers.erl
+++ b/deps/rabbit/src/rabbit_exchange_type_headers.erl
@@ -45,11 +45,12 @@ validate_binding(_X, #binding{args = Args}) ->
     case rabbit_misc:table_lookup(Args, <<"x-match">>) of
         {longstr, <<"all">>} -> ok;
         {longstr, <<"any">>} -> ok;
+        {longstr, <<"all-with-x">>} -> ok;
         {longstr, <<"any-with-x">>} -> ok;
         {longstr, Other}     -> {error,
                                  {binding_invalid,
                                   "Invalid x-match field value ~p; "
-                                  "expected all, any, or any-with-x", [Other]}};
+                                  "expected all, any, all-with-x, or any-with-x", [Other]}};
         {Type,    Other}     -> {error,
                                  {binding_invalid,
                                   "Invalid x-match field type ~p (value ~p); "
@@ -61,6 +62,7 @@ validate_binding(_X, #binding{args = Args}) ->
 
 parse_x_match({longstr, <<"all">>}) -> all;
 parse_x_match({longstr, <<"any">>}) -> any;
+parse_x_match({longstr, <<"all-with-x">>}) -> all_with_x;
 parse_x_match({longstr, <<"any-with-x">>}) -> any_with_x;
 parse_x_match(_) -> all. %% legacy; we didn't validate
 
@@ -84,18 +86,25 @@ headers_match(Args, Data) ->
 
 % A bit less horrendous algorithm :)
 headers_match(_, _, false, _, all) -> false;
+headers_match(_, _, false, _, all_with_x) -> false;
 headers_match(_, _, _, true, any) -> true;
 headers_match(_, _, _, true, any_with_x) -> true;
 
 % No more bindings, return current state
 headers_match([], _Data, AllMatch, _AnyMatch, all) -> AllMatch;
+headers_match([], _Data, AllMatch, _AnyMatch, all_with_x) -> AllMatch;
 headers_match([], _Data, _AllMatch, AnyMatch, any) -> AnyMatch;
 headers_match([], _Data, _AllMatch, AnyMatch, any_with_x) -> AnyMatch;
 
-% Delete bindings starting with x-
+%% Always delete binding x-match
+headers_match([{<<"x-match">>, _PT, _PV} | PRest], Data,
+              AllMatch, AnyMatch, MatchKind) ->
+    headers_match(PRest, Data, AllMatch, AnyMatch, MatchKind);
+% Delete all other bindings starting with x-
+% unless x-match is set to all-with-x or any-with-x
 headers_match([{<<"x-", _/binary>>, _PT, _PV} | PRest], Data,
               AllMatch, AnyMatch, MatchKind)
-  when MatchKind =/= any_with_x ->
+  when MatchKind =/= all_with_x, MatchKind =/= any_with_x ->
     headers_match(PRest, Data, AllMatch, AnyMatch, MatchKind);
 
 % No more data, but still bindings, false with all


### PR DESCRIPTION
This is a follow-up of https://github.com/rabbitmq/rabbitmq-server/pull/4143.

Similar to `any-with-x`.

Use case: This allows routing messages to different target queues
based on their `x-first-death-reason` AND `x-first-death-queue`
headers.

Following PRs need to be merged:
1. https://github.com/rabbitmq/rabbitmq-website/pull/1364
2. https://github.com/rabbitmq/rabbitmq-java-client/pull/725

Tests can be found in:
1. https://github.com/rabbitmq/rabbitmq-java-client/pull/725, and
2. branch [quorum-queues-v2](https://github.com/rabbitmq/rabbitmq-server/tree/quorum-queues-v2) (currently in [this commit](https://github.com/rabbitmq/rabbitmq-server/commit/c89674e15f9dba78525cea4e598817e19bc8253f) called "Add test for all-with-x binding argument" which will however be force pushed soon). I added the test to branch `quorum-queues-v2` because we plan to merge this branch soon into `master` and I didn't want get more conflicts when merging the branch into `master`.