### PR TITLE
Use rabbitmq 3.9 for mixed version testsing

### DIFF
--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -9,11 +9,11 @@ rabbitmq_package_generic_unix(
             [
                 "sbin/*",
                 "escript/*",
-                "plugins/**/*",
             ],
             exclude = ["sbin/rabbitmqctl"],
         ) + [
-            "@inet_tcp_proxy//:erlang_app",
+            "//plugins:standard_plugins",
+            "//plugins:inet_tcp_proxy_ez",
         ],
     rabbitmqctl = "sbin/rabbitmqctl",
 )

--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -9,11 +9,11 @@ rabbitmq_package_generic_unix(
             [
                 "sbin/*",
                 "escript/*",
+                "plugins/**/*",
             ],
             exclude = ["sbin/rabbitmqctl"],
         ) + [
-            "//plugins:standard_plugins",
-            "//plugins:inet_tcp_proxy_ez",
+            "@inet_tcp_proxy//:erlang_app",
         ],
     rabbitmqctl = "sbin/rabbitmqctl",
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -75,33 +75,10 @@ load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
 
 activemq_archive()
 
-ADD_PLUGINS_DIR_BUILD_FILE = """set -euo pipefail
-
-cat << EOF > plugins/BUILD.bazel
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
-
-pkg_zip(
-    name = "inet_tcp_proxy_ez",
-    package_dir = "inet_tcp_proxy/ebin",
-    srcs = [
-        "@inet_tcp_proxy//:erlang_app",
-    ],
-    package_file_name = "inet_tcp_proxy.ez",
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "standard_plugins",
-    srcs = glob(["*.ez"]),
-    visibility = ["//visibility:public"],
-)
-EOF
-"""
-
 http_archive(
-    name = "rabbitmq-server-generic-unix-3.8.22",
+    name = "rabbitmq-server-generic-unix-3.9",
     build_file = "@//:BUILD.package_generic_unix",
-    patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-    strip_prefix = "rabbitmq_server-3.8.22",
-    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.22/rabbitmq-server-generic-unix-3.8.22.tar.xz"],
+    sha256 = "4672fad92a815b879cc78a5a9fd28445152b61745d68acd50432c15f96792171",
+    strip_prefix = "rabbitmq_server-3.9.13",
+    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.9.13/rabbitmq-server-generic-unix-3.9.13.tar.xz"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -75,9 +75,33 @@ load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
 
 activemq_archive()
 
+ADD_PLUGINS_DIR_BUILD_FILE = """set -euo pipefail
+
+cat << EOF > plugins/BUILD.bazel
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+
+pkg_zip(
+    name = "inet_tcp_proxy_ez",
+    package_dir = "inet_tcp_proxy/ebin",
+    srcs = [
+        "@inet_tcp_proxy//:erlang_app",
+    ],
+    package_file_name = "inet_tcp_proxy-0.1.0.ez",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "standard_plugins",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+EOF
+"""
+
 http_archive(
     name = "rabbitmq-server-generic-unix-3.9",
     build_file = "@//:BUILD.package_generic_unix",
+    patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
     sha256 = "4672fad92a815b879cc78a5a9fd28445152b61745d68acd50432c15f96792171",
     strip_prefix = "rabbitmq_server-3.9.13",
     urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.9.13/rabbitmq-server-generic-unix-3.9.13.tar.xz"],

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -226,11 +226,11 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.8.22/rabbitmq-run",
+            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.9/rabbitmq-run",
         }.items() + test_env.items()),
         tools = [
             ":rabbitmq-for-tests-run",
-            "@rabbitmq-server-generic-unix-3.8.22//:rabbitmq-run",
+            "@rabbitmq-server-generic-unix-3.9//:rabbitmq-run",
         ] + tools,
         runtime_deps = [
             "//deps/rabbitmq_cli:elixir_app",


### PR DESCRIPTION
Backport to `v3.10.x` only