### PR TITLE
Fix `rabbitmqctl list_queues --help` output

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -21,7 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
             messages_persistent message_bytes message_bytes_ready
             message_bytes_unacknowledged message_bytes_ram message_bytes_persistent
             head_message_timestamp disk_reads disk_writes consumers
-            # these are aliases
             consumer_utilisation consumer_capacity
             memory slave_pids synchronised_slave_pids state type
             leader members online)a


### PR DESCRIPTION
Before this commit, the help output showed:

```
...
Arguments and Options

<column>
	must be one of #, aliases, are, arguments, auto_delete,
    consumer_capacity, consumer_utilisation, consumers, disk_reads,
    disk_writes, durable, exclusive, exclusive_consumer_pid,
    exclusive_consumer_tag, head_message_timestamp, leader, members,
    memory, message_bytes, message_bytes_persistent, message_bytes_ram,
    message_bytes_ready, message_bytes_unacknowledged, messages,
    messages_persistent, messages_ram, messages_ready,
    messages_ready_ram, messages_unacknowledged,
    messages_unacknowledged_ram, name, online, owner_pid, pid, policy,
    slave_pids, state, synchronised_slave_pids, these, type
...
```