### PR TITLE
Wait between retries if nxdomain

### DIFF
--- a/deps/rabbit_common/src/rabbit_nodes_common.erl
+++ b/deps/rabbit_common/src/rabbit_nodes_common.erl
@@ -56,6 +56,9 @@ names(Hostname, RetriesLeft) ->
     {ok, R } -> {ok, R};
     noport ->
       names(Hostname, RetriesLeft - 1);
+    {error, nxdomain} ->
+      timer:sleep(3000),
+      names(Hostname, RetriesLeft - 1);
     {error, _} ->
       names(Hostname, RetriesLeft - 1)
   end.


### PR DESCRIPTION
In `kind` version 0.10.0, when creating a 5-node RabbitMQ cluster
with the new parallel PodManagementPolicy, we observed that some
pods were restarted. Their logs includ:

```
10:10:03.794 [error]
10:10:03.804 [error] BOOT FAILED
10:10:03.805 [error] ===========
BOOT FAILED
10:10:03.805 [error] ERROR: epmd error for host r1-server-0.r1-nodes.rabbitmq-system: nxdomain (non-existing domain)
10:10:03.805 [error]
===========
ERROR: epmd error for host r1-server-0.r1-nodes.rabbitmq-system: nxdomain (non-existing domain)
10:10:04.806 [error] Supervisor rabbit_prelaunch_sup had child prelaunch started with rabbit_prelaunch:run_prelaunch_first_phase() at undefined exit with reason {epmd_error,"r1-server-0.r1-nodes.rabbitmq-system",nxdomain} in context start_error
10:10:04.806 [error] CRASH REPORT Process <0.152.0> with 0 neighbours exited with reason: {{shutdown,{failed_to_start_child,prelaunch,{epmd_error,"r1-server-0.r1-nodes.rabbitmq-system",nxdomain}}},{rabbit_prelaunch_app,start,[normal,[]]}} in application_master:init/4 line 138
```

Eventually, after some pods restarted up to 2 times, all pods were running and ready.

In `kind`, we observed that during the first couple of seconds, nslookup was failing as well for that domain
with nxdomain.
It took up to 30 seconds until nslookup succeeded.

With this commit, pods don't need to be restarted when creating a fresh RabbitMQ cluster.

---

This commit and above commit message is from March 2021. We never created a PR to rabbitmq-server because we thought this issue exists on `kind` only. However, in the meantime multiple RabbitMQ users have reported this issue on other K8s:
* https://github.com/rabbitmq/cluster-operator/issues/958 running on "vanilla Kubernetes setup via kubeadm, version 1.21.7"
* https://rabbitmq.slack.com/archives/CTMSV81HA/p1643064900023000  running on "EKS 1.21"