### PR TITLE
Disable kernel.prevent_overlapping_partitions early on boot

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -24,6 +24,7 @@ setup(Context) ->
     %% TODO: Check if directories/files are inside Mnesia dir.
 
     ok = set_default_config(),
+    ok = disable_kernel_overlapping_partitions(),
 
     AdditionalConfigFiles = find_additional_config_files(Context),
     AdvancedConfigFile = find_actual_advanced_config_file(Context),
@@ -585,3 +586,9 @@ get_input_iodevice() ->
                     end
             end
     end.
+
+disable_kernel_overlapping_partitions() ->
+    %% This new "fixed" behavior seriously affects our own partition handling,
+    %% and potentially even libraries such as Aten and Ra,
+    %% so disable this to be forward-compatible with Erlang 25
+    application:set_env(kernel, prevent_overlapping_partitions, false).

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -81,6 +81,7 @@ start_rabbitmq_server() {
         ${RABBITMQ_SERVER_START_ARGS} \
         -syslog logger '[]' \
         -syslog syslog_error_logger false \
+        -kernel prevent_overlapping_partitions false \
         "$@"
 }
 

--- a/deps/rabbit/scripts/rabbitmq-server.bat
+++ b/deps/rabbit/scripts/rabbitmq-server.bat
@@ -70,6 +70,7 @@ if "!RABBITMQ_ALLOW_INPUT!"=="" (
 !RABBITMQ_SERVER_START_ARGS! ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
+-kernel prevent_overlapping_partitions false ^
 !STAR!
 
 if ERRORLEVEL 1 (

--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -200,6 +200,7 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 !RABBITMQ_DIST_ARG! ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
+-kernel prevent_overlapping_partitions false ^
 !STARVAR!
 
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:\=\\!

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -399,6 +399,10 @@ start_it(StartType) ->
             ?LOG_INFO("RabbitMQ is asked to start...", [],
                       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
             try
+                %% This new "fixed" behavior seriously affects our own partition handling,
+                %% and potentially even libraries such as Aten and Ra,
+                %% so disable this to be forward-compatible with Erlang 25
+                _ = application:set_env(kernel, prevent_overlapping_partitions, false),
                 {ok, _} = application:ensure_all_started(rabbitmq_prelaunch,
                                                          StartType),
                 {ok, _} = application:ensure_all_started(rabbit,

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -399,10 +399,6 @@ start_it(StartType) ->
             ?LOG_INFO("RabbitMQ is asked to start...", [],
                       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
             try
-                %% This new "fixed" behavior seriously affects our own partition handling,
-                %% and potentially even libraries such as Aten and Ra,
-                %% so disable this to be forward-compatible with Erlang 25
-                _ = application:set_env(kernel, prevent_overlapping_partitions, false),
                 {ok, _} = application:ensure_all_started(rabbitmq_prelaunch,
                                                          StartType),
                 {ok, _} = application:ensure_all_started(rabbit,


### PR DESCRIPTION
This new "fixed" behavior seriously affects our own partition handling,
and potentially even libraries such as Aten and Ra,
so disable this to be forward-compatible with Erlang 25.