### PR TITLE
Add quorum queues support for MQTT

### DIFF
--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -258,11 +258,8 @@ fun(Conf) ->
     {LingerOn, LingerTimeout}
 end}.
 
-%% Queue data type can be classic or quorum
+%% Durable queue type to be used for QoS 1 subscriptions
 %%
-%%
-%% {queue_type, classic},
 
-
-{mapping, "mqtt.queue_type", "rabbitmq_mqtt.queue_type",
+{mapping, "mqtt.durable_queue_type", "rabbitmq_mqtt.durable_queue_type",
     [{datatype, {enum, [classic, quorum]}}]}.

--- a/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
+++ b/deps/rabbitmq_mqtt/priv/schema/rabbitmq_mqtt.schema
@@ -257,3 +257,12 @@ fun(Conf) ->
     LingerTimeout = cuttlefish:conf_get("mqtt.tcp_listen_options.linger.timeout", Conf, 0),
     {LingerOn, LingerTimeout}
 end}.
+
+%% Queue data type can be classic or quorum
+%%
+%%
+%% {queue_type, classic},
+
+
+{mapping, "mqtt.queue_type", "rabbitmq_mqtt.queue_type",
+    [{datatype, {enum, [classic, quorum]}}]}.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -785,7 +785,7 @@ delivery_mode(?QOS_1) -> 2;
 delivery_mode(?QOS_2) -> 2.
 
 maybe_quorum(Qos1Args, CleanSession, Queue) ->
-    case {rabbit_mqtt_util:env(queue_type), CleanSession} of
+    case {rabbit_mqtt_util:env(durable_queue_type), CleanSession} of
       %% it is possible to Quorum queues only if Clean Session == False
       %% else always use Classic queues
       %% Clean Session == True sets auto-delete to True and quorum queues

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -123,6 +123,11 @@ handle_cast({close_connection, Reason},
 handle_cast(Msg, State) ->
     {stop, {mqtt_unexpected_cast, Msg}, State}.
 
+handle_info({#'basic.deliver'{}, #amqp_msg{}} = Delivery,
+    State) ->
+    %% receiving a message from a quorum queue
+    %% no delivery context
+    handle_info(erlang:insert_element(3, Delivery, undefined), State);
 handle_info({#'basic.deliver'{}, #amqp_msg{}, _DeliveryCtx} = Delivery,
             State = #state{ proc_state = ProcState }) ->
     callback_reply(State, rabbit_mqtt_processor:amqp_callback(Delivery,

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
@@ -14,6 +14,7 @@
    mqtt.listeners.tcp.default = 1883
    mqtt.tcp_listen_options.backlog = 128
    mqtt.tcp_listen_options.nodelay = true
+   mqtt.queue_type = classic
    mqtt.proxy_protocol = false",
   [{rabbit,[{tcp_listeners,[5672]}]},
    {rabbitmq_mqtt,
@@ -28,6 +29,7 @@
         {ssl_listeners,[]},
         {tcp_listeners,[1883]},
         {tcp_listen_options,[{backlog,128},{nodelay,true}]},
+        {queue_type,classic},
         {proxy_protocol,false}]}],
   [rabbitmq_mqtt]},
 

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE_data/rabbitmq_mqtt.snippets
@@ -14,7 +14,7 @@
    mqtt.listeners.tcp.default = 1883
    mqtt.tcp_listen_options.backlog = 128
    mqtt.tcp_listen_options.nodelay = true
-   mqtt.queue_type = classic
+   mqtt.durable_queue_type = classic
    mqtt.proxy_protocol = false",
   [{rabbit,[{tcp_listeners,[5672]}]},
    {rabbitmq_mqtt,
@@ -29,7 +29,7 @@
         {ssl_listeners,[]},
         {tcp_listeners,[1883]},
         {tcp_listen_options,[{backlog,128},{nodelay,true}]},
-        {queue_type,classic},
+        {durable_queue_type,classic},
         {proxy_protocol,false}]}],
   [rabbitmq_mqtt]},
 

--- a/deps/rabbitmq_mqtt/test/processor_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/processor_SUITE.erl
@@ -24,7 +24,8 @@ groups() ->
                                 interprets_colons_in_username_if_option_not_set,
                                 get_vhosts_from_global_runtime_parameter,
                                 get_vhost,
-                                add_client_id_to_adapter_info
+                                add_client_id_to_adapter_info,
+                                quorum_configuration
                                ]}
     ].
 
@@ -209,3 +210,22 @@ clear_vhost_global_parameters() ->
         ok = mnesia:delete(rabbit_runtime_parameters, mqtt_port_to_vhost_mapping, write)
                          end,
     {atomic, ok} = mnesia:transaction(DeleteParameterFun).
+
+quorum_configuration(_Config) ->
+    MyArgs = [],
+%%  default setting with CleanSession = true of false
+    QMustBeClassic = rabbit_mqtt_processor:maybe_quorum(MyArgs, true, <<"">>),
+    ?assertEqual(QMustBeClassic, []),
+%%  default setting with CleanSession = true of false
+    QMustBeClassicEvenFalse = rabbit_mqtt_processor:maybe_quorum(MyArgs, false, <<"">>),
+    ?assertEqual(QMustBeClassicEvenFalse, []),
+    application:set_env(rabbitmq_mqtt, queue_type, quorum),
+%%  quorum setting with CleanSession  == false must me quorum
+    QMustBeQuorum = rabbit_mqtt_processor:maybe_quorum(MyArgs, false, <<"">>),
+    ?assertEqual(QMustBeQuorum, [{<<"x-queue-type">>, longstr, <<"quorum">>}]),
+
+    %%  quorum setting with CleanSession  == true must me classic since
+    %% quorum does not support auto-delete
+    QEvenQuorumMustBeClassic = rabbit_mqtt_processor:maybe_quorum(MyArgs, true, <<"">>),
+    ?assertEqual(QEvenQuorumMustBeClassic, []),
+    ok.

--- a/deps/rabbitmq_mqtt/test/processor_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/processor_SUITE.erl
@@ -219,7 +219,7 @@ quorum_configuration(_Config) ->
 %%  default setting with CleanSession = true of false
     QMustBeClassicEvenFalse = rabbit_mqtt_processor:maybe_quorum(MyArgs, false, <<"">>),
     ?assertEqual(QMustBeClassicEvenFalse, []),
-    application:set_env(rabbitmq_mqtt, queue_type, quorum),
+    application:set_env(rabbitmq_mqtt, durable_queue_type, quorum),
 %%  quorum setting with CleanSession  == false must me quorum
     QMustBeQuorum = rabbit_mqtt_processor:maybe_quorum(MyArgs, false, <<"">>),
     ?assertEqual(QMustBeQuorum, [{<<"x-queue-type">>, longstr, <<"quorum">>}]),

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -169,19 +169,19 @@ stats(Config) ->
                               [connection_coarse_metrics, Pid]),
     emqttc:disconnect(C).
 
-get_queue_type(Server, Q0) ->
+get_durable_queue_type(Server, Q0) ->
     QNameRes = rabbit_misc:r(<<"/">>, queue, Q0),
     {ok, Q1} = rpc:call(Server, rabbit_amqqueue, lookup, [QNameRes]),
     amqqueue:get_type(Q1).
 
 set_env(QueueType) ->
-    application:set_env(rabbitmq_mqtt, queue_type, QueueType).
+    application:set_env(rabbitmq_mqtt, durable_queue_type, QueueType).
 
 get_env() ->
-    rabbit_mqtt_util:env(queue_type).
+    rabbit_mqtt_util:env(durable_queue_type).
 
 
-validate_queue_type(Config, ClientName, CleanSession, Expected) ->
+validate_durable_queue_type(Config, ClientName, CleanSession, Expected) ->
     P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     {ok, C} = emqttc:start_link([{host, "localhost"},
@@ -198,7 +198,7 @@ validate_queue_type(Config, ClientName, CleanSession, Expected) ->
     Prefix = <<"mqtt-subscription-">>,
     Suffix = <<"qos1">>,
     Q= <<Prefix/binary, ClientName/binary, Suffix/binary>>,
-    ?assertEqual(Expected,get_queue_type(Server,Q)),
+    ?assertEqual(Expected,get_durable_queue_type(Server,Q)),
     timer:sleep(500),
     emqttc:disconnect(C).
 
@@ -207,7 +207,7 @@ quorum_session_false(Config) ->
   %%  test if the quorum queue is enable after the setting
     Default = rpc(Config, reader_SUITE, get_env, []),
     rpc(Config, reader_SUITE, set_env, [quorum]),
-    validate_queue_type(Config, <<"qCleanSessionFalse">>, false, rabbit_quorum_queue),
+    validate_durable_queue_type(Config, <<"qCleanSessionFalse">>, false, rabbit_quorum_queue),
     rpc(Config, reader_SUITE, set_env, [Default]).
 
 quorum_session_true(Config) ->
@@ -215,16 +215,16 @@ quorum_session_true(Config) ->
   %% doesn't support auto-delete
     Default = rpc(Config, reader_SUITE, get_env, []),
     rpc(Config, reader_SUITE, set_env, [quorum]),
-    validate_queue_type(Config, <<"qCleanSessionTrue">>, true, rabbit_classic_queue),
+    validate_durable_queue_type(Config, <<"qCleanSessionTrue">>, true, rabbit_classic_queue),
     rpc(Config, reader_SUITE, set_env, [Default]).
 
 classic_session_true(Config) ->
   %%  with default configuration the queue is classic
-    validate_queue_type(Config, <<"cCleanSessionTrue">>, true, rabbit_classic_queue).
+    validate_durable_queue_type(Config, <<"cCleanSessionTrue">>, true, rabbit_classic_queue).
 
 classic_session_false(Config) ->
   %%  with default configuration the queue is classic
-    validate_queue_type(Config, <<"cCleanSessionFalse">>, false, rabbit_classic_queue).
+    validate_durable_queue_type(Config, <<"cCleanSessionFalse">>, false, rabbit_classic_queue).
 
 
 expect_publishes(_Topic, []) -> ok;

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -12,7 +12,8 @@
 
 all() ->
     [
-      {group, non_parallel_tests}
+      {group, non_parallel_tests},
+      {group, non_parallel_tests_quorum}
     ].
 
 groups() ->
@@ -21,7 +22,13 @@ groups() ->
                                 block,
                                 handle_invalid_frames,
                                 stats
-                               ]}
+                               ]},
+      {non_parallel_tests_quorum, [], [
+                                quorum_session_false,
+                                quorum_session_true,
+                                classic_session_true,
+                                classic_session_false
+      ]}
     ].
 
 suite() ->
@@ -55,6 +62,14 @@ end_per_suite(Config) ->
       rabbit_ct_client_helpers:teardown_steps() ++
       rabbit_ct_broker_helpers:teardown_steps()).
 
+init_per_group(non_parallel_tests_quorum, Config) ->
+%%  Added for quorum queue test else the mixing test would fail
+%% with "feature flag is disabled"
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
+        ok -> Config;
+        Skip -> Skip
+    end,
+  Config;
 init_per_group(_, Config) ->
     Config.
 
@@ -153,6 +168,64 @@ stats(Config) ->
     [{Pid, _, _, _, _}] = rpc(Config, ets, lookup,
                               [connection_coarse_metrics, Pid]),
     emqttc:disconnect(C).
+
+get_queue_type(Server, Q0) ->
+    QNameRes = rabbit_misc:r(<<"/">>, queue, Q0),
+    {ok, Q1} = rpc:call(Server, rabbit_amqqueue, lookup, [QNameRes]),
+    amqqueue:get_type(Q1).
+
+set_env(QueueType) ->
+    application:set_env(rabbitmq_mqtt, queue_type, QueueType).
+
+get_env() ->
+    rabbit_mqtt_util:env(queue_type).
+
+
+validate_queue_type(Config, ClientName, CleanSession, Expected) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    {ok, C} = emqttc:start_link([{host, "localhost"},
+    {port, P},
+    {clean_sess, CleanSession},
+    {client_id, ClientName},
+    {proto_ver, 3},
+    {logger, info},
+    {puback_timeout, 1}]),
+    emqttc:subscribe(C, <<"TopicB">>, qos1),
+    emqttc:publish(C, <<"TopicB">>, <<"Payload">>),
+    expect_publishes(<<"TopicB">>, [<<"Payload">>]),
+    emqttc:unsubscribe(C, [<<"TopicB">>]),
+    Prefix = <<"mqtt-subscription-">>,
+    Suffix = <<"qos1">>,
+    Q= <<Prefix/binary, ClientName/binary, Suffix/binary>>,
+    ?assertEqual(Expected,get_queue_type(Server,Q)),
+    timer:sleep(500),
+    emqttc:disconnect(C).
+
+%% quorum queue test when enable
+quorum_session_false(Config) ->
+  %%  test if the quorum queue is enable after the setting
+    Default = rpc(Config, reader_SUITE, get_env, []),
+    rpc(Config, reader_SUITE, set_env, [quorum]),
+    validate_queue_type(Config, <<"qCleanSessionFalse">>, false, rabbit_quorum_queue),
+    rpc(Config, reader_SUITE, set_env, [Default]).
+
+quorum_session_true(Config) ->
+  %%  in case clean session == true must be classic since quorum
+  %% doesn't support auto-delete
+    Default = rpc(Config, reader_SUITE, get_env, []),
+    rpc(Config, reader_SUITE, set_env, [quorum]),
+    validate_queue_type(Config, <<"qCleanSessionTrue">>, true, rabbit_classic_queue),
+    rpc(Config, reader_SUITE, set_env, [Default]).
+
+classic_session_true(Config) ->
+  %%  with default configuration the queue is classic
+    validate_queue_type(Config, <<"cCleanSessionTrue">>, true, rabbit_classic_queue).
+
+classic_session_false(Config) ->
+  %%  with default configuration the queue is classic
+    validate_queue_type(Config, <<"cCleanSessionFalse">>, false, rabbit_classic_queue).
+
 
 expect_publishes(_Topic, []) -> ok;
 expect_publishes(Topic, [Payload|Rest]) ->


### PR DESCRIPTION
Enable the quorum queue for MQTT **only if CleanSession is False**.
QQs don't support auto-delete flag so in case Clean session is True
the queue will be a classic queue.

Add another group test non_parallel_tests_quorum.
For Mixed test the quorum_queue feature flag must be enabled.


How to test:
```
make run-broker RABBITMQ_CONFIG_FILE=myfile.conf PLUGINS='rabbitmq_mqtt rabbitmq_management'
```

where `myfile.conf` is:
```
mqtt.queue_type = quorum
```

python client recv:
```python
import paho.mqtt.client as mqtt


def on_connect(client, userdata, flags, rc):
    print("Connected with result code " + str(rc))
    client.subscribe("paho/temperature", qos=1)


def on_message(client, userdata, msg):
    print(msg.topic + " " + str(msg.payload))


def on_disconnect(client, userdata, rc):
    print("Disconnected: " + str(rc))


client = mqtt.Client(client_id="myclient", clean_session=False)
client.on_connect = on_connect
client.on_message = on_message
client.on_disconnect = on_disconnect

client.connect("localhost", 1883, 60)
client.loop_forever()
```

send:
```python
import datetime
import paho.mqtt.client as mqtt
import time
def on_connect(client, userdata, flags, rc):
    print("Connected with result code " + str(rc))

client = mqtt.Client()
client.on_connect = on_connect

client.connect("localhost", 1883, 60)
for i in range(110):
    client.publish("paho/temperature", "temperature {}".format(datetime.datetime.now()), qos=1)
    time.sleep(1)

client.loop_forever()
```

Important: 
Read this PR https://github.com/rabbitmq/rabbitmq-server/pull/4185 for all the story.
I had to create another because of a wrong rebase. 
 
 @pjk25 I created [different tests](https://github.com/rabbitmq/rabbitmq-server/compare/mqtt_quorum?expand=1#diff-3b107a60a328b7cde1f97b843c8318d87d53c753bc0e240661962d9d4d48c18cR206-R227).
 