### PR TITLE
rabbitmqct {encode, decode}: accept more values via standard input

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/input.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/input.ex
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Core.Input do
   alias RabbitMQ.CLI.Core.Config

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -7,7 +7,7 @@
 alias RabbitMQ.CLI.Core.Helpers
 
 defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
-  alias RabbitMQ.CLI.Core.DocGuide
+  alias RabbitMQ.CLI.Core.{DocGuide, Input}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -32,7 +32,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
     {args, Helpers.atomize_values(with_defaults, @atomized_keys)}
   end
 
-  def validate(args, _) when length(args) < 2 do
+  def validate(args, _) when length(args) < 1 do
     {:validation_failure, {:not_enough_args, "Please provide a value to decode and a passphrase"}}
   end
 
@@ -40,7 +40,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
     {:validation_failure, :too_many_args}
   end
 
-  def validate(args, opts) when length(args) === 2 do
+  def validate(_args, opts) do
     case {supports_cipher(opts.cipher), supports_hash(opts.hash), opts.iterations > 0} do
       {false, _, _} ->
         {:validation_failure, {:bad_argument, "The requested cipher is not supported"}}
@@ -55,6 +55,31 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
 
       {true, true, true} ->
         :ok
+    end
+  end
+
+  def run([value], %{cipher: cipher, hash: hash, iterations: iterations} = opts) do
+    case Input.consume_single_line_string_with_prompt("Passphrase: ", opts) do
+      :eof -> {:error, :not_enough_args}
+      passphrase ->
+        try do
+          term_value = Helpers.evaluate_input_as_term(value)
+
+          term_to_decrypt =
+            case term_value do
+              {:encrypted, _} = encrypted ->
+                encrypted
+              _ ->
+                {:encrypted, term_value}
+            end
+
+          result = :rabbit_pbe.decrypt_term(cipher, hash, iterations, passphrase, term_to_decrypt)
+          {:ok, result}
+        catch
+          _, _ ->
+            {:error,
+             "Failed to decrypt the value. Things to check: is the passphrase correct? Are the cipher and hash algorithms the same as those used for encryption?"}
+        end
     end
   end
 
@@ -81,8 +106,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def banner([_, _], _) do
-    "Decrypting value ..."
+  def banner(_, _) do
+    "Decrypting value..."
   end
 
   def usage, do: "decode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 alias RabbitMQ.CLI.Core.Helpers
 

--- a/deps/rabbitmq_cli/test/ctl/decode_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/decode_command_test.exs
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule DecodeCommandTest do
   use ExUnit.Case, async: false
@@ -20,11 +20,13 @@ defmodule DecodeCommandTest do
     assert :ok == @command.validate(["value", "secret"], context[:opts])
   end
 
-  test "validate: providing zero or one positional argument fails", context do
+  test "validate: providing no positional arguments fails", context do
     assert match?({:validation_failure, {:not_enough_args, _}},
                   @command.validate([], context[:opts]))
-    assert match?({:validation_failure, {:not_enough_args, _}},
-                  @command.validate(["value"], context[:opts]))
+  end
+
+  test "validate: providing one positional argument passes", context do
+    assert :ok == @command.validate(["value"], context[:opts])
   end
 
   test "validate: providing three or more positional argument fails", context do

--- a/deps/rabbitmq_cli/test/ctl/encode_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/encode_command_test.exs
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule EncodeCommandTest do
   use ExUnit.Case, async: false

--- a/deps/rabbitmq_cli/test/ctl/encode_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/encode_command_test.exs
@@ -21,11 +21,9 @@ defmodule EncodeCommandTest do
     assert :ok == @command.validate(["value", "secret"], context[:opts])
   end
 
-  test "validate: providing zero or one positional argument fails", context do
-    assert match?({:validation_failure, {:not_enough_args, _}},
-                  @command.validate([], context[:opts]))
-    assert match?({:validation_failure, {:not_enough_args, _}},
-                  @command.validate(["value"], context[:opts]))
+  test "validate: providing zero or one positional argument passes", context do
+    assert :ok == @command.validate([], context[:opts])
+    assert :ok == @command.validate(["value"], context[:opts])
   end
 
   test "validate: providing three or more positional argument fails", context do


### PR DESCRIPTION
Per discussion with @lhoguin.

References #4216.
