### PR TITLE
File Handle Cache optimizations that benefit classic mirrored queues

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -69,6 +69,7 @@ _APP_ENV = """[
 	    {server_properties, []},
 	    {collect_statistics, none},
 	    {collect_statistics_interval, 5000},
+	    {classic_queue_collect_fd_stats, true},
 	    {mnesia_table_loading_retry_timeout, 30000},
 	    {mnesia_table_loading_retry_limit, 10},
 	    {auth_mechanisms, ['PLAIN', 'AMQPLAIN']},

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -44,6 +44,7 @@ define PROJECT_ENV
 	    {server_properties, []},
 	    {collect_statistics, none},
 	    {collect_statistics_interval, 5000},
+	    {classic_queue_collect_fd_stats, true},
 	    {mnesia_table_loading_retry_timeout, 30000},
 	    {mnesia_table_loading_retry_limit, 10},
 	    {auth_mechanisms, ['PLAIN', 'AMQPLAIN']},

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1243,6 +1243,14 @@ end}.
 {mapping, "collect_statistics_interval", "rabbit.collect_statistics_interval",
     [{datatype, integer}]}.
 
+%% Enable/disable file_handle_cache statistics. Disabeling this
+%% can help in cases of lock contention on the backing ets table.
+%%
+%% {classic_queue.collect_fd_stats, true},
+
+{mapping, "classic_queue.collect_fd_stats", "rabbit.classic_queue_collect_fd_stats",
+    [{datatype, {enum, [true, false]}}]}.
+
 %%
 %% Misc/Advanced Options
 %% =====================

--- a/deps/rabbit/test/unit_gm_SUITE.erl
+++ b/deps/rabbit/test/unit_gm_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
     ].
 
 init_per_suite(Config) ->
+    ok = application:set_env(rabbit, classic_queue_collect_fd_stats, true),
     ok = application:set_env(mnesia, dir, ?config(priv_dir, Config)),
     ok = application:start(mnesia),
     {ok, FHC} = file_handle_cache:start_link(),

--- a/deps/rabbit_common/src/file_handle_cache_stats.erl
+++ b/deps/rabbit_common/src/file_handle_cache_stats.erl
@@ -31,20 +31,32 @@ init() ->
 
 update(Op, Bytes, Thunk) ->
     {Time, Res} = timer_tc(Thunk),
-    _ = ets:update_counter(?TABLE, {Op, count}, 1),
-    _ = ets:update_counter(?TABLE, {Op, bytes}, Bytes),
-    _ = ets:update_counter(?TABLE, {Op, time}, Time),
-    Res.
+    case application:get_env(rabbit, classic_queue_collect_fd_stats) of
+        {ok, false} -> Res;
+        {ok, true}  ->
+            _ = ets:update_counter(?TABLE, {Op, count}, 1),
+            _ = ets:update_counter(?TABLE, {Op, bytes}, Bytes),
+            _ = ets:update_counter(?TABLE, {Op, time}, Time),
+            Res
+    end.
 
 update(Op, Thunk) ->
     {Time, Res} = timer_tc(Thunk),
-    _ = ets:update_counter(?TABLE, {Op, count}, 1),
-    _ = ets:update_counter(?TABLE, {Op, time}, Time),
-    Res.
+    case application:get_env(rabbit, classic_queue_collect_fd_stats) of
+        {ok, false} -> Res;
+        {ok, true}  ->
+            _ = ets:update_counter(?TABLE, {Op, count}, 1),
+            _ = ets:update_counter(?TABLE, {Op, time}, Time),
+            Res
+    end.
 
 update(Op) ->
-    ets:update_counter(?TABLE, {Op, count}, 1),
-    ok.
+    case application:get_env(rabbit, classic_queue_collect_fd_stats) of
+        {ok, false} -> ok;
+        {ok, true}  ->
+            ets:update_counter(?TABLE, {Op, count}, 1),
+            ok
+    end.
 
 get() ->
     lists:sort(ets:tab2list(?TABLE)).


### PR DESCRIPTION
## Proposed Changes

When trying to use a large amount of durable mirrored queues (non quorum queues) we noticed that the rabbitmq processes spent a lot of time in `ETS` (as reported by `rabbitmq-diagnostics runtime_thread_stats`). When analyzing the details we came to the conclusion that most of this time is spent in lock contention on the `file_handle_cache_stats` ETS table (as reported by lcnt).

This PR tries to improove the situation in two ways:
1. enable `write_concurrency` for the table 
2. add an option to disable the statistics stored in `file_handle_cache_stats` completly

The first point already improves the situation significantly (from 60% collections to 25% as reported by lcnt). 

The second point is not really ideal from my perspective, but it allows us to get our performance requirements fulfilled.
If there is a better solution i would be happy to adapt the change.

Used perftest parameters:
`--auto-delete "false" -f persistent --producer-random-start-delay "30" --queue-pattern perf-test-%d --queue-pattern-from "1" --queue-pattern-to "400" --producers "400" --consumers "500" --heartbeat-sender-threads "10" --rate "10"`

Changes in the amount of consumed messages after each change:
* Without changes we get to 500-1000msg/sec
* With the first change we get to around 1500msg/sec
* The last change gives us a stable 4000msg/sec

We also noticed that rabbitmqctl commands improved significantly in speed after each change.

lcnt statistics after the first point is implemented:
```
 lock                                                                             id  #tries  #collisions  collisions [%]  time [us]  duration [%]
 -----                                                                            --- ------- ------------ --------------- ---------- -------------
db_hash_slot                               file_handle_cache_stats  518404       123849         23.8904  161167277   157.1665
db_hash_slot                               file_handle_cache_stats  262166        13130          5.0083   22819879       22.2534
<snip>
```

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

Honestly not sure about this one.

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [in progress] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

I am unsure how ad where to add tests for this solution as this is also my first time writing erlang.
If you could advise me there i would be happy to introduce apply these changes.

## Further Comments

I came to the conclusion that `file_handle_cache_stats` is only used for statistics provided to the administrators. Therefor i implemented the changes by disabeling the statistics completely.
If i missunderstood this and the statistics are used inside rabbitmq then this change might need to be adapted.

Thank you
