### PR TITLE
LDAP: match on tuples instead of the #eldap_search_result record for OTP 24.3 compat

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -829,7 +829,12 @@ dn_lookup(Username, LDAP) ->
                        {attributes, ["distinguishedName"]}]) of
         {ok, {referral, Referrals}} ->
             {error, {referrals_not_supported, Referrals}};
-        {ok, #eldap_search_result{entries = [#eldap_entry{object_name = DN}]}}->
+            %% support #eldap_search_result before and after
+            %% https://github.com/erlang/otp/pull/5538
+        {ok, {eldap_search_result, [#eldap_entry{object_name = DN}], _Referrals}}->
+            ?L1("DN lookup: ~s -> ~s", [Username, DN]),
+            DN;
+        {ok, {eldap_search_result, [#eldap_entry{object_name = DN}], _Referrals, _Controls}}->
             ?L1("DN lookup: ~s -> ~s", [Username, DN]),
             DN;
         {ok, #eldap_search_result{entries = Entries}} ->


### PR DESCRIPTION
In https://github.com/erlang/otp/pull/5538, the eldap_search_result
record structure has changed:
https://github.com/erlang/otp/pull/5538/files#diff-30e064e89b115da7e974f229ed5c92f28e489da679ef42f17e70b9e7cf874179R24

It does have a default but for code
compiled on, say, Erlang 23.0, which is the case for current RabbitMQ
releases, it would still be a breaking change resulting in
case expression matching failures (a case_clause).

Note that CI would not hit this issue. In order to reproduce, you have to build on Erlang pre-24.3 but run on 24.3.

Closes #4284.