### PR TITLE
Make backing_queue_SUITE fast on macOS

### DIFF
--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -1844,10 +1844,10 @@ variable_queue_with_holes(VQ0) ->
     IndexMod = index_mod(),
     Count = IndexMod:next_segment_boundary(0)*2 + 2 * Interval,
     Seq = lists:seq(1, Count),
-    VQ1 = variable_queue_set_ram_duration_target(0, VQ0),
-    VQ2 = variable_queue_publish(
+    VQ1 = variable_queue_publish(
             false, 1, Count,
-            fun (_, P) -> P end, fun erlang:term_to_binary/1, VQ1),
+            fun (_, P) -> P end, fun erlang:term_to_binary/1, VQ0),
+    VQ2 = variable_queue_set_ram_duration_target(0, VQ1),
     {VQ3, AcksR} = variable_queue_fetch(Count, false, false, Count, VQ2),
     Acks = lists:reverse(AcksR),
     AckSeqs = lists:zip(Acks, Seq),


### PR DESCRIPTION
This very small patch requires extended explanations. The patch
swaps two lines in a rabbit_variable_queue setup: one which sets
the memory hint to 0 which results in reduce_memory_usage to
always flush to disk and fsync; and another which publishes a
lot of messages to the queue that will after that point be
manipulated further to get the queue in the exact right state
for the relevant tests.

The problem with calling reduce_memory_usage after every single
message has been published is not writing to disk (v2 tests do
not suffer from performance issues in that regard) but rather
that rabbit_queue_index will always flush its journal (containing
the one message), which results in opening the segment file,
appending to it, and closing it. The file handling is done
by file_handle_cache which, in this case, will always fsync
the data before closing the file. And that's this one fsync
per message that makes the relevant tests very slow.

By swapping the lines, meaning we publish all messages first
and then set the memory hint to 0, we end up with a single
reduce_memory_usage call that results in an fsync, at the
end. (There may be other fsyncs as part of normal operations.)
And still get the same result because all messages will have
been flushed to disk, only this time in far fewer operations.

This doesn't seem to have been causing problems on CI which
already runs the tests very fast but should help macOS and
possibly other development environments.