### PR TITLE
Clear unacknowledged messages in channel state when queue leader restarts

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -167,7 +167,7 @@
              queue_states,
              tick_timer,
              publishing_mode = false :: boolean(),
-             obsolete_deliver_tags = []
+             obsolete_delivery_tags = []
             }).
 
 -define(QUEUE, lqueue).
@@ -1340,9 +1340,9 @@ handle_method(#'basic.nack'{delivery_tag = DeliveryTag,
 handle_method(#'basic.ack'{delivery_tag = DeliveryTag,
                            multiple     = Multiple},
               _, State = #ch{unacked_message_q = UAMQ, tx = Tx,
-                             obsolete_deliver_tags = ODTags}) ->
+                             obsolete_delivery_tags = ODTags}) ->
     {Acked, Remaining, ODTags1} = collect_acks(UAMQ, DeliveryTag, Multiple, ODTags),
-    State1 = State#ch{unacked_message_q = Remaining, obsolete_deliver_tags = ODTags1},
+    State1 = State#ch{unacked_message_q = Remaining, obsolete_delivery_tags = ODTags1},
     {noreply, case Tx of
                   none         -> {State2, Actions} = ack(Acked, State1),
                                   handle_queue_actions(Actions, State2);
@@ -1877,7 +1877,7 @@ handle_consuming_queue_down_or_eol(QName,
               end
       end, State#ch{queue_consumers = maps:remove(QName, QCons),
             unacked_message_q = UAMQ1,
-            obsolete_deliver_tags = ObsoleteDeliverTags}, ConsumerTags).
+            obsolete_delivery_tags = ObsoleteDeliverTags}, ConsumerTags).
 
 %% [0] There is a slight danger here that if a queue is deleted and
 %% then recreated again the reconsume will succeed even though it was
@@ -1968,9 +1968,9 @@ basic_return(#basic_message{exchange_name = ExchangeName,
            Content).
 
 reject(DeliveryTag, Requeue, Multiple,
-       State = #ch{unacked_message_q = UAMQ, tx = Tx, obsolete_deliver_tags = ODTags}) ->
+       State = #ch{unacked_message_q = UAMQ, tx = Tx, obsolete_delivery_tags = ODTags}) ->
     {Acked, Remaining, ODTags1} = collect_acks(UAMQ, DeliveryTag, Multiple, ODTags),
-    State1 = State#ch{unacked_message_q = Remaining, obsolete_deliver_tags = ODTags1},
+    State1 = State#ch{unacked_message_q = Remaining, obsolete_delivery_tags = ODTags1},
     {noreply, case Tx of
                   none ->
                       {State2, Actions} = internal_reject(Requeue, Acked, State1#ch.limiter, State1),

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1843,12 +1843,13 @@ consumer_monitor(ConsumerTag,
     QCons1 = maps:put(QRef, CTags1, QCons),
     State#ch{queue_consumers = QCons1}.
 
+%% Moves pending acks from unacknowledged to outdated for the given queue
 maybe_move_pending_acks_to_outdated_on_queue_down(QName, UAMQ, UAMQRet, OutdatedDeliveryTags) ->
     case ?QUEUE:out(UAMQ) of
-        {{value, #pending_ack{queue = QName, delivery_tag = Tag}}, QTail} ->
-            maybe_move_pending_acks_to_outdated_on_queue_down(QName, QTail, UAMQRet, [Tag | OutdatedDeliveryTags]);
-        {{value, Value}, QTail} ->
-            maybe_move_pending_acks_to_outdated_on_queue_down(QName, QTail, ?QUEUE:in(Value, UAMQRet), OutdatedDeliveryTags);
+        {{value, #pending_ack{queue = QName, delivery_tag = Tag}}, UAMQTail} ->
+            maybe_move_pending_acks_to_outdated_on_queue_down(QName, UAMQTail, UAMQRet, [Tag | OutdatedDeliveryTags]);
+        {{value, Value}, UAMQTail} ->
+            maybe_move_pending_acks_to_outdated_on_queue_down(QName, UAMQTail, ?QUEUE:in(Value, UAMQRet), OutdatedDeliveryTags);
         {empty, _} ->
             %% keep outdated delivery tags sorted in youngest-first order
             {UAMQRet, lists:sort(OutdatedDeliveryTags)}

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2062,7 +2062,7 @@ collect_acks(UAMQ, 0, true, ODTags) ->
 collect_acks(UAMQ, DeliveryTag, Multiple, ODTags) ->
     collect_acks([], [], UAMQ, DeliveryTag, Multiple, ODTags).
 
-collect_acks(AckedAcc, StillPendingAcc, UAMQ, DeliveryTag, Multiple, []) ->
+collect_acks(AckedAcc, StillPendingAcc, UAMQ, DeliveryTag, Multiple, [] = _ODTags) ->
     case ?QUEUE:out(UAMQ) of
         {{value, UnackedMsg = #pending_ack{delivery_tag = PendingDT}}, UAMQTail} ->
             %% ack of a single delivery

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -166,7 +166,8 @@
              interceptor_state,
              queue_states,
              tick_timer,
-             publishing_mode = false :: boolean()
+             publishing_mode = false :: boolean(),
+             obsolete_deliver_tags = []
             }).
 
 -define(QUEUE, lqueue).
@@ -1338,9 +1339,10 @@ handle_method(#'basic.nack'{delivery_tag = DeliveryTag,
 
 handle_method(#'basic.ack'{delivery_tag = DeliveryTag,
                            multiple     = Multiple},
-              _, State = #ch{unacked_message_q = UAMQ, tx = Tx}) ->
-    {Acked, Remaining} = collect_acks(UAMQ, DeliveryTag, Multiple),
-    State1 = State#ch{unacked_message_q = Remaining},
+              _, State = #ch{unacked_message_q = UAMQ, tx = Tx,
+                             obsolete_deliver_tags = ODTags}) ->
+    {Acked, Remaining, ODTags1} = collect_acks(UAMQ, DeliveryTag, Multiple, ODTags),
+    State1 = State#ch{unacked_message_q = Remaining, obsolete_deliver_tags = ODTags1},
     {noreply, case Tx of
                   none         -> {State2, Actions} = ack(Acked, State1),
                                   handle_queue_actions(Actions, State2);
@@ -1838,12 +1840,26 @@ consumer_monitor(ConsumerTag,
     QCons1 = maps:put(QRef, CTags1, QCons),
     State#ch{queue_consumers = QCons1}.
 
+delete_uamq_queue_down_or_eol(QName, UAMQ, UAMQRet, ObsoleteDeliverTags) ->
+    case ?QUEUE:out(UAMQ) of
+        {{value, #pending_ack{queue = QName, delivery_tag = Tag}}, QTail} ->
+            delete_uamq_queue_down_or_eol(QName, QTail, UAMQRet, [Tag | ObsoleteDeliverTags]);
+        {{value, Value}, QTail} ->
+            delete_uamq_queue_down_or_eol(QName, QTail, ?QUEUE:in(Value, UAMQRet), ObsoleteDeliverTags);
+        {empty, _} ->
+            %% return ObsoleteDeliverTags in youngest-first order
+            {UAMQRet, lists:sort(ObsoleteDeliverTags)}
+    end.
+
 handle_consuming_queue_down_or_eol(QName,
-                                   State = #ch{queue_consumers = QCons}) ->
+                                   State = #ch{queue_consumers = QCons,
+                                       unacked_message_q = UAMQ}) ->
     ConsumerTags = case maps:find(QName, QCons) of
                        error       -> gb_sets:new();
                        {ok, CTags} -> CTags
                    end,
+    %% Delete the UAMQ of old QPId
+    {UAMQ1, ObsoleteDeliverTags} = delete_uamq_queue_down_or_eol(QName, UAMQ, ?QUEUE:new(), []),
     gb_sets:fold(
       fun (CTag, StateN = #ch{consumer_mapping = CMap}) ->
               case queue_down_consumer_action(CTag, CMap) of
@@ -1859,7 +1875,9 @@ handle_consuming_queue_down_or_eol(QName,
                               cancel_consumer(CTag, QName, StateN)
                       end
               end
-      end, State#ch{queue_consumers = maps:remove(QName, QCons)}, ConsumerTags).
+      end, State#ch{queue_consumers = maps:remove(QName, QCons),
+            unacked_message_q = UAMQ1,
+            obsolete_deliver_tags = ObsoleteDeliverTags}, ConsumerTags).
 
 %% [0] There is a slight danger here that if a queue is deleted and
 %% then recreated again the reconsume will succeed even though it was
@@ -1950,9 +1968,9 @@ basic_return(#basic_message{exchange_name = ExchangeName,
            Content).
 
 reject(DeliveryTag, Requeue, Multiple,
-       State = #ch{unacked_message_q = UAMQ, tx = Tx}) ->
-    {Acked, Remaining} = collect_acks(UAMQ, DeliveryTag, Multiple),
-    State1 = State#ch{unacked_message_q = Remaining},
+       State = #ch{unacked_message_q = UAMQ, tx = Tx, obsolete_deliver_tags = ODTags}) ->
+    {Acked, Remaining, ODTags1} = collect_acks(UAMQ, DeliveryTag, Multiple, ODTags),
+    State1 = State#ch{unacked_message_q = Remaining, obsolete_deliver_tags = ODTags1},
     {noreply, case Tx of
                   none ->
                       {State2, Actions} = internal_reject(Requeue, Acked, State1#ch.limiter, State1),
@@ -2030,12 +2048,12 @@ record_sent(Type, QueueType, Tag, AckRequired,
     State#ch{unacked_message_q = UAMQ1, next_tag = DeliveryTag + 1}.
 
 %% NB: returns acks in youngest-first order
-collect_acks(Q, 0, true) ->
-    {lists:reverse(?QUEUE:to_list(Q)), ?QUEUE:new()};
-collect_acks(Q, DeliveryTag, Multiple) ->
-    collect_acks([], [], Q, DeliveryTag, Multiple).
+collect_acks(Q, 0, true, ODTags) ->
+    {lists:reverse(?QUEUE:to_list(Q)), ?QUEUE:new(), ODTags};
+collect_acks(Q, DeliveryTag, Multiple, ODTags) ->
+    collect_acks([], [], Q, DeliveryTag, Multiple, ODTags).
 
-collect_acks(ToAcc, PrefixAcc, Q, DeliveryTag, Multiple) ->
+collect_acks(ToAcc, PrefixAcc, Q, DeliveryTag, Multiple, []) ->
     case ?QUEUE:out(Q) of
         {{value, UnackedMsg = #pending_ack{delivery_tag = CurrentDeliveryTag}},
          QTail} ->
@@ -2046,16 +2064,53 @@ collect_acks(ToAcc, PrefixAcc, Q, DeliveryTag, Multiple) ->
                         _  -> ?QUEUE:join(
                                  ?QUEUE:from_list(lists:reverse(PrefixAcc)),
                                  QTail)
-                    end};
+                    end, []};
                Multiple ->
                     collect_acks([UnackedMsg | ToAcc], PrefixAcc,
-                                 QTail, DeliveryTag, Multiple);
+                                 QTail, DeliveryTag, Multiple, []);
                true ->
                     collect_acks(ToAcc, [UnackedMsg | PrefixAcc],
-                                 QTail, DeliveryTag, Multiple)
+                                 QTail, DeliveryTag, Multiple, [])
             end;
         {empty, _} ->
             precondition_failed("unknown delivery tag ~w", [DeliveryTag])
+    end;
+collect_acks(ToAcc, PrefixAcc, Q, DeliveryTag, Multiple, ODTags) ->
+    case ?QUEUE:out(Q) of
+        {{value, UnackedMsg = #pending_ack{delivery_tag = CurrentDeliveryTag}},
+         QTail} ->
+            if CurrentDeliveryTag == DeliveryTag ->
+                   {[UnackedMsg | ToAcc],
+                    case PrefixAcc of
+                        [] -> QTail;
+                        _  -> ?QUEUE:join(
+                                 ?QUEUE:from_list(lists:reverse(PrefixAcc)),
+                                 QTail)
+                    end, ODTags};
+               Multiple ->
+                   collect_acks([UnackedMsg | ToAcc], PrefixAcc,
+                                 QTail, DeliveryTag, Multiple,
+                                lists:filter(fun(ODTag) -> ODTag > CurrentDeliveryTag end, ODTags));
+               true ->
+                   collect_acks(ToAcc, [UnackedMsg | PrefixAcc],
+                                 QTail, DeliveryTag, Multiple, lists:delete(CurrentDeliveryTag, ODTags))
+            end;
+        {empty, _} ->
+            IsODTag = lists:member(DeliveryTag, ODTags),
+            case IsODTag of
+                true ->
+                    ODTags1 =
+                        case Multiple of
+                            true -> lists:filter(fun(ODTag) -> ODTag > DeliveryTag end, ODTags);
+                            _ -> lists:delete(DeliveryTag, ODTags)
+                        end,
+                    {ToAcc,
+                        case PrefixAcc of
+                            [] -> ?QUEUE:new();
+                            _  -> ?QUEUE:from_list(lists:reverse(PrefixAcc))
+                        end, ODTags1};
+                _ -> precondition_failed("unknown delivery tag ~w", [DeliveryTag])
+            end
     end.
 
 %% NB: Acked is in youngest-first order
@@ -2336,6 +2391,7 @@ coalesce_and_send(MsgSeqNos, NegativeMsgSeqNos, MkMsgFun, State = #ch{unconfirme
     [ok = send(MkMsgFun(SeqNo, false), State) || SeqNo <- Ss],
     State.
 
+ack_cons(_Tag, [], Acks)              -> Acks;
 ack_cons(Tag, Acked, [{Tag, Acks} | L]) -> [{Tag, Acked ++ Acks} | L];
 ack_cons(Tag, Acked, Acks)              -> [{Tag, Acked} | Acks].
 

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -501,6 +501,8 @@ settle(QRef, Op, CTag, MsgIds, Ctxs)
             {ok, Ctxs, []};
         #ctx{state = State0,
              module = Mod} = Ctx ->
+            %% rabbit_log:debug("Settling messages ~p for consumer tag '~s'",
+            %%                  [MsgIds, CTag]),
             case Mod:settle(Op, CTag, MsgIds, State0) of
                 {State, Actions} ->
                     {ok, set_ctx(QRef, Ctx#ctx{state = State}, Ctxs), Actions};


### PR DESCRIPTION
This is #4004 by @tomyouyou, rebased against `master`.

## Problem Definition

In a system with slow-acknowledging consumers that use manual acknowledgements, a queue leader restart
with acknowledgements flowing after consumer reconnection can result in extra messages being acknowledged.

## Solution

With this change, deliveries pending acknowledgements ("UAMGs" or "unacknowledged messages" in channel state)
are tracked with some extra bells and whistles:

 * When channel detects queue leader failure, all pending UAMGs for that queue are moved to
    a separate list called "outdated pending acknowledgements". This makes overly eager acking
    reported in #4004 impossible when a "stale" consumer ack comes in
 * When an unknown delivery tags comes in (there are no matches in UAMGs on this channel), instead
    of immediately returning a `406 precondition failed` error, we consult the list of outdated pending acks.
    If a pending ack with the same delivery tag is found there, it is returned for settlement with the queue
    (acknowledgement at the queue level)

Compared to #4004, this PR tracks actual `#pending_ack` records and not just delivery tags as outdated.
This makes it possible to actually settle stale acknowledgements (we still have all the context of the delivery,
namely queue reference and message ID).

## Steps to Reproduce the Issue

Reproduction of this issue is a pain because it's timing dependent.

From #4004: 

1. Make preparations, such as creating queues, etc

``` shell
date;python msg_test.py create_queue localhost 'queue=q12;durable=false' 
date;python msg_test.py create_exchange localhost 'exchange=ex11;exchange_type=topic'
date;python msg_test.py bind localhost 'exchange=ex11;queue=q12;routing_key=exq11'
```

2. Create a consumer, it will send an acknowledgement after 10s when receiving message.

``` shell
date;python msg_test.py consume localhost 'queue=q12;auto_ack=false;interval=10'
```

3. Publish five messages.
  
``` shell
date;python msg_test.py publish localhost 'exchange=ex11;routing_key=exq11;msg_hdr="_unique_id:123";count=5'
```

4. Before the consumer answers, kill the leader pid of the target queue and it will restart automatically.
  
5. Publish another five messages, so ten messages were published in total.  

6. After waiting for the consumer to answer the first five messages, restart the consumer immediately.
 
Note: The new queue leader process will mistakenly think that these first five acknowledgements are the replies of the last five messages. Therefore, the last five messages will be deleted from the queue.

```  shell
date;python msg_test.py consume localhost 'queue=q12;auto_ack=false;interval=10'
# => Wed Jan 19 09:38:11 CST 2022
# => 2022-01-19 09:38:11.699 start the 0 th thread
# => [0]connect to 10.228.103.136 ok
# => 2022-01-19 09:38:11.732  [*] Waiting for messages from q12. To exit press CTRL+C
# => 2022-01-19 09:39:32.670  [0] Received '_unique_id:"_unique_' ack:True delivery_tag:1 red:False sleep:10, average_time:0 tag:None count:1
# => 2022-01-19 09:39:42.674  [0] Received '_unique_id:"_unique_' ack:True delivery_tag:2 red:False sleep:10, average_time:0 tag:None count:2
# => 2022-01-19 09:39:52.677  [0] Received '_unique_id:"_unique_' ack:True delivery_tag:3 red:False sleep:10, average_time:0 tag:None count:3
# => 2022-01-19 09:40:02.680  [0] Received '_unique_id:"_unique_' ack:True delivery_tag:4 red:False sleep:10, average_time:0 tag:None count:4
# => 2022-01-19 09:40:12.690  [0] Received '_unique_id:"_unique_' ack:True delivery_tag:5 red:False sleep:10, average_time:0 tag:None count:5

date;python msg_test.py consume localhost 'queue=q12;auto_ack=false;interval=10'
# => Wed Jan 19 09:40:15 CST 2022
# => 2022-01-19 09:40:15.909 start the 0 th thread
# => [0]connect to 10.228.103.136 ok
# => 2022-01-19 09:40:15.932  [*] Waiting for messages from q12. To exit press CTRL+C


rabbitmqctl list_queues
# => Timeout: 60.0 seconds ...
# => Listing queues for vhost / ...
# => name    messages        messages_ready  messages_unacknowledged consumers
# => q12     0       0       0       1
```

This command shows that there are no messages in the queue, so the new consumer will never receive the last five messages.
  
In other words, there are ten messages in total, while consumers can only process the first five messages. The last five messages were lost.
