### PR TITLE
Use bazel for building the oci in github actions

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: packaging/docker-image
-          push: false
+          push: true
           tags: |
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -76,12 +76,12 @@ jobs:
           cat << EOF >> user.bazelrc
             build:buildbuddy --build_metadata=ROLE=CI
             build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
-            build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-oci-${{ matrix.erlang_version }}
+            build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-oci
             build:buildbuddy --repository_cache=/home/runner/repo-cache/
             build:buildbuddy --color=yes
             build:buildbuddy --disk_cache=
 
-            build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
+            build --@rules_erlang//:erlang_version=${{ steps.load-info.outputs.otp }}
             build --@rules_erlang//:erlang_home=${ERLANG_HOME}
             build --//:elixir_home=${ELIXIR_HOME}
           EOF
@@ -90,6 +90,11 @@ jobs:
         run: |
           sed -i"_orig" '/APP_VERSION/ s/3.10.0/${{ github.sha }}/' rabbitmq.bzl
           bazelisk build :package-generic-unix
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: package-generic-unix-${{ steps.load-info.outputs.otp }}.tar.xz
+          path: ${{ github.workspace }}/bazel-bin/package-generic-unix.tar.xz
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -91,10 +91,16 @@ jobs:
           sed -i"_orig" '/APP_VERSION/ s/3.10.0/${{ github.sha }}/' rabbitmq.bzl
           bazelisk build :package-generic-unix
 
-      - uses: actions/upload-artifact@v3
+      - name: Resolve generic unix package path
+        run: |
+          echo "::set-output name=ARTIFACT_PATH::$(readlink -f ${GENERIC_UNIX_ARCHIVE})"
+        id: resolve-artifact-path
+
+      - name: Save the package as a workflow artifact
+        uses: actions/upload-artifact@v3
         with:
           name: package-generic-unix-${{ steps.load-info.outputs.otp }}.tar.xz
-          path: ${{ github.workspace }}/bazel-bin/package-generic-unix.tar.xz
+          path: ${{ steps.resolve-artifact-path.outputs.ARTIFACT_PATH }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -6,13 +6,15 @@ on:
       - 'deps/**'
       - 'packaging/**'
       - 'scripts/**'
-      - Makefile
-      - plugins.mk
-      - rabbitmq-components.mk
+      - .bazelrc
+      - .bazelversion
+      - BUILD.*
+      - '*.bzl'
+      - '*.bazel'
       - .github/workflows/oci.yaml
   workflow_dispatch:
 env:
-  GENERIC_UNIX_ARCHIVE: ${{ github.workspace }}/PACKAGES/rabbitmq-server-generic-unix-${{ github.sha }}.tar.xz
+  GENERIC_UNIX_ARCHIVE: ${{ github.workspace }}/bazel-bin/package-generic-unix.tar.xz
   RABBITMQ_VERSION: ${{ github.sha }}
   VERSION: ${{ github.sha }}
 jobs:
@@ -56,9 +58,38 @@ jobs:
           otp-version: ${{ steps.load-info.outputs.otp }}
           elixir-version: ${{ steps.load-info.outputs.elixir }}
 
+      - name: MOUNT BAZEL CACHE
+        uses: actions/cache@v1
+        with:
+          path: "/home/runner/repo-cache/"
+          key: repo-cache
+
+      - name: CONFIGURE BAZEL
+        run: |
+          ERLANG_HOME="$(dirname $(dirname $(which erl)))"
+          ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
+          if [ -n "${{ secrets.BUILDBUDDY_API_KEY }}" ]; then
+          cat << EOF >> user.bazelrc
+            build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
+          EOF
+          fi
+          cat << EOF >> user.bazelrc
+            build:buildbuddy --build_metadata=ROLE=CI
+            build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
+            build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-oci-${{ matrix.erlang_version }}
+            build:buildbuddy --repository_cache=/home/runner/repo-cache/
+            build:buildbuddy --color=yes
+            build:buildbuddy --disk_cache=
+
+            build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
+            build --@rules_erlang//:erlang_home=${ERLANG_HOME}
+            build --//:elixir_home=${ELIXIR_HOME}
+          EOF
+
       - name: Build generic unix package
         run: |
-          make package-generic-unix PROJECT_VERSION=${{ github.sha }}
+          sed -i"_orig" '/APP_VERSION/ s/3.10.0/${{ github.sha }}/' rabbitmq.bzl
+          bazelisk build :package-generic-unix
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -92,7 +123,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: packaging/docker-image
-          push: true
+          push: false
           tags: |
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -2,16 +2,6 @@
 name: OCI
 on:
   push:
-    paths:
-      - 'deps/**'
-      - 'packaging/**'
-      - 'scripts/**'
-      - .bazelrc
-      - .bazelversion
-      - BUILD.*
-      - '*.bzl'
-      - '*.bazel'
-      - .github/workflows/oci.yaml
   workflow_dispatch:
 env:
   GENERIC_UNIX_ARCHIVE: ${{ github.workspace }}/bazel-bin/package-generic-unix.tar.xz

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -212,6 +212,7 @@ erlang_app(
         name = "ra",
         branch = "main",
         remote = "https://github.com/rabbitmq/ra.git",
+        patch_cmds = [RA_INJECT_GIT_VERSION],
     )
 
     hex_archive(
@@ -282,3 +283,9 @@ erlang_app(
         branch = "master",
         build_file = rabbitmq_workspace + "//:BUILD.trust_store_http",
     )
+
+RA_INJECT_GIT_VERSION = """
+VERSION=$(git rev-parse HEAD)
+echo "Injecting ${VERSION} into ra.app.src..."
+sed -i"_orig" "/vsn,/ s/2\\.[0-9]\\.[0-9]/${VERSION}/" src/ra.app.src
+"""


### PR DESCRIPTION
Use bazel for consistency, and for convenience of injecting the ra commit hash as its version