### PR TITLE
Allow selective cli test runs with --test_env TEST_FILE

### DIFF
--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -86,7 +86,9 @@ cd ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 export ERL_LIBS=$DEPS_DIR
 
 # run the actual tests
-"{elixir_home}"/bin/mix test --trace --max-failures 1
+set +u
+set -x
+"{elixir_home}"/bin/mix test --trace --max-failures 1 ${{TEST_FILE}}
     """.format(
             begins_with_fun = BEGINS_WITH_FUN,
             query_erlang_version = QUERY_ERL_VERSION,


### PR DESCRIPTION
i.e. `bazel test //deps/rabbitmq_cli:all --test_env
TEST_FILE=test/ctl/add_user_command_test.exs`

For now this option only is honored on mac/linux