### PR TITLE
Fix next_seq_id value when none is found in terms

### DIFF
--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1788,7 +1788,7 @@ init(QueueVsn, IsDurable, IndexMod, IndexState, StoreState, DeltaCount, DeltaByt
         case Terms of
             non_clean_shutdown -> {HiSeqId, HiSeqId, DeltaCount, DeltaBytes};
             _                  -> NextSeqId0 = proplists:get_value(next_seq_id,
-                                                                   Terms, 0),
+                                                                   Terms, HiSeqId),
                                   {NextSeqId0,
                                    proplists:get_value(next_deliver_seq_id,
                                                        Terms, NextSeqId0),


### PR DESCRIPTION
This happens when upgrading from 3.9 or earlier.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/4373

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

If English isn't your first language, don't worry about it and try to communicate the problem you are trying to solve to the best of your abilities.
As long as we can understand the intent, it's all good.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
