### PR TITLE
Attempt to reduce flakes in aws integration tests

### DIFF
--- a/deps/rabbitmq_peer_discovery_aws/test/aws_ecs_util.erl
+++ b/deps/rabbitmq_peer_discovery_aws/test/aws_ecs_util.erl
@@ -169,6 +169,7 @@ ecs_up(Config) ->
     ProfileName = ?config(ecs_profile_name, Config),
     ClusterSize = ?config(ecs_cluster_size, Config),
     UpCmd = [EcsCliCmd, "up",
+             "--force",
              "--instance-role", InstanceRole,
              "--size", integer_to_list(ClusterSize),
              "--instance-type", "t2.medium",

--- a/deps/rabbitmq_peer_discovery_aws/test/integration_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_aws/test/integration_SUITE.erl
@@ -44,8 +44,9 @@ groups() ->
 init_per_suite(Config) ->
     case rabbit_ct_helpers:is_mixed_versions() of
         true ->
-            %% These test would like passed in mixed versions, but they won't
-            %% actually honor mixed versions as currently specified via env var
+            %% These test would likely pass in mixed versions, but they won't
+            %% actually honor mixed versions like the other suites, as these
+            %% tests are docker image based
             {skip, "not mixed versions compatible"};
         _ ->
             inets:start(),


### PR DESCRIPTION
## Proposed Changes

Add the `--force` flag to use of `ecs-cli up ...` since occasionally we have seen `Error executing 'up': A CloudFormation stack already exists for the cluster 'rabbitmq-peer-discovery-aws-actions-v3-9-x'. Please specify '--force' to clean up your existing resources` in the logs.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
