### PR TITLE
Remove unused code for queue and consumer args

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -449,16 +449,6 @@ capabilities() ->
                                <<"queue-leader-locator">>, <<"initial-cluster-size">>,
                                %% Quorum policies
                                <<"dead-letter-strategy">>],
-      queue_arguments => [<<"x-expires">>, <<"x-message-ttl">>, <<"x-dead-letter-exchange">>,
-                          <<"x-dead-letter-routing-key">>, <<"x-max-length">>,
-                          <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,
-                          <<"x-max-in-memory-bytes">>, <<"x-max-priority">>,
-                          <<"x-overflow">>, <<"x-queue-mode">>, <<"x-queue-version">>,
-                          <<"x-single-active-consumer">>,
-                          <<"x-queue-type">>, <<"x-queue-master-locator">>],
-      consumer_arguments => [<<"x-cancel-on-ha-failover">>,
-                             <<"x-priority">>, <<"x-credit">>
-                            ],
       server_named => true}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -395,14 +395,6 @@ capabilities() ->
             %% Stream policies
             <<"max-age">>, <<"stream-max-segment-size-bytes">>,
             <<"queue-leader-locator">>, <<"initial-cluster-size">>],
-          queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
-                              <<"x-dead-letter-strategy">>, <<"x-expires">>, <<"x-max-length">>,
-                              <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,
-                              <<"x-max-in-memory-bytes">>, <<"x-overflow">>,
-                              <<"x-single-active-consumer">>, <<"x-queue-type">>,
-                              <<"x-quorum-initial-group-size">>, <<"x-delivery-limit">>,
-                              <<"x-message-ttl">>],
-      consumer_arguments => [<<"x-priority">>, <<"x-credit">>],
       server_named => false}.
 
 rpc_delete_metrics(QName) ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -978,12 +978,6 @@ capabilities() ->
             <<"queue-master-locator">>,
             %% Quorum policies
             <<"dead-letter-strategy">>],
-      queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
-                          <<"x-max-length">>, <<"x-max-length-bytes">>,
-                          <<"x-single-active-consumer">>, <<"x-queue-type">>,
-                          <<"x-max-age">>, <<"x-stream-max-segment-size-bytes">>,
-                          <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],
-      consumer_arguments => [<<"x-stream-offset">>],
       server_named => false}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->


### PR DESCRIPTION
Before this commit, rabbit_stream_queue supported nonsensical
queue arguments such as
* x-dead-letter-exchange
* x-dead-letter-routing-key
* x-single-active-consumer

It seems that the listed queue and consumer arguments of classic, quorum, and
stream queues are nowhere validated.

While we could add validation, it will break all client applications
that have accidentally used wrong arguments.