### PR TITLE
Fixed reading SSL settings from rabbitmqadmin config file

### DIFF
--- a/deps/rabbitmq_management/bin/rabbitmqadmin
+++ b/deps/rabbitmq_management/bin/rabbitmqadmin
@@ -331,6 +331,8 @@ default_options = {"hostname": "localhost",
                    "username": "guest",
                    "password": "guest",
                    "ssl": False,
+                   "ssl_insecure": False,
+                   "ssl_disable_hostname_verification": False,
                    "request_timeout": 120,
                    "verbose": True,
                    "format": "table",
@@ -393,9 +395,9 @@ def make_parser():
     add("--ssl-ca-cert-file", dest="ssl_ca_cert_file",
         help="PEM format CA certificate file for SSL")
     add("--ssl-disable-hostname-verification", dest="ssl_disable_hostname_verification",
-        help="Disables peer hostname verification", default=False, action="store_true")
+        help="Disables peer hostname verification", action="store_true")
     add("-k", "--ssl-insecure", dest="ssl_insecure",
-        help="Disables all SSL validations like curl's '-k' argument", default=False, action="store_true")
+        help="Disables all SSL validations like curl's '-k' argument", action="store_true")
     add("-t", "--request-timeout", dest="request_timeout",
         help="HTTP request timeout in seconds", type="int")
     add("-f", "--format", dest="format",
@@ -470,13 +472,14 @@ def merge_config_file_options(cli_options, final_options):
                 assert_usage(False, msg)
         else:
             for key, section_val in section_settings.items():
-                # special case --ssl
-                if key == 'ssl':
+                # if CLI options contain this key, do not set it from the config file
+                if getattr(cli_options, key) is not None:
+                    continue
+                # special case for boolean values
+                if section_val == "True" or section_val == "False":
                     setattr(final_options, key, section_val == "True")
                 else:
-                    # if CLI options do not contain this key, set it from the config file
-                    if getattr(cli_options, key) is None:
-                        setattr(final_options, key, section_val)
+                    setattr(final_options, key, section_val)
     return final_options
 
 def expand_base_uri_options(cli_options, final_options):


### PR DESCRIPTION
I am using a self-signed certificate for RabbitMQ. In order to connect to the server using rabbitmqadmin I have to set the flag --ssl-insecure. When trying to set this flag in the rabbitmqadmin config file I noticed that it doesn't work.

## Proposed Changes

I've extended the python script so that the boolean SSL options can be defined in the config file. It is still possible to override the config values with cli options.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it