### PR TITLE
Add quorum queue-leader-locator

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1212,7 +1212,7 @@ end}.
 {mapping, "cluster_keepalive_interval", "rabbit.cluster_keepalive_interval",
     [{datatype, integer}]}.
 
-%% Queue master locator
+%% Queue master locator (classic queues)
 %%
 
 {mapping, "queue_master_locator", "rabbit.queue_master_locator",
@@ -1221,6 +1221,17 @@ end}.
 {translation, "rabbit.queue_master_locator",
 fun(Conf) ->
     list_to_binary(cuttlefish:conf_get("queue_master_locator", Conf))
+end}.
+
+%% Queue leader locator (quorum queues and streams)
+%%
+
+{mapping, "queue_leader_locator", "rabbit.queue_leader_locator",
+    [{datatype, string}]}.
+
+{translation, "rabbit.queue_leader_locator",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("queue_leader_locator", Conf))
 end}.
 
 %%

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -979,16 +979,15 @@ check_overflow(Val, _Args) when is_binary(Val) ->
 check_overflow(_Val, _Args) ->
     {error, invalid_overflow}.
 
--define(KNOWN_LEADER_LOCATORS, [<<"client-local">>, <<"random">>, <<"least-leaders">>]).
 check_queue_leader_locator_arg({longstr, Val}, _Args) ->
-    case lists:member(Val, ?KNOWN_LEADER_LOCATORS) of
+    case lists:member(Val, rabbit_queue_location:queue_leader_locators()) of
         true  -> ok;
         false -> {error, invalid_queue_locator_arg}
     end;
 check_queue_leader_locator_arg({Type, _}, _Args) ->
     {error, {unacceptable_type, Type}};
 check_queue_leader_locator_arg(Val, _Args) when is_binary(Val) ->
-    case lists:member(Val, ?KNOWN_LEADER_LOCATORS) of
+    case lists:member(Val, rabbit_queue_location:queue_leader_locators()) of
         true  -> ok;
         false -> {error, invalid_queue_locator_arg}
     end;

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -683,12 +683,17 @@ add_queue_int(_Queue, R = #resource{kind = queue,
     rabbit_log:warning("Skipping import of a queue whose name begins with 'amq.', "
                        "name: ~s, acting user: ~s", [Name, ActingUser]);
 add_queue_int(Queue, Name, ActingUser) ->
-    rabbit_amqqueue:declare(Name,
-                            maps:get(durable,                         Queue, undefined),
-                            maps:get(auto_delete,                     Queue, undefined),
-                            args(maps:get(arguments, Queue, undefined)),
-                            none,
-                            ActingUser).
+    case rabbit_amqqueue:lookup(Name) of
+        {ok, _} ->
+            ok;
+        {error, not_found} ->
+            rabbit_amqqueue:declare(Name,
+                                    maps:get(durable, Queue, undefined),
+                                    maps:get(auto_delete, Queue, undefined),
+                                    args(maps:get(arguments, Queue, undefined)),
+                                    none,
+                                    ActingUser)
+    end.
 
 add_exchange(Exchange, ActingUser) ->
     add_exchange_int(Exchange, r(exchange, Exchange), ActingUser).

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -683,19 +683,12 @@ add_queue_int(_Queue, R = #resource{kind = queue,
     rabbit_log:warning("Skipping import of a queue whose name begins with 'amq.', "
                        "name: ~s, acting user: ~s", [Name, ActingUser]);
 add_queue_int(Queue, Name, ActingUser) ->
-    case rabbit_amqqueue:lookup(Name) of
-        {ok, _} ->
-            %% Skip declaring a queue that already exists to avoid
-            %% potentially expensive node and leader selection.
-            ok;
-        {error, not_found} ->
-            rabbit_amqqueue:declare(Name,
-                                    maps:get(durable, Queue, undefined),
-                                    maps:get(auto_delete, Queue, undefined),
-                                    args(maps:get(arguments, Queue, undefined)),
-                                    none,
-                                    ActingUser)
-    end.
+    rabbit_amqqueue:declare(Name,
+                            maps:get(durable,                         Queue, undefined),
+                            maps:get(auto_delete,                     Queue, undefined),
+                            args(maps:get(arguments, Queue, undefined)),
+                            none,
+                            ActingUser).
 
 add_exchange(Exchange, ActingUser) ->
     add_exchange_int(Exchange, r(exchange, Exchange), ActingUser).

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -683,12 +683,19 @@ add_queue_int(_Queue, R = #resource{kind = queue,
     rabbit_log:warning("Skipping import of a queue whose name begins with 'amq.', "
                        "name: ~s, acting user: ~s", [Name, ActingUser]);
 add_queue_int(Queue, Name, ActingUser) ->
-    rabbit_amqqueue:declare(Name,
-                            maps:get(durable,                         Queue, undefined),
-                            maps:get(auto_delete,                     Queue, undefined),
-                            args(maps:get(arguments, Queue, undefined)),
-                            none,
-                            ActingUser).
+    case rabbit_amqqueue:lookup(Name) of
+        {ok, _} ->
+            %% Skip declaring a queue that already exists to avoid
+            %% potentially expensive node and leader selection.
+            ok;
+        {error, not_found} ->
+            rabbit_amqqueue:declare(Name,
+                                    maps:get(durable, Queue, undefined),
+                                    maps:get(auto_delete, Queue, undefined),
+                                    args(maps:get(arguments, Queue, undefined)),
+                                    none,
+                                    ActingUser)
+    end.
 
 add_exchange(Exchange, ActingUser) ->
     add_exchange_int(Exchange, r(exchange, Exchange), ActingUser).

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -457,7 +457,8 @@ is_process_alive({Name, Node}) ->
 is_registered_process_alive(Name) ->
     is_pid(whereis(Name)).
 
--spec cluster_nodes('all' | 'disc' | 'ram' | 'running') -> [node()].
+-spec cluster_nodes('all' | 'disc' | 'ram' | 'running') -> [node()];
+                   ('status') -> {[node()], [node()], [node()]}.
 
 cluster_nodes(WhichNodes) -> cluster_status(WhichNodes).
 

--- a/deps/rabbit/src/rabbit_policies.erl
+++ b/deps/rabbit/src/rabbit_policies.erl
@@ -168,6 +168,9 @@ validate_policy0(<<"max-age">>, Value) ->
 
 validate_policy0(<<"queue-leader-locator">>, <<"client-local">>) ->
     ok;
+validate_policy0(<<"queue-leader-locator">>, <<"balanced">>) ->
+    ok;
+%% 'random' and 'least-leaders' are deprecated and get mapped to 'balanced'
 validate_policy0(<<"queue-leader-locator">>, <<"random">>) ->
     ok;
 validate_policy0(<<"queue-leader-locator">>, <<"least-leaders">>) ->

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -11,6 +11,10 @@
 
 -export([select_leader_and_followers/2]).
 
+-define(QUEUES_LIMIT_FOR_LEAST_REPLICAS_SELECTION, 1_000).
+
+-spec select_leader_and_followers(amqqueue:amqqueue(), pos_integer()) ->
+    {Leader :: node(), Followers :: [node()]}.
 select_leader_and_followers(Q, Size)
   when (?amqqueue_is_quorum(Q) orelse ?amqqueue_is_stream(Q)) andalso is_integer(Size) ->
     QueueType = amqqueue:get_type(Q),
@@ -27,50 +31,63 @@ select_leader_and_followers(Q, Size)
     Followers = lists:delete(Leader, Replicas),
     {Leader, Followers}.
 
+-spec select_replicas(pos_integer(), [node(),...], [node(),...], function()) ->
+    {[node(),...], function()}.
 select_replicas(Size, AllNodes, _, Fun)
   when length(AllNodes) =< Size ->
     {AllNodes, Fun};
-select_replicas(Size, _, RunningNodes, Fun)
-  when length(RunningNodes) =:= Size ->
-    {RunningNodes, Fun};
 select_replicas(Size, AllNodes, RunningNodes, GetQueues) ->
     %% Select nodes in the following order:
-    %% 1. local node (to have data locality for declaring client)
-    %% 2. running nodes
-    %% 3. nodes with least replicas (to have a "balanced" RabbitMQ cluster).
+    %% 1.   Local node to have data locality for declaring client.
+    %% 2.   Running nodes.
+    %% 3.1. If there are few queues: Nodes with least replicas to have a "balanced" RabbitMQ cluster.
+    %% 3.2. If there are many queues: Randomly to avoid expensive calculation of counting replicas
+    %%      per node. Random replica selection is good enough for most use cases.
     Local = node(),
     true = lists:member(Local, AllNodes),
-    true = lists:member(Local, RunningNodes),
-    Counters0 = maps:from_list([{Node, 0} || Node <- lists:delete(Local, AllNodes)]),
-    Queues = GetQueues(),
-    Counters = lists:foldl(fun(Q, Acc) ->
-                                   #{nodes := Nodes} = amqqueue:get_type_state(Q),
-                                   lists:foldl(fun(N, A)
-                                                     when is_map_key(N, A) ->
-                                                       maps:update_with(N, fun(C) -> C+1 end, A);
-                                                  (_, A) ->
-                                                       A
-                                               end, Acc, Nodes)
-                           end, Counters0, Queues),
-    L0 = maps:to_list(Counters),
-    L1 = lists:sort(fun({N0, C0}, {N1, C1}) ->
-                            case {lists:member(N0, RunningNodes),
-                                  lists:member(N1, RunningNodes)} of
-                                {true, false} ->
-                                    true;
-                                {false, true} ->
-                                    false;
-                                _ ->
-                                    C0 =< C1
-                            end
-                    end, L0),
-    {L2, _} = lists:split(Size - 1, L1),
-    L = lists:map(fun({N, _}) -> N end, L2),
-    {[Local | L], fun() -> Queues end}.
+    RemoteNodes = lists:delete(Local, AllNodes),
+    case rabbit_amqqueue:count() of
+        Count when Count =< ?QUEUES_LIMIT_FOR_LEAST_REPLICAS_SELECTION ->
+            Counters0 = maps:from_list([{N, 0} || N <- RemoteNodes]),
+            Queues = GetQueues(),
+            Counters = lists:foldl(fun(Q, Acc) ->
+                                           #{nodes := Nodes} = amqqueue:get_type_state(Q),
+                                           lists:foldl(fun(N, A)
+                                                             when is_map_key(N, A) ->
+                                                               maps:update_with(N, fun(C) -> C+1 end, A);
+                                                          (_, A) ->
+                                                               A
+                                                       end, Acc, Nodes)
+                                   end, Counters0, Queues),
+            L0 = maps:to_list(Counters),
+            L1 = lists:sort(fun({N0, C0}, {N1, C1}) ->
+                                    case {lists:member(N0, RunningNodes),
+                                          lists:member(N1, RunningNodes)} of
+                                        {true, false} ->
+                                            true;
+                                        {false, true} ->
+                                            false;
+                                        _ ->
+                                            C0 =< C1
+                                    end
+                            end, L0),
+            {L2, _} = lists:split(Size - 1, L1),
+            L = lists:map(fun({N, _}) -> N end, L2),
+            {[Local | L], fun() -> Queues end};
+        _ ->
+            L0 = shuffle(RemoteNodes),
+            L1 = lists:sort(fun(X, _Y) ->
+                                    lists:member(X, RunningNodes)
+                            end, L0),
+            {L, _} = lists:split(Size - 1, L1),
+            {[Local | L], GetQueues}
+    end.
 
 leader_locator(undefined) -> <<"client-local">>;
 leader_locator(Val) -> Val.
 
+-spec leader_node(nonempty_binary(), [node(),...], [node(),...], function()) ->
+    node().
 leader_node(<<"client-local">>, _, _, _) ->
     node();
 leader_node(<<"random">>, Nodes0, RunningNodes, _) ->
@@ -95,17 +112,21 @@ leader_node(<<"least-leaders">>, Nodes0, RunningNodes, GetQueues)
     {Node, _} = hd(lists:keysort(2, maps:to_list(Counters))),
     Node.
 
-potential_leaders(Nodes, AllRunningNodes) ->
-    RunningNodes = lists:filter(fun(N) ->
-                                        lists:member(N, AllRunningNodes)
-                                end, Nodes),
-    case rabbit_maintenance:filter_out_drained_nodes_local_read(RunningNodes) of
+potential_leaders(Replicas, RunningNodes) ->
+    case lists:filter(fun(R) ->
+                              lists:member(R, RunningNodes)
+                      end, Replicas) of
         [] ->
-            %% All running nodes are drained. Let's place the leader on a drained node
-            %% respecting the requested queue-leader-locator streategy.
-            RunningNodes;
-        Filtered ->
-            Filtered
+            Replicas;
+        RunningReplicas ->
+            case rabbit_maintenance:filter_out_drained_nodes_local_read(RunningReplicas) of
+                [] ->
+                    %% All selected replica nodes are drained. Let's place the leader on a
+                    %% drained node respecting the requested queue-leader-locator streategy.
+                    RunningReplicas;
+                Filtered ->
+                    Filtered
+            end
     end.
 
 %% Return a function so that queues are fetched lazily (i.e. only when needed,
@@ -117,3 +138,8 @@ get_queues_for_type(QueueType) ->
                                                  amqqueue:pattern_match_on_type(QueueType))
                end)
     end.
+
+shuffle(L0) when is_list(L0) ->
+    L1 = lists:map(fun(E) -> {rand:uniform(), E} end, L0),
+    L = lists:keysort(1, L1),
+    lists:map(fun({_, E}) -> E end, L).

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -16,7 +16,7 @@
 -define(QUEUE_LEADER_LOCATORS, [<<"client-local">>, <<"balanced">>] ++ ?QUEUE_LEADER_LOCATORS_DEPRECATED).
 -define(QUEUE_COUNT_START_RANDOM_SELECTION, 1_000).
 
--type queue_leader_locator() :: nonempty_binary().
+-type queue_leader_locator() :: binary().
 
 -spec queue_leader_locators() ->
     [queue_leader_locator()].

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -1,0 +1,119 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_queue_location).
+
+-include("amqqueue.hrl").
+
+-export([select_leader_and_followers/2]).
+
+select_leader_and_followers(Q, Size)
+  when (?amqqueue_is_quorum(Q) orelse ?amqqueue_is_stream(Q)) andalso is_integer(Size) ->
+    QueueType = amqqueue:get_type(Q),
+    GetQueues0 = get_queues_for_type(QueueType),
+    {AllNodes, _DiscNodes, RunningNodes} = rabbit_mnesia:cluster_nodes(status),
+    {Replicas, GetQueues} = select_replicas(Size, AllNodes, RunningNodes, GetQueues0),
+    LeaderLocator = leader_locator(
+                      rabbit_queue_type_util:args_policy_lookup(
+                        <<"queue-leader-locator">>,
+                        fun (PolVal, _ArgVal) ->
+                                PolVal
+                        end, Q)),
+    Leader = leader_node(LeaderLocator, Replicas, RunningNodes, GetQueues),
+    Followers = lists:delete(Leader, Replicas),
+    {Leader, Followers}.
+
+select_replicas(Size, AllNodes, _, Fun)
+  when length(AllNodes) =< Size ->
+    {AllNodes, Fun};
+select_replicas(Size, _, RunningNodes, Fun)
+  when length(RunningNodes) =:= Size ->
+    {RunningNodes, Fun};
+select_replicas(Size, AllNodes, RunningNodes, GetQueues) ->
+    %% Select nodes in the following order:
+    %% 1. local node (to have data locality for declaring client)
+    %% 2. running nodes
+    %% 3. nodes with least replicas (to have a "balanced" RabbitMQ cluster).
+    Local = node(),
+    true = lists:member(Local, AllNodes),
+    true = lists:member(Local, RunningNodes),
+    Counters0 = maps:from_list([{Node, 0} || Node <- lists:delete(Local, AllNodes)]),
+    Queues = GetQueues(),
+    Counters = lists:foldl(fun(Q, Acc) ->
+                                   #{nodes := Nodes} = amqqueue:get_type_state(Q),
+                                   lists:foldl(fun(N, A)
+                                                     when is_map_key(N, A) ->
+                                                       maps:update_with(N, fun(C) -> C+1 end, A);
+                                                  (_, A) ->
+                                                       A
+                                               end, Acc, Nodes)
+                           end, Counters0, Queues),
+    L0 = maps:to_list(Counters),
+    L1 = lists:sort(fun({N0, C0}, {N1, C1}) ->
+                            case {lists:member(N0, RunningNodes),
+                                  lists:member(N1, RunningNodes)} of
+                                {true, false} ->
+                                    true;
+                                {false, true} ->
+                                    false;
+                                _ ->
+                                    C0 =< C1
+                            end
+                    end, L0),
+    {L2, _} = lists:split(Size - 1, L1),
+    L = lists:map(fun({N, _}) -> N end, L2),
+    {[Local | L], fun() -> Queues end}.
+
+leader_locator(undefined) -> <<"client-local">>;
+leader_locator(Val) -> Val.
+
+leader_node(<<"client-local">>, _, _, _) ->
+    node();
+leader_node(<<"random">>, Nodes0, RunningNodes, _) ->
+    Nodes = potential_leaders(Nodes0, RunningNodes),
+    lists:nth(rand:uniform(length(Nodes)), Nodes);
+leader_node(<<"least-leaders">>, Nodes0, RunningNodes, GetQueues)
+  when is_function(GetQueues, 0) ->
+    Nodes = potential_leaders(Nodes0, RunningNodes),
+    Counters0 = maps:from_list([{N, 0} || N <- Nodes]),
+    Counters = lists:foldl(fun(Q, Acc) ->
+                                   case amqqueue:get_pid(Q) of
+                                       {RaName, LeaderNode}
+                                         when is_atom(RaName), is_atom(LeaderNode), is_map_key(LeaderNode, Acc) ->
+                                           maps:update_with(LeaderNode, fun(C) -> C+1 end, Acc);
+                                       StreamLeaderPid
+                                         when is_pid(StreamLeaderPid), is_map_key(node(StreamLeaderPid), Acc) ->
+                                           maps:update_with(node(StreamLeaderPid), fun(C) -> C+1 end, Acc);
+                                       _ ->
+                                           Acc
+                                   end
+                           end, Counters0, GetQueues()),
+    {Node, _} = hd(lists:keysort(2, maps:to_list(Counters))),
+    Node.
+
+potential_leaders(Nodes, AllRunningNodes) ->
+    RunningNodes = lists:filter(fun(N) ->
+                                        lists:member(N, AllRunningNodes)
+                                end, Nodes),
+    case rabbit_maintenance:filter_out_drained_nodes_local_read(RunningNodes) of
+        [] ->
+            %% All running nodes are drained. Let's place the leader on a drained node
+            %% respecting the requested queue-leader-locator streategy.
+            RunningNodes;
+        Filtered ->
+            Filtered
+    end.
+
+%% Return a function so that queues are fetched lazily (i.e. only when needed,
+%% and at most once when no amqqueue migration is going on).
+get_queues_for_type(QueueType) ->
+    fun() -> rabbit_amqqueue:list_with_possible_retry(
+               fun() ->
+                       mnesia:dirty_match_object(rabbit_queue,
+                                                 amqqueue:pattern_match_on_type(QueueType))
+               end)
+    end.

--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -12,9 +12,9 @@
 -export([queue_leader_locators/0,
          select_leader_and_followers/2]).
 
--define(QUEUES_LIMIT_FOR_LEAST_REPLICAS_SELECTION, 1_000).
--define(QUEUE_LEADER_LOCATORS, [<<"client-local">>, <<"random">>, <<"least-leaders">>]).
--define(DEFAULT_QUEUE_LEADER_LOCATOR, <<"client-local">>).
+-define(QUEUE_LEADER_LOCATORS_DEPRECATED, [<<"random">>, <<"least-leaders">>]).
+-define(QUEUE_LEADER_LOCATORS, [<<"client-local">>, <<"balanced">>] ++ ?QUEUE_LEADER_LOCATORS_DEPRECATED).
+-define(QUEUE_COUNT_START_RANDOM_SELECTION, 1_000).
 
 -type queue_leader_locator() :: nonempty_binary().
 
@@ -27,98 +27,100 @@ queue_leader_locators() ->
     {Leader :: node(), Followers :: [node()]}.
 select_leader_and_followers(Q, Size)
   when (?amqqueue_is_quorum(Q) orelse ?amqqueue_is_stream(Q)) andalso is_integer(Size) ->
+    {AllNodes, _DiscNodes, RunningNodes} = rabbit_mnesia:cluster_nodes(status),
+    true = lists:member(node(), AllNodes),
     QueueType = amqqueue:get_type(Q),
     GetQueues0 = get_queues_for_type(QueueType),
-    {AllNodes, _DiscNodes, RunningNodes} = rabbit_mnesia:cluster_nodes(status),
-    {Replicas, GetQueues} = select_replicas(Size, AllNodes, RunningNodes, GetQueues0),
+    QueueCount = rabbit_amqqueue:count(),
+    {Replicas, GetQueues} = select_replicas(Size, AllNodes, RunningNodes, QueueCount, GetQueues0),
     LeaderLocator = leader_locator(Q),
-    Leader = leader_node(LeaderLocator, Replicas, RunningNodes, GetQueues),
+    Leader = leader_node(LeaderLocator, Replicas, RunningNodes, QueueCount, GetQueues),
     Followers = lists:delete(Leader, Replicas),
     {Leader, Followers}.
-
--spec select_replicas(pos_integer(), [node(),...], [node(),...], function()) ->
-    {[node(),...], function()}.
-select_replicas(Size, AllNodes, _, Fun)
-  when length(AllNodes) =< Size ->
-    {AllNodes, Fun};
-select_replicas(Size, AllNodes, RunningNodes, GetQueues) ->
-    %% Select nodes in the following order:
-    %% 1.   Local node to have data locality for declaring client.
-    %% 2.   Running nodes.
-    %% 3.1. If there are few queues: Nodes with least replicas to have a "balanced" RabbitMQ cluster.
-    %% 3.2. If there are many queues: Randomly to avoid expensive calculation of counting replicas
-    %%      per node. Random replica selection is good enough for most use cases.
-    Local = node(),
-    true = lists:member(Local, AllNodes),
-    RemoteNodes = lists:delete(Local, AllNodes),
-    case rabbit_amqqueue:count() of
-        Count when Count =< ?QUEUES_LIMIT_FOR_LEAST_REPLICAS_SELECTION ->
-            Counters0 = maps:from_list([{N, 0} || N <- RemoteNodes]),
-            Queues = GetQueues(),
-            Counters = lists:foldl(fun(Q, Acc) ->
-                                           #{nodes := Nodes} = amqqueue:get_type_state(Q),
-                                           lists:foldl(fun(N, A)
-                                                             when is_map_key(N, A) ->
-                                                               maps:update_with(N, fun(C) -> C+1 end, A);
-                                                          (_, A) ->
-                                                               A
-                                                       end, Acc, Nodes)
-                                   end, Counters0, Queues),
-            L0 = maps:to_list(Counters),
-            L1 = lists:sort(fun({N0, C0}, {N1, C1}) ->
-                                    case {lists:member(N0, RunningNodes),
-                                          lists:member(N1, RunningNodes)} of
-                                        {true, false} ->
-                                            true;
-                                        {false, true} ->
-                                            false;
-                                        _ ->
-                                            C0 =< C1
-                                    end
-                            end, L0),
-            {L2, _} = lists:split(Size - 1, L1),
-            L = lists:map(fun({N, _}) -> N end, L2),
-            {[Local | L], fun() -> Queues end};
-        _ ->
-            L0 = shuffle(RemoteNodes),
-            L1 = lists:sort(fun(X, _Y) ->
-                                    lists:member(X, RunningNodes)
-                            end, L0),
-            {L, _} = lists:split(Size - 1, L1),
-            {[Local | L], GetQueues}
-    end.
 
 -spec leader_locator(amqqueue:amqqueue()) ->
     queue_leader_locator().
 leader_locator(Q) ->
-    case rabbit_queue_type_util:args_policy_lookup(
-           <<"queue-leader-locator">>,
-           fun (PolVal, _ArgVal) -> PolVal end,
-           Q) of
-        undefined ->
-            case application:get_env(rabbit, queue_leader_locator) of
-                {ok, Locator} ->
-                    case lists:member(Locator, ?QUEUE_LEADER_LOCATORS) of
-                        true ->
-                            Locator;
-                        false ->
-                            ?DEFAULT_QUEUE_LEADER_LOCATOR
-                    end;
-                undefined ->
-                    ?DEFAULT_QUEUE_LEADER_LOCATOR
-            end;
-        Val ->
-            Val
-    end.
+    L = case rabbit_queue_type_util:args_policy_lookup(
+               <<"queue-leader-locator">>,
+               fun (PolVal, _ArgVal) -> PolVal end,
+               Q) of
+            undefined ->
+                application:get_env(rabbit, queue_leader_locator, undefined);
+            Val ->
+                Val
+        end,
+    leader_locator0(L).
 
--spec leader_node(queue_leader_locator(), [node(),...], [node(),...], function()) ->
+leader_locator0(<<"client-local">>) ->
+    <<"client-local">>;
+leader_locator0(<<"balanced">>) ->
+    <<"balanced">>;
+%% 'random' and 'least-leaders' are deprecated
+leader_locator0(<<"random">>) ->
+    <<"balanced">>;
+leader_locator0(<<"least-leaders">>) ->
+    <<"balanced">>;
+leader_locator0(_) ->
+    %% default
+    <<"client-local">>.
+
+-spec select_replicas(pos_integer(), [node(),...], [node(),...], non_neg_integer(), function()) ->
+    {[node(),...], function()}.
+select_replicas(Size, AllNodes, _, _, Fun)
+  when length(AllNodes) =< Size ->
+    {AllNodes, Fun};
+%% Select nodes in the following order:
+%% 1.   Local node to have data locality for declaring client.
+%% 2.   Running nodes.
+%% 3.1. If there are many queues: Randomly to avoid expensive calculation of counting replicas
+%%      per node. Random replica selection is good enough for most use cases.
+%% 3.2. If there are few queues: Nodes with least replicas to have a "balanced" RabbitMQ cluster.
+select_replicas(Size, AllNodes, RunningNodes, QueueCount, GetQueues)
+  when QueueCount >= ?QUEUE_COUNT_START_RANDOM_SELECTION ->
+    L0 = shuffle(lists:delete(node(), AllNodes)),
+    L1 = lists:sort(fun(X, _Y) ->
+                            lists:member(X, RunningNodes)
+                    end, L0),
+    {L, _} = lists:split(Size - 1, L1),
+    {[node() | L], GetQueues};
+select_replicas(Size, AllNodes, RunningNodes, _, GetQueues) ->
+    Counters0 = maps:from_list([{N, 0} || N <- lists:delete(node(), AllNodes)]),
+    Queues = GetQueues(),
+    Counters = lists:foldl(fun(Q, Acc) ->
+                                   #{nodes := Nodes} = amqqueue:get_type_state(Q),
+                                   lists:foldl(fun(N, A)
+                                                     when is_map_key(N, A) ->
+                                                       maps:update_with(N, fun(C) -> C+1 end, A);
+                                                  (_, A) ->
+                                                       A
+                                               end, Acc, Nodes)
+                           end, Counters0, Queues),
+    L0 = maps:to_list(Counters),
+    L1 = lists:sort(fun({N0, C0}, {N1, C1}) ->
+                            case {lists:member(N0, RunningNodes),
+                                  lists:member(N1, RunningNodes)} of
+                                {true, false} ->
+                                    true;
+                                {false, true} ->
+                                    false;
+                                _ ->
+                                    C0 =< C1
+                            end
+                    end, L0),
+    {L2, _} = lists:split(Size - 1, L1),
+    L = lists:map(fun({N, _}) -> N end, L2),
+    {[node() | L], fun() -> Queues end}.
+
+-spec leader_node(queue_leader_locator(), [node(),...], [node(),...], non_neg_integer(), function()) ->
     node().
-leader_node(<<"client-local">>, _, _, _) ->
+leader_node(<<"client-local">>, _, _, _, _) ->
     node();
-leader_node(<<"random">>, Nodes0, RunningNodes, _) ->
+leader_node(<<"balanced">>, Nodes0, RunningNodes, QueueCount, _)
+  when QueueCount >= ?QUEUE_COUNT_START_RANDOM_SELECTION ->
     Nodes = potential_leaders(Nodes0, RunningNodes),
     lists:nth(rand:uniform(length(Nodes)), Nodes);
-leader_node(<<"least-leaders">>, Nodes0, RunningNodes, GetQueues)
+leader_node(<<"balanced">>, Nodes0, RunningNodes, _, GetQueues)
   when is_function(GetQueues, 0) ->
     Nodes = potential_leaders(Nodes0, RunningNodes),
     Counters0 = maps:from_list([{N, 0} || N <- Nodes]),
@@ -146,8 +148,6 @@ potential_leaders(Replicas, RunningNodes) ->
         RunningReplicas ->
             case rabbit_maintenance:filter_out_drained_nodes_local_read(RunningReplicas) of
                 [] ->
-                    %% All selected replica nodes are drained. Let's place the leader on a
-                    %% drained node respecting the requested queue-leader-locator streategy.
                     RunningReplicas;
                 Filtered ->
                     Filtered

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -1,3 +1,10 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
 -module(rabbit_queue_type).
 -include("amqqueue.hrl").
 -include_lib("rabbit_common/include/resource.hrl").

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -179,6 +179,7 @@ start_cluster(Q) ->
                  {error, {too_long, N}} ->
                      rabbit_data_coercion:to_atom(ra:new_uid(N))
              end,
+    Id = {RaName, node()},
     AllQuorumQs = rabbit_amqqueue:list_with_possible_retry(
                     fun() ->
                             mnesia:dirty_match_object(rabbit_queue,
@@ -210,7 +211,7 @@ start_cluster(Q) ->
                     %% keys
                     %% TODO: handle error - what should be done if the
                     %% config cannot be updated
-                    ok = rabbit_fifo_client:update_machine_state({RaName, node()},
+                    ok = rabbit_fifo_client:update_machine_state(Id,
                                                                  ra_machine_config(NewQ)),
                     notify_decorators(QName, startup),
                     rabbit_event:notify(queue_created,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -408,7 +408,7 @@ capabilities() ->
                               <<"x-max-in-memory-bytes">>, <<"x-overflow">>,
                               <<"x-single-active-consumer">>, <<"x-queue-type">>,
                               <<"x-quorum-initial-group-size">>, <<"x-delivery-limit">>,
-                              <<"x-message-ttl">>],
+                              <<"x-message-ttl">>, <<"x-queue-leader-locator">>],
       consumer_arguments => [<<"x-priority">>, <<"x-credit">>],
       server_named => false}.
 

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1050,9 +1050,7 @@ apply_leader_locator_strategy(#{leader_node := Leader,
                                              Acc
                                      end
                              end, Counters0, rabbit_amqqueue:list())),
-    Ordered = lists:sort(fun({_, V1}, {_, V2}) ->
-                                 V1 =< V2
-                         end, Counters),
+    Ordered = lists:keysort(2, Counters),
     %% We could have potentially introduced nodes that are not in the list of replicas if
     %% initial cluster size is smaller than the cluster size. Let's select the first one
     %% that is on the list of replicas

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -45,6 +45,7 @@ groups() ->
                                import_case11,
                                import_case12,
                                import_case13,
+                               import_case13a,
                                import_case14,
                                import_case15,
                                import_case16,
@@ -226,6 +227,31 @@ import_case13(Config) ->
             ?assertEqual([{<<"x-max-length">>, long, 991},
                           {<<"x-queue-type">>, longstr, <<"quorum">>}],
                          amqqueue:get_arguments(Q));
+        Skip ->
+            Skip
+    end.
+
+import_case13a(Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
+        ok ->
+            import_file_case(Config, "case13"),
+            VHost = <<"/">>,
+            QueueName = <<"definitions.import.case13.qq.1">>,
+            QueueIsImported =
+            fun () ->
+                    case queue_lookup(Config, VHost, QueueName) of
+                        {ok, _} -> true;
+                        _       -> false
+                    end
+            end,
+            rabbit_ct_helpers:await_condition(QueueIsImported, 20000),
+            {ok, Q} = queue_lookup(Config, VHost, QueueName),
+
+            %% We expect that importing an existing queue (i.e. same vhost and name)
+            %% but with different arguments and different properties is a no-op.
+            import_file_case(Config, "case13a"),
+            timer:sleep(1000),
+            ?assertMatch({ok, Q}, queue_lookup(Config, VHost, QueueName));
         Skip ->
             Skip
     end.

--- a/deps/rabbit/test/definition_import_SUITE_data/case13a.json
+++ b/deps/rabbit/test/definition_import_SUITE_data/case13a.json
@@ -1,0 +1,55 @@
+{
+  "bindings": [],
+  "exchanges": [],
+  "global_parameters": [
+    {
+      "name": "cluster_name",
+      "value": "rabbit@localhost"
+    }
+  ],
+  "parameters": [],
+  "permissions": [
+    {
+      "configure": ".*",
+      "read": ".*",
+      "user": "guest",
+      "vhost": "/",
+      "write": ".*"
+    }
+  ],
+  "policies": [],
+  "queues": [
+    {
+      "arguments": {
+        "x-max-length": 7,
+        "x-queue-type": "stream"
+      },
+      "auto_delete": true,
+      "durable": false,
+      "name": "definitions.import.case13.qq.1",
+      "type": "stream",
+      "vhost": "/"
+    }
+  ],
+  "rabbit_version": "3.8.6.gad0c0bd",
+  "rabbitmq_version": "3.8.6.gad0c0bd",
+  "topic_permissions": [],
+  "users": [
+    {
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "name": "guest",
+      "password_hash": "e8lL5PHYcbv3Pd53EUoTOMnVDmsLDgVJXqSQMT+mrO4LVIdW",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts": [
+    {
+      "limits": [],
+      "metadata": {
+        "description": "Default virtual host",
+        "tags": []
+      },
+      "name": "/"
+    }
+  ]
+}

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -72,10 +72,8 @@ groups() ->
                                             file_handle_reservations_above_limit,
                                             node_removal_is_not_quorum_critical,
                                             leader_locator_client_local,
-                                            leader_locator_least_leaders,
-                                            leader_locator_least_leaders_maintenance,
-                                            leader_locator_random,
-                                            leader_locator_random_maintenance,
+                                            leader_locator_balanced,
+                                            leader_locator_balanced_maintenance,
                                             leader_locator_policy
                                            ]
                        ++ all_tests()},
@@ -2624,7 +2622,7 @@ leader_locator_client_local(Config) ->
                       amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      end || Server <- Servers].
 
-leader_locator_least_leaders(Config) ->
+leader_locator_balanced(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Qs = [?config(queue_name, Config),
@@ -2635,7 +2633,7 @@ leader_locator_least_leaders(Config) ->
                    ?assertMatch({'queue.declare_ok', Q, 0, 0},
                                 declare(Ch, Q,
                                         [{<<"x-queue-type">>, longstr, <<"quorum">>},
-                                         {<<"x-queue-leader-locator">>, longstr, <<"least-leaders">>}])),
+                                         {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
                    {ok, _, {_, Leader}} = ra:members({ra_name(Q), Server}),
                    Leader
                end || Q <- Qs],
@@ -2645,7 +2643,7 @@ leader_locator_least_leaders(Config) ->
                   amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      || Q <- Qs].
 
-leader_locator_least_leaders_maintenance(Config) ->
+leader_locator_balanced_maintenance(Config) ->
     [S1, S2, S3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
     Qs = [?config(queue_name, Config),
@@ -2657,7 +2655,7 @@ leader_locator_least_leaders_maintenance(Config) ->
                    ?assertMatch({'queue.declare_ok', Q, 0, 0},
                                 declare(Ch, Q,
                                         [{<<"x-queue-type">>, longstr, <<"quorum">>},
-                                         {<<"x-queue-leader-locator">>, longstr, <<"least-leaders">>}])),
+                                         {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
                    {ok, _, {_, Leader}} = ra:members({ra_name(Q), S1}),
                    Leader
                end || Q <- Qs],
@@ -2670,44 +2668,6 @@ leader_locator_least_leaders_maintenance(Config) ->
                   amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      || Q <- Qs].
 
-leader_locator_random(Config) ->
-    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
-    Q = ?config(queue_name, Config),
-
-    Leaders = [begin
-                   ?assertMatch({'queue.declare_ok', Q, 0, 0},
-                                declare(Ch, Q,
-                                        [{<<"x-queue-type">>, longstr, <<"quorum">>},
-                                         {<<"x-queue-leader-locator">>, longstr, <<"random">>}])),
-                   {ok, _, {_, Leader}} = ra:members({ra_name(Q), Server}),
-                   ?assertMatch(#'queue.delete_ok'{},
-                                amqp_channel:call(Ch, #'queue.delete'{queue = Q})),
-                   Leader
-               end || _ <- lists:seq(1, 15)],
-    ?assertEqual(3, sets:size(sets:from_list(Leaders))).
-
-leader_locator_random_maintenance(Config) ->
-    [S1, S2, S3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
-    Q = ?config(queue_name, Config),
-
-    rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
-    Leaders = [begin
-                   ?assertMatch({'queue.declare_ok', Q, 0, 0},
-                                declare(Ch, Q,
-                                        [{<<"x-queue-type">>, longstr, <<"quorum">>},
-                                         {<<"x-queue-leader-locator">>, longstr, <<"random">>}])),
-                   {ok, _, {_, Leader}} = ra:members({ra_name(Q), S1}),
-                   ?assertMatch(#'queue.delete_ok'{},
-                                amqp_channel:call(Ch, #'queue.delete'{queue = Q})),
-                   Leader
-               end || _ <- lists:seq(1, 12)],
-    ?assert(lists:member(S1, Leaders)),
-    ?assertNot(lists:member(S2, Leaders)),
-    ?assert(lists:member(S3, Leaders)),
-    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2).
-
 leader_locator_policy(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
@@ -2716,7 +2676,7 @@ leader_locator_policy(Config) ->
           <<"leader_locator_policy_q3">>],
     ok = rabbit_ct_broker_helpers:set_policy(
            Config, 0, <<"my-leader-locator">>, <<"leader_locator_policy_.*">>, <<"queues">>,
-           [{<<"queue-leader-locator">>, <<"least-leaders">>}]),
+           [{<<"queue-leader-locator">>, <<"balanced">>}]),
 
     Leaders = [begin
                    ?assertMatch({'queue.declare_ok', Q, 0, 0},

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -74,6 +74,7 @@ groups() ->
                                             leader_locator_client_local,
                                             leader_locator_balanced,
                                             leader_locator_balanced_maintenance,
+                                            leader_locator_balanced_random_maintenance,
                                             leader_locator_policy
                                            ]
                        ++ all_tests()},
@@ -288,6 +289,9 @@ init_per_testcase(Testcase, Config) ->
             {skip, "start_queue_concurrent isn't mixed versions compatible"};
         leader_locator_client_local when IsMixed ->
             {skip, "leader_locator_client_local isn't mixed versions compatible because "
+             "delete_declare isn't mixed versions reliable"};
+        leader_locator_balanced_random_maintenance when IsMixed ->
+            {skip, "leader_locator_balanced_random_maintenance isn't mixed versions compatible because "
              "delete_declare isn't mixed versions reliable"};
         _ ->
             Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
@@ -2673,6 +2677,39 @@ leader_locator_balanced_maintenance(Config) ->
     [?assertMatch(#'queue.delete_ok'{},
                   amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      || Q <- Qs].
+
+leader_locator_balanced_random_maintenance(Config) ->
+    [S1, S2, S3] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
+    Q = ?config(queue_name, Config),
+
+    true = rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                      [rabbit, queue_leader_locator, <<"balanced">>]),
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                      [rabbit, queue_count_start_random_selection, 0]),
+
+    Leaders = [begin
+                   ?assertMatch({'queue.declare_ok', Q, 0, 0},
+                                declare(Ch, Q,
+                                        [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                         {<<"x-quorum-initial-group-size">>, long, 2}])),
+                   {ok, [{_, R1}, {_, R2}], {_, Leader}} = ra:members({ra_name(Q), S1}),
+                   ?assert(lists:member(R1, Servers)),
+                   ?assert(lists:member(R2, Servers)),
+                   ?assertMatch(#'queue.delete_ok'{},
+                                amqp_channel:call(Ch, #'queue.delete'{queue = Q})),
+                   Leader
+               end || _ <- lists:seq(1, 10)],
+    ?assert(lists:member(S1, Leaders)),
+    ?assertNot(lists:member(S2, Leaders)),
+    ?assert(lists:member(S3, Leaders)),
+
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, unset_env,
+                                      [rabbit, queue_leader_locator]),
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, unset_env,
+                                      [rabbit, queue_count_start_random_selection]),
+    true = rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2).
 
 leader_locator_policy(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -212,6 +212,8 @@ init_per_group(Group, Config) ->
                             %% more time after clustering before running the
                             %% tests.
                             timer:sleep(ClusterSize * 1000),
+                            ok = rabbit_ct_broker_helpers:enable_feature_flag(
+                                   Config2, maintenance_mode_status),
                             Config2;
                         Skip ->
                             end_per_group(Group, Config2),
@@ -2650,7 +2652,7 @@ leader_locator_balanced_maintenance(Config) ->
           ?config(alt_queue_name, Config),
           <<"leader_locator_policy_q3">>],
 
-    rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
+    true = rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
     Leaders = [begin
                    ?assertMatch({'queue.declare_ok', Q, 0, 0},
                                 declare(Ch, Q,
@@ -2663,7 +2665,7 @@ leader_locator_balanced_maintenance(Config) ->
     ?assertNot(lists:member(S2, Leaders)),
     ?assert(lists:member(S3, Leaders)),
 
-    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2),
+    true = rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2),
     [?assertMatch(#'queue.delete_ok'{},
                   amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      || Q <- Qs].

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -84,7 +84,8 @@ groups() ->
                                             quorum_cluster_size_3,
                                             quorum_cluster_size_7,
                                             node_removal_is_not_quorum_critical,
-                                            select_nodes_with_least_replicas
+                                            select_nodes_with_least_replicas,
+                                            select_nodes_with_least_replicas_node_down
                                            ]},
                       {clustered_with_partitions, [],
                        [
@@ -1402,6 +1403,11 @@ declare_during_node_down(Config) ->
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
 
     RaName = ra_name(QQ),
+    {ok, Members0, _} = ra:members({RaName, Server}),
+    %% Since there are not sufficient running nodes, we expect that
+    %% also stopped nodes are selected as replicas.
+    Members = lists:map(fun({_, N}) -> N end, Members0),
+    ?assert(same_elements(Members, Servers)),
     timer:sleep(2000),
     rabbit_ct_broker_helpers:start_node(Config, DownServer),
     publish(Ch, QQ),
@@ -2736,17 +2742,50 @@ select_nodes_with_least_replicas(Config) ->
                                 declare(Ch, Q,
                                         [{<<"x-queue-type">>, longstr, <<"quorum">>},
                                          {<<"x-quorum-initial-group-size">>, long, 3}])),
-                   {ok, Members, _} = ra:members({ra_name(Q), Server}),
-                   ?assertEqual(3, length(Members)),
-                   lists:map(fun({_, N}) -> N end, Members)
+                   {ok, Members0, _} = ra:members({ra_name(Q), Server}),
+                   ?assertEqual(3, length(Members0)),
+                   lists:map(fun({_, N}) -> N end, Members0)
                end || Q <- Qs],
     %% Assert that second queue selected the nodes where first queue does not have replicas.
     ?assertEqual(5, sets:size(sets:from_list(lists:flatten(Members)))),
+
+    [?assertMatch(#'queue.delete_ok'{},
+                  amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
+     || Q <- Qs].
+
+select_nodes_with_least_replicas_node_down(Config) ->
+    [S1, S2 | _ ] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ?assertEqual(ok, rabbit_control_helper:command(stop_app, S2)),
+    RunningNodes = lists:delete(S2, Servers),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
+    Qs = [?config(queue_name, Config),
+          ?config(alt_queue_name, Config)],
+
+    timer:sleep(1000),
+    Members = [begin
+                   ?assertMatch({'queue.declare_ok', Q, 0, 0},
+                                declare(Ch, Q,
+                                        [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                         {<<"x-quorum-initial-group-size">>, long, 3}])),
+                   {ok, Members0, _} = ra:members({ra_name(Q), S1}),
+                   ?assertEqual(3, length(Members0)),
+                   lists:map(fun({_, N}) -> N end, Members0)
+               end || Q <- Qs],
+    %% Assert that
+    %% 1. no replicas got placed on a node which is down because there are sufficient running nodes, and
+    %% 2. second queue selected the nodes where first queue does not have replicas.
+    ?assert(same_elements(lists:flatten(Members), RunningNodes)),
+
+    ?assertEqual(ok, rabbit_control_helper:command(start_app, S2)),
     [?assertMatch(#'queue.delete_ok'{},
                   amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      || Q <- Qs].
 
 %%----------------------------------------------------------------------------
+
+same_elements(L1, L2)
+  when is_list(L1), is_list(L2) ->
+    lists:usort(L1) =:= lists:usort(L2).
 
 declare(Ch, Q) ->
     declare(Ch, Q, []).

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -286,13 +286,17 @@ init_per_testcase(Testcase, Config) ->
             {skip, "start_queue isn't mixed versions compatible"};
         start_queue_concurrent when IsMixed andalso ClusterSize == 5 ->
             {skip, "start_queue_concurrent isn't mixed versions compatible"};
+        leader_locator_client_local when IsMixed ->
+            {skip, "leader_locator_client_local isn't mixed versions compatible because "
+             "delete_declare isn't mixed versions reliable"};
         _ ->
             Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
             rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
             Q = rabbit_data_coercion:to_binary(Testcase),
             Config2 = rabbit_ct_helpers:set_config(Config1,
                                                    [{queue_name, Q},
-                                                    {alt_queue_name, <<Q/binary, "_alt">>}
+                                                    {alt_queue_name, <<Q/binary, "_alt">>},
+                                                    {alt_2_queue_name, <<Q/binary, "_alt_2">>}
                                                    ]),
             EnableFF = rabbit_ct_broker_helpers:enable_feature_flag(
                          Config2, quorum_queue),
@@ -2629,7 +2633,7 @@ leader_locator_balanced(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Qs = [?config(queue_name, Config),
           ?config(alt_queue_name, Config),
-          <<"leader_locator_policy_q3">>],
+          ?config(alt_2_queue_name, Config)],
 
     Leaders = [begin
                    ?assertMatch({'queue.declare_ok', Q, 0, 0},
@@ -2650,7 +2654,7 @@ leader_locator_balanced_maintenance(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
     Qs = [?config(queue_name, Config),
           ?config(alt_queue_name, Config),
-          <<"leader_locator_policy_q3">>],
+          ?config(alt_2_queue_name, Config)],
 
     true = rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
     Leaders = [begin
@@ -2675,7 +2679,7 @@ leader_locator_policy(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Qs = [?config(queue_name, Config),
           ?config(alt_queue_name, Config),
-          <<"leader_locator_policy_q3">>],
+          ?config(alt_2_queue_name, Config)],
     ok = rabbit_ct_broker_helpers:set_policy(
            Config, 0, <<"my-leader-locator">>, <<"leader_locator_policy_.*">>, <<"queues">>,
            [{<<"queue-leader-locator">>, <<"balanced">>}]),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -73,7 +73,9 @@ groups() ->
                                             node_removal_is_not_quorum_critical,
                                             leader_locator_client_local,
                                             leader_locator_least_leaders,
+                                            leader_locator_least_leaders_maintenance,
                                             leader_locator_random,
+                                            leader_locator_random_maintenance,
                                             leader_locator_policy
                                            ]
                        ++ all_tests()},
@@ -2637,6 +2639,31 @@ leader_locator_least_leaders(Config) ->
                   amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
      || Q <- Qs].
 
+leader_locator_least_leaders_maintenance(Config) ->
+    [S1, S2, S3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
+    Qs = [?config(queue_name, Config),
+          ?config(alt_queue_name, Config),
+          <<"leader_locator_policy_q3">>],
+
+    rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
+    Leaders = [begin
+                   ?assertMatch({'queue.declare_ok', Q, 0, 0},
+                                declare(Ch, Q,
+                                        [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                         {<<"x-queue-leader-locator">>, longstr, <<"least-leaders">>}])),
+                   {ok, _, {_, Leader}} = ra:members({ra_name(Q), S1}),
+                   Leader
+               end || Q <- Qs],
+    ?assert(lists:member(S1, Leaders)),
+    ?assertNot(lists:member(S2, Leaders)),
+    ?assert(lists:member(S3, Leaders)),
+
+    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2),
+    [?assertMatch(#'queue.delete_ok'{},
+                  amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
+     || Q <- Qs].
+
 leader_locator_random(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
@@ -2653,6 +2680,27 @@ leader_locator_random(Config) ->
                    Leader
                end || _ <- lists:seq(1, 15)],
     ?assertEqual(3, sets:size(sets:from_list(Leaders))).
+
+leader_locator_random_maintenance(Config) ->
+    [S1, S2, S3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
+    Q = ?config(queue_name, Config),
+
+    rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
+    Leaders = [begin
+                   ?assertMatch({'queue.declare_ok', Q, 0, 0},
+                                declare(Ch, Q,
+                                        [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                         {<<"x-queue-leader-locator">>, longstr, <<"random">>}])),
+                   {ok, _, {_, Leader}} = ra:members({ra_name(Q), S1}),
+                   ?assertMatch(#'queue.delete_ok'{},
+                                amqp_channel:call(Ch, #'queue.delete'{queue = Q})),
+                   Leader
+               end || _ <- lists:seq(1, 12)],
+    ?assert(lists:member(S1, Leaders)),
+    ?assertNot(lists:member(S2, Leaders)),
+    ?assert(lists:member(S3, Leaders)),
+    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2).
 
 leader_locator_policy(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -184,6 +184,8 @@ init_per_group1(Group, Config) ->
                     ok = rabbit_ct_broker_helpers:rpc(
                            Config2, 0, application, set_env,
                            [rabbit, channel_tick_interval, 100]),
+                    ok = rabbit_ct_broker_helpers:enable_feature_flag(
+                           Config2, maintenance_mode_status),
                     Config2;
                 {skip, _} = Skip ->
                     end_per_group(Group, Config2),
@@ -1884,7 +1886,7 @@ leader_locator_balanced_maintenance(Config) ->
     ?assertEqual({'queue.declare_ok', Q2, 0, 0},
                  declare(Ch2, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                    {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
-    rabbit_ct_broker_helpers:mark_as_being_drained(Config, Server3),
+    true = rabbit_ct_broker_helpers:mark_as_being_drained(Config, Server3),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
                  declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                   {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
@@ -1893,7 +1895,7 @@ leader_locator_balanced_maintenance(Config) ->
     Leader = proplists:get_value(leader, Info),
     ?assert(lists:member(Leader, [Server1, Server2])),
 
-    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, Server3),
+    true = rabbit_ct_broker_helpers:unmark_as_being_drained(Config, Server3),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
 select_nodes_with_least_replicas(Config) ->

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -51,7 +51,9 @@ groups() ->
            add_replicas,
            publish_coordinator_unavailable,
            leader_locator_policy,
-           queue_size_on_declare
+           queue_size_on_declare,
+           leader_locator_random_maintenance,
+           leader_locator_least_leaders_maintenance
           ]},
      {cluster_size_3_1, [], [shrink_coordinator_cluster]},
      {cluster_size_3_2, [], [recover,
@@ -1860,6 +1862,26 @@ leader_locator_random(Config) ->
       end, 10),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
+leader_locator_random_maintenance(Config) ->
+    [S1, S2, S3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, S1),
+    Q = ?config(queue_name, Config),
+    rabbit_ct_broker_helpers:mark_as_being_drained(Config, S2),
+
+    [begin
+         ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                      declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                      {<<"x-queue-leader-locator">>, longstr, <<"random">>}])),
+
+         Info = find_queue_info(Config, [leader]),
+         Leader = proplists:get_value(leader, Info),
+         ?assert(lists:member(Leader, [S1, S3])),
+         ?assertMatch(#'queue.delete_ok'{},
+                      amqp_channel:call(Ch, #'queue.delete'{queue = Q}))
+     end || _ <- lists:seq(1, 7)],
+    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, S2).
+
 leader_locator_least_leaders(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
@@ -1883,6 +1905,31 @@ leader_locator_least_leaders(Config) ->
     Leader = proplists:get_value(leader, Info),
 
     ?assert(lists:member(Leader, [Server2, Server3])),
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
+
+leader_locator_least_leaders_maintenance(Config) ->
+    [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server2),
+    Q = ?config(queue_name, Config),
+    Q1 = <<"q1">>,
+    Q2 = <<"q2">>,
+    ?assertEqual({'queue.declare_ok', Q1, 0, 0},
+                 declare(Ch1, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                   {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+    ?assertEqual({'queue.declare_ok', Q2, 0, 0},
+                 declare(Ch2, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                   {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+    rabbit_ct_broker_helpers:mark_as_being_drained(Config, Server3),
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                  {<<"x-queue-leader-locator">>, longstr, <<"least-leaders">>}])),
+
+    Info = find_queue_info(Config, [leader]),
+    Leader = proplists:get_value(leader, Info),
+    ?assert(lists:member(Leader, [Server1, Server2])),
+
+    rabbit_ct_broker_helpers:unmark_as_being_drained(Config, Server3),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
 leader_locator_policy(Config) ->

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -1033,7 +1033,7 @@ is_mixed_versions(Config) ->
 %% -------------------------------------------------------------------
 
 await_condition(ConditionFun) ->
-    await_condition(ConditionFun, 10000).
+    await_condition(ConditionFun, 10_000).
 
 await_condition(ConditionFun, Timeout) ->
     Retries = ceil(Timeout / 50),

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -237,7 +237,7 @@ var HELP = {
        'Set the queue into master location mode, determining the rule by which the queue master is located when declared on a cluster of nodes.<br/>(Sets the "<a target="_blank" href="https://www.rabbitmq.com/ha.html">x-queue-master-locator</a>" argument.)',
 
     'queue-leader-locator':
-       'Set the queue into leader location mode, determining the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are <code>client-local</code>, <code>random</code> and <code>least-leaders</code>.',
+       'Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are <code>client-local</code> (default), <code>random</code> and <code>least-leaders</code>.',
 
     'queue-initial-cluster-size':
        'Set the queue initial cluster size.',

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -237,7 +237,7 @@ var HELP = {
        'Set the queue into master location mode, determining the rule by which the queue master is located when declared on a cluster of nodes.<br/>(Sets the "<a target="_blank" href="https://www.rabbitmq.com/ha.html">x-queue-master-locator</a>" argument.)',
 
     'queue-leader-locator':
-       'Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are <code>client-local</code> (default), <code>random</code> and <code>least-leaders</code>.',
+       'Set the rule by which the queue leader is located when declared on a cluster of nodes. Valid values are <code>client-local</code> (default) and <code>balanced</code>.',
 
     'queue-initial-cluster-size':
        'Set the queue initial cluster size.',

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -117,7 +117,7 @@
                   </br>
                   <span class="argument-link" field="definition" key="queue-mode" type="string" value="lazy">Lazy mode</span> |
                   <span class="argument-link" field="definition" key="queue-version" type="number">Version</span> <span class="help" id="queue-version"></span> |
-                  <span class="argument-link" field="definition" key="queue-master-locator" type="string">Master Locator</span></br>
+                  <span class="argument-link" field="definition" key="queue-master-locator" type="string">Master locator</span></br>
                 </td>
               </tr>
               <tr>
@@ -126,7 +126,9 @@
                   <span class="argument-link" field="definition" key="delivery-limit" type="number">Delivery limit</span>
                   <span class="help" id="delivery-limit"></span> |
                   <span class="argument-link" field="definition" key="dead-letter-strategy" type="string">Dead letter strategy</span>
-                  <span class="help" id="queue-dead-letter-strategy"></span>
+                  <span class="help" id="queue-dead-letter-strategy"></span> |
+                  <span class="argument-link" field="definition" key="queue-leader-locator" type="string">Leader locator</span>
+                  <span class="help" id="queue-leader-locator"></span>
                 </td>
               </tr>
               <tr>
@@ -135,7 +137,9 @@
                   <span class="argument-link" field="definition" key="max-age" type="string">Max age</span>
                   <span class="help" id="queue-max-age"></span> |
                   <span class="argument-link" field="definition" key="stream-max-segment-size-bytes" type="number">Max segment size in bytes</span>
-                  <span class="help" id="queue-stream-max-segment-size-bytes"></span>
+                  <span class="help" id="queue-stream-max-segment-size-bytes"></span> |
+                  <span class="argument-link" field="definition" key="queue-leader-locator" type="string">Leader locator</span>
+                  <span class="help" id="queue-leader-locator"></span>
                 </td>
               </tr>
               <tr>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -330,13 +330,15 @@
                 <% } %>
                 <% if (queue_type == "quorum") { %>
                   <span class="argument-link" field="arguments" key="x-delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span>
-                  | <span class="argument-link" field="arguments" key="x-quorum-initial-group-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span>
-                  | <span class="argument-link" field="arguments" key="x-dead-letter-strategy" type="string">Dead letter strategy</span><span class="help" id="queue-dead-letter-strategy"></span><br/>
+                  | <span class="argument-link" field="arguments" key="x-quorum-initial-group-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span><br/>
+                  <span class="argument-link" field="arguments" key="x-dead-letter-strategy" type="string">Dead letter strategy</span><span class="help" id="queue-dead-letter-strategy"></span>
                 <% } %>
                 <% if (queue_type == "stream") { %>
                   <span class="argument-link" field="arguments" key="x-max-age" type="string">Max time retention</span><span class="help" id="queue-max-age"></span>
                   | <span class="argument-link" field="arguments" key="x-stream-max-segment-size-bytes" type="number">Max segment size in bytes</span><span class="help" id="queue-stream-max-segment-size-bytes"></span>
                   | <span class="argument-link" field="arguments" key="x-initial-cluster-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span>
+                <% } %>
+                <% if (queue_type != "classic") { %>
                   | <span class="argument-link" field="arguments" key="x-queue-leader-locator" type="string">Leader locator</span><span class="help" id="queue-leader-locator"></span>
                 <% } %>
                 </td>

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
@@ -99,6 +99,9 @@ validate_stream_arguments(#{stream_max_segment_size_bytes := Value} =
 validate_stream_arguments(#{leader_locator := <<"client-local">>} =
                               Opts) ->
     validate_stream_arguments(maps:remove(leader_locator, Opts));
+validate_stream_arguments(#{leader_locator := <<"balanced">>} = Opts) ->
+    validate_stream_arguments(maps:remove(leader_locator, Opts));
+%% 'random' and 'least-leaders' are deprecated and get mapped to 'balanced'
 validate_stream_arguments(#{leader_locator := <<"random">>} = Opts) ->
     validate_stream_arguments(maps:remove(leader_locator, Opts));
 validate_stream_arguments(#{leader_locator := <<"least-leaders">>} =
@@ -107,7 +110,7 @@ validate_stream_arguments(#{leader_locator := <<"least-leaders">>} =
 validate_stream_arguments(#{leader_locator := _}) ->
     {validation_failure,
      "Invalid value for --leader-locator, valid values "
-     "are client-local, random, least-leaders."};
+     "are client-local, balanced."};
 validate_stream_arguments(#{initial_cluster_size := Value} = Opts) ->
     try
         case rabbit_data_coercion:to_integer(Value) of
@@ -160,8 +163,7 @@ usage_additional() ->
       "example values: 500mb, 1gb."],
      ["--leader-locator <leader-locator>",
       "Leader locator strategy for partition streams, "
-      "possible values are client-local, least-leaders, "
-      "random."],
+      "possible values are client-local, balanced."],
      ["--initial-cluster-size <initial-cluster-size>",
       "The initial cluster size of partition streams."]].
 

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -169,9 +169,7 @@ validate_stream_queue_arguments([{<<"x-initial-cluster-size">>, long,
 validate_stream_queue_arguments([{<<"x-queue-leader-locator">>,
                                   longstr, Locator}
                                  | T]) ->
-    case lists:member(Locator,
-                      [<<"client-local">>, <<"random">>, <<"least-leaders">>])
-    of
+    case lists:member(Locator, rabbit_queue_location:queue_leader_locators()) of
         true ->
             validate_stream_queue_arguments(T);
         false ->


### PR DESCRIPTION
### Changes

**Prior** to this PR:
1. When a new quorum queue was created, the local node + **random** nodes were selected as replicas. Nodes that are `down` were chosen with same probability than nodes that are `running`.
2. Always **local** node became leader.

For example, when a client connects to a single RabbitMQ node and creates N quorum queues, all N leaders will be on that node. Also, if N is small and the RabbitMQ cluster has many nodes (e.g. 7), some nodes might not host any quorum queue replicas at all.

**After** this PR:
1. When a new quorum queue is created, the local node + RabbitMQ nodes with the **least** quorum queue replicas are selected (if total number of queues is less than 1k). This will nicely distribute the quorum queue replicas across the RabbitMQ cluster. Furthermore, nodes that are `running` are preferred being selected over nodes that are `down`. The same will apply to streams.
2. Support `(x-)queue-leader-locator` argument, policy, and rabbitmq.conf option with values `client-local` (stays the default), and `balanced`.

From now on, streams and quorum queues share the same replica selection + leader selection code and therefore behave the same.

Prior to this PR, streams used to support `queue-leader-locator` values `client-local`, `random`, and `least-leaders`.
After this PR,`random` and `least-leaders` are deprecated and get mapped to `balanced`.

From my point of view (+ @mkuratczyk came up with the idea), exposing value `random` to users via configuration does not make sense. When would a user want to set `random` over `least-leaders`? I cannot think of any use case.
Instead, what users want to set is either `client-local` or some form of balancing the leaders. How the leaders are balanced is an implementation detail that shouldn't be exposed to users. In this PR's `balanced` implementation, the leader gets placed on the nodes with the least leaders for the same queue type if the number of overall queues is low (currently set to 1k). If the number of overall queues is high, the leader will be placed randomly across the selected replicas. This ensures that queues get created fast. We see with `min-masters` that queue leader calculations becomes slow with many thousand queues. Randomness will do the job of balancing leaders across the cluster good enough when there are already many queues. There are some edge cases in this implementation: For example when there are more than 1k classic queues defined on a single node, we still use randomness to select replicas and leaders for quorum queues and streams. In the long term, the `balanced` implementation should count the leaders across **all** queue types, not just its own queue type. (In the future we could even use current resource usage or other metrics as decision how leaders are balanced across the cluster. Again, it is an implementation detail that the user shouldn't care about.)

I didn't touch the `queue-master-locator` code for classic queues. So, classic queues continue to support `client-local`, `random`, and `min-masters`. Once classic mirrored queues are gone in 4.0, we can consolidate classic queues with this PR's implementation, i.e. using only values `client-local` and `balanced`.

### Performance

Declaring 5k 3-replica quorum queues sequentially via AMQP on a 5-node K8s cluster:
| `queue-leader-locator`  | Time |
| ------------- | ------------- |
| prior to PR  |  4m13s |
| `client-local`  |  3m0s |
| `balanced`  |   3m30s |

### TODOs:
- [ ] Add docs for `queue-leader-locator` for both quorum queues and streams