### PR TITLE
Remove max-in-memory-* in Management UI

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -197,12 +197,6 @@ var HELP = {
     'queue-max-length-bytes':
       'Total body size for ready messages a queue can contain before it starts to drop them from its head.<br/>(Sets the "<a target="_blank" href="https://rabbitmq.com/maxlength.html">x-max-length-bytes</a>" argument.)',
 
-    'queue-max-in-memory-length':
-      'How many (ready) messages a quorum queue can contain in memory before it starts storing them on disk only.<br/>(Sets the x-max-in-memory-length argument.)',
-
-    'queue-max-in-memory-bytes':
-      'Total body size for ready messages a quorum queue can contain in memory before it starts storing them on disk only.<br/>(Sets the x-max-in-memory-bytes argument.)',
-
     'queue-max-age':
       'How long a message published to a stream queue can live before it is discarded.',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -123,18 +123,14 @@
               <tr>
                 <td>Queues [Quorum]</td>
                 <td>
-                  <span class="argument-link" field="definition" key="max-in-memory-length" type="number">Max in memory length</span>
-                  <span class="help" id="queue-max-in-memory-length"></span> |
-                  <span class="argument-link" field="definition" key="max-in-memory-bytes" type="number">Max in memory bytes</span>
-                  <span class="help" id="queue-max-in-memory-bytes"></span> |
                   <span class="argument-link" field="definition" key="delivery-limit" type="number">Delivery limit</span>
-                  <span class="help" id="delivery-limit"></span></br>
+                  <span class="help" id="delivery-limit"></span> |
                   <span class="argument-link" field="definition" key="dead-letter-strategy" type="string">Dead letter strategy</span>
                   <span class="help" id="queue-dead-letter-strategy"></span>
                 </td>
               </tr>
               <tr>
-                <td>Queues [Stream]</td>
+                <td>Streams</td>
                 <td>
                   <span class="argument-link" field="definition" key="max-age" type="string">Max age</span>
                   <span class="help" id="queue-max-age"></span> |
@@ -287,10 +283,6 @@
               <tr>
                 <td>Queues [Quorum]</td>
                 <td>
-                  <span class="argument-link" field="definitionop" key="max-in-memory-length" type="number">Max in memory length</span>
-                  <span class="help" id="queue-max-in-memory-length"></span> |
-                  <span class="argument-link" field="definitionop" key="max-in-memory-bytes" type="number">Max in memory bytes</span>
-                  <span class="help" id="queue-max-in-memory-bytes"></span> |
                   <span class="argument-link" field="definitionop" key="delivery-limit" type="string">Delivery limit</span>
                   <span class="help" id="delivery-limit"></span>
                 </td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -330,10 +330,8 @@
                 <% } %>
                 <% if (queue_type == "quorum") { %>
                   <span class="argument-link" field="arguments" key="x-delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span>
-                  | <span class="argument-link" field="arguments" key="x-max-in-memory-length" type="number">Max in memory length</span><span class="help" id="queue-max-in-memory-length"></span>
-                  | <span class="argument-link" field="arguments" key="x-max-in-memory-bytes" type="number">Max in memory bytes</span><span class="help" id="queue-max-in-memory-bytes"></span>
-                  | <span class="argument-link" field="arguments" key="x-quorum-initial-group-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span><br/>
-                  <span class="argument-link" field="arguments" key="x-dead-letter-strategy" type="string">Dead letter strategy</span><span class="help" id="queue-dead-letter-strategy"></span><br/>
+                  | <span class="argument-link" field="arguments" key="x-quorum-initial-group-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span>
+                  | <span class="argument-link" field="arguments" key="x-dead-letter-strategy" type="string">Dead letter strategy</span><span class="help" id="queue-dead-letter-strategy"></span><br/>
                 <% } %>
                 <% if (queue_type == "stream") { %>
                   <span class="argument-link" field="arguments" key="x-max-age" type="string">Max time retention</span><span class="help" id="queue-max-age"></span>


### PR DESCRIPTION
Remove quorum queue arguments and quorum queue policies
(x-)max-in-memory-length and (x-)max-in-memory-bytes
from the Management UI since they are deprecated since RabbitMQ 3.10.

They have no effect anymore since message bodies will not be stored in
memory. See https://github.com/rabbitmq/rabbitmq-server/issues/3898.