### PR TITLE
Attempt to make the OCI workflow behave reasonably for PRs

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -103,7 +103,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.image_tag_suffix }}-buildx-
 
+      - name: Check for Push Credentials
+        id: authorized
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]; then
+            echo "::set-output name=PUSH::true"
+          else
+            echo "::set-output name=PUSH::false"
+          fi
+
       - name: Login to DockerHub
+        if: steps.authorized.outputs.PUSH
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -124,7 +134,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: packaging/docker-image
-          push: true
+          push: ${{ steps.authorized.outputs.PUSH }}
           tags: |
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}


### PR DESCRIPTION
When repo secrets are not available to the actions run, the docker image is built, but not published