### PR TITLE
Upgrade eetcd to 0.3.5

### DIFF
--- a/deps/rabbitmq_peer_discovery_etcd/Makefile
+++ b/deps/rabbitmq_peer_discovery_etcd/Makefile
@@ -6,7 +6,7 @@ DEPS = rabbit_common rabbitmq_peer_discovery_common rabbit eetcd gun
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers ct_helper meck
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
 dep_gun = hex 1.3.3
-dep_eetcd = hex 0.3.3
+dep_eetcd = hex 0.3.5
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/release-notes/3.10.0.md
+++ b/release-notes/3.10.0.md
@@ -321,5 +321,6 @@ This release includes all applicable [bug fixes that shipped in `3.9.x` releases
  * `osiris` upgraded from [`1.0.0` to `1.2.4`](https://github.com/rabbitmq/osiris/compare/v1.0.0...v1.2.4)
  * `ranch` upgraded from [`2.0.0` to `2.1.0`](https://github.com/ninenines/ranch/compare/2.0.0...2.1.0)
  * `prometheus` upgraded from [`4.8.1` to `4.8.2`](https://github.com/deadtrickster/prometheus.erl/compare/06425c21a39c1564164f1cc3fe5bdfa8b23b1f78...v4.8.2)
+ * `eetcd` upgraded from [`0.3.3` to `0.3.5`](https://github.com/zhongwencool/eetcd/compare/v0.3.3...v0.3.5)
  * `observer_cli` upgraded from [`1.6.2` to `1.7.2`](https://github.com/zhongwencool/observer_cli/compare/1.6.2...1.7.2)
  * `gen_batch_server` upgraded from [`0.8.6` to `0.8.7`](https://github.com/rabbitmq/gen-batch-server/compare/38191672ee0f22a8d5291c6c09f8c07178d565ca...v0.8.7)

--- a/release-notes/3.9.15.md
+++ b/release-notes/3.9.15.md
@@ -75,6 +75,7 @@ Contributors are encouraged to update them together with their changes. This hel
 
  * `ra` upgraded [from `2.0.4` to `2.0.7`](https://github.com/rabbitmq/ra/compare/v2.0.4...v2.0.7)
  * `prometheus` upgraded from [`4.8.1` to `4.8.2`](https://github.com/deadtrickster/prometheus.erl/compare/06425c21a39c1564164f1cc3fe5bdfa8b23b1f78...v4.8.2)
+ * `eetcd` upgraded from [`0.3.3` to `0.3.5`](https://github.com/zhongwencool/eetcd/compare/v0.3.3...v0.3.5)
 
 
 ## Source Code Archives

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -71,8 +71,8 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
 
     hex_pm_erlang_app(
         name = "eetcd",
-        version = "0.3.3",
-        sha256 = "8fb280156ddd1b7b34d0f446c5711832385bff512c05378dcea8362f4f5060d6",
+        version = "0.3.5",
+        sha256 = "af9d5158ad03a6794d412708d605be5dd1ebd0b8a1271786530d99f165bb0cff",
         runtime_deps = [
             "@gun//:erlang_app",
         ],


### PR DESCRIPTION
[Commit list](https://github.com/zhongwencool/eetcd/compare/v0.3.3...v0.3.5) on GitHub.

Kudos to @zhongwencool for quickly responding to my request for a new release.