### PR TITLE
CQ: Merge lazy/default behavior into a unified mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include plugins.mk
 # Note: When including NIFs in a release make sure to build
 # them on the appropriate platform for the target environment.
 # For example build looking_glass on Linux when targeting Docker.
-ADDITIONAL_PLUGINS ?=
+ADDITIONAL_PLUGINS ?= looking_glass
 
 DEPS = rabbit_common rabbit $(PLUGINS) $(ADDITIONAL_PLUGINS)
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include plugins.mk
 # Note: When including NIFs in a release make sure to build
 # them on the appropriate platform for the target environment.
 # For example build looking_glass on Linux when targeting Docker.
-ADDITIONAL_PLUGINS ?= looking_glass
+ADDITIONAL_PLUGINS ?=
 
 DEPS = rabbit_common rabbit $(PLUGINS) $(ADDITIONAL_PLUGINS)
 

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -309,7 +309,7 @@ suites = [
         PACKAGE,
         name = "classic_queue_prop_SUITE",
         size = "large",
-        shard_count = 5,
+        shard_count = 3,
         sharding_method = "case",
         deps = [
             "@proper//:erlang_app",

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -502,14 +502,7 @@ next_state(State = #q{q = Q,
                       backing_queue       = BQ,
                       backing_queue_state = BQS,
                       msg_id_to_channel   = MTC}) ->
-%    try
-        assert_invariant(State),
-%    catch C:E:S ->
-%        rabbit_time_travel_dbg:dump(),
-%        rabbit_time_travel_dbg:print(),
-%        logger:error("BAD STATE ~p", [State]),
-%        erlang:raise(C,E,S)
-%    end,
+    assert_invariant(State),
     {MsgIds, BQS1} = BQ:drain_confirmed(BQS),
     MTC1 = confirm_messages(MsgIds, MTC, amqqueue:get_name(Q)),
     State1 = State#q{backing_queue_state = BQS1, msg_id_to_channel = MTC1},

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -502,7 +502,14 @@ next_state(State = #q{q = Q,
                       backing_queue       = BQ,
                       backing_queue_state = BQS,
                       msg_id_to_channel   = MTC}) ->
-    assert_invariant(State),
+    try
+        assert_invariant(State)
+    catch C:E:S ->
+        rabbit_time_travel_dbg:dump(),
+        rabbit_time_travel_dbg:print(),
+        logger:error("BAD STATE ~p", [State]),
+        erlang:raise(C,E,S)
+    end,
     {MsgIds, BQS1} = BQ:drain_confirmed(BQS),
     MTC1 = confirm_messages(MsgIds, MTC, amqqueue:get_name(Q)),
     State1 = State#q{backing_queue_state = BQS1, msg_id_to_channel = MTC1},

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -502,14 +502,14 @@ next_state(State = #q{q = Q,
                       backing_queue       = BQ,
                       backing_queue_state = BQS,
                       msg_id_to_channel   = MTC}) ->
-    try
-        assert_invariant(State)
-    catch C:E:S ->
-        rabbit_time_travel_dbg:dump(),
-        rabbit_time_travel_dbg:print(),
-        logger:error("BAD STATE ~p", [State]),
-        erlang:raise(C,E,S)
-    end,
+%    try
+        assert_invariant(State),
+%    catch C:E:S ->
+%        rabbit_time_travel_dbg:dump(),
+%        rabbit_time_travel_dbg:print(),
+%        logger:error("BAD STATE ~p", [State]),
+%        erlang:raise(C,E,S)
+%    end,
     {MsgIds, BQS1} = BQ:drain_confirmed(BQS),
     MTC1 = confirm_messages(MsgIds, MTC, amqqueue:get_name(Q)),
     State1 = State#q{backing_queue_state = BQS1, msg_id_to_channel = MTC1},
@@ -1281,9 +1281,6 @@ prioritise_cast(Msg, _Len, State) ->
 %% stack are optimised for that) and to make things easier to reason
 %% about. Finally, we prioritise ack over resume since it should
 %% always reduce memory use.
-%% bump_reduce_memory_use is prioritised over publishes, because sending
-%% credit to self is hard to reason about. Consumers can continue while
-%% reduce_memory_use is in progress.
 
 consumer_bias(#q{backing_queue = BQ, backing_queue_state = BQS}, Low, High) ->
     case BQ:msg_rates(BQS) of
@@ -1301,7 +1298,6 @@ prioritise_info(Msg, _Len, #q{q = Q}) ->
         {drop_expired, _Version}             -> 8;
         emit_stats                           -> 7;
         sync_timeout                         -> 6;
-        bump_reduce_memory_use               -> 1;
         _                                    -> 0
     end.
 
@@ -1783,10 +1779,6 @@ handle_info({bump_credit, Msg}, State = #q{backing_queue       = BQ,
     %% rabbit_variable_queue:msg_store_write/4.
     credit_flow:handle_bump_msg(Msg),
     noreply(State#q{backing_queue_state = BQ:resume(BQS)});
-handle_info(bump_reduce_memory_use, State = #q{backing_queue       = BQ,
-                                               backing_queue_state = BQS0}) ->
-    BQS1 = BQ:handle_info(bump_reduce_memory_use, BQS0),
-    noreply(State#q{backing_queue_state = BQ:resume(BQS1)});
 
 handle_info(Info, State) ->
     {stop, {unhandled_info, Info}, State}.

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -257,11 +257,6 @@
                             [ack()], Acc, state())
                            -> Acc.
 
-%% Called when rabbit_amqqueue_process receives a message via
-%% handle_info and it should be processed by the backing
-%% queue
--callback handle_info(term(), state()) -> state().
-
 -spec info_keys() -> rabbit_types:info_keys().
 
 info_keys() -> ?INFO_KEYS.

--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -9,7 +9,7 @@
 
 -export([erase/1, init/3, reset_state/1, recover/7,
          terminate/3, delete_and_terminate/1,
-         publish/7, ack/2, read/3]).
+         publish/7, publish/8, ack/2, read/3]).
 
 %% Recovery. Unlike other functions in this module, these
 %% apply to all queues all at once.
@@ -290,7 +290,7 @@ recover_segments(State0 = #qi { queue_name = Name, dir = Dir }, Terms, IsMsgStor
                 list_to_integer(filename:basename(F, ?SEGMENT_EXTENSION))
             || F <- SegmentFiles]),
             %% We use a temporary store state to check that messages do exist.
-            StoreState0 = rabbit_classic_queue_store_v2:init(Name, OnSyncMsgFun),
+            StoreState0 = rabbit_classic_queue_store_v2:init(Name),
             {State1, StoreState} = recover_segments(State0, ContainsCheckFun, StoreState0, CountersRef, Segments),
             _ = rabbit_classic_queue_store_v2:terminate(StoreState),
             State1
@@ -482,7 +482,7 @@ recover_index_v1_dirty(State0 = #qi{ queue_name = Name }, Terms, IsMsgStoreClean
 recover_index_v1_common(State0 = #qi{ queue_name = Name, dir = Dir },
                         V1State, CountersRef) ->
     %% Use a temporary per-queue store state to store embedded messages.
-    StoreState0 = rabbit_classic_queue_store_v2:init(Name, fun(_, _) -> ok end),
+    StoreState0 = rabbit_classic_queue_store_v2:init(Name),
     %% Go through the v1 index and publish messages to the v2 index.
     {LoSeqId, HiSeqId, _} = rabbit_queue_index:bounds(V1State),
     %% When resuming after a crash we need to double check the messages that are both
@@ -564,9 +564,12 @@ delete_and_terminate(State = #qi { dir = Dir,
               rabbit_types:message_properties(), boolean(),
               non_neg_integer() | infinity, State) -> State when State::state().
 
+publish(MsgId, SeqId, Location, Props, IsPersistent, TargetRamCount, State) ->
+    publish(MsgId, SeqId, Location, Props, IsPersistent, true, TargetRamCount, State).
+
 %% Because we always persist to the msg_store, the Msg(Or)Id argument
 %% here is always a binary, never a record.
-publish(MsgId, SeqId, Location, Props, IsPersistent, TargetRamCount,
+publish(MsgId, SeqId, Location, Props, IsPersistent, ShouldConfirm, TargetRamCount,
         State0 = #qi { write_buffer = WriteBuffer0,
                        segments = Segments }) ->
     ?DEBUG("~0p ~0p ~0p ~0p ~0p ~0p ~0p", [MsgId, SeqId, Location, Props, IsPersistent, TargetRamCount, State0]),
@@ -583,7 +586,7 @@ publish(MsgId, SeqId, Location, Props, IsPersistent, TargetRamCount,
     end,
     %% When publisher confirms have been requested for this
     %% message we mark the message as unconfirmed.
-    State = maybe_mark_unconfirmed(MsgId, Props, State2),
+    State = maybe_mark_unconfirmed(MsgId, Props, ShouldConfirm, State2),
     maybe_flush_buffer(State, SegmentEntryCount).
 
 new_segment_file(Segment, SegmentEntryCount, State = #qi{ segments = Segments }) ->
@@ -657,9 +660,9 @@ reduce_fd_usage(SegmentToOpen, State = #qi{ fds = OpenFds0 }) ->
     end.
 
 maybe_mark_unconfirmed(MsgId, #message_properties{ needs_confirming = true },
-        State = #qi { confirms = Confirms }) ->
+        true, State = #qi { confirms = Confirms }) ->
     State#qi{ confirms = sets:add_element(MsgId, Confirms) };
-maybe_mark_unconfirmed(_, _, State) ->
+maybe_mark_unconfirmed(_, _, _, State) ->
     State.
 
 maybe_flush_buffer(State = #qi { write_buffer = WriteBuffer,
@@ -1183,7 +1186,7 @@ stop(VHost) ->
 
 pre_publish(MsgOrId, SeqId, Location, Props, IsPersistent, TargetRamCount, State) ->
     ?DEBUG("~0p ~0p ~0p ~0p ~0p ~0p ~0p", [MsgOrId, SeqId, Location, Props, IsPersistent, TargetRamCount, State]),
-    publish(MsgOrId, SeqId, Location, Props, IsPersistent, TargetRamCount, State).
+    publish(MsgOrId, SeqId, Location, Props, IsPersistent, false, TargetRamCount, State).
 
 flush_pre_publish_cache(TargetRamCount, State) ->
     ?DEBUG("~0p ~0p", [TargetRamCount, State]),

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -265,6 +265,9 @@ sync(State = #qs{ confirms = Confirms,
 -spec read(rabbit_variable_queue:seq_id(), msg_location(), State)
         -> {rabbit_types:basic_message(), State} when State::state().
 
+%% @todo We should try to have a read_many for when reading many from the index
+%%       so that we fetch many different messages in a single file:pread. See
+%%       if that helps improve the performance.
 read(SeqId, DiskLocation, State = #qs{ cache = Cache }) ->
     ?DEBUG("~0p ~0p ~0p", [SeqId, DiskLocation, State]),
     case Cache of

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -168,7 +168,8 @@ get_write_offset(Segment, Size, State = #qs{ write_segment = WriteSegment })
            ?VERSION:8,
            FromSeqId:64/unsigned,
            ToSeqId:64/unsigned,
-           0:344 >>),
+           0:344 >>,
+        [raw]),
     {?HEADER_SIZE, State#qs{ write_segment = Segment,
                              write_offset = ?HEADER_SIZE + ?ENTRY_HEADER_SIZE + Size }}.
 

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -186,6 +186,10 @@ write(SeqId, Msg=#basic_message{ id = MsgId }, Props, State0) ->
     %%       after reading it back from disk. But we have to support
     %%       going back to v1 for the time being. When rolling back
     %%       to v1 is no longer possible, set `id = undefined` here.
+    %% @todo We should manage flushing to disk ourselves so that we
+    %%       only do term_to_iovec if the message is going to hit
+    %%       the disk. If it won't, we can replace it with an empty
+    %%       binary. The size can be estimated via erlang:external_size/1.
     MsgIovec = term_to_iovec(Msg),
     Size = iolist_size(MsgIovec),
     %% Calculate the CRC for the data if configured to do so.

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -279,9 +279,6 @@ build_data({_, Size, Msg}, CheckCRC32) ->
 -spec read(rabbit_variable_queue:seq_id(), msg_location(), State)
         -> {rabbit_types:basic_message(), State} when State::state().
 
-%% @todo We should try to have a read_many for when reading many from the index
-%%       so that we fetch many different messages in a single file:pread. See
-%%       if that helps improve the performance.
 read(SeqId, DiskLocation, State = #qs{ write_buffer = WriteBuffer,
                                        cache = Cache }) ->
     ?DEBUG("~0p ~0p ~0p", [SeqId, DiskLocation, State]),
@@ -323,6 +320,9 @@ read_from_disk(SeqId, {?MODULE, Offset, Size}, State0) ->
     end,
     Msg = binary_to_term(MsgBin),
     {Msg, State}.
+
+-spec read_many([{rabbit_variable_queue:seq_id(), msg_location()}], State)
+        -> {[rabbit_types:basic_message()], State} when State::state().
 
 read_many([], State) ->
     {[], State};

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -390,7 +390,6 @@ consolidate_reads([], _, Segment, _, Acc, Segs) ->
 read_many_from_disk(Segs, Msgs, State) ->
     %% We read from segments in reverse order because
     %% we need to control the order of returned messages.
-    %% @todo As a result it doesn't help much to keep the read FD.
     Keys = lists:reverse(lists:sort(maps:keys(Segs))),
     lists:foldl(fun(Segment, {Acc0, FoldState0}) ->
         {ok, Fd, FoldState} = get_read_fd(Segment, FoldState0),

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -62,9 +62,6 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
-%% We need this to directly access the delayed file io pid.
--include_lib("kernel/include/file.hrl").
-
 %% Set to true to get an awful lot of debug logs.
 -if(false).
 -define(DEBUG(X,Y), logger:debug("~0p: " ++ X, [?FUNCTION_NAME|Y])).
@@ -72,43 +69,34 @@
 -define(DEBUG(X,Y), _ = X, _ = Y, ok).
 -endif.
 
+-type buffer() :: #{
+    %% SeqId => {Offset, Size, Msg}
+    rabbit_variable_queue:seq_id() => {non_neg_integer(), non_neg_integer(), #basic_message{}}
+}.
+
 -record(qs, {
     %% Store directory - same as the queue index.
     dir :: file:filename(),
 
-    %% We keep up to one write fd open at any time.
-    %% Because queues are FIFO, writes are mostly sequential
-    %% and they occur only once, we do not need to worry
-    %% much about writing to multiple different segment
-    %% files.
-    %%
-    %% We keep track of which segment is open, its fd,
+    %% We keep track of which segment is open
     %% and the current offset in the file. This offset
     %% is the position at which the next message will
-    %% be written, and it will be kept track in the
-    %% queue (and potentially in the queue index) for
-    %% a later read.
+    %% be written. The offset will be returned to be
+    %% kept track of in the queue (or queue index) for
+    %% later reads.
     write_segment = undefined :: undefined | non_neg_integer(),
-    write_fd = undefined :: undefined | file:fd(),
     write_offset = ?HEADER_SIZE :: non_neg_integer(),
+
+    %% We must keep the offset, expected size and message in order
+    %% to write the message.
+    write_buffer = #{} :: buffer(),
+    write_buffer_size = 0 :: non_neg_integer(),
 
     %% We keep a cache of messages for faster reading
     %% for the cases where consumers can keep up with
-    %% producers. Messages are written to the case as
-    %% long as there is space available. Messages are
-    %% not removed from the cache until the message
-    %% is either acked or removed by the queue. This
-    %% means that only a subset of messages may make
-    %% it onto the store. We do not prune messages as
-    %% that could lead to caching messages and pruning
-    %% them before they can be read from the cache.
-    %%
-    %% The cache size is the size of the messages,
-    %% it does not include the metadata. The real
-    %% cache size will therefore potentially be larger
-    %% than the configured maximum size.
-    cache = #{} :: #{ rabbit_variable_queue:seq_id() => {non_neg_integer(), #basic_message{}}},
-    cache_size = 0 :: non_neg_integer(),
+    %% producers. The write_buffer becomes the cache
+    %% when it is written to disk.
+    cache = #{} :: buffer(),
 
     %% Similarly, we keep track of a single read fd.
     %% We cannot share this fd with the write fd because
@@ -133,23 +121,14 @@ init(#resource{ virtual_host = VHost } = Name) ->
 
 -spec terminate(State) -> State when State::state().
 
-terminate(State = #qs{ write_fd = WriteFd,
-                       read_fd = ReadFd }) ->
-    ?DEBUG("~0p", [State]),
-    %% Fsync and close all FDs as needed.
-    maybe_sync_close_fd(WriteFd),
+terminate(State0 = #qs{ read_fd = ReadFd }) ->
+    ?DEBUG("~0p", [State0]),
+    State = flush_buffer(State0),
     maybe_close_fd(ReadFd),
     State#qs{ write_segment = undefined,
-              write_fd = undefined,
               write_offset = ?HEADER_SIZE,
               read_segment = undefined,
               read_fd = undefined }.
-
-maybe_sync_close_fd(undefined) ->
-    ok;
-maybe_sync_close_fd(Fd) ->
-    ok = file:sync(Fd),
-    ok = file:close(Fd).
 
 maybe_close_fd(undefined) ->
     ok;
@@ -160,82 +139,120 @@ maybe_close_fd(Fd) ->
             rabbit_types:message_properties(), State)
         -> {msg_location(), State} when State::state().
 
-write(SeqId, Msg, Props, State0) ->
+%% @todo I think we can disable the old message store at the same
+%%       place where we create MsgId. If many queues receive the
+%%       message, then we create an MsgId. If not, we don't. But
+%%       we can only do this after removing support for v1.
+write(SeqId, Msg, Props, State0 = #qs{ write_buffer = WriteBuffer0,
+                                       write_buffer_size = WriteBufferSize }) ->
     ?DEBUG("~0p ~0p ~0p ~0p", [SeqId, Msg, Props, State0]),
     SegmentEntryCount = segment_entry_count(),
     Segment = SeqId div SegmentEntryCount,
-    %% We simply append to the related segment file.
-    %% We will then return the offset and size. That
-    %% combined with the SeqId is enough to find the
-    %% message again.
-    {Fd, Offset, State1} = get_write_fd(Segment, State0),
-    %% @todo We could remove MsgId because we are not going to use it
-    %%       after reading it back from disk. But we have to support
-    %%       going back to v1 for the time being. When rolling back
-    %%       to v1 is no longer possible, set `id = undefined` here.
-    %% @todo We should manage flushing to disk ourselves so that we
-    %%       only do term_to_iovec if the message is going to hit
-    %%       the disk. If it won't, we can replace it with an empty
-    %%       binary. The size can be estimated via erlang:external_size/1.
-    MsgIovec = term_to_iovec(Msg),
-    Size = iolist_size(MsgIovec),
-    %% Calculate the CRC for the data if configured to do so.
-    %% We will truncate the CRC to 16 bits to save on space. (Idea taken from postgres.)
-    {UseCRC32, CRC32} = case check_crc32() of
-        true -> {1, erlang:crc32(MsgIovec)};
-        false -> {0, 0}
-    end,
-    %% Append to the buffer. A short entry header is prepended:
-    %% Size:32, Flags:8, CRC32:16, Unused:8.
-    ok = file:write(Fd, [<<Size:32/unsigned, 0:7, UseCRC32:1, CRC32:16, 0:8>>, MsgIovec]),
-    %% Maybe cache the message.
-    State = maybe_cache(SeqId, Size, Msg, State1),
-    %% Keep track of the offset we are at.
-    {{?MODULE, Offset, Size}, State#qs{ write_offset = Offset + Size + ?ENTRY_HEADER_SIZE }}.
+    Size = erlang:external_size(Msg),
+    {Offset, State1} = get_write_offset(Segment, Size, State0),
+    WriteBuffer = WriteBuffer0#{SeqId => {Offset, Size, Msg}},
+    State = State1#qs{ write_buffer = WriteBuffer,
+                       write_buffer_size = WriteBufferSize + Size },
+    {{?MODULE, Offset, Size}, maybe_flush_buffer(State)}.
 
-get_write_fd(Segment, State = #qs{ write_fd = Fd,
-                                   write_segment = Segment,
-                                   write_offset = Offset }) ->
-    {Fd, Offset, State};
-get_write_fd(Segment, State = #qs{ write_fd = OldFd }) ->
-    maybe_close_fd(OldFd),
-    {ok, Fd} = file:open(segment_file(Segment, State), [read, append, raw, binary, {delayed_write, 512000, 10000}]),
-    {ok, Offset0} = file:position(Fd, eof),
-    %% If we are at offset 0, write the file header.
-    Offset = case Offset0 of
-        0 ->
-            SegmentEntryCount = segment_entry_count(),
-            FromSeqId = Segment * SegmentEntryCount,
-            ToSeqId = FromSeqId + SegmentEntryCount,
-            ok = file:write(Fd, << ?MAGIC:32,
-                                   ?VERSION:8,
-                                   FromSeqId:64/unsigned,
-                                   ToSeqId:64/unsigned,
-                                   0:344 >>),
-            ?HEADER_SIZE;
-        _ ->
-            Offset0
-    end,
-    {Fd, Offset, State#qs{ write_segment = Segment,
-                           write_fd = Fd }}.
-
-maybe_cache(SeqId, MsgSize, Msg, State = #qs{ cache = Cache,
-                                              cache_size = CacheSize }) ->
-    MaxCacheSize = max_cache_size(),
-    if
-        CacheSize + MsgSize > MaxCacheSize ->
-            State;
-        true ->
-            State#qs{ cache = Cache#{ SeqId => {MsgSize, Msg} },
-                      cache_size = CacheSize + MsgSize }
-    end.
+get_write_offset(Segment, Size, State = #qs{ write_segment = Segment,
+                                             write_offset = Offset }) ->
+    {Offset, State#qs{ write_offset = Offset + ?ENTRY_HEADER_SIZE + Size }};
+get_write_offset(Segment, Size, State = #qs{ write_segment = WriteSegment })
+        when Segment > WriteSegment; WriteSegment =:= undefined ->
+    SegmentEntryCount = segment_entry_count(),
+    FromSeqId = Segment * SegmentEntryCount,
+    ToSeqId = FromSeqId + SegmentEntryCount,
+    ok = file:write_file(segment_file(Segment, State),
+        << ?MAGIC:32,
+           ?VERSION:8,
+           FromSeqId:64/unsigned,
+           ToSeqId:64/unsigned,
+           0:344 >>),
+    {?HEADER_SIZE, State#qs{ write_segment = Segment,
+                             write_offset = ?HEADER_SIZE + ?ENTRY_HEADER_SIZE + Size }}.
 
 -spec sync(State) -> State when State::state().
 
 sync(State) ->
     ?DEBUG("~0p", [State]),
-    flush_write_fd(State),
-    State.
+    flush_buffer(State).
+
+maybe_flush_buffer(State = #qs{ write_buffer_size = WriteBufferSize }) ->
+    case WriteBufferSize >= max_cache_size() of
+        true -> flush_buffer(State);
+        false -> State
+    end.
+
+flush_buffer(State = #qs{ write_buffer_size = 0 }) ->
+    State;
+flush_buffer(State0 = #qs{ write_buffer = WriteBuffer }) ->
+    CheckCRC32 = check_crc32(),
+    SegmentEntryCount = segment_entry_count(),
+    %% First we prepare the writes sorted by segment.
+    WriteList = lists:sort(maps:to_list(WriteBuffer)),
+    Writes = flush_buffer_build(WriteList, CheckCRC32, SegmentEntryCount),
+    %% Then we do the writes for each segment.
+    State = lists:foldl(fun({Segment, LocBytes}, FoldState) ->
+        {ok, Fd} = file:open(segment_file(Segment, FoldState), [read, write, raw, binary]),
+        ok = file:pwrite(Fd, lists:sort(LocBytes)),
+        ok = file:close(Fd),
+        FoldState
+    end, State0, Writes),
+    %% Finally we move the write_buffer to the cache.
+    State#qs{ write_buffer = #{},
+              write_buffer_size = 0,
+              cache = WriteBuffer }.
+
+flush_buffer_build(WriteBuffer = [{FirstSeqId, {Offset, _, _}}|_],
+                   CheckCRC32, SegmentEntryCount) ->
+    Segment = FirstSeqId div SegmentEntryCount,
+    SegmentThreshold = (1 + Segment) * SegmentEntryCount,
+    {Tail, LocBytes} = flush_buffer_build(WriteBuffer,
+        CheckCRC32, SegmentThreshold, ?HEADER_SIZE, Offset, [], []),
+    [{Segment, LocBytes}|flush_buffer_build(Tail, CheckCRC32, SegmentEntryCount)];
+flush_buffer_build([], _, _) ->
+    [].
+
+flush_buffer_build(Tail = [{SeqId, _}|_], _, SegmentThreshold, _, WriteOffset, WriteAcc, Acc)
+        when SeqId >= SegmentThreshold ->
+    case WriteAcc of
+        [] -> {Tail, Acc};
+        _ -> {Tail, [{WriteOffset, lists:reverse(WriteAcc)}|Acc]}
+    end;
+flush_buffer_build([{_, Entry = {Offset, Size, _}}|Tail],
+        CheckCRC32, SegmentEntryCount, Offset, WriteOffset, WriteAcc, Acc) ->
+    flush_buffer_build(Tail, CheckCRC32, SegmentEntryCount,
+        Offset + ?ENTRY_HEADER_SIZE + Size, WriteOffset,
+        [build_data(Entry, CheckCRC32)|WriteAcc], Acc);
+flush_buffer_build([{_, Entry = {Offset, Size, _}}|Tail],
+        CheckCRC32, SegmentEntryCount, _, _, [], Acc) ->
+    flush_buffer_build(Tail, CheckCRC32, SegmentEntryCount,
+        Offset + ?ENTRY_HEADER_SIZE + Size, Offset, [build_data(Entry, CheckCRC32)], Acc);
+flush_buffer_build([{_, Entry = {Offset, Size, _}}|Tail],
+        CheckCRC32, SegmentEntryCount, _, WriteOffset, WriteAcc, Acc) ->
+    flush_buffer_build(Tail, CheckCRC32, SegmentEntryCount,
+        Offset + ?ENTRY_HEADER_SIZE + Size, Offset, [build_data(Entry, CheckCRC32)],
+        [{WriteOffset, lists:reverse(WriteAcc)}|Acc]);
+flush_buffer_build([], _, _, _, _, [], Acc) ->
+    {[], Acc};
+flush_buffer_build([], _, _, _, WriteOffset, WriteAcc, Acc) ->
+    {[], [{WriteOffset, lists:reverse(WriteAcc)}|Acc]}.
+
+build_data({_, Size, Msg}, CheckCRC32) ->
+    MsgIovec = term_to_iovec(Msg),
+    Padding = (Size - iolist_size(MsgIovec)) * 8,
+    %% Calculate the CRC for the data if configured to do so.
+    %% We will truncate the CRC to 16 bits to save on space. (Idea taken from postgres.)
+    %% @todo Move check_crc32 to flush_buffer.
+    {UseCRC32, CRC32} = case CheckCRC32 of
+        true -> {1, erlang:crc32(MsgIovec)};
+        false -> {0, 0}
+    end,
+    [
+        <<Size:32/unsigned, 0:7, UseCRC32:1, CRC32:16, 0:8>>,
+        MsgIovec, <<0:Padding>>
+    ].
 
 -spec read(rabbit_variable_queue:seq_id(), msg_location(), State)
         -> {rabbit_types:basic_message(), State} when State::state().
@@ -243,13 +260,19 @@ sync(State) ->
 %% @todo We should try to have a read_many for when reading many from the index
 %%       so that we fetch many different messages in a single file:pread. See
 %%       if that helps improve the performance.
-read(SeqId, DiskLocation, State = #qs{ cache = Cache }) ->
+read(SeqId, DiskLocation, State = #qs{ write_buffer = WriteBuffer,
+                                       cache = Cache }) ->
     ?DEBUG("~0p ~0p ~0p", [SeqId, DiskLocation, State]),
-    case Cache of
-        #{ SeqId := {_, Msg} } ->
+    case WriteBuffer of
+        #{ SeqId := {_, _, Msg} } ->
             {Msg, State};
         _ ->
-            read_from_disk(SeqId, DiskLocation, State)
+            case Cache of
+                #{ SeqId := {_, _, Msg} } ->
+                    {Msg, State};
+                _ ->
+                    read_from_disk(SeqId, DiskLocation, State)
+            end
     end.
 
 read_from_disk(SeqId, {?MODULE, Offset, Size}, State0) ->
@@ -265,6 +288,7 @@ read_from_disk(SeqId, {?MODULE, Offset, Size}, State0) ->
             ok;
         1 ->
             %% We only want to check the CRC32 if configured to do so.
+            %% @todo Always check if the message has a CRC32 to be consistent with QQs.
             case check_crc32() of
                 false ->
                     ok;
@@ -286,11 +310,9 @@ read_from_disk(SeqId, {?MODULE, Offset, Size}, State0) ->
 
 get_read_fd(Segment, State = #qs{ read_segment = Segment,
                                   read_fd = Fd }) ->
-    maybe_flush_write_fd(Segment, State),
     {ok, Fd, State};
 get_read_fd(Segment, State = #qs{ read_fd = OldFd }) ->
     maybe_close_fd(OldFd),
-    maybe_flush_write_fd(Segment, State),
     case file:open(segment_file(Segment, State), [read, raw, binary]) of
         {ok, Fd} ->
             case file:read(Fd, ?HEADER_SIZE) of
@@ -309,24 +331,6 @@ get_read_fd(Segment, State = #qs{ read_fd = OldFd }) ->
         {error, enoent} ->
             {{error, no_file}, State}
     end.
-
-maybe_flush_write_fd(Segment, State = #qs{ write_segment = Segment }) ->
-    flush_write_fd(State);
-maybe_flush_write_fd(_, _) ->
-    ok.
-
-flush_write_fd(#qs{ write_fd = undefined }) ->
-    ok;
-flush_write_fd(#qs{ write_fd = Fd }) ->
-    %% We tell the pid handling delayed writes to flush to disk
-    %% without issuing a separate command to the fd. We need
-    %% to do this in order to read from a separate fd that
-    %% points to the same file.
-    #file_descriptor{
-        module = raw_file_io_delayed, %% assert
-        data = #{ pid := Pid }
-    } = Fd,
-    gen_statem:call(Pid, '$synchronous_flush').
 
 -spec check_msg_on_disk(rabbit_variable_queue:seq_id(), msg_location(), State)
         -> {ok | {error, any()}, State} when State::state().
@@ -372,17 +376,18 @@ check_msg_on_disk(SeqId, {?MODULE, Offset, Size}, State0) ->
 
 -spec remove(rabbit_variable_queue:seq_id(), State) -> State when State::state().
 
-%% We only remove the message from the cache. We will remove
-%% the message from the disk when we delete the segment file.
-remove(SeqId, State = #qs{ cache = Cache0,
-                           cache_size = CacheSize }) ->
+%% We only remove the message from the write_buffer. We will remove
+%% the message from the disk when we delete the segment file, and
+%% from the cache on the next write.
+remove(SeqId, State = #qs{ write_buffer = WriteBuffer0,
+                           write_buffer_size = WriteBufferSize }) ->
     ?DEBUG("~0p ~0p", [SeqId, State]),
-    case maps:take(SeqId, Cache0) of
+    case maps:take(SeqId, WriteBuffer0) of
         error ->
             State;
-        {{MsgSize, _}, Cache} ->
-            State#qs{ cache = Cache,
-                      cache_size = CacheSize - MsgSize }
+        {{_, MsgSize, _}, WriteBuffer} ->
+            State#qs{ write_buffer = WriteBuffer,
+                      write_buffer_size = WriteBufferSize - MsgSize }
     end.
 
 -spec delete_segments([non_neg_integer()], State) -> State when State::state().
@@ -392,32 +397,16 @@ remove(SeqId, State = #qs{ cache = Cache0,
 delete_segments([], State) ->
     ?DEBUG("[] ~0p", [State]),
     State;
-delete_segments(Segments, State0 = #qs{ write_segment = WriteSegment,
-                                        write_fd = WriteFd,
+delete_segments(Segments, State0 = #qs{ write_buffer = WriteBuffer0,
+                                        write_buffer_size = WriteBufferSize0,
                                         read_segment = ReadSegment,
-                                        read_fd = ReadFd,
-                                        cache = Cache0,
-                                        cache_size = CacheSize0 }) ->
+                                        read_fd = ReadFd }) ->
     ?DEBUG("~0p ~0p", [Segments, State0]),
     %% First we have to close fds for the segments, if any.
     %% 'undefined' is never in Segments so we don't
     %% need to special case it.
-    CloseWrite = lists:member(WriteSegment, Segments),
     CloseRead = lists:member(ReadSegment, Segments),
     State = if
-        CloseWrite andalso CloseRead ->
-            ok = file:close(WriteFd),
-            ok = file:close(ReadFd),
-            State0#qs{ write_segment = undefined,
-                       write_fd = undefined,
-                       write_offset = ?HEADER_SIZE,
-                       read_segment = undefined,
-                       read_fd = undefined };
-        CloseWrite ->
-            ok = file:close(WriteFd),
-            State0#qs{ write_segment = undefined,
-                       write_fd = undefined,
-                       write_offset = ?HEADER_SIZE };
         CloseRead ->
             ok = file:close(ReadFd),
             State0#qs{ read_segment = undefined,
@@ -434,23 +423,27 @@ delete_segments(Segments, State0 = #qs{ write_segment = WriteSegment,
             {error, enoent} -> ok
         end
     || Segment <- Segments],
-    %% Finally, we remove any entries from the cache that fall within
+    %% Finally, we remove any entries from the buffer that fall within
     %% the segments that were deleted. For simplicity's sake, we take
     %% the highest SeqId from these files and remove any SeqId lower
-    %% than or equal to this SeqId from the cache.
+    %% than or equal to this SeqId from the buffer.
+    %%
+    %% @todo If this becomes a performance issue we may take inspiration
+    %%       from sets:filter/2.
     HighestSegment = lists:foldl(fun
         (S, SAcc) when S > SAcc -> S;
         (_, SAcc) -> SAcc
     end, -1, Segments),
     HighestSeqId = (1 + HighestSegment) * segment_entry_count(),
-    {Cache, CacheSize} = maps:fold(fun
-        (SeqId, {MsgSize, _}, {CacheAcc, CacheSize1}) when SeqId =< HighestSeqId ->
-            {CacheAcc, CacheSize1 - MsgSize};
-        (SeqId, Value, {CacheAcc, CacheSize1}) ->
-            {CacheAcc#{SeqId => Value}, CacheSize1}
-    end, {#{}, CacheSize0}, Cache0),
-    State#qs{ cache = Cache,
-              cache_size = CacheSize }.
+    {WriteBuffer, WriteBufferSize} = maps:fold(fun
+        (SeqId, {_, MsgSize, _}, {WriteBufferAcc, WriteBufferSize1})
+                when SeqId =< HighestSeqId ->
+            {WriteBufferAcc, WriteBufferSize1 - MsgSize};
+        (SeqId, Value, {WriteBufferAcc, WriteBufferSize1}) ->
+            {WriteBufferAcc#{SeqId => Value}, WriteBufferSize1}
+    end, {#{}, WriteBufferSize0}, WriteBuffer0),
+    State#qs{ write_buffer = WriteBuffer,
+              write_buffer_size = WriteBufferSize }.
 
 %% ----
 %%

--- a/deps/rabbit/src/rabbit_mirror_queue_master.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_master.erl
@@ -16,7 +16,7 @@
          needs_timeout/1, timeout/1, handle_pre_hibernate/1, resume/1,
          msg_rates/1, info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
          set_queue_version/2,
-         zip_msgs_and_acks/4, handle_info/2]).
+         zip_msgs_and_acks/4]).
 
 -export([start/2, stop/1, delete_crashed/1]).
 
@@ -417,10 +417,6 @@ timeout(State = #state { backing_queue = BQ, backing_queue_state = BQS }) ->
 handle_pre_hibernate(State = #state { backing_queue       = BQ,
                                       backing_queue_state = BQS }) ->
     State #state { backing_queue_state = BQ:handle_pre_hibernate(BQS) }.
-
-handle_info(Msg, State = #state { backing_queue       = BQ,
-                                  backing_queue_state = BQS }) ->
-    State #state { backing_queue_state = BQ:handle_info(Msg, BQS) }.
 
 resume(State = #state { backing_queue       = BQ,
                         backing_queue_state = BQS }) ->

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -385,14 +385,6 @@ handle_info({bump_credit, Msg}, State) ->
     credit_flow:handle_bump_msg(Msg),
     noreply(State);
 
-handle_info(bump_reduce_memory_use, State = #state{backing_queue       = BQ,
-                                                backing_queue_state = BQS}) ->
-    BQS1 = BQ:handle_info(bump_reduce_memory_use, BQS),
-    BQS2 = BQ:resume(BQS1),
-    noreply(State#state{
-        backing_queue_state = BQS2
-    });
-
 %% In the event of a short partition during sync we can detect the
 %% master's 'death', drop out of sync, and then receive sync messages
 %% which were still in flight. Ignore them.

--- a/deps/rabbit/src/rabbit_mirror_queue_sync.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_sync.erl
@@ -333,8 +333,6 @@ wait_for_credit(SPids) ->
 
 wait_for_resources(Ref, SPids) ->
     erlang:garbage_collect(),
-    % Probably bump_reduce_memory_use messages should be handled here as well,
-    % otherwise the BQ is not pushing messages to disk
     receive
         {conserve_resources, memory, false} ->
             SPids;
@@ -414,11 +412,7 @@ slave_sync_loop(Args = {Ref, MRef, Syncer, BQ, UpdateRamDuration, Parent},
         %% If the master throws an exception
         {'$gen_cast', {gm, {delete_and_terminate, Reason}}} ->
             BQ:delete_and_terminate(Reason, BQS),
-            {stop, Reason, {[], TRef, undefined}};
-        bump_reduce_memory_use -> 
-            BQS1 = BQ:handle_info(bump_reduce_memory_use, BQS),
-            BQS2 = BQ:resume(BQS1),
-            slave_sync_loop(Args, {MA, TRef, BQS2})
+            {stop, Reason, {[], TRef, undefined}}
     end.
 
 %% We are partitioning messages by the Unacked element in the tuple.

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -757,7 +757,9 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
 
     FileHandlesEts  = ets:new(rabbit_msg_store_shared_file_handles,
                               [ordered_set, public]),
-    CurFileCacheEts = ets:new(rabbit_msg_store_cur_file, [set, public]),
+    CurFileCacheEts = ets:new(rabbit_msg_store_cur_file, [set, public,
+                              {read_concurrency, true},
+                              {write_concurrency, true}]),
     FlyingEts       = ets:new(rabbit_msg_store_flying, [set, public,
                               {read_concurrency, true},
                               {write_concurrency, true}]),

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -758,7 +758,9 @@ init([VHost, Type, BaseDir, ClientRefs, StartupFunState]) ->
     FileHandlesEts  = ets:new(rabbit_msg_store_shared_file_handles,
                               [ordered_set, public]),
     CurFileCacheEts = ets:new(rabbit_msg_store_cur_file, [set, public]),
-    FlyingEts       = ets:new(rabbit_msg_store_flying, [set, public]),
+    FlyingEts       = ets:new(rabbit_msg_store_flying, [set, public,
+                              {read_concurrency, true},
+                              {write_concurrency, true}]),
 
     {ok, FileSizeLimit} = application:get_env(rabbit, msg_store_file_size_limit),
 

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -974,6 +974,12 @@ handle_info(sync, State) ->
 handle_info(timeout, State) ->
     noreply(internal_sync(State));
 
+%% @todo When a CQ crashes the message store does not remove
+%%       the client information and clean up. This eventually
+%%       leads to the queue running a full recovery on the next
+%%       message store restart because the store will keep the
+%%       crashed queue's ref in its persistent state and fail
+%%       to find the corresponding ref during start.
 handle_info({'DOWN', _MRef, process, Pid, _Reason}, State) ->
     %% similar to what happens in
     %% rabbit_amqqueue_process:handle_ch_down but with a relation of

--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -35,7 +35,7 @@
          handle_pre_hibernate/1, resume/1, msg_rates/1,
          info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
          set_queue_version/2,
-         zip_msgs_and_acks/4, handle_info/2]).
+         zip_msgs_and_acks/4]).
 
 -record(state, {bq, bqss, max_priority}).
 -record(passthrough, {bq, bqs}).
@@ -394,11 +394,6 @@ handle_pre_hibernate(State = #state{bq = BQ}) ->
           end, State);
 handle_pre_hibernate(State = #passthrough{bq = BQ, bqs = BQS}) ->
     ?passthrough1(handle_pre_hibernate(BQS)).
-
-handle_info(Msg, State = #state{bq = BQ}) ->
-    foreach1(fun (_P, BQSN) -> BQ:handle_info(Msg, BQSN) end, State);
-handle_info(Msg, State = #passthrough{bq = BQ, bqs = BQS}) ->
-    ?passthrough1(handle_info(Msg, BQS)).
 
 resume(State = #state{bq = BQ}) ->
     foreach1(fun (_P, BQSN) -> BQ:resume(BQSN) end, State);

--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -734,7 +734,7 @@ recover_index_v2_dirty(State0 = #qistate { queue_name = Name,
 recover_index_v2_common(State0 = #qistate { queue_name = Name, dir = Dir },
                         V2State, CountersRef) ->
     %% Use a temporary per-queue store state to read embedded messages.
-    StoreState0 = rabbit_classic_queue_store_v2:init(Name, fun(_, _) -> ok end),
+    StoreState0 = rabbit_classic_queue_store_v2:init(Name),
     %% Go through the v2 index and publish messages to v1 index.
     {LoSeqId, HiSeqId, _} = rabbit_classic_queue_index_v2:bounds(V2State),
     %% When resuming after a crash we need to double check the messages that are both

--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -12,7 +12,7 @@
 -export([erase/1, init/3, reset_state/1, recover/7,
          terminate/3, delete_and_terminate/1,
          pre_publish/7, flush_pre_publish_cache/2,
-         publish/7, deliver/2, ack/2, sync/1, needs_sync/1, flush/1,
+         publish/7, publish/8, deliver/2, ack/2, sync/1, needs_sync/1, flush/1,
          read/3, next_segment_boundary/1, bounds/1, start/2, stop/1]).
 
 -export([add_queue_ttl/0, avoid_zeroes/0, store_msg_size/0, store_msg/0]).
@@ -429,6 +429,9 @@ publish(MsgOrId, SeqId, _Location, MsgProps, IsPersistent, JournalSizeHint, Stat
     maybe_flush_journal(
       JournalSizeHint,
       add_to_journal(SeqId, {IsPersistent, Bin, MsgBin}, State1)).
+
+publish(MsgOrId, SeqId, Location, MsgProps, IsPersistent, _, JournalSizeHint, State) ->
+    publish(MsgOrId, SeqId, Location, MsgProps, IsPersistent, JournalSizeHint, State).
 
 maybe_needs_confirming(MsgProps, MsgOrId,
         State = #qistate{unconfirmed     = UC,

--- a/deps/rabbit/src/rabbit_time_travel_dbg.erl
+++ b/deps/rabbit/src/rabbit_time_travel_dbg.erl
@@ -1,3 +1,21 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% This module is a debugging utility mainly meant for debugging
+%% test failures. It should not be used in production in its
+%% current form.
+%%
+%% The tracer is started and configured against a pid and a set
+%% of applications. Then update the code where you need to
+%% obtain events, such as a crash. Wrapping the crash in
+%% a try/catch and adding rabbit_time_travel_dbg:print()
+%% will print up to 1000 events before the crash occured,
+%% allowing you to easily figure out what happened.
+
 -module(rabbit_time_travel_dbg).
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1974,7 +1974,7 @@ count_pending_acks(#vqstate { ram_pending_ack   = RPA,
     gb_trees:size(RPA) + gb_trees:size(DPA) + gb_trees:size(QPA).
 
 %% @todo This should set the out rate to infinity temporarily while we drop deltas.
-purge_betas_and_deltas(DelsAndAcksFun, State = #vqstate { mode = Mode }) ->
+purge_betas_and_deltas(DelsAndAcksFun, State) ->
     State0 = #vqstate { q3 = Q3 } = maybe_deltas_to_betas(DelsAndAcksFun, State),
 
     case ?QUEUE:is_empty(Q3) of

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -2154,7 +2154,7 @@ publish_delivered1(Msg = #basic_message { is_persistent = IsPersistent, id = Msg
                                       unconfirmed         = UC }) ->
     IsPersistent1 = IsDurable andalso IsPersistent,
     MsgStatus = msg_status(Version, IsPersistent1, true, SeqId, Msg, MsgProps, IndexMaxSize),
-    {MsgStatus1, State1} = PersistFun(true, true, MsgStatus, State),
+    {MsgStatus1, State1} = PersistFun(false, false, MsgStatus, State),
     State2 = record_pending_ack(m(MsgStatus1), State1),
     UC1 = gb_sets_maybe_insert(NeedsConfirming, MsgId, UC),
     {SeqId,

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -2104,6 +2104,7 @@ publish1(Msg = #basic_message { is_persistent = IsPersistent, id = MsgId },
          MsgProps = #message_properties { needs_confirming = NeedsConfirming },
          IsDelivered, _ChPid, _Flow, PersistFun,
          State = #vqstate { q3 = Q3, delta = Delta = #delta { count = DeltaCount },
+                            len                 = Len,
                             version             = Version,
                             qi_embed_msgs_below = IndexMaxSize,
                             next_seq_id         = SeqId,
@@ -2113,8 +2114,9 @@ publish1(Msg = #basic_message { is_persistent = IsPersistent, id = MsgId },
                             unconfirmed         = UC }) ->
     IsPersistent1 = IsDurable andalso IsPersistent,
     MsgStatus = msg_status(Version, IsPersistent1, IsDelivered, SeqId, Msg, MsgProps, IndexMaxSize),
-    State4 = case {DeltaCount, ?QUEUE:len(Q3)} of
-                 {0, Q3Len} when Q3Len < 16384 -> %% @todo It would be interesting to get a dynamic max size.
+    State4 = case DeltaCount of
+                 %% Len is the same as Q3Len when DeltaCount =:= 0.
+                 0 when Len < 16384 -> %% @todo It would be interesting to get a dynamic max size.
                      {MsgStatus1, State1} = PersistFun(false, false, MsgStatus, State),
                      State2 = State1 #vqstate { q3 = ?QUEUE:in(m(MsgStatus1), Q3) },
                      %% @todo I am not sure about the stats from this.

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -931,7 +931,7 @@ handle_pre_hibernate(State = #vqstate { index_mod   = IndexMod,
                      unconfirmed_simple = sets:new([{version,2}]),
                      confirmed   = sets:union(C, UCS) }.
 
-resume(State) -> a(State).
+resume(State) -> a(timeout(State)).
 
 msg_rates(#vqstate { rates = #rates { in  = AvgIngressRate,
                                       out = AvgEgressRate } }) ->

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1222,6 +1222,7 @@ convert_from_v2_to_v1_msg_status(MsgStatus0, State1 = #vqstate{ store_state = St
                                                                 ram_bytes = RamBytes }, Ready) ->
     case MsgStatus0 of
         #msg_status{ seq_id = SeqId,
+                     msg = undefined,
                      msg_location = MsgLocation = {rabbit_classic_queue_store_v2, _, _} } ->
             {Msg, StoreState} = rabbit_classic_queue_store_v2:read(SeqId, MsgLocation, StoreState0),
             MsgStatus = MsgStatus0#msg_status{ msg = Msg,

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1999,11 +1999,7 @@ count_pending_acks(#vqstate { ram_pending_ack   = RPA,
     gb_trees:size(RPA) + gb_trees:size(DPA) + gb_trees:size(QPA).
 
 purge_betas_and_deltas(DelsAndAcksFun, State = #vqstate { mode = Mode }) ->
-    State0 = #vqstate { q3 = Q3 } =
-        case Mode of
-            lazy -> maybe_deltas_to_betas(DelsAndAcksFun, State);
-            _    -> State
-        end,
+    State0 = #vqstate { q3 = Q3 } = maybe_deltas_to_betas(DelsAndAcksFun, State),
 
     case ?QUEUE:is_empty(Q3) of
         true  -> State0;

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -20,7 +20,7 @@
 -define(VHOST, <<"/">>).
 
 -define(VARIABLE_QUEUE_TESTCASES, [
-    variable_queue_dynamic_duration_change,
+%    variable_queue_dynamic_duration_change,
     variable_queue_partial_segments_delta_thing,
     variable_queue_all_the_bits_not_covered_elsewhere_A,
     variable_queue_all_the_bits_not_covered_elsewhere_B,
@@ -934,41 +934,41 @@ get_queue_sup_pid([{_, SupPid, _, _} | Rest], QueuePid) ->
 get_queue_sup_pid([], _QueuePid) ->
     undefined.
 
-variable_queue_dynamic_duration_change(Config) ->
-    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
-      ?MODULE, variable_queue_dynamic_duration_change1, [Config]).
-
-variable_queue_dynamic_duration_change1(Config) ->
-    with_fresh_variable_queue(
-      fun variable_queue_dynamic_duration_change2/2,
-      ?config(variable_queue_type, Config)).
-
-variable_queue_dynamic_duration_change2(VQ0, _QName) ->
-    IndexMod = index_mod(),
-    SegmentSize = IndexMod:next_segment_boundary(0),
-
-    %% start by sending in a couple of segments worth
-    Len = 2*SegmentSize,
-    VQ1 = variable_queue_publish(false, Len, VQ0),
-    %% squeeze and relax queue
-    Churn = Len div 32,
-    VQ2 = publish_fetch_and_ack(Churn, Len, VQ1),
-
-    {Duration, VQ3} = rabbit_variable_queue:ram_duration(VQ2),
-    VQ7 = lists:foldl(
-            fun (Duration1, VQ4) ->
-                    {_Duration, VQ5} = rabbit_variable_queue:ram_duration(VQ4),
-                    VQ6 = variable_queue_set_ram_duration_target(
-                            Duration1, VQ5),
-                    publish_fetch_and_ack(Churn, Len, VQ6)
-            end, VQ3, [Duration / 4, 0, Duration / 4, infinity]),
-
-    %% drain
-    {VQ8, AckTags} = variable_queue_fetch(Len, false, false, Len, VQ7),
-    {_Guids, VQ9} = rabbit_variable_queue:ack(AckTags, VQ8),
-    {empty, VQ10} = rabbit_variable_queue:fetch(true, VQ9),
-
-    VQ10.
+%variable_queue_dynamic_duration_change(Config) ->
+%    passed = rabbit_ct_broker_helpers:rpc(Config, 0,
+%      ?MODULE, variable_queue_dynamic_duration_change1, [Config]).
+%
+%variable_queue_dynamic_duration_change1(Config) ->
+%    with_fresh_variable_queue(
+%      fun variable_queue_dynamic_duration_change2/2,
+%      ?config(variable_queue_type, Config)).
+%
+%variable_queue_dynamic_duration_change2(VQ0, _QName) ->
+%    IndexMod = index_mod(),
+%    SegmentSize = IndexMod:next_segment_boundary(0),
+%
+%    %% start by sending in a couple of segments worth
+%    Len = 2*SegmentSize,
+%    VQ1 = variable_queue_publish(false, Len, VQ0),
+%    %% squeeze and relax queue
+%    Churn = Len div 32,
+%    VQ2 = publish_fetch_and_ack(Churn, Len, VQ1),
+%
+%    {Duration, VQ3} = rabbit_variable_queue:ram_duration(VQ2),
+%    VQ7 = lists:foldl(
+%            fun (Duration1, VQ4) ->
+%                    {_Duration, VQ5} = rabbit_variable_queue:ram_duration(VQ4),
+%                    VQ6 = variable_queue_set_ram_duration_target(
+%                            Duration1, VQ5),
+%                    publish_fetch_and_ack(Churn, Len, VQ6)
+%            end, VQ3, [Duration / 4, 0, Duration / 4, infinity]),
+%
+%    %% drain
+%    {VQ8, AckTags} = variable_queue_fetch(Len, false, false, Len, VQ7),
+%    {_Guids, VQ9} = rabbit_variable_queue:ack(AckTags, VQ8),
+%    {empty, VQ10} = rabbit_variable_queue:fetch(true, VQ9),
+%
+%    VQ10.
 
 variable_queue_partial_segments_delta_thing(Config) ->
     passed = rabbit_ct_broker_helpers:rpc(Config, 0,

--- a/deps/rabbit/test/classic_queue_prop_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_prop_SUITE.erl
@@ -544,7 +544,11 @@ postcondition(_, {call, _, cmd_channel_publish, _}, Msg) ->
 postcondition(_, {call, _, cmd_channel_publish_many, _}, Msgs) ->
     lists:all(fun(Msg) -> is_record(Msg, amqp_msg) end, Msgs);
 postcondition(_, {call, _, cmd_channel_wait_for_confirms, _}, Res) ->
-    Res =:= true;
+    %% It is possible for nacks to be sent during restarts.
+    %% This is a rare event but it is not a bug, the client
+    %% is simply expected to take action. Timeouts are
+    %% always a bug however (acks/nacks not sent at all).
+    Res =:= true orelse Res =:= false;
 postcondition(_, {call, _, cmd_channel_consume, _}, _) ->
     true;
 postcondition(_, {call, _, cmd_channel_cancel, _}, _) ->

--- a/deps/rabbit/test/classic_queue_prop_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_prop_SUITE.erl
@@ -1102,7 +1102,7 @@ reg_v1_full_recover_only_journal(Config) ->
 
 do_reg_v1_full_recover_only_journal(Config) ->
 
-    St0 = #cq{name=prop_classic_queue_v1, mode=lazy, version=1,
+    St0 = #cq{name=prop_classic_queue_v1, version=1,
               config=minimal_config(Config)},
 
     Res1 = cmd_setup_queue(St0),

--- a/deps/rabbit/test/lazy_queue_SUITE.erl
+++ b/deps/rabbit/test/lazy_queue_SUITE.erl
@@ -192,18 +192,11 @@ set_ha_mode_policy(Config, Node, Mode) ->
       [{<<"queue-mode">>, Mode}]).
 
 
-wait_for_queue_mode(_Node, _Q, _Mode, Max) when Max < 0 ->
-    fail;
-wait_for_queue_mode(Node, Q, Mode, Max) ->
-    case get_queue_mode(Node, Q) of
-        Mode  -> ok;
-        _     -> timer:sleep(100),
-                 wait_for_queue_mode(Node, Q, Mode, Max - 100)
-    end.
+wait_for_queue_mode(_, _, _, _) ->
+    ok.
 
-assert_queue_mode(Node, Q, Expected) ->
-    Actual = get_queue_mode(Node, Q),
-    Expected = Actual.
+assert_queue_mode(_, _, _) ->
+    ok.
 
 get_queue_mode(Node, Q) ->
     QNameRes = rabbit_misc:r(<<"/">>, queue, Q),

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -64,7 +64,6 @@
 -export([append_rpc_all_nodes/4, append_rpc_all_nodes/5]).
 -export([os_cmd/1]).
 -export([is_os_process_alive/1]).
--export([gb_sets_difference/2]).
 -export([version/0, otp_release/0, platform_and_version/0, otp_system_version/0,
          rabbitmq_and_erlang_versions/0, which_applications/0]).
 -export([sequence_error/1]).
@@ -232,7 +231,6 @@
 -spec format_message_queue(any(), priority_queue:q()) -> term().
 -spec os_cmd(string()) -> string().
 -spec is_os_process_alive(non_neg_integer()) -> boolean().
--spec gb_sets_difference(gb_sets:set(), gb_sets:set()) -> gb_sets:set().
 -spec version() -> string().
 -spec otp_release() -> string().
 -spec otp_system_version() -> string().
@@ -1207,9 +1205,6 @@ exit_loop(Port) ->
         {Port, {exit_status, Rc}} -> Rc;
         {Port, _}                 -> exit_loop(Port)
     end.
-
-gb_sets_difference(S1, S2) ->
-    gb_sets:fold(fun gb_sets:delete_any/2, S1, S2).
 
 version() ->
     {ok, VSN} = application:get_key(rabbit, vsn),

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -467,11 +467,11 @@ queue_coarse_metrics_per_object_test(Config) ->
 
 queue_metrics_per_object_test(Config) ->
     Expected1 =  #{#{queue => "vhost-1-queue-with-consumer", vhost => "vhost-1"} => [7],
-                   #{queue => "vhost-1-queue-with-messages", vhost => "vhost-1"} => [7]},
+                   #{queue => "vhost-1-queue-with-messages", vhost => "vhost-1"} => [1]},
     Expected2 =  #{#{queue => "vhost-2-queue-with-consumer", vhost => "vhost-2"} => [11],
-                   #{queue => "vhost-2-queue-with-messages", vhost => "vhost-2"} => [11]},
+                   #{queue => "vhost-2-queue-with-messages", vhost => "vhost-2"} => [1]},
     ExpectedD =  #{#{queue => "default-queue-with-consumer", vhost => "/"} => [3],
-                   #{queue => "default-queue-with-messages", vhost => "/"} => [3]},
+                   #{queue => "default-queue-with-messages", vhost => "/"} => [1]},
     {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?vhost=vhost-1&family=queue_metrics", [], 200),
     ?assertEqual(Expected1,
                  map_get(rabbitmq_detailed_queue_messages_ram, parse_response(Body1))),

--- a/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
+++ b/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
@@ -148,6 +148,9 @@ e2e_test(Config) ->
                          routing_key = <<"">>
                         }),
 
+    %% Wait a few seconds for all messages to be queued.
+    timer:sleep(3000),
+
     #'queue.declare_ok'{message_count = Count, queue = Q} =
         amqp_channel:call(Chan, #'queue.declare' {
                                    passive   = true,


### PR DESCRIPTION
No longer reduce memory usage as well (except an explicit GC that I am pondering about removing).

Beyond simplifying the implementation, this branch also provides better performance than either default or lazy modes.

See this comment before reviewing/merging: https://github.com/rabbitmq/rabbitmq-server/pull/4522#issuecomment-1241913743

See #2832