### PR TITLE
Speed up reimport queue definitions

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -683,12 +683,17 @@ add_queue_int(_Queue, R = #resource{kind = queue,
     rabbit_log:warning("Skipping import of a queue whose name begins with 'amq.', "
                        "name: ~s, acting user: ~s", [Name, ActingUser]);
 add_queue_int(Queue, Name, ActingUser) ->
-    rabbit_amqqueue:declare(Name,
-                            maps:get(durable,                         Queue, undefined),
-                            maps:get(auto_delete,                     Queue, undefined),
-                            args(maps:get(arguments, Queue, undefined)),
-                            none,
-                            ActingUser).
+    case rabbit_amqqueue:lookup(Name) of
+        {ok, _} ->
+            ok;
+        {error, not_found} ->
+            rabbit_amqqueue:declare(Name,
+                                    maps:get(durable, Queue, undefined),
+                                    maps:get(auto_delete, Queue, undefined),
+                                    args(maps:get(arguments, Queue, undefined)),
+                                    none,
+                                    ActingUser)
+    end.
 
 add_exchange(Exchange, ActingUser) ->
     add_exchange_int(Exchange, r(exchange, Exchange), ActingUser).

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -45,6 +45,7 @@ groups() ->
                                import_case11,
                                import_case12,
                                import_case13,
+                               import_case13a,
                                import_case14,
                                import_case15,
                                import_case16,
@@ -226,6 +227,31 @@ import_case13(Config) ->
             ?assertEqual([{<<"x-max-length">>, long, 991},
                           {<<"x-queue-type">>, longstr, <<"quorum">>}],
                          amqqueue:get_arguments(Q));
+        Skip ->
+            Skip
+    end.
+
+import_case13a(Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue) of
+        ok ->
+            import_file_case(Config, "case13"),
+            VHost = <<"/">>,
+            QueueName = <<"definitions.import.case13.qq.1">>,
+            QueueIsImported =
+            fun () ->
+                    case queue_lookup(Config, VHost, QueueName) of
+                        {ok, _} -> true;
+                        _       -> false
+                    end
+            end,
+            rabbit_ct_helpers:await_condition(QueueIsImported, 20000),
+            {ok, Q} = queue_lookup(Config, VHost, QueueName),
+
+            %% We expect that importing an existing queue (i.e. same vhost and name)
+            %% but with different arguments and different properties is a no-op.
+            import_file_case(Config, "case13a"),
+            timer:sleep(1000),
+            ?assertMatch({ok, Q}, queue_lookup(Config, VHost, QueueName));
         Skip ->
             Skip
     end.

--- a/deps/rabbit/test/definition_import_SUITE_data/case13a.json
+++ b/deps/rabbit/test/definition_import_SUITE_data/case13a.json
@@ -1,0 +1,55 @@
+{
+  "bindings": [],
+  "exchanges": [],
+  "global_parameters": [
+    {
+      "name": "cluster_name",
+      "value": "rabbit@localhost"
+    }
+  ],
+  "parameters": [],
+  "permissions": [
+    {
+      "configure": ".*",
+      "read": ".*",
+      "user": "guest",
+      "vhost": "/",
+      "write": ".*"
+    }
+  ],
+  "policies": [],
+  "queues": [
+    {
+      "arguments": {
+        "x-max-length": 7,
+        "x-queue-type": "stream"
+      },
+      "auto_delete": true,
+      "durable": false,
+      "name": "definitions.import.case13.qq.1",
+      "type": "stream",
+      "vhost": "/"
+    }
+  ],
+  "rabbit_version": "3.8.6.gad0c0bd",
+  "rabbitmq_version": "3.8.6.gad0c0bd",
+  "topic_permissions": [],
+  "users": [
+    {
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "name": "guest",
+      "password_hash": "e8lL5PHYcbv3Pd53EUoTOMnVDmsLDgVJXqSQMT+mrO4LVIdW",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts": [
+    {
+      "limits": [],
+      "metadata": {
+        "description": "Default virtual host",
+        "tags": []
+      },
+      "name": "/"
+    }
+  ]
+}


### PR DESCRIPTION
The channel does not declare a queue that already exists.
Let's do the same when importing definitions.

On a 5-node cluster re-importing 40,000 classic non-mirrored queues with
`queue-master-locator` set to `min-masters` takes 11min32sec before this
change and 3sec after this change. So it's 230 times faster after this
change.

With even more queues, the speed-up factor will be much greater.

This solves the pain points of https://github.com/rabbitmq/rabbitmq-server/pull/3402 (column `reimport (sec)` and rows `old min-masters`).