### PR TITLE
SI prefix formatter improvement

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -36,9 +36,10 @@ function fmt_string(str, unknown) {
     return fmt_escape_html("" + str);
 }
 
-function fmt_si_prefix(num0, max0, thousand, allow_fractions) {
+function fmt_si_prefix(num0, max0, binary, allow_fractions) {
     if (num == 0) return 0;
 
+    var thousand = binary ? 1024 : 1000;
     function f(n, m, p) {
         if (m > thousand) return f(n / thousand, m / thousand, p + 1);
         else return [n, m, p];
@@ -49,8 +50,9 @@ function fmt_si_prefix(num0, max0, thousand, allow_fractions) {
     var max = num_power[1];
     var power = num_power[2];
     var powers = ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+    var suffix = powers[power] + ((power != 0 && binary) ? 'i' : '');
     return (((power != 0 || allow_fractions) && max <= 10) ? num.toFixed(1) :
-            num.toFixed(0)) + " " + powers[power];
+            num.toFixed(0)) + " " + suffix;
 }
 
 function fmt_boolean(b, unknown) {
@@ -318,7 +320,7 @@ function fmt_plain(num) {
 }
 
 function fmt_plain_axis(num, max) {
-    return fmt_si_prefix(num, max, 1000, true);
+    return fmt_si_prefix(num, max, false, true);
 }
 
 function fmt_rate(num) {
@@ -331,8 +333,8 @@ function fmt_rate_axis(num, max) {
 
 function fmt_bytes(bytes) {
     if (bytes == undefined) return UNKNOWN_REPR;
-    var prefix = fmt_si_prefix(bytes, bytes, 1024, false);
-    return prefix + (prefix.endsWith(' ') ? 'B' : 'iB');
+    var prefix = fmt_si_prefix(bytes, bytes, true, false);
+    return prefix + 'B';
 }
 
 function fmt_bytes_axis(num, max) {


### PR DESCRIPTION
## Proposed Changes

fmt_si_prefix should add the letter 'i' for the binary SI prefixes (Ki, Mi, Gi, etc)
Currently it is added in the caller method. (fmt_bytes)

fmt_si_prefix method receives a boolean value instead of the current thousand integer parameter.
If the boolean value is true, a binary prefix (thousand = 1024), otherwise a decimal prefix (thousand = 1000) will be calulated.

See #4525
@michaelklishin mentioned that I can assume that this function is used under the rabbitmq org only.
I checked it with the github's search, and not used anywhere except in the affected javascript file. (formatter.js)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
- [x] Small refactoring

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
