### PR TITLE
CQ: Fix potential crash when collecting stats

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1163,25 +1163,37 @@ i(memory, _) ->
     M;
 i(slave_pids, #q{q = Q0}) ->
     Name = amqqueue:get_name(Q0),
-    {ok, Q} = rabbit_amqqueue:lookup(Name),
-    case rabbit_mirror_queue_misc:is_mirrored(Q) of
-        false -> '';
-        true  -> amqqueue:get_slave_pids(Q)
+    case rabbit_amqqueue:lookup(Name) of
+        {ok, Q} ->
+            case rabbit_mirror_queue_misc:is_mirrored(Q) of
+                false -> '';
+                true  -> amqqueue:get_slave_pids(Q)
+            end;
+        {error, not_found} ->
+            ''
     end;
 i(synchronised_slave_pids, #q{q = Q0}) ->
     Name = amqqueue:get_name(Q0),
-    {ok, Q} = rabbit_amqqueue:lookup(Name),
-    case rabbit_mirror_queue_misc:is_mirrored(Q) of
-        false -> '';
-        true  -> amqqueue:get_sync_slave_pids(Q)
+    case rabbit_amqqueue:lookup(Name) of
+        {ok, Q} ->
+            case rabbit_mirror_queue_misc:is_mirrored(Q) of
+                false -> '';
+                true  -> amqqueue:get_sync_slave_pids(Q)
+            end;
+        {error, not_found} ->
+            ''
     end;
 i(recoverable_slaves, #q{q = Q0}) ->
     Name = amqqueue:get_name(Q0),
     Durable = amqqueue:is_durable(Q0),
-    {ok, Q} = rabbit_amqqueue:lookup(Name),
-    case Durable andalso rabbit_mirror_queue_misc:is_mirrored(Q) of
-        false -> '';
-        true  -> amqqueue:get_recoverable_slaves(Q)
+    case rabbit_amqqueue:lookup(Name) of
+        {ok, Q} ->
+            case Durable andalso rabbit_mirror_queue_misc:is_mirrored(Q) of
+                false -> '';
+                true  -> amqqueue:get_recoverable_slaves(Q)
+            end;
+        {error, not_found} ->
+            ''
     end;
 i(state, #q{status = running}) -> credit_flow:state();
 i(state, #q{status = State})   -> State;


### PR DESCRIPTION
The CQ is looking up itself when collecting CMQ stats.
There seems to be a potential race condition on init
where the initial stats update happens before the
queue can be looked up. To prevent the crash, we
ensure that when the queue is not found we don't
return stats for these items.