### PR TITLE
Make 3.9 fifo_client forward-compatible with 3.10

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -151,7 +151,7 @@ enqueue(Correlation, Msg,
         0 ->
             %% the leader is running the old version
             enqueue(Correlation, Msg, State0#state{queue_status = go});
-        1 ->
+        N when is_integer(N) ->
             %% were running the new version on the leader do sync initialisation
             %% of enqueuer session
             Reg = rabbit_fifo:make_register_enqueuer(self()),


### PR DESCRIPTION
Currently, when upgrading to 3.10, some errors may occur that
are fairly innocent - the client should just reconnect to another node
and everything should be back to normal. This PR will prevent errors for
those who will upgrade to 3.10 from more recent 3.9 patch releases.

Example error:
```
** {{case_clause,2},
    [{rabbit_fifo_client,enqueue,3,
                         [{file,"rabbit_fifo_client.erl"},{line,150}]},
     {rabbit_quorum_queue,'-deliver/2-fun-0-',4,
                          [{file,"rabbit_quorum_queue.erl"},{line,851}]},
     {lists,foldl,3,[{file,"lists.erl"},{line,1267}]},
     {rabbit_queue_type,'-deliver0/3-fun-3-',4,
                        [{file,"rabbit_queue_type.erl"},{line,480}]},
     {maps,fold_1,3,[{file,"maps.erl"},{line,410}]},
     {rabbit_queue_type,deliver0,3,
                        [{file,"rabbit_queue_type.erl"},{line,479}]},
     {rabbit_queue_type,deliver,3,[{file,"rabbit_queue_type.erl"},{line,454}]},
     {rabbit_channel,deliver_to_queues,2,
                     [{file,"rabbit_channel.erl"},{line,2190}]}]}
```

