### PR TITLE
Add filter for "Discarding message..." messages

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_early_logging.erl
@@ -23,6 +23,7 @@
          translate_formatter_conf/2,
          translate_journald_fields_conf/2]).
 -export([filter_log_event/2]).
+-export([filter_discarded_message/2]).
 
 -ifdef(TEST).
 -export([levels/0,
@@ -51,7 +52,7 @@ is_configured() ->
     persistent_term:get(?CONFIGURED_KEY, false).
 
 add_rmqlog_filter(LogLevels) ->
-    add_erlang_specific_filters(LogLevels),
+    ok = add_primary_filters(),
     FilterConfig0 = lists:foldl(
                       fun
                           ({_, V}, FC) when is_boolean(V) -> FC;
@@ -67,22 +68,23 @@ add_rmqlog_filter(LogLevels) ->
     ok = logger:set_primary_config(level, all),
     ok = persistent_term:put(?CONFIGURED_KEY, true).
 
-add_erlang_specific_filters(_) ->
-    _ = logger:add_handler_filter(
-          default, progress_reports, {fun logger_filters:progress/2, stop}),
-    MsgFilter = fun(#{level := error, meta := #{error_logger := #{emulator := true, tag := error}}, msg := {"~s~n", Msg}}, _FilterArg) ->
-                        case string:find(Msg, "Discarding message ") of
-                            nomatch ->
-                                ignore;
-                            _ ->
-                                stop
-                        end;
-                   (_LogEvent, _FilterArg) ->
-                        ignore
-                end,
-    _ = logger:add_handler_filter(
-          default, discarded_messages, {MsgFilter, undefined}),
-    ok.
+add_primary_filters() ->
+    ok = logger:add_primary_filter(
+          progress_reports, {fun logger_filters:progress/2, stop}),
+    ok = logger:add_primary_filter(
+          discarded_messages, {fun filter_discarded_message/2, stop}).
+
+filter_discarded_message(#{level := error,
+                           meta := #{error_logger := #{emulator := true, tag := error}},
+                           msg := {"~s~n", Msg}}, OnMatch) ->
+    case string:find(Msg, "Discarding message") of
+        nomatch ->
+            ignore;
+        _ ->
+            OnMatch
+    end;
+filter_discarded_message(_LogEvent, _OnMatch) ->
+    ignore.
 
 filter_log_event(
   #{meta := #{domain := ?RMQLOG_DOMAIN_GLOBAL}} = LogEvent,


### PR DESCRIPTION
Fixes #4557

This could be made more exact using a pre-compiled regex. We could also add rate-limiting if we'd like to see _some_ of these messages.

For reference this is what the incoming log event looks like:

```
#{level => error,
  meta =>
      #{error_logger => #{emulator => true,tag => error},
        gl => <0.523.0>,pid => <0.524.0>,time => 1649875295952127},
  msg =>
      {"~s~n",
       ["Discarding message {'$gen_cast',{force_event_refresh,#Ref<0.3562112581.1020788738.75815>}} from <0.524.0> to <0.21163.0> in an old incarnation (1649873792) of this node (1649873793)\n"]}}
```