### PR TITLE
Validate queue and consumer arguments

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -779,7 +779,7 @@ check_arguments_type_and_value(QueueName, Args, Validators) ->
                           ok             -> ok;
                           {error, Error} -> rabbit_misc:protocol_error(
                                               precondition_failed,
-                                              "invalid arg '~s' for queue ~s: ~255p",
+                                              "invalid arg '~s' for ~s: ~255p",
                                               [Key, rabbit_misc:rs(QueueName),
                                                Error])
                       end
@@ -795,7 +795,7 @@ check_arguments_key(QueueName, QueueType, Args, InvalidArgs) ->
                               true ->
                                   rabbit_misc:protocol_error(
                                     precondition_failed,
-                                    "invalid arg '~s' for queue ~s of type ~s",
+                                    "invalid arg '~s' for ~s of queue type ~s",
                                     [ArgKey, rabbit_misc:rs(QueueName), QueueType])
                           end
                   end, Args).

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -779,7 +779,7 @@ check_arguments_type_and_value(QueueName, Args, Validators) ->
                           ok             -> ok;
                           {error, Error} -> rabbit_misc:protocol_error(
                                               precondition_failed,
-                                              "invalid arg '~s' for ~s: ~255p",
+                                              "invalid arg '~s' for queue ~s: ~255p",
                                               [Key, rabbit_misc:rs(QueueName),
                                                Error])
                       end
@@ -795,7 +795,7 @@ check_arguments_key(QueueName, QueueType, Args, InvalidArgs) ->
                               true ->
                                   rabbit_misc:protocol_error(
                                     precondition_failed,
-                                    "invalid arg '~s' for ~s of queue type ~s",
+                                    "invalid arg '~s' for queue ~s of type ~s",
                                     [ArgKey, rabbit_misc:rs(QueueName), QueueType])
                           end
                   end, Args).

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -444,21 +444,19 @@ recover_durable_queues(QueuesAndRecoveryTerms) ->
     [Q || {_, {new, Q}} <- Results].
 
 capabilities() ->
-    #{unsupported_policies => [ %% Stream policies
+    #{unsupported_policies => [%% Stream policies
                                <<"max-age">>, <<"stream-max-segment-size-bytes">>,
                                <<"queue-leader-locator">>, <<"initial-cluster-size">>,
                                %% Quorum policies
-                               <<"dead-letter-strategy">>],
+                               <<"delivery-limit">>, <<"dead-letter-strategy">>],
       queue_arguments => [<<"x-expires">>, <<"x-message-ttl">>, <<"x-dead-letter-exchange">>,
                           <<"x-dead-letter-routing-key">>, <<"x-max-length">>,
-                          <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,
-                          <<"x-max-in-memory-bytes">>, <<"x-max-priority">>,
+                          <<"x-max-length-bytes">>, <<"x-max-priority">>,
                           <<"x-overflow">>, <<"x-queue-mode">>, <<"x-queue-version">>,
-                          <<"x-single-active-consumer">>,
-                          <<"x-queue-type">>, <<"x-queue-master-locator">>],
+                          <<"x-single-active-consumer">>, <<"x-queue-type">>,
+                          <<"x-queue-master-locator">>],
       consumer_arguments => [<<"x-cancel-on-ha-failover">>,
-                             <<"x-priority">>, <<"x-credit">>
-                            ],
+                             <<"x-priority">>, <<"x-credit">>],
       server_named => true}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -42,8 +42,8 @@
          find_name_from_pid/2,
          is_policy_applicable/2,
          is_server_named_allowed/1,
-         queue_arguments/0,
-         queue_arguments/1,
+         arguments/1,
+         arguments/2,
          notify_decorators/1
          ]).
 
@@ -51,12 +51,17 @@
 -type queue_ref() :: queue_name() | atom().
 -type queue_state() :: term().
 -type msg_tag() :: term().
+-type arguments() :: queue_arguments | consumer_arguments.
+-type queue_type() :: rabbit_classic_queue | rabbit_quorum_queue | rabbit_stream_queue.
 
 -define(STATE, ?MODULE).
 
 %% Recoverable slaves shouldn't really be a generic one, but let's keep it here until
 %% mirrored queues are deprecated.
 -define(DOWN_KEYS, [name, durable, auto_delete, arguments, pid, recoverable_slaves, type, state]).
+
+%% TODO resolve all registered queue types from registry
+-define(QUEUE_TYPES, [rabbit_classic_queue, rabbit_quorum_queue, rabbit_stream_queue]).
 
 -define(QREF(QueueReference),
     (is_tuple(QueueReference) andalso element(1, QueueReference) == resource)
@@ -323,23 +328,23 @@ is_policy_applicable(Q, Policy) ->
                       not lists:member(P, NotApplicable)
               end, Policy).
 
+-spec is_server_named_allowed(queue_type()) -> boolean().
 is_server_named_allowed(Type) ->
     Capabilities = Type:capabilities(),
     maps:get(server_named, Capabilities, false).
 
--spec queue_arguments() -> [binary()].
-queue_arguments() ->
-    Types = [rabbit_classic_queue, rabbit_quorum_queue, rabbit_stream_queue],
+-spec arguments(arguments()) -> [binary()].
+arguments(ArgumentType) ->
     Args0 = lists:map(fun(T) ->
-                              maps:get(queue_arguments, T:capabilities(), [])
-                      end, Types),
+                              maps:get(ArgumentType, T:capabilities(), [])
+                      end, ?QUEUE_TYPES),
     Args = lists:flatten(Args0),
-    sets:to_list(sets:from_list(Args)).
+    lists:usort(Args).
 
--spec queue_arguments(atom()) -> [binary()].
-queue_arguments(Type) ->
-    Capabilities = Type:capabilities(),
-    maps:get(queue_arguments, Capabilities, []).
+-spec arguments(arguments(), queue_type()) -> [binary()].
+arguments(ArgumentType, QueueType) ->
+    Capabilities = QueueType:capabilities(),
+    maps:get(ArgumentType, Capabilities, []).
 
 notify_decorators(Q) ->
     Mod = amqqueue:get_type(Q),
@@ -402,16 +407,15 @@ is_recoverable(Q) ->
     {Recovered :: [amqqueue:amqqueue()],
      Failed :: [amqqueue:amqqueue()]}.
 recover(VHost, Qs) ->
-   ByType = lists:foldl(
-              fun (Q, Acc) ->
-                      T = amqqueue:get_type(Q),
-                      maps:update_with(T, fun (X) ->
-                                                  [Q | X]
-                                          end, Acc)
-                      %% TODO resolve all registered queue types from registry
-              end, #{rabbit_classic_queue => [],
-                     rabbit_quorum_queue => [],
-                     rabbit_stream_queue => []}, Qs),
+    ByType0 = lists:map(fun(T) -> {T, []} end, ?QUEUE_TYPES),
+    ByType1 = maps:from_list(ByType0),
+    ByType = lists:foldl(
+               fun (Q, Acc) ->
+                       T = amqqueue:get_type(Q),
+                       maps:update_with(T, fun (X) ->
+                                                   [Q | X]
+                                           end, Acc)
+               end, ByType1, Qs),
    maps:fold(fun (Mod, Queues, {R0, F0}) ->
                      {Taken, {R, F}} =  timer:tc(Mod, recover, [VHost, Queues]),
                      rabbit_log:info("Recovering ~b queues of type ~s took ~bms",

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -42,6 +42,8 @@
          find_name_from_pid/2,
          is_policy_applicable/2,
          is_server_named_allowed/1,
+         queue_arguments/0,
+         queue_arguments/1,
          notify_decorators/1
          ]).
 
@@ -324,6 +326,20 @@ is_policy_applicable(Q, Policy) ->
 is_server_named_allowed(Type) ->
     Capabilities = Type:capabilities(),
     maps:get(server_named, Capabilities, false).
+
+-spec queue_arguments() -> [binary()].
+queue_arguments() ->
+    Types = [rabbit_classic_queue, rabbit_quorum_queue, rabbit_stream_queue],
+    Args0 = lists:map(fun(T) ->
+                              maps:get(queue_arguments, T:capabilities(), [])
+                      end, Types),
+    Args = lists:flatten(Args0),
+    sets:to_list(sets:from_list(Args)).
+
+-spec queue_arguments(atom()) -> [binary()].
+queue_arguments(Type) ->
+    Capabilities = Type:capabilities(),
+    maps:get(queue_arguments, Capabilities, []).
 
 notify_decorators(Q) ->
     Mod = amqqueue:get_type(Q),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -394,21 +394,20 @@ filter_quorum_critical(Queues, ReplicaStates) ->
                  end, Queues).
 
 capabilities() ->
-    #{unsupported_policies =>
-          [ %% Classic policies
-            <<"max-priority">>, <<"queue-mode">>,
-            <<"single-active-consumer">>, <<"ha-mode">>, <<"ha-params">>,
-            <<"ha-sync-mode">>, <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
-            <<"queue-master-locator">>,
-            %% Stream policies
-            <<"max-age">>, <<"stream-max-segment-size-bytes">>, <<"initial-cluster-size">>],
-          queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
-                              <<"x-dead-letter-strategy">>, <<"x-expires">>, <<"x-max-length">>,
-                              <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,
-                              <<"x-max-in-memory-bytes">>, <<"x-overflow">>,
-                              <<"x-single-active-consumer">>, <<"x-queue-type">>,
-                              <<"x-quorum-initial-group-size">>, <<"x-delivery-limit">>,
-                              <<"x-message-ttl">>, <<"x-queue-leader-locator">>],
+    #{unsupported_policies => [%% Classic policies
+                               <<"max-priority">>, <<"queue-mode">>,
+                               <<"single-active-consumer">>, <<"ha-mode">>, <<"ha-params">>,
+                               <<"ha-sync-mode">>, <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
+                               <<"queue-master-locator">>,
+                               %% Stream policies
+                               <<"max-age">>, <<"stream-max-segment-size-bytes">>, <<"initial-cluster-size">>],
+      queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
+                          <<"x-dead-letter-strategy">>, <<"x-expires">>, <<"x-max-length">>,
+                          <<"x-max-length-bytes">>, <<"x-max-in-memory-length">>,
+                          <<"x-max-in-memory-bytes">>, <<"x-overflow">>,
+                          <<"x-single-active-consumer">>, <<"x-queue-type">>,
+                          <<"x-quorum-initial-group-size">>, <<"x-delivery-limit">>,
+                          <<"x-message-ttl">>, <<"x-queue-leader-locator">>],
       consumer_arguments => [<<"x-priority">>, <<"x-credit">>],
       server_named => false}.
 

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -939,21 +939,18 @@ msg_to_iodata(#basic_message{exchange_name = #resource{name = Exchange},
     rabbit_msg_record:to_iodata(R).
 
 capabilities() ->
-    #{unsupported_policies =>
-          [ %% Classic policies
-            <<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
-            <<"dead-letter-routing-key">>, <<"max-length">>,
-            <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
-            <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
-            <<"single-active-consumer">>, <<"delivery-limit">>,
-            <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
-            <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
-            <<"queue-master-locator">>,
-            %% Quorum policies
-            <<"dead-letter-strategy">>],
-      queue_arguments => [<<"x-dead-letter-exchange">>, <<"x-dead-letter-routing-key">>,
-                          <<"x-max-length">>, <<"x-max-length-bytes">>,
-                          <<"x-single-active-consumer">>, <<"x-queue-type">>,
+    #{unsupported_policies => [%% Classic policies
+                               <<"expires">>, <<"message-ttl">>, <<"dead-letter-exchange">>,
+                               <<"dead-letter-routing-key">>, <<"max-length">>,
+                               <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
+                               <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
+                               <<"single-active-consumer">>, <<"delivery-limit">>,
+                               <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
+                               <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
+                               <<"queue-master-locator">>,
+                               %% Quorum policies
+                               <<"dead-letter-strategy">>],
+      queue_arguments => [<<"x-max-length-bytes">>, <<"x-queue-type">>,
                           <<"x-max-age">>, <<"x-stream-max-segment-size-bytes">>,
                           <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],
       consumer_arguments => [<<"x-stream-offset">>],

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -953,7 +953,7 @@ capabilities() ->
       queue_arguments => [<<"x-max-length-bytes">>, <<"x-queue-type">>,
                           <<"x-max-age">>, <<"x-stream-max-segment-size-bytes">>,
                           <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],
-      consumer_arguments => [<<"x-stream-offset">>],
+      consumer_arguments => [<<"x-stream-offset">>, <<"x-credit">>],
       server_named => false}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
@@ -743,8 +743,9 @@ target_quorum_queue_delete_create(Config) ->
 %% 2. Target queue can be classic queue, quorum queue, or stream queue.
 %%
 %% Lesson learnt by writing this test:
-%% If there are multiple target queues, messages will not be sent to target non-mirrored classic queues
-%% (even if durable) when their host node is temporarily down because these queues get (temporarily) deleted. See:
+%% If there are multiple target queues, messages will not be sent / routed to target non-mirrored durable classic queues
+%% when their host node is temporarily down because these queues get temporarily deleted from the rabbit_queue RAM table
+%% (but will still be present in the rabbit_durable_queue DISC table). See:
 %% https://github.com/rabbitmq/rabbitmq-server/blob/cf76b479300b767b8ea450293d096cbf729ed734/deps/rabbit/src/rabbit_amqqueue.erl#L1955-L1964
 many_target_queues(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
Follow up of https://github.com/rabbitmq/rabbitmq-server/pull/4404.

Throw a `PRECONDITION_FAILED` error when a queue is created with an
invalid argument or when a consumer subscribes with an invalid argument.

There can be RabbitMQ plugins and extensions out there defining arbitrary
queue arguments. Therefore we only check that a queue is not declared
with arguments that we know are supported only by other queue types.

The benefit of this change is that queues are not mistakenly declared with the wrong arguments.

This change will reduce a lot of confusion when it comes to what arguments are supported by what queue type.

Example 1:
Before this PR, a stream could be created with `x-dead-letter-exchange` queue argument set. Users wonder why the stream does not dead letter any messages. After this PR, stream creation fails early with a meaningful error message because that argument is only supported for classic and quorum queues.

Example 2:
Before this PR, a stream could be created with `x-max-length` queue argument set. Users wonder why the stream contains more messages than configured via `x-max-length`. After this PR, stream creation fails early with a meaningful error message because that argument is only supported for classic and quorum queues. Streams support `x-max-length-bytes` and `x-max-age`.

Example 3:
Before this PR, a quorum queue could be created with `x-queue-master-locator` queue argument set. Users wonder why it doesn't have any effect. After this PR, queue creation will fail with a meaningful error message.

All changes are backwards compatible, except invalid **consumer** arguments which I expect to be rare.
For example, when a consumer had consumer argument `x-priority` set to connect to a stream via AMQP, this will start failing after this PR.