### PR TITLE
Speed up reimport exchange definitions

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -709,17 +709,22 @@ add_exchange_int(_Exchange, R = #resource{kind = exchange,
     rabbit_log:warning("Skipping import of an exchange whose name begins with 'amq.', "
                        "name: ~s, acting user: ~s", [Name, ActingUser]);
 add_exchange_int(Exchange, Name, ActingUser) ->
-    Internal = case maps:get(internal, Exchange, undefined) of
-                   undefined -> false; %% =< 2.2.0
-                   I         -> I
-               end,
-    rabbit_exchange:declare(Name,
-                            rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
-                            maps:get(durable,                         Exchange, undefined),
-                            maps:get(auto_delete,                     Exchange, undefined),
-                            Internal,
-                            args(maps:get(arguments, Exchange, undefined)),
-                            ActingUser).
+    case rabbit_exchange:lookup(Name) of
+        {ok, _} ->
+            ok;
+        {error, not_found} ->
+            Internal = case maps:get(internal, Exchange, undefined) of
+                           undefined -> false; %% =< 2.2.0
+                           I         -> I
+                       end,
+            rabbit_exchange:declare(Name,
+                                    rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
+                                    maps:get(durable,                         Exchange, undefined),
+                                    maps:get(auto_delete,                     Exchange, undefined),
+                                    Internal,
+                                    args(maps:get(arguments, Exchange, undefined)),
+                                    ActingUser)
+    end.
 
 add_binding(Binding, ActingUser) ->
     DestType = dest_type(Binding),


### PR DESCRIPTION
Apply the same to exchanges what was done for queues in https://github.com/rabbitmq/rabbitmq-server/pull/4524.

For exchanges, the channel also bails out early in https://github.com/rabbitmq/rabbitmq-server/blob/37a34486728565e3945fe1b77f29269d2f20bee3/deps/rabbit/src/rabbit_channel.erl#L2709-L2711

Re-importing 100,000 exchanges in a 7 node RabbitMQ cluster on K8s takes 25 - 42 seconds before this commit and 
 4 - 6 seconds after this commit.