### PR TITLE
OAuth 2: support for scope aliases

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -25,12 +25,30 @@
 -ifdef(TEST).
 -compile(export_all).
 -endif.
-%%--------------------------------------------------------------------
+
+%%
+%% App environment
+%%
+
+-type app_env() :: [{atom(), any()}].
 
 -define(APP, rabbitmq_auth_backend_oauth2).
 -define(RESOURCE_SERVER_ID, resource_server_id).
 %% a term used by the IdentityServer community
--define(COMPLEX_CLAIM, extra_scopes_source).
+-define(COMPLEX_CLAIM_APP_ENV_KEY, extra_scopes_source).
+%% scope aliases map "role names" to a set of scopes
+-define(SCOPE_ALIASES_APP_ENV_KEY, scope_aliases).
+
+%%
+%% Key JWT fields
+%%
+
+-define(AUD_JWT_FIELD, <<"aud">>).
+-define(SCOPE_JWT_FIELD, <<"scope">>).
+
+%%
+%% API
+%%
 
 description() ->
     [{name, <<"OAuth 2">>},
@@ -143,39 +161,113 @@ validate_token_expiry(#{}) -> ok.
 
 -spec check_token(binary()) -> {ok, map()} | {error, term()}.
 check_token(Token) ->
+    Settings = application:get_all_env(?APP),
     case uaa_jwt:decode_and_verify(Token) of
         {error, Reason} -> {refused, {error, Reason}};
-        {true, Payload} -> validate_payload(post_process_payload(Payload));
+        {true, Payload} -> validate_payload(post_process_payload(Payload, Settings));
         {false, _}      -> {refused, signature_invalid}
     end.
 
 post_process_payload(Payload) when is_map(Payload) ->
+    post_process_payload(Payload, []).
+
+post_process_payload(Payload, AppEnv) when is_map(Payload) ->
     Payload0 = maps:map(fun(K, V) ->
                         case K of
-                            <<"aud">>   when is_binary(V) -> binary:split(V, <<" ">>, [global, trim_all]);
-                            <<"scope">> when is_binary(V) -> binary:split(V, <<" ">>, [global, trim_all]);
+                            ?AUD_JWT_FIELD   when is_binary(V) -> binary:split(V, <<" ">>, [global, trim_all]);
+                            ?SCOPE_JWT_FIELD when is_binary(V) -> binary:split(V, <<" ">>, [global, trim_all]);
                             _ -> V
                         end
         end,
         Payload
     ),
     Payload1 = case does_include_complex_claim_field(Payload0) of
-        true  -> post_process_payload_complex_claim(Payload0);
+        true  -> post_process_payload_with_complex_claim(Payload0);
         false -> Payload0
         end,
 
     Payload2 = case maps:is_key(<<"authorization">>, Payload1) of
-        true -> post_process_payload_keycloak(Payload1);
+        true  -> post_process_payload_in_keycloak_format(Payload1);
         false -> Payload1
         end,
 
+    Payload3 = case has_configured_scope_aliases(AppEnv) of
+        true  -> post_process_payload_with_scope_aliases(Payload2, AppEnv);
+        false -> Payload2
+        end,
+
+    Payload3.
+
+-spec has_configured_scope_aliases(AppEnv :: app_env()) -> boolean().
+has_configured_scope_aliases(AppEnv) ->
+    Map = maps:from_list(AppEnv),
+    maps:is_key(scope_mappings, Map).
+
+
+-spec post_process_payload_with_scope_aliases(Payload :: map(), AppEnv :: app_env()) -> map().
+%% This is for those hopeless environments where the token structure is so out of
+%% messaging team's control that even the extra scopes field is no longer an option.
+%%
+%% This assumes that scopes can be random values that do not follow the RabbitMQ
+%% convention, or any other convention, in any way. They are just random client role IDs.
+%% See rabbitmq/rabbitmq-server#4588 for details.
+post_process_payload_with_scope_aliases(Payload, AppEnv) ->
+    %% try JWT scope field value for alias
+    Payload1 = post_process_payload_with_scope_alias_in_scope_field(Payload, AppEnv),
+    %% try the configurable 'extra_scopes_source' field value for alias
+    Payload2 = post_process_payload_with_scope_alias_in_extra_scopes_source(Payload1, AppEnv),
     Payload2.
 
-does_include_complex_claim_field(Payload) when is_map(Payload) ->
-        maps:is_key(application:get_env(?APP, ?COMPLEX_CLAIM, undefined), Payload).
+-spec post_process_payload_with_scope_alias_in_scope_field(Payload :: map(),
+                                                           AppEnv :: app_env()) -> map().
+%% First attempt: use the value in the 'scope' field for alias
+post_process_payload_with_scope_alias_in_scope_field(Payload, AppEnv) ->
+    ScopeMappings = proplists:get_value(?SCOPE_ALIASES_APP_ENV_KEY, AppEnv, #{}),
+    post_process_payload_with_scope_alias_field_named(Payload, ?SCOPE_JWT_FIELD, ScopeMappings).
 
-post_process_payload_complex_claim(Payload) ->
-    ComplexClaim = maps:get(application:get_env(?APP, ?COMPLEX_CLAIM, undefined), Payload),
+
+-spec post_process_payload_with_scope_alias_in_extra_scopes_source(Payload :: map(),
+                                                                   AppEnv :: app_env()) -> map().
+%% Second attempt: use the value in the configurable 'extra scopes source' field for alias
+post_process_payload_with_scope_alias_in_extra_scopes_source(Payload, AppEnv) ->
+    ExtraScopesField = proplists:get_value(?COMPLEX_CLAIM_APP_ENV_KEY, AppEnv, undefined),
+    case ExtraScopesField of
+        %% nothing ot inject
+        undefined -> Payload;
+        _         ->
+            ScopeMappings = proplists:get_value(?SCOPE_ALIASES_APP_ENV_KEY, AppEnv, #{}),
+            post_process_payload_with_scope_alias_field_named(Payload, ExtraScopesField, ScopeMappings)
+    end.
+
+
+-spec post_process_payload_with_scope_alias_field_named(Payload :: map(),
+                                                        Field :: binary(),
+                                                        Scopes :: map()) -> map().
+post_process_payload_with_scope_alias_field_named(Payload, undefined, _AppEnv) ->
+    Payload;
+post_process_payload_with_scope_alias_field_named(Payload, ScopeAlias, AppEnv) ->
+    AdditionalScopes = case ScopeAlias of
+        undefined -> [];
+        _         ->
+            ScopeMappings = proplists:get_value(<<"scope_mappings">>, AppEnv, #{}),
+            maps:get(ScopeAlias, ScopeMappings, [])
+    end,
+
+    case AdditionalScopes of
+        [] -> Payload;
+        _  ->
+            ExistingScopes = maps:get(?SCOPE_JWT_FIELD, Payload, []),
+            maps:put(?SCOPE_JWT_FIELD, AdditionalScopes ++ ExistingScopes, Payload)
+    end.
+
+
+-spec does_include_complex_claim_field(Payload :: map()) -> boolean().
+does_include_complex_claim_field(Payload) when is_map(Payload) ->
+        maps:is_key(application:get_env(?APP, ?COMPLEX_CLAIM_APP_ENV_KEY, undefined), Payload).
+
+-spec post_process_payload_with_complex_claim(Payload :: map()) -> map().
+post_process_payload_with_complex_claim(Payload) ->
+    ComplexClaim = maps:get(application:get_env(?APP, ?COMPLEX_CLAIM_APP_ENV_KEY, undefined), Payload),
     ResourceServerId = rabbit_data_coercion:to_binary(application:get_env(?APP, ?RESOURCE_SERVER_ID, <<>>)),
 
     AdditionalScopes =
@@ -199,18 +291,19 @@ post_process_payload_complex_claim(Payload) ->
     case AdditionalScopes of
         [] -> Payload;
         _  ->
-            ExistingScopes = maps:get(<<"scope">>, Payload, []),
-            maps:put(<<"scope">>, AdditionalScopes ++ ExistingScopes, Payload)
+            ExistingScopes = maps:get(?SCOPE_JWT_FIELD, Payload, []),
+            maps:put(?SCOPE_JWT_FIELD, AdditionalScopes ++ ExistingScopes, Payload)
         end.
 
+-spec post_process_payload_in_keycloak_format(Payload :: map()) -> map().
 %% keycloak token format: https://github.com/rabbitmq/rabbitmq-auth-backend-oauth2/issues/36
-post_process_payload_keycloak(#{<<"authorization">> := Authorization} = Payload) ->
+post_process_payload_in_keycloak_format(#{<<"authorization">> := Authorization} = Payload) ->
     AdditionalScopes = case maps:get(<<"permissions">>, Authorization, undefined) of
         undefined   -> [];
         Permissions -> extract_scopes_from_keycloak_permissions([], Permissions)
     end,
-    ExistingScopes = maps:get(<<"scope">>, Payload),
-    maps:put(<<"scope">>, AdditionalScopes ++ ExistingScopes, Payload).
+    ExistingScopes = maps:get(?SCOPE_JWT_FIELD, Payload),
+    maps:put(?SCOPE_JWT_FIELD, AdditionalScopes ++ ExistingScopes, Payload).
 
 extract_scopes_from_keycloak_permissions(Acc, []) ->
     Acc;
@@ -225,14 +318,14 @@ extract_scopes_from_keycloak_permissions(Acc, [H | T]) when is_map(H) ->
 extract_scopes_from_keycloak_permissions(Acc, [_ | T]) ->
     extract_scopes_from_keycloak_permissions(Acc, T).
 
-validate_payload(#{<<"scope">> := _Scope, <<"aud">> := _Aud} = DecodedToken) ->
+validate_payload(#{?SCOPE_JWT_FIELD := _Scope, ?AUD_JWT_FIELD := _Aud} = DecodedToken) ->
     ResourceServerEnv = application:get_env(?APP, ?RESOURCE_SERVER_ID, <<>>),
     ResourceServerId = rabbit_data_coercion:to_binary(ResourceServerEnv),
     validate_payload(DecodedToken, ResourceServerId).
 
-validate_payload(#{<<"scope">> := Scope, <<"aud">> := Aud} = DecodedToken, ResourceServerId) ->
+validate_payload(#{?SCOPE_JWT_FIELD := Scope, ?AUD_JWT_FIELD := Aud} = DecodedToken, ResourceServerId) ->
     case check_aud(Aud, ResourceServerId) of
-        ok           -> {ok, DecodedToken#{<<"scope">> => filter_scopes(Scope, ResourceServerId)}};
+        ok           -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ResourceServerId)}};
         {error, Err} -> {refused, {invalid_aud, Err}}
     end.
 
@@ -254,7 +347,7 @@ check_aud(Aud, ResourceServerId) ->
 
 %%--------------------------------------------------------------------
 
-get_scopes(#{<<"scope">> := Scope}) -> Scope.
+get_scopes(#{?SCOPE_JWT_FIELD := Scope}) -> Scope.
 
 -spec token_from_context(map()) -> binary() | undefined.
 token_from_context(AuthProps) ->
@@ -296,10 +389,12 @@ username_from(ClientProvidedUsername, DecodedToken) ->
             Value
     end.
 
+-define(TAG_SCOPE_PREFIX, <<"tag:">>).
+
 -spec tags_from(map()) -> list(atom()).
 tags_from(DecodedToken) ->
-    Scopes    = maps:get(<<"scope">>, DecodedToken, []),
-    TagScopes = matching_scopes_without_prefix(Scopes, <<"tag:">>),
+    Scopes    = maps:get(?SCOPE_JWT_FIELD, DecodedToken, []),
+    TagScopes = matching_scopes_without_prefix(Scopes, ?TAG_SCOPE_PREFIX),
     lists:usort(lists:map(fun rabbit_data_coercion:to_atom/1, TagScopes)).
 
 matching_scopes_without_prefix(Scopes, PrefixPattern) ->

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
@@ -70,10 +70,10 @@ expired_token() ->
     expired_token_with_scopes(full_permission_scopes()).
 
 expired_token_with_scopes(Scopes) ->
-    token_with_scopes_and_expiration(Scopes, os:system_time(seconds) - 10).
+    token_with_scopes_and_expiration(Scopes, seconds_in_the_past(10)).
 
 fixture_token_with_scopes(Scopes) ->
-    token_with_scopes_and_expiration(Scopes, os:system_time(seconds) + 30).
+    token_with_scopes_and_expiration(Scopes, default_expiration_moment()).
 
 token_with_scopes_and_expiration(Scopes, Expiration) ->
     %% expiration is a timestamp with precision in seconds
@@ -97,3 +97,37 @@ fixture_token(ExtraScopes) ->
 
 fixture_token_with_full_permissions() ->
     fixture_token_with_scopes(full_permission_scopes()).
+
+token_with_scope_alias_in_scope_field(Alias) ->
+    %% expiration is a timestamp with precision in seconds
+    #{<<"exp">> => default_expiration_moment(),
+      <<"kid">> => <<"token-key">>,
+      <<"iss">> => <<"unit_test">>,
+      <<"foo">> => <<"bar">>,
+      <<"aud">> => [<<"rabbitmq">>],
+      <<"scope">> => Alias}.
+
+token_with_scope_alias_in_claim_field(Alias, Scopes) ->
+    %% expiration is a timestamp with precision in seconds
+    #{<<"exp">> => default_expiration_moment(),
+      <<"kid">> => <<"token-key">>,
+      <<"iss">> => <<"unit_test">>,
+      <<"foo">> => <<"bar">>,
+      <<"aud">> => [<<"rabbitmq">>],
+      <<"scope">>  => Scopes,
+      <<"claims">> => Alias}.
+
+seconds_in_the_future() ->
+    seconds_in_the_future(30).
+
+seconds_in_the_future(N) ->
+    os:system_time(seconds) + N.
+
+seconds_in_the_past() ->
+    seconds_in_the_past(10).
+
+seconds_in_the_past(N) ->
+    os:system_time(seconds) - N.
+
+default_expiration_moment() ->
+    seconds_in_the_future(30).

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -56,7 +56,9 @@ groups() ->
 
      {scope_aliases, [], [
                        test_successful_connection_with_with_scope_alias_in_extra_scopes_source,
-                       test_successful_connection_with_scope_alias_in_scope_field
+                       test_successful_connection_with_scope_alias_in_scope_field,
+                       test_failed_connection_with_with_non_existent_scope_alias_in_extra_scopes_source,
+                       test_failed_connection_with_non_existent_scope_alias_in_scope_field
                       ]}
     ].
 
@@ -460,3 +462,16 @@ test_successful_connection_with_scope_alias_in_scope_field(Config) ->
     #'queue.declare_ok'{} =
         amqp_channel:call(Ch, #'queue.declare'{queue = <<"one">>, exclusive = true}),
     close_connection_and_channel(Conn, Ch).
+
+test_failed_connection_with_with_non_existent_scope_alias_in_extra_scopes_source(Config) ->
+    {_Algo, Token} = generate_valid_token_with_extra_fields(
+        Config,
+        #{<<"claims">> => <<"non-existent alias 24823478374">>}
+    ),
+    ?assertMatch({error, not_allowed},
+                 open_unmanaged_connection(Config, 0, <<"vhost1">>, <<"username">>, Token)).
+
+test_failed_connection_with_non_existent_scope_alias_in_scope_field(Config) ->
+    {_Algo, Token} = generate_valid_token(Config, <<"non-existent alias a8798s7doaisd79">>),
+    ?assertMatch({error, not_allowed},
+                 open_unmanaged_connection(Config, 0, <<"vhost2">>, <<"username">>, Token)).

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -22,7 +22,7 @@ all() ->
     [
      {group, basic_happy_path},
      {group, basic_unhappy_path},
-     {group, extra_scope_source},
+     {group, extra_scopes_source},
      {group, scope_aliases}
     ].
 
@@ -43,7 +43,7 @@ groups() ->
                        test_failed_token_refresh_case2
                       ]},
 
-     {extra_scope_source, [], [
+     {extra_scopes_source, [], [
                        test_successful_connection_with_complex_claim_as_a_map,
                        test_successful_connection_with_complex_claim_as_a_list,
                        test_successful_connection_with_complex_claim_as_a_binary,
@@ -135,16 +135,16 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) when Testcase =:= test_failed_token_refresh_case1 orelse
                                         Testcase =:= test_failed_token_refresh_case2 ->
     rabbit_ct_broker_helpers:delete_vhost(Config, <<"vhost4">>),
-    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    rabbit_ct_helpers:testcase_finished(Config, Testcase),
     Config;
 
 end_per_testcase(Testcase, Config) when Testcase =:= test_successful_connection_with_complex_claim_as_a_map orelse
                                         Testcase =:= test_successful_connection_with_complex_claim_as_a_list orelse
                                         Testcase =:= test_successful_connection_with_complex_claim_as_a_binary ->
   rabbit_ct_broker_helpers:delete_vhost(Config, <<"vhost1">>),
-  ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
-    [rabbitmq_auth_backend_oauth2, extra_scopes_source, undefined]),
-  rabbit_ct_helpers:testcase_started(Config, Testcase),
+  ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, unset_env,
+    [rabbitmq_auth_backend_oauth2, extra_scopes_source]),
+  rabbit_ct_helpers:testcase_finished(Config, Testcase),
   Config;
 
 end_per_testcase(Testcase, Config) ->

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -22,6 +22,7 @@ all() ->
     [
      {group, basic_happy_path},
      {group, basic_unhappy_path},
+     {group, token_refresh},
      {group, extra_scopes_source},
      {group, scope_aliases}
     ].
@@ -38,10 +39,13 @@ groups() ->
                        test_failed_connection_with_expired_token,
                        test_failed_connection_with_a_non_token,
                        test_failed_connection_with_a_token_with_insufficient_vhost_permission,
-                       test_failed_connection_with_a_token_with_insufficient_resource_permission,
+                       test_failed_connection_with_a_token_with_insufficient_resource_permission
+                      ]},
+
+     {token_refresh, [], [
                        test_failed_token_refresh_case1,
                        test_failed_token_refresh_case2
-                      ]},
+     ]},
 
      {extra_scopes_source, [], [
                        test_successful_connection_with_complex_claim_as_a_map,
@@ -106,7 +110,6 @@ end_per_group(_Group, Config) ->
                   end,
                   [<<"vhost1">>, <<"vhost2">>, <<"vhost3">>, <<"vhost4">>]),
     Config.
-
 
 init_per_testcase(Testcase, Config) when Testcase =:= test_successful_connection_with_a_full_permission_token_and_explicitly_configured_vhost orelse
                                          Testcase =:= test_successful_token_refresh ->

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -20,24 +20,21 @@
 
 all() ->
     [
-     {group, happy_path},
-     {group, unhappy_path},
+     {group, basic_happy_path},
+     {group, basic_unhappy_path},
+     {group, extra_scope_source},
      {group, scope_aliases}
     ].
 
 groups() ->
     [
-     {happy_path, [], [
+     {basic_happy_path, [], [
                        test_successful_connection_with_a_full_permission_token_and_all_defaults,
                        test_successful_connection_with_a_full_permission_token_and_explicitly_configured_vhost,
                        test_successful_connection_with_simple_strings_for_aud_and_scope,
-                       test_successful_connection_with_complex_claim_as_a_map,
-                       test_successful_connection_with_complex_claim_as_a_list,
-                       test_successful_connection_with_complex_claim_as_a_binary,
-                       test_successful_connection_with_keycloak_token,
                        test_successful_token_refresh
                       ]},
-     {unhappy_path, [], [
+     {basic_unhappy_path, [], [
                        test_failed_connection_with_expired_token,
                        test_failed_connection_with_a_non_token,
                        test_failed_connection_with_a_token_with_insufficient_vhost_permission,
@@ -45,6 +42,13 @@ groups() ->
                        test_failed_token_refresh_case1,
                        test_failed_token_refresh_case2
                       ]},
+
+     {extra_scope_source, [], [
+                       test_successful_connection_with_complex_claim_as_a_map,
+                       test_successful_connection_with_complex_claim_as_a_list,
+                       test_successful_connection_with_complex_claim_as_a_binary,
+                       test_successful_connection_with_keycloak_token
+     ]},
 
      {scope_aliases, [], [
                        test_successful_connection_with_a_token_with_scope_alias_in_extra_scopes_source

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -281,7 +281,9 @@ test_successful_access_with_a_token_that_uses_scope_alias_in_scope_field(_) ->
             <<"rabbitmq.write:vhost/two">>,
             <<"rabbitmq.read:vhost/one">>,
             <<"rabbitmq.read:vhost/two">>,
-            <<"rabbitmq.read:vhost/two/abc">>
+            <<"rabbitmq.read:vhost/two/abc">>,
+            <<"rabbitmq.tag:management">>,
+            <<"rabbitmq.tag:custom">>
         ]
     }),
 
@@ -289,7 +291,8 @@ test_successful_access_with_a_token_that_uses_scope_alias_in_scope_field(_) ->
     Username = <<"username">>,
     Token    = ?UTIL_MOD:sign_token_hs(?UTIL_MOD:token_with_scope_alias_in_scope_field(Alias), Jwk),
 
-    {ok, AuthUser} = rabbit_auth_backend_oauth2:user_login_authentication(Username, [{password, Token}]),
+    {ok, #auth_user{username = Username, tags = [custom, management]} = AuthUser} =
+        rabbit_auth_backend_oauth2:user_login_authentication(Username, [{password, Token}]),
     assert_vhost_access_granted(AuthUser, VHost),
     assert_vhost_access_denied(AuthUser, <<"some-other-vhost">>),
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -29,7 +29,8 @@ all() ->
         test_incorrect_kid,
         test_post_process_token_payload,
         test_post_process_token_payload_keycloak,
-        test_post_process_token_payload_complex_claims
+        test_post_process_token_payload_complex_claims,
+        test_successful_access_with_a_token_that_uses_scope_alias_in_scope_field
     ].
 
 init_per_suite(Config) ->
@@ -286,6 +287,42 @@ test_successful_access_with_a_token_that_has_tag_scopes(_) ->
 
     {ok, #auth_user{username = Username, tags = [management, policymaker]}} =
         rabbit_auth_backend_oauth2:user_login_authentication(Username, [{password, Token}]).
+
+test_successful_access_with_a_token_that_uses_scope_alias_in_scope_field(_) ->
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    application:set_env(rabbitmq_auth_backend_oauth2, key_config, UaaEnv),
+    application:set_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<"rabbitmq">>),
+    Alias = <<"client-alias-1">>,
+    application:set_env(rabbitmq_auth_backend_oauth2, scope_aliases, #{
+        Alias => [
+            <<"rabbitmq.configure:vhost/one">>,
+            <<"rabbitmq.write:vhost/two">>,
+            <<"rabbitmq.read:vhost/one">>,
+            <<"rabbitmq.read:vhost/two">>,
+            <<"rabbitmq.read:vhost/two/abc">>
+        ]
+    }),
+
+    VHost = <<"vhost">>,
+    Username = <<"username">>,
+    Token    = ?UTIL_MOD:sign_token_hs(?UTIL_MOD:token_with_scope_alias_in_scope_field(Alias), Jwk),
+
+    {ok, AuthUser} = rabbit_auth_backend_oauth2:user_login_authentication(Username, [{password, Token}]),
+    assert_vhost_access_granted(AuthUser, VHost),
+    assert_vhost_access_denied(AuthUser, <<"some-other-vhost">>),
+
+    assert_resource_access_granted(AuthUser, VHost, <<"one">>, configure),
+    assert_resource_access_granted(AuthUser, VHost, <<"one">>, read),
+    assert_resource_access_granted(AuthUser, VHost, <<"two">>, read),
+    assert_resource_access_granted(AuthUser, VHost, <<"two">>, write),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, configure),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, read),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, write),
+
+    application:unset_env(rabbitmq_auth_backend_oauth2, scope_aliases),
+    application:unset_env(rabbitmq_auth_backend_oauth2, key_config),
+    application:unset_env(rabbitmq_auth_backend_oauth2, resource_server_id).
 
 test_unsuccessful_access_with_a_bogus_token(_) ->
     Username = <<"username">>,
@@ -549,3 +586,31 @@ test_validate_payload(_) ->
     ?assertEqual({ok, #{<<"aud">>   => [?RESOURCE_SERVER_ID],
                         <<"scope">> => [<<"bar">>, <<"other.third">>]}},
                  rabbit_auth_backend_oauth2:validate_payload(KnownResourceServerId, ?RESOURCE_SERVER_ID)).
+
+
+%%
+%% Helpers
+%%
+
+assert_vhost_access_granted(AuthUser, VHost) ->
+    assert_vhost_access_response(true, AuthUser, VHost).
+
+assert_vhost_access_denied(AuthUser, VHost) ->
+    assert_vhost_access_response(false, AuthUser, VHost).
+
+assert_vhost_access_response(ExpectedResult, AuthUser, VHost) ->
+    ?assertEqual(ExpectedResult,
+        rabbit_auth_backend_oauth2:check_vhost_access(AuthUser, VHost, none)).
+
+assert_resource_access_granted(AuthUser, VHost, ResourceName, PermissionKind) ->
+        assert_resource_access_response(true, AuthUser, VHost, ResourceName, PermissionKind).
+
+assert_resource_access_denied(AuthUser, VHost, ResourceName, PermissionKind) ->
+        assert_resource_access_response(false, AuthUser, VHost, ResourceName, PermissionKind).
+
+assert_resource_access_response(ExpectedResult, AuthUser, VHost, ResourceName, PermissionKind) ->
+    ?assertEqual(ExpectedResult,
+            rabbit_auth_backend_oauth2:check_resource_access(
+                          AuthUser,
+                          rabbit_misc:r(VHost, queue, ResourceName),
+                          PermissionKind, #{})).

--- a/release-notes/3.10.0.md
+++ b/release-notes/3.10.0.md
@@ -283,6 +283,16 @@ This release includes all applicable [bug fixes that shipped in `3.9.x` releases
 
 #### Enhancements
 
+*  The plugin now supports scope aliases. In some environments, it's unrealistic to
+   adopt JWTs that follow the `scope` convention assumed by the plugin. Instead,
+   identity services fill `scope` or `claims` field with a "role name" or "role alias"
+   that implicitly maps to a set of scopes/permissions.
+
+   With this feature, RabbitMQ operators can map those values to a set of
+   scopes that can be translated to RabbitMQ permissions.
+
+   GitHub issue: [#4588](https://github.com/rabbitmq/rabbitmq-server/issues/4588)
+
  * Improvements to JKW support and new HTTPS settings.
 
    Contributed by @anhanhnguyen (Erlang Solutions).


### PR DESCRIPTION
## Proposed Changes

This introduces scope alias support to the OAuth 2 plugin.
The goal is to allow users who have no control over what
scopes their JWT tokens include, map "role names" retrieved
from their identity provider to a set of scopes
that follow the convention used by the plugin.
See #4588 for background.

Per discussion with @MarcialRosales, we try to fetch
aliases from two sources, based on feedback from two different
users who seemingly rely on the same family of identity
provider products:

 * Use the JWT scope field value first
 * Use extra_scopes_source app env setting second

Just like with the existing extra scopes/complex claim
support originally contributed for Keycloak/identityProvider,
we merge all these scopes obtained from "alternative sources"
with the value of the JWT scopes field. This implicitly
assumes that the result makes sense semantically and
there will not be conflicting scopes. That's on the user to
make sure of.


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Closes #4588