### PR TITLE
Drop -Wrace_conditions from Dialyzer opts

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -6722,7 +6722,7 @@ export DIALYZER_PLT
 
 PLT_APPS ?=
 DIALYZER_DIRS ?= --src -r $(wildcard src) $(ALL_APPS_DIRS)
-DIALYZER_OPTS ?= -Werror_handling -Wrace_conditions -Wunmatched_returns # -Wunderspecs
+DIALYZER_OPTS ?= -Werror_handling -Wunmatched_returns # -Wunderspecs
 DIALYZER_PLT_OPTS ?=
 
 # Core targets.


### PR DESCRIPTION
For Erlang 25 compatibility.

Since ninenines/erlang.mk#947 has been merged, no reason
not to do it in RabbitMQ's temporary fork.