### PR TITLE
Return empty array when JMS topic exchange state does not exist

### DIFF
--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_jms_topic_exchange.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_jms_topic_exchange.erl
@@ -274,9 +274,6 @@ delete_state(XName) ->
 % Basic read for update
 read_state_for_update(XName) -> read_state(XName, write).
 
-% Basic read
-read_state(XName) -> read_state(XName, read).
-
 % Lockable read
 read_state(XName, Lock) ->
   case mnesia:read(?JMS_TOPIC_TABLE, XName, Lock) of


### PR DESCRIPTION
Instead of exiting. A few messages can get routed to a deleted
exchange. The exchange has no state in Mnesia, so the previous
code would return an error that would bubble up to the publisher
and closing its channel. The exchange is created for a subscriber,
so this would mean the deletion of a subscriber would impact
a publisher.