### PR TITLE
Remove leftover compiler option for get_stacktrace

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_channel).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 %% rabbit_channel processes represent an AMQP 0-9-1 channels.
 %%
 %% Connections parse protocol frames coming from clients and

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_node_monitor).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -behaviour(gen_server).
 
 -export([start_link/0]).

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -6,11 +6,6 @@
 %%
 
 -module(rabbit_reader).
-
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 %% This is an AMQP 0-9-1 connection implementation. If AMQP 1.0 plugin is enabled,
 %% this module passes control of incoming AMQP 1.0 connections to it.
 %%

--- a/deps/rabbit/src/rabbit_vhost_process.erl
+++ b/deps/rabbit/src/rabbit_vhost_process.erl
@@ -21,10 +21,6 @@
 
 -module(rabbit_vhost_process).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -define(TICKTIME_RATIO, 4).

--- a/deps/rabbitmq_amqp1_0/include/rabbit_amqp1_0.hrl
+++ b/deps/rabbitmq_amqp1_0/include/rabbit_amqp1_0.hrl
@@ -13,9 +13,9 @@
 -define(SAFE(F),
         ((fun() ->
                   try F
-                  catch __T:__E ->
+                  catch __T:__E:__ST ->
                           io:format("~p:~p thrown debugging~n~p~n",
-                                    [__T, __E, erlang:get_stacktrace()])
+                                    [__T, __E, __ST])
                   end
           end)())).
 

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_amqp1_0_reader).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("kernel/include/inet.hrl").

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_process.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_process.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_amqp1_0_session_process).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -behaviour(gen_server2).
 
 -export([init/1, terminate/2, code_change/3,

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt_jwt.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt_jwt.erl
@@ -6,10 +6,6 @@
 %%
 -module(uaa_jwt_jwt).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -export([decode/1, decode_and_verify/2, get_key_id/1]).
 
 -include_lib("jose/include/jose_jwt.hrl").

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_mgmt_external_stats).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -behaviour(gen_server).
 
 -export([start_link/0]).

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_mqtt_reader).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -behaviour(gen_server2).
 
 -export([start_link/2]).

--- a/deps/rabbitmq_trust_store/src/rabbit_trust_store.erl
+++ b/deps/rabbitmq_trust_store/src/rabbit_trust_store.erl
@@ -7,10 +7,6 @@
 
 -module(rabbit_trust_store).
 
-%% Transitional step until we can require Erlang/OTP 21 and
-%% use the now recommended try/catch syntax for obtaining the stack trace.
--compile(nowarn_deprecated_function).
-
 -behaviour(gen_server).
 
 -export([mode/0, refresh/0, list/0]). %% Console Interface.


### PR DESCRIPTION
## Proposed Changes

Remove no more applicable comment. If the nowarn option is still needed the comment should be updated in the affected modules. (CI will tell - compiles without warning locally)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
