### PR TITLE
Use rabbitmqctl await_startup instead if erl eval

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -320,11 +320,6 @@ endif
 
 RMQCTL_WAIT_TIMEOUT ?= 60
 
-define rmq_started
-true = rpc:call('$(1)', rabbit, is_running, []),
-halt().
-endef
-
 start-background-node: node-tmpdir $(DIST_TARGET)
 	$(BASIC_SCRIPT_ENV_SETTINGS) \
 	  RABBITMQ_NODE_ONLY=true \
@@ -340,7 +335,7 @@ start-background-broker: node-tmpdir $(DIST_TARGET)
 	ERL_LIBS="$(DIST_ERL_LIBS)" \
 	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) wait --timeout $(RMQCTL_WAIT_TIMEOUT) $(RABBITMQ_PID_FILE) && \
 	ERL_LIBS="$(DIST_ERL_LIBS)" \
-	  $(call erlang,$(call rmq_started,$(RABBITMQ_NODENAME)),-sname sbb-$$$$ -hidden)
+	  $(RABBITMQCTL) --node $(RABBITMQ_NODENAME) await_startup
 
 start-rabbit-on-node:
 	$(exec_verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \

--- a/rabbitmq_run.bzl
+++ b/rabbitmq_run.bzl
@@ -1,6 +1,5 @@
 load("@rules_erlang//:erlang_home.bzl", "ErlangHomeProvider", "ErlangVersionProvider")
 load("@rules_erlang//:util.bzl", "path_join", "windows_path")
-load("@rules_erlang//:ct.bzl", "sanitize_sname")
 load(":rabbitmq_home.bzl", "RabbitmqHomeInfo", "rabbitmq_home_short_path")
 
 def _impl(ctx):
@@ -11,8 +10,6 @@ def _impl(ctx):
         path_join(rabbitmq_home_path, "plugins"),
     ])
 
-    sname = sanitize_sname("sbb-" + ctx.attr.name)
-
     if not ctx.attr.is_windows:
         output = ctx.actions.declare_file(ctx.label.name)
         ctx.actions.expand_template(
@@ -22,7 +19,6 @@ def _impl(ctx):
                 "{RABBITMQ_HOME}": rabbitmq_home_path,
                 "{ERL_LIBS}": erl_libs,
                 "{ERLANG_HOME}": ctx.attr._erlang_home[ErlangHomeProvider].path,
-                "{SNAME}": sname,
             },
             is_executable = True,
         )
@@ -35,7 +31,6 @@ def _impl(ctx):
                 "{RABBITMQ_HOME}": windows_path(rabbitmq_home_path),
                 "{ERL_LIBS}": erl_libs,
                 "{ERLANG_HOME}": windows_path(ctx.attr._erlang_home[ErlangHomeProvider].path),
-                "{SNAME}": sname,
             },
             is_executable = True,
         )

--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -164,11 +164,9 @@ case $CMD in
             --timeout ${RMQCTL_WAIT_TIMEOUT} \
             ${RABBITMQ_PID_FILE}
 
-        {ERLANG_HOME}/bin/erl \
-            -noinput \
-            -eval "true = rpc:call('${RABBITMQ_NODENAME}', rabbit, is_running, []), halt()." \
-            -sname {SNAME} \
-            -hidden
+        ${RABBITMQ_SCRIPTS_DIR}/rabbitmqctl \
+            --node ${RABBITMQ_NODENAME} \
+            await_startup
         ;;
     stop-node)
         pid=$(test -f $RABBITMQ_PID_FILE && cat $RABBITMQ_PID_FILE); \


### PR DESCRIPTION
when starting background nodes for tests

It's would probably also be worth checking that listeners are up before considering the node ready for tests