### PR TITLE
No longer file:allocate CQv2 index files

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -323,9 +323,6 @@ recover_segments(State0, ContainsCheckFun, StoreState0, CountersRef, [Segment|Ta
         {ok, <<?MAGIC:32,?VERSION:8,
                _FromSeqId:64/unsigned,_ToSeqId:64/unsigned,
                _/bits>>} ->
-            %% Double check the file size before attempting to parse it.
-            SegmentFileSize = ?HEADER_SIZE + SegmentEntryCount * ?ENTRY_SIZE,
-            {ok, #file_info{size = SegmentFileSize}} = file:read_file_info(Fd),
             {Action, State, StoreState1} = recover_segment(State0, ContainsCheckFun, StoreState0, CountersRef, Fd,
                                                           Segment, 0, SegmentEntryCount,
                                                           SegmentEntryCount, []),
@@ -436,7 +433,13 @@ recover_segment(State, ContainsCheckFun, StoreState0, CountersRef, Fd,
         {ok, << 0:8, _/bits >>} ->
             recover_segment(State, ContainsCheckFun, StoreState0, CountersRef,
                             Fd, Segment, ThisEntry + 1, SegmentEntryCount,
-                            Unacked - 1, LocBytes0)
+                            Unacked - 1, LocBytes0);
+        %% We reached the end of a partial file. There are no more entries.
+        %% We skip ThisEntry to SegmentEntryCount to reach the final clause.
+        eof ->
+            recover_segment(State, ContainsCheckFun, StoreState0, CountersRef,
+                            Fd, Segment, SegmentEntryCount, SegmentEntryCount,
+                            Unacked - (SegmentEntryCount - ThisEntry), LocBytes0)
     end.
 
 recover_index_v1_clean(State0 = #qi{ queue_name = Name }, Terms, IsMsgStoreClean,
@@ -587,28 +590,6 @@ new_segment_file(Segment, SegmentEntryCount, State = #qi{ segments = Segments })
     #qi{ fds = OpenFds } = reduce_fd_usage(Segment, State),
     false = maps:is_key(Segment, OpenFds), %% assert
     {ok, Fd} = file:open(segment_file(Segment, State), [read, write, raw, binary]),
-    %% We must preallocate space for the file. We want the space
-    %% to be allocated to not have to worry about errors when
-    %% writing later on.
-    Size = ?HEADER_SIZE + SegmentEntryCount * ?ENTRY_SIZE,
-    case file:allocate(Fd, 0, Size) of
-        ok ->
-            ok;
-        %% For filesystems using copy-on-write such as ZFS, file preallocation
-        %% does not make any sense. For instance, on FreeBSD+ZFS,
-        %% posix_fallocate(2) fails with `EINVAL'.
-        %%
-        %% FIXME: Filling the file with zeroes is counter-productive because
-        %% it eats free space for no benefits and even worsen situations where
-        %% the disk is short on free space. However we still do it because the
-        %% rest of the code assumes that the file is preallocated.
-        {error, einval} ->
-            fill_file_with_zeroes(Fd, Size);
-        %% On some platforms file:allocate is not supported (e.g. Windows).
-        %% In that case we fill the file with zeroes manually.
-        {error, enotsup} ->
-            fill_file_with_zeroes(Fd, Size)
-    end,
     %% We then write the segment file header. It contains
     %% some useful info and some reserved bytes for future use.
     %% We currently do not make use of this information. It is
@@ -624,14 +605,6 @@ new_segment_file(Segment, SegmentEntryCount, State = #qi{ segments = Segments })
     %% Keep the file open.
     State#qi{ segments = Segments#{Segment => 1},
               fds = OpenFds#{Segment => Fd} }.
-
-fill_file_with_zeroes(Fd, Size) ->
-    ok = file:write(Fd, <<0:Size/unit:8>>),
-    {ok, 0} = file:position(Fd, bof),
-    %% We do a full GC immediately after because we do not want
-    %% to keep around the large binary we used to fill the file.
-    _ = garbage_collect(),
-    ok.
 
 %% We try to keep the number of FDs open at 4 at a maximum.
 %% Under normal circumstances we will end up with 1 or 2
@@ -997,11 +970,20 @@ read_from_disk(SeqIdsToRead0, State0 = #qi{ write_buffer = WriteBuffer }, Acc0) 
     case get_fd(FirstSeqId, State0) of
         {Fd, OffsetForSeqId, State} ->
             file_handle_cache_stats:update(queue_index_read),
-            {ok, EntriesBin} = file:pread(Fd, OffsetForSeqId, ReadSize),
-            %% We cons new entries into the Acc and only reverse it when we
-            %% are completely done reading new entries.
-            Acc = parse_entries(EntriesBin, FirstSeqId, WriteBuffer, Acc0),
-            read_from_disk(SeqIdsToRead, State, Acc);
+            %% When reading further than the end of a partial file,
+            %% file:pread/3 will return what it could read.
+            case file:pread(Fd, OffsetForSeqId, ReadSize) of
+                {ok, EntriesBin} ->
+                    %% We cons new entries into the Acc and only reverse it when we
+                    %% are completely done reading new entries.
+                    Acc = parse_entries(EntriesBin, FirstSeqId, WriteBuffer, Acc0),
+                    read_from_disk(SeqIdsToRead, State, Acc);
+                eof ->
+                    %% We reached the end of a partial file.
+                    %% Everything past that point is non-existent.
+                    %% This probably does not happen outside of tests.
+                    read_from_disk(SeqIdsToRead, State0, Acc0)
+            end;
         %% The segment file no longer exists. This is equivalent to a file
         %% where all entries are non-existent/acked. This can happen after
         %% a crash due to rabbit_variable_queue's understanding of bounds.
@@ -1179,7 +1161,10 @@ queue_index_walker_segment(Fd, Gatherer, N, Total) ->
             queue_index_walker_segment(Fd, Gatherer, N + 1, Total);
         %% We found an ack, a transient entry or a non-entry. Skip it.
         {ok, _} ->
-            queue_index_walker_segment(Fd, Gatherer, N + 1, Total)
+            queue_index_walker_segment(Fd, Gatherer, N + 1, Total);
+        %% We reached the end of a partial segment file.
+        eof ->
+            ok
     end.
 
 stop(VHost) ->


### PR DESCRIPTION
As discussed on Slack following https://github.com/rabbitmq/rabbitmq-server/pull/4721.

This is both an alternative fix for https://github.com/rabbitmq/rabbitmq-server/pull/4721 and an improvement to the way v2 index segment files are handled: we no longer pre-allocate the files, so there is no platform differences anymore (there was for at least Windows and FreeBSD+ZFS), and the files do not unnecessarily take space on disk.