### PR TITLE
Use `stdlib/include/assert.hrl` where we need `?assert()` macros only and not other EUnit macros

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -7,7 +7,7 @@
 
 -module(rabbit).
 
--include_lib("eunit/include/eunit.hrl").
+-include_lib("stdlib/include/assert.hrl").
 -include_lib("kernel/include/logger.hrl").
 -include_lib("rabbit_common/include/logging.hrl").
 


### PR DESCRIPTION
Otherwise, this adds a dependency on EUnit. Also, `eunit.hrl` defines `TEST` which might defeat some `-ifdef(TEST)` we may use.