### PR TITLE
Ensure maintenance mode state table exists after node [re]boot

### DIFF
--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -29,7 +29,8 @@
     transfer_leadership_of_quorum_queues/1,
     transfer_leadership_of_classic_mirrored_queues/1,
     status_table_name/0,
-    status_table_definition/0
+    status_table_definition/0,
+    boot/0
 ]).
 
 -define(TABLE, rabbit_node_maintenance_states).
@@ -43,6 +44,39 @@
 -export_type([
     maintenance_status/0
 ]).
+
+%%
+%% Boot
+%%
+
+-rabbit_boot_step({rabbit_maintenance_mode_state,
+    [{description, "initializes maintenance mode state"},
+        {mfa,         {?MODULE, boot, []}},
+        {requires,    networking}]}).
+
+boot() ->
+    case rabbit_feature_flags:is_enabled(?FEATURE_FLAG, non_blocking) of
+        true ->
+            TableName = status_table_name(),
+            rabbit_log:info(
+                "Creating table ~s for feature flag `~s`",
+                [TableName, ?FEATURE_FLAG]),
+            try
+                _ = rabbit_table:create(
+                    TableName,
+                    status_table_definition()),
+                _ = rabbit_table:ensure_table_copy(TableName, node())
+            catch throw:Reason  ->
+                rabbit_log:error(
+                    "Failed to create maintenance status table: ~p",
+                    [Reason])
+            end;
+        false ->
+            ok;
+        state_changing ->
+            %% feature flag migration will do the job for us
+            ok
+    end.
 
 %%
 %% API

--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -64,8 +64,7 @@ boot() ->
             try
                 _ = rabbit_table:create(
                     TableName,
-                    status_table_definition()),
-                _ = rabbit_table:ensure_table_copy(TableName, node())
+                    status_table_definition())
             catch throw:Reason  ->
                 rabbit_log:error(
                     "Failed to create maintenance status table: ~p",


### PR DESCRIPTION
## Proposed Changes

Some users were surprised by the current approach to
state table setup, so let's set make sure we ensure the table exists
on every boot (if the feature flag is enabled).

Per discussion in https://github.com/rabbitmq/discussions/issues/183#issuecomment-1119849840.
Closes #4755.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #755)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
