### PR TITLE
Add test-node-logs and remote-test-node-logs rules for bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -203,3 +203,56 @@ EOF
 """,
     executable = True,
 )
+
+genrule(
+    name = "test-node-logs",
+    outs = ["open-test-node-logs.sh"],
+    cmd = """set -euo pipefail
+cat << 'EOF' > $@
+    set -euo pipefail
+    if [ $$# -eq 0 ]; then
+        echo "Usage: bazel run test-node-logs TEST_LABEL [shard_index]"
+        exit 1
+    fi
+
+    RELATIVE=$${1#//}
+    PACKAGE=$${RELATIVE%%:*}
+    SUITE=$${RELATIVE##*:}
+    OUTPUT_DIR=test.outputs
+    if [ $$# -gt 1 ]; then
+        OUTPUT_DIR=shard_$$2_of_*/test.outputs
+    fi
+    open bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/ct_run.*/deps.*/run.*/log_private
+EOF
+""",
+    executable = True,
+)
+
+# NOTE: this rule may not work properly if --remote_download_minimal has been used,
+#       which is currently the default for remote runs
+genrule(
+    name = "remote-test-node-logs",
+    outs = ["open-remote-test-node-logs.sh"],
+    cmd = """set -euo pipefail
+cat << 'EOF' > $@
+    set -euo pipefail
+    if [ $$# -eq 0 ]; then
+        echo "Usage: bazel run remote-test-node-logs TEST_LABEL [shard_index]"
+        exit 1
+    fi
+
+    RELATIVE=$${1#//}
+    PACKAGE=$${RELATIVE%%:*}
+    SUITE=$${RELATIVE##*:}
+    OUTPUT_DIR=test.outputs
+    if [ $$# -gt 1 ]; then
+        OUTPUT_DIR=shard_$$2_of_*/test.outputs
+    fi
+    TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
+    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip outputs.zip
+    open $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/index.html
+    open $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/ct_run.*/deps.*/run.*/log_private
+EOF
+""",
+    executable = True,
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -205,13 +205,13 @@ EOF
 )
 
 genrule(
-    name = "test-node-logs",
-    outs = ["open-test-node-logs.sh"],
+    name = "test-node-data",
+    outs = ["open-test-node-data.sh"],
     cmd = """set -euo pipefail
 cat << 'EOF' > $@
     set -euo pipefail
     if [ $$# -eq 0 ]; then
-        echo "Usage: bazel run test-node-logs TEST_LABEL [shard_index]"
+        echo "Usage: bazel run test-node-data TEST_LABEL [shard_index]"
         exit 1
     fi
 
@@ -231,13 +231,13 @@ EOF
 # NOTE: this rule may not work properly if --remote_download_minimal has been used,
 #       which is currently the default for remote runs
 genrule(
-    name = "remote-test-node-logs",
-    outs = ["open-remote-test-node-logs.sh"],
+    name = "remote-test-node-data",
+    outs = ["open-remote-test-node-data.sh"],
     cmd = """set -euo pipefail
 cat << 'EOF' > $@
     set -euo pipefail
     if [ $$# -eq 0 ]; then
-        echo "Usage: bazel run remote-test-node-logs TEST_LABEL [shard_index]"
+        echo "Usage: bazel run remote-test-node-data TEST_LABEL [shard_index]"
         exit 1
     fi
 


### PR DESCRIPTION
For convenience when opening up the directory containing the rabbitmq node logs produced by integration tests