### PR TITLE
Check queue and exchange existence with ets:member/2

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -13,7 +13,8 @@
          delete_immediately/1, delete_exclusive/2, delete/4, purge/1,
          forget_all_durable/1]).
 -export([pseudo_queue/2, pseudo_queue/3, immutable/1]).
--export([lookup/1, lookup_many/1, not_found_or_absent/1, not_found_or_absent_dirty/1,
+-export([exists/1, lookup/1, lookup_many/1,
+         not_found_or_absent/1, not_found_or_absent_dirty/1,
          with/2, with/3, with_or_die/2,
          assert_equivalence/5,
          check_exclusive_access/2, with_exclusive_access_or_die/3,
@@ -397,6 +398,10 @@ lookup(Name) ->
 
 lookup_many(Names) when is_list(Names) ->
     lookup(Names).
+
+-spec exists(name()) -> boolean().
+exists(Name) ->
+    ets:member(rabbit_queue, Name).
 
 -spec not_found_or_absent(name()) -> not_found_or_absent().
 

--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -139,10 +139,7 @@ exists(#binding{source = ?DEFAULT_EXCHANGE(_),
                 destination = #resource{kind = queue, name = QName} = Queue,
                 key = QName,
                 args = []}) ->
-    case rabbit_amqqueue:lookup(Queue) of
-        {ok, _} -> true;
-        {error, not_found} -> false
-    end;
+    rabbit_amqqueue:exists(Queue);
 exists(Binding) ->
     binding_action(
       Binding, fun (_Src, _Dst, B) ->

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -10,7 +10,7 @@
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 
 -export([recover/1, policy_changed/2, callback/4, declare/7,
-         assert_equivalence/6, assert_args_equivalence/2, check_type/1,
+         assert_equivalence/6, assert_args_equivalence/2, check_type/1, exists/1,
          lookup/1, lookup_many/1, lookup_or_die/1, list/0, list/1, lookup_scratch/2,
          update_scratch/3, update_decorators/1, immutable/1,
          info_keys/0, info/1, info/2, info_all/1, info_all/2, info_all/4,
@@ -219,6 +219,10 @@ assert_args_equivalence(#exchange{ name = Name, arguments = Args },
     %% "alternate-exchange".
     rabbit_misc:assert_args_equivalence(Args, RequiredArgs, Name,
                                         [<<"alternate-exchange">>]).
+
+-spec exists(name()) -> boolean().
+exists(Name) ->
+    ets:member(rabbit_exchange, Name).
 
 -spec lookup
         (name()) -> rabbit_types:ok(rabbit_types:exchange()) |

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -213,10 +213,10 @@ wait_for_queue_deleted(QRef, 0) ->
     rabbit_log:debug("Received deletion event for ~s but queue still exists in ETS table.",
                      [rabbit_misc:rs(QRef)]);
 wait_for_queue_deleted(QRef, N) ->
-    case rabbit_amqqueue:lookup(QRef) of
-        {error, not_found} ->
+    case rabbit_amqqueue:exists(QRef) of
+        false ->
             ok;
-        _ ->
+        true ->
             timer:sleep(50),
             wait_for_queue_deleted(QRef, N-1)
     end.

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
@@ -70,13 +70,13 @@ init([Table]) ->
                             proplists:get_value(global, Policies)},
                 rates_mode = RatesMode,
                 old_aggr_stats = #{},
-                lookup_queue = fun queue_exists/1,
-                lookup_exchange = fun exchange_exists/1,
+                lookup_queue = fun rabbit_amqqueue:exists/1,
+                lookup_exchange = fun rabbit_exchange:exists/1,
                 filter_aggregated_queue_metrics_pattern = FilterPattern}}.
 
 handle_call(reset_lookups, _From, State) ->
-    {reply, ok, State#state{lookup_queue = fun queue_exists/1,
-                            lookup_exchange = fun exchange_exists/1}};
+    {reply, ok, State#state{lookup_queue = fun rabbit_amqqueue:exists/1,
+                            lookup_exchange = fun rabbit_exchange:exists/1}};
 handle_call({override_lookups, Lookups}, _From, State) ->
     {reply, ok, State#state{lookup_queue = pget(queue, Lookups),
                             lookup_exchange = pget(exchange, Lookups)}};
@@ -649,22 +649,6 @@ vhost({queue_stats, #resource{virtual_host = VHost}}) ->
     VHost;
 vhost({TName, Pid}) ->
     pget(vhost, lookup_element(TName, Pid, 2)).
-
-exchange_exists(Name) ->
-    case rabbit_exchange:lookup(Name) of
-        {ok, _} ->
-            true;
-        _ ->
-            false
-    end.
-
-queue_exists(Name) ->
-    case rabbit_amqqueue:lookup(Name) of
-        {ok, _} ->
-            true;
-        _ ->
-            false
-    end.
 
 insert_with_index(Table, Key, Tuple) ->
     Insert = ets:insert(Table, Tuple),

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -548,13 +548,10 @@ maybe_clean_sess(PState = #proc_state { clean_sess = true,
             end
     end.
 
-session_present(VHost, ClientId)  ->
+session_present(VHost, ClientId) ->
     {_, QueueQ1} = rabbit_mqtt_util:subcription_queue_name(ClientId),
     QueueName = rabbit_misc:r(VHost, queue, QueueQ1),
-    case rabbit_amqqueue:lookup(QueueName) of
-        {ok, _} -> true;
-        {error, not_found} -> false
-    end.
+    rabbit_amqqueue:exists(QueueName).
 
 make_will_msg(#mqtt_frame_connect{ will_flag   = false }) ->
     undefined;

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -643,12 +643,7 @@ exchange_exists(VirtualHost, Name) ->
     case rabbit_stream_utils:enforce_correct_name(Name) of
         {ok, CorrectName} ->
             ExchangeName = rabbit_misc:r(VirtualHost, exchange, CorrectName),
-            case rabbit_exchange:lookup(ExchangeName) of
-                {ok, _} ->
-                    {ok, true};
-                {error, not_found} ->
-                    {ok, false}
-            end;
+            {ok, rabbit_exchange:exists(ExchangeName)};
         error ->
             {error, validation_failed}
     end.
@@ -657,12 +652,7 @@ queue_exists(VirtualHost, Name) ->
     case rabbit_stream_utils:enforce_correct_name(Name) of
         {ok, CorrectName} ->
             QueueName = rabbit_misc:r(VirtualHost, queue, CorrectName),
-            case rabbit_amqqueue:lookup(QueueName) of
-                {ok, _} ->
-                    {ok, true};
-                {error, not_found} ->
-                    {ok, false}
-            end;
+            {ok, rabbit_amqqueue:exists(QueueName)};
         error ->
             {error, validation_failed}
     end.


### PR DESCRIPTION
This reduces memory usage since the object does not get copied from ETS and improves code readability.