### PR TITLE
Avoid ETS lookup if no extra_bcc queue set

### DIFF
--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -412,45 +412,20 @@ info_all(VHostPath, Items, Ref, AggregatorPid) ->
 route(#exchange{name = #resource{virtual_host = VHost, name = RName} = XName,
                 decorators = Decorators} = X,
       #delivery{message = #basic_message{routing_keys = RKs}} = Delivery) ->
-    QNames = case RName of
-                 <<>> ->
-                     RKsSorted = lists:usort(RKs),
-                     [rabbit_channel:deliver_reply(RK, Delivery) ||
-                      RK <- RKsSorted, virtual_reply_queue(RK)],
-                     [rabbit_misc:r(VHost, queue, RK) || RK <- RKsSorted,
-                                                         not virtual_reply_queue(RK)];
-                 _ ->
-                     Decs = rabbit_exchange_decorator:select(route, Decorators),
-                     lists:usort(route1(Delivery, Decs, {[X], XName, []}))
-             end,
-    Qs = rabbit_amqqueue:lookup(QNames),
-    ExtraBccQNames = infer_extra_bcc(Qs),
-    ExtraBccQNames ++ QNames.
+    case RName of
+        <<>> ->
+            RKsSorted = lists:usort(RKs),
+            [rabbit_channel:deliver_reply(RK, Delivery) ||
+             RK <- RKsSorted, virtual_reply_queue(RK)],
+            [rabbit_misc:r(VHost, queue, RK) || RK <- RKsSorted,
+                                                not virtual_reply_queue(RK)];
+        _ ->
+            Decs = rabbit_exchange_decorator:select(route, Decorators),
+            lists:usort(route1(Delivery, Decs, {[X], XName, []}))
+    end.
 
 virtual_reply_queue(<<"amq.rabbitmq.reply-to.", _/binary>>) -> true;
 virtual_reply_queue(_)                                      -> false.
-
--spec infer_extra_bcc([amqqueue:amqqueue()]) -> [rabbit_amqqueue:name()].
-infer_extra_bcc([]) ->
-    [];
-infer_extra_bcc([Q]) ->
-    case amqqueue:get_options(Q) of
-        #{extra_bcc := BCC} ->
-            #resource{virtual_host = VHost} = amqqueue:get_name(Q),
-            [rabbit_misc:r(VHost, queue, BCC)];
-        _                   ->
-            []
-    end;
-infer_extra_bcc(Qs) ->
-    lists:foldl(fun(Q, Acc) ->
-                        case amqqueue:get_options(Q) of
-                            #{extra_bcc := BCC} ->
-                                #resource{virtual_host = VHost} = amqqueue:get_name(Q),
-                                [rabbit_misc:r(VHost, queue, BCC) | Acc];
-                            _                   ->
-                                Acc
-                        end
-                end, [], Qs).
 
 route1(_, _, {[], _, QNames}) ->
     QNames;


### PR DESCRIPTION
A queue (Q1) can have an extra_bcc queue (Q2).
Whenever a message is routed to Q1, it must also be routed to Q2.

Commit https://github.com/rabbitmq/rabbitmq-server/commit/fc2d37ed1cd10e9c26d40ce898df9340cf57d063 (in 3.10.x, but not in 3.9.x) puts the logic to determine extra_bcc queues into `rabbit_exchange:route/2`. 
That is functionally correct because it ensures that messages being dead lettered to target queues will also route to the target queues' extra_bcc queues. For every message being routed, that commit uses` ets:lookup/2` just to check for an extra_bcc queue (blue rectangle D below).

Technically, that commit is not a regression because it does not slow down the common case where a message is routed to a single target queue because before that commit `rabbit_channel:deliver_to_queues/3` used two `ets:lookup/2` calls (blue rectangles A and B below).

However we can do better by avoiding the `ets:lookup/2` for the common case where there is no extra_bcc queue set.

One option is to use `ets:lookup_element/3` to only fetch the queue `options` field as demonstrated [here](https://github.com/ansd/rabbitmq-server/blob/c305c4abcfda4b0fd0bc063f1d6c4c78b4ae4078/deps/rabbit/src/rabbit_exchange.erl#L438).

A better option (implemented in this PR) is determining whether to send to an extra_bcc queue in the rabbit_channel and in the at-most and at-least once dead lettering modules where the queue records have already been looked up.

### Performance

Single node RabbitMQ cluster and latest Java perf-test client running both on the same Intel NUC11 with 8 CPUs, 32GB RAM, Ubuntu 22.04, Erlang OTP 25.0-rc3.

RabbitMQ server started via
```
make run-broker LEAVE_PLUGINS_DISABLED=1 RABBITMQ_CONFIG_FILE="advanced.config" RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+JPperf true +S 4"
```

<details>
<summary>advanced.config</summary>

```
[
 {rabbit,[
  {vm_memory_high_watermark,{absolute,12_000_000_000}},
  {credit_flow_default_credit, {1600, 800}}
 ]}
].
```
</details>

2 publishers sending to a stream:
```
-x 2 -y 0 -qa x-queue-type=stream -ad false -f persistent -u some-long-queue-name-to-copy-more-memory-from-ets -z 15
```
**Sending rate avg (msgs/s):**
3.9.17: 252k - 260k
3.10.1: 250k - 262k 
PR: 259k - 273k

### CPU Flame Graphs
**3.9.17**
A is [this line](https://github.com/rabbitmq/rabbitmq-server/blob/b555dc1cf8d7f93b64044207889b7c214c759a2a/deps/rabbit/src/rabbit_channel.erl#L2185)
B is [this line](https://github.com/rabbitmq/rabbitmq-server/blob/b555dc1cf8d7f93b64044207889b7c214c759a2a/deps/rabbit/src/rabbit_channel.erl#L2177)
![3-9-17](https://user-images.githubusercontent.com/12648310/167811464-f57b3d09-a157-4753-a38b-a282b438a096.png)


**3.10.1**
C is [this line](https://github.com/rabbitmq/rabbitmq-server/blob/f1bc7c547c6410ce630d56e99ecc1b40b8683d47/deps/rabbit/src/rabbit_channel.erl#L2177)
D is [this line](https://github.com/rabbitmq/rabbitmq-server/blob/f1bc7c547c6410ce630d56e99ecc1b40b8683d47/deps/rabbit/src/rabbit_exchange.erl#L426)
![3-10-1](https://user-images.githubusercontent.com/12648310/167811617-650335fe-d32e-4350-9fee-1f0a8396bc13.png)

**This PR**
No additional ETS lookup and therefore faster routing.
![PR](https://user-images.githubusercontent.com/12648310/167811751-2f5aacbb-56de-4a4e-863c-684838e551e3.png)

