### PR TITLE
Change default format of log level to full name

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
@@ -73,7 +73,7 @@ format_level1(Level, #{level_format := lc4}) ->
 format_level1(Level, #{level_format := uc4}) ->
     level_4letter_uc_name(Level);
 format_level1(Level, _) ->
-    level_4letter_lc_name(Level).
+    level_lc_name(Level).
 
 level_lc_name(debug)     -> "debug";
 level_lc_name(info)      -> "info";

--- a/deps/rabbit/test/logging_SUITE.erl
+++ b/deps/rabbit/test/logging_SUITE.erl
@@ -551,7 +551,7 @@ setting_message_format_works(Config) ->
 
     RandomMsgBin = list_to_binary(RandomMsg),
     ?assertEqual(
-       <<"level=warn ",
+       <<"level=warning ",
          "md_key=md_value ",
          "unknown_field=<unknown unknown_field> "
          "msg=", RandomMsgBin/binary>>,


### PR DESCRIPTION
The default format of how the log level gets printed should be the full
name. For example, we want `debug` instead of `dbug`.

This was also the default behaviour before commit aca638abbbe (see https://github.com/rabbitmq/rabbitmq-server/commit/aca638abbbefb9493a7e60db66ccd8fddff69ef3#diff-be25cb23b0fcb421484b241a21ec52ffab9b5e3b3e85e1916e3a40ffef933f78L38-L39).

