### PR TITLE
Save memory when acking messages to quorum queue

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -292,7 +292,10 @@ settle(ConsumerTag, [_|_] = MsgIds,
     %% sent once we have seen enough notifications
     Unsent = maps:update_with(ConsumerId,
                               fun ({Settles, Returns, Discards}) ->
-                                      {Settles ++ MsgIds, Returns, Discards}
+                                      %% MsgIds has fewer elements than Settles.
+                                      %% Therefore put it on the left side of the ++ operator.
+                                      %% The order in which messages are settled does not matter.
+                                      {MsgIds ++ Settles, Returns, Discards}
                               end, {MsgIds, [], []}, Unsent0),
     {State0#state{unsent_commands = Unsent}, []}.
 


### PR DESCRIPTION
List `MsgIds` has fewer elements than list `Settles`.
Therefore, put it on the left side of the `++` operator.

The mmap memory flame graph revealed that before this commit
5%-8% of all `mmap()` system calls happened in function
`rabbit_fifo_client:settle/3`:

![before](https://user-images.githubusercontent.com/12648310/168066988-2b3c7e48-c05e-4de5-b719-ace43e666192.png)


After this commit only 1.6% - 1.8% of all `mmap()` system calls happen in
this function:
![after](https://user-images.githubusercontent.com/12648310/168067013-2eb850af-f4d3-4800-8196-47c094cb12ff.png)

Applying the following patch before this PR
```
diff --git a/deps/rabbit/src/rabbit_fifo_client.erl b/deps/rabbit/src/rabbit_fifo_client.erl
index de1dc77e8d..a573a42355 100644
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -292,6 +292,8 @@ settle(ConsumerTag, [_|_] = MsgIds,
     %% sent once we have seen enough notifications
     Unsent = maps:update_with(ConsumerId,
                               fun ({Settles, Returns, Discards}) ->
+                                      rabbit_log:debug("length(Settles): ~b, length(MsgIds): ~b",
+                                                       [length(Settles), length(MsgIds)]),
                                       {Settles ++ MsgIds, Returns, Discards}
                               end, {MsgIds, [], []}, Unsent0),
     {State0#state{unsent_commands = Unsent}, []}.
```

outputs for
`-x 1 -y 1 -qa x-queue-type=quorum -ad false -f persistent -u qq`,
i.e. acking every message:
```
2022-05-12 10:45:48.694901+00:00 [debug] <0.667.0> length(Settles): 317, length(MsgIds): 1
2022-05-12 10:45:48.694913+00:00 [debug] <0.667.0> length(Settles): 318, length(MsgIds): 1
2022-05-12 10:45:48.694923+00:00 [debug] <0.667.0> length(Settles): 319, length(MsgIds): 1
2022-05-12 10:45:48.695268+00:00 [debug] <0.667.0> length(Settles): 1, length(MsgIds): 1
2022-05-12 10:45:48.695289+00:00 [debug] <0.667.0> length(Settles): 2, length(MsgIds): 1
```

and for
`-x 1 -y 1 -qa x-queue-type=quorum -ad false -f persistent -u qq1 --multi-ack-every 10`,
i.e. acking every 10th message:
```
2022-05-12 11:10:25.067923+00:00 [debug] <0.1220.0> length(Settles): 990, length(MsgIds): 10
2022-05-12 11:10:25.067943+00:00 [debug] <0.1220.0> length(Settles): 1000, length(MsgIds): 10
2022-05-12 11:10:25.068510+00:00 [debug] <0.1220.0> length(Settles): 10, length(MsgIds): 10
2022-05-12 11:10:25.068606+00:00 [debug] <0.1220.0> length(Settles): 20, length(MsgIds): 10
```

The mmap memory flame graph can be generated via:
```
sudo perf record -e syscalls:sys_enter_mmap -p $(cat "$HOME/scratch/rabbit/test/rabbit@$HOSTNAME/rabbit@$HOSTNAME.pid") -g -- sleep 30
```

IIUC the order in which messages are settled does not matter at all in `rabbit_fifo`.

However, we cannot do the same for discarded messages (`Discards`)
because the order in which messages will be dead lettered need to be
preserved.

