### PR TITLE
Set maximum expiration

### DIFF
--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -2527,7 +2527,7 @@ per_message_ttl_expiration_too_high(Config) ->
     MonitorRef = erlang:monitor(process, Ch),
 
     ok =  amqp_channel:cast(Ch, #'basic.publish'{},
-                            #amqp_msg{props = #'P_basic'{expiration = integer_to_binary(100*365*24*60*60*1000+1)}}),
+                            #amqp_msg{props = #'P_basic'{expiration = integer_to_binary(10*365*24*60*60*1000+1)}}),
     receive
         {'DOWN', MonitorRef, process, Ch,
          {shutdown, {server_initiated_close, 406, <<"PRECONDITION_FAILED - invalid expiration", _/binary>>}}} ->

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -1265,8 +1265,14 @@ sequence_error([T])                      -> T;
 sequence_error([{error, _} = Error | _]) -> Error;
 sequence_error([_ | Rest])               -> sequence_error(Rest).
 
-check_expiry(N) when N < 0                 -> {error, {value_negative, N}};
-check_expiry(_N)                           -> ok.
+check_expiry(N)
+  when N < 0 ->
+    {error, {value_negative, N}};
+check_expiry(N)
+  when N > 3_153_600_000_000 -> %% 100 years in milliseconds
+    {error, {value_too_large, N}};
+check_expiry(_N) ->
+    ok.
 
 base64url(In) ->
     lists:reverse(lists:foldl(fun ($\+, Acc) -> [$\- | Acc];

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -1269,7 +1269,7 @@ check_expiry(N)
   when N < 0 ->
     {error, {value_negative, N}};
 check_expiry(N)
-  when N > 3_153_600_000_000 -> %% 100 years in milliseconds
+  when N > 315_360_000_000 -> %% 10 years in milliseconds
     {error, {value_too_large, N}};
 check_expiry(_N) ->
     ok.


### PR DESCRIPTION
Issue was reported in https://rabbitmq.slack.com/archives/C1EDN83PA/p1652795406845919

When applications accidentally set an unreasonable high value for
the message TTL expiration field, e.g. 6779303336614035452,
before this commit quorum queue and classic queue processes crashed:

```
2022-05-17 13:35:26.488670+00:00 [notice] <0.1000.0> queue 'test' in vhost '/': candidate -> leader in term: 2 machine version: 2
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>   crasher:
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>     initial call: ra_server_proc:init/1
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>     pid: <0.1000.0>
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>     registered_name: '%2F_test'
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>     exception error: bad argument
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>       in function  erlang:start_timer/4
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>          called as erlang:start_timer(6779303336614035351,<0.1000.0>,
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>                                       {timeout,expire_msgs},
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>                                       [])
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>          *** argument 1: exceeds the maximum supported time value
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>       in call from gen_statem:loop_timeouts_start/16 (gen_statem.erl, line 2108)
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>     ancestors: [<0.999.0>,ra_server_sup_sup,<0.250.0>,ra_systems_sup,ra_sup,
2022-05-17 13:35:26.489492+00:00 [error] <0.1000.0>                   <0.186.0>]
```

In this commit, we disallow expiry fields higher than 100 years.
This causes the channel to be closed which is better than crashing the
queue process.

This new validation applies to message TTLs and queue expiry.

From the docs of erlang:start_timer/4:

> The absolute point in time, the timer is set to expire on, must be in the interval
> [erlang:convert_time_unit(erlang:system_info(start_time), native, millisecond),
>  erlang:convert_time_unit(erlang:system_info(end_time), native, millisecond)].
> If a relative time is specified, the Time value is not allowed to be negative.
> 
> end_time:
> The last Erlang monotonic time in native time unit that can be represented
> internally in the current Erlang runtime system instance.
> The time between the start time and the end time is at least a quarter of a millennium.