### PR TITLE
Implement fallback secret for credentials obfuscation (by @luos)

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -145,6 +145,7 @@ _APP_ENV = """[
 	    {tracking_execution_timeout, 15000},
 	    {stream_messages_soft_limit, 256},
         {track_auth_attempt_source, false},
+        {credentials_obfuscation_fallback_secret, <<"nocookie">>},
         {dead_letter_worker_consumer_prefetch, 32},
         {dead_letter_worker_publisher_confirm_timeout, 180000}
 	  ]

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -122,9 +122,10 @@ define PROJECT_ENV
 	    %% interval at which connection/channel tracking executes post operations
 	    {tracking_execution_timeout, 15000},
 	    {stream_messages_soft_limit, 256},
-        {track_auth_attempt_source, false},
-        {dead_letter_worker_consumer_prefetch, 32},
-        {dead_letter_worker_publisher_confirm_timeout, 180000}
+      {track_auth_attempt_source, false},
+			{credentials_obfuscation_fallback_secret, <<"nocookie">>},
+      {dead_letter_worker_consumer_prefetch, 32},
+      {dead_letter_worker_publisher_confirm_timeout, 180000}
 	  ]
 endef
 

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -71,7 +71,6 @@ setup(Context) ->
                     #{config_files => [],
                       config_advanced_file => undefined}
             end,
-    ok = set_credentials_obfuscation_secret(),
     ?LOG_DEBUG(
       "Saving config state to application env: ~p", [State],
       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
@@ -444,18 +443,6 @@ redact_env_var([{password, _Value} | Rest], Acc) ->
     redact_env_var(Rest, Acc ++ [{password, "********"}]);
 redact_env_var([AppVar | Rest], Acc) ->
     redact_env_var(Rest, [AppVar | Acc]).
-
-set_credentials_obfuscation_secret() ->
-    ?LOG_DEBUG(
-      "Refreshing credentials obfuscation configuration from env: ~p",
-      [application:get_all_env(credentials_obfuscation)],
-      #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
-    ok = credentials_obfuscation:refresh_config(),
-    CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
-    ?LOG_DEBUG(
-      "Setting credentials obfuscation secret to '~s'", [CookieBin],
-      #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
-    ok = credentials_obfuscation:set_secret(CookieBin).
 
 %% -------------------------------------------------------------------
 %% Config decryption.

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -32,6 +32,8 @@ setup(#{nodename := Node, nodename_type := NameType} = Context) ->
             throw({error, {erlang_dist_running_with_unexpected_nodename,
                            Unexpected, Node}})
     end,
+    ok = set_credentials_obfuscation_secret(),
+
     ok.
 
 do_setup(#{nodename := Node,
@@ -131,3 +133,21 @@ dist_port_use_check_fail(Port, Host) ->
         [Name] ->
             throw({error, {dist_port_already_used, Port, Name, Host}})
     end.
+
+set_credentials_obfuscation_secret() ->
+    ?LOG_DEBUG(
+        "Refreshing credentials obfuscation configuration from env: ~p",
+        [application:get_all_env(credentials_obfuscation)],
+        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
+    ok = credentials_obfuscation:refresh_config(),
+    CookieBin = rabbit_data_coercion:to_binary(erlang:get_cookie()),
+    ?LOG_DEBUG(
+        "Setting credentials obfuscation secret to '~s'", [CookieBin],
+        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
+    ok = credentials_obfuscation:set_secret(CookieBin),
+    Fallback = application:get_env(rabbit, 
+                                   credentials_obfuscation_fallback_secret, 
+                                   <<"nocookie">>),
+    ok = credentials_obfuscation:set_fallback_secret(Fallback).
+
+    

--- a/deps/rabbit/test/cluster_SUITE.erl
+++ b/deps/rabbit/test/cluster_SUITE.erl
@@ -312,24 +312,35 @@ queue_name(Config, Name) ->
 queue_name(Name) ->
     rabbit_misc:r(<<"/">>, queue, Name).
 
-credentials_obfuscation(Config) -> 
-    Value = <<"amqp://something">>,
-    Obfuscated0 = obfuscate_secret(Config, 0, Value),
-    Obfuscated1 = obfuscate_secret(Config, 1, Value),
-    
-    ok = rabbit_ct_broker_helpers:restart_broker(Config, 1),
+credentials_obfuscation(Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        false ->
+          case rabbit_ct_broker_helpers:enable_feature_flag(Config, virtual_host_metadata) of
+              ok ->
+                    Value = <<"amqp://something">>,
+                    Obfuscated0 = obfuscate_secret(Config, 0, Value),
+                    Obfuscated1 = obfuscate_secret(Config, 1, Value),
 
-    ?assertEqual(Value, deobfuscate_secret(Config, 0, Obfuscated0)),
-    ?assertEqual(Value, deobfuscate_secret(Config, 1, Obfuscated1)),
-    ?assertEqual(Value, deobfuscate_secret(Config, 0, Obfuscated1)),
-    ?assertEqual(Value, deobfuscate_secret(Config, 1, Obfuscated1)),
+                    ok = rabbit_ct_broker_helpers:restart_broker(Config, 1),
 
-    Obfuscated2 = obfuscate_secret(Config, 1, Value),
-    
-    ok = rabbit_ct_broker_helpers:restart_broker(Config, 0),
+                    ?assertEqual(Value, deobfuscate_secret(Config, 0, Obfuscated0)),
+                    ?assertEqual(Value, deobfuscate_secret(Config, 1, Obfuscated1)),
+                    ?assertEqual(Value, deobfuscate_secret(Config, 0, Obfuscated1)),
+                    ?assertEqual(Value, deobfuscate_secret(Config, 1, Obfuscated1)),
 
-    ?assertEqual(Value, deobfuscate_secret(Config, 0, Obfuscated2)),
-    ok.
+                    Obfuscated2 = obfuscate_secret(Config, 1, Value),
+
+                    ok = rabbit_ct_broker_helpers:restart_broker(Config, 0),
+
+                    ?assertEqual(Value, deobfuscate_secret(Config, 0, Obfuscated2)),
+                    ok;
+              Skip ->
+                  Skip
+          end;
+        _ ->
+          %% skip the test in mixed version mode
+          {skip, "Should not run in mixed version environments"}
+      end.
 obfuscate_secret(Config, Node, Value) -> 
     {encrypted, _} = Result = rabbit_ct_broker_helpers:rpc(Config, Node, 
         credentials_obfuscation, encrypt, [Value]),


### PR DESCRIPTION
This PR is submitted on behalf of @luos.

## Proposed Changes

This introduces support for `credentials_obfuscation`'s fallback secret. This mechanism
was added for secret rotation and upgrades.

This also moves the moment when the primary secret is set to earlier in the boot process.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

