### PR TITLE
Clients may send duplicate messages when a node is powered down.

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2175,7 +2175,8 @@ deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{ex
                                         msg_seq_no = MsgSeqNo},
                    RoutedToQueueNames = [QName]}, State0 = #ch{queue_states = QueueStates0}) -> %% optimisation when there is one queue
     Qs0 = rabbit_amqqueue:lookup(RoutedToQueueNames),
-    Qs = rabbit_amqqueue:prepend_extra_bcc(Qs0),
+    Qs1 = rabbit_amqqueue:prepend_extra_bcc(Qs0),
+    Qs = lists:filter(fun(Q) -> amqqueue:get_state(Q) =:= live end, Qs1),	
     QueueNames = lists:map(fun amqqueue:get_name/1, Qs),
     case rabbit_queue_type:deliver(Qs, Delivery, QueueStates0) of
         {ok, QueueStates, Actions}  ->
@@ -2212,7 +2213,8 @@ deliver_to_queues({Delivery = #delivery{message    = Message = #basic_message{ex
                                         msg_seq_no = MsgSeqNo},
                    RoutedToQueueNames}, State0 = #ch{queue_states = QueueStates0}) ->
     Qs0 = rabbit_amqqueue:lookup(RoutedToQueueNames),
-    Qs = rabbit_amqqueue:prepend_extra_bcc(Qs0),
+    Qs1 = rabbit_amqqueue:prepend_extra_bcc(Qs0),
+    Qs = lists:filter(fun(Q) -> amqqueue:get_state(Q) =:= live end, Qs1),	
     QueueNames = lists:map(fun amqqueue:get_name/1, Qs),
     case rabbit_queue_type:deliver(Qs, Delivery, QueueStates0) of
         {ok, QueueStates, Actions}  ->


### PR DESCRIPTION
When a message is routed to multiple queues, such as Q1 and Q2, and Q1 status is stopped,
Although Q2 has received the message normally, the broker will still respond to client with NACK.
The client might think that it is failed and will resend the message.
For instance,the oslo-messaging amqp client of openstack will resend the message automatically when NACK is received.
The resending might failed again. so the client may send a large number of duplicate messages.

The queue status may be stopped under the following conditions:
1. The queue status will change to stopped,when its node is powered down.
If there are a large number of queues in the power down node, it will take a long time to delete these queues. Therefore, the stopped queue may last for a period of time before it is deleted.
2. The durable queue status will change to stopped,when its node is powered down.

To reproduce the issue:
1. Build a 3-node cluster, such as node1, node2 and node3.
2. Create a durable node1_q1, bind it with a fanout exchange f_ex1.
3. Create a node2_q1, bind it with f_ex1.   
3. Power down node1, then the node1_q1 status will change to stopped.
4. Publish a message to f_ex1.
   node2_q1 will receive the message normally, while the server will respond to client with NACK, as follows:
   
   2022-05-24 14:47:28.242 0 message(s)  
Traceback (most recent call last):
  File "msg_test.py", line 714, in <module>
    main()
  File "msg_test.py", line 711, in main
    do()
  File "msg_test.py", line 608, in do
    properties=properties_l)
  File "build/bdist.linux-x86_64/egg/pika/adapters/blocking_connection.py", line 2220, in basic_publish
pika.exceptions.NackError: 0 message(s) NACKed

