### PR TITLE
Allow updating config (eg log level) of log exchange

### DIFF
--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -30,8 +30,13 @@ adding_handler(Config) ->
     Config1 = start_setup_proc(Config),
     {ok, Config1}.
 
-changing_config(_SetOrUpdate, OldConfig, _NewConfig) ->
-    {ok, OldConfig}.
+changing_config(_SetOrUpdate, OldConfig, NewConfig) ->
+    %% Keep exchange and setup_proc unchanged in the internal config,
+    %% if they are defined.
+    #{config := OldInternalConfig} = OldConfig,
+    #{config := NewInternalConfig0} = NewConfig,
+    NewInternalConfig = maps:merge(NewInternalConfig0, maps:with([exchange, setup_proc], OldInternalConfig)),
+    {ok, NewConfig#{config := NewInternalConfig}}.
 
 filter_config(Config) ->
     Config.


### PR DESCRIPTION
## Proposed Changes

Before this fix `rabbitmqctl set_log_level <level>` did not change the exchange logger.
Based on Slack discussion: https://rabbitmq.slack.com/archives/C1EDN83PA/p1650880658556919

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
