### PR TITLE
Fix `rabbitmqctl status` when the disk_free cannot be determined

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/information_unit.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/information_unit.ex
@@ -30,12 +30,16 @@ defmodule RabbitMQ.CLI.InformationUnit do
     :rabbit_resource_monitor_misc.parse_information_unit(val)
   end
 
-  def convert(bytes, "bytes") do
+  def convert(bytes, "bytes") when is_number(bytes) do
     bytes
   end
 
-  def convert(bytes, unit) do
+  def convert(bytes, unit) when is_number(bytes) do
     do_convert(bytes, String.downcase(unit))
+  end
+
+  def convert(:unknown, _) do
+    :unknown
   end
 
   def known_unit?(val) do

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -7,6 +7,11 @@ build --//:elixir_home=/Users/rabbitmq/.kiex/elixirs/elixir-1.12.0/lib/elixir
 # adding "--spawn_strategy=local" to the invocation is a workaround
 build --spawn_strategy=local
 
+# --experimental_strict_action_env breaks memory size detection on macOS,
+# so turn it off for local runs
+build --noexperimental_strict_action_env
+build:buildbuddy --experimental_strict_action_env
+
 # don't re-run flakes automatically on the local machine
 build --flaky_test_attempts=1
 


### PR DESCRIPTION
By adjusting RabbitMQ.CLI.InformationUnit to no longer attempt to convert non-numeric values