### PR TITLE
Skip default definitions when definitions are imported using management.load_definitions

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -216,7 +216,9 @@ all_definitions() ->
 
 -spec has_configured_definitions_to_load() -> boolean().
 has_configured_definitions_to_load() ->
-    has_configured_definitions_to_load_via_classic_option() or has_configured_definitions_to_load_via_modern_option().
+    has_configured_definitions_to_load_via_classic_option() or
+        has_configured_definitions_to_load_via_modern_option() or
+        has_configured_definitions_to_load_via_management_option().
 
 %% Retained for backwards compatibility, implicitly assumes the local filesystem source
 maybe_load_definitions(App, Key) ->
@@ -240,6 +242,13 @@ has_configured_definitions_to_load_via_modern_option() ->
 
 has_configured_definitions_to_load_via_classic_option() ->
     case application:get_env(rabbit, load_definitions) of
+        undefined   -> false;
+        {ok, none}  -> false;
+        {ok, _Path} -> true
+    end.
+
+has_configured_definitions_to_load_via_management_option() ->
+    case application:get_env(rabbitmq_management, load_definitions) of
         undefined   -> false;
         {ok, none}  -> false;
         {ok, _Path} -> true


### PR DESCRIPTION
There was a missing condition reported on the mailing list.
If the old-school `management.load_definitions` was used in the config file,
the guest user was still created.

Test case:
1. Start RabbitMQ with any definitions loaded using `management.load_definitions`
2. `rabbitmqctl list_users`
3. Without this PR, `guest` user exists, but it shouldn't