### PR TITLE
Seshat 0.3.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -199,9 +199,9 @@ erlang_package.hex(
     sha256 = "3624feb7a4b78fd9ae0e66cc3158fe7422770ad6987a1ebf8df4d3303b1c4b0c",
 )
 
-erlang_package.git(
-    repository = "rabbitmq/seshat",
-    tag = "0.1.0",
+erlang_package.hex(
+    name = "seshat",
+    version = "0.3.2",
 )
 
 erlang_package.hex(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -130,8 +130,7 @@ erlang_package.hex(
 
 erlang_package.git(
     repository = "rabbitmq/osiris",
-    tag = "v1.2.7",
-    # branch = "main",
+    branch = "main",
     patch_cmds = ["""
 VERSION=$(git rev-parse HEAD)
 echo "Injecting ${VERSION} into Makefile..."

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -147,7 +147,7 @@ PLT_APPS += mnesia
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
 dep_osiris = git https://github.com/rabbitmq/osiris v1.2.7
 dep_systemd = hex 0.6.1
-dep_seshat = git https://github.com/rabbitmq/seshat 0.1.0
+dep_seshat = hex 0.3.2
 
 define usage_xml_to_erl
 $(subst __,_,$(patsubst $(DOCS_DIR)/rabbitmq%.1.xml, src/rabbit_%_usage.erl, $(subst -,_,$(1))))

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -145,7 +145,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.2.7
+dep_osiris = git https://github.com/rabbitmq/osiris main
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.3.2
 

--- a/deps/rabbit/src/rabbit_global_counters.erl
+++ b/deps/rabbit/src/rabbit_global_counters.erl
@@ -186,23 +186,23 @@ init(Labels) ->
     init(Labels, []).
 
 init(Labels = [{protocol, Protocol}, {queue_type, QueueType}], Extra) ->
-    _ = seshat_counters:new_group(?MODULE),
-    Counters = seshat_counters:new(?MODULE, Labels, ?PROTOCOL_QUEUE_TYPE_COUNTERS ++ Extra),
+    _ = seshat:new_group(?MODULE),
+    Counters = seshat:new(?MODULE, Labels, ?PROTOCOL_QUEUE_TYPE_COUNTERS ++ Extra),
     persistent_term:put({?MODULE, Protocol, QueueType}, Counters);
 init(Labels = [{protocol, Protocol}], Extra) ->
-    _ = seshat_counters:new_group(?MODULE),
-    Counters = seshat_counters:new(?MODULE, Labels, ?PROTOCOL_COUNTERS ++ Extra),
+    _ = seshat:new_group(?MODULE),
+    Counters = seshat:new(?MODULE, Labels, ?PROTOCOL_COUNTERS ++ Extra),
     persistent_term:put({?MODULE, Protocol}, Counters);
 init(Labels = [{queue_type, QueueType}, {dead_letter_strategy, DLS}], Extra) ->
-    _ = seshat_counters:new_group(?MODULE),
-    Counters = seshat_counters:new(?MODULE, Labels, ?MESSAGES_DEAD_LETTERED_COUNTERS ++ Extra),
+    _ = seshat:new_group(?MODULE),
+    Counters = seshat:new(?MODULE, Labels, ?MESSAGES_DEAD_LETTERED_COUNTERS ++ Extra),
     persistent_term:put({?MODULE, QueueType, DLS}, Counters).
 
 overview() ->
-    seshat_counters:overview(?MODULE).
+    seshat:overview(?MODULE).
 
 prometheus_format() ->
-    seshat_counters:prometheus_format(?MODULE).
+    seshat:format(?MODULE).
 
 increase_protocol_counter(Protocol, Counter, Num) ->
     counters:add(fetch(Protocol), Counter, Num).

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -209,15 +209,9 @@ erlang_app(
         sha256 = "3624feb7a4b78fd9ae0e66cc3158fe7422770ad6987a1ebf8df4d3303b1c4b0c",
     )
 
-    github_erlang_app(
+    hex_pm_erlang_app(
         name = "seshat",
-        org = "rabbitmq",
-        ref = "0.1.0",
-        version = "0.1.0",
-        extra_apps = [
-            "sasl",
-            "crypto",
-        ],
+        version = "0.3.2",
     )
 
     hex_pm_erlang_app(

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -156,7 +156,7 @@ erlang_app(
 
     git_repository(
         name = "osiris",
-        tag  = "v1.2.7",
+        branch = "main",
         remote = "https://github.com/rabbitmq/osiris.git",
     )
 


### PR DESCRIPTION
Update seshat to use hex 0.3.2 with an updated API.

Also changed uses of `osiris_counters:overview/0` to `osiris_counters:overview/1` where applicable which _may_ address https://github.com/rabbitmq/perf-and-stability/issues/16

https://github.com/rabbitmq/osiris/pull/80

Backports of this PR will also require a new osiris tag.