### PR TITLE
Update Erlang.mk and switch to new xref code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-dist.mk \
 
 DISABLE_DISTCLEAN = 1
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
+XREF_SCOPE = app deps
+XREF_EXTRA_APP_DIRS = $(filter-out deps/rabbitmq_cli/_build/dev/lib/rabbit_common/,$(wildcard deps/rabbitmq_cli/_build/dev/lib/*/)) deps/rabbit/apps/rabbitmq_prelaunch/
 
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
+# Include Elixir libraries in the Xref checks.
+xref: ERL_LIBS := $(ERL_LIBS):$(CURDIR)/apps:$(CURDIR)/deps:$(dir $(shell elixir --eval ":io.format '~s~n', [:code.lib_dir :elixir ]"))
 
 ifneq ($(wildcard deps/.hex/cache.erl),)
 deps:: restore-hex-cache-ets-file

--- a/deps/amqp_client/Makefile
+++ b/deps/amqp_client/Makefile
@@ -53,8 +53,6 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 
 PLT_APPS = ssl public_key
 
-WITHOUT = plugins/proper
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -164,12 +164,6 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 	      rabbit_common/mk/rabbitmq-test.mk \
 	      rabbit_common/mk/rabbitmq-tools.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 

--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -47,8 +47,6 @@ DEP_PLUGINS = $(PROJECT)/mk/rabbitmq-build.mk \
 	      $(PROJECT)/mk/rabbitmq-test.mk \
 	      $(PROJECT)/mk/rabbitmq-tools.mk
 
-WITHOUT = plugins/proper
-
 PLT_APPS += mnesia crypto ssl
 
 include ../../rabbitmq-components.mk

--- a/deps/rabbitmq_amqp1_0/Makefile
+++ b/deps/rabbitmq_amqp1_0/Makefile
@@ -23,12 +23,6 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 .DEFAULT_GOAL = all
 $(PROJECT).d:: $(EXTRA_SOURCES)
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 

--- a/deps/rabbitmq_auth_backend_cache/Makefile
+++ b/deps/rabbitmq_auth_backend_cache/Makefile
@@ -22,11 +22,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_auth_backend_http/Makefile
+++ b/deps/rabbitmq_auth_backend_http/Makefile
@@ -25,11 +25,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers cowboy
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_auth_backend_ldap/Makefile
+++ b/deps/rabbitmq_auth_backend_ldap/Makefile
@@ -42,11 +42,5 @@ dep_ct_helper = git https://github.com/extend/ct_helper.git master
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -11,11 +11,5 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 dep_jose = git https://github.com/potatosalad/erlang-jose 2b1d66b
 dep_base64url = hex 1.0.1
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_auth_mechanism_ssl/Makefile
+++ b/deps/rabbitmq_auth_mechanism_ssl/Makefile
@@ -17,11 +17,5 @@ DEPS = rabbit_common rabbit
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_aws/Makefile
+++ b/deps/rabbitmq_aws/Makefile
@@ -12,11 +12,5 @@ BUILD_DEPS = rabbit_common
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 TEST_DEPS = meck
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -21,19 +21,6 @@ ifeq ($(VERBOSE_TEST),true)
 MIX_TEST := $(MIX_TEST) --trace
 endif
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
-WITHOUT = plugins/cover \
-	  plugins/ct \
-	  plugins/dialyzer \
-	  plugins/eunit \
-	  plugins/proper \
-	  plugins/triq
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 

--- a/deps/rabbitmq_consistent_hash_exchange/Makefile
+++ b/deps/rabbitmq_consistent_hash_exchange/Makefile
@@ -11,11 +11,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_ct_client_helpers/Makefile
+++ b/deps/rabbitmq_ct_client_helpers/Makefile
@@ -3,12 +3,6 @@ PROJECT_DESCRIPTION = Common Test helpers for RabbitMQ (client-side helpers)
 
 DEPS = rabbit_common rabbitmq_ct_helpers amqp_client
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 	      rabbit_common/mk/rabbitmq-tools.mk
 

--- a/deps/rabbitmq_ct_helpers/Makefile
+++ b/deps/rabbitmq_ct_helpers/Makefile
@@ -8,12 +8,6 @@ dep_rabbit_common  = git-subfolder https://github.com/rabbitmq/rabbitmq-server m
 dep_rabbit         = git-subfolder https://github.com/rabbitmq/rabbitmq-server master deps/rabbit
 dep_inet_tcp_proxy = git https://github.com/rabbitmq/inet_tcp_proxy master
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 	      rabbit_common/mk/rabbitmq-dist.mk \
 	      rabbit_common/mk/rabbitmq-run.mk \

--- a/deps/rabbitmq_event_exchange/Makefile
+++ b/deps/rabbitmq_event_exchange/Makefile
@@ -11,10 +11,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_federation/Makefile
+++ b/deps/rabbitmq_federation/Makefile
@@ -19,11 +19,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_federation_management/Makefile
+++ b/deps/rabbitmq_federation_management/Makefile
@@ -11,11 +11,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_jms_topic_exchange/Makefile
+++ b/deps/rabbitmq_jms_topic_exchange/Makefile
@@ -7,11 +7,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -31,12 +31,6 @@ BUILD_DEPS += ranch
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 

--- a/deps/rabbitmq_management_agent/Makefile
+++ b/deps/rabbitmq_management_agent/Makefile
@@ -23,12 +23,6 @@ LOCAL_DEPS += xmerl mnesia ranch ssl crypto public_key
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 TEST_DEPS := $(filter-out rabbitmq_test,$(TEST_DEPS))
 include ../../erlang.mk

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -40,12 +40,6 @@ dep_emqttc = git https://github.com/rabbitmq/emqttc.git remove-logging
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 

--- a/deps/rabbitmq_peer_discovery_aws/Makefile
+++ b/deps/rabbitmq_peer_discovery_aws/Makefile
@@ -9,11 +9,5 @@ dep_ct_helper = git https://github.com/extend/ct_helper.git master
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_peer_discovery_common/Makefile
+++ b/deps/rabbitmq_peer_discovery_common/Makefile
@@ -10,11 +10,5 @@ dep_ct_helper = git https://github.com/extend/ct_helper.git master
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_peer_discovery_consul/Makefile
+++ b/deps/rabbitmq_peer_discovery_consul/Makefile
@@ -9,11 +9,5 @@ dep_ct_helper = git https://github.com/extend/ct_helper.git master
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_peer_discovery_etcd/Makefile
+++ b/deps/rabbitmq_peer_discovery_etcd/Makefile
@@ -11,11 +11,5 @@ dep_eetcd = hex 0.3.5
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_peer_discovery_k8s/Makefile
+++ b/deps/rabbitmq_peer_discovery_k8s/Makefile
@@ -9,11 +9,5 @@ dep_ct_helper = git https://github.com/extend/ct_helper.git master
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_prometheus/Makefile
+++ b/deps/rabbitmq_prometheus/Makefile
@@ -15,12 +15,6 @@ EUNIT_OPTS = no_tty, {report, {eunit_progress, [colored, profile]}}
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 ifneq ($(DISABLE_METRICS_COLLECTOR),)
 RABBITMQ_CONFIG_FILE = $(CURDIR)/rabbitmq-disable-metrics-collector.conf
 export RABBITMQ_CONFIG_FILE

--- a/deps/rabbitmq_random_exchange/Makefile
+++ b/deps/rabbitmq_random_exchange/Makefile
@@ -7,11 +7,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_recent_history_exchange/Makefile
+++ b/deps/rabbitmq_recent_history_exchange/Makefile
@@ -11,11 +11,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_sharding/Makefile
+++ b/deps/rabbitmq_sharding/Makefile
@@ -11,11 +11,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_shovel/Makefile
+++ b/deps/rabbitmq_shovel/Makefile
@@ -29,12 +29,5 @@ DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk elvis_mk
 dep_elvis_mk = git https://github.com/inaka/elvis.mk.git master
 
-
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_shovel_management/Makefile
+++ b/deps/rabbitmq_shovel_management/Makefile
@@ -11,11 +11,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_amqp1_0
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_stomp/Makefile
+++ b/deps/rabbitmq_stomp/Makefile
@@ -36,11 +36,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_stream/Makefile
+++ b/deps/rabbitmq_stream/Makefile
@@ -27,11 +27,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_stream_common/Makefile
+++ b/deps/rabbitmq_stream_common/Makefile
@@ -14,11 +14,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_stream_management/Makefile
+++ b/deps/rabbitmq_stream_management/Makefile
@@ -14,11 +14,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_top/Makefile
+++ b/deps/rabbitmq_top/Makefile
@@ -11,11 +11,5 @@ DEPS = rabbit_common rabbit amqp_client rabbitmq_management
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_tracing/Makefile
+++ b/deps/rabbitmq_tracing/Makefile
@@ -20,11 +20,5 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_trust_store/Makefile
+++ b/deps/rabbitmq_trust_store/Makefile
@@ -19,11 +19,5 @@ dep_trust_store_http = git https://github.com/rabbitmq/trust_store_http.git
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_web_dispatch/Makefile
+++ b/deps/rabbitmq_web_dispatch/Makefile
@@ -15,12 +15,6 @@ dep_cowboy = hex 2.0.0
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 TEST_DEPS := $(filter-out rabbitmq_test,$(TEST_DEPS))
 include ../../erlang.mk

--- a/deps/rabbitmq_web_mqtt/Makefile
+++ b/deps/rabbitmq_web_mqtt/Makefile
@@ -23,11 +23,5 @@ BUILD_DEPS += ranch
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_web_mqtt_examples/Makefile
+++ b/deps/rabbitmq_web_mqtt_examples/Makefile
@@ -13,11 +13,5 @@ DEPS = rabbit_common rabbit rabbitmq_web_dispatch rabbitmq_web_mqtt
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_web_stomp/Makefile
+++ b/deps/rabbitmq_web_stomp/Makefile
@@ -29,11 +29,5 @@ BUILD_DEPS += ranch
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_web_stomp_examples/Makefile
+++ b/deps/rabbitmq_web_stomp_examples/Makefile
@@ -13,11 +13,5 @@ DEPS = rabbit_common rabbit rabbitmq_web_dispatch rabbitmq_web_stomp
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
-# reviewed and merged.
-
-ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
-ERLANG_MK_COMMIT = rabbitmq-tmp
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/erlang.mk
+++ b/erlang.mk
@@ -17,7 +17,7 @@
 ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 export ERLANG_MK_FILENAME
 
-ERLANG_MK_VERSION = 2019.07.01-53-gd80984c
+ERLANG_MK_VERSION = 2022.05.31-4-ga310407-dirty
 ERLANG_MK_WITHOUT = 
 
 # Make 3.81 and 3.82 are deprecated.
@@ -2735,7 +2735,7 @@ pkg_mochiweb_description = MochiWeb is an Erlang library for building lightweigh
 pkg_mochiweb_homepage = https://github.com/mochi/mochiweb
 pkg_mochiweb_fetch = git
 pkg_mochiweb_repo = https://github.com/mochi/mochiweb
-pkg_mochiweb_commit = master
+pkg_mochiweb_commit = main
 
 PACKAGES += mochiweb_xpath
 pkg_mochiweb_xpath_name = mochiweb_xpath
@@ -3391,7 +3391,7 @@ pkg_relx_description = Sane, simple release creation for Erlang
 pkg_relx_homepage = https://github.com/erlware/relx
 pkg_relx_fetch = git
 pkg_relx_repo = https://github.com/erlware/relx
-pkg_relx_commit = master
+pkg_relx_commit = main
 
 PACKAGES += resource_discovery
 pkg_resource_discovery_name = resource_discovery
@@ -4959,9 +4959,12 @@ endef
 define dep_autopatch_appsrc_script.erl
 	AppSrc = "$(call core_native_path,$(DEPS_DIR)/$1/src/$1.app.src)",
 	AppSrcScript = AppSrc ++ ".script",
-	{ok, Conf0} = file:consult(AppSrc),
+	Conf1 = case file:consult(AppSrc) of
+		{ok, Conf0} -> Conf0;
+		{error, enoent} -> []
+	end,
 	Bindings0 = erl_eval:new_bindings(),
-	Bindings1 = erl_eval:add_binding('CONFIG', Conf0, Bindings0),
+	Bindings1 = erl_eval:add_binding('CONFIG', Conf1, Bindings0),
 	Bindings = erl_eval:add_binding('SCRIPT', AppSrcScript, Bindings1),
 	Conf = case file:script(AppSrcScript, Bindings) of
 		{ok, [C]} -> C;
@@ -5829,6 +5832,8 @@ endef
 
 define bs_relx_config
 {release, {$p_release, "1"}, [$p, sasl, runtime_tools]}.
+{dev_mode, false}.
+{include_erts, true}.
 {extended_start_script, true}.
 {sys_config, "config/sys.config"}.
 {vm_args, "config/vm.args"}.
@@ -6185,6 +6190,8 @@ endif
 	$(verbose) mkdir config/
 	$(verbose) $(call core_render,bs_sys_config,config/sys.config)
 	$(verbose) $(call core_render,bs_vm_args,config/vm.args)
+	$(verbose) awk '/^include erlang.mk/ && !ins {print "BUILD_DEPS += relx";ins=1};{print}' Makefile > Makefile.bak
+	$(verbose) mv Makefile.bak Makefile
 
 new-app:
 ifndef in
@@ -7460,27 +7467,19 @@ endif
 # Copyright (c) 2013-2016, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
+ifeq ($(filter relx,$(BUILD_DEPS) $(DEPS) $(REL_DEPS)),relx)
 .PHONY: relx-rel relx-relup distclean-relx-rel run
 
 # Configuration.
 
-RELX ?= $(ERLANG_MK_TMP)/relx
 RELX_CONFIG ?= $(CURDIR)/relx.config
 
-RELX_URL ?= https://erlang.mk/res/relx-v3.27.0
-RELX_OPTS ?=
 RELX_OUTPUT_DIR ?= _rel
 RELX_REL_EXT ?=
 RELX_TAR ?= 1
 
 ifdef SFX
 	RELX_TAR = 1
-endif
-
-ifeq ($(firstword $(RELX_OPTS)),-o)
-	RELX_OUTPUT_DIR = $(word 2,$(RELX_OPTS))
-else
-	RELX_OPTS += -o $(RELX_OUTPUT_DIR)
 endif
 
 # Core targets.
@@ -7497,21 +7496,59 @@ distclean:: distclean-relx-rel
 
 # Plugin-specific targets.
 
-$(RELX): | $(ERLANG_MK_TMP)
-	$(gen_verbose) $(call core_http_get,$(RELX),$(RELX_URL))
-	$(verbose) chmod +x $(RELX)
+define relx_release.erl
+	{ok, Config} = file:consult("$(call core_native_path,$(RELX_CONFIG))"),
+	{release, {Name, Vsn0}, _} = lists:keyfind(release, 1, Config),
+	Vsn = case Vsn0 of
+		{cmd, Cmd} -> os:cmd(Cmd);
+		semver -> "";
+		{semver, _} -> "";
+		VsnStr -> Vsn0
+	end,
+	{ok, _} = relx:build_release(#{name => Name, vsn => Vsn}, Config),
+	halt(0).
+endef
 
-relx-rel: $(RELX) rel-deps app
-	$(verbose) $(RELX) $(if $(filter 1,$V),-V 3) -c $(RELX_CONFIG) $(RELX_OPTS) release
+define relx_tar.erl
+	{ok, Config} = file:consult("$(call core_native_path,$(RELX_CONFIG))"),
+	{release, {Name, Vsn0}, _} = lists:keyfind(release, 1, Config),
+	Vsn = case Vsn0 of
+		{cmd, Cmd} -> os:cmd(Cmd);
+		semver -> "";
+		{semver, _} -> "";
+		VsnStr -> Vsn0
+	end,
+	{ok, _} = relx:build_tar(#{name => Name, vsn => Vsn}, Config),
+	halt(0).
+endef
+
+define relx_relup.erl
+	{ok, Config} = file:consult("$(call core_native_path,$(RELX_CONFIG))"),
+	{release, {Name, Vsn0}, _} = lists:keyfind(release, 1, Config),
+	Vsn = case Vsn0 of
+		{cmd, Cmd} -> os:cmd(Cmd);
+		semver -> "";
+		{semver, _} -> "";
+		VsnStr -> Vsn0
+	end,
+	{ok, _} = relx:build_relup(Name, Vsn, undefined, Config ++ [{output_dir, "$(RELX_OUTPUT_DIR)"}]),
+	halt(0).
+endef
+
+relx-rel: rel-deps app
+	$(call erlang,$(call relx_release.erl),-pa ebin/)
 	$(verbose) $(MAKE) relx-post-rel
 ifeq ($(RELX_TAR),1)
-	$(verbose) $(RELX) $(if $(filter 1,$V),-V 3) -c $(RELX_CONFIG) $(RELX_OPTS) tar
+	$(call erlang,$(call relx_tar.erl),-pa ebin/)
 endif
 
-relx-relup: $(RELX) rel-deps app
-	$(verbose) $(RELX) $(if $(filter 1,$V),-V 3) -c $(RELX_CONFIG) $(RELX_OPTS) release
+relx-relup: rel-deps app
+	$(call erlang,$(call relx_release.erl),-pa ebin/)
 	$(MAKE) relx-post-rel
-	$(verbose) $(RELX) $(if $(filter 1,$V),-V 3) -c $(RELX_CONFIG) $(RELX_OPTS) relup $(if $(filter 1,$(RELX_TAR)),tar)
+	$(call erlang,$(call relx_relup.erl),-pa ebin/)
+ifeq ($(RELX_TAR),1)
+	$(call erlang,$(call relx_tar.erl),-pa ebin/)
+endif
 
 distclean-relx-rel:
 	$(gen_verbose) rm -rf $(RELX_OUTPUT_DIR)
@@ -7567,6 +7604,7 @@ help::
 		"Relx targets:" \
 		"  run         Compile the project, build the release and run it"
 
+endif
 endif
 
 # Copyright (c) 2015-2016, Loïc Hoguin <essen@ninenines.eu>
@@ -7739,45 +7777,223 @@ triq: test-build cover-data-dir
 endif
 endif
 
-# Copyright (c) 2016, Loïc Hoguin <essen@ninenines.eu>
-# Copyright (c) 2015, Erlang Solutions Ltd.
+# Copyright (c) 2022, Loïc Hoguin <essen@ninenines.eu>
 # This file is part of erlang.mk and subject to the terms of the ISC License.
 
-.PHONY: xref distclean-xref
+.PHONY: xref
 
 # Configuration.
 
-ifeq ($(XREF_CONFIG),)
-	XREFR_ARGS :=
-else
-	XREFR_ARGS := -c $(XREF_CONFIG)
-endif
+# We do not use locals_not_used or deprecated_function_calls
+# because the compiler will error out by default in those
+# cases with Erlang.mk. Deprecated functions may make sense
+# in some cases but few libraries define them. We do not
+# use exports_not_used by default because it hinders more
+# than it helps library projects such as Cowboy. Finally,
+# undefined_functions provides little that undefined_function_calls
+# doesn't already provide, so it's not enabled by default.
+XREF_CHECKS ?= [undefined_function_calls]
 
-XREFR ?= $(CURDIR)/xrefr
-export XREFR
+# Instead of predefined checks a query can be evaluated
+# using the Xref DSL. The $q variable is used in that case.
 
-XREFR_URL ?= https://github.com/inaka/xref_runner/releases/download/1.1.0/xrefr
+# The scope is a list of keywords that correspond to
+# application directories, being essentially an easy way
+# to configure which applications to analyze. With:
+#
+# - app:  .
+# - apps: $(ALL_APPS_DIRS)
+# - deps: $(ALL_DEPS_DIRS)
+# - otp:  Built-in Erlang/OTP applications.
+#
+# The default is conservative (app) and will not be
+# appropriate for all types of queries (for example
+# application_call requires adding all applications
+# that might be called or they will not be found).
+XREF_SCOPE ?= app # apps deps otp
+
+# If the above is not enough, additional application
+# directories can be configured.
+XREF_EXTRA_APP_DIRS ?=
+
+# As well as additional non-application directories.
+XREF_EXTRA_DIRS ?=
+
+# Erlang.mk supports -ignore_xref([...]) with forms
+# {M, F, A} | {F, A} | M, the latter ignoring whole
+# modules. Ignores can also be provided project-wide.
+XREF_IGNORE ?= []
+
+# All callbacks may be ignored. Erlang.mk will ignore
+# them automatically for exports_not_used (unless it
+# is explicitly disabled by the user).
+XREF_IGNORE_CALLBACKS ?=
 
 # Core targets.
 
 help::
 	$(verbose) printf '%s\n' '' \
 		'Xref targets:' \
-		'  xref        Run Xrefr using $$XREF_CONFIG as config file if defined'
-
-distclean:: distclean-xref
+		'  xref         Analyze the project using Xref' \
+		'  xref q=QUERY Evaluate an Xref query'
 
 # Plugin-specific targets.
 
-$(XREFR):
-	$(gen_verbose) $(call core_http_get,$(XREFR),$(XREFR_URL))
-	$(verbose) chmod +x $(XREFR)
+define xref.erl
+	{ok, Xref} = xref:start([]),
+	Scope = [$(call comma_list,$(XREF_SCOPE))],
+	AppDirs0 = [$(call comma_list,$(foreach d,$(XREF_EXTRA_APP_DIRS),"$d"))],
+	AppDirs1 = case lists:member(otp, Scope) of
+		false -> AppDirs0;
+		true ->
+			RootDir = code:root_dir(),
+			AppDirs0 ++ [filename:dirname(P) || P <- code:get_path(), lists:prefix(RootDir, P)]
+	end,
+	AppDirs2 = case lists:member(deps, Scope) of
+		false -> AppDirs1;
+		true -> [$(call comma_list,$(foreach d,$(ALL_DEPS_DIRS),"$d"))] ++ AppDirs1
+	end,
+	AppDirs3 = case lists:member(apps, Scope) of
+		false -> AppDirs2;
+		true -> [$(call comma_list,$(foreach d,$(ALL_APPS_DIRS),"$d"))] ++ AppDirs2
+	end,
+	AppDirs = case lists:member(app, Scope) of
+		false -> AppDirs3;
+		true -> ["../$(notdir $(CURDIR))"|AppDirs3]
+	end,
+	[{ok, _} = xref:add_application(Xref, AppDir, [{builtins, true}]) || AppDir <- AppDirs],
+	ExtraDirs = [$(call comma_list,$(foreach d,$(XREF_EXTRA_DIRS),"$d"))],
+	[{ok, _} = xref:add_directory(Xref, ExtraDir, [{builtins, true}]) || ExtraDir <- ExtraDirs],
+	ok = xref:set_library_path(Xref, code:get_path() -- (["ebin", "."] ++ AppDirs ++ ExtraDirs)),
+	Checks = case {$1, is_list($2)} of
+		{check, true} -> $2;
+		{check, false} -> [$2];
+		{query, _} -> [$2]
+	end,
+	FinalRes = [begin
+		IsInformational = case $1 of
+			query -> true;
+			check ->
+				is_tuple(Check) andalso
+					lists:member(element(1, Check),
+						[call, use, module_call, module_use, application_call, application_use])
+		end,
+		{ok, Res0} = case $1 of
+			check -> xref:analyze(Xref, Check);
+			query -> xref:q(Xref, Check)
+		end,
+		Res = case IsInformational of
+			true -> Res0;
+			false ->
+				lists:filter(fun(R) ->
+					{Mod, MFA} = case R of
+						{MFA0 = {M, _, _}, _} -> {M, MFA0};
+						{M, _, _} -> {M, R}
+					end,
+					Attrs = try
+						Mod:module_info(attributes)
+					catch error:undef ->
+						[]
+					end,
+					InlineIgnores = lists:flatten([
+						[case V of
+							M when is_atom(M) -> {M, '_', '_'};
+							{F, A} -> {Mod, F, A};
+							_ -> V
+						end || V <- Values]
+					|| {ignore_xref, Values} <- Attrs]),
+					BuiltinIgnores = [
+						{eunit_test, wrapper_test_exported_, 0}
+					],
+					DoCallbackIgnores = case {Check, "$(strip $(XREF_IGNORE_CALLBACKS))"} of
+						{exports_not_used, ""} -> true;
+						{_, "0"} -> false;
+						_ -> true
+					end,
+					CallbackIgnores = case DoCallbackIgnores of
+						false -> [];
+						true ->
+							Behaviors = lists:flatten([
+								[BL || {behavior, BL} <- Attrs],
+								[BL || {behaviour, BL} <- Attrs]
+							]),
+							[{Mod, CF, CA} || B <- Behaviors, {CF, CA} <- B:behaviour_info(callbacks)]
+					end,
+					WideIgnores = if
+						is_list($(XREF_IGNORE)) ->
+							[if is_atom(I) -> {I, '_', '_'}; true -> I end
+								|| I <- $(XREF_IGNORE)];
+						true -> [$(XREF_IGNORE)]
+					end,
+					Ignores = InlineIgnores ++ BuiltinIgnores ++ CallbackIgnores ++ WideIgnores,
+					not (lists:member(MFA, Ignores)
+					orelse lists:member({Mod, '_', '_'}, Ignores))
+				end, Res0)
+		end,
+		case Res of
+			[] -> ok;
+			_ when IsInformational ->
+				case Check of
+					{call, {CM, CF, CA}} ->
+						io:format("Functions that ~s:~s/~b calls:~n", [CM, CF, CA]);
+					{use, {CM, CF, CA}} ->
+						io:format("Function ~s:~s/~b is called by:~n", [CM, CF, CA]);
+					{module_call, CMod} ->
+						io:format("Modules that ~s calls:~n", [CMod]);
+					{module_use, CMod} ->
+						io:format("Module ~s is used by:~n", [CMod]);
+					{application_call, CApp} ->
+						io:format("Applications that ~s calls:~n", [CApp]);
+					{application_use, CApp} ->
+						io:format("Application ~s is used by:~n", [CApp]);
+					_ when $1 =:= query ->
+						io:format("Query ~s returned:~n", [Check])
+				end,
+				[case R of
+					{{InM, InF, InA}, {M, F, A}} ->
+						io:format("- ~s:~s/~b called by ~s:~s/~b~n",
+							[M, F, A, InM, InF, InA]);
+					{M, F, A} ->
+						io:format("- ~s:~s/~b~n", [M, F, A]);
+					ModOrApp ->
+						io:format("- ~s~n", [ModOrApp])
+				end || R <- Res],
+				ok;
+			_ ->
+				[case {Check, R} of
+					{undefined_function_calls, {{InM, InF, InA}, {M, F, A}}} ->
+						io:format("Undefined function ~s:~s/~b called by ~s:~s/~b~n",
+							[M, F, A, InM, InF, InA]);
+					{undefined_functions, {M, F, A}} ->
+						io:format("Undefined function ~s:~s/~b~n", [M, F, A]);
+					{locals_not_used, {M, F, A}} ->
+						io:format("Unused local function ~s:~s/~b~n", [M, F, A]);
+					{exports_not_used, {M, F, A}} ->
+						io:format("Unused exported function ~s:~s/~b~n", [M, F, A]);
+					{deprecated_function_calls, {{InM, InF, InA}, {M, F, A}}} ->
+						io:format("Deprecated function ~s:~s/~b called by ~s:~s/~b~n",
+							[M, F, A, InM, InF, InA]);
+					{deprecated_functions, {M, F, A}} ->
+						io:format("Deprecated function ~s:~s/~b~n", [M, F, A]);
+					_ ->
+						io:format("~p: ~p~n", [Check, R])
+				end || R <- Res],
+				error
+		end
+	end || Check <- Checks],
+	stopped = xref:stop(Xref),
+	case lists:usort(FinalRes) of
+		[ok] -> halt(0);
+		_ -> halt(1)
+	end
+endef
 
-xref: deps app $(XREFR)
-	$(gen_verbose) $(XREFR) $(XREFR_ARGS)
-
-distclean-xref:
-	$(gen_verbose) rm -rf $(XREFR)
+xref: deps app
+ifdef q
+	$(verbose) $(call erlang,$(call xref.erl,query,"$q"),-pa ebin/)
+else
+	$(verbose) $(call erlang,$(call xref.erl,check,$(XREF_CHECKS)),-pa ebin/)
+endif
 
 # Copyright (c) 2016, Loïc Hoguin <essen@ninenines.eu>
 # Copyright (c) 2015, Viktor Söderqvist <viktor@zuiderkwast.se>


### PR DESCRIPTION
## Proposed Changes

This updates Erlang.mk and switches to the new xref functionality. When running `make xref` on the full repository we get the following warnings currently:

```
Undefined function Elixir.CSV.Encode.Atom:__impl__/1 called by Elixir.CSV.Encode:impl_for/1
Undefined function Elixir.CSV.Encode.Float:__impl__/1 called by Elixir.CSV.Encode:impl_for/1
Undefined function Elixir.CSV.Encode.Function:__impl__/1 called by Elixir.CSV.Encode:impl_for/1
Undefined function Elixir.CSV.Encode.Integer:__impl__/1 called by Elixir.CSV.Encode:impl_for/1
Undefined function Elixir.CSV.Encode.Port:__impl__/1 called by Elixir.CSV.Encode:impl_for/1
Undefined function Elixir.CSV.Encode.Reference:__impl__/1 called by Elixir.CSV.Encode:impl_for/1
Undefined function Elixir.JSON.Decoder.Atom:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Float:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Function:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Integer:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Map:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.PID:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Port:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Reference:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Decoder.Tuple:__impl__/1 called by Elixir.JSON.Decoder:impl_for/1
Undefined function Elixir.JSON.Encoder.Function:__impl__/1 called by Elixir.JSON.Encoder:impl_for/1
Undefined function Elixir.JSON.Encoder.PID:__impl__/1 called by Elixir.JSON.Encoder:impl_for/1
Undefined function Elixir.JSON.Encoder.Port:__impl__/1 called by Elixir.JSON.Encoder:impl_for/1
Undefined function Elixir.JSON.Encoder.Reference:__impl__/1 called by Elixir.JSON.Encoder:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Float:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Function:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Integer:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Map:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.PID:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Port:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Reference:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function Elixir.RabbitMQ.CLI.Core.DataCoercion.Tuple:__impl__/1 called by Elixir.RabbitMQ.CLI.Core.DataCoercion:impl_for/1
Undefined function os:list_env_vars/0 called by rabbit_env:env_vars/0
Undefined function credentials_obfuscation:set_fallback_secret/1 called by rabbit_prelaunch_dist:set_credentials_obfuscation_secret/0
```

There's probably something I need to figure out around this `__impl__/1` Elixir stuff. The other two can be fixed by adding `-ignore_xref`.

Some interesting usage:

```
$ make xref XREF_CHECKS="{application_use,rabbit}"
Application rabbit is used by:
- rabbit
- rabbitmq_amqp1_0
- rabbitmq_auth_backend_ldap
- rabbitmq_auth_mechanism_ssl
- rabbitmq_consistent_hash_exchange
- rabbitmq_event_exchange
- rabbitmq_federation
- rabbitmq_jms_topic_exchange
- rabbitmq_management
- rabbitmq_management_agent
- rabbitmq_mqtt
- rabbitmq_peer_discovery_aws
- rabbitmq_peer_discovery_common
- rabbitmq_peer_discovery_consul
- rabbitmq_peer_discovery_k8s
- rabbitmq_prometheus
- rabbitmq_random_exchange
- rabbitmq_recent_history_exchange
- rabbitmq_sharding
- rabbitmq_shovel
- rabbitmq_stomp
- rabbitmq_stream
- rabbitmq_stream_management
- rabbitmq_tracing
- rabbitmq_trust_store
- rabbitmq_web_dispatch
- rabbitmq_web_mqtt
- rabbitmq_web_stomp
- rabbitmqctl
```

Another:

```
$ make xref XREF_CHECKS="{module_use,file_handle_cache}"
Module file_handle_cache is used by:
- file_handle_cache
- rabbit
- rabbit_amqqueue
- rabbit_amqqueue_process
- rabbit_classic_queue_index_v2
- rabbit_fhc_helpers
- rabbit_file
- rabbit_mgmt_external_stats
- rabbit_mirror_queue_slave
- rabbit_mirror_queue_sync
- rabbit_msg_file
- rabbit_msg_store
- rabbit_msg_store_gc
- rabbit_networking
- rabbit_queue_index
- rabbit_quorum_queue
- rabbit_web_mqtt_handler
- rabbit_web_stomp_handler
- worker_pool_worker
```

## Types of Changes

- [x] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
