### PR TITLE
Add custom consult code to rabbit_prelaunch_file module

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
@@ -46,6 +46,12 @@ dialyze(
     warnings_as_errors = False,
 )
 
-rabbitmq_suite(
-    name = "rabbit_logger_std_h_SUITE",
-)
+suites = [
+    rabbitmq_suite(
+        name = "rabbit_logger_std_h_SUITE",
+    ),
+    rabbitmq_suite(
+        name = "rabbit_prelaunch_file_SUITE",
+        size = "small",
+    ),
+]

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_logger_fmt_helpers.erl
@@ -132,8 +132,8 @@ level_4letter_uc_name(emergency) -> "EMGC".
 format_msg(Msg, Meta, #{single_line := true} = Config) ->
       FormattedMsg = format_msg1(Msg, Meta, Config),
       %% The following behavior is the same as the one in the official
-      %% `logger_formatter'; the code is taken from that module (as of
-      %% c5ed910098e9c2787e2c3f9f462c84322064e00d in the master branch).
+      %% `logger_formatter'; the code is taken from:
+      %% https://github.com/erlang/otp/blob/c5ed910098e9c2787e2c3f9f462c84322064e00d/lib/kernel/src/logger_formatter.erl
       FormattedMsg1 = string:strip(FormattedMsg, both),
       re:replace(
         FormattedMsg1,

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -201,7 +201,7 @@ determine_config_format(File) ->
         0 ->
             cuttlefish;
         _ ->
-            case file:consult(File) of
+            case rabbit_prelaunch_file:consult_file(File) of
                 {ok, _} -> erlang;
                 _       -> cuttlefish
             end
@@ -384,7 +384,7 @@ override_with_advanced_config(Config, AdvancedConfigFile) ->
       "Override with advanced configuration file \"~ts\"",
       [AdvancedConfigFile],
       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
-    case file:consult(AdvancedConfigFile) of
+    case rabbit_prelaunch_file:consult_file(AdvancedConfigFile) of
         {ok, [AdvancedConfig]} ->
             cuttlefish_advanced:overlay(Config, AdvancedConfig);
         {ok, OtherTerms} ->

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_file.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_file.erl
@@ -1,0 +1,95 @@
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% Copyright Ericsson AB 2011-2022. All Rights Reserved.
+%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+%% This code originated here and has been modified to suit RabbitMQ:
+%% https://github.com/erlang/otp/blob/2d43af53899d35423f1c83887026089c91bce010/lib/ssl/src/ssl_dist_sup.erl
+%%
+
+-module(rabbit_prelaunch_file).
+
+-export([consult_file/1, consult_string/1]).
+
+%%
+%% consult_file/consult_string API
+%%
+
+-spec consult_file(atom() | string()) ->
+    {'error',{'badfile',atom() | string() | {_,_} | {'scan_error',{_,_,_},non_neg_integer() | {_,_}}}} | {'ok',_}.
+consult_file(Path) ->
+    case erl_prim_loader:get_file(Path) of
+        {ok, Binary, _FullName} ->
+            Encoding =
+                case epp:read_encoding_from_binary(Binary) of
+                    none ->
+                        latin1;
+                    Enc ->
+                        Enc
+                end,
+            case unicode:characters_to_list(Binary, Encoding) of
+                {error, _String, Rest} ->
+                    {error, {badfile, {encoding_error, Rest}}};
+                {incomplete, _String, Rest} ->
+                    {error, {badfile, {encoding_incomplete, Rest}}};
+                String when is_list(String) ->
+                    consult_string(String)
+            end;
+        error ->
+            {error, {badfile, Path}}
+    end.
+
+-spec consult_string(string()) ->
+    {'error',{'badfile',{_,_} | {'scan_error',{_,_,_},non_neg_integer() | {_,_}}}} | {'ok',_}.
+consult_string(String) ->
+    case erl_scan:string(String) of
+        {error, Info, Location} ->
+            {error, {badfile, {scan_error, Info, Location}}};
+        {ok, Tokens, _EndLocation} ->
+            consult_tokens(Tokens)
+    end.
+
+%%
+%% consult_file / consult_string implementation
+%%
+
+consult_tokens(Tokens) ->
+    case erl_parse:parse_exprs(Tokens) of
+        {error, Info} ->
+            {error, {badfile, {parse_error, Info}}};
+        {ok, [Expr]} ->
+            consult_expression(Expr);
+        {ok, Other} ->
+            {error, {badfile, {parse_error, Other}}}
+    end.
+
+consult_expression(Expr) ->
+    Result = try
+            erl_eval:expr(Expr, erl_eval:new_bindings())
+        catch
+            Class:Error0 ->
+                {error, {badfile, {Class, Error0}}}
+        end,
+    case Result of
+        {value, Value, Bs} ->
+            case erl_eval:bindings(Bs) of
+                [] ->
+                    {ok, [Value]};
+                Other ->
+                    {error, {badfile, {bindings, Other}}}
+            end;
+        Error1 ->
+            Error1
+    end.
+

--- a/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE.erl
@@ -1,0 +1,82 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_prelaunch_file_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [{group, tests}].
+
+all_tests() ->
+    [consult_advanced_config, consult_rabbitmq_config, consult_badfile].
+
+groups() ->
+    [{tests, [], all_tests()}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+consult_advanced_config(Config) ->
+    MatchFun = public_key:pkix_verify_hostname_match_fun(https),
+    AdvancedConfigPath =
+        filename:join(?config(data_dir, Config), "advanced.config"),
+    {ok, [AdvancedConfig]} = rabbit_prelaunch_file:consult_file(AdvancedConfigPath),
+    ?assertMatch([{rabbit, [{log, [{console, [{enabled, true}, {level, debug}]}]},
+                           {loopback_users, []},
+                           {ssl_listeners, [5671]},
+                           {ssl_options,
+                            [{cacertfile, "/path/to/certs/ca_certificate.pem"},
+                             {certfile, "/path/to/certs/server_certificate.pem"},
+                             {keyfile, "/path/to/certs/server_key.pem"},
+                             {fail_if_no_peer_cert, true},
+                             {verify, verify_peer},
+                             {customize_hostname_check, [{match_fun, MatchFun}]}]},
+                           {background_gc_enabled, true},
+                           {background_gc_target_interval, 1000}]}], AdvancedConfig),
+    _Json = rabbit_json:encode(AdvancedConfig).
+
+consult_rabbitmq_config(Config) ->
+    RabbitMQConfigPath = filename:join(?config(data_dir, Config), "rabbitmq.config"),
+    {ok, [RabbitMQConfig]} = rabbit_prelaunch_file:consult_file(RabbitMQConfigPath),
+    ?assertMatch(
+       [{rabbit,[{consumer_timeout,none}]},
+        {kernel,
+         [{inet_dist_use_interface,{127,0,0,1}}]}], RabbitMQConfig).
+
+consult_badfile(Config) ->
+    AdvancedConfigPath =
+        filename:join(?config(data_dir, Config), "bad-advanced.config"),
+    ?assertMatch({error, {badfile, {error, undef}}},
+                 rabbit_prelaunch_file:consult_file(AdvancedConfigPath)).

--- a/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE_data/advanced.config
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE_data/advanced.config
@@ -1,0 +1,24 @@
+[
+    {rabbit, [
+        {log, [
+            {console, [
+                {enabled, true},
+                {level, debug}
+            ]}
+        ]},
+        {loopback_users, []},
+        {ssl_listeners, [5671]},
+        {ssl_options, [
+            {cacertfile, "/path/to/certs/ca_certificate.pem"},
+            {certfile,   "/path/to/certs/server_certificate.pem"},
+            {keyfile,    "/path/to/certs/server_key.pem"},
+            {fail_if_no_peer_cert, true},
+            {verify, verify_peer},
+            {customize_hostname_check, [
+                {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+            ]}
+        ]},
+        {background_gc_enabled, true},
+        {background_gc_target_interval, 1000}
+    ]}
+].

--- a/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE_data/bad-advanced.config
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE_data/bad-advanced.config
@@ -1,0 +1,24 @@
+[
+    {rabbit, [
+        {log, [
+            {console, [
+                {enabled, true},
+                {level, debug}
+            ]}
+        ]},
+        {loopback_users, []},
+        {ssl_listeners, [5671]},
+        {ssl_options, [
+            {cacertfile, "/path/to/certs/ca_certificate.pem"},
+            {certfile,   "/path/to/certs/server_certificate.pem"},
+            {keyfile,    "/path/to/certs/server_key.pem"},
+            {fail_if_no_peer_cert, true},
+            {verify, verify_peer},
+            {customize_hostname_check, [
+                {match_fun, foobar:bazbat(https)}
+            ]}
+        ]},
+        {background_gc_enabled, true},
+        {background_gc_target_interval, 1000}
+    ]}
+].

--- a/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE_data/rabbitmq.config
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/test/rabbit_prelaunch_file_SUITE_data/rabbitmq.config
@@ -1,0 +1,9 @@
+[
+  {rabbit, [
+    {consumer_timeout, none}
+  ]},
+
+  {kernel, [
+    {inet_dist_use_interface, {127,0,0,1}}
+  ]}
+].

--- a/deps/rabbit_common/src/rabbit_data_coercion.erl
+++ b/deps/rabbit_common/src/rabbit_data_coercion.erl
@@ -11,10 +11,11 @@
 -export([to_atom/2, atomize_keys/1, to_list_of_binaries/1]).
 
 -spec to_binary(Val :: binary() | list() | atom() | integer()) -> binary().
-to_binary(Val) when is_list(Val)    -> list_to_binary(Val);
-to_binary(Val) when is_atom(Val)    -> atom_to_binary(Val, utf8);
-to_binary(Val) when is_integer(Val) -> integer_to_binary(Val);
-to_binary(Val)                      -> Val.
+to_binary(Val) when is_list(Val)     -> list_to_binary(Val);
+to_binary(Val) when is_atom(Val)     -> atom_to_binary(Val, utf8);
+to_binary(Val) when is_integer(Val)  -> integer_to_binary(Val);
+to_binary(Val) when is_function(Val) -> list_to_binary(io_lib:format("~w", [Val]));
+to_binary(Val)                       -> Val.
 
 -spec to_list(Val :: integer() | list() | binary() | atom() | map()) -> list().
 to_list(Val) when is_list(Val)    -> Val;

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -252,7 +252,7 @@ format_socket_opts([{ssl_opts, Value} | Tail], Acc) ->
 %% exclude options that have values that are nested
 %% data structures or may include functions. They are fairly
 %% obscure and not worth reporting via HTTP API.
-format_socket_opts([{verify_fun, _Value} | Tail], Acc) ->
+format_socket_opts([{customize_hostname_check, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
 format_socket_opts([{crl_cache, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
@@ -277,7 +277,10 @@ format_socket_opts([{ciphers, _Value} | Tail], Acc) ->
 format_socket_opts([Head | Tail], Acc) when is_atom(Head) ->
     format_socket_opts(Tail, [{Head, true} | Acc]);
 %% verify_fun value is a tuple that includes a function
-format_socket_opts([_Head = {verify_fun, _Value} | Tail], Acc) ->
+format_socket_opts([{verify_fun, _Value} | Tail], Acc) ->
+    format_socket_opts(Tail, Acc);
+%% match_fun value is a tuple that includes a function
+format_socket_opts([{match_fun, _Value} | Tail], Acc) ->
     format_socket_opts(Tail, Acc);
 format_socket_opts([Head = {Name, Value} | Tail], Acc) when is_list(Value) ->
     case io_lib:printable_unicode_list(Value) of


### PR DESCRIPTION
This will be used as part of the fix for rabbitmq/osiris#78

If a RabbitMQ `advanced.config` file contains the following:

```
{customize_hostname_check, [
    {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
]}
```

...`file:consult/1` will fail because it does not evaluate terms in the
file.

The code in `rabbit_consult` was copied from this OTP module:

https://github.com/erlang/otp/blob/master/lib/ssl/src/ssl_dist_sup.erl

...and then modified for our use.