### PR TITLE
Temporarily tag osiris to v1.2.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -130,7 +130,7 @@ erlang_package.hex(
 
 erlang_package.git(
     repository = "rabbitmq/osiris",
-    tag = "v1.2.7"
+    tag = "v1.2.7",
     # branch = "main",
     patch_cmds = ["""
 VERSION=$(git rev-parse HEAD)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -130,7 +130,8 @@ erlang_package.hex(
 
 erlang_package.git(
     repository = "rabbitmq/osiris",
-    branch = "main",
+    tag = "v1.2.7"
+    # branch = "main",
     patch_cmds = ["""
 VERSION=$(git rev-parse HEAD)
 echo "Injecting ${VERSION} into Makefile..."

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -145,7 +145,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris main
+dep_osiris = git https://github.com/rabbitmq/osiris v1.2.7
 dep_systemd = hex 0.6.1
 dep_seshat = git https://github.com/rabbitmq/seshat 0.1.0
 


### PR DESCRIPTION
This is so what we can merge the breaking osiris seshat changes without breaking RabbitMQ master CI.