### PR TITLE
Fix quorum queue crash when reject with requeue followed by dead-letter

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -87,7 +87,7 @@
                   msg_id :: msg_id(),
                   index :: ra:index(),
                   header :: msg_header(),
-                  msg :: msg()}).
+                  msg :: raw_msg()}).
 -record(register_enqueuer, {pid :: pid()}).
 -record(checkout, {consumer_id :: consumer_id(),
                    spec :: checkout_spec(),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -1057,8 +1057,7 @@ invalid_policy(Config) ->
     Info = rpc:call(Server, rabbit_quorum_queue, infos,
                     [rabbit_misc:r(<<"/">>, queue, QQ)]),
     ?assertEqual('', proplists:get_value(policy, Info)),
-    ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"ha">>),
-    ok.
+    ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"ha">>).
 
 pre_existing_invalid_policy(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
Prior to this commit, for at-most-once and at-least-once dead lettering
a quorum queue crashed if:
1. no delivery-limit set (causing Ra #requeue{} instead of #enqueue{} command
when message gets requeued)
2. message got rejected with requeue = true
3. requeued message got dead lettered

Fixes #4940 

Originally reported in https://rabbitmq.slack.com/archives/C1EDN83PA/p1653655585585309