### PR TITLE
Switch the default python binary for codegen scripts to python3

### DIFF
--- a/deps/amqp10_common/development.post.mk
+++ b/deps/amqp10_common/development.post.mk
@@ -2,7 +2,7 @@
 # Framing sources generation.
 # --------------------------------------------------------------------
 
-PYTHON       ?= python
+PYTHON       ?= python3
 CODEGEN       = $(CURDIR)/codegen.py
 CODEGEN_DIR  ?= $(DEPS_DIR)/rabbitmq_codegen
 CODEGEN_AMQP  = $(CODEGEN_DIR)/amqp_codegen.py

--- a/deps/rabbit_common/development.post.mk
+++ b/deps/rabbit_common/development.post.mk
@@ -2,7 +2,7 @@
 # Framing sources generation.
 # --------------------------------------------------------------------
 
-PYTHON       ?= python
+PYTHON       ?= python3
 CODEGEN       = $(CURDIR)/codegen.py
 CODEGEN_DIR  ?= $(DEPS_DIR)/rabbitmq_codegen
 CODEGEN_AMQP  = $(CODEGEN_DIR)/amqp_codegen.py


### PR DESCRIPTION
`python` is not likely to be installed at this point