### PR TITLE
Remove duplicate call to rabbit_exchange_decorator:set/1

### DIFF
--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -167,8 +167,7 @@ store(X = #exchange{durable = false}) ->
 
 store_ram(X) ->
     X1 = rabbit_exchange_decorator:set(X),
-    ok = mnesia:write(rabbit_exchange, rabbit_exchange_decorator:set(X1),
-                      write),
+    ok = mnesia:write(rabbit_exchange, X1, write),
     X1.
 
 %% Used with binaries sent over the wire; the type may not exist.


### PR DESCRIPTION
Same as #4926 by @gomoripeti which fails for no apparent reason
on BuildBuddy.
