### PR TITLE
Log two more connection lifecycle events for AMQP 1.0 clients

### DIFF
--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -671,6 +671,10 @@ auth_phase_1_0(Response,
         {ok, User = #user{username = Username}} ->
             case rabbit_access_control:check_user_loopback(Username, Sock) of
                 ok ->
+                    rabbit_log_connection:info(
+                        "AMQP 1.0 connection ~p (~s): "
+                        "user '~s' authenticated and granted access to vhost '~s'",
+                        [self(), Username]),
                     rabbit_core_metrics:auth_attempt_succeeded(<<>>, Username, amqp10),
                     ok;
                 not_allowed ->
@@ -709,6 +713,10 @@ send_to_new_1_0_session(Channel, Frame, State) ->
             put({channel, Channel}, {ch_fr_pid, ChFrPid}),
             put({ch_sup_pid, ChSupPid}, {{channel, Channel}, {ch_fr_pid, ChFrPid}}),
             put({ch_fr_pid, ChFrPid}, {channel, Channel}),
+            rabbit_log_connection:info(
+                        "AMQP 1.0 connection ~p (~s): "
+                        "user '~s' authenticated and granted access to vhost '~s'",
+                        [self(), User#user.username, vhost(Hostname)]),
             ok = rabbit_amqp1_0_session:process_frame(ChFrPid, Frame);
         {error, {not_allowed, _}} ->
             rabbit_log:error("AMQP 1.0: user '~s' is not allowed to access virtual host '~s'",


### PR DESCRIPTION
Same idea as #4973 by @per-ivan but uses a slightly more standard log message format (standard for other protocols RabbitMQ supports, that is).