### PR TITLE
Use rabbit_prelaunch_file:consult_file/1 for Osiris TLS replication configuration

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -91,6 +91,7 @@ set_default_config() ->
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     OsirisConfig =
         case osiris_util:get_replication_configuration_from_tls_dist(
+                fun rabbit_prelaunch_file:consult_file/1,
                 fun osiris_log/3) of
             [] ->
                 [];


### PR DESCRIPTION
Instead of file:consult/1, which does not support parsing function definition.

References rabbitmq/osiris#78

Depends on https://github.com/rabbitmq/osiris/pull/81.