### PR TITLE
Remove Erlang 25 from the build matrix for now

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         erlang_major:
         - "24"
-        - "25"
+        #! - "25"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -74,8 +74,8 @@ jobs:
         include:
         - erlang_version: "24"
           elixir_version: 1.12.3
-        - erlang_version: "25"
-          elixir_version: 1.13.4
+        #! - erlang_version: "25"
+        #!   elixir_version: 1.13.4
     timeout-minutes: 60
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -13,8 +13,8 @@ jobs:
         include:
         - erlang_version: "24"
           elixir_version: 1.12.3
-        - erlang_version: "25"
-          elixir_version: 1.13.4
+        #! - erlang_version: "25"
+        #!   elixir_version: 1.13.4
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         erlang_major:
         - "23"
         - "24"
-        - "25"
+        #! - "25"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -79,8 +79,8 @@ jobs:
           elixir_version: 1.10.4
         - erlang_version: "24"
           elixir_version: 1.12.3
-        - erlang_version: "25"
-          elixir_version: 1.13.4
+        #! - erlang_version: "25"
+        #!   elixir_version: 1.13.4
     timeout-minutes: 60
     steps:
     - name: CHECKOUT REPOSITORY


### PR DESCRIPTION
Federation suites fail consistently, though manual testing does not show a problem. These changes can be reverted once the suites are fixed.