### PR TITLE
Limit stream max segment size to 3 GB

### DIFF
--- a/deps/rabbit/src/rabbit_policies.erl
+++ b/deps/rabbit/src/rabbit_policies.erl
@@ -185,7 +185,7 @@ validate_policy0(<<"initial-cluster-size">>, Value) ->
     {error, "~p is not a valid cluster size", [Value]};
 
 validate_policy0(<<"stream-max-segment-size-bytes">>, Value)
-  when is_integer(Value), Value >= 0 ->
+  when is_integer(Value), Value >= 0, Value =< ?MAX_STREAM_MAX_SEGMENT_SIZE ->
     ok;
 validate_policy0(<<"stream-max-segment-size-bytes">>, Value) ->
     {error, "~p is not a valid segment size", [Value]}.

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -116,6 +116,7 @@ all_tests() ->
      max_age_policy,
      max_segment_size_bytes_validation,
      max_segment_size_bytes_policy,
+     max_segment_size_bytes_policy_validation,
      purge,
      update_retention_policy,
      queue_info,
@@ -2136,6 +2137,25 @@ queue_info(Config) ->
                   (lists:sort(Servers) == lists:sort(proplists:get_value(online, Info)))
       end),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
+
+max_segment_size_bytes_policy_validation(Config) ->
+    ok = rabbit_ct_broker_helpers:set_policy(
+           Config, 0, <<"segment">>, <<"max_segment_size_bytes.*">>, <<"queues">>,
+           [{<<"stream-max-segment-size-bytes">>, ?MAX_STREAM_MAX_SEGMENT_SIZE - 1_000}]),
+
+    ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"segment">>),
+
+    {error_string, _} = rabbit_ct_broker_helpers:rpc(
+                          Config, 0,
+                          rabbit_policy, set,
+                          [<<"/">>,
+                           <<"segment">>,
+                           <<"max_segment_size_bytes.*">>,
+                           [{<<"stream-max-segment-size-bytes">>, ?MAX_STREAM_MAX_SEGMENT_SIZE + 1_000}],
+                           0,
+                           <<"queues">>,
+                           <<"acting-user">>]),
+    ok.
 
 max_segment_size_bytes_policy(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -272,3 +272,7 @@
 
 %% 3.6, 3.7, early 3.8
 -define(LEGACY_INDEX_SEGMENT_ENTRY_COUNT, 16384).
+
+%% Max value for stream max segment size
+-define(MAX_STREAM_MAX_SEGMENT_SIZE, 3_000_000_000).
+

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
@@ -95,7 +95,8 @@ validate_stream_arguments(#{stream_max_segment_size_bytes := Value} =
 validate_stream_arguments(#{leader_locator := <<"client-local">>} =
                               Opts) ->
     validate_stream_arguments(maps:remove(leader_locator, Opts));
-validate_stream_arguments(#{leader_locator := <<"balanced">>} = Opts) ->
+validate_stream_arguments(#{leader_locator := <<"balanced">>} =
+                              Opts) ->
     validate_stream_arguments(maps:remove(leader_locator, Opts));
 %% 'random' and 'least-leaders' are deprecated and get mapped to 'balanced'
 validate_stream_arguments(#{leader_locator := <<"random">>} = Opts) ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -176,7 +176,9 @@ validate_stream_queue_arguments([{<<"x-initial-cluster-size">>, long,
 validate_stream_queue_arguments([{<<"x-queue-leader-locator">>,
                                   longstr, Locator}
                                  | T]) ->
-    case lists:member(Locator, rabbit_queue_location:queue_leader_locators()) of
+    case lists:member(Locator,
+                      rabbit_queue_location:queue_leader_locators())
+    of
         true ->
             validate_stream_queue_arguments(T);
         false ->
@@ -538,7 +540,15 @@ create_stream(VirtualHost, Reference, Arguments, Username) ->
                                 {error, Err} ->
                                     rabbit_log:warning("Error while creating ~p stream, ~p",
                                                        [Reference, Err]),
-                                    {error, internal_error}
+                                    {error, internal_error};
+                                {protocol_error,
+                                 precondition_failed,
+                                 Msg,
+                                 Args} ->
+                                    rabbit_log:warning("Error while creating ~p stream, "
+                                                       ++ Msg,
+                                                       [Reference] ++ Args),
+                                    {error, validation_failed}
                             end
                         catch
                             exit:Error ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -819,11 +819,11 @@ open(info,
 
                         Conn1 =
                             maybe_send_consumer_update(Transport,
-                                                  Connection0,
-                                                  SubId,
-                                                  Active,
-                                                  true,
-                                                  Extra),
+                                                       Connection0,
+                                                       SubId,
+                                                       Active,
+                                                       true,
+                                                       Extra),
                         {Conn1,
                          ConnState0#stream_connection_state{consumers =
                                                                 Consumers0#{SubId
@@ -1738,9 +1738,7 @@ handle_frame_post_auth(Transport,
                                                       User, #{})
         of
             ok ->
-                case rabbit_stream_manager:lookup_leader(VirtualHost,
-                                                         Stream)
-                of
+                case rabbit_stream_manager:lookup_leader(VirtualHost, Stream) of
                     {error, not_found} ->
                         rabbit_global_counters:increase_protocol_counter(stream,
                                                                          ?STREAM_DOES_NOT_EXIST,
@@ -1748,8 +1746,7 @@ handle_frame_post_auth(Transport,
                         {?RESPONSE_CODE_STREAM_DOES_NOT_EXIST, 0};
                     {ok, LeaderPid} ->
                         {?RESPONSE_CODE_OK,
-                         case osiris:fetch_writer_seq(LeaderPid, Reference)
-                         of
+                         case osiris:fetch_writer_seq(LeaderPid, Reference) of
                              undefined ->
                                  0;
                              Offt ->
@@ -2777,15 +2774,16 @@ maybe_register_consumer(VirtualHost,
 maybe_send_consumer_update(_, Connection, _, _, false = _Sac, _) ->
     Connection;
 maybe_send_consumer_update(Transport,
-                      #stream_connection{socket = S,
-                                         correlation_id_sequence = CorrIdSeq,
-                                         outstanding_requests =
-                                             OutstandingRequests0} =
-                          Connection,
-                      SubscriptionId,
-                      Active,
-                      true = _Sac,
-                      Extra) ->
+                           #stream_connection{socket = S,
+                                              correlation_id_sequence =
+                                                  CorrIdSeq,
+                                              outstanding_requests =
+                                                  OutstandingRequests0} =
+                               Connection,
+                           SubscriptionId,
+                           Active,
+                           true = _Sac,
+                           Extra) ->
     rabbit_log:debug("SAC subscription ~p, active = ~p",
                      [SubscriptionId, Active]),
     Frame =

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -44,7 +44,8 @@ groups() ->
        timeout_peer_properties_exchanged,
        unauthenticated_client_rejected_authenticating,
        timeout_authenticating,
-       timeout_close_sent]},
+       timeout_close_sent,
+       max_segment_size_bytes_validation]},
      %% Run `test_global_counters` on its own so the global metrics are
      %% initialised to 0 for each testcase
      {single_node_1, [], [test_global_counters]},
@@ -324,6 +325,29 @@ sac_ff(Config) ->
     test_delete_stream(gen_tcp, S, Stream, C),
     test_close(gen_tcp, S, C),
     closed = wait_for_socket_close(gen_tcp, S, 10),
+    ok.
+
+max_segment_size_bytes_validation(Config) ->
+    Transport = gen_tcp,
+    Port = get_stream_port(Config),
+    {ok, S} =
+        Transport:connect("localhost", Port,
+                          [{active, false}, {mode, binary}]),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(Transport, S, C0),
+    C2 = test_authenticate(Transport, S, C1),
+    Stream = <<"stream-max-segment-size">>,
+    CreateStreamFrame =
+        rabbit_stream_core:frame({request, 1,
+                                  {create_stream, Stream,
+                                   #{<<"stream-max-segment-size-bytes">> =>
+                                         <<"3000000001">>}}}),
+    ok = Transport:send(S, CreateStreamFrame),
+    {Cmd, C3} = receive_commands(Transport, S, C2),
+    ?assertMatch({response, 1,
+                  {create_stream, ?RESPONSE_CODE_PRECONDITION_FAILED}},
+                 Cmd),
+    test_close(Transport, S, C3),
     ok.
 
 consumer_count(Config) ->


### PR DESCRIPTION
Values too large can overflow the stream position field
in the index (32 bit int).