### PR TITLE
rabbit_classic_queue: Use `rabbit_feature_flags`, not `rabbit_ff_registry`

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -514,7 +514,7 @@ update_msg_status(down, Pid, #msg_status{pending = P} = S) ->
 confirm_to_sender(Pid, QName, MsgSeqNos) ->
     %% the stream queue included the queue type refactoring and thus requires
     %% a different message format
-    Evt = case rabbit_ff_registry:is_enabled(stream_queue) of
+    Evt = case rabbit_feature_flags:is_enabled(stream_queue) of
               true ->
                   {queue_event, QName, {confirm, MsgSeqNos, self()}};
               false ->
@@ -523,7 +523,7 @@ confirm_to_sender(Pid, QName, MsgSeqNos) ->
     gen_server2:cast(Pid, Evt).
 
 send_rejection(Pid, QName, MsgSeqNo) ->
-    case rabbit_ff_registry:is_enabled(stream_queue) of
+    case rabbit_feature_flags:is_enabled(stream_queue) of
         true ->
             gen_server2:cast(Pid, {queue_event, QName,
                                    {reject_publish, MsgSeqNo, self()}});


### PR DESCRIPTION
`rabbit_ff_registry` is an internal module of the feature flags subsystem, it is not meant to be called outside of it. In particular, it may lead to crashes very difficult to debug when a feature flag is enabled. The reason is that this module is compiled and reloaded at runtime, so the module may disappear for a small period of time. Another reason is that a process calling `rabbit_ff_registry` may hold that module, preventing the feature flags subsystem from performing its task.

The correct public API to query the state of a feature flag is `rabbit_feature_flags:is_enabled/1`. It will always return a boolean. If the feature flag being queried is in `state_changing` state, this function takes care of waiting for the outcome.

See #5018.