### PR TITLE
Use a more unique exchange names in federation exchange suite

### DIFF
--- a/deps/rabbitmq_federation/test/exchange_SUITE.erl
+++ b/deps/rabbitmq_federation/test/exchange_SUITE.erl
@@ -222,14 +222,14 @@ single_channel_mode(Config) ->
 multiple_upstreams(Config) ->
     with_ch(Config,
       fun (Ch) ->
-              Q = bind_queue(Ch, <<"fed12.downstream">>, <<"key">>),
+              Q = bind_queue(Ch, <<"xfed12.downstream">>, <<"key">>),
               await_binding(Config, 0, <<"upstream">>, <<"key">>),
               await_binding(Config, 0, <<"upstream2">>, <<"key">>),
               publish_expect(Ch, <<"upstream">>, <<"key">>, Q, <<"HELLO1">>),
               publish_expect(Ch, <<"upstream2">>, <<"key">>, Q, <<"HELLO2">>)
       end, [x(<<"upstream">>),
             x(<<"upstream2">>),
-            x(<<"fed12.downstream">>)]).
+            x(<<"xfed12.downstream">>)]).
 
 multiple_upstreams_pattern(Config) ->
     set_upstream(Config, 0, <<"local453x">>,
@@ -314,7 +314,7 @@ multiple_downstreams(Config) ->
     with_ch(Config,
       fun (Ch) ->
               Q1 = bind_queue(Ch, <<"fed.downstream">>, <<"key">>),
-              Q12 = bind_queue(Ch, <<"fed12.downstream2">>, <<"key">>),
+              Q12 = bind_queue(Ch, <<"xfed12.downstream2">>, <<"key">>),
               await_binding(Config, 0, <<"upstream">>, <<"key">>, 2),
               await_binding(Config, 0, <<"upstream2">>, <<"key">>),
               publish(Ch, <<"upstream">>, <<"key">>, <<"HELLO1">>),
@@ -323,7 +323,7 @@ multiple_downstreams(Config) ->
               expect(Ch, Q12, [<<"HELLO1">>, <<"HELLO2">>])
       end, upstream_downstream() ++
           [x(<<"upstream2">>),
-           x(<<"fed12.downstream2">>)]).
+           x(<<"xfed12.downstream2">>)]).
 
 e2e(Config) ->
     with_ch(Config,

--- a/deps/rabbitmq_federation/test/rabbit_federation_test_util.erl
+++ b/deps/rabbitmq_federation/test/rabbit_federation_test_util.erl
@@ -99,7 +99,7 @@ setup_federation_with_upstream_params(Config, ExtraParams) ->
         {<<"federation-upstream-set">>, <<"upstream">>}]),
 
     rabbit_ct_broker_helpers:set_policy(Config, 0,
-      <<"fed12">>, <<"^fed12\.">>, <<"all">>, [
+      <<"xfed12">>, <<"^xfed12\.">>, <<"all">>, [
         {<<"federation-upstream-set">>, <<"upstream12">>}]),
 
     rabbit_ct_broker_helpers:set_policy(Config, 0,


### PR DESCRIPTION
This is to avoid a case where multiple policies are matches for a given
exchange and the federation exchage suite causing indeterminacy in the
policy being applied to certain exchanges. This caused failures due to
internal changes in ETS set ordering between OTP 24 and 25.
