### PR TITLE
Change normal connection close log level from warning to debug

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -490,8 +490,8 @@ handle_info(Msg,
                                          NewConnectionStep]),
             Transition(NewConnectionStep, StatemData, Connection1, State1);
         {Closed, S} ->
-            rabbit_log_connection:warning("Stream protocol connection socket ~w closed",
-                                          [S]),
+            rabbit_log_connection:debug("Stream protocol connection socket ~w closed",
+                                        [S]),
             stop;
         {Error, S, Reason} ->
             rabbit_log_connection:warning("Socket error ~p [~w]", [Reason, S]),


### PR DESCRIPTION
This line gets logged when the client closes the connection to the
stream port before it authenticates successfully.

Some external load balancers for example connect to the stream port to
do health checks without sending any stream protocol frame.

This commits prevents the RabbitMQ log from being polluted.