### PR TITLE
Add missing bazel deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,16 @@ module(
     version = "3.10.0",
 )
 
+bazel_dep(
+    name = "rules_pkg",
+    version = "0.5.1",
+)
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.2.0",
+)
+
 bazel_dep(name = "rules_erlang", version = "3.0.1")
 
 archive_override(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,11 @@ bazel_dep(
     version = "1.2.0",
 )
 
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.1",
+)
+
 bazel_dep(name = "rules_erlang", version = "3.0.1")
 
 archive_override(
@@ -295,4 +300,19 @@ use_repo(
     "sysmon_handler",
     "systemd",
     "trust_store_http",
+)
+
+rbe = use_extension(
+    "//bazel/bzlmod:extensions.bzl",
+    "rbe",
+)
+
+rbe.git_repository(
+    remote = "https://github.com/rabbitmq/rbe-erlang-platform.git",
+    branch = "linux-rbe",
+)
+
+use_repo(
+    rbe,
+    "rbe",
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -15,11 +15,11 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "rules_pkg",
-    sha256 = "038f1caa773a7e35b3663865ffb003169c6a71dc995e39bf4815792f385d837d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
     ],
+    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -15,11 +15,11 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
     ],
-    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/bazel/bzlmod/extensions.bzl
+++ b/bazel/bzlmod/extensions.bzl
@@ -1,0 +1,37 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def _rbe(ctx):
+    for mod in ctx.modules:
+        for repo in mod.tags.git_repository:
+            if repo.commit != "":
+                git_repository(
+                    name = "rbe",
+                    commit = repo.commit,
+                    remote = repo.remote,
+                )
+            if repo.tag != "":
+                git_repository(
+                    name = "rbe",
+                    tag = repo.tag,
+                    remote = repo.remote,
+                )
+            if repo.branch != "":
+                git_repository(
+                    name = "rbe",
+                    branch = repo.branch,
+                    remote = repo.remote,
+                )
+
+git_repository_tag = tag_class(attrs = {
+    "remote": attr.string(),
+    "branch": attr.string(),
+    "tag": attr.string(),
+    "commit": attr.string(),
+})
+
+rbe = module_extension(
+    implementation = _rbe,
+    tag_classes = {
+        "git_repository": git_repository_tag,
+    },
+)

--- a/bazel/bzlmod/extensions.bzl
+++ b/bazel/bzlmod/extensions.bzl
@@ -1,26 +1,27 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def _rbe(ctx):
+    rbe_repo_props = []
     for mod in ctx.modules:
         for repo in mod.tags.git_repository:
+            props = {"remote": repo.remote}
             if repo.commit != "":
-                git_repository(
-                    name = "rbe",
-                    commit = repo.commit,
-                    remote = repo.remote,
-                )
+                props["commit"] = repo.commit
             if repo.tag != "":
-                git_repository(
-                    name = "rbe",
-                    tag = repo.tag,
-                    remote = repo.remote,
-                )
+                props["tag"] = repo.tag
             if repo.branch != "":
-                git_repository(
-                    name = "rbe",
-                    branch = repo.branch,
-                    remote = repo.remote,
-                )
+                props["branch"] = repo.branch
+            if not props in rbe_repo_props:
+                rbe_repo_props.append(props)
+
+    if len(rbe_repo_props) > 1:
+        fail("Multiple definitions for @rbe exist: {}".format(rbe_repo_props))
+
+    if len(rbe_repo_props) > 0:
+        git_repository(
+            name = "rbe",
+            **rbe_repo_props[0]
+        )
 
 git_repository_tag = tag_class(attrs = {
     "remote": attr.string(),

--- a/dist.bzl
+++ b/dist.bzl
@@ -67,6 +67,52 @@ def _copy_script(ctx, script):
     )
     return dest
 
+def _scripts_and_escripts_private_impl(ctx):
+    plugins = flat_deps(ctx.attr.plugins)
+
+    scripts = [_copy_script(ctx, script) for script in ctx.files._scripts]
+
+    rabbitmq_ctl_copies = [
+        "rabbitmq-diagnostics",
+        "rabbitmq-plugins",
+        "rabbitmq-queues",
+        "rabbitmq-streams",
+        "rabbitmq-tanzu",
+        "rabbitmq-upgrade",
+        "rabbitmqctl",
+    ]
+    escripts = [link_escript(ctx, escript) for escript in rabbitmq_ctl_copies]
+
+    rabbitmqctl = None
+    for script in scripts:
+        if script.basename == "rabbitmqctl":
+            rabbitmqctl = script
+    if rabbitmqctl == None:
+        fail("could not find rabbitmqct among", scripts)
+
+    return [
+        RabbitmqHomeInfo(
+            rabbitmqctl = rabbitmqctl,
+        ),
+        DefaultInfo(
+            files = depset(scripts + escripts),
+        ),
+    ]
+
+scripts_and_escripts_private = rule(
+    implementation = _scripts_and_escripts_private_impl,
+    attrs = RABBITMQ_HOME_ATTRS,
+)
+
+def scripts_and_escripts(**kwargs):
+    scripts_and_escripts_private(
+        is_windows = select({
+            "@bazel_tools//src/conditions:host_windows": True,
+            "//conditions:default": False,
+        }),
+        **kwargs
+    )
+
 def _extract_version(p):
     return "erl -eval '{ok, [{application, _, AppInfo}]} = file:consult(\"" + p + "\"), Version = proplists:get_value(vsn, AppInfo), io:fwrite(Version), halt().' -noshell"
 
@@ -76,7 +122,9 @@ def _app_file(plugin_lib_info):
             return f
     fail(".app file not found in {}".format(plugin_lib_info))
 
-def _plugins_dir(ctx, plugins):
+def _versioned_plugins_dir_impl(ctx):
+    plugins = flat_deps(ctx.attr.plugins)
+
     plugins_dir = ctx.actions.declare_directory(path_join(ctx.label.name, "plugins"))
 
     (erlang_home, _, runfiles) = erlang_dirs(ctx)
@@ -94,12 +142,6 @@ def _plugins_dir(ctx, plugins):
         app_file = _app_file(lib_info)
         extract_version = _extract_version(app_file.path)
         commands.append("PLUGIN_VERSION=$({erlang_home}/bin/{extract_version})".format(erlang_home = erlang_home, extract_version = extract_version))
-
-        commands.append(
-            "echo \"Assembling {lib_name}-$PLUGIN_VERSION...\"".format(
-                lib_name = lib_info.app_name,
-            ),
-        )
 
         commands.append(
             "mkdir -p {plugins_dir}/{lib_name}-$PLUGIN_VERSION/include".format(
@@ -166,50 +208,20 @@ def _plugins_dir(ctx, plugins):
         command = "\n".join(commands),
     )
 
-    return plugins_dir
-
-def _versioned_rabbitmq_home_impl(ctx):
-    plugins = flat_deps(ctx.attr.plugins)
-
-    scripts = [_copy_script(ctx, script) for script in ctx.files._scripts]
-
-    rabbitmq_ctl_copies = [
-        "rabbitmq-diagnostics",
-        "rabbitmq-plugins",
-        "rabbitmq-queues",
-        "rabbitmq-streams",
-        "rabbitmq-tanzu",
-        "rabbitmq-upgrade",
-        "rabbitmqctl",
-    ]
-    escripts = [link_escript(ctx, escript) for escript in rabbitmq_ctl_copies]
-
-    plugins_dir = _plugins_dir(ctx, plugins)
-
-    rabbitmqctl = None
-    for script in scripts:
-        if script.basename == "rabbitmqctl":
-            rabbitmqctl = script
-    if rabbitmqctl == None:
-        fail("could not find rabbitmqct among", scripts)
-
     return [
-        RabbitmqHomeInfo(
-            rabbitmqctl = rabbitmqctl,
-        ),
         DefaultInfo(
-            files = depset(scripts + escripts + [plugins_dir]),
+            files = depset([plugins_dir]),
         ),
     ]
 
-versioned_rabbitmq_home_private = rule(
-    implementation = _versioned_rabbitmq_home_impl,
+versioned_plugins_dir_private = rule(
+    implementation = _versioned_plugins_dir_impl,
     attrs = RABBITMQ_HOME_ATTRS,
     toolchains = ["@rules_erlang//tools:toolchain_type"],
 )
 
-def versioned_rabbitmq_home(**kwargs):
-    versioned_rabbitmq_home_private(
+def versioned_plugins_dir(**kwargs):
+    versioned_plugins_dir_private(
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,
             "//conditions:default": False,
@@ -262,21 +274,34 @@ def package_generic_unix(plugins):
         visibility = ["//visibility:public"],
     )
 
-    versioned_rabbitmq_home(
-        name = "dist-home",
+    scripts_and_escripts(
+        name = "scripts-and-escripts",
+    )
+
+    versioned_plugins_dir(
+        name = "plugins-dir",
         plugins = plugins,
     )
 
     pkg_tar(
-        name = "package-generic-unix",
+        name = "plugins-tar",
         srcs = [
-            ":dist-home",
+            ":plugins-dir",
         ],
+        package_dir = "plugins",
+    )
+
+    pkg_tar(
+        name = "package-generic-unix",
         extension = "tar.xz",
+        srcs = [
+            ":scripts-and-escripts",
+        ],
         package_dir = "rabbitmq_server-{}".format(APP_VERSION),
-        strip_prefix = "dist-home",
+        strip_prefix = "scripts-and-escripts",
         visibility = ["//visibility:public"],
         deps = [
+            ":plugins-tar",
             ":license-files",
             ":release-notes",
             ":scripts",
@@ -316,6 +341,7 @@ def source_archive(plugins):
 
     pkg_tar(
         name = "source_archive",
+        extension = "tar.gz",
         srcs = [
             ":root-licenses",
         ],


### PR DESCRIPTION
These build deps must be included in the `MODULE.bazel` file if `rabbitmq-server` is itself to be used as a `bazel_dep` in another module with bzlmod