### PR TITLE
Use v2 sets when recovering bindings if available

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -94,8 +94,8 @@ recover() ->
 -spec recover([rabbit_exchange:name()], [rabbit_amqqueue:name()]) ->
                         'ok'.
 recover(XNames, QNames) ->
-    XNameSet = sets:from_list(XNames),
-    QNameSet = sets:from_list(QNames),
+    XNameSet = sets:from_list(XNames, [{version, 2}]),
+    QNameSet = sets:from_list(QNames, [{version, 2}]),
     SelectSet = fun (#resource{kind = exchange}) -> XNameSet;
                     (#resource{kind = queue})    -> QNameSet
                 end,


### PR DESCRIPTION
## Proposed Changes

The overhead of calling function_exported should be balanced out by
faster set creation in case of from_list, especially for long lists.

timer:tc sets:from_list microbenchmark shows 
few 10K queues: 40ms -> 4ms
100K exchanges: 340ms -> 40ms


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Loading the binding is actually dominated by inserting into the routes tables, not sets:from_list. In case of these huge definitions the gain might be considered negligible. But this change is applicable even after replacing mnesia with khepri.

Alternatively the compatibility code in rabbit_misc can be avoided (not to add some micor-tech-dept), and just using v2 sets in future RabbitMQ versions which only will support OTP 24+ (ie merge to master but dont backport to 3.9, 3.10, 3.11 etc)
