### PR TITLE
Allow `bazel run test-logs` to work when logs are compressed

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -114,7 +114,11 @@ cat << 'EOF' > $@
     if [ $$# -gt 1 ]; then
         OUTPUT_DIR=shard_$$2_of_*/test.outputs
     fi
-    open bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/index.html
+    cd bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR
+    if [ -f outputs.zip ]; then
+        unzip -u outputs.zip
+    fi
+    open index.html
 EOF
 """,
     executable = True,
@@ -139,8 +143,8 @@ cat << 'EOF' > $@
         OUTPUT_DIR=shard_$$2_of_*/test.outputs
     fi
     TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
-    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip outputs.zip
-    open $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/index.html
+    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip -u outputs.zip
+    open index.html
 EOF
 """,
     executable = True,
@@ -164,7 +168,12 @@ cat << 'EOF' > $@
     if [ $$# -gt 1 ]; then
         OUTPUT_DIR=shard_$$2_of_*/test.outputs
     fi
-    open bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/ct_run.*/deps.*/run.*/log_private
+    cd bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR
+    if [ -f outputs.zip ]; then
+        unzip -u outputs.zip
+    fi
+    open index.html
+    open ct_run.*/deps.*/run.*/log_private
 EOF
 """,
     executable = True,
@@ -191,9 +200,9 @@ cat << 'EOF' > $@
         OUTPUT_DIR=shard_$$2_of_*/test.outputs
     fi
     TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
-    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip outputs.zip
-    open $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/index.html
-    open $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR/ct_run.*/deps.*/run.*/log_private
+    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip -u outputs.zip
+    open index.html
+    open ct_run.*/deps.*/run.*/log_private
 EOF
 """,
     executable = True,


### PR DESCRIPTION
As happens if the spawn_strategy is not set to local

Also makes the implementaion of related commands more consistent