### PR TITLE
RFC Channel tracking improvements

### DIFF
--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -59,6 +59,9 @@
 
 -export([close_connections/3]).
 
+%% primary key of tracked connections
+-type id() :: rabbit_types:tracked_connection_id().
+
 %%
 %% API
 %%
@@ -165,8 +168,7 @@ handle_cast({node_deleted, Details}) ->
     delete_per_vhost_tracked_connections_table_for_node(Node),
     delete_per_user_tracked_connections_table_for_node(Node).
 
--spec register_tracked(rabbit_types:tracked_connection()) -> ok.
--dialyzer([{nowarn_function, [register_tracked/1]}]).
+-spec register_tracked(rabbit_types:tracked_connection()) -> id().
 
 register_tracked(#tracked_connection{username = Username, vhost = VHost, id = ConnId, node = Node} = Conn) when Node =:= node() ->
     TableName = tracked_connection_table_name_for(Node),
@@ -181,9 +183,9 @@ register_tracked(#tracked_connection{username = Username, vhost = VHost, id = Co
         [#tracked_connection{}] ->
             ok
     end,
-    ok.
+    ConnId.
 
--spec unregister_tracked(rabbit_types:tracked_connection_id()) -> ok.
+-spec unregister_tracked(id()) -> ok.
 
 unregister_tracked(ConnId = {Node, _Name}) when Node =:= node() ->
     TableName = tracked_connection_table_name_for(Node),

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -202,7 +202,8 @@ user_limits_migration(_FeatureName, _FeatureProps, enable) ->
     rabbit_table:wait([Tab], _Retry = true),
     Fun = fun(Row) -> internal_user:upgrade_to(internal_user_v2, Row) end,
     case mnesia:transform_table(Tab, Fun, internal_user:fields(internal_user_v2)) of
-        {atomic, ok}      -> ok;
+        {atomic, ok}      ->
+            rabbit_channel_tracking_handler:add_handler();
         {aborted, Reason} -> {error, Reason}
     end;
 user_limits_migration(_FeatureName, _FeatureProps, is_enabled) ->

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -186,7 +186,6 @@ join_discovered_peers_with_retries(TryNodes, NodeType, RetriesLeft, DelayInterva
             rabbit_log:info("Node '~s' selected for auto-clustering", [Node]),
             {ok, {_, DiscNodes, _}} = discover_cluster0(Node),
             init_db_and_upgrade(DiscNodes, NodeType, true, _Retry = true),
-            rabbit_connection_tracking:boot(),
             rabbit_node_monitor:notify_joined_cluster();
         none ->
             RetriesLeft1 = RetriesLeft - 1,
@@ -238,7 +237,6 @@ join_cluster(DiscoveryNode, NodeType) ->
                                     [ClusterNodes, NodeType]),
                     ok = init_db_with_mnesia(ClusterNodes, NodeType,
                                              true, true, _Retry = true),
-                    rabbit_connection_tracking:boot(),
                     rabbit_node_monitor:notify_joined_cluster(),
                     ok;
                 {error, Reason} ->

--- a/deps/rabbit/src/rabbit_tracking.erl
+++ b/deps/rabbit/src/rabbit_tracking.erl
@@ -13,15 +13,16 @@
 %%  * rabbit_connection_tracking
 %%  * rabbit_channel_tracking
 
+%% callback specific id returned by `register_tracked/1'
+-type id() :: term().
+
 -callback boot() -> ok.
 -callback update_tracked(term()) -> ok.
 -callback handle_cast(term()) -> ok.
 -callback register_tracked(
               rabbit_types:tracked_connection() |
-                  rabbit_types:tracked_channel()) -> 'ok'.
--callback unregister_tracked(
-              rabbit_types:tracked_connection_id() |
-                  rabbit_types:tracked_channel_id()) -> 'ok'.
+                  rabbit_types:tracked_channel()) -> id().
+-callback unregister_tracked(id()) -> 'ok'.
 -callback count_tracked_items_in(term()) -> non_neg_integer().
 -callback clear_tracking_tables() -> 'ok'.
 -callback shutdown_tracked_items(list(), term()) -> ok.

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -193,12 +193,12 @@
 %% Used to track detailed information
 %% about channels.
 -record(tracked_channel, {
+            pid, %% key in channel tracking table
             %% {Node, ChannelName}
             id,
             node,
             vhost,
             name,
-            pid,
             username,
             connection}).
 


### PR DESCRIPTION
## Proposed Changes

These changes try to reduce the overhead of channel tracking.

I'd like to request some guidance on a few things
1) changing the #tracked_channel{} record (field order) (https://github.com/rabbitmq/rabbitmq-server/pull/5084/files#diff-95cf3628dbe97cf5a880e399fcc4b397d4717d75229bab78e2696b102768b226R196): This record is returned by the list[_of_user|on_node] functions so could theoretically travel between nodes with different versions. But I dont see these functions used anywhere. And the shape of the record does not change, just the values would be mixed up. What is the correct or practical way to change record format in this case?
2) changing the key field of the channel_tracking table (https://github.com/rabbitmq/rabbitmq-server/pull/5084/files#diff-db98dcef04e61dfe1a3337886a0d45adf3cabf7f70126b4890d64f07e2cb8a6dR245-R255) : the table is memory-only and has a copy on only one node. Therefore it's safe to change attributes order as the table is empty at startup when the upgrade should happen. After I added the custom code for the upgrade I noticed the rabbit_upgrade and rabbit_upgrade_functions modules - is that the right way to do any mnesia table changes? is this a local or mnesia upgrade step?
3) channel-tracking a noop if not used: I skipped adding a rabbit_event handler if user_limits feature is disabled (as an easy fix). However I dont think its enough in practice. A feature cannot be disabled once enabled (if I understand correctly) and even if there is a per-user connection limit, there could be no channel-limit. There could be more clever solutions (like only add the handler if at least one user has channel-limit) Or an explicit solution to add a config to disable channel-tracking. What do you think? Which route should I explore?


Rough results of optimisation (commit a9f1f04d422f5d75df64989db4cccc4b1b1a4732)

Closing 10,000 channels (my flamegraphs are not perfect. it's not visible where `mnesia_lib:db_match_object/3` is called from, but they disappear after the change)
Before
![cpu_close_channels_10000_2](https://user-images.githubusercontent.com/3725991/174808895-e6a21a36-1756-4054-adcd-b6522ec801f2.svg)

After
![cpu_close_channels_10000_optimized](https://user-images.githubusercontent.com/3725991/174808914-f7582a8d-90c7-4ace-a69c-c582f6690f47.svg)


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
