### PR TITLE
Use our own fork of the bazel-central-registry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --experimental_enable_bzlmod
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/dev/
 
 build --incompatible_strict_action_env
 build --local_test_jobs=1

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -310,3 +310,13 @@ use_repo(
     rbe,
     "rbe",
 )
+
+secondary_umbrella = use_extension(
+    "//bazel/bzlmod:extensions.bzl",
+    "secondary_umbrella",
+)
+
+use_repo(
+    secondary_umbrella,
+    "rabbitmq-server-generic-unix-3.9",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,13 +18,7 @@ bazel_dep(
     version = "0.0.1",
 )
 
-bazel_dep(name = "rules_erlang", version = "3.0.1")
-
-archive_override(
-    module_name = "rules_erlang",
-    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/3.2.0.zip"],
-    strip_prefix = "rules_erlang-3.2.0",
-)
+bazel_dep(name = "rules_erlang", version = "3.2.0")
 
 erlang_package = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -85,37 +85,6 @@ load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
 
 activemq_archive()
 
-ADD_PLUGINS_DIR_BUILD_FILE = """set -euo pipefail
+load("//bazel/bzlmod:secondary_umbrella.bzl", "secondary_umbrella")
 
-cat << EOF > plugins/BUILD.bazel
-load("@rules_pkg//:pkg.bzl", "pkg_zip")
-
-pkg_zip(
-    name = "inet_tcp_proxy_ez",
-    package_dir = "inet_tcp_proxy/ebin",
-    srcs = [
-        "@inet_tcp_proxy_dist//:erlang_app",
-    ],
-    package_file_name = "inet_tcp_proxy-0.1.0.ez",
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "standard_plugins",
-    srcs = glob(["**/*"]),
-    visibility = ["//visibility:public"],
-)
-EOF
-"""
-
-http_archive(
-    name = "rabbitmq-server-generic-unix-3.9",
-    build_file = "@//:BUILD.package_generic_unix",
-    patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-    repo_mapping = {
-        "@inet_tcp_proxy_dist": "@rules_erlang.erlang_package.inet_tcp_proxy_dist",
-    },
-    sha256 = "4672fad92a815b879cc78a5a9fd28445152b61745d68acd50432c15f96792171",
-    strip_prefix = "rabbitmq_server-3.9.13",
-    urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.9.13/rabbitmq-server-generic-unix-3.9.13.tar.xz"],
-)
+secondary_umbrella()

--- a/bazel/bzlmod/extensions.bzl
+++ b/bazel/bzlmod/extensions.bzl
@@ -1,4 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load(
+    ":secondary_umbrella.bzl",
+    fetch_secondary_umbrella = "secondary_umbrella",
+)
 
 def _rbe(ctx):
     rbe_repo_props = []
@@ -35,4 +39,11 @@ rbe = module_extension(
     tag_classes = {
         "git_repository": git_repository_tag,
     },
+)
+
+def _secondary_umbrella(ctx):
+    fetch_secondary_umbrella()
+
+secondary_umbrella = module_extension(
+    implementation = _secondary_umbrella,
 )

--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -1,0 +1,34 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+ADD_PLUGINS_DIR_BUILD_FILE = """set -euo pipefail
+
+cat << EOF > plugins/BUILD.bazel
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+
+pkg_zip(
+    name = "inet_tcp_proxy_ez",
+    package_dir = "inet_tcp_proxy/ebin",
+    srcs = [
+        "@inet_tcp_proxy_dist//:erlang_app",
+    ],
+    package_file_name = "inet_tcp_proxy-0.1.0.ez",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "standard_plugins",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+EOF
+"""
+
+def secondary_umbrella():
+    http_archive(
+        name = "rabbitmq-server-generic-unix-3.9",
+        build_file = "@//:BUILD.package_generic_unix",
+        patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
+        sha256 = "4672fad92a815b879cc78a5a9fd28445152b61745d68acd50432c15f96792171",
+        strip_prefix = "rabbitmq_server-3.9.13",
+        urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.9.13/rabbitmq-server-generic-unix-3.9.13.tar.xz"],
+    )


### PR DESCRIPTION
## Proposed Changes

rules_erlang 3.2.0 fails the BCR ci due to recent breakage on the bazel side, but works perfectly fine with rabbitmq-server

using our fork of the registry allows use to use 3.2.0 without an override, which is convenient for our other projects that depend on rabbitmq-server for testing

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

