### PR TITLE
Remove dependency on rabbit_channel for deliveries

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -579,10 +579,10 @@ assert_invariant(State = #q{consumers = Consumers, single_active_consumer_on = f
 
 is_empty(#q{backing_queue = BQ, backing_queue_state = BQS}) -> BQ:is_empty(BQS).
 
-maybe_send_drained(WasEmpty, State) ->
+maybe_send_drained(WasEmpty, #q{q = Q} = State) ->
     case (not WasEmpty) andalso is_empty(State) of
         true  -> notify_decorators(State),
-                 rabbit_queue_consumers:send_drained();
+                 rabbit_queue_consumers:send_drained(amqqueue:get_name(Q));
         false -> ok
     end,
     State.
@@ -1355,7 +1355,8 @@ handle_call({basic_get, ChPid, NoAck, LimiterPid}, _From,
 
 handle_call({basic_consume, NoAck, ChPid, LimiterPid, LimiterActive,
              PrefetchCount, ConsumerTag, ExclusiveConsume, Args, OkMsg, ActingUser},
-            _From, State = #q{consumers             = Consumers,
+            _From, State = #q{q = Q,
+                              consumers = Consumers,
                               active_consumer = Holder,
                               single_active_consumer_on = SingleActiveConsumerOn}) ->
     ConsumerRegistration = case SingleActiveConsumerOn of
@@ -1364,11 +1365,12 @@ handle_call({basic_consume, NoAck, ChPid, LimiterPid, LimiterActive,
                 true  ->
                     {error, reply({error, exclusive_consume_unavailable}, State)};
                 false ->
-                  Consumers1 = rabbit_queue_consumers:add(
-                    ChPid, ConsumerTag, NoAck,
-                    LimiterPid, LimiterActive,
-                    PrefetchCount, Args, is_empty(State),
-                    ActingUser, Consumers),
+                    Consumers1 = rabbit_queue_consumers:add(
+                                   amqqueue:get_name(Q),
+                                   ChPid, ConsumerTag, NoAck,
+                                   LimiterPid, LimiterActive,
+                                   PrefetchCount, Args, is_empty(State),
+                                   ActingUser, Consumers),
 
                   case Holder of
                       none ->
@@ -1386,6 +1388,7 @@ handle_call({basic_consume, NoAck, ChPid, LimiterPid, LimiterActive,
               in_use -> {error, reply({error, exclusive_consume_unavailable}, State)};
               ok     ->
                     Consumers1 = rabbit_queue_consumers:add(
+                                   amqqueue:get_name(Q),
                                    ChPid, ConsumerTag, NoAck,
                                    LimiterPid, LimiterActive,
                                    PrefetchCount, Args, is_empty(State),
@@ -1652,9 +1655,10 @@ handle_cast({credit, ChPid, CTag, Credit, Drain},
                        backing_queue_state = BQS,
                        q = Q}) ->
     Len = BQ:len(BQS),
-    rabbit_classic_queue:send_queue_event(ChPid, amqqueue:get_name(Q), {send_credit_reply, Len}),
+    rabbit_classic_queue:send_credit_reply(ChPid, amqqueue:get_name(Q), Len),
     noreply(
-      case rabbit_queue_consumers:credit(Len == 0, Credit, Drain, ChPid, CTag,
+      case rabbit_queue_consumers:credit(amqqueue:get_name(Q),
+                                         Len == 0, Credit, Drain, ChPid, CTag,
                                          Consumers) of
           unchanged               -> State;
           {unblocked, Consumers1} -> State1 = State#q{consumers = Consumers1},

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -15,6 +15,7 @@
          discover/1,
          feature_flag_name/1,
          default/0,
+         is_supported/0,
          is_enabled/1,
          is_compatible/4,
          declare/2,
@@ -126,7 +127,6 @@
               actions/0,
               settle_op/0]).
 
-%% is the queue type feature enabled
 -callback is_enabled() -> boolean().
 
 -callback is_compatible(Durable :: boolean(),
@@ -244,6 +244,13 @@ feature_flag_name(_) ->
 default() ->
     rabbit_classic_queue.
 
+%% is the queue type API supported in the cluster
+is_supported() ->
+    %% the stream_queue feature enables
+    %% the queue_type internal message API
+    rabbit_feature_flags:is_enabled(stream_queue).
+
+%% is a specific queue type implementation enabled
 -spec is_enabled(module()) -> boolean().
 is_enabled(Type) ->
     Type:is_enabled().

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1305,7 +1305,7 @@ dlh(undefined, _, Strategy, _, QName) ->
 dlh(Exchange, RoutingKey, <<"at-least-once">>, reject_publish, QName) ->
     %% Feature flag stream_queue includes the rabbit_queue_type refactor
     %% which is required by rabbit_fifo_dlx_worker.
-    case rabbit_feature_flags:is_enabled(stream_queue) of
+    case rabbit_queue_type:is_supported() of
         true ->
             at_least_once;
         false ->


### PR DESCRIPTION
Some queue -> channel messages from classic queues
were missed when the queue type API was introduced. This commit fixes that
which should make use of classic queues portable outside of the
channel.

This includes some refactoring to make more explicit that
the stream_queue feature flag also enables queue types.
