### PR TITLE
Handle quorum queue timeout errors on rare 'basic.get' operations

### DIFF
--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -548,7 +548,8 @@ credit(Q, CTag, Credit, Drain, Ctxs) ->
 -spec dequeue(amqqueue:amqqueue(), boolean(),
               pid(), rabbit_types:ctag(), state()) ->
     {ok, non_neg_integer(), term(), state()}  |
-    {empty, state()}.
+    {empty, state()} | rabbit_types:error(term()) |
+    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 dequeue(Q, NoAck, LimiterPid, CTag, Ctxs) ->
     #ctx{state = State0} = Ctx = get_ctx(Q, Ctxs),
     Mod = amqqueue:get_type(Q),
@@ -559,6 +560,8 @@ dequeue(Q, NoAck, LimiterPid, CTag, Ctxs) ->
             {empty, set_ctx(Q, Ctx#ctx{state = State}, Ctxs)};
         {error, _} = Err ->
             Err;
+        {timeout, _} = Err ->
+            {error, Err};
         {protocol_error, _, _, _} = Err ->
             Err
     end.


### PR DESCRIPTION
## Proposed Changes

Hello! 👋 On rare usage of AMQP `basic.get` on quorum queues, a user is occasionally
seeing the following crash reports:

```
 {{case_clause,
     {timeout,
         {'xxxxxxxx-QUEUE-NAME-xxxxxxx','xxxxxxxx-NODE-NAME-xxxxxxx'}}},
 [{rabbit_queue_type,dequeue,5,[{file,"rabbit_queue_type.erl"},{line,555}]},
  {rabbit_misc,with_exit_handler,2,[{file,"rabbit_misc.erl"},{line,528}]},

```

This change adds appropriate handling to avoid noisy crashes on the channel process(es).


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
