### PR TITLE
Make adding bindings idempotent

### DIFF
--- a/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
+++ b/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
@@ -57,7 +57,7 @@ suites = [
     rabbitmq_integration_suite(
         PACKAGE,
         name = "rabbit_exchange_type_consistent_hash_SUITE",
-        shard_count = 2,
+        shard_count = 3,
     ),
 ]
 

--- a/deps/rabbitmq_consistent_hash_exchange/include/rabbitmq_consistent_hash_exchange.hrl
+++ b/deps/rabbitmq_consistent_hash_exchange/include/rabbitmq_consistent_hash_exchange.hrl
@@ -1,7 +1,7 @@
+-type bucket() :: non_neg_integer().
+
 -record(chx_hash_ring, {
-  %% a resource
-  exchange,
-  %% a map of bucket => queue | exchange
-  bucket_map,
-  next_bucket_number
+  exchange :: rabbit_exchange:name(),
+  bucket_map :: #{bucket() => rabbit_types:binding_destination()},
+  next_bucket_number :: bucket()
 }).

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
@@ -193,23 +193,33 @@ policy_changed(_X1, _X2) -> ok.
 add_binding(transaction, X,
             B = #binding{source = S, destination = D, key = K}) ->
     Weight = rabbit_data_coercion:to_integer(K),
-    rabbit_log:debug("Consistent hashing exchange: adding binding from "
-                     "exchange ~s to destination ~s with routing key '~s'", [rabbit_misc:rs(S), rabbit_misc:rs(D), K]),
 
     case mnesia:read(?HASH_RING_STATE_TABLE, S) of
         [State0 = #chx_hash_ring{bucket_map = BM0,
                                  next_bucket_number = NexN0}] ->
-            NextN    = NexN0 + Weight,
-            %% hi/lo bucket counters are 0-based but weight is 1-based
-            Range   = lists:seq(NexN0, (NextN - 1)),
-            BM      = lists:foldl(fun(Key, Acc) ->
-                                          maps:put(Key, D, Acc)
-                                  end, BM0, Range),
-            State   = State0#chx_hash_ring{bucket_map = BM,
-                                           next_bucket_number = NextN},
+            case map_has_value(BM0, D) of
+                true ->
+                    rabbit_log:debug("Consistent hashing exchange: NOT adding binding from "
+                                     "exchange ~s to destination ~s with routing key '~s' "
+                                     "because this binding (possibly with a different "
+                                     "routing key) already exists",
+                                     [rabbit_misc:rs(S), rabbit_misc:rs(D), K]);
+                false ->
+                    rabbit_log:debug("Consistent hashing exchange: adding binding from "
+                                     "exchange ~s to destination ~s with routing key '~s'",
+                                     [rabbit_misc:rs(S), rabbit_misc:rs(D), K]),
+                    NextN    = NexN0 + Weight,
+                    %% hi/lo bucket counters are 0-based but weight is 1-based
+                    Range   = lists:seq(NexN0, (NextN - 1)),
+                    BM      = lists:foldl(fun(Key, Acc) ->
+                                                  maps:put(Key, D, Acc)
+                                          end, BM0, Range),
+                    State   = State0#chx_hash_ring{bucket_map = BM,
+                                                   next_bucket_number = NextN},
 
-            ok = mnesia:write(?HASH_RING_STATE_TABLE, State, write),
-            ok;
+                    ok = mnesia:write(?HASH_RING_STATE_TABLE, State, write),
+                    ok
+            end;
         [] ->
             maybe_initialise_hash_ring_state(transaction, S),
             add_binding(transaction, X, B)
@@ -340,3 +350,22 @@ hash_on(Args) ->
         {Header, undefined}    -> Header;
         {undefined, Property}  -> Property
     end.
+
+-spec map_has_value(#{non_neg_integer() => rabbit_types:binding_destination()},
+                    rabbit_types:binding_destination()) ->
+    boolean().
+map_has_value(Map, Val) ->
+    I = maps:iterator(Map),
+    map_has_value0(maps:next(I), Val).
+
+-spec map_has_value0(none | {non_neg_integer(),
+                             rabbit_types:binding_destination(),
+                             maps:iterator()},
+                     rabbit_types:binding_destination()) ->
+    boolean().
+map_has_value0(none, _Val) ->
+    false;
+map_has_value0({_Bucket, SameVal, _I}, SameVal) ->
+    true;
+map_has_value0({_Bucket, _OtherVal, I}, Val) ->
+    map_has_value0(maps:next(I), Val).

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
@@ -236,6 +236,7 @@ remove_bindings(none, X, Bindings) ->
      fun() -> remove_bindings(transaction, X, Bindings) end),
     ok.
 
+-spec remove_binding(#binding{}) -> ok.
 remove_binding(#binding{source = S, destination = D, key = RK}) ->
     rabbit_log:debug("Consistent hashing exchange: removing binding "
                      "from exchange '~p' to destination '~p' with routing key '~s'",
@@ -275,6 +276,8 @@ remove_binding(#binding{source = S, destination = D, key = RK}) ->
             ok
     end.
 
+-spec ring_state(vhost:name(), rabbit_misc:resource_name()) ->
+    {ok, #chx_hash_ring{}} | {error, not_found}.
 ring_state(VirtualHost, Exchange) ->
     Resource = rabbit_misc:r(VirtualHost, exchange, Exchange),
     case mnesia:dirty_read(?HASH_RING_STATE_TABLE, Resource) of
@@ -351,14 +354,14 @@ hash_on(Args) ->
         {undefined, Property}  -> Property
     end.
 
--spec map_has_value(#{non_neg_integer() => rabbit_types:binding_destination()},
+-spec map_has_value(#{bucket() => rabbit_types:binding_destination()},
                     rabbit_types:binding_destination()) ->
     boolean().
 map_has_value(Map, Val) ->
     I = maps:iterator(Map),
     map_has_value0(maps:next(I), Val).
 
--spec map_has_value0(none | {non_neg_integer(),
+-spec map_has_value0(none | {bucket(),
                              rabbit_types:binding_destination(),
                              maps:iterator()},
                      rabbit_types:binding_destination()) ->


### PR DESCRIPTION
The change in this PR are by @ansd. The branch implements one of the options listed in #3386.

## Changes

> First binding wins.
> Duplicate bindings, i.e. bindings with the same source exchange and
> same destination queue / exchange but possibly different routing key
> (weight) are ignored from now on by the consistent hash exchange.
> 
> This applies only to bindings being added.
> For bindings being deleted, any duplicate binding (independent of its
> routing key) will delete all buckets for the given source and
> destination. (This is to ensure that buckets for a given source and
> destination can be deleted for when upgrading from a version prior
> to this commit. This was also the behaviour prior to this commit,
> so nothing changes in that regard.)
> 
> Note that duplicate bindings continue to be created in RabbitMQ.
> (They are only ignored by the consistent hash exchange.)
> 
> Adding a binding will perform linear search in the bucket map.
> This is already stated in the README:
> "These two operations use linear algorithms to update the ring."
> 
> The linear search when adding a binding could be optimised by
> adding another Mnesia table field which will require a new migration and
> feature flag. Hence, such an optimization is left out in this commit.

Fixes #3386.
