### PR TITLE
Use microsecond abbreviation 'us' instead of 'µs'

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -387,7 +387,7 @@ start_it(StartType) ->
 
                 T1 = erlang:timestamp(),
                 ?LOG_DEBUG(
-                  "Time to start RabbitMQ: ~p µs",
+                  "Time to start RabbitMQ: ~p us",
                   [timer:now_diff(T1, T0)]),
                 stop_boot_marker(Marker),
                 ok

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -932,7 +932,7 @@ query_supported_feature_flags() ->
     TestsuiteProviders = [App || {App, _, _} <- AttributesFromTestsuite],
     T1 = erlang:timestamp(),
     rabbit_log_feature_flags:debug(
-      "Feature flags: time to find supported feature flags: ~p µs",
+      "Feature flags: time to find supported feature flags: ~p us",
       [timer:now_diff(T1, T0)]),
     AllAttributes = AttributesPerApp ++ AttributesFromTestsuite,
     AllApps = lists:usort(ScannedApps ++ TestsuiteProviders),

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -220,7 +220,7 @@ maybe_initialize_registry(NewSupportedFeatureFlags,
                                          WrittenToDisk),
             T1 = erlang:timestamp(),
             rabbit_log_feature_flags:debug(
-              "Feature flags: time to regen registry: ~p µs",
+              "Feature flags: time to regen registry: ~p us",
               [timer:now_diff(T1, T0)]),
             Ret;
         false ->

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -867,7 +867,7 @@ handle_nodes_in_parallel(NodeConfigs, Fun) ->
                          T2 = erlang:timestamp(),
                          ct:pal(
                            ?LOW_IMPORTANCE,
-                           "Time to run ~p for node ~s: ~b µs",
+                           "Time to run ~p for node ~s: ~b us",
                           [Fun,
                            ?config(nodename, NodeConfig),
                            timer:now_diff(T2, T1)]),
@@ -884,7 +884,7 @@ wait_for_node_handling([], Fun, T0, Results) ->
     T3 = erlang:timestamp(),
     ct:pal(
       ?LOW_IMPORTANCE,
-      "Time to run ~p for all nodes: ~b µs",
+      "Time to run ~p for all nodes: ~b us",
       [Fun, timer:now_diff(T3, T0)]),
     Results;
 wait_for_node_handling(Procs, Fun, T0, Results) ->


### PR DESCRIPTION
`us` is used when Unicode is not available.

Prior to this commit:
```
$ kubectl logs r1-server-0 -c rabbitmq | ag time
2022-06-30 13:37:35.253927+00:00 [debug] <0.336.0> wal: recovered 00000003.wal time taken 0ms
2022-06-30 13:37:35.262592+00:00 [debug] <0.349.0> wal: recovered 00000003.wal time taken 0ms
2022-06-30 13:37:35.489016+00:00 [debug] <0.352.0> Feature flags: time to find supported feature flags: 76468 �s
2022-06-30 13:37:35.495193+00:00 [debug] <0.352.0> Feature flags: time to regen registry: 6032 �s
2022-06-30 13:37:35.500574+00:00 [debug] <0.361.0> Feature flags: time to find supported feature flags: 937 �s
2022-06-30 13:37:35.500603+00:00 [debug] <26705.398.0> Feature flags: time to find supported feature flags: 891 �s
2022-06-30 13:37:35.507998+00:00 [debug] <26705.398.0> Feature flags: time to regen registry: 7199 �s
2022-06-30 13:37:35.509092+00:00 [debug] <0.361.0> Feature flags: time to regen registry: 8396 �s
```

... I'm sure this can be fixed in my terminal / editor / kubectl. But let's not output those characters in the first place.