### PR TITLE
Add client-side TLS options support to Consul peer discovery

### DIFF
--- a/deps/rabbitmq_peer_discovery_consul/priv/schema/rabbitmq_peer_discovery_consul.schema
+++ b/deps/rabbitmq_peer_discovery_consul/priv/schema/rabbitmq_peer_discovery_consul.schema
@@ -322,3 +322,119 @@ fun(Conf) ->
         Value -> Value
     end
 end}.
+
+
+%%
+%% TLS client options
+%%
+
+{mapping, "cluster_formation.consul.ssl_options", "rabbit.cluster_formation.peer_discovery_consul.ssl_options", [
+    {datatype, {enum, [none]}}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options",
+fun(Conf) ->
+case cuttlefish:conf_get("cluster_formation.consul.ssl_options", Conf, undefined) of
+    none -> [];
+    _    -> cuttlefish:invalid("Invalid cluster_formation.consul.ssl_options")
+end
+end}.
+
+{mapping, "cluster_formation.consul.ssl_options.verify", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.verify", [
+{datatype, {enum, [verify_peer, verify_none]}}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.fail_if_no_peer_cert", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.fail_if_no_peer_cert", [
+{datatype, {enum, [true, false]}}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.cacertfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cacertfile",
+[{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.certfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.certfile",
+[{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.cacerts.$name", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cacerts",
+[{datatype, string}]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cacerts",
+fun(Conf) ->
+Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.cacerts", Conf),
+[ list_to_binary(V) || {_, V} <- Settings ]
+end}.
+
+{mapping, "cluster_formation.consul.ssl_options.cert", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cert",
+[{datatype, string}]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.cert",
+fun(Conf) ->
+list_to_binary(cuttlefish:conf_get("cluster_formation.consul.ssl_options.cert", Conf))
+end}.
+
+{mapping, "cluster_formation.consul.ssl_options.crl_check", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.crl_check",
+[{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.depth", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.depth",
+[{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.dh", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.dh",
+[{datatype, string}]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.dh",
+fun(Conf) ->
+list_to_binary(cuttlefish:conf_get("cluster_formation.consul.ssl_options.dh", Conf))
+end}.
+
+{mapping, "cluster_formation.consul.ssl_options.dhfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.dhfile",
+[{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.key.RSAPrivateKey", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+[{datatype, string}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.key.DSAPrivateKey", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+[{datatype, string}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.key.PrivateKeyInfo", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+[{datatype, string}]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.key",
+fun(Conf) ->
+case cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.key", Conf) of
+    [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
+    _ -> undefined
+end
+end}.
+
+{mapping, "cluster_formation.consul.ssl_options.keyfile", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.keyfile",
+[{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.log_alert", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.log_alert",
+[{datatype, {enum, [true, false]}}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.password", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.password",
+[{datatype, string}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.psk_identity", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.psk_identity",
+[{datatype, string}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.reuse_sessions", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.reuse_sessions",
+[{datatype, {enum, [true, false]}}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.secure_renegotiate", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.secure_renegotiate",
+[{datatype, {enum, [true, false]}}]}.
+
+{mapping, "cluster_formation.consul.ssl_options.versions.$version", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.versions",
+[{datatype, atom}]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.versions",
+fun(Conf) ->
+Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.versions", Conf),
+[V || {_, V} <- Settings]
+end}.
+
+{mapping, "cluster_formation.consul.ssl_options.ciphers.$cipher", "rabbit.cluster_formation.peer_discovery_consul.ssl_options.ciphers",
+[{datatype, string}]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.ssl_options.ciphers",
+fun(Conf) ->
+Settings = cuttlefish_variable:filter_by_prefix("cluster_formation.consul.ssl_options.ciphers", Conf),
+lists:reverse([V || {_, V} <- Settings])
+end}.

--- a/deps/rabbitmq_peer_discovery_consul/src/rabbit_peer_discovery_consul.erl
+++ b/deps/rabbitmq_peer_discovery_consul/src/rabbit_peer_discovery_consul.erl
@@ -19,8 +19,11 @@
          post_registration/0, lock/1, unlock/1]).
 -export([send_health_check_pass/0]).
 -export([session_ttl_update_callback/1]).
-%% useful for debugging from the REPL with RABBITMQ_ALLOW_INPUT
+%% for debugging from the REPL
 -export([service_id/0, service_address/0]).
+%% for debugging from the REPL
+-export([http_options/1, http_options/2]).
+
 %% for tests
 -ifdef(TEST).
 -compile(export_all).
@@ -63,13 +66,15 @@ list_nodes() ->
            end,
     Fun2 = fun(Proplist) ->
                    M = maps:from_list(Proplist),
+                   Path = rabbit_peer_discovery_httpc:build_path([v1, health, service, get_config_key(consul_svc, M)]),
+                   HttpOpts = http_options(M),
                    case rabbit_peer_discovery_httpc:get(get_config_key(consul_scheme, M),
                                                         get_config_key(consul_host, M),
                                                         get_integer_config_key(consul_port, M),
-                                                        rabbit_peer_discovery_httpc:build_path([v1, health, service, get_config_key(consul_svc, M)]),
+                                                        Path,
                                                         list_nodes_query_args(),
                                                         maybe_add_acl([]),
-                                                        []) of
+                                                        HttpOpts) of
                        {ok, Nodes} ->
                            IncludeWithWarnings = get_config_key(consul_include_nodes_with_warnings, M),
                            Result = extract_nodes(
@@ -117,12 +122,16 @@ unregister() ->
   ?LOG_DEBUG(
      "Unregistering with Consul using service ID '~s'", [ID],
      #{domain => ?RMQLOG_DOMAIN_PEER_DIS}),
+  Path = rabbit_peer_discovery_httpc:build_path([v1, agent, service, deregister, ID]),
+  Headers = maybe_add_acl([]),
+  HttpOpts = http_options(M),
   case rabbit_peer_discovery_httpc:put(get_config_key(consul_scheme, M),
                                        get_config_key(consul_host, M),
                                        get_integer_config_key(consul_port, M),
-                                       rabbit_peer_discovery_httpc:build_path([v1, agent, service, deregister, ID]),
+                                       Path,
                                        [],
-                                       maybe_add_acl([]),
+                                       Headers,
+                                       HttpOpts,
                                        []) of
     {ok, Response} ->
           ?LOG_INFO(
@@ -198,6 +207,30 @@ get_integer_config_key(Key, Map) ->
     ?CONFIG_MODULE:get_integer(Key, ?CONFIG_MAPPING, Map).
 
 
+-spec http_options(Map :: #{atom() => peer_discovery_config_value()}) -> list().
+http_options(M) ->
+  case maps:get(ssl_options, M, none) of
+    none -> [];
+    []   -> [];
+    Opts -> [{ssl, Opts}]
+  end.
+
+
+-spec http_options(HttpOpts0 :: list(), Map :: #{atom() => peer_discovery_config_value()}) -> list().
+http_options(HttpOpts0, M) ->
+  TLSOpts = case get_config_key(consul_scheme, M) of
+    "http"  -> [];
+    "https" ->
+      case maps:get(ssl_options, M, none) of
+        none -> [];
+        []   -> [];
+        Opts -> [{ssl, Opts}]
+      end
+  end,
+
+  HttpOpts1 = [TLSOpts | HttpOpts0],
+  HttpOpts1.
+
 -spec filter_nodes(ConsulResult :: list(), AllowWarning :: atom()) -> list().
 filter_nodes(Nodes, Warn) ->
   case Warn of
@@ -234,11 +267,11 @@ extract_nodes([H | T], Nodes) ->
   extract_nodes(T, lists:merge(Nodes, [NodeName])).
 
 -spec maybe_add_acl(QArgs :: list()) -> list().
-maybe_add_acl(QArgs) ->
+maybe_add_acl(List) ->
   M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
   case get_config_key(consul_acl_token, M) of
-    "undefined" -> QArgs;
-    ACL         -> lists:append(QArgs, [{"X-Consul-Token", ACL}])
+    "undefined" -> List;
+    ACL         -> [{"X-Consul-Token", ACL} | List]
   end.
 
 -spec list_nodes_query_args() -> list().
@@ -469,7 +502,6 @@ maybe_add_domain(Value) ->
       false -> Value
   end.
 
-
 %%--------------------------------------------------------------------
 %% @doc
 %% Let Consul know that this node is still around
@@ -484,12 +516,16 @@ send_health_check_pass() ->
   ?LOG_DEBUG(
      "Running Consul health check",
      #{domain => ?RMQLOG_DOMAIN_PEER_DIS}),
+  Path = rabbit_peer_discovery_httpc:build_path([v1, agent, check, pass, Service]),
+  Headers = maybe_add_acl([]),
+  HttpOpts = http_options(M),
   case rabbit_peer_discovery_httpc:put(get_config_key(consul_scheme, M),
                                        get_config_key(consul_host, M),
                                        get_integer_config_key(consul_port, M),
-                                       rabbit_peer_discovery_httpc:build_path([v1, agent, check, pass, Service]),
+                                       Path,
                                        [],
-                                       maybe_add_acl([]),
+                                       Headers,
+                                       HttpOpts,
                                        []) of
     {ok, []} -> ok;
     {error, "429"} ->
@@ -591,12 +627,14 @@ consul_session_create(Query, Headers, Body) ->
     M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
     case serialize_json_body(Body) of
         {ok, Serialized} ->
+            HttpOpts = http_options(M),
             rabbit_peer_discovery_httpc:put(get_config_key(consul_scheme, M),
                                             get_config_key(consul_host, M),
                                             get_integer_config_key(consul_port, M),
                                             "v1/session/create",
                                             Query,
                                             Headers,
+                                            HttpOpts,
                                             Serialized);
         {error, _} = Err ->
             Err
@@ -712,12 +750,14 @@ consul_kv_write(Path, Query, Headers, Body) ->
     M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
     case serialize_json_body(Body) of
         {ok, Serialized} ->
+            HttpOpts = http_options(M),
             rabbit_peer_discovery_httpc:put(get_config_key(consul_scheme, M),
                                             get_config_key(consul_host, M),
                                             get_integer_config_key(consul_port, M),
                                             "v1/kv/" ++ Path,
                                             Query,
                                             Headers,
+                                            HttpOpts,
                                             Serialized);
         {error, _} = Err ->
             Err
@@ -735,13 +775,14 @@ consul_kv_write(Path, Query, Headers, Body) ->
       Headers :: [{string(), string()}].
 consul_kv_read(Path, Query, Headers) ->
     M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
+    HttpOpts = http_options(M),
     rabbit_peer_discovery_httpc:get(get_config_key(consul_scheme, M),
                                     get_config_key(consul_host, M),
                                     get_integer_config_key(consul_port, M),
                                     "v1/kv/" ++ Path,
                                     Query,
                                     Headers,
-                                    []).
+                                    HttpOpts).
 
 %%--------------------------------------------------------------------
 %% @private
@@ -819,10 +860,13 @@ session_ttl_update_callback(SessionId) ->
 -spec consul_session_renew(string(), [{string(), string()}], [{string(), string()}]) -> {ok, term()} | {error, string()}.
 consul_session_renew(SessionId, Query, Headers) ->
     M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
+    Path = rabbit_peer_discovery_httpc:build_path([v1, session, renew, rabbit_data_coercion:to_atom(SessionId)]),
+    HttpOpts = http_options(M),
     rabbit_peer_discovery_httpc:put(get_config_key(consul_scheme, M),
                                     get_config_key(consul_host, M),
                                     get_integer_config_key(consul_port, M),
-                                    rabbit_peer_discovery_httpc:build_path([v1, session, renew, rabbit_data_coercion:to_atom(SessionId)]),
+                                    Path,
                                     Query,
                                     Headers,
+                                    HttpOpts,
                                     []).

--- a/deps/rabbitmq_peer_discovery_consul/src/rabbit_peer_discovery_consul.erl
+++ b/deps/rabbitmq_peer_discovery_consul/src/rabbit_peer_discovery_consul.erl
@@ -101,13 +101,17 @@ register() ->
       ?LOG_DEBUG(
          "Consul registration body: ~s", [Body],
          #{domain => ?RMQLOG_DOMAIN_PEER_DIS}),
+      Path = rabbit_peer_discovery_httpc:build_path([v1, agent, service, register]),
+      Headers = maybe_add_acl([]),
+      HttpOpts = http_options(M),
       case rabbit_peer_discovery_httpc:put(get_config_key(consul_scheme, M),
-                                            get_config_key(consul_host, M),
-                                            get_integer_config_key(consul_port, M),
-                                            rabbit_peer_discovery_httpc:build_path([v1, agent, service, register]),
-                                            [],
-                                            maybe_add_acl([]),
-                                            Body) of
+                                           get_config_key(consul_host, M),
+                                           get_integer_config_key(consul_port, M),
+                                           Path,
+                                           [],
+                                           Headers,
+                                           HttpOpts,
+                                           Body) of
         {ok, _} -> ok;
         Error   -> Error
       end;

--- a/deps/rabbitmq_peer_discovery_consul/test/rabbitmq_peer_discovery_consul_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_consul/test/rabbitmq_peer_discovery_consul_SUITE.erl
@@ -439,7 +439,7 @@ list_nodes_return_value_nodes_in_warning_state_filtered_out_test(_Config) ->
 registration_with_all_default_values_test(_Config) ->
           meck:expect(rabbit_log, debug, fun(_Message) -> ok end),
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
@@ -456,7 +456,7 @@ registration_with_all_default_values_test(_Config) ->
 
 registration_with_cluster_name_test(_Config) ->
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("localhost", Host),
               ?assertEqual(8500, Port),
@@ -473,7 +473,7 @@ registration_with_cluster_name_test(_Config) ->
 
 registration_without_acl_token_test(_Config) ->
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("https", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8501, Port),
@@ -495,7 +495,7 @@ registration_without_acl_token_test(_Config) ->
 
 registration_with_acl_token_test(_Config) ->
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("https", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8501, Port),
@@ -520,7 +520,7 @@ registration_with_auto_addr_test(_Config) ->
            meck:expect(rabbit_peer_discovery_util, node_hostname, fun(true)  -> "bob.consul.node";
                                                                      (false) -> "bob" end),
            meck:expect(rabbit_peer_discovery_httpc, put,
-             fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+             fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                ?assertEqual("http", Scheme),
                ?assertEqual("consul.service.consul", Host),
                ?assertEqual(8500, Port),
@@ -544,7 +544,7 @@ registration_with_auto_addr_from_nodename_test(_Config) ->
           meck:expect(rabbit_peer_discovery_util, node_hostname, fun(true)  -> "bob.consul.node";
                                                                     (false) -> "bob" end),
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
@@ -572,7 +572,7 @@ registration_with_auto_addr_nic_test(_Config) ->
               {ok, "172.16.4.50"}
             end),
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
@@ -600,7 +600,7 @@ registration_with_auto_addr_nic_issue_12_test(_Config) ->
               {ok, "172.16.4.50"}
             end),
           meck:expect(rabbit_peer_discovery_httpc, put,
-            fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+            fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
               ?assertEqual("http", Scheme),
               ?assertEqual("consul.service.consul", Host),
               ?assertEqual(8500, Port),
@@ -622,7 +622,7 @@ registration_with_auto_addr_nic_issue_12_test(_Config) ->
 
 registration_generic_error_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _Body) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, _Body) ->
              {error, "testing"}
            end),
          ?assertEqual({error, "testing"}, rabbit_peer_discovery_consul:register()),
@@ -630,7 +630,7 @@ registration_generic_error_test(_Config) ->
 
 health_check_with_all_defaults_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts, _Body) ->
              ?assertEqual("http", Scheme),
              ?assertEqual("localhost", Host),
              ?assertEqual(8500, Port),
@@ -645,7 +645,7 @@ health_check_with_all_defaults_test(_Config) ->
 
 health_check_without_acl_token_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts, _Body) ->
              ?assertEqual("https", Scheme),
              ?assertEqual("consul.service.consul", Host),
              ?assertEqual(8501, Port),
@@ -664,7 +664,7 @@ health_check_without_acl_token_test(_Config) ->
 
 health_check_with_acl_token_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts, _Body) ->
              ?assertEqual("http", Scheme),
              ?assertEqual("consul.service.consul", Host),
              ?assertEqual(8500, Port),
@@ -685,7 +685,7 @@ health_check_error_handling_test(_Config) ->
            ok
          end),
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _HttpOpts) ->
+           fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _HttpOpts, _Body) ->
              {error, "testing"}
            end),
          ?assertEqual(ok, rabbit_peer_discovery_consul:send_health_check_pass()),
@@ -695,7 +695,7 @@ health_check_error_handling_test(_Config) ->
 
 unregistration_with_all_defaults_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts, Body) ->
              ?assertEqual("http", Scheme),
              ?assertEqual("localhost", Host),
              ?assertEqual(8500, Port),
@@ -703,6 +703,7 @@ unregistration_with_all_defaults_test(_Config) ->
              ?assertEqual([], Args),
              ?assertEqual([], Headers),
              ?assertEqual([], HttpOpts),
+             ?assertEqual([], Body),
              {ok, []}
            end),
          ?assertEqual(ok, rabbit_peer_discovery_consul:unregister()),
@@ -711,7 +712,7 @@ unregistration_with_all_defaults_test(_Config) ->
 
 unregistration_without_acl_token_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts, Body) ->
              ?assertEqual("https", Scheme),
              ?assertEqual("consul.service.consul", Host),
              ?assertEqual(8501, Port),
@@ -719,6 +720,7 @@ unregistration_without_acl_token_test(_Config) ->
              ?assertEqual([], Args),
              ?assertEqual([], Headers),
              ?assertEqual([], HttpOpts),
+             ?assertEqual([], Body),
              {ok, []}
            end),
          os:putenv("CONSUL_SCHEME", "https"),
@@ -732,7 +734,7 @@ unregistration_without_acl_token_test(_Config) ->
 
 unregistration_with_acl_token_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts) ->
+           fun(Scheme, Host, Port, Path, Args, Headers, HttpOpts, Body) ->
              ?assertEqual("http", Scheme),
              ?assertEqual("consul.service.consul", Host),
              ?assertEqual(8500, Port),
@@ -740,6 +742,7 @@ unregistration_with_acl_token_test(_Config) ->
              ?assertEqual([], Args),
              ?assertEqual([{"X-Consul-Token", "token-value"}], Headers),
              ?assertEqual([], HttpOpts),
+             ?assertEqual([], Body),
              {ok, []}
            end),
          os:putenv("CONSUL_HOST", "consul.service.consul"),
@@ -750,7 +753,7 @@ unregistration_with_acl_token_test(_Config) ->
 
 unregistration_with_generic_error_test(_Config) ->
          meck:expect(rabbit_peer_discovery_httpc, put,
-           fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _HttpOpts) ->
+           fun(_Scheme, _Host, _Port, _Path, _Args, _Headers, _HttpOpts, _Body) ->
              {error, "testing"}
            end),
          ?assertEqual({error, "testing"}, rabbit_peer_discovery_consul:unregister()),
@@ -772,7 +775,7 @@ startup_lock_path_with_cluster_name_test(_Config) ->
 
 create_session_without_token_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -788,7 +791,7 @@ create_session_without_token_test(_Config) ->
 
 create_session_with_token_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -901,7 +904,7 @@ wait_for_lock_release_without_session_test(_Config) ->
 
 acquire_lock_successfully_acquired_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -916,7 +919,7 @@ acquire_lock_successfully_acquired_test(_Config) ->
 
 acquire_lock_not_acquired_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -931,7 +934,7 @@ acquire_lock_not_acquired_test(_Config) ->
 
 acquire_lock_with_token_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -947,7 +950,7 @@ acquire_lock_with_token_test(_Config) ->
 
 release_lock_successfully_released_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -962,7 +965,7 @@ release_lock_successfully_released_test(_Config) ->
 
 release_lock_not_released_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -977,7 +980,7 @@ release_lock_not_released_test(_Config) ->
 
 release_lock_with_token_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -1024,7 +1027,7 @@ consul_kv_read_custom_values_test(_Config) ->
 
 consul_kv_write_default_values_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -1039,7 +1042,7 @@ consul_kv_write_default_values_test(_Config) ->
 
 consul_kv_write_custom_values_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("consul.node.consul", Host),
                         ?assertEqual(8501, Port),
@@ -1056,7 +1059,7 @@ consul_kv_write_custom_values_test(_Config) ->
 
 consul_session_create_default_values_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -1071,7 +1074,7 @@ consul_session_create_default_values_test(_Config) ->
 
 consul_session_create_custom_values_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("consul.node.consul", Host),
                         ?assertEqual(8501, Port),
@@ -1088,7 +1091,7 @@ consul_session_create_custom_values_test(_Config) ->
 
 consul_session_renew_default_values_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("localhost", Host),
                         ?assertEqual(8500, Port),
@@ -1103,7 +1106,7 @@ consul_session_renew_default_values_test(_Config) ->
 
 consul_session_renew_custom_values_test(_Config) ->
     meck:expect(rabbit_peer_discovery_httpc, put,
-                fun(Scheme, Host, Port, Path, Args, Headers, Body) ->
+                fun(Scheme, Host, Port, Path, Args, Headers, _HttpOpts, Body) ->
                         ?assertEqual("http", Scheme),
                         ?assertEqual("consul.node.consul", Host),
                         ?assertEqual(8501, Port),


### PR DESCRIPTION
This introduces TLS-related options support to Consul peer discovery, like https://github.com/rabbitmq/rabbitmq-server/commit/87bbf0c68ec6785548909f30ce878658579654cd did for etc.

Closes #5116.

Kudos to @dcorbacho for helping me with Meck-based tests.


## QA Environment

It took some effort to [set up Consul with TLS for client connections](https://learn.hashicorp.com/tutorials/consul/tls-encryption-secure-existing-datacenter), even though Consul docs are pretty great.

However, there are several caveats:

 * There are configuration settings in the docs that Consul 1.12 reports as deprecated
 * Certificate generation can be done using tls-gen but it might be easier to do it using Consul CLI
 * HTTPS port must be enabled explicitly from the command line (in RabbitMQ it is done via the config file)
 * TLS peer verification for HTTPS clients can be disabled separately from gRPC connections

Here is how I started Consul (a single server node with bootstrapping enabled):

``` shell
# HTTPS port MUST be enabled explicitly even if config file has TLS settings
consul agent -config-file=./config.hcl -https-port 8501
```

Here is the `rabbitmq.conf` used:

``` ini
cluster_formation.peer_discovery_backend = rabbitmq_peer_discovery_consul

# cluster_formation.consul.scheme = http
cluster_formation.consul.scheme = https
cluster_formation.consul.host = localhost
# uses HTTP
# cluster_formation.consul.port = 8500
# uses HTTPS
cluster_formation.consul.port = 8501
#
cluster_formation.consul.svc = rabbitmq

## do compute service address
# cluster_formation.consul.svc_addr_auto = true
## compute service address using node name
# cluster_formation.consul.svc_addr_use_nodename = true
## use long RabbitMQ node names?
# cluster_formation.consul.use_longname = true

cluster_formation.consul.svc_addr_auto = true
# cluster_formation.consul.svc_addr = warp10
cluster_formation.consul.use_longname = true

# cluster_formation.proxy.http_proxy = proxy.example.local
# cluster_formation.proxy.proxy_exclusions.1 = localhost
# cluster_formation.proxy.proxy_exclusions.2 = 127.0.0.1

cluster_formation.consul.svc_tags.1 = qa
cluster_formation.consul.svc_tags.2 = 3.8

cluster_formation.consul.svc_meta.owner = team-xyz
cluster_formation.consul.svc_meta.service = service-one
cluster_formation.consul.svc_meta.stats_url = https://service-one.eng.megacorp.local/stats/

# cluster_formation.consul.svc_ttl = 60

log.console.level = debug
log.file.level = debug

cluster_formation.consul.lock_prefix = rabbitmq-prefix
```

Here is the Consul config in HCL:

``` hcl
#
# General
#

server    = true
bootstrap = true

datacenter = "dc1"
data_dir = "./data"
log_level = "INFO"
node_name = "agent1"

server = true
ui_config {
  enabled = true
}

addresses {
  http = "0.0.0.0"
}

client_addr = "0.0.0.0",
bind_addr = "0.0.0.0",
advertise_addr = "127.0.0.1"

#
# TLS
#

# accept HTTPS connections without a certificate
verify_incoming = false
verify_incoming_rpc = true

verify_outgoing = true

# verify_server_hostname = true
ca_file = "consul-agent-ca.pem"
cert_file = "dc1-server-consul-0.pem"
key_file = "dc1-server-consul-0-key.pem"
```