### PR TITLE
Add `bazel run test-logs` fallback for non-desktop session

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -117,24 +117,33 @@ genrule(
     outs = ["open-test-logs.sh"],
     cmd = """set -euo pipefail
 cat << 'EOF' > $@
-    set -euo pipefail
-    if [ $$# -eq 0 ]; then
-        echo "Usage: bazel run test-logs TEST_LABEL [shard_index]"
-        exit 1
-    fi
+#!/bin/bash
+set -euo pipefail
+if [ $$# -eq 0 ]; then
+    echo "Usage: bazel run test-logs TEST_LABEL [shard_index]"
+    exit 1
+fi
 
-    RELATIVE=$${1#//}
-    PACKAGE=$${RELATIVE%%:*}
-    SUITE=$${RELATIVE##*:}
-    OUTPUT_DIR=test.outputs
-    if [ $$# -gt 1 ]; then
-        OUTPUT_DIR=shard_$$2_of_*/test.outputs
-    fi
-    cd bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR
-    if [ -f outputs.zip ]; then
-        unzip -u outputs.zip
-    fi
-    open index.html
+RELATIVE=$${1#//}
+PACKAGE=$${RELATIVE%%:*}
+SUITE=$${RELATIVE##*:}
+OUTPUT_DIR=test.outputs
+if [ $$# -gt 1 ]; then
+    OUTPUT_DIR=shard_$$2_of_*/test.outputs
+fi
+cd "bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR"
+if [ -f outputs.zip ]; then
+    unzip -u outputs.zip
+fi
+set +e
+open index.html
+rc=$$?
+set -e
+if [[ $$rc -eq 3 ]]; then
+  # For xdg-open exit code 3 means "A required tool could not be found." That is, there is no browser.
+  echo "Open your browser at http://$$(hostname -s):8000/index.html"
+  python -m http.server 8000
+fi
 EOF
 """,
     executable = True,
@@ -145,22 +154,23 @@ genrule(
     outs = ["open-remote-test-logs.sh"],
     cmd = """set -euo pipefail
 cat << 'EOF' > $@
-    set -euo pipefail
-    if [ $$# -eq 0 ]; then
-        echo "Usage: bazel run remote-test-logs TEST_LABEL [shard_index]"
-        exit 1
-    fi
+#!/bin/bash
+set -euo pipefail
+if [ $$# -eq 0 ]; then
+    echo "Usage: bazel run remote-test-logs TEST_LABEL [shard_index]"
+    exit 1
+fi
 
-    RELATIVE=$${1#//}
-    PACKAGE=$${RELATIVE%%:*}
-    SUITE=$${RELATIVE##*:}
-    OUTPUT_DIR=test.outputs
-    if [ $$# -gt 1 ]; then
-        OUTPUT_DIR=shard_$$2_of_*/test.outputs
-    fi
-    TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
-    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip -u outputs.zip
-    open index.html
+RELATIVE=$${1#//}
+PACKAGE=$${RELATIVE%%:*}
+SUITE=$${RELATIVE##*:}
+OUTPUT_DIR=test.outputs
+if [ $$# -gt 1 ]; then
+    OUTPUT_DIR=shard_$$2_of_*/test.outputs
+fi
+TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
+cd "$$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR" && unzip -u outputs.zip
+open index.html
 EOF
 """,
     executable = True,


### PR DESCRIPTION
My workflow is developing RabbitMQ on an Ubuntu server.
Since it doesn't have a desktop or browser, let's fallback
for `bazel run test-logs` command to start an HTTP server instead.

From now on, I can run conveniently:
```
david@nuc:~/workspace/rabbitmq-server$ bazel run test-logs //deps/rabbitmq_auth_backend_oauth2:unit_SUITE --config=local
INFO: Analyzed target //:test-logs (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:test-logs up-to-date:
  bazel-bin/open-test-logs.sh
INFO: Elapsed time: 0.047s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Archive:  outputs.zip
Couldn't find a suitable web browser!

Set the BROWSER environment variable to your desired browser.

Warning: program returned non-zero exit code #256
/usr/bin/open: 882: www-browser: not found
/usr/bin/open: 882: links2: not found
/usr/bin/open: 882: elinks: not found
/usr/bin/open: 882: links: not found
/usr/bin/open: 882: lynx: not found
/usr/bin/open: 882: w3m: not found
xdg-open: no method available for opening 'index.html'
Open your browser at http://nuc:8000/index.html
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
```

and then open http://nuc:8000/index.html in my browser on MacOS.

(If that's too customised, we don't have to merge this and I can create my own short script instead.)