### PR TITLE
Lower log level on stream creation validation failure

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -563,10 +563,18 @@ create_stream(VirtualHost, Reference, Arguments, Username) ->
                 end
             catch
                 exit:ExitError ->
-                    % likely to be a problem of inequivalent args on an existing stream
-                    rabbit_log:error("Error while creating ~p stream: ~p",
-                                     [Reference, ExitError]),
-                    {error, validation_failed}
+                    case ExitError of
+                        % likely a problem of inequivalent args on an existing stream
+                        {amqp_error, precondition_failed, M, _} ->
+                            rabbit_log:info("Error while creating ~p stream, "
+                                            ++ M,
+                                            [Reference]),
+                            {error, validation_failed};
+                        E ->
+                            rabbit_log:warning("Error while creating ~p stream, ~p",
+                                             [Reference, E]),
+                            {error, validation_failed}
+                    end
             end;
         error ->
             {error, validation_failed}

--- a/deps/rabbitmq_stream/src/rabbit_stream_sup.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_sup.erl
@@ -64,7 +64,7 @@ init([]) ->
                                   credits_required_for_unblocking,
                                   ?DEFAULT_CREDITS_REQUIRED_FOR_UNBLOCKING),
           frame_max =>
-              application:get_env(rabbitmq_stream, frame_max, 
+              application:get_env(rabbitmq_stream, frame_max,
                                   ?DEFAULT_FRAME_MAX),
           heartbeat =>
               application:get_env(rabbitmq_stream, heartbeat,


### PR DESCRIPTION
No need to log an error when the arguments are not the same,
info is enough.