### PR TITLE
Make computing checksums for quorum queues configurable

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2256,6 +2256,9 @@ end}.
     end
 }.
 
+{mapping, "quorum_queue.compute_checksums", "rabbit.quorum_compute_checksums", [
+    {datatype, {enum, [true, false]}}]}.
+
 % ===============================
 % Validators
 % ===============================

--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -72,7 +72,12 @@ ensure_ra_system_started(RaSystem) ->
 
 get_config(quorum_queues = RaSystem) ->
     DefaultConfig = get_default_config(),
-    DefaultConfig#{name => RaSystem}; % names => ra_system:derive_names(quorum)
+    Checksums = application:get_env(rabbit, quorum_compute_checksums, false),
+    WalChecksums = application:get_env(rabbit, quorum_wal_compute_checksums, Checksums),
+    SegmentChecksums = application:get_env(rabbit, quorum_segment_compute_checksums, Checksums),
+    DefaultConfig#{name => RaSystem, % names => ra_system:derive_names(quorum)
+                   wal_compute_checksums => WalChecksums,
+                   segment_compute_checksums => SegmentChecksums};
 get_config(coordination = RaSystem) ->
     DefaultConfig = get_default_config(),
     CoordDataDir = filename:join(

--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -72,7 +72,7 @@ ensure_ra_system_started(RaSystem) ->
 
 get_config(quorum_queues = RaSystem) ->
     DefaultConfig = get_default_config(),
-    Checksums = application:get_env(rabbit, quorum_compute_checksums, false),
+    Checksums = application:get_env(rabbit, quorum_compute_checksums, true),
     WalChecksums = application:get_env(rabbit, quorum_wal_compute_checksums, Checksums),
     SegmentChecksums = application:get_env(rabbit, quorum_segment_compute_checksums, Checksums),
     DefaultConfig#{name => RaSystem, % names => ra_system:derive_names(quorum)

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -812,5 +812,16 @@ credential_validator.regexp = ^abc\\d+",
   {classic_queue_default_version_invalid,
    "classic_queue.default_version = 3",
    [],
+   []},
+
+  %%
+  %% Quorum queue
+  %%
+
+  {quorum_queue_compute_checksums,
+   "quorum_queue.compute_checksums = true",
+   [{rabbit, [
+      {quorum_compute_checksums, true}
+     ]}],
    []}
 ].


### PR DESCRIPTION
Make use of https://github.com/rabbitmq/ra/pull/292. The checksums are computed (enabled) by default.

See https://github.com/rabbitmq/ra/pull/292#pullrequestreview-1013194678 for performance improvements.

The user can opt-out to compute checksums for both WAL and segments in `rabbitmq.conf`:
```
quorum_queue.compute_checksums = false
```

The user can also disable checksumming for WAL or segments in the `advanced.config`, for example:
```
[{rabbit, [{quorum_segment_compute_checksums, false}]}].
```

The naming scheme `quorum_queue.compute_checksums` of `rabbitmq.conf` is consistent with other queue type specific settings such as `classic_queue.default_version`.

The naming scheme `quorum_segment_compute_checksums` and `quorum_wal_compute_checksums` in the `advanced.config` is consistent with other quorum queue settings: `quorum_snapshot_interval`, `quorum_tick_interval`, `quorum_cluster_size`.