### PR TITLE
Add process_start_time_seconds metric.

### DIFF
--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_process_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_process_collector.erl
@@ -1,0 +1,64 @@
+-module(prometheus_process_collector).
+-export([deregister_cleanup/1,
+         collect_mf/2,
+         collect_metrics/2,
+         get_process_info/0]).
+
+-import(prometheus_model_helpers, [create_mf/5,
+                                   gauge_metric/1,
+                                   gauge_metric/2]).
+
+-behaviour(prometheus_collector).
+
+-define(METRICS, [{process_start_time_seconds, gauge,
+                   "Start time of the process since unix epoch in seconds."}
+                 ]).
+
+%% API exports
+-export([]).
+
+%%====================================================================
+%% Collector API
+%%====================================================================
+
+deregister_cleanup(_) -> ok.
+
+collect_mf(_Registry, Callback) ->
+    ProcessInfo = get_process_info(),
+    [mf(Callback, Metric, ProcessInfo) || Metric <- ?METRICS],
+    ok.
+
+collect_metrics(_, {Fun, Proplist}) ->
+    Fun(Proplist).
+
+mf(Callback, Metric, Proplist) ->
+    {Name, Type, Help, Fun} = case Metric of
+                                  {Key, Type1, Help1} ->
+                                      {Key, Type1, Help1, fun (Proplist1) ->
+                                                                  metric(Type1, [], proplists:get_value(Key, Proplist1))
+                                                          end};
+                                  {Key, Type1, Help1, Fun1} ->
+                                      {Key, Type1, Help1, Fun1}
+                              end,
+    Callback(create_mf(Name, Help, Type, ?MODULE, {Fun, Proplist})).
+
+%%====================================================================
+%% Private Parts
+%%====================================================================
+
+metric(gauge, Labels, Value) ->
+    gauge_metric(Labels, Value).
+
+get_process_info() ->
+    [{process_start_time_seconds,
+      case persistent_term:get(process_start_time_seconds, undefined) of
+          undefined -> 
+	      Value = compute_process_start_time_seconds(),
+	      persistent_term:put(process_start_time_seconds, Value),
+	      Value;
+          Value -> Value
+      end}].
+
+compute_process_start_time_seconds() ->
+    erlang:convert_time_unit(erlang:system_time() - (erlang:monotonic_time() -
+                                                         erlang:system_info(start_time)), native, second).

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
@@ -16,7 +16,8 @@ build_dispatcher() ->
     prometheus_registry:register_collectors([
         prometheus_rabbitmq_core_metrics_collector,
         prometheus_rabbitmq_global_metrics_collector,
-        prometheus_rabbitmq_alarm_metrics_collector]),
+        prometheus_rabbitmq_alarm_metrics_collector,
+        prometheus_process_collector]),
     prometheus_registry:register_collectors('per-object', [
         prometheus_vm_system_info_collector,
         prometheus_vm_dist_collector,


### PR DESCRIPTION
## Proposed Changes

Here I add just a single new metric `process_start_time_seconds` as requested in #4539.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I wouldn't close #4539 yet. I still believe it's reasonable to integrate prometheus_process_collector.
