### PR TITLE
Make RabbitMQ 3.8.x feature flags mandatory

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -7,12 +7,7 @@
 
 -module(rabbit_core_ff).
 
--export([quorum_queue_migration/3,
-         implicit_default_bindings_migration/3,
-         virtual_host_metadata_migration/3,
-         maintenance_mode_status_migration/3,
-         user_limits_migration/3,
-         direct_exchange_routing_v2_migration/3]).
+-export([direct_exchange_routing_v2_migration/3]).
 
 -rabbit_feature_flag(
    {classic_mirrored_queue_version,
@@ -24,8 +19,7 @@
    {quorum_queue,
     #{desc          => "Support queues of type `quorum`",
       doc_url       => "https://www.rabbitmq.com/quorum-queues.html",
-      stability     => stable,
-      migration_fun => {?MODULE, quorum_queue_migration}
+      stability     => required
      }}).
 
 -rabbit_feature_flag(
@@ -40,29 +34,25 @@
    {implicit_default_bindings,
     #{desc          => "Default bindings are now implicit, instead of "
                        "being stored in the database",
-      stability     => stable,
-      migration_fun => {?MODULE, implicit_default_bindings_migration}
+      stability     => required
      }}).
 
 -rabbit_feature_flag(
    {virtual_host_metadata,
     #{desc          => "Virtual host metadata (description, tags, etc)",
-      stability     => stable,
-      migration_fun => {?MODULE, virtual_host_metadata_migration}
+      stability     => required
      }}).
 
 -rabbit_feature_flag(
    {maintenance_mode_status,
     #{desc          => "Maintenance mode status",
-      stability     => stable,
-      migration_fun => {?MODULE, maintenance_mode_status_migration}
+      stability     => required
      }}).
 
 -rabbit_feature_flag(
     {user_limits,
      #{desc          => "Configure connection and channel limits for a user",
-       stability     => stable,
-       migration_fun => {?MODULE, user_limits_migration}
+       stability     => required
      }}).
 
 -rabbit_feature_flag(
@@ -86,121 +76,6 @@
      #{desc          => "Feature flags subsystem V2",
        stability     => stable
      }}).
-
-%% -------------------------------------------------------------------
-%% Quorum queues.
-%% -------------------------------------------------------------------
-
--define(quorum_queue_tables, [rabbit_queue,
-                              rabbit_durable_queue]).
-
-quorum_queue_migration(FeatureName, _FeatureProps, enable) ->
-    Tables = ?quorum_queue_tables,
-    rabbit_table:wait(Tables, _Retry = true),
-    Fields = amqqueue:fields(amqqueue_v2),
-    migrate_to_amqqueue_with_type(FeatureName, Tables, Fields);
-quorum_queue_migration(_FeatureName, _FeatureProps, is_enabled) ->
-    Tables = ?quorum_queue_tables,
-    rabbit_table:wait(Tables, _Retry = true),
-    Fields = amqqueue:fields(amqqueue_v2),
-    mnesia:table_info(rabbit_queue, attributes) =:= Fields andalso
-    mnesia:table_info(rabbit_durable_queue, attributes) =:= Fields.
-
-migrate_to_amqqueue_with_type(FeatureName, [Table | Rest], Fields) ->
-    rabbit_log_feature_flags:info(
-      "Feature flag `~s`:   migrating Mnesia table ~s...",
-      [FeatureName, Table]),
-    Fun = fun(Queue) -> amqqueue:upgrade_to(amqqueue_v2, Queue) end,
-    case mnesia:transform_table(Table, Fun, Fields) of
-        {atomic, ok}      -> migrate_to_amqqueue_with_type(FeatureName,
-                                                           Rest,
-                                                           Fields);
-        {aborted, Reason} -> {error, Reason}
-    end;
-migrate_to_amqqueue_with_type(FeatureName, [], _) ->
-    rabbit_log_feature_flags:info(
-      "Feature flag `~s`:   Mnesia tables migration done",
-      [FeatureName]),
-    ok.
-
-%% -------------------------------------------------------------------
-%% Default bindings.
-%% -------------------------------------------------------------------
-
-implicit_default_bindings_migration(FeatureName, _FeatureProps,
-                                    enable) ->
-    %% Default exchange bindings are now implicit (not stored in the
-    %% route tables). It should be safe to remove them outside of a
-    %% transaction.
-    rabbit_table:wait([rabbit_queue]),
-    Queues = mnesia:dirty_all_keys(rabbit_queue),
-    remove_explicit_default_bindings(FeatureName, Queues);
-implicit_default_bindings_migration(_Feature_Name, _FeatureProps,
-                                    is_enabled) ->
-    undefined.
-
-remove_explicit_default_bindings(_FeatureName, []) ->
-    ok;
-remove_explicit_default_bindings(FeatureName, Queues) ->
-    rabbit_log_feature_flags:info(
-      "Feature flag `~s`:   deleting explicit default bindings "
-      "for ~b queues (it may take some time)...",
-      [FeatureName, length(Queues)]),
-    [rabbit_binding:remove_default_exchange_binding_rows_of(Q)
-     || Q <- Queues],
-    ok.
-
-%% -------------------------------------------------------------------
-%% Virtual host metadata.
-%% -------------------------------------------------------------------
-
-virtual_host_metadata_migration(_FeatureName, _FeatureProps, enable) ->
-    Tab = rabbit_vhost,
-    rabbit_table:wait([Tab], _Retry = true),
-    Fun = fun(Row) -> vhost:upgrade_to(vhost_v2, Row) end,
-    case mnesia:transform_table(Tab, Fun, vhost:fields(vhost_v2)) of
-        {atomic, ok}      -> ok;
-        {aborted, Reason} -> {error, Reason}
-    end;
-virtual_host_metadata_migration(_FeatureName, _FeatureProps, is_enabled) ->
-    mnesia:table_info(rabbit_vhost, attributes) =:= vhost:fields(vhost_v2).
-
-%% -------------------------------------------------------------------
-%% Maintenance mode.
-%% -------------------------------------------------------------------
-
-maintenance_mode_status_migration(FeatureName, _FeatureProps, enable) ->
-    TableName = rabbit_maintenance:status_table_name(),
-    rabbit_log:info(
-      "Creating table ~s for feature flag `~s`",
-      [TableName, FeatureName]),
-    try
-        _ = rabbit_table:create(
-              TableName,
-              rabbit_maintenance:status_table_definition()),
-        _ = rabbit_table:ensure_table_copy(TableName, node(), disc_copies)
-    catch throw:Reason  ->
-        rabbit_log:error(
-          "Failed to create maintenance status table: ~p",
-          [Reason])
-    end;
-maintenance_mode_status_migration(_FeatureName, _FeatureProps, is_enabled) ->
-    rabbit_table:exists(rabbit_maintenance:status_table_name()).
-
-%% -------------------------------------------------------------------
-%% User limits.
-%% -------------------------------------------------------------------
-
-user_limits_migration(_FeatureName, _FeatureProps, enable) ->
-    Tab = rabbit_user,
-    rabbit_table:wait([Tab], _Retry = true),
-    Fun = fun(Row) -> internal_user:upgrade_to(internal_user_v2, Row) end,
-    case mnesia:transform_table(Tab, Fun, internal_user:fields(internal_user_v2)) of
-        {atomic, ok}      -> ok;
-        {aborted, Reason} -> {error, Reason}
-    end;
-user_limits_migration(_FeatureName, _FeatureProps, is_enabled) ->
-    mnesia:table_info(rabbit_user, attributes) =:= internal_user:fields(internal_user_v2).
 
 %% -------------------------------------------------------------------
 %% Direct exchange routing v2.

--- a/deps/rabbit/src/rabbit_ff_extra.erl
+++ b/deps/rabbit/src/rabbit_ff_extra.erl
@@ -80,7 +80,8 @@ cli_info(FeatureFlags) ->
 %% @param Options Options to tune what is displayed and how.
 
 info(Options) ->
-    %% Two tables: one for stable feature flags, one for experimental ones.
+    %% Two tables: one for stable/required feature flags, one for
+    %% experimental ones.
     StableFF = rabbit_feature_flags:list(all, stable),
     case maps:size(StableFF) of
         0 ->

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -27,6 +27,7 @@
          enable_feature_flag_when_ff_file_is_unwritable/1,
          enable_feature_flag_with_a_network_partition/1,
          mark_feature_flag_as_enabled_with_a_network_partition/1,
+         required_feature_flag_enabled_by_default/1,
 
          clustering_ok_with_ff_disabled_everywhere/1,
          clustering_ok_with_ff_enabled_on_some_nodes/1,
@@ -35,6 +36,7 @@
          clustering_denied_with_new_ff_enabled/1,
          clustering_ok_with_new_ff_disabled_from_plugin_on_some_nodes/1,
          clustering_ok_with_new_ff_enabled_from_plugin_on_some_nodes/1,
+         clustering_ok_with_supported_required_ff/1,
          activating_plugin_with_new_ff_disabled/1,
          activating_plugin_with_new_ff_enabled/1
         ]).
@@ -55,14 +57,16 @@ groups() ->
      {enabling_on_single_node, [],
       [
        enable_feature_flag_in_a_healthy_situation,
-       enable_unsupported_feature_flag_in_a_healthy_situation
+       enable_unsupported_feature_flag_in_a_healthy_situation,
+       required_feature_flag_enabled_by_default
       ]},
      {enabling_in_cluster, [],
       [
        enable_feature_flag_in_a_healthy_situation,
        enable_unsupported_feature_flag_in_a_healthy_situation,
        enable_feature_flag_with_a_network_partition,
-       mark_feature_flag_as_enabled_with_a_network_partition
+       mark_feature_flag_as_enabled_with_a_network_partition,
+       required_feature_flag_enabled_by_default
       ]},
      {clustering, [],
       [
@@ -72,7 +76,8 @@ groups() ->
        clustering_ok_with_new_ff_disabled,
        clustering_denied_with_new_ff_enabled,
        clustering_ok_with_new_ff_disabled_from_plugin_on_some_nodes,
-       clustering_ok_with_new_ff_enabled_from_plugin_on_some_nodes
+       clustering_ok_with_new_ff_enabled_from_plugin_on_some_nodes,
+       clustering_ok_with_supported_required_ff
       ]},
      {activating_plugin, [],
       [
@@ -988,6 +993,64 @@ clustering_ok_with_new_ff_enabled_from_plugin_on_some_nodes(Config) ->
         false ->
             ok
     end,
+    ok.
+
+required_feature_flag_enabled_by_default(Config) ->
+    StableFName = ff_from_testsuite,
+    RequiredFName = quorum_queue,
+    ClusterSize = ?config(rmq_nodes_count, Config),
+    True = lists:duplicate(ClusterSize, true),
+    False = lists:duplicate(ClusterSize, false),
+
+    %% Restart the first node to make sure it evaluates again the list of
+    %% required flags. Indeed, the testsuite injects its required feature
+    %% flag after the nodes booted and we don't want to verify a
+    %% testsuite-specific handling.
+    %[Node | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    %?assertEqual(ok, rabbit_ct_broker_helpers:stop_node(Config, Node)),
+    %?assertEqual(ok, rabbit_ct_broker_helpers:start_node(Config, Node)),
+
+    %% The stable feature flag is supported but disabled.
+    ?assertEqual(
+       True,
+       is_feature_flag_supported(Config, StableFName)),
+    ?assertEqual(
+       False,
+       is_feature_flag_enabled(Config, StableFName)),
+
+    %% The required feature flag is supported and enabled.
+    ?assertEqual(
+       True,
+       is_feature_flag_supported(Config, RequiredFName)),
+    ?assertEqual(
+       True,
+       is_feature_flag_enabled(Config, RequiredFName)).
+
+clustering_ok_with_supported_required_ff(Config) ->
+    %% All feature flags are disabled. Clustering the two nodes should be
+    %% accepted because they are compatible.
+
+    log_feature_flags_of_all_nodes(Config),
+    ?assertEqual([true, true],
+                 is_feature_flag_supported(Config, ff_from_testsuite)),
+    ?assertEqual([false, false],
+                 is_feature_flag_enabled(Config, ff_from_testsuite)),
+    ?assertEqual([true, true],
+                 is_feature_flag_supported(Config, quorum_queue)),
+    ?assertEqual([true, true],
+                 is_feature_flag_enabled(Config, quorum_queue)),
+
+    ?assertEqual(Config, rabbit_ct_broker_helpers:cluster_nodes(Config)),
+
+    log_feature_flags_of_all_nodes(Config),
+    ?assertEqual([true, true],
+                 is_feature_flag_supported(Config, ff_from_testsuite)),
+    ?assertEqual([false, false],
+                 is_feature_flag_enabled(Config, ff_from_testsuite)),
+    ?assertEqual([true, true],
+                 is_feature_flag_supported(Config, quorum_queue)),
+    ?assertEqual([true, true],
+                 is_feature_flag_enabled(Config, quorum_queue)),
     ok.
 
 activating_plugin_with_new_ff_disabled(Config) ->

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -222,7 +222,7 @@ maybe_enable_feature_flags_v2(Config) ->
     ok.
 
 override_running_nodes(Nodes) when is_list(Nodes) ->
-    ct:pal("Overring (running) remote nodes for ~p", [Nodes]),
+    ct:pal("Overriding (running) remote nodes for ~p", [Nodes]),
     _ = [begin
              ok = rpc:call(
                     Node, rabbit_feature_flags, override_nodes,

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -889,7 +889,7 @@ enable_feature_flag_in_cluster_and_add_member_concurrently_mfv1(Config) ->
     OtherMigratedNodes = [receive
                               {Node, MigFunPid2, waiting} ->
                                   MigFunPid2 ! proceed,
-                                  Node 
+                                  Node
                           end || Node <- ExpectedNodes -- [FirstMigratedNode]],
     MigratedNodes = [FirstMigratedNode | OtherMigratedNodes],
     ?assertEqual(lists:sort(ExpectedNodes), lists:sort(MigratedNodes)),


### PR DESCRIPTION
This patch makes feature flags introduced during the life of RabbitMQ 3.8.x mandatory.

The compatibility and migration code behind feature flags marked mandatory is removed. This means two things:
1. Mandatory feature flags are always enabled on the very first boot of a new RabbitMQ node.
2. Affected feature flags MUST be enabled BEFORE upgrading to the version of RabbitMQ which consider them mandatory. A node will refuse to start if a mandatory feature flag is disabled, because all the compatibility code was removed.

In this patch, the following feature flags are now mandatory:
* `quorum_queue`
* `implicit_default_bindings`
* `virtual_host_metadata`
* `maintenance_mode_status`
* `user_limits`

Therefore, if this patch lands in RabbitMQ 3.11.0, a user must enable `quorum_queue` (and all other feature flags listed below) before he/she upgrades from RabbitMQ 3.10.x (or before) to 3.11.x.

Here is an example of an upgraded RabbitMQ node trying to start without the mandatory feature flags enabled:
```
2022-07-13 11:29:28.366877+02:00 [error] <0.232.0> Feature flags: `implicit_default_bindings`: mandatory feature flag not enabled! It must be enabled before upgrading RabbitMQ.
2022-07-13 11:29:28.366905+02:00 [error] <0.232.0> Failed to initialize feature flags registry: {disabled_mandatory_feature_flag,
2022-07-13 11:29:28.366905+02:00 [error] <0.232.0>                                               implicit_default_bindings}
2022-07-13 11:29:28.372830+02:00 [error] <0.232.0>
2022-07-13 11:29:28.372830+02:00 [error] <0.232.0> BOOT FAILED
2022-07-13 11:29:28.372830+02:00 [error] <0.232.0> ===========
2022-07-13 11:29:28.372830+02:00 [error] <0.232.0> Error during startup: {error,failed_to_initialize_feature_flags_registry}
2022-07-13 11:29:28.372830+02:00 [error] <0.232.0>
```

This patch only covers the support for mandatory feature flags and marks the feature flags listed above. As part of that, their migration code is removed because the code now makes an assertion that a mandatory feature flag has no migration function (which will never be executed anyway). However, the removal of the compatibility code will come in a separate pull request.