### PR TITLE
Ensure rabbit_index_route table is created after joining a cluster

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1054,6 +1054,11 @@ suites = [
         name = "direct_exchange_routing_v2_SUITE",
         size = "medium",
     ),
+    rabbitmq_integration_suite(
+        PACKAGE,
+        name = "direct_exchange_routing_v2_post_3_11_SUITE",
+        size = "small",
+    ),
 ]
 
 assert_suites(

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -597,6 +597,7 @@ init_db_and_upgrade(ClusterNodes, NodeType, CheckOtherNodes, Retry) ->
     end,
     %% ...and all nodes will need to wait for tables
     rabbit_table:wait_for_replicated(Retry),
+    rabbit_table:maybe_ensure_index_route_table(),
     ok.
 
 init_db_with_mnesia(ClusterNodes, NodeType,

--- a/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
+++ b/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
@@ -88,7 +88,8 @@ start_broker(Group, Config0) ->
 
 end_per_group(Group, Config)
   when Group =:= start_feature_flag_enabled;
-       Group =:= start_feature_flag_disabled ->
+       Group =:= start_feature_flag_disabled;
+       Group =:= unclustered_cluster_size_2 ->
     rabbit_ct_helpers:run_steps(Config,
                                 rabbit_ct_client_helpers:teardown_steps() ++
                                 rabbit_ct_broker_helpers:teardown_steps());

--- a/deps/rabbit/test/direct_exchange_routing_v2_post_3_11_SUITE.erl
+++ b/deps/rabbit/test/direct_exchange_routing_v2_post_3_11_SUITE.erl
@@ -33,8 +33,13 @@ suite() ->
     ].
 
 init_per_suite(Config) ->
-    rabbit_ct_helpers:log_environment(),
-    rabbit_ct_helpers:run_setup_steps(Config, []).
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "This test suite won't work in mixed mode with pre 3.11 releases"};
+        false ->
+            rabbit_ct_helpers:log_environment(),
+            rabbit_ct_helpers:run_setup_steps(Config, [])
+    end.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).

--- a/deps/rabbit/test/direct_exchange_routing_v2_post_3_11_SUITE.erl
+++ b/deps/rabbit/test/direct_exchange_routing_v2_post_3_11_SUITE.erl
@@ -1,0 +1,107 @@
+-module(direct_exchange_routing_v2_post_3_11_SUITE).
+
+%% Test suite for the feature flag direct_exchange_routing_v2
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+-define(FEATURE_FLAG, direct_exchange_routing_v2).
+-define(INDEX_TABLE_NAME, rabbit_index_route).
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+     {group, unclustered_cluster_size_2}
+    ].
+
+groups() ->
+    [
+     {unclustered_cluster_size_2, [], [cluster_formation]}
+    ].
+
+suite() ->
+    [
+     %% If a test hangs, no need to wait for 30 minutes.
+     {timetrap, {minutes, 8}}
+    ].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config, []).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(unclustered_cluster_size_2 = Group, Config0) ->
+    Config = rabbit_ct_helpers:set_config(Config0, [{rmq_nodes_count, 2},
+                                                    {rmq_nodes_clustered, false}]),
+    Config1 = start_broker(Group, Config),
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config1, ?FEATURE_FLAG) of
+        ok ->
+            Config1;
+        {skip, _} = Skip ->
+            end_per_group(Group, Config1),
+            Skip
+    end.
+
+start_broker(Group, Config0) ->
+    Size = rabbit_ct_helpers:get_config(Config0, rmq_nodes_count),
+    Config = rabbit_ct_helpers:set_config(Config0, {rmq_nodename_suffix,
+                                                    io_lib:format("cluster_size_~b-~s", [Size, Group])}),
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_broker_helpers:setup_steps() ++
+                                rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_client_helpers:teardown_steps() ++
+                                rabbit_ct_broker_helpers:teardown_steps());
+end_per_group(_Group, Config) ->
+    Config.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    %% Test that all bindings got removed from the database.
+    ?assertEqual([0,0,0,0,0],
+                 lists:map(fun(Table) ->
+                                   table_size(Config, Table)
+                           end, [rabbit_durable_route,
+                                 rabbit_semi_durable_route,
+                                 rabbit_route,
+                                 rabbit_reverse_route,
+                                 ?INDEX_TABLE_NAME])
+                ).
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+cluster_formation(Config) ->
+    Servers0 = [Server1, Server2] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    ?assertMatch([Server1], rabbit_ct_broker_helpers:rpc(Config, 0, mnesia, table_info,
+                                                         [?INDEX_TABLE_NAME, ram_copies])),
+    ?assertMatch([Server2], rabbit_ct_broker_helpers:rpc(Config, 1, mnesia, table_info,
+                                                         [?INDEX_TABLE_NAME, ram_copies])),
+    ok = rabbit_control_helper:command(stop_app, Server1),
+    ok = rabbit_control_helper:command(join_cluster, Server1, [atom_to_list(Server2)], []),
+    rabbit_control_helper:command(start_app, Server1),
+    Servers = lists:sort(Servers0),
+    ?assertMatch(Servers, lists:sort(rabbit_ct_broker_helpers:rpc(Config, 0, mnesia, table_info,
+                                                                  [?INDEX_TABLE_NAME, ram_copies]))),
+    ?assertMatch(Servers, lists:sort(rabbit_ct_broker_helpers:rpc(Config, 1, mnesia, table_info,
+                                                                  [?INDEX_TABLE_NAME, ram_copies]))).
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+table_size(Config, Table) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ets, info, [Table, size], 5000).


### PR DESCRIPTION
With the feature flags controller changes, the enabled features are not re-enabled every time a node starts. When an already initialised node joins the cluster (`stop_app`, `join_cluster`, `start_app` sequence), the `rabbit_index_route` table is missing on the nodes that have been reset. This table needs to be considered as an special case.


## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

