### PR TITLE
Make the "exclusive" tests in CI public

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,7 +106,7 @@ jobs:
         fi
         cat << EOF >> user.bazelrc
           build:buildbuddy --build_metadata=ROLE=CI
-          build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
+          build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
           build:buildbuddy --repository_cache=/home/runner/repo-cache/
           build:buildbuddy --color=yes
           build:buildbuddy --disk_cache=


### PR DESCRIPTION
exclusive means they run locally on the github actions worker instead of buildbuddy (i.e. they don't work correctly in a dockerized environment)

at one point this included the aws peer discovery integration tests, which have credentials in the logs

since this is no longer the case, we can make these public