### PR TITLE
Fixup the source_archive macro in dist.bzl

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -145,9 +145,7 @@ pkg_tar(
 
 package_generic_unix(plugins = PLUGINS)
 
-source_archive(plugins = PLUGINS + [
-    "//deps/rabbitmq_cli:rabbitmqctl",
-])
+source_archive(plugins = PLUGINS)
 
 genrule(
     name = "test-logs",

--- a/dist.bzl
+++ b/dist.bzl
@@ -290,7 +290,9 @@ def source_archive(
         rabbitmq_workspace = "@"):
     source_tree(
         name = "source-tree",
-        deps = plugins,
+        deps = plugins + [
+            rabbitmq_workspace + "//deps/rabbitmq_cli:rabbitmqctl",
+        ],
     )
 
     pkg_tar(
@@ -305,7 +307,7 @@ def source_archive(
     pkg_tar(
         name = "cli-deps-archive",
         deps = [
-            "//deps/rabbitmq_cli:fetched_srcs",
+            rabbitmq_workspace + "//deps/rabbitmq_cli:fetched_srcs",
         ],
         package_dir = "deps/rabbitmq_cli",
     )


### PR DESCRIPTION
Previously the macro did not refer to the cli sources correctly if invoked outside of the root of this workspace