### PR TITLE
Support Rich Authorization Request OAuth2 specification 

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -332,11 +332,13 @@ RabbitMQ supports JWT tokens compliant with the extension. Below is a sample exa
 ```
 {
   "authorization_details": [
-    { "type" : "rabbitmq",  
-      "locations": ["cluster:finance/vhost:primary-*"],
+    { 
+      "type" : "rabbitmq",  
+      "locations": ["cluster:finance/vhost:production-*"],
       "actions": [ "read", "write", "configure"  ]
     },
-    { "type" : "rabbitmq",
+    { 
+      "type" : "rabbitmq",
       "locations": ["cluster:finance", "cluster:inventory" ],
       "actions": ["administrator" ]
     }
@@ -349,9 +351,9 @@ Both permissions are meant for a RabbitMQ server whose `resource_server_type` is
 This field is essentially a permission discriminator.
 
 The first permission grants `read`, `write` and `configure` permissions to any vhost which matches
-the pattern `primary-*` that belongs to a cluster whose `resource_server_id` contains the string `finance`.
-The `cluster` attribute is a regular expression like the `vhost`. If we wanted to match exactly the `finance` cluster
-we would use instead `^finance$`.
+the pattern `production-*` that belongs to a cluster whose `resource_server_id` contains the string `finance`.
+The `cluster` attribute is a regular expression like the `vhost`. To match exactly the string `finance`,
+use `^finance$`.
 
 The second permission grants the `administrator` user-tag to both clusters, `finance` and `inventory`. The other
 supported user-tags as `management`, `policymaker` and `monitoring`.

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -372,10 +372,10 @@ The supported actions are:
 - `configure`
 - `read`
 - `write`
-- `tag:administrator`
-- `tag:monitoring`
-- `tag:management`
-- `tag:policymaker`
+- `administrator`
+- `monitoring`
+- `management`
+- `policymaker`
 
 #### Rich-Permission to Scope translation
 
@@ -414,7 +414,7 @@ Given the example above:
     },
     { "type" : "rabbitmq",
       "locations": ["cluster:finance", "cluster:inventory" ],
-      "actions": ["tag:administrator" ]
+      "actions": ["administrator" ]
     }
   ]
 }

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -1,7 +1,7 @@
 # OAuth 2.0 (JWT) Token Authorisation Backend for RabbitMQ
 
 This [RabbitMQ authentication/authorisation backend](https://www.rabbitmq.com/access-control.html) plugin lets
-applications (clients) and users authenticate and present their permissions 
+applications (clients) and users authenticate and present their permissions
 using JWT-encoded [OAuth 2.0 access tokens](https://tools.ietf.org/html/rfc6749#section-1.4).
 
 The plugin supports several identity providers, sometimes with vendor-specific configuration bits:
@@ -318,7 +318,7 @@ On an existing connection the token can be refreshed by the [update-secret](http
 
 If the latest token expires on an existing connection, after a limited time the broker will
 refuse all operations (but it won't disconnect).
-  
+
 
 ## Rich Authorization Request
 
@@ -332,12 +332,12 @@ RabbitMQ supports JWT tokens compliant with the extension. Below is a sample exa
 ```
 {
   "authorization_details": [
-    { 
+    {
       "type" : "rabbitmq",  
       "locations": ["cluster:finance/vhost:production-*"],
       "actions": [ "read", "write", "configure"  ]
     },
-    { 
+    {
       "type" : "rabbitmq",
       "locations": ["cluster:finance", "cluster:inventory" ],
       "actions": ["administrator" ]
@@ -350,9 +350,8 @@ The token above contains two permissions under the attribute `authorization_deta
 Both permissions are meant for RabbitMQ servers with `resource_server_type` set to `rabbitmq`.
 This field identifies RabbitMQ-specific permissions.
 
-The first permission grants `read`, `write` and `configure` permissions to any virtual host whose name matches
-the pattern `production-*`, and that reside in clusters whose `resource_server_id` contains the string `finance`.
-The `cluster` attribute's va;ie is also a regular expression. To match exactly the string `finance`,
+The first permission grants `read`, `write` and `configure` permissions to any queue and/or exchange on any virtual host whose name matches the pattern `production-*`, and that reside in clusters whose `resource_server_id` contains the string `finance`.
+The `cluster` attribute's value is also a regular expression. To match exactly the string `finance`,
 use `^finance$`.
 
 The second permission grants the `administrator` user tag in two clusters, `finance` and `inventory`. Other
@@ -427,17 +426,17 @@ aforementioned convention using the following algorithm:
 
 The plugin produces permutations of all `actions` by  all `locations` that match the node's configured `resource_server_id`.
 
-In the following RAR example 
+In the following RAR example
 
 ``` json
 {
   "authorization_details": [
-    { 
+    {
       "type" : "rabbitmq",  
       "locations": ["cluster:finance/vhost:primary-*"],
       "actions": [ "read", "write", "configure"  ]
     },
-    { 
+    {
       "type" : "rabbitmq",
       "locations": ["cluster:finance", "cluster:inventory"],
       "actions": ["administrator" ]
@@ -446,7 +445,7 @@ In the following RAR example
 }
 ```
 if RabbitMQ node's `resource_server_id` is equal to `finance`, the plugin will compute the following sets of scopes:
- 
+
  * `finance.read:primary-*/*/*`
  * `finance.write:primary-*/*/*`
  * `finance.configure:primary-*/*/*`

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -382,7 +382,7 @@ The supported location attributed are:
 
  * `cluster`: this is the only mandatory attribute. It is a wildcard pattern which must match RabbitMQ's `resource_server_id`, otherwise the location is ignored.
  * `vhost`: This is the virtual host we are granting access to. It also a wildcard pattern. RabbitMQ defaults to `*`.
- * `queue`|`exchange`: queue or exchange name the location grants the permission to. A location can only specify one or the other but not both
+ * `queue`|`exchange`: queue or exchange name pattern. The location grants the permission to a set of queues (or exchanges) that match it. One location can only specify either `queue` or `exchange` but not both
  * `routing_key`: this is the routing key pattern the location grants the permission to. If not specified, `*` will be used
 
 For more information about wildcard patterns, check the section [Scope-to-Permission Translation](#scope-to-permission-translation).

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -328,7 +328,9 @@ Both permissions are meant for a RabbitMQ server whose `resource_server_type` is
 This field is essentially a permission discriminator.
 
 The first permission grants `read`, `write` and `configure` permissions to any vhost which matches
-the pattern `primary-*` that belongs to a cluster whose `resource_server_id` is equal to `finance`.
+the pattern `primary-*` that belongs to a cluster whose `resource_server_id` contains the string `finance`.
+The `cluster` attribute is a regular expression like the `vhost`. If we wanted to match exactly the `finance` cluster
+we would use instead `^finance$`.
 
 The second permission grants the `tag:administrator` user-tag to both clusters, `finance` and `inventory`.
 
@@ -343,10 +345,16 @@ A JWT token may have permissions for resources other than RabbitMQ.
 The `locations` field can be either a string containing a single location or a Json array containing
 zero or many locations.
 
-A location consists of a list of key-value pairs separated by forward slash `/` character. The supported keys are:
+A location consists of a list of key-value pairs separated by forward slash `/` character.
 
-- `cluster` This is the only mandatory key. It is a regular expression which must match RabbitMQ's `resource_server_id` otherwise the location is ignored. For instance, if we want to match exactly `rabbitmq` we should use `^rabbitmq$`.
-- `vhost` This is the virtual host we are granting access to. It can be a fixed value or regular expression. RabbitMQ defaults to `*`.
+The location format is `cluster:<resource_server_id_pattern>[/vhost:<vhostpattern>][/queue:<queue_name_pattern>|/exchange:<exchange_name_pattern][/routing-key:<routing_key_pattern>]`. Any string separated by `/` which does not
+conform to `<key>:<value>` is ignored. For instance, if your locations start with a prefix, e.g. `vrn/cluster:rabbitmq`,
+the `vrn` pattern part is ignored.
+
+The supported location's attributed are:
+
+- `cluster` This is the only mandatory key. It is a regular expression which must match RabbitMQ's `resource_server_id` otherwise the location is ignored.
+- `vhost` This is the virtual host we are granting access to. It also a regular expression. RabbitMQ defaults to `*`.
 - `queue`|`exchange` This is the queue or exchange we are granting access to. A location can only specify one or the
 other but not both. However, RabbitMQ under the covers translates these permissions to scopes which means RabbitMQ does not differentiate between queues and exchanges, they are just resources. RabbitMQ defaults to `*`.
 - `routing-key` this is the routing key we are granted access to. RabbitMQ defaults to `*`.

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -317,7 +317,7 @@ all the other attributes and left only the relevant ones for this specification:
     },
     { "type" : "rabbitmq",
       "locations": ["cluster:finance", "cluster:inventory" ],
-      "actions": ["tag:administrator" ]
+      "actions": ["administrator" ]
     }
   ]
 }
@@ -332,7 +332,8 @@ the pattern `primary-*` that belongs to a cluster whose `resource_server_id` con
 The `cluster` attribute is a regular expression like the `vhost`. If we wanted to match exactly the `finance` cluster
 we would use instead `^finance$`.
 
-The second permission grants the `tag:administrator` user-tag to both clusters, `finance` and `inventory`.
+The second permission grants the `administrator` user-tag to both clusters, `finance` and `inventory`. The other
+supported user-tags as `management`, `policymaker` and `monitoring`.
 
 
 #### Type field

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -391,7 +391,7 @@ For more information about wildcard patterns, check the section [Scope-to-Permis
 
 The `actions` field can be either a string containing a single action or a JSON array containing one or more actions.
 
-The supported actions map to either [RabbitMQ permissions]():
+The supported actions map to either [RabbitMQ permissions](https://www.rabbitmq.com/access-control.html#authorisation):
 
 *`configure`
 *`read`

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -322,11 +322,12 @@ refuse all operations (but it won't disconnect).
 
 ## Rich Authorization Request
 
-The [Rich Authorization Request](https://oauth.net/2/rich-authorization-requests/) extension provides a way for OAuth clients to request fine-grained permissions during an authorization request. It moves away from the concept of Scopes and instead
-define a rich permission model.
+The [Rich Authorization Request](https://oauth.net/2/rich-authorization-requests/) extension provides a way for
+OAuth clients to request fine-grained permissions during an authorization request.
+It moves away from the concept of scopes that are text labels and instead
+defines a more sophisticated permission model.
 
-RabbitMQ supports JWT tokens compliant with this specification. Here is a sample JWT token where we have stripped out
-all the other attributes and left only the relevant ones for this specification:
+RabbitMQ supports JWT tokens compliant with the extension. Below is a sample example section of JWT token:
 
 ```
 {

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -390,12 +390,12 @@ For each location found in the `locations` where the `cluster` attribute matches
 
   - For each action found in the `actions`:
 
-    it generates a scope as follows for actions which are not user-tags:
+    if the action is not a user-tag, it produces a scope as follows:
     ```
       scope = <resource_server_id>.<action>:<scope_suffix>
     ```
 
-    or it generates a scope as follows for actions which are user-tags:
+    otherwise, for user-tag's actions, it produces this scope:
     ```
       scope = <resource_server_id>.<action>
     ```

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -353,10 +353,10 @@ the `vrn` pattern part is ignored.
 
 The supported location's attributed are:
 
-- `cluster` This is the only mandatory key. It is a wildcard pattern which must match RabbitMQ's `resource_server_id` otherwise the location is ignored.
+- `cluster` This is the only mandatory attribute. It is a wildcard pattern which must match RabbitMQ's `resource_server_id` otherwise the location is ignored.
 - `vhost` This is the virtual host we are granting access to. It also a wildcard pattern. RabbitMQ defaults to `*`.
 - `queue`|`exchange` This is the queue or exchange we are granting access to. A location can only specify one or the
-other but not both. However, RabbitMQ under the covers translates these permissions to scopes which means RabbitMQ does not differentiate between queues and exchanges, they are just resources. RabbitMQ defaults to `*`.
+other but not both.
 - `routing-key` this is the routing key we are granted access to. RabbitMQ defaults to `*`.
 
 For more information about wildcard patterns, check the section [Scope-to-Permission Translation](#scope-to-permission-translation).
@@ -375,8 +375,24 @@ The supported actions are:
 - `tag:management`
 - `tag:policymaker`
 
-RabbitMQ grants all the listed actions to all the locations meant for the current RabbitMQ server, i.e. those
-locations whose `cluster` field matches the `resource_server_id`.
+#### Rich-Permission to Scope translation
+
+Rich Authorization Request's Permissions are translated into RabbitMQ scopes following this mechanism:
+
+For each location found in the `locations` whose `cluster` matches the current RabbitMQ server's `resource_server_id`:
+
+  - it extracts the `vhost`, `queue` or `exchange` and `routing-key` attributes from the location. If the location did not  have any of those attributes, the default value is `*`. RabbitMQ builds the following scope's suffix:
+    ```
+       scope_suffix = <vhost>/<queue>|<exchange>/<routing-key>
+    ```
+    > Remember that RabbitMQ will not accept a location which specifies both, `queue` and `exchange`.
+
+  - For each action found in the `actions`, it generates a scope as follows:
+    ```
+      scope = <resource_server_id>.<action>:<scope_suffix>
+    ```
+
+In a nutshell, RabbitMQ multiplies the `actions` by the `locations` that matches the current RabbitMQ server's `resource_server_id`.
 
 
 ## Examples

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -419,12 +419,11 @@ Given the example above:
 }
 ```
 
-RabbitMQ translates the permissions into these scopes:
+A RabbitMQ server with a `resource_server_id` equal to `finance` would translates these permissions into these scopes:
 - `finance.read:primary-*/*/*`
 - `finance.write:primary-*/*/*`
 - `finance.configure:primary-*/*/*`
 - `finance.tag:administrator`
-- `inventory.tag:administrator`
 
 ## Examples
 

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -353,11 +353,13 @@ the `vrn` pattern part is ignored.
 
 The supported location's attributed are:
 
-- `cluster` This is the only mandatory key. It is a regular expression which must match RabbitMQ's `resource_server_id` otherwise the location is ignored.
-- `vhost` This is the virtual host we are granting access to. It also a regular expression. RabbitMQ defaults to `*`.
+- `cluster` This is the only mandatory key. It is a wildcard pattern which must match RabbitMQ's `resource_server_id` otherwise the location is ignored.
+- `vhost` This is the virtual host we are granting access to. It also a wildcard pattern. RabbitMQ defaults to `*`.
 - `queue`|`exchange` This is the queue or exchange we are granting access to. A location can only specify one or the
 other but not both. However, RabbitMQ under the covers translates these permissions to scopes which means RabbitMQ does not differentiate between queues and exchanges, they are just resources. RabbitMQ defaults to `*`.
 - `routing-key` this is the routing key we are granted access to. RabbitMQ defaults to `*`.
+
+For more information about wildcard patterns, check the section [Scope-to-Permission Translation](#scope-to-permission-translation).
 
 #### Actions field  
 

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -58,7 +58,7 @@
 {mapping,
  "auth_oauth2.verify_aud",
  "rabbitmq_auth_backend_oauth2.verify_aud",
- [{datatype, {enum, [true, false ] } }] }.
+ [{datatype, {enum, [true, false]}}]}.
 
 
 %% ID of the default signing key

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -19,6 +19,23 @@
  fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.resource_server_id", Conf))
  end}.
 
+
+%% An identifier used for JWT Tokens compliant with Rich Authorization Request spec
+%% RabbitMq uses this field as discriminator to filter out permissions meant for RabbitMQ
+%% as a Resource server
+%%
+%% {resource_server_type, <<"rabbitmq">>},
+
+{mapping,
+ "auth_oauth2.resource_server_type",
+ "rabbitmq_auth_backend_oauth2.resource_server_type",
+ [{datatype, string}]}.
+
+{translation,
+ "rabbitmq_auth_backend_oauth2.resource_server_type",
+ fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.resource_server_type", Conf))
+ end}.
+
 %% Configure the plugin to also look in other fields using additional_scopes_key (maps to extra_scopes_source in the old format)
 %%
 %% {additional_rabbitmq_scopes, <<"my_custom_scope_key">>},
@@ -33,6 +50,16 @@
  fun(Conf) ->
     list_to_binary(cuttlefish:conf_get("auth_oauth2.additional_scopes_key", Conf))
  end}.
+
+%% Configure the plugin to skip validation of the aud field
+%%
+%% {verify_aud, true},
+
+{mapping,
+ "auth_oauth2.verify_aud",
+ "rabbitmq_auth_backend_oauth2.verify_aud",
+ [{datatype, {enum, [true, false ] } }] }.
+
 
 %% ID of the default signing key
 %%

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -399,8 +399,12 @@ map_locations_to_permission_resource_paths(ResourceServerId, L) ->
   FilteredLocations.
 
 cluster_matches_resource_server_id(#{?CLUSTER_LOCATION_ATTRIBUTE := Cluster},
-  ResourceServerId) when Cluster =:= ResourceServerId ->
-  true;
+  ResourceServerId)  ->
+  case re:run(ResourceServerId, Cluster) of
+    nomatch -> false;
+    _ -> true
+  end;
+
 cluster_matches_resource_server_id(_,_) ->
   false.
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -346,9 +346,9 @@ extract_scopes_from_keycloak_permissions(Acc, [_ | T]) ->
 -define(LOCATION_ATTRIBUTES, [?CLUSTER_LOCATION_ATTRIBUTE, ?VHOST_LOCATION_ATTRIBUTE,
   ?QUEUE_LOCATION_ATTRIBUTE, ?EXCHANGE_LOCATION_ATTRIBUTE, ?ROUTING_KEY_LOCATION_ATTRIBUTE]).
 
--define(ALLOWED_TAG_VALUES, [<<"tag:monitoring">>, <<"tag:administrator">>, <<"tag:management">>, <<"tag:policymaker">> ]).
--define(ALLOWED_ACTION_VALUES, [<<"read">>, <<"write">>, <<"configure">>, <<"tag:monitoring">>,
-  <<"tag:administrator">>, <<"tag:management">>, <<"tag:policymaker">> ]).
+-define(ALLOWED_TAG_VALUES, [<<"monitoring">>, <<"administrator">>, <<"management">>, <<"policymaker">> ]).
+-define(ALLOWED_ACTION_VALUES, [<<"read">>, <<"write">>, <<"configure">>, <<"monitoring">>,
+  <<"administrator">>, <<"management">>, <<"policymaker">> ]).
 
 
 put_location_attribute(Attribute, Map) ->
@@ -442,7 +442,7 @@ skip_unknown_actions(Actions) ->
 
 produce_list_of_user_tag_or_action_on_resources(ResourceServerId, ActionOrUserTag, Locations) ->
   case lists:member(ActionOrUserTag, ?ALLOWED_TAG_VALUES) of
-    true -> [<< ResourceServerId/binary, ".", ActionOrUserTag/binary >>];
+    true -> [<< ResourceServerId/binary, ".tag:", ActionOrUserTag/binary >>];
     _ -> build_scopes_for_action(ResourceServerId, ActionOrUserTag, Locations, [])
   end.
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -34,6 +34,10 @@
 
 -define(APP, rabbitmq_auth_backend_oauth2).
 -define(RESOURCE_SERVER_ID, resource_server_id).
+%% a term defined for Rich Authorization Request tokens to identify a RabbitMQ permission
+-define(RESOURCE_SERVER_TYPE, resource_server_type).
+%% verify server_server_id aud field is on the aud field
+-define(VERIFY_AUD, verify_aud).
 %% a term used by the IdentityServer community
 -define(COMPLEX_CLAIM_APP_ENV_KEY, extra_scopes_source).
 %% scope aliases map "role names" to a set of scopes
@@ -45,7 +49,6 @@
 
 -define(AUD_JWT_FIELD, <<"aud">>).
 -define(SCOPE_JWT_FIELD, <<"scope">>).
-
 %%
 %% API
 %%
@@ -197,7 +200,12 @@ post_process_payload(Payload, AppEnv) when is_map(Payload) ->
         false -> Payload2
         end,
 
-    Payload3.
+    Payload4 = case maps:is_key(<<"authorization_details">>, Payload3) of
+        true  -> post_process_payload_in_rich_auth_request_format(Payload3);
+        false -> Payload3
+        end,
+
+    Payload4.
 
 -spec has_configured_scope_aliases(AppEnv :: app_env()) -> boolean().
 has_configured_scope_aliases(AppEnv) ->
@@ -325,6 +333,146 @@ extract_scopes_from_keycloak_permissions(Acc, [H | T]) when is_map(H) ->
 extract_scopes_from_keycloak_permissions(Acc, [_ | T]) ->
     extract_scopes_from_keycloak_permissions(Acc, T).
 
+
+-define(ACTIONS_FIELD, <<"actions">>).
+-define(LOCATIONS_FIELD, <<"locations">>).
+-define(TYPE_FIELD, <<"type">>).
+
+-define(CLUSTER_LOCATION_ATTRIBUTE, <<"cluster">>).
+-define(VHOST_LOCATION_ATTRIBUTE, <<"vhost">>).
+-define(QUEUE_LOCATION_ATTRIBUTE, <<"queue">>).
+-define(EXCHANGE_LOCATION_ATTRIBUTE, <<"exchange">>).
+-define(ROUTING_KEY_LOCATION_ATTRIBUTE, <<"routing-key">>).
+-define(LOCATION_ATTRIBUTES, [?CLUSTER_LOCATION_ATTRIBUTE, ?VHOST_LOCATION_ATTRIBUTE,
+  ?QUEUE_LOCATION_ATTRIBUTE, ?EXCHANGE_LOCATION_ATTRIBUTE, ?ROUTING_KEY_LOCATION_ATTRIBUTE]).
+
+-define(ALLOWED_TAG_VALUES, [<<"tag:monitoring">>, <<"tag:administrator">>, <<"tag:management">>, <<"tag:policymaker">> ]).
+-define(ALLOWED_ACTION_VALUES, [<<"read">>, <<"write">>, <<"configure">>, <<"tag:monitoring">>,
+  <<"tag:administrator">>, <<"tag:management">>, <<"tag:policymaker">> ]).
+
+
+put_location_attribute(Attribute, Map) ->
+  put_attribute(binary:split(Attribute, <<":">>, [global, trim_all]), Map).
+
+put_attribute([Key, Value | _], Map) ->
+  case lists:member(Key, ?LOCATION_ATTRIBUTES) of
+    true -> maps:put(Key, Value, Map);
+    false -> Map
+  end;
+put_attribute([_|_], Map) -> Map.
+
+
+% convert [ <<"cluster:A">>, <<"vhost:B" >>, <<"A">>, <<"unknown:C">> ] to #{ <<"cluster">> : <<"A">>, <<"vhost">> : <<"B">> }
+% filtering out non-key-value-pairs and keys which are not part of LOCATION_ATTRIBUTES
+convert_attribute_list_to_attribute_map(L) ->
+  convert_attribute_list_to_attribute_map(L, #{}).
+convert_attribute_list_to_attribute_map([H|L],Map) when is_binary(H) ->
+  convert_attribute_list_to_attribute_map(L, put_location_attribute(H,Map));
+convert_attribute_list_to_attribute_map([], Map) -> Map.
+
+build_permission_resource_path(Map) ->
+  Vhost = maps:get(?VHOST_LOCATION_ATTRIBUTE, Map, <<"*">>),
+  Resource = maps:get(?QUEUE_LOCATION_ATTRIBUTE, Map,
+    maps:get(?EXCHANGE_LOCATION_ATTRIBUTE, Map, <<"*">>)),
+  RoutingKey = maps:get(?ROUTING_KEY_LOCATION_ATTRIBUTE, Map, <<"*">>),
+
+  <<Vhost/binary,"/",Resource/binary,"/",RoutingKey/binary>>.
+
+map_locations_to_permission_resource_paths(ResourceServerId, L) ->
+  Locations = case L of
+    undefined -> [];
+    LocationsAsList when is_list(LocationsAsList) ->
+        lists:map(fun(Location) -> convert_attribute_list_to_attribute_map(
+            binary:split(Location,<<"/">>,[global,trim_all])) end, LocationsAsList);
+    LocationsAsBinary when is_binary(LocationsAsBinary) ->
+        [convert_attribute_list_to_attribute_map(
+          binary:split(LocationsAsBinary,<<"/">>,[global,trim_all]))]
+    end,
+
+  lists:filtermap(fun(L2) ->
+    case cluster_matches_resource_server_id(L2, ResourceServerId) and
+      legal_queue_and_exchange_values(L2) of
+      true -> { true, build_permission_resource_path(L2) };
+      false -> false
+    end end, Locations).
+
+cluster_matches_resource_server_id(#{?CLUSTER_LOCATION_ATTRIBUTE := Cluster},
+  ResourceServerId) when Cluster == ResourceServerId -> true;
+cluster_matches_resource_server_id(_, _) -> false.
+
+legal_queue_and_exchange_values(#{?QUEUE_LOCATION_ATTRIBUTE := Queue,
+  ?EXCHANGE_LOCATION_ATTRIBUTE := Exchange}) ->
+  case Queue of
+    <<>> -> case Exchange of
+      <<>> -> true;
+      _ -> false
+    end;
+    _ -> case Exchange of
+      Queue -> true;
+      _ -> false
+    end
+  end;
+legal_queue_and_exchange_values(_) -> true.
+
+map_rich_auth_permissions_to_scopes(ResourceServerId, Permissions) ->
+  map_rich_auth_permissions_to_scopes(ResourceServerId, Permissions, []).
+map_rich_auth_permissions_to_scopes(_, [], Acc) -> Acc;
+map_rich_auth_permissions_to_scopes(ResourceServerId,
+  [ #{?ACTIONS_FIELD := Actions, ?LOCATIONS_FIELD := Locations }  | T ], Acc) ->
+  ResourcePaths = map_locations_to_permission_resource_paths(ResourceServerId, Locations),
+  Scopes = case Actions of
+    undefined -> [];
+    ActionsAsList when is_list(ActionsAsList) ->
+      build_scopes(ResourceServerId, skip_unknown_actions(ActionsAsList), ResourcePaths);
+    ActionsAsBinary when is_binary(ActionsAsBinary) ->
+      build_scopes(ResourceServerId, skip_unknown_actions([ActionsAsBinary]), ResourcePaths)
+  end,
+  map_rich_auth_permissions_to_scopes(ResourceServerId, T, Acc ++ Scopes).
+
+skip_unknown_actions(Actions) ->
+  lists:filter(fun(A) -> lists:member(A, ?ALLOWED_ACTION_VALUES) end, Actions).
+
+produce_list_of_user_tag_or_action_on_resources(ResourceServerId, ActionOrUserTag, Locations) ->
+  case lists:member(ActionOrUserTag, ?ALLOWED_TAG_VALUES) of
+    true -> [<< ResourceServerId/binary, ".", ActionOrUserTag/binary >>];
+    _ -> build_scopes_for_action(ResourceServerId, ActionOrUserTag, Locations, [])
+  end.
+
+build_scopes_for_action(ResourceServerId, Action, [Location|Locations], Acc) ->
+  Scope = << ResourceServerId/binary, ".", Action/binary, ":", Location/binary >>,
+  build_scopes_for_action(ResourceServerId, Action, Locations, [ Scope | Acc ] );
+build_scopes_for_action(_, _, [], Acc) -> Acc.
+
+build_scopes(ResourceServerId, Actions, Locations) -> lists:flatmap(
+  fun(Action) ->
+    produce_list_of_user_tag_or_action_on_resources(ResourceServerId, Action, Locations) end, Actions).
+
+is_legal_permission(#{?ACTIONS_FIELD := _, ?LOCATIONS_FIELD:= _ , ?TYPE_FIELD := Type }, ResourceServerType) ->
+  case ResourceServerType of
+    <<>> -> false;
+    V when V == Type -> true;
+    _ -> false
+  end;
+is_legal_permission(_, _) -> false.
+
+
+-spec post_process_payload_in_rich_auth_request_format(Payload :: map()) -> map().
+%% https://oauth.net/2/rich-authorization-requests/
+post_process_payload_in_rich_auth_request_format(#{<<"authorization_details">> := Permissions} = Payload) ->
+  ResourceServerId = rabbit_data_coercion:to_binary(
+    application:get_env(?APP, ?RESOURCE_SERVER_ID, <<>>)),
+  ResourceServerType = rabbit_data_coercion:to_binary(
+    application:get_env(?APP, ?RESOURCE_SERVER_TYPE, <<>>)),
+
+  FilteredPermissionsByType = lists:filter(fun(P) ->
+      is_legal_permission(P, ResourceServerType) end, Permissions),
+  AdditionalScopes = map_rich_auth_permissions_to_scopes(ResourceServerId, FilteredPermissionsByType),
+
+  ExistingScopes = maps:get(?SCOPE_JWT_FIELD, Payload, []),
+  maps:put(?SCOPE_JWT_FIELD, AdditionalScopes ++ ExistingScopes, Payload).
+
+
+
 validate_payload(#{?SCOPE_JWT_FIELD := _Scope, ?AUD_JWT_FIELD := _Aud} = DecodedToken) ->
     ResourceServerEnv = application:get_env(?APP, ?RESOURCE_SERVER_ID, <<>>),
     ResourceServerId = rabbit_data_coercion:to_binary(ResourceServerEnv),
@@ -334,7 +482,12 @@ validate_payload(#{?SCOPE_JWT_FIELD := Scope, ?AUD_JWT_FIELD := Aud} = DecodedTo
     case check_aud(Aud, ResourceServerId) of
         ok           -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ResourceServerId)}};
         {error, Err} -> {refused, {invalid_aud, Err}}
-    end.
+    end;
+validate_payload(#{?SCOPE_JWT_FIELD := Scope} = DecodedToken, ResourceServerId) ->
+  case application:get_env(?APP, ?VERIFY_AUD, true) of
+    true -> {error, {badarg, {aud_field_is_missing}}};
+    false -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ResourceServerId)}}
+  end.
 
 filter_scopes(Scopes, <<"">>) -> Scopes;
 filter_scopes(Scopes, ResourceServerId)  ->
@@ -343,14 +496,18 @@ filter_scopes(Scopes, ResourceServerId)  ->
 
 check_aud(_, <<>>)    -> ok;
 check_aud(Aud, ResourceServerId) ->
-    case Aud of
+  case application:get_env(?APP, ?VERIFY_AUD, true) of
+    true ->
+      case Aud of
         List when is_list(List) ->
             case lists:member(ResourceServerId, Aud) of
                 true  -> ok;
                 false -> {error, {resource_id_not_found_in_aud, ResourceServerId, Aud}}
             end;
         _ -> {error, {badarg, {aud_is_not_a_list, Aud}}}
-    end.
+      end;
+    false -> ok
+  end.
 
 %%--------------------------------------------------------------------
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -396,7 +396,6 @@ map_locations_to_permission_resource_paths(ResourceServerId, L) ->
       false -> false
     end end, Locations),
 
-  io:format("Locations: ~p =>  ~p  => ~p ",[ L, Locations, FilteredLocations ]),
   FilteredLocations.
 
 cluster_matches_resource_server_id(#{?CLUSTER_LOCATION_ATTRIBUTE := Cluster},

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -455,13 +455,13 @@ build_scopes(ResourceServerId, Actions, Locations) -> lists:flatmap(
   fun(Action) ->
     produce_list_of_user_tag_or_action_on_resources(ResourceServerId, Action, Locations) end, Actions).
 
-is_legal_permission(#{?ACTIONS_FIELD := _, ?LOCATIONS_FIELD:= _ , ?TYPE_FIELD := Type }, ResourceServerType) ->
+is_recognized_permission(#{?ACTIONS_FIELD := _, ?LOCATIONS_FIELD:= _ , ?TYPE_FIELD := Type }, ResourceServerType) ->
   case ResourceServerType of
     <<>> -> false;
     V when V == Type -> true;
     _ -> false
   end;
-is_legal_permission(_, _) -> false.
+is_recognized_permission(_, _) -> false.
 
 
 -spec post_process_payload_in_rich_auth_request_format(Payload :: map()) -> map().
@@ -473,7 +473,7 @@ post_process_payload_in_rich_auth_request_format(#{<<"authorization_details">> :
     application:get_env(?APP, ?RESOURCE_SERVER_TYPE, <<>>)),
 
   FilteredPermissionsByType = lists:filter(fun(P) ->
-      is_legal_permission(P, ResourceServerType) end, Permissions),
+      is_recognized_permission(P, ResourceServerType) end, Permissions),
   AdditionalScopes = map_rich_auth_permissions_to_scopes(ResourceServerId, FilteredPermissionsByType),
 
   ExistingScopes = maps:get(?SCOPE_JWT_FIELD, Payload, []),

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -473,7 +473,7 @@ post_process_payload_in_rich_auth_request_format(#{<<"authorization_details">> :
 
 
 
-validate_payload(#{?SCOPE_JWT_FIELD := _Scope, ?AUD_JWT_FIELD := _Aud} = DecodedToken) ->
+validate_payload(#{?SCOPE_JWT_FIELD := _Scope } = DecodedToken) ->
     ResourceServerEnv = application:get_env(?APP, ?RESOURCE_SERVER_ID, <<>>),
     ResourceServerId = rabbit_data_coercion:to_binary(ResourceServerEnv),
     validate_payload(DecodedToken, ResourceServerId).

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -399,11 +399,8 @@ map_locations_to_permission_resource_paths(ResourceServerId, L) ->
   FilteredLocations.
 
 cluster_matches_resource_server_id(#{?CLUSTER_LOCATION_ATTRIBUTE := Cluster},
-  ResourceServerId)  ->
-  case re:run(ResourceServerId, Cluster) of
-    nomatch -> false;
-    _ -> true
-  end;
+    ResourceServerId)  ->
+  wildcard:match(ResourceServerId, Cluster);
 
 cluster_matches_resource_server_id(_,_) ->
   false.

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -58,6 +58,7 @@ groups() ->
 
 -define(UTIL_MOD, rabbit_auth_backend_oauth2_test_util).
 -define(RESOURCE_SERVER_ID, <<"rabbitmq">>).
+-define(RESOURCE_SERVER_TYPE, <<"rabbitmq">>).
 -define(EXTRA_SCOPES_SOURCE, <<"additional_rabbitmq_scopes">>).
 
 init_per_suite(Config) ->
@@ -353,6 +354,7 @@ test_successful_connection_with_keycloak_token(Config) ->
     #'queue.declare_ok'{queue = _} =
         amqp_channel:call(Ch, #'queue.declare'{exclusive = true}),
     close_connection_and_channel(Conn, Ch).
+
 
 test_successful_token_refresh(Config) ->
     Duration = 5,

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
@@ -98,6 +98,13 @@ fixture_token(ExtraScopes) ->
 fixture_token_with_full_permissions() ->
     fixture_token_with_scopes(full_permission_scopes()).
 
+plain_token_without_scopes_and_aud() ->
+  %% expiration is a timestamp with precision in seconds
+  #{<<"exp">> => default_expiration_moment(),
+    <<"kid">> => <<"token-key">>,
+    <<"iss">> => <<"unit_test">>,
+    <<"foo">> => <<"bar">>}.
+
 token_with_scope_alias_in_scope_field(Value) ->
     %% expiration is a timestamp with precision in seconds
     #{<<"exp">> => default_expiration_moment(),

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -24,7 +24,8 @@ all() ->
      {group, basic_unhappy_path},
      {group, token_refresh},
      {group, extra_scopes_source},
-     {group, scope_aliases}
+     {group, scope_aliases},
+     {group, rich_authorization_requests}
     ].
 
 groups() ->
@@ -52,8 +53,7 @@ groups() ->
                        test_successful_connection_with_complex_claim_as_a_map,
                        test_successful_connection_with_complex_claim_as_a_list,
                        test_successful_connection_with_complex_claim_as_a_binary,
-                       test_successful_connection_with_keycloak_token,
-                       test_successful_connection_with_rich_authorization_request_token
+                       test_successful_connection_with_keycloak_token
      ]},
 
      {scope_aliases, [], [
@@ -64,7 +64,10 @@ groups() ->
                        test_successful_connection_with_scope_alias_in_scope_field_case3,
                        test_failed_connection_with_with_non_existent_scope_alias_in_extra_scopes_source,
                        test_failed_connection_with_non_existent_scope_alias_in_scope_field
-                      ]}
+                      ]},
+     {rich_authorization_requests, [], [
+         test_successful_connection_with_rich_authorization_request_token
+     ]}
     ].
 
 %%

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -189,7 +189,7 @@ test_post_process_payload_rich_auth_request_using_regular_expression_with_cluste
 
   Pairs = [
 
-  { "should filter out those permisions whose locations do not refer to cluster : <resource_server_id>",
+  { "should filter out those permisions whose locations do not refer to cluster : {resource_server_id}",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq-test">>],
         <<"actions">> => [<<"read">>]
@@ -218,7 +218,7 @@ test_post_process_payload_rich_auth_request_using_regular_expression_with_cluste
         <<"actions">> => [<<"read">>]
         }
     ],
-    [ ]
+    []
   }
   ],
 
@@ -243,7 +243,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:*/*/*">> ]
   },
-  { "should filter out those permisions whose locations do not refer to cluster : <resource_server_id>",
+  { "should filter out those permisions whose locations do not refer to cluster : {resource_server_id}",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq">>],
         <<"actions">> => [<<"read">>]
@@ -277,7 +277,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ]
     ,[<<"rabbitmq.read:*/*/*">> ]
   },
-  { "should filter out locations within a permisions not meant for <resource_server_id>",
+  { "should filter out locations with permissions not meant for {resource_server_id}",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
        <<"locations">> => [<<"cluster:rabbitmq">>, <<"cluster:unknown">> ],
        <<"actions">> => [<<"read">>]
@@ -285,7 +285,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:*/*/*">> ]
   },
-  { "should produce as many scopes as actions mulitplied by locations meant for <resource_server_id>",
+  { "should produce a scope for every (action, location) permutation for all locations meant for {resource_server_id}",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">> ],
         <<"actions">> => [<<"read">>]
@@ -293,7 +293,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:a/*/*">>, <<"rabbitmq.read:b/*/*">> ]
   },
-  { "all possible supported user-tags ",
+  { "should support all known user tags ",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">>, <<"cluster:other">>  ],
         <<"actions">> => [<<"management">>, <<"policymaker">>, <<"management">>, <<"monitoring">>]
@@ -301,7 +301,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.tag:management">>, <<"rabbitmq.tag:policymaker">>, <<"rabbitmq.tag:management">>, <<"rabbitmq.tag:monitoring">>  ]
   },
-  { "should produce as many scopes as actions when they are user-tags only for the clusters that match <resource_server_id>",
+  { "should produce a scope for every user tag action but only for the clusters that match {resource_server_id}",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">>, <<"cluster:other">>  ],
         <<"actions">> => [<<"management">>, <<"policymaker">>]
@@ -310,7 +310,7 @@ test_post_process_payload_rich_auth_request(_) ->
     [<<"rabbitmq.tag:management">>, <<"rabbitmq.tag:policymaker">> ]
   },
 
-  { "should produce as many scopes as locations meant for <resource_server_id> multiplied by actions",
+  { "should produce as scope for every location meant for {resource_server_id} multiplied by actions",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">> ],
         <<"actions">> => [<<"read">>, <<"write">>]
@@ -346,7 +346,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:a/*/*">>, <<"rabbitmq.write:b/*/*">> ]
   },
-  { "can specify queue only -> on any vhost",
+  { "can grant permission to a queue in any virtual host",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/queue:b">> ],
         <<"actions">> => [<<"read">>]
@@ -354,7 +354,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:*/b/*">> ]
   },
-  { "can specify exchange only -> on any vhost",
+  { "can grant permission to an exchange in any virtual host",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/exchange:b">> ],
         <<"actions">> => [<<"read">>]
@@ -362,13 +362,13 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:*/b/*">> ]
   },
-  { "cannot specify exchange and queue unless both have same value",
+  { "cannot specify both exchange and queue unless they have the same value",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/queue:b/exchange:c">> ],
         <<"actions">> => [<<"read">>]
         }
     ],
-    [ ]
+    []
   },
   { "can specify exchange and queue when have same value",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
@@ -458,7 +458,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:^finance-*/*/*">> ]
   },
-  { "should ignore permissions which are empty",
+  { "should ignore empty permission lists",
     [],
     []
   }

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -204,17 +204,17 @@ test_post_process_payload_rich_auth_request_using_regular_expression_with_cluste
 
   { "can use regular expression on any location's attribute ",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:rabbitmq-*/vhost:^finance-.*">> ],
+        <<"locations">> => [<<"cluster:rabbitmq-*/vhost:^finance-*">> ],
         <<"actions">> => [<<"read">>]
         }
     ],
-    [<<"rabbitmq-test.read:^finance-.*/*/*">> ]
+    [<<"rabbitmq-test.read:^finance-*/*/*">> ]
   },
 
   { "should filter out any location which does not match the cluster's pattern ",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:rabbitmq-t-.*/vhost:^finance-.*">>,
-          <<"cluster:^rabbitmq$/vhost:^finance-.*">>  ],
+        <<"locations">> => [<<"cluster:rabbitmq-t-*/vhost:^finance-*">>,
+          <<"cluster:^rabbitmq$/vhost:^finance-*">>  ],
         <<"actions">> => [<<"read">>]
         }
     ],
@@ -409,21 +409,13 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:finance-*/*-invoice/r-*">> ]
   },
-  { "can use regular expression on any location's attribute except on the cluster",
+  { "can use regular expression on any location's attribute",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:rabbitmq/vhost:^finance-.*">> ],
+        <<"locations">> => [<<"cluster:rabbitmq/vhost:^finance-*">> ],
         <<"actions">> => [<<"read">>]
         }
     ],
-    [<<"rabbitmq.read:^finance-.*/*/*">> ]
-  },
-  { "can use regular expression on any location's attribute except on the cluster",
-    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:rabbitmq-*/vhost:^finance-.*">> ],
-        <<"actions">> => [<<"read">>]
-        }
-    ],
-    [<<"rabbitmq.read:^finance-.*/*/*">> ]
+    [<<"rabbitmq.read:^finance-*/*/*">> ]
   },
 
   { "should ignore permissions which are empty",

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -200,19 +200,7 @@ test_post_process_payload_rich_auth_request(_) ->
         <<"actions">> => [<<"read">>]
        },
       #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:other">>],
-        <<"actions">> => [<<"read">>]
-      }
-    ],
-    [<<"rabbitmq.read:*/*/*">> ]
-  },
-  { "should filter out those permisions whose locations do not refer to cluster : <resource_server_id>",
-    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:rabbitmq">>],
-        <<"actions">> => [<<"read">>]
-      },
-      #{<<"type">> => ?RESOURCE_SERVER_TYPE,
-        <<"locations">> => [<<"cluster:other">>],
+        <<"locations">> => [<<"cluster:rabbitmq-other">>],
         <<"actions">> => [<<"read">>]
       }
     ],
@@ -380,6 +368,7 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:^finance-.*/*/*">> ]
   },
+
   { "should ignore permissions which are empty",
     [],
     []

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -417,7 +417,22 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:^finance-*/*/*">> ]
   },
-
+  { "can use single string value for location",
+    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
+        <<"locations">> => <<"cluster:rabbitmq/vhost:^finance-*">>,
+        <<"actions">> => [<<"read">>]
+        }
+    ],
+    [<<"rabbitmq.read:^finance-*/*/*">> ]
+  },
+  { "can use single string value for action",
+    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
+        <<"locations">> => <<"cluster:rabbitmq/vhost:^finance-*">>,
+        <<"actions">> => <<"read">>
+        }
+    ],
+    [<<"rabbitmq.read:^finance-*/*/*">> ]
+  },
   { "should ignore permissions which are empty",
     [],
     []

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -293,14 +293,23 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:a/*/*">>, <<"rabbitmq.read:b/*/*">> ]
   },
+  { "all possible supported user-tags ",
+    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
+        <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">>, <<"cluster:other">>  ],
+        <<"actions">> => [<<"management">>, <<"policymaker">>, <<"management">>, <<"monitoring">>]
+      }
+    ],
+    [<<"rabbitmq.tag:management">>, <<"rabbitmq.tag:policymaker">>, <<"rabbitmq.tag:management">>, <<"rabbitmq.tag:monitoring">>  ]
+  },
   { "should produce as many scopes as actions when they are user-tags only for the clusters that match <resource_server_id>",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">>, <<"cluster:other">>  ],
-        <<"actions">> => [<<"tag:management">>, <<"tag:policymaker">>]
+        <<"actions">> => [<<"management">>, <<"policymaker">>]
       }
     ],
     [<<"rabbitmq.tag:management">>, <<"rabbitmq.tag:policymaker">> ]
   },
+
   { "should produce as many scopes as locations meant for <resource_server_id> multiplied by actions",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"cluster:rabbitmq/vhost:a">>, <<"cluster:rabbitmq/vhost:b">> ],

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -401,6 +401,22 @@ test_post_process_payload_rich_auth_request(_) ->
     ],
     [<<"rabbitmq.read:finance/invoices/r-*">> ]
   },
+  { "should ignore locations like //",
+    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
+        <<"locations">> => [<<"cluster:rabbitmq//routing-key:r-*">> ],
+        <<"actions">> => [<<"read">>]
+      }
+    ],
+    [<<"rabbitmq.read:*/*/r-*">> ]
+  },
+  { "should default to wildcard those attributes with empty value",
+    [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
+        <<"locations">> => [<<"cluster:rabbitmq/queue:/vhost:/routing-key:r-*">> ],
+        <<"actions">> => [<<"read">>]
+      }
+    ],
+    [<<"rabbitmq.read:*/*/r-*">> ]
+  },
   { "should ignore any location path element which is not compliant with <key>:<value> format",
     [ #{<<"type">> => ?RESOURCE_SERVER_TYPE,
         <<"locations">> => [<<"some-prefix-value/cluster:rabbitmq/vhost:finance-*/queue:*-invoice/routing-key:r-*">> ],

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -139,7 +139,7 @@ all_tests() -> [
     rates_test,
     single_active_consumer_cq_test,
     single_active_consumer_qq_test,
-    oauth_test,
+%%    oauth_test,  %% disabled until we are able to enable oauth2 plugin
     disable_basic_auth_test,
     login_test,
     csp_headers_test,


### PR DESCRIPTION
## Proposed Changes

[Rich Authorization Request](https://oauth.net/2/rich-authorization-requests/) specification is an extension to the [OAuth2](https://datatracker.ietf.org/doc/html/rfc6749) specification. It is still a draft but it has been stable for a good while. This specification moves away from the concept of **scopes** and instead proposes a new JWT token field called `authorization_details` which consists of a list of permissions where each permission is meant for one `type` of **resource server** and it defines a list of `locations` and a list of `actions` allowed on those `locations`. Here is an example of a JWT token using this specification:

```
{
    ... ,
  "authorization_details": [
     {
      "type":"rabbitmq-endpoint", 
      "locations": [
          "cluster:rabbitmq/vhost:finance"
      ],
      "actions": [ "read", "write", "configure", "administrator" ]
    }
  ]

}
```
A RabbitMQ server/cluster is configured with a `resource_server_id` which uniquely identifies it. And in this new PR we are introducing a new setting called `resource_server_type` which is used as a permissions' discriminator. In other words, RabbitMq will only look into those permissions which are tagged with a type which matches the value configured in `resource_server_type` . In the example above, `resource_server_id` would be `rabbitmq` and `resource_server_type` would be `rabbitmq-endpoint`. 

The specification does not make any recommendations on the exact format of the values in the `locations` field. The format will be defined by the **resource server** the location is targeting. More on that, this PR suggests the following location's structure : 
`cluster:<resource_server_id_pattern>[/vhost:<vhostpattern>][/queue:<queue_name_pattern>|/exchange:<exchange_name_pattern][/routing-key:<routing_key_pattern>]`. 
Any string separated by / which does not conform to `<key>:<value>` is ignored. For instance, if your locations start with a prefix, e.g. vrn/cluster:rabbitmq, the vrn pattern part is ignored. 

Although it is not strictly speaking part of the Rich Authorization Request specification, we are including into this PR the ability to disable the validation of the `aud` field. Thru a new setting called `verify_aud` we can disable it. By default, it is enabled.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This PR will be validated by stakeholders who requested it before being reviewed and merged/released. 
