### PR TITLE
Remove pre-maintenance_mode_status compatibility code

### DIFF
--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -74,19 +74,11 @@ init_per_testcase(quorum_queue_leadership_transfer = Testcase, Config) ->
                 Config1,
                 rabbit_ct_broker_helpers:setup_steps() ++
                 rabbit_ct_client_helpers:setup_steps()),
-    MaintenanceModeFFEnabled = rabbit_ct_broker_helpers:enable_feature_flag(
-                                Config2, maintenance_mode_status),
     QuorumQueueFFEnabled = rabbit_ct_broker_helpers:enable_feature_flag(
                                 Config2, quorum_queue),
-    case MaintenanceModeFFEnabled of
+    case QuorumQueueFFEnabled of
         ok ->
-            case QuorumQueueFFEnabled of
-                ok ->
-                    Config2;
-                Skip ->
-                    end_per_testcase(Testcase, Config2),
-                    Skip
-            end;
+            Config2;
         Skip ->
             end_per_testcase(Testcase, Config2),
             Skip
@@ -100,21 +92,11 @@ init_per_testcase(Testcase, Config) ->
         {rmq_nodename_suffix, Testcase},
         {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}}
       ]),
-    Config2 = rabbit_ct_helpers:run_steps(
-                Config1,
-                rabbit_ct_broker_helpers:setup_steps() ++
-                rabbit_ct_client_helpers:setup_steps() ++
-                [fun rabbit_ct_broker_helpers:set_ha_policy_all/1]),
-    MaintenanceModeFFEnabled = rabbit_ct_broker_helpers:enable_feature_flag(
-                                Config2,
-                                maintenance_mode_status),
-    case MaintenanceModeFFEnabled of
-        ok ->
-            Config2;
-        Skip ->
-            end_per_testcase(Testcase, Config2),
-            Skip
-    end.
+    rabbit_ct_helpers:run_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps() ++
+      [fun rabbit_ct_broker_helpers:set_ha_policy_all/1]).
 
 end_per_testcase(Testcase, Config) ->
     Config1 = rabbit_ct_helpers:run_steps(Config,

--- a/deps/rabbit/test/queue_master_location_SUITE.erl
+++ b/deps/rabbit/test/queue_master_location_SUITE.erl
@@ -109,26 +109,10 @@ init_per_testcase(Testcase, Config) ->
         {rmq_nodename_suffix, Testcase},
         {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}}
       ]),
-    Config2 = rabbit_ct_helpers:run_steps(
-                Config1,
-                rabbit_ct_broker_helpers:setup_steps() ++
-                rabbit_ct_client_helpers:setup_steps()),
-    Group = proplists:get_value(name, ?config(tc_group_properties, Config)),
-    FFEnabled = case Group of
-                    maintenance_mode ->
-                        rabbit_ct_broker_helpers:enable_feature_flag(
-                          Config2,
-                          maintenance_mode_status);
-                    _ ->
-                        ok
-                end,
-    case FFEnabled of
-        ok ->
-            Config2;
-        Skip ->
-            end_per_testcase(Testcase, Config2),
-            Skip
-    end.
+    rabbit_ct_helpers:run_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
 
 end_per_testcase(Testcase, Config) ->
     Config1 = rabbit_ct_helpers:run_steps(Config,

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -223,8 +223,6 @@ init_per_group(Group, Config) ->
                             %% tests.
                             timer:sleep(ClusterSize * 1000),
                             ok = rabbit_ct_broker_helpers:enable_feature_flag(
-                                   Config2, maintenance_mode_status),
-                            ok = rabbit_ct_broker_helpers:enable_feature_flag(
                                    Config2, virtual_host_metadata),
                             Config2;
                         Skip ->

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -188,8 +188,6 @@ init_per_group1(Group, Config) ->
                     ok = rabbit_ct_broker_helpers:rpc(
                            Config2, 0, application, set_env,
                            [rabbit, channel_tick_interval, 100]),
-                    ok = rabbit_ct_broker_helpers:enable_feature_flag(
-                           Config2, maintenance_mode_status),
                     Config2;
                 {skip, _} = Skip ->
                     end_per_group(Group, Config2),

--- a/deps/rabbitmq_cli/test/upgrade/drain_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/drain_command_test.exs
@@ -23,8 +23,6 @@ defmodule DrainCommandTest do
   end
 
   setup context do
-    enable_feature_flag(:maintenance_mode_status)
-
     {:ok, opts: %{
         node: get_rabbit_hostname(),
         timeout: context[:test_timeout] || 5000

--- a/deps/rabbitmq_cli/test/upgrade/revive_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/revive_command_test.exs
@@ -23,8 +23,6 @@ defmodule ReviveCommandTest do
   end
 
   setup context do
-    enable_feature_flag(:maintenance_mode_status)
-
     {:ok, opts: %{
         node: get_rabbit_hostname(),
         timeout: context[:test_timeout] || 5000

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -83,7 +83,6 @@ init_per_group(Group, Config)
                                                      [{forced_feature_flags_on_init,
                                                        [classic_mirrored_queue_version,
                                                         implicit_default_bindings,
-                                                        maintenance_mode_status,
                                                         virtual_host_metadata,
                                                         quorum_queue,
                                                         stream_queue]}]})


### PR DESCRIPTION
Maintenance mode, introduced in RabbitMQ 3.8.x, was a breaking change protected behind a feature flag. This allowed a RabbitMQ cluster to be upgraded one node at a time, without having to stop the entire cluster.

The compatibility code is in the wild for long enough. The `maintenance_mode_status` feature flag was marked as required in a
previous commit (see #5202). This allows us to remove code in this patch.

References #5215.