### PR TITLE
rabbit_stream: Use rabbit_feature_flags, not `rabbit_ff_registry`

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -39,8 +39,7 @@
 -include("rabbit_stream_metrics.hrl").
 
 start(_Type, _Args) ->
-    FeatureFlagsEnabled = rabbit_ff_registry:list(enabled),
-    case maps:is_key(stream_queue, FeatureFlagsEnabled) of
+    case rabbit_feature_flags:is_enabled(stream_queue) of
         true ->
             rabbit_stream_metrics:init(),
             rabbit_global_counters:init([{protocol, stream}],


### PR DESCRIPTION
`rabbit_ff_registry` is an internal module of the feature flags subsystem, it is not meant to be called outside of it. In particular, it
may lead to crashes very difficult to debug when a feature flag is enabled. The reason is that this module is compiled and reloaded at runtime, so the module may disappear for a small period of time. Another reason is that a process calling `rabbit_ff_registry` may hold that module, preventing the feature flags subsystem from performing its task.

The correct public API to query the state of a feature flag is `rabbit_feature_flags:is_enabled/1`. It will always return a boolean. If the feature flag being queried is in `state_changing` state, this function takes care of waiting for the outcome.

See #5018.