### PR TITLE
Feature flags: Support "auto-enable" feature flags

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -871,6 +871,7 @@ start(normal, []) ->
         %% will be used. We start it now because we can't wait for boot steps
         %% to do this (feature flags are refreshed before boot steps run).
         ok = rabbit_sup:start_child(rabbit_ff_controller),
+        rabbit_feature_flags:enable_auto(),
 
         %% Compatibility with older RabbitMQ versions + required by
         %% rabbit_node_monitor:notify_node_up/0:


### PR DESCRIPTION
A feature flag can be marked as "auto-enable" by setting `auto_enable` to true in its properties.

An auto-enable feature flag is automatically enabled as soon as all nodes in the cluster support it. This is achieved by trying to enable it when RabbitMQ starts, when a plugin is enabled/disabled or when a node joins/re-joins a cluster. If the feature flag can't be enabled, the error is ignored.

However, it should be used cautiously, especially if the feature flag has a migration function, because it might be enabled at an inappropriate time w.r.t. the user's workload.