### PR TITLE
Restore the feature flags suite under mixed version testing

### DIFF
--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -28,7 +28,6 @@ def secondary_umbrella():
         name = "rabbitmq-server-generic-unix-3.10",
         build_file = "@//:BUILD.package_generic_unix",
         patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-        sha256 = "d8cb9d3d851ced368dd070e21535bc8e90f6f2b8d206dd5b4fd7f3a8180ea03c",
         strip_prefix = "rabbitmq_server-3.10.6",
         urls = ["https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/package-generic-unix-for-mixed-version-testing-v3.10.6.tar.xz"],
     )

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -847,9 +847,7 @@ clustering_ok_with_new_ff_disabled(Config) ->
                         #{desc => "Time travel with RabbitMQ",
                           provided_by => rabbit,
                           stability => stable}},
-    rabbit_ct_broker_helpers:rpc(
-      Config, 0,
-      rabbit_feature_flags, inject_test_feature_flags, [NewFeatureFlags]),
+    inject_ff_on_nodes(Config, [0], NewFeatureFlags),
 
     FFSubsysOk = is_feature_flag_subsystem_available(Config),
 
@@ -883,9 +881,7 @@ clustering_denied_with_new_ff_enabled(Config) ->
                         #{desc => "Time travel with RabbitMQ",
                           provided_by => rabbit,
                           stability => stable}},
-    rabbit_ct_broker_helpers:rpc(
-      Config, 0,
-      rabbit_feature_flags, inject_test_feature_flags, [NewFeatureFlags]),
+    inject_ff_on_nodes(Config, [0], NewFeatureFlags),
     enable_feature_flag_on(Config, 0, time_travel),
 
     FFSubsysOk = is_feature_flag_subsystem_available(Config),
@@ -1262,12 +1258,42 @@ declare_arbitrary_feature_flag(Config) ->
                      #{desc => "My feature flag",
                        provided_by => ?MODULE,
                        stability => stable}},
-    rabbit_ct_broker_helpers:rpc_all(
-      Config,
-      rabbit_feature_flags,
-      inject_test_feature_flags,
-      [FeatureFlags]),
+    inject_ff_on_nodes(Config, FeatureFlags),
     ok.
+
+inject_ff_on_nodes(Config, FeatureFlags) ->
+    Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    inject_ff_on_nodes(Config, Nodes, FeatureFlags).
+
+inject_ff_on_nodes(Config, Nodes, FeatureFlags)
+  when is_list(Nodes) andalso is_map(FeatureFlags) ->
+    UseFFv2_0 = rabbit_ct_broker_helpers:rpc(
+                Config, Nodes,
+                rabbit_feature_flags, is_supported_locally,
+                [feature_flags_v2]),
+    UseFFv2 = lists:zip(Nodes, UseFFv2_0),
+    lists:map(
+      fun
+          ({Node, true}) ->
+              rabbit_ct_broker_helpers:rpc(
+                Config, Node,
+                rabbit_feature_flags,
+                inject_test_feature_flags,
+                [FeatureFlags]);
+          ({Node, false}) ->
+              Attributes = feature_flags_to_app_attrs(FeatureFlags),
+              rabbit_ct_broker_helpers:rpc(
+                Config, Node,
+                rabbit_feature_flags,
+                inject_test_feature_flags,
+                [Attributes])
+      end, UseFFv2).
+
+%% Convert to the format expected on RabbitMQ up-to 3.10.x.
+feature_flags_to_app_attrs(FeatureFlags) when is_map(FeatureFlags) ->
+    [{?MODULE, % Application
+      ?MODULE, % Module
+      maps:to_list(FeatureFlags)}].
 
 block(Pairs)   -> [block(X, Y) || {X, Y} <- Pairs].
 unblock(Pairs) -> [allow(X, Y) || {X, Y} <- Pairs].

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -118,53 +118,31 @@ init_per_group(enabling_on_single_node, Config) ->
       Config,
       [{rmq_nodes_count, 1}]);
 init_per_group(enabling_in_cluster, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            %% This test relies on functions only exported for test,
-            %% which is not true of mixed version nodes in bazel
-            {skip, "mixed mode not supported"};
-        _ ->
-            rabbit_ct_helpers:set_config(
-              Config,
-              [{rmq_nodes_count, 5}])
-    end;
+    rabbit_ct_helpers:set_config(
+      Config,
+      [{rmq_nodes_count, 5}]);
 init_per_group(clustering, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            %% This test relies on functions only exported for test,
-            %% which is not true of mixed version nodes in bazel
-            {skip, "mixed mode not supported"};
-        _ ->
-            Config1 = rabbit_ct_helpers:set_config(
-                        Config,
-                        [{rmq_nodes_count, 2},
-                         {rmq_nodes_clustered, false},
-                         {start_rmq_with_plugins_disabled, true}]),
-            rabbit_ct_helpers:run_setup_steps(Config1, [
-                                                        fun prepare_my_plugin/1,
-                                                        fun work_around_cli_and_rabbit_circular_dep/1
-                                                       ])
-    end;
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{rmq_nodes_count, 2},
+                 {rmq_nodes_clustered, false},
+                 {start_rmq_with_plugins_disabled, true}]),
+    rabbit_ct_helpers:run_setup_steps(Config1, [
+                                                fun prepare_my_plugin/1,
+                                                fun work_around_cli_and_rabbit_circular_dep/1
+                                               ]);
 init_per_group(activating_plugin, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            %% mixed mode testing in bazel uses a production build of
-            %% the broker, however this group invokes functions via
-            %% rpc that are only available in test builds
-            {skip, "mixed mode not supported"};
-        _ ->
-            Config1 = rabbit_ct_helpers:set_config(
-                        Config,
-                        [{rmq_nodes_count, 2},
-                         {rmq_nodes_clustered, true},
-                         {start_rmq_with_plugins_disabled, true}]),
-            rabbit_ct_helpers:run_setup_steps(
-              Config1,
-              [
-               fun prepare_my_plugin/1,
-               fun work_around_cli_and_rabbit_circular_dep/1
-              ])
-    end;
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{rmq_nodes_count, 2},
+                 {rmq_nodes_clustered, true},
+                 {start_rmq_with_plugins_disabled, true}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      [
+       fun prepare_my_plugin/1,
+       fun work_around_cli_and_rabbit_circular_dep/1
+      ]);
 init_per_group(_, Config) ->
     Config.
 

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -127,22 +127,14 @@ init_per_group(clustering, Config) ->
                 [{rmq_nodes_count, 2},
                  {rmq_nodes_clustered, false},
                  {start_rmq_with_plugins_disabled, true}]),
-    rabbit_ct_helpers:run_setup_steps(Config1, [
-                                                fun prepare_my_plugin/1,
-                                                fun work_around_cli_and_rabbit_circular_dep/1
-                                               ]);
+    rabbit_ct_helpers:run_setup_steps(Config1, [fun prepare_my_plugin/1]);
 init_per_group(activating_plugin, Config) ->
     Config1 = rabbit_ct_helpers:set_config(
                 Config,
                 [{rmq_nodes_count, 2},
                  {rmq_nodes_clustered, true},
                  {start_rmq_with_plugins_disabled, true}]),
-    rabbit_ct_helpers:run_setup_steps(
-      Config1,
-      [
-       fun prepare_my_plugin/1,
-       fun work_around_cli_and_rabbit_circular_dep/1
-      ]);
+    rabbit_ct_helpers:run_setup_steps(Config1,[fun prepare_my_plugin/1]);
 init_per_group(_, Config) ->
     Config.
 
@@ -1187,40 +1179,6 @@ remove_other_plugins(PluginSrcDir, OtherPlugins) ->
     ok = rabbit_file:recursive_delete(
            [filename:join(PluginSrcDir, OtherPlugin)
             || OtherPlugin <- OtherPlugins]).
-
-work_around_cli_and_rabbit_circular_dep(Config) ->
-    %% FIXME: We also need to copy `rabbit` in `my_plugins` plugins
-    %% directory, not because `my_plugin` depends on it, but because the
-    %% CLI erroneously depends on the broker.
-    %%
-    %% This can't be fixed easily because this is a circular dependency
-    %% (i.e. the broker depends on the CLI). So until a proper solution
-    %% is implemented, keep this second copy of the broker for the CLI
-    %% to find it.
-    InitialPluginsDir = filename:join(
-                          ?config(current_srcdir, Config),
-                          "plugins"),
-    PluginsDir = ?config(rmq_plugins_dir, Config),
-    lists:foreach(
-      fun(Path) ->
-              Filename = filename:basename(Path),
-              IsRabbit = re:run(
-                           Filename,
-                           "^rabbit-", [{capture, none}]) =:= match,
-              case IsRabbit of
-                  true ->
-                      Dest = filename:join(PluginsDir, Filename),
-                      ct:pal(
-                        ?LOW_IMPORTANCE,
-                        "Copy `~s` to `~s` to fix CLI erroneous "
-                        "dependency on `rabbit`", [Path, Dest]),
-                      ok = rabbit_file:recursive_copy(Path, Dest);
-                  false ->
-                      ok
-              end
-      end,
-      filelib:wildcard(filename:join(InitialPluginsDir, "*"))),
-    Config.
 
 enable_feature_flag_on(Config, Node, FeatureName) ->
     rabbit_ct_broker_helpers:rpc(

--- a/deps/rabbit/test/feature_flags_with_unpriveleged_user_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_with_unpriveleged_user_SUITE.erl
@@ -54,16 +54,9 @@ end_per_suite(Config) ->
     feature_flags_SUITE:end_per_suite(Config).
 
 init_per_group(enabling_in_cluster, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            %% This test relies on functions only exported for test,
-            %% which is not true of mixed version nodes in bazel
-            {skip, "mixed mode not supported"};
-        _ ->
-            rabbit_ct_helpers:set_config(
-              Config,
-              [{rmq_nodes_count, 3}])
-    end;
+    rabbit_ct_helpers:set_config(
+      Config,
+      [{rmq_nodes_count, 3}]);
 init_per_group(Group, Config) ->
     feature_flags_SUITE:init_per_group(Group, Config).
 


### PR DESCRIPTION
Previously when CI switched to bazel, these tests were skipped because they relied on functions only exported for test, and bazel mixed version testing uses non-dev builds of rabbit for the secondary umbrella. Recent changes to the suite mean that this is no longer the case.