### PR TITLE
Log when acquiring or releasing a global lock

### DIFF
--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -546,18 +546,8 @@ lock_registry_and_enable(#{states_per_node := _} = Inventory, FeatureName) ->
     %% registered name to prevent concurrent runs). But this is used in
     %% `rabbit_feature_flags:is_enabled()' to block while the state is
     %% `state_changing'.
-    ?LOG_DEBUG(
-       "Feature flags: acquiring registry state change lock",
-       [],
-       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
     rabbit_ff_registry_factory:acquire_state_change_lock(),
-
     Ret = enable_with_registry_locked(Inventory, FeatureName),
-
-    ?LOG_DEBUG(
-       "Feature flags: releasing registry state change lock",
-       [],
-       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
     rabbit_ff_registry_factory:release_state_change_lock(),
     Ret.
 

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -25,10 +25,22 @@
 
 -type registry_vsn() :: term().
 
+-spec acquire_state_change_lock() -> boolean().
 acquire_state_change_lock() ->
-    global:set_lock(?FF_STATE_CHANGE_LOCK).
+    rabbit_log_feature_flags:debug(
+      "Feature flags: acquiring lock ~p",
+      [?FF_STATE_CHANGE_LOCK]),
+    Ret = global:set_lock(?FF_STATE_CHANGE_LOCK),
+    rabbit_log_feature_flags:debug(
+      "Feature flags: acquired lock ~p",
+      [?FF_STATE_CHANGE_LOCK]),
+    Ret.
 
+-spec release_state_change_lock() -> true.
 release_state_change_lock() ->
+    rabbit_log_feature_flags:debug(
+      "Feature flags: releasing lock ~p",
+      [?FF_STATE_CHANGE_LOCK]),
     global:del_lock(?FF_STATE_CHANGE_LOCK).
 
 -spec initialize_registry() -> ok | {error, any()} | no_return().


### PR DESCRIPTION
to easily detect dead locks.

Prior to this commit, one caller of function
`rabbit_ff_registry_factory:acquire_state_change_lock/0`
was logging that it acquires the lock.
However, there are other callers which did not log.
Therefore, it was impossible to detect any dead locks by just
looking at the the logs.