### PR TITLE
Include rabbit_index_route in rabbit_table:definitions/0

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -21,8 +21,7 @@
          remove_for_destination/2, remove_transient_for_destination/1,
          remove_default_exchange_binding_rows_of/1]).
 
--export([implicit_for_destination/1, reverse_binding/1,
-         index_route_table_definition/0, populate_index_route_table/0]).
+-export([implicit_for_destination/1, reverse_binding/1, populate_index_route_table/0]).
 -export([new/4]).
 
 -define(DEFAULT_EXCHANGE(VHostPath), #resource{virtual_host = VHostPath,
@@ -765,17 +764,6 @@ del_notify(Bs, ActingUser) -> [rabbit_event:notify(
 
 x_callback(Serial, X, F, Bs) ->
     ok = rabbit_exchange:callback(X, F, Serial, [X, Bs]).
-
--spec index_route_table_definition() -> list(tuple()).
-index_route_table_definition() ->
-    maps:to_list(
-      #{
-        record_name => index_route,
-        attributes  => record_info(fields, index_route),
-        type => bag,
-        ram_copies => rabbit_nodes:all(),
-        storage_properties => [{ets, [{read_concurrency, true}]}]
-       }).
 
 -spec populate_index_route_table() -> ok.
 populate_index_route_table() ->

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -90,8 +90,7 @@ direct_exchange_routing_v2_migration(#ffcommand{name = FeatureName,
     TableName = rabbit_index_route,
     ok = rabbit_table:wait([rabbit_route], _Retry = true),
     try
-        ok = rabbit_table:create(TableName,
-                                 rabbit_binding:index_route_table_definition()),
+        ok = rabbit_table:create(TableName, rabbit_table:rabbit_index_route_definition()),
         case rabbit_table:ensure_table_copy(TableName, node(), ram_copies) of
             ok ->
                 ok = rabbit_binding:populate_index_route_table();

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -597,7 +597,7 @@ init_db_and_upgrade(ClusterNodes, NodeType, CheckOtherNodes, Retry) ->
     end,
     %% ...and all nodes will need to wait for tables
     rabbit_table:wait_for_replicated(Retry),
-    ok = rabbit_table:ensure_feature_flag_tables().
+    ok.
 
 init_db_with_mnesia(ClusterNodes, NodeType,
                     CheckOtherNodes, CheckConsistency, Retry) ->

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -14,7 +14,7 @@
     check_schema_integrity/1, clear_ram_only_tables/0, retry_timeout/0,
     wait_for_replicated/0, exists/1]).
 
--export([ensure_feature_flag_tables/0]).
+-export([rabbit_index_route_definition/0]).
 
 %% for testing purposes
 -export([definitions/0]).
@@ -298,6 +298,7 @@ definitions(ram) ->
         {Tab, TabDef} <- definitions()].
 
 definitions() ->
+    Definitions =
     [{rabbit_user,
       [{record_name, internal_user},
        {attributes, internal_user:fields()},
@@ -389,27 +390,24 @@ definitions() ->
        {match, amqqueue:pattern_match_on_name(queue_name_match())}]}
     ]
         ++ gm:table_definitions()
-        ++ mirrored_supervisor:table_definitions().
+        ++ mirrored_supervisor:table_definitions(),
 
-%% To allow for rolling upgrades, new Mnesia tables must be created behind feature flags.
-%% However, feature flags are not designed to initialize RabbitMQ.
-%% Therefore, this function is called upon node boot and ensures that:
-%%
-%% 1. For a single node cluster that already ran the feature flag migration function creating
-%% the table, but got subsequently reset, the table must be created again upon node boot.
-%%
-%% 2. For a stand-alone node that already ran the feature flag migration function adding a
-%% table copy and subsequently joins a new cluster, it must add a table copy again upon node boot.
--spec ensure_feature_flag_tables() -> ok.
-ensure_feature_flag_tables() ->
-    %% Currently, direct_exchange_routing_v2 is the only feature flag that creates a Mnesia table.
     case rabbit_feature_flags:is_enabled(direct_exchange_routing_v2) of
         true ->
-            ok = create(rabbit_index_route, rabbit_binding:index_route_table_definition()),
-            ok = ensure_table_copy(rabbit_index_route, node(), ram_copies);
+            Definitions ++ [{rabbit_index_route, rabbit_index_route_definition()}];
         false ->
-            ok
+            Definitions
     end.
+
+-spec rabbit_index_route_definition() -> list(tuple()).
+rabbit_index_route_definition() ->
+    [{record_name, index_route},
+     {attributes, record_info(fields, index_route)},
+     {type, bag},
+     {storage_properties, [{ets, [{read_concurrency, true}]}]},
+     {match, #index_route{source_key = {exchange_name_match(), '_'},
+                          destination = binding_destination_match(),
+                          _='_'}}].
 
 binding_match() ->
     #binding{source = exchange_name_match(),


### PR DESCRIPTION
This commit attempts to address the feedback in
https://github.com/rabbitmq/rabbitmq-server/pull/5254#discussion_r924497137.

Delete special code paths like function rabbit_table:ensure_feature_flag_tables/0
as they are confusing.

Instead, handle the new rabbit_index_route table as any other Mnesia
table if feature flag direct_exchange_routing_v2 is enabled.

Note that this commit comes with one important restriction:
A feature flag migration function MUST NOT call
rabbit_table:definitions/0 (directly or indirectly) as this will result
in a deadlock where the migration function is stuck on the global lock
with resource ID 'feature_flags_state_change' when checking for
rabbit_feature_flags:is_enabled(direct_exchange_routing_v2)
because the migration function runs in a different (RPC) process than
the function that holds the 'feature_flags_state_change' lock.
The latter lock is set before a feature gets enabled and released
after the feature flag got enabled.