### PR TITLE
Split the OCI workflow into a nightly and on push phase for less flakiness

### DIFF
--- a/.github/workflows/oci-base.yaml
+++ b/.github/workflows/oci-base.yaml
@@ -1,0 +1,58 @@
+# https://github.com/marketplace/actions/build-and-push-docker-images
+name: OCI Base Image
+on:
+  schedule:
+  - cron: '0 3 * * *'
+  workflow_dispatch:
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3.0.5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.image_tag_suffix }}-buildx-${{ github.event.pull_request.head.sha || github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.image_tag_suffix }}-buildx-
+
+      - name: Check for Push Credentials
+        id: authorized
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]; then
+            echo "::set-output name=PUSH::true"
+          else
+            echo "::set-output name=PUSH::false"
+          fi
+
+      - name: Login to DockerHub
+        if: steps.authorized.outputs.PUSH == 'true'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: packaging/base-image
+          pull: true
+          push: ${{ steps.authorized.outputs.PUSH }}
+          tags: |
+            pivotalrabbitmq/ubuntu:20.04
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -130,7 +130,6 @@ jobs:
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}
           build-args: |
-            BASE=pivotalrabbitmq/ubuntu
             SKIP_PGP_VERIFY=true
             PGP_KEYSERVER=pgpkeys.eu
             OTP_VERSION=${{ steps.load-info.outputs.otp }}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -124,6 +124,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: packaging/docker-image
+          pull: true
           push: ${{ steps.authorized.outputs.PUSH }}
           tags: |
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -130,6 +130,7 @@ jobs:
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_1 }}
             pivotalrabbitmq/rabbitmq:${{ steps.compute-tags.outputs.TAG_2 }}
           build-args: |
+            BASE=pivotalrabbitmq/ubuntu
             SKIP_PGP_VERIFY=true
             PGP_KEYSERVER=pgpkeys.eu
             OTP_VERSION=${{ steps.load-info.outputs.otp }}

--- a/packaging/base-image/Dockerfile
+++ b/packaging/base-image/Dockerfile
@@ -1,0 +1,18 @@
+# The official Canonical Ubuntu Bionic image is ideal from a security perspective,
+# especially for the enterprises that we, the RabbitMQ team, have to deal with
+FROM ubuntu:20.04
+
+RUN set -eux; \
+        apt-get update; \
+        apt-get install -y lsb-release ubuntu-dbgsym-keyring; \
+        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse" > /etc/apt/sources.list.d/ddebs.list; \
+        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse" >> /etc/apt/sources.list.d/ddebs.list; \
+        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" >> /etc/apt/sources.list.d/ddebs.list; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends \
+ # grab gosu for easy step-down from root
+        libc6-dbg \
+        libgcc-s1-dbgsym \
+        libstdc++6-dbgsym \
+        libtinfo6-dbgsym \
+        zlib1g-dbgsym

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -4,19 +4,9 @@ FROM ubuntu:20.04
 
 RUN set -eux; \
         apt-get update; \
-        apt-get install -y lsb-release ubuntu-dbgsym-keyring; \
-        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse" > /etc/apt/sources.list.d/ddebs.list; \
-        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse" >> /etc/apt/sources.list.d/ddebs.list; \
-        echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" >> /etc/apt/sources.list.d/ddebs.list; \
-        apt-get update; \
         apt-get install -y --no-install-recommends \
 # grab gosu for easy step-down from root
         gosu \
-        libc6-dbg \
-        libgcc-s1-dbgsym \
-        libstdc++6-dbgsym \
-        libtinfo6-dbgsym \
-        zlib1g-dbgsym \
         ; \
 	rm -rf /var/lib/apt/lists/*; \
 # verify that the "gosu" binary works

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -1,6 +1,7 @@
 # The official Canonical Ubuntu Bionic image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:20.04
+ARG BASE=ubuntu
+FROM ${BASE}:20.04
 
 RUN set -eux; \
         apt-get update; \

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -117,7 +117,7 @@ RUN set -eux; \
 # Download, verify & extract OTP_SOURCE
 	mkdir -p "$OTP_PATH"; \
 	wget --progress dot:giga --output-document "$OTP_PATH.tar.gz" "$OTP_SOURCE_URL"; \
-	test "$SKIP_OTP_VERIFY" == "true" || echo "$OTP_SOURCE_SHA256 *$OTP_PATH.tar.gz" | sha256sum --check --strict -; \
+	test "$SKIP_OTP_VERIFY" = "true" || echo "$OTP_SOURCE_SHA256 *$OTP_PATH.tar.gz" | sha256sum --check --strict -; \
 	tar --extract --file "$OTP_PATH.tar.gz" --directory "$OTP_PATH" --strip-components 1; \
 	\
 # Configure Erlang/OTP for compilation, disable unused features & applications


### PR DESCRIPTION
in an attempt to reduce flakiness due to expired package mirrors

https://linuxtut.com/en/e3c12a3478bba2a1f9b4/