### PR TITLE
CQ: Fix two accidental state overwrites

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -982,7 +982,7 @@ read_from_disk(SeqIdsToRead0, State0 = #qi{ write_buffer = WriteBuffer }, Acc0) 
                     %% We reached the end of a partial file.
                     %% Everything past that point is non-existent.
                     %% This probably does not happen outside of tests.
-                    read_from_disk(SeqIdsToRead, State0, Acc0)
+                    read_from_disk(SeqIdsToRead, State, Acc0)
             end;
         %% The segment file no longer exists. This is equivalent to a file
         %% where all entries are non-existent/acked. This can happen after

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -2094,9 +2094,7 @@ remove_by_predicate(Pred, State = #vqstate {out_counter = OutCount}) ->
 %%
 %% @todo See todo in remove_by_predicate/2 function.
 fetch_by_predicate(Pred, Fun, FetchAcc,
-                   State = #vqstate {
-                              index_state = IndexState1,
-                              out_counter = OutCount}) ->
+                   State = #vqstate { out_counter = OutCount}) ->
     {MsgProps, QAcc, State1} =
         collect_by_predicate(Pred, ?QUEUE:new(), State),
 
@@ -2106,7 +2104,6 @@ fetch_by_predicate(Pred, Fun, FetchAcc,
     {MsgProps, FetchAcc1, maybe_update_rates(
                             State2 #vqstate {
                               next_deliver_seq_id = NextDeliverSeqId,
-                              index_state         = IndexState1,
                               out_counter         = OutCount + ?QUEUE:len(QAcc)})}.
 
 %% We try to do here the same as what remove(true, State) does but


### PR DESCRIPTION
The main issue was the one in fetch_by_predicate which resulted
in a double file:close on a single FD, the second failing and
triggering a badmatch. It only occurs for CQv2 in lazy mode
and with a high enough consume rate. It is possible that in
other conditions problems did occur but were not detected.

The other was detected while looking for the original issue,
but might not have created any bug.

Fix for https://github.com/rabbitmq/rabbitmq-server/issues/5252 which has Python scripts that can be used to confirm the problem went away.

