### PR TITLE
Move connection and channel tracking tables to ETS

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -79,6 +79,12 @@
                     {requires,    database},
                     {enables,     external_infrastructure}]}).
 
+-rabbit_boot_step({tracking_metadata_store,
+                   [{description, "tracking infrastructure"},
+                    {mfa,         {rabbit_sup, start_child, [rabbit_tracking_store]}},
+                    {requires,    database},
+                    {enables,     external_infrastructure}]}).
+
 -rabbit_boot_step({code_server_cache,
                    [{description, "code_server cache server"},
                     {mfa,         {rabbit_sup, start_child, [code_server_cache]}},

--- a/deps/rabbit/src/rabbit_channel_tracking.erl
+++ b/deps/rabbit/src/rabbit_channel_tracking.erl
@@ -227,7 +227,7 @@ shutdown_tracked_items(TrackedItems, _Args) ->
 list() ->
     lists:foldl(
       fun (Node, Acc) ->
-              list_on_node(Node) ++ Acc
+              Acc ++ list_on_node(Node)
       end, [], rabbit_nodes:all_running()).
 
 -spec list_of_user(rabbit_types:username()) -> [rabbit_types:tracked_channel()].

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -456,7 +456,7 @@ lookup_mnesia(Name, Node) ->
 list() ->
     lists:foldl(
       fun (Node, Acc) ->
-              list_on_node(Node) ++ Acc
+              Acc ++ list_on_node(Node)
       end, [], rabbit_nodes:all_running()).
 
 -spec count() -> non_neg_integer().

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -26,38 +26,32 @@
          clear_tracking_tables/0,
          shutdown_tracked_items/2]).
 
--export([ensure_tracked_connections_table_for_node/1,
-         ensure_per_vhost_tracked_connections_table_for_node/1,
-         ensure_per_user_tracked_connections_table_for_node/1,
-
-         ensure_tracked_connections_table_for_this_node/0,
-         ensure_per_vhost_tracked_connections_table_for_this_node/0,
-         ensure_per_user_tracked_connections_table_for_this_node/0,
-
-         tracked_connection_table_name_for/1,
+-export([tracked_connection_table_name_for/1,
          tracked_connection_per_vhost_table_name_for/1,
          tracked_connection_per_user_table_name_for/1,
          get_all_tracked_connection_table_names_for_node/1,
-
-         delete_tracked_connections_table_for_node/1,
-         delete_per_vhost_tracked_connections_table_for_node/1,
-         delete_per_user_tracked_connections_table_for_node/1,
-         delete_tracked_connection_user_entry/1,
-         delete_tracked_connection_vhost_entry/1,
-
          clear_tracked_connection_tables_for_this_node/0,
 
+         ensure_tracked_tables_for_this_node/0,
+
+         delete_tracked_connection_user_entry/1,
+         delete_tracked_connection_vhost_entry/1,
          list/0, list/1, list_on_node/1, list_on_node/2, list_of_user/1,
          tracked_connection_from_connection_created/1,
          tracked_connection_from_connection_state/1,
-         lookup/1,
-         count/0]).
+         lookup/1, count/0]).
+
+-export([migrate_tracking_records/0]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -import(rabbit_misc, [pget/2]).
 
 -export([close_connections/3]).
+
+-define(TRACKED_CONNECTION_TABLE, tracked_connection).
+-define(TRACKED_CONNECTION_TABLE_PER_USER, tracked_connection_per_user).
+-define(TRACKED_CONNECTION_TABLE_PER_VHOST, tracked_connection_per_vhost).
 
 %%
 %% API
@@ -71,14 +65,8 @@
 %% node.
 boot() ->
     ensure_tracked_connections_table_for_this_node(),
-    rabbit_log:info("Setting up a table for connection tracking on this node: ~p",
-                    [tracked_connection_table_name_for(node())]),
     ensure_per_vhost_tracked_connections_table_for_this_node(),
-    rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~p",
-                    [tracked_connection_per_vhost_table_name_for(node())]),
     ensure_per_user_tracked_connections_table_for_this_node(),
-    rabbit_log:info("Setting up a table for per-user connection counting on this node: ~p",
-                    [tracked_connection_per_user_table_name_for(node())]),
     clear_tracking_tables(),
     ok.
 
@@ -159,16 +147,38 @@ handle_cast({user_deleted, Details}) ->
         rabbit_misc:format("user '~s' is deleted", [Username]));
 %% A node had been deleted from the cluster.
 handle_cast({node_deleted, Details}) ->
-    Node = pget(node, Details),
-    rabbit_log_connection:info("Node '~s' was removed from the cluster, deleting its connection tracking tables...", [Node]),
-    delete_tracked_connections_table_for_node(Node),
-    delete_per_vhost_tracked_connections_table_for_node(Node),
-    delete_per_user_tracked_connections_table_for_node(Node).
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true ->
+            ok;
+        false ->
+            Node = pget(node, Details),
+            rabbit_log_connection:info("Node '~s' was removed from the cluster, deleting its connection tracking tables...", [Node]),
+            delete_tracked_connections_table_for_node(Node),
+            delete_per_vhost_tracked_connections_table_for_node(Node),
+            delete_per_user_tracked_connections_table_for_node(Node)
+    end.
 
 -spec register_tracked(rabbit_types:tracked_connection()) -> ok.
 -dialyzer([{nowarn_function, [register_tracked/1]}]).
 
-register_tracked(#tracked_connection{username = Username, vhost = VHost, id = ConnId, node = Node} = Conn) when Node =:= node() ->
+register_tracked(#tracked_connection{node = Node} = Conn) when Node =:= node() ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> register_tracked_ets(Conn);
+        false -> register_tracked_mnesia(Conn)
+    end.
+
+register_tracked_ets(#tracked_connection{username = Username, vhost = VHost, id = ConnId} = Conn) ->
+    case ets:lookup(?TRACKED_CONNECTION_TABLE, ConnId) of
+        []    ->
+            ets:insert(?TRACKED_CONNECTION_TABLE, Conn),
+            ets:update_counter(?TRACKED_CONNECTION_TABLE_PER_VHOST, VHost, 1, {VHost, 0}),
+            ets:update_counter(?TRACKED_CONNECTION_TABLE_PER_USER, Username, 1, {Username, 0});
+        [#tracked_connection{}] ->
+            ok
+    end,
+    ok.
+
+register_tracked_mnesia(#tracked_connection{username = Username, vhost = VHost, id = ConnId, node = Node} = Conn) ->
     TableName = tracked_connection_table_name_for(Node),
     PerVhostTableName = tracked_connection_per_vhost_table_name_for(Node),
     PerUserConnTableName = tracked_connection_per_user_table_name_for(Node),
@@ -184,8 +194,22 @@ register_tracked(#tracked_connection{username = Username, vhost = VHost, id = Co
     ok.
 
 -spec unregister_tracked(rabbit_types:tracked_connection_id()) -> ok.
-
 unregister_tracked(ConnId = {Node, _Name}) when Node =:= node() ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> unregister_tracked_ets(ConnId);
+        false -> unregister_tracked_mnesia(ConnId)
+    end.
+
+unregister_tracked_ets(ConnId) ->
+    case ets:lookup(?TRACKED_CONNECTION_TABLE, ConnId) of
+        []     -> ok;
+        [#tracked_connection{vhost = VHost, username = Username}] ->
+            ets:update_counter(?TRACKED_CONNECTION_TABLE_PER_USER, Username, -1),
+            ets:update_counter(?TRACKED_CONNECTION_TABLE_PER_VHOST, VHost, -1),
+            ets:delete(?TRACKED_CONNECTION_TABLE, ConnId)
+    end.
+
+unregister_tracked_mnesia(ConnId = {Node, _Name}) ->
     TableName = tracked_connection_table_name_for(Node),
     PerVhostTableName = tracked_connection_per_vhost_table_name_for(Node),
     PerUserConnTableName = tracked_connection_per_user_table_name_for(Node),
@@ -198,14 +222,30 @@ unregister_tracked(ConnId = {Node, _Name}) when Node =:= node() ->
     end.
 
 -spec count_tracked_items_in({atom(), rabbit_types:vhost()}) -> non_neg_integer().
+count_tracked_items_in(Type) ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> count_tracked_items_in_ets(Type);
+        false -> count_tracked_items_in_mnesia(Type)
+    end.    
 
-count_tracked_items_in({vhost, VirtualHost}) ->
-    rabbit_tracking:count_tracked_items(
+count_tracked_items_in_ets({vhost, VirtualHost}) ->
+    rabbit_tracking:count_tracked_items_ets(
+        ?TRACKED_CONNECTION_TABLE_PER_VHOST,
+        VirtualHost,
+        "connections in vhost");
+count_tracked_items_in_ets({user, Username}) ->
+    rabbit_tracking:count_tracked_items_ets(
+        ?TRACKED_CONNECTION_TABLE_PER_USER,
+        Username,
+        "connections for user").
+
+count_tracked_items_in_mnesia({vhost, VirtualHost}) ->
+    rabbit_tracking:count_tracked_items_mnesia(
         fun tracked_connection_per_vhost_table_name_for/1,
         #tracked_connection_per_vhost.connection_count, VirtualHost,
         "connections in vhost");
-count_tracked_items_in({user, Username}) ->
-    rabbit_tracking:count_tracked_items(
+count_tracked_items_in_mnesia({user, Username}) ->
+    rabbit_tracking:count_tracked_items_mnesia(
         fun tracked_connection_per_user_table_name_for/1,
         #tracked_connection_per_user.connection_count, Username,
         "connections for user").
@@ -213,7 +253,10 @@ count_tracked_items_in({user, Username}) ->
 -spec clear_tracking_tables() -> ok.
 
 clear_tracking_tables() ->
-    clear_tracked_connection_tables_for_this_node().
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> ok;
+        false -> clear_tracked_connection_tables_for_this_node()
+    end.
 
 -spec shutdown_tracked_items(list(), term()) -> ok.
 
@@ -222,59 +265,105 @@ shutdown_tracked_items(TrackedItems, Message) ->
 
 %% Extended API
 
+ensure_tracked_tables_for_this_node() ->
+    ensure_tracked_connections_table_for_this_node_ets(),
+    ensure_per_vhost_tracked_connections_table_for_this_node_ets(),
+    ensure_per_user_tracked_connections_table_for_this_node_ets().
+
 -spec ensure_tracked_connections_table_for_this_node() -> ok.
 
 ensure_tracked_connections_table_for_this_node() ->
-    ensure_tracked_connections_table_for_node(node()).
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true ->
+            ok;
+        false ->
+            ensure_tracked_connections_table_for_this_node_mnesia()
+    end.
 
+ensure_tracked_connections_table_for_this_node_ets() ->
+    ets:new(?TRACKED_CONNECTION_TABLE, [named_table, public, {write_concurrency, true},
+                                        {keypos, #tracked_connection.id}]),
+    rabbit_log:info("Setting up a table for connection tracking on this node: ~p",
+                    [?TRACKED_CONNECTION_TABLE]).
 
--spec ensure_per_vhost_tracked_connections_table_for_this_node() -> ok.
-
-ensure_per_vhost_tracked_connections_table_for_this_node() ->
-    ensure_per_vhost_tracked_connections_table_for_node(node()).
-
-
--spec ensure_per_user_tracked_connections_table_for_this_node() -> ok.
-
-ensure_per_user_tracked_connections_table_for_this_node() ->
-    ensure_per_user_tracked_connections_table_for_node(node()).
-
-
-%% Create tables
--spec ensure_tracked_connections_table_for_node(node()) -> ok.
-
-ensure_tracked_connections_table_for_node(Node) ->
+ensure_tracked_connections_table_for_this_node_mnesia() ->
+    Node = node(),
     TableName = tracked_connection_table_name_for(Node),
     case mnesia:create_table(TableName, [{record_name, tracked_connection},
                                          {attributes, record_info(fields, tracked_connection)}]) of
-        {atomic, ok}                   -> ok;
-        {aborted, {already_exists, _}} -> ok;
+        {atomic, ok}                   ->
+            rabbit_log:info("Setting up a table for connection tracking on this node: ~p",
+                            [TableName]),
+            ok;
+        {aborted, {already_exists, _}} ->
+            rabbit_log:info("Setting up a table for connection tracking on this node: ~p",
+                            [TableName]);
         {aborted, Error}               ->
             rabbit_log:error("Failed to create a tracked connection table for node ~p: ~p", [Node, Error]),
             ok
     end.
 
--spec ensure_per_vhost_tracked_connections_table_for_node(node()) -> ok.
+-spec ensure_per_vhost_tracked_connections_table_for_this_node() -> ok.
 
-ensure_per_vhost_tracked_connections_table_for_node(Node) ->
+ensure_per_vhost_tracked_connections_table_for_this_node() ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true ->
+            ok;
+        false ->
+            ensure_per_vhost_tracked_connections_table_for_this_node_mnesia()
+    end.
+
+ensure_per_vhost_tracked_connections_table_for_this_node_ets() ->
+    rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~p",
+                    [?TRACKED_CONNECTION_TABLE_PER_VHOST]),
+    ets:new(?TRACKED_CONNECTION_TABLE_PER_VHOST, [named_table, public, {write_concurrency, true}]).
+
+ensure_per_vhost_tracked_connections_table_for_this_node_mnesia() ->
+    Node = node(),
     TableName = tracked_connection_per_vhost_table_name_for(Node),
     case mnesia:create_table(TableName, [{record_name, tracked_connection_per_vhost},
                                          {attributes, record_info(fields, tracked_connection_per_vhost)}]) of
-        {atomic, ok}                   -> ok;
-        {aborted, {already_exists, _}} -> ok;
+        {atomic, ok}                   ->
+            rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~p",
+                            [TableName]),
+            ok;
+        {aborted, {already_exists, _}} ->
+            rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~p",
+                            [TableName]),
+            ok;
         {aborted, Error}               ->
             rabbit_log:error("Failed to create a per-vhost tracked connection table for node ~p: ~p", [Node, Error]),
             ok
     end.
 
--spec ensure_per_user_tracked_connections_table_for_node(node()) -> ok.
+-spec ensure_per_user_tracked_connections_table_for_this_node() -> ok.
 
-ensure_per_user_tracked_connections_table_for_node(Node) ->
+ensure_per_user_tracked_connections_table_for_this_node() ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true ->
+            ok;
+        false ->
+            ensure_per_user_tracked_connections_table_for_this_node_mnesia()
+    end.
+
+ensure_per_user_tracked_connections_table_for_this_node_ets() ->
+    ets:new(?TRACKED_CONNECTION_TABLE_PER_USER, [named_table, public, {write_concurrency, true}]),
+    rabbit_log:info("Setting up a table for per-user connection counting on this node: ~p",
+                    [?TRACKED_CONNECTION_TABLE_PER_USER]).
+
+ensure_per_user_tracked_connections_table_for_this_node_mnesia() ->
+    Node = node(),
     TableName = tracked_connection_per_user_table_name_for(Node),
     case mnesia:create_table(TableName, [{record_name, tracked_connection_per_user},
                                          {attributes, record_info(fields, tracked_connection_per_user)}]) of
-        {atomic, ok}                   -> ok;
-        {aborted, {already_exists, _}} -> ok;
+        {atomic, ok}                   ->
+            rabbit_log:info("Setting up a table for per-user connection counting on this node: ~p",
+                            [TableName]),
+            ok;
+        {aborted, {already_exists, _}} ->
+            rabbit_log:info("Setting up a table for per-user connection counting on this node: ~p",
+                            [TableName]),
+            ok;
         {aborted, Error}               ->
             rabbit_log:error("Failed to create a per-user tracked connection table for node ~p: ~p", [Node, Error]),
             ok
@@ -305,7 +394,7 @@ delete_per_vhost_tracked_connections_table_for_node(Node) ->
 delete_per_user_tracked_connections_table_for_node(Node) ->
     TableName = tracked_connection_per_user_table_name_for(Node),
     rabbit_tracking:delete_tracking_table(TableName, Node,
-        "per-user tracked connection").
+                                          "per-user tracked connection").
 
 -spec tracked_connection_table_name_for(node()) -> atom().
 
@@ -338,31 +427,36 @@ lookup(Name) ->
 
 lookup(_, []) ->
     not_found;
+lookup(Name, [Node | Nodes]) when Node == node() ->
+    case lookup_internal(Name, Node) of
+        [] -> lookup(Name, Nodes);
+        [Row] -> Row
+    end;
 lookup(Name, [Node | Nodes]) ->
-    TableName = tracked_connection_table_name_for(Node),
-    case mnesia:dirty_read(TableName, {Node, Name}) of
+    case rabbit_misc:rpc_call(Node, ?MODULE, lookup, [Name, [Node]]) of
         [] -> lookup(Name, Nodes);
         [Row] -> Row
     end.
+
+lookup_internal(Name, Node) ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> lookup_ets(Name, Node);
+        false -> lookup_mnesia(Name, Node)
+    end.
+
+lookup_ets(Name, Node) ->
+    ets:lookup(?TRACKED_CONNECTION_TABLE, {Node, Name}).
+
+lookup_mnesia(Name, Node) ->
+    TableName = tracked_connection_table_name_for(Node),
+    mnesia:dirty_read(TableName, {Node, Name}).
 
 -spec list() -> [rabbit_types:tracked_connection()].
 
 list() ->
     lists:foldl(
       fun (Node, Acc) ->
-              Tab = tracked_connection_table_name_for(Node),
-              try
-                  Acc ++
-                  mnesia:dirty_match_object(Tab, #tracked_connection{_ = '_'})
-              catch
-                  exit:{aborted, {no_exists, [Tab, _]}} ->
-                      %% The table might not exist yet (or is already gone)
-                      %% between the time rabbit_nodes:all_running() runs and
-                      %% returns a specific node, and
-                      %% mnesia:dirty_match_object() is called for that node's
-                      %% table.
-                      Acc
-              end
+              list_on_node(Node) ++ Acc
       end, [], rabbit_nodes:all_running()).
 
 -spec count() -> non_neg_integer().
@@ -370,59 +464,148 @@ list() ->
 count() ->
     lists:foldl(
       fun (Node, Acc) ->
-              Tab = tracked_connection_table_name_for(Node),
-              %% mnesia:table_info() returns 0 if the table doesn't exist. We
-              %% don't need the same kind of protection as the list() function
-              %% above.
-              Acc + mnesia:table_info(Tab, size)
+              count_on_node(Node) + Acc
       end, 0, rabbit_nodes:all_running()).
+
+count_on_node(Node) ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true when Node == node() ->
+            count_on_node_ets();
+        true ->
+            case rabbit_misc:rpc_call(Node, ?MODULE, count_on_node, [Node]) of
+                Int when is_integer(Int) ->
+                    Int;
+                _ ->
+                    0
+            end;
+        false ->
+            count_on_node_mnesia(Node)
+    end.
+
+count_on_node_ets() ->
+    case ets:info(?TRACKED_CONNECTION_TABLE, size) of
+        undefined -> 0;
+        Size -> Size
+    end.
+
+count_on_node_mnesia(Node) ->
+    Tab = tracked_connection_table_name_for(Node),
+    %% mnesia:table_info() returns 0 if the table doesn't exist. We
+    %% don't need the same kind of protection as the list() function
+    %% above.
+    mnesia:table_info(Tab, size).
 
 -spec list(rabbit_types:vhost()) -> [rabbit_types:tracked_connection()].
 
 list(VHost) ->
-    rabbit_tracking:match_tracked_items(
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> list_ets(VHost);
+        false -> list_mnesia(VHost)
+    end.
+
+list_ets(VHost) ->
+    rabbit_tracking:match_tracked_items_ets(
+        ?TRACKED_CONNECTION_TABLE,
+        #tracked_connection{vhost = VHost, _ = '_'}).
+
+list_mnesia(VHost) ->
+    rabbit_tracking:match_tracked_items_mnesia(
         fun tracked_connection_table_name_for/1,
         #tracked_connection{vhost = VHost, _ = '_'}).
 
 -spec list_on_node(node()) -> [rabbit_types:tracked_connection()].
-
 list_on_node(Node) ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true when Node == node() ->
+            list_on_node_ets();
+        true ->
+            case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node]) of
+                List when is_list(List) ->
+                    List;
+                _ ->
+                    []
+            end;
+        false ->
+            list_on_node_mnesia(Node)
+    end.
+
+list_on_node_ets() ->
+    ets:tab2list(?TRACKED_CONNECTION_TABLE).
+
+list_on_node_mnesia(Node) ->
     try mnesia:dirty_match_object(
           tracked_connection_table_name_for(Node),
           #tracked_connection{_ = '_'})
-    catch exit:{aborted, {no_exists, _}} -> []
+    catch exit:{aborted, {no_exists, _}} ->
+            %% The table might not exist yet (or is already gone)
+            %% between the time rabbit_nodes:all_running() runs and
+            %% returns a specific node, and
+            %% mnesia:dirty_match_object() is called for that node's
+            %% table.
+            []
     end.
 
 -spec list_on_node(node(), rabbit_types:vhost()) -> [rabbit_types:tracked_connection()].
 
 list_on_node(Node, VHost) ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true when Node == node() ->
+            list_on_node_ets(VHost);
+        true ->
+            case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node, VHost]) of
+                List when is_list(List) ->
+                    List;
+                _ ->
+                    []
+            end;
+        false ->
+            list_on_node_mnesia(Node, VHost)
+    end.
+
+list_on_node_ets(VHost) ->
+    ets:match_object(?TRACKED_CONNECTION_TABLE,
+                     #tracked_connection{vhost = VHost, _ = '_'}).
+
+list_on_node_mnesia(Node, VHost) ->
     try mnesia:dirty_match_object(
           tracked_connection_table_name_for(Node),
           #tracked_connection{vhost = VHost, _ = '_'})
     catch exit:{aborted, {no_exists, _}} -> []
     end.
 
-
 -spec list_of_user(rabbit_types:username()) -> [rabbit_types:tracked_connection()].
 
 list_of_user(Username) ->
-    rabbit_tracking:match_tracked_items(
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true -> list_of_user_ets(Username);
+        false -> list_of_user_mnesia(Username)
+    end.
+
+list_of_user_ets(Username) ->
+    rabbit_tracking:match_tracked_items_ets(
+      ?TRACKED_CONNECTION_TABLE,
+      #tracked_connection{username = Username, _ = '_'}).
+
+list_of_user_mnesia(Username) ->
+    rabbit_tracking:match_tracked_items_mnesia(
         fun tracked_connection_table_name_for/1,
         #tracked_connection{username = Username, _ = '_'}).
 
 %% Internal, delete tracked entries
 
-delete_tracked_connection_vhost_entry(Vhost) ->
+delete_tracked_connection_vhost_entry(VHost) ->
     rabbit_tracking:delete_tracked_entry(
-        {rabbit_vhost, exists, [Vhost]},
-        fun tracked_connection_per_vhost_table_name_for/1,
-        Vhost).
+      {rabbit_vhost, exists, [VHost]},
+      ?TRACKED_CONNECTION_TABLE_PER_VHOST,
+      fun tracked_connection_per_vhost_table_name_for/1,
+      VHost).
 
 delete_tracked_connection_user_entry(Username) ->
     rabbit_tracking:delete_tracked_entry(
-        {rabbit_auth_backend_internal, exists, [Username]},
-        fun tracked_connection_per_user_table_name_for/1,
-        Username).
+      {rabbit_auth_backend_internal, exists, [Username]},
+      ?TRACKED_CONNECTION_TABLE_PER_USER,
+      fun tracked_connection_per_user_table_name_for/1,
+      Username).
 
 %% Returns a #tracked_connection from connection_created
 %% event details.
@@ -532,3 +715,38 @@ close_connection(#tracked_connection{pid = Pid}, Message) ->
     % best effort, this will work for connections to the stream plugin
     Node = node(Pid),
     rpc:call(Node, gen_server, call, [Pid, {shutdown, Message}, infinity]).
+
+migrate_tracking_records() ->
+    Node = node(),
+    rabbit_misc:execute_mnesia_transaction(
+      fun () ->
+              Table = tracked_connection_table_name_for(Node),
+              mnesia:lock({table, Table}, read),
+              Connections = mnesia:select(Table, [{'$1',[],['$1']}]),
+              lists:foreach(
+                fun(Connection) ->
+                        ets:insert(tracked_connection, Connection)
+                end, Connections)
+      end),
+    rabbit_misc:execute_mnesia_transaction(
+      fun () ->
+              Table = tracked_connection_per_user_table_name_for(Node),
+              mnesia:lock({table, Table}, read),
+              Connections = mnesia:select(Table, [{'$1',[],['$1']}]),
+              lists:foreach(
+                fun(#tracked_connection_per_user{connection_count = C,
+                                                 user = Username}) ->
+                        ets:update_counter(tracked_connection_per_user, Username, C, {Username, 0})
+                end, Connections)
+      end),
+    rabbit_misc:execute_mnesia_transaction(
+      fun () ->
+              Table = tracked_connection_per_vhost_table_name_for(Node),
+              mnesia:lock({table, Table}, read),
+              Connections = mnesia:select(Table, [{'$1',[],['$1']}]),
+              lists:foreach(
+                fun(#tracked_connection_per_vhost{connection_count = C,
+                                                  vhost = VHost}) ->
+                        ets:update_counter(tracked_connection_per_vhost, VHost, C, {VHost, 0})
+                end, Connections)
+      end).

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -9,7 +9,11 @@
 
 -export([direct_exchange_routing_v2_enable/1,
          listener_records_in_ets_enable/1,
-         listener_records_in_ets_post_enable/1]).
+         listener_records_in_ets_post_enable/1,
+         tracking_records_in_ets_enable/1,
+         tracking_records_in_ets_post_enable/1]).
+
+-include("feature_flags.hrl").
 
 -rabbit_feature_flag(
    {classic_mirrored_queue_version,
@@ -90,6 +94,14 @@
                       {?MODULE, listener_records_in_ets_post_enable}}
      }}).
 
+-rabbit_feature_flag(
+   {tracking_records_in_ets,
+    #{desc          => "Store tracking records in ETS instead of Mnesia",
+      stability     => stable,
+      depends_on    => [feature_flags_v2],
+      migration_fun => {?MODULE, tracking_records_in_ets_migration}
+     }}).
+
 %% -------------------------------------------------------------------
 %% Direct exchange routing v2.
 %% -------------------------------------------------------------------
@@ -164,5 +176,45 @@ listener_records_in_ets_post_enable(#{feature_name := FeatureName}) ->
             rabbit_log_feature_flags:error(
               "Feature flags: `~s`: failed to delete Mnesia table: ~p",
               [FeatureName, Reason]),
+            ok
+    end.
+
+tracking_records_in_ets_enable(#{feature_name := FeatureName}) ->
+    try
+        rabbit_connection_tracking:migrate_tracking_records(),
+        rabbit_channel_tracking:migrate_tracking_records()
+    catch
+        throw:{error, {no_exists, _}} ->
+            ok;
+        throw:{error, Reason} ->
+            rabbit_log_feature_flags:error("Enabling feature flag ~s failed: ~p",
+                                           [FeatureName, Reason]),
+            {error, Reason}
+    end.
+
+tracking_records_in_ets_post_enable(#{feature_name = FeatureName}) ->
+    try
+        [delete_table(FeatureName, Tab) ||
+            Tab <- rabbit_connection_tracking:get_all_tracked_connection_table_names_for_node(node())],
+        [delete_table(FeatureName, Tab) ||
+            Tab <- rabbit_channel_tracking:get_all_tracked_channel_table_names_for_node(node())]
+    catch
+        throw:{error, Reason} ->
+            rabbit_log_feature_flags:error("Enabling feature flag ~s failed: ~p",
+                                           [FeatureName, Reason]),
+            %% adheres to the callback interface
+            ok
+    end.
+
+delete_table(FeatureName, Tab) ->
+    case mnesia:delete_table(Tab) of
+        {atomic, ok} ->
+            ok;
+        {aborted, {no_exists, _}} ->
+            ok;
+        {aborted, Err} ->
+            rabbit_log_feature_flags:error("Enabling feature flag ~s failed to delete mnesia table ~p: ~p",
+                                           [FeatureName, Tab, Err]),
+            %% adheres to the callback interface
             ok
     end.

--- a/deps/rabbit/src/rabbit_tracking.erl
+++ b/deps/rabbit/src/rabbit_tracking.erl
@@ -26,9 +26,10 @@
 -callback clear_tracking_tables() -> 'ok'.
 -callback shutdown_tracked_items(list(), term()) -> ok.
 
--export([id/2, count_tracked_items/4, match_tracked_items/2,
-         clear_tracking_table/1, delete_tracking_table/3,
-         delete_tracked_entry/3]).
+-export([id/2, delete_tracked_entry/4, delete_tracked_entry_internal/4,
+         clear_tracking_table/1, delete_tracking_table/3]).
+-export([count_tracked_items_ets/3, match_tracked_items_ets/2]).
+-export([count_tracked_items_mnesia/4, match_tracked_items_mnesia/2]).
 
 %%----------------------------------------------------------------------------
 
@@ -37,10 +38,29 @@
 
 id(Node, Name) -> {Node, Name}.
 
--spec count_tracked_items(function(), integer(), term(), string()) ->
+-spec count_tracked_items_ets(atom(), term(), string()) ->
     non_neg_integer().
+count_tracked_items_ets(Tab, Key, ContextMsg) ->
+    lists:foldl(fun (Node, Acc) when Node == node() ->
+                        N = case ets:lookup(Tab, Key) of
+                                []         -> 0;
+                                [{_, Val}] -> Val
+                            end,
+                        Acc + N;
+                    (Node, Acc) ->
+                        N = case rabbit_misc:rpc_call(Node, ets, lookup, [Tab, Key]) of
+                                [] -> 0;
+                                [{_, Val}] -> Val;
+                                {badrpc, Err} ->
+                                    rabbit_log:error(
+                                      "Failed to fetch number of ~p ~p on node ~p:~n~p",
+                                      [ContextMsg, Key, Node, Err]),
+                                    0
+                            end,
+                        Acc + N
+                end, 0, rabbit_nodes:all_running()).
 
-count_tracked_items(TableNameFun, CountRecPosition, Key, ContextMsg) ->
+count_tracked_items_mnesia(TableNameFun, CountRecPosition, Key, ContextMsg) ->
     lists:foldl(fun (Node, Acc) ->
                         Tab = TableNameFun(Node),
                         try
@@ -58,9 +78,23 @@ count_tracked_items(TableNameFun, CountRecPosition, Key, ContextMsg) ->
                         end
                 end, 0, rabbit_nodes:all_running()).
 
--spec match_tracked_items(function(), tuple()) -> term().
+-spec match_tracked_items_ets(atom(), tuple()) -> term().
+match_tracked_items_ets(Tab, MatchSpec) ->
+    lists:foldl(
+      fun (Node, Acc) when Node == node() ->
+              Acc ++ ets:match_object(
+                       Tab,
+                       MatchSpec);
+          (Node, Acc) ->
+              case rabbit_misc:rpc_call(Node, ets, match_object, [Tab, MatchSpec]) of
+                  List when is_list(List) ->
+                      Acc ++ List;
+                  _ ->
+                      Acc
+              end
+      end, [], rabbit_nodes:all_running()).
 
-match_tracked_items(TableNameFun, MatchSpec) ->
+match_tracked_items_mnesia(TableNameFun, MatchSpec) ->
     lists:foldl(
         fun (Node, Acc) ->
                 Tab = TableNameFun(Node),
@@ -70,7 +104,6 @@ match_tracked_items(TableNameFun, MatchSpec) ->
         end, [], rabbit_nodes:all_running()).
 
 -spec clear_tracking_table(atom()) -> ok.
-
 clear_tracking_table(TableName) ->
     case mnesia:clear_table(TableName) of
         {atomic, ok} -> ok;
@@ -89,15 +122,35 @@ delete_tracking_table(TableName, Node, ContextMsg) ->
             ok
     end.
 
--spec delete_tracked_entry({atom(), atom(), list()}, function(), term()) -> ok.
-
-delete_tracked_entry(_ExistsCheckSpec = {M, F, A}, TableNameFun, Key) ->
+-spec delete_tracked_entry({atom(), atom(), list()}, atom(), function(), term()) -> ok.
+delete_tracked_entry(_ExistsCheckSpec = {M, F, A}, TableName, TableNameFun, Key) ->
     ClusterNodes = rabbit_nodes:all_running(),
     ExistsInCluster =
         lists:any(fun(Node) -> rpc:call(Node, M, F, A) end, ClusterNodes),
     case ExistsInCluster of
         false ->
-            [mnesia:dirty_delete(TableNameFun(Node), Key) || Node <- ClusterNodes];
+            [delete_tracked_entry_internal(Node, TableName, TableNameFun, Key)
+             || Node <- ClusterNodes];
         true ->
             ok
     end.
+
+delete_tracked_entry_internal(Node, Tab, TableNameFun, Key) when Node == node() ->
+    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
+        true ->
+            true = ets:delete(Tab, Key),
+            ok;
+        false ->
+            mnesia:dirty_delete(TableNameFun(Node), Key),
+            ok
+    end;
+delete_tracked_entry_internal(Node, Tab, TableNameFun, Key) ->
+    case rabbit_misc:rpc_call(Node, ?MODULE, delete_tracked_entry_internal, [Node, Tab, TableNameFun, Key]) of
+        ok ->
+            ok;
+        _ ->
+            %% Node could be down, but also in a mixed version cluster this function is not
+            %% implemented on pre 3.11.x releases. Ensure that we clean up any mnesia table
+            mnesia:dirty_delete(TableNameFun(Node), Key)
+    end,
+    ok.

--- a/deps/rabbit/src/rabbit_tracking_store.erl
+++ b/deps/rabbit/src/rabbit_tracking_store.erl
@@ -1,0 +1,47 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+-module(rabbit_tracking_store).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, format_status/2]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    rabbit_connection_tracking:ensure_tracked_tables_for_this_node(),
+    rabbit_channel_tracking:ensure_tracked_tables_for_this_node(),
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+format_status(_Opt, Status) ->
+    Status.

--- a/deps/rabbit/src/rabbit_tracking_store.erl
+++ b/deps/rabbit/src/rabbit_tracking_store.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 -module(rabbit_tracking_store).
 

--- a/deps/rabbit/test/per_user_connection_channel_tracking_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_channel_tracking_SUITE.erl
@@ -536,6 +536,7 @@ cluster_vhost_deletion(Config) ->
     [?assertEqual(false, is_process_alive(Ch)) || Ch <- Chans1],
 
     %% ensure vhost entry is cleared after 'tracking_execution_timeout'
+
     ?assertEqual(false, exists_in_tracked_connection_per_vhost_table(Config, 0, Vhost)),
     ?assertEqual(false, exists_in_tracked_connection_per_vhost_table(Config, 1, Vhost)),
 
@@ -770,6 +771,7 @@ exists_in_tracked_connection_per_vhost_table(Config, VHost) ->
 exists_in_tracked_connection_per_vhost_table(Config, NodeIndex, VHost) ->
     exists_in_tracking_table(Config, NodeIndex,
         fun rabbit_connection_tracking:tracked_connection_per_vhost_table_name_for/1,
+        tracked_connection_per_vhost,
         VHost).
 
 exists_in_tracked_connection_per_user_table(Config, Username) ->
@@ -777,6 +779,7 @@ exists_in_tracked_connection_per_user_table(Config, Username) ->
 exists_in_tracked_connection_per_user_table(Config, NodeIndex, Username) ->
     exists_in_tracking_table(Config, NodeIndex,
         fun rabbit_connection_tracking:tracked_connection_per_user_table_name_for/1,
+        tracked_connection_per_user,
         Username).
 
 exists_in_tracked_channel_per_user_table(Config, Username) ->
@@ -784,16 +787,24 @@ exists_in_tracked_channel_per_user_table(Config, Username) ->
 exists_in_tracked_channel_per_user_table(Config, NodeIndex, Username) ->
     exists_in_tracking_table(Config, NodeIndex,
         fun rabbit_channel_tracking:tracked_channel_per_user_table_name_for/1,
+        tracked_channel_per_user,
         Username).
 
-exists_in_tracking_table(Config, NodeIndex, TableNameFun, Key) ->
+exists_in_tracking_table(Config, NodeIndex, TableNameFun, Table, Key) ->
     Node = rabbit_ct_broker_helpers:get_node_config(
                 Config, NodeIndex, nodename),
     Tab = TableNameFun(Node),
-    AllKeys = rabbit_ct_broker_helpers:rpc(Config, NodeIndex,
-                                           mnesia,
-                                           dirty_all_keys, [Tab]),
-    lists:member(Key, AllKeys).
+    try
+        AllKeys = rabbit_ct_broker_helpers:rpc(Config, NodeIndex,
+                                               mnesia,
+                                               dirty_all_keys, [Tab]),
+        lists:member(Key, AllKeys)
+    catch
+        _:_ ->
+            All = rabbit_ct_broker_helpers:rpc(Config, NodeIndex,
+                                               ets, lookup, [Table, Key]),
+            lists:keymember(Key, 1, All)
+    end.
 
 mimic_vhost_down(Config, NodeIndex, VHost) ->
     rabbit_ct_broker_helpers:rpc(Config, NodeIndex,


### PR DESCRIPTION
The original cluster-wide tracking tables were transformed into local tables, which are ram only. These can be moved into ets tables making its use much simpler

Same implementation changes as those in https://github.com/rabbitmq/rabbitmq-server/issues/5213