### PR TITLE
Restore the mixed-ness of mixed version testing

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -410,12 +410,16 @@ ensure_rabbitmq_run_cmd(Config) ->
     end.
 
 ensure_rabbitmq_run_secondary_cmd(Config) ->
-    Path = os:getenv("RABBITMQ_RUN_SECONDARY"),
-    case filelib:is_file(Path) of
-        true  ->
-            set_config(Config, {rabbitmq_run_secondary_cmd, Path});
+    case os:getenv("RABBITMQ_RUN_SECONDARY") of
         false ->
-            Config
+            Config;
+        Path ->
+            case filelib:is_file(Path) of
+                true  ->
+                    set_config(Config, {rabbitmq_run_secondary_cmd, Path});
+                false ->
+                    error("RABBITMQ_RUN_SECONDARY was set, but is not a valid file")
+            end
     end.
 
 ensure_erl_call_cmd(Config) ->

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -263,7 +263,7 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/rabbitmq-server-generic-unix-3.9/rabbitmq-run",
+            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/.secondary_umbrella.rabbitmq-server-generic-unix-3.9/rabbitmq-run",
             "LANG": "C.UTF-8",
         }.items() + test_env.items()),
         tools = [


### PR DESCRIPTION
## Proposed Changes

When the fetch of the secondary umbrella was moved into bzlmod, this changed its path at the time of test execution. Tests will now fail if a secondary umbrella is specified for bazel, but does not exist.

The path is also corrected.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Thanks @dumbbell for noticing the incorrect node versions in these tests.