### PR TITLE
Configure default queue type by vhost

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -17,7 +17,7 @@
          not_found_or_absent/1, not_found_or_absent_dirty/1,
          with/2, with/3, with_or_die/2,
          assert_equivalence/5,
-         augment_declare_args/4,
+         augment_declare_args/5,
          check_exclusive_access/2, with_exclusive_access_or_die/3,
          stat/1, deliver/2,
          requeue/3, ack/3, reject/4]).
@@ -730,26 +730,36 @@ assert_equivalence(Q, DurableDeclare, AutoDeleteDeclare, Args1, Owner) ->
     ok = rabbit_misc:assert_field_equivalence(AutoDeleteQ, AutoDeleteDeclare, QName, auto_delete),
     ok = assert_args_equivalence(Q, Args1).
 
-augment_declare_args(VHost, Exclusive, Durable, Args0) ->
+-spec augment_declare_args(vhost:name(), boolean(),
+                           boolean(), boolean(),
+                           rabbit_framing:amqp_table()) ->
+    rabbit_framing:amqp_table().
+augment_declare_args(VHost, Durable, Exclusive, AutoDelete, Args0) ->
     V = rabbit_vhost:lookup(VHost),
     HasQTypeArg = rabbit_misc:table_lookup(Args0, <<"x-queue-type">>) =/= undefined,
     case vhost:get_metadata(V) of
         #{default_queue_type := DefaultQueueType}
-          when not HasQTypeArg andalso
-               not Exclusive andalso
-               Durable ->
-            %% patch up declare arguments with x-queue-type if there
-            %% is a vhost default set the queue is druable and not exclusive
-            %% and there is no queue type argument
-            %% present
-            rabbit_misc:set_table_value(
-              Args0,
-              <<"x-queue-type">>,
-              longstr,
-              queue_type_declare_tag(DefaultQueueType));
+          when is_binary(DefaultQueueType) andalso
+               not HasQTypeArg ->
+            Type = rabbit_queue_type:discover(DefaultQueueType),
+            case rabbit_queue_type:is_compatible(Type, Durable,
+                                                 Exclusive, AutoDelete) of
+                true ->
+                    %% patch up declare arguments with x-queue-type if there
+                    %% is a vhost default set the queue is druable and not exclusive
+                    %% and there is no queue type argument
+                    %% present
+                    rabbit_misc:set_table_value(Args0,
+                                                <<"x-queue-type">>,
+                                                longstr,
+                                                DefaultQueueType);
+                false ->
+                    Args0
+            end;
         _ ->
             Args0
     end.
+
 -spec check_exclusive_access(amqqueue:amqqueue(), pid()) ->
           'ok' | rabbit_types:channel_exit().
 
@@ -2151,12 +2161,3 @@ get_bcc_queue(Q, BCCName) ->
     #resource{virtual_host = VHost} = amqqueue:get_name(Q),
     BCCQueueName = rabbit_misc:r(VHost, queue, BCCName),
     rabbit_amqqueue:lookup(BCCQueueName).
-
-
-queue_type_declare_tag(rabbit_quorum_queue) ->
-    <<"quorum">>;
-queue_type_declare_tag(rabbit_classic_queue) ->
-    <<"classic">>;
-queue_type_declare_tag(rabbit_stream_queue) ->
-    <<"stream">>.
-

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2519,13 +2519,15 @@ handle_method(#'queue.declare'{queue       = QueueNameBin,
                                exclusive   = ExclusiveDeclare,
                                auto_delete = AutoDelete,
                                nowait      = NoWait,
-                               arguments   = Args} = Declare,
+                               arguments   = Args0} = Declare,
               ConnPid, AuthzContext, CollectorPid, VHostPath,
               #user{username = Username} = User) ->
     Owner = case ExclusiveDeclare of
                 true  -> ConnPid;
                 false -> none
             end,
+    Args = rabbit_amqqueue:augment_declare_args(VHostPath, ExclusiveDeclare,
+                                                DurableDeclare, Args0),
     StrippedQueueNameBin = strip_cr_lf(QueueNameBin),
     Durable = DurableDeclare andalso not ExclusiveDeclare,
     ActualNameBin = case StrippedQueueNameBin of

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2526,8 +2526,11 @@ handle_method(#'queue.declare'{queue       = QueueNameBin,
                 true  -> ConnPid;
                 false -> none
             end,
-    Args = rabbit_amqqueue:augment_declare_args(VHostPath, ExclusiveDeclare,
-                                                DurableDeclare, Args0),
+    Args = rabbit_amqqueue:augment_declare_args(VHostPath,
+                                                DurableDeclare,
+                                                ExclusiveDeclare,
+                                                AutoDelete,
+                                                Args0),
     StrippedQueueNameBin = strip_cr_lf(QueueNameBin),
     Durable = DurableDeclare andalso not ExclusiveDeclare,
     ActualNameBin = case StrippedQueueNameBin of

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -20,6 +20,7 @@
 
 -export([
          is_enabled/0,
+         is_compatible/3,
          declare/2,
          delete/4,
          is_recoverable/1,
@@ -52,6 +53,10 @@
          send_queue_event/3]).
 
 is_enabled() -> true.
+
+-spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
+is_compatible(_, _, _) ->
+    true.
 
 declare(Q, Node) when ?amqqueue_is_classic(Q) ->
     QName = amqqueue:get_name(Q),

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -15,6 +15,7 @@
          discover/1,
          default/0,
          is_enabled/1,
+         is_compatible/4,
          declare/2,
          delete/4,
          is_recoverable/1,
@@ -127,6 +128,11 @@
 %% is the queue type feature enabled
 -callback is_enabled() -> boolean().
 
+-callback is_compatible(Durable :: boolean(),
+                        Exclusive :: boolean(),
+                        AutoDelete :: boolean()) ->
+    boolean().
+
 -callback declare(amqqueue:amqqueue(), node()) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'absent', amqqueue:amqqueue(), absent_reason()} |
@@ -231,6 +237,11 @@ default() ->
 -spec is_enabled(module()) -> boolean().
 is_enabled(Type) ->
     Type:is_enabled().
+
+-spec is_compatible(module(), boolean(), boolean(), boolean()) ->
+    boolean().
+is_compatible(Type, Durable, Exclusive, AutoDelete) ->
+    Type:is_compatible(Durable, Exclusive, AutoDelete).
 
 -spec declare(amqqueue:amqqueue(), node()) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -64,6 +64,7 @@
          spawn_notify_decorators/3]).
 
 -export([is_enabled/0,
+         is_compatible/3,
          declare/2]).
 
 -import(rabbit_queue_type_util, [args_policy_lookup/3,
@@ -116,7 +117,13 @@
 is_enabled() ->
     rabbit_feature_flags:is_enabled(quorum_queue).
 
-%%----------------------------------------------------------------------------
+-spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
+is_compatible(_Durable = true,
+              _Exclusive = false,
+              _AutoDelete = false) ->
+    true;
+is_compatible(_, _, _) ->
+    false.
 
 -spec init(amqqueue:amqqueue()) -> {ok, rabbit_fifo_client:state()}.
 init(Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -10,6 +10,7 @@
 -behaviour(rabbit_queue_type).
 
 -export([is_enabled/0,
+         is_compatible/3,
          declare/2,
          delete/4,
          purge/1,
@@ -86,6 +87,15 @@
 -spec is_enabled() -> boolean().
 is_enabled() ->
     rabbit_feature_flags:is_enabled(stream_queue).
+
+-spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
+is_compatible(_Durable = true,
+              _Exclusive = false,
+              _AutoDelete = false) ->
+    true;
+is_compatible(_, _, _) ->
+    false.
+
 
 -spec declare(amqqueue:amqqueue(), node()) ->
     {'new' | 'existing', amqqueue:amqqueue()} |

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -20,7 +20,8 @@
 -export([dir/1, msg_store_dir_path/1, msg_store_dir_wildcard/0, config_file_path/1, ensure_config_file/1]).
 -export([delete_storage/1]).
 -export([vhost_down/1]).
--export([put_vhost/6]).
+-export([put_vhost/5,
+         put_vhost/6]).
 
 %%
 %% API
@@ -278,6 +279,9 @@ delete(VHost, ActingUser) ->
     %% on all the nodes.
     rabbit_vhost_sup_sup:delete_on_all_nodes(VHost),
     ok.
+
+put_vhost(Name, Description, Tags0, Trace, Username) ->
+    put_vhost(Name, Description, Tags0, undefined, Trace, Username).
 
 put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
     Tags = case Tags0 of
@@ -580,6 +584,7 @@ i(tracing, VHost) -> rabbit_trace:enabled(vhost:get_name(VHost));
 i(cluster_state, VHost) -> vhost_cluster_state(vhost:get_name(VHost));
 i(description, VHost) -> vhost:get_description(VHost);
 i(tags, VHost) -> vhost:get_tags(VHost);
+i(default_queue_type, VHost) -> vhost:get_default_queue_type(VHost);
 i(metadata, VHost) -> vhost:get_metadata(VHost);
 i(Item, VHost)     ->
   rabbit_log:error("Don't know how to compute a virtual host info item '~s' for virtual host '~p'", [Item, VHost]),

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -500,20 +500,20 @@ update_tags(VHostName, Tags) ->
     ConvertedTags = [rabbit_data_coercion:to_atom(I) || I <- Tags],
     update(VHostName, fun(Record) ->
         Meta0 = vhost:get_metadata(Record),
-        Meta  = maps:update(tags, ConvertedTags, Meta0),
+        Meta  = maps:put(tags, ConvertedTags, Meta0),
         vhost:set_metadata(Record, Meta)
     end).
 
 -spec tag_with(vhost:name(), [atom()]) -> vhost:vhost() | rabbit_types:ok_or_error(any()).
 tag_with(VHostName, Tags) when is_list(Tags) ->
     update_metadata(VHostName, fun(#{tags := Tags0} = Meta) ->
-        maps:update(tags, lists:usort(Tags0 ++ Tags), Meta)
+        maps:put(tags, lists:usort(Tags0 ++ Tags), Meta)
     end).
 
 -spec untag_from(vhost:name(), [atom()]) -> vhost:vhost() | rabbit_types:ok_or_error(any()).
 untag_from(VHostName, Tags) when is_list(Tags) ->
     update_metadata(VHostName, fun(#{tags := Tags0} = Meta) ->
-        maps:update(tags, lists:usort(Tags0 -- Tags), Meta)
+        maps:put(tags, lists:usort(Tags0 -- Tags), Meta)
     end).
 
 set_limits(VHost, undefined) ->

--- a/deps/rabbit/src/vhost.erl
+++ b/deps/rabbit/src/vhost.erl
@@ -25,6 +25,7 @@
   get_metadata/1,
   get_description/1,
   get_tags/1,
+  get_default_queue_type/1,
   set_limits/2,
   set_metadata/2,
   merge_metadata/2,
@@ -130,8 +131,16 @@ info_keys() ->
     case record_version_to_use() of
         %% note: this reports description and tags separately even though
         %% they are stored in the metadata map. MK.
-        ?record_version -> [name, description, tags, metadata, tracing, cluster_state];
-        _               -> vhost_v1:info_keys()
+        ?record_version ->
+            [name,
+             description,
+             tags,
+             default_queue_type,
+             metadata,
+             tracing,
+             cluster_state];
+        _ ->
+            vhost_v1:info_keys()
     end.
 
 -spec pattern_match_all() -> vhost_pattern().
@@ -165,6 +174,12 @@ get_tags(#vhost{} = VHost) ->
     maps:get(tags, get_metadata(VHost), undefined);
 get_tags(VHost) ->
     vhost_v1:get_tags(VHost).
+
+-spec get_default_queue_type(vhost()) -> binary() | undefined.
+get_default_queue_type(#vhost{} = VHost) ->
+    maps:get(default_queue_type, get_metadata(VHost), undefined);
+get_default_queue_type(_VHost) ->
+    undefined.
 
 set_limits(VHost, Value) ->
     case record_version_to_use() of

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -125,6 +125,7 @@ all_tests() ->
      cancel_sync_queue,
      idempotent_recover,
      vhost_with_quorum_queue_is_deleted,
+     vhost_with_default_queue_type_declares_quorum_queue,
      delete_immediately_by_resource,
      consume_redelivery_count,
      subscribe_redelivery_count,
@@ -223,6 +224,8 @@ init_per_group(Group, Config) ->
                             timer:sleep(ClusterSize * 1000),
                             ok = rabbit_ct_broker_helpers:enable_feature_flag(
                                    Config2, maintenance_mode_status),
+                            ok = rabbit_ct_broker_helpers:enable_feature_flag(
+                                   Config2, virtual_host_metadata),
                             Config2;
                         Skip ->
                             end_per_group(Group, Config2),
@@ -703,6 +706,52 @@ vhost_with_quorum_queue_is_deleted(Config) ->
     ok = rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
     %% validate quorum queues got deleted
     undefined = rpc:call(Node, ra_directory, where_is, [quorum_queues, RaName]),
+    ok.
+
+vhost_with_default_queue_type_declares_quorum_queue(Config) ->
+    Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    VHost = atom_to_binary(?FUNCTION_NAME, utf8),
+    QName = atom_to_binary(?FUNCTION_NAME, utf8),
+    % RaName = binary_to_atom(<<VHost/binary, "_", QName/binary>>, utf8),
+    User = ?config(rmq_username, Config),
+
+    AddVhostArgs = [VHost, #{default_queue_type => rabbit_quorum_queue}, User],
+    ok = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_vhost, add,
+                                            AddVhostArgs),
+    ok = rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, Node, VHost),
+    {ok, Ch} = amqp_connection:open_channel(Conn),
+    ?assertEqual({'queue.declare_ok', QName, 0, 0}, declare(Ch, QName, [])),
+    assert_queue_type(Node, VHost, QName, rabbit_quorum_queue),
+    %% declaring again without a queue arg is ok
+    ?assertEqual({'queue.declare_ok', QName, 0, 0}, declare(Ch, QName, [])),
+    %% also using an explicit queue type should be ok
+    ?assertEqual({'queue.declare_ok', QName, 0, 0},
+                 declare(Ch, QName, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    %% passive should work without x-queue-type
+    ?assertEqual({'queue.declare_ok', QName, 0, 0}, declare_passive(Ch, QName, [])),
+    %% passive with x-queue-type also should work
+    ?assertEqual({'queue.declare_ok', QName, 0, 0},
+                 declare_passive(Ch, QName, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    %% declaring an exclusive queue should declare a classic queue
+    QNameEx = iolist_to_binary([QName, <<"_exclusive">>]),
+    ?assertEqual({'queue.declare_ok', QNameEx, 0, 0},
+                 amqp_channel:call(Ch, #'queue.declare'{queue = QNameEx,
+                                                        exclusive = true,
+                                                        durable = false,
+                                                        arguments = []})),
+    assert_queue_type(Node, VHost, QNameEx, rabbit_classic_queue),
+
+    %% transient declares should also fall back to classic queues
+    QNameTr = iolist_to_binary([QName, <<"_transient">>]),
+    ?assertEqual({'queue.declare_ok', QNameTr, 0, 0},
+                 amqp_channel:call(Ch, #'queue.declare'{queue = QNameTr,
+                                                        exclusive = false,
+                                                        durable = false,
+                                                        arguments = []})),
+    assert_queue_type(Node, VHost, QNameEx, rabbit_classic_queue),
+    amqp_connection:close(Conn),
     ok.
 
 restart_all_types(Config) ->
@@ -2938,12 +2987,21 @@ declare(Ch, Q, Args) ->
                                            auto_delete = false,
                                            arguments = Args}).
 
+declare_passive(Ch, Q, Args) ->
+    amqp_channel:call(Ch, #'queue.declare'{queue = Q,
+                                           durable = true,
+                                           auto_delete = false,
+                                           passive = true,
+                                           arguments = Args}).
 assert_queue_type(Server, Q, Expected) ->
-    Actual = get_queue_type(Server, Q),
+    assert_queue_type(Server, <<"/">>, Q, Expected).
+
+assert_queue_type(Server, VHost, Q, Expected) ->
+    Actual = get_queue_type(Server, VHost, Q),
     Expected = Actual.
 
-get_queue_type(Server, Q0) ->
-    QNameRes = rabbit_misc:r(<<"/">>, queue, Q0),
+get_queue_type(Server, VHost, Q0) ->
+    QNameRes = rabbit_misc:r(VHost, queue, Q0),
     {ok, Q1} = rpc:call(Server, rabbit_amqqueue, lookup, [QNameRes]),
     amqqueue:get_type(Q1).
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -42,7 +42,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
       ["<vhost>", "Virtual host name"],
       ["--description <description>", "Virtual host description"],
       ["--tags <tags>", "Command separated list of tags"],
-      ["--default-queue-type <quorum|classic|stream>", "Queue type name"]
+      ["--default-queue-type <quorum|classic|stream>", "Queue type to use if no type is explicitly provided by the client"]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -29,6 +29,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   def run([vhost], %{node: node_name, description: desc, tags: tags}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, description, tags, Helpers.cli_acting_user()])
   end
+  def run([vhost], %{node: node_name}) do
+    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
+  end
 
   use RabbitMQ.CLI.DefaultOutput
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -10,7 +10,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   def switches(), do: [description: :string,
-                       tags: :string]
+                       tags: :string,
+                       default_queue_type: :string]
   def aliases(), do: [d: :description]
 
   def merge_defaults(args, opts) do
@@ -19,25 +20,26 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
+  def run([vhost], %{node: node_name, description: desc, tags: tags, default_queue_type: default_qt}) do
+    meta = %{description: desc,
+             tags: parse_tags(tags),
+             default_queue_type: default_qt}
+    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, meta, Helpers.cli_acting_user()])
+  end
   def run([vhost], %{node: node_name, description: desc, tags: tags}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, desc, parse_tags(tags), Helpers.cli_acting_user()])
-  end
-  def run([vhost], %{node: node_name, tags: tags}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, "", parse_tags(tags), Helpers.cli_acting_user()])
-  end
-  def run([vhost], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
+    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, description, tags, Helpers.cli_acting_user()])
   end
 
   use RabbitMQ.CLI.DefaultOutput
 
-  def usage, do: "add_vhost <vhost> [--description <description> --tags \"<tag1>,<tag2>,<...>\"]"
+  def usage, do: "add_vhost <vhost> [--description <description> --tags \"<tag1>,<tag2>,<...>\" --default-queue-type <quorum|classic|stream>]"
 
   def usage_additional() do
     [
       ["<vhost>", "Virtual host name"],
       ["--description <description>", "Virtual host description"],
-      ["--tags <tags>", "Command separated list of tags"]
+      ["--tags <tags>", "Command separated list of tags"],
+      ["--default-queue-type <quorum|classic|stream>", "Queue type name"]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -11,7 +11,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  @info_keys ~w(name description tags tracing cluster_state)a
+  @info_keys ~w(name description tags default_queue_type tracing cluster_state)a
 
   def info_keys(), do: @info_keys
 

--- a/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
@@ -34,6 +34,7 @@ defmodule AddVhostCommandTest do
     assert @command.validate(["new-vhost"], %{}) == :ok
     assert @command.validate(["new-vhost"], %{description: "Used by team A"}) == :ok
     assert @command.validate(["new-vhost"], %{description: "Used by team A for QA purposes", tags: "qa,team-a"}) == :ok
+    assert @command.validate(["new-vhost"], %{description: "Used by team A for QA purposes", tags: "qa,team-a", default_queue_type: "quorum"}) == :ok
   end
 
   @tag vhost: @vhost

--- a/deps/rabbitmq_management/priv/www/js/tmpl/vhosts.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/vhosts.ejs
@@ -156,6 +156,17 @@
           <th><label>Tags:</label></th>
           <td><input type="text" name="tags"/></td>
         </tr>
+        <tr>
+          <th><label>Default Queue Type:</label></th>
+          <td>
+            <!-- <select name="queuetype" onchange="select_queue_type(queuetype)"> -->
+            <select name="defaultqueuetype">
+                <option value="classic">Classic</option>
+                <option value="quorum">Quorum</option>
+                <option value="stream">Stream</option>
+            </select>
+          </td>
+        </tr>
       </table>
       <input type="submit" value="Add virtual host"/>
     </form>


### PR DESCRIPTION
This allows operators to override the default queue type on a per-vhost
basis by setting the default_queue_type metadata key on the vhost record.

When a queue is declared without specifiying a queue type (x-queue-type)
and there is a default set for the vhost we will augment the declare arguments
with the default. This allows future declares with and without the x-queue-type
argument to succeed.

Also adds a new field to the management create vhost form as well as a new flag for the `rabbitmqctl add_vhost` command.