### PR TITLE
Hide new ets listeners table behind a feature flag 

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -147,11 +147,13 @@ listener_records_in_ets_migration(#ffcommand{name = FeatureName,
             {aborted, Err} ->
                 rabbit_log_feature_flags:error("Enabling feature flag ~s failed to delete mnesia table: ~p",
                                                [FeatureName, Err]),
-                {error, {failed_to_delete_mnesia_table, Err}}
+                %% adheres to the callback interface
+                ok
         end
     catch
         throw:{error, Reason} ->
             rabbit_log_feature_flags:error("Enabling feature flag ~s failed: ~p",
                                            [FeatureName, Reason]),
-            {error, Reason}
+            %% adheres to the callback interface
+            ok
     end.

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -560,18 +560,33 @@ init_db(ClusterNodes, NodeType, CheckOtherNodes) ->
             throw({error, cannot_create_standalone_ram_node});
         {[], false, disc} ->
             %% RAM -> disc, starting from scratch
-            ok = create_schema();
+            ok = create_schema(),
+            ensure_feature_flags_are_in_sync(Nodes, NodeIsVirgin),
+            ok;
         {[], true, disc} ->
             %% First disc node up
             maybe_force_load(),
+            ensure_feature_flags_are_in_sync(Nodes, NodeIsVirgin),
             ok;
         {[_ | _], _, _} ->
             %% Subsequent node in cluster, catch up
             maybe_force_load(),
+            %% We want to synchronize feature flags first before we wait for
+            %% tables (which is needed to ensure the local view of the tables
+            %% matches the rest of the cluster). The reason is that some
+            %% feature flags may add or remove tables. In this case the list
+            %% of tables returned by `rabbit_table:definitions()' usually
+            %% depends on the state of feature flags but this state is local.
+            %%
+            %% For instance, a feature flag may remove a table (so it's gone
+            %% from the cluster). If we were to wait for that table locally
+            %% before synchronizing feature flags, we would wait forever;
+            %% indeed the feature flag being disabled before sync,
+            %% `rabbit_table:definitions()' would return the old table.
+            ensure_feature_flags_are_in_sync(Nodes, NodeIsVirgin),
             ok = rabbit_table:wait_for_replicated(_Retry = true),
             ok = rabbit_table:ensure_local_copies(NodeType)
     end,
-    ensure_feature_flags_are_in_sync(Nodes, NodeIsVirgin),
     ensure_schema_integrity(),
     rabbit_node_monitor:update_cluster_status(),
     ok.

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -778,6 +778,7 @@ handle_dead_rabbit(Node, State = #state{partitions = Partitions,
     ok = rabbit_amqqueue:on_node_down(Node),
     ok = rabbit_alarm:on_node_down(Node),
     ok = rabbit_mnesia:on_node_down(Node),
+    ok = rabbit_networking:on_node_down(Node),
     %% If we have been partitioned, and we are now in the only remaining
     %% partition, we no longer care about partitions - forget them. Note
     %% that we do not attempt to deal with individual (other) partitions


### PR DESCRIPTION
`listener_records_to_ets`

Keep mnesia support
Allows to run in a mixed-version cluster

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

