### PR TITLE
rabbit_feature_flags: Don't call a feature_flags_v2-compatible migration function with `is_enabled`

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -2021,17 +2021,22 @@ verify_which_feature_flags_are_actually_enabled() ->
     %% function fails), we keep the current state of the feature flag.
     List1 = maps:fold(
               fun(Name, Props, Acc) ->
-                      Ret = run_migration_fun(Name, Props, is_enabled),
-                      case Ret of
+                      case uses_migration_fun_v2(Name) of
                           true ->
-                              [Name | Acc];
-                          false ->
                               Acc;
-                          _ ->
-                              MarkedAsEnabled = is_enabled(Name),
-                              case MarkedAsEnabled of
-                                  true  -> [Name | Acc];
-                                  false -> Acc
+                          false ->
+                              Ret = run_migration_fun(Name, Props, is_enabled),
+                              case Ret of
+                                  true ->
+                                      [Name | Acc];
+                                  false ->
+                                      Acc;
+                                  _ ->
+                                      MarkedAsEnabled = is_enabled(Name),
+                                      case MarkedAsEnabled of
+                                          true  -> [Name | Acc];
+                                          false -> Acc
+                                      end
                               end
                       end
               end,


### PR DESCRIPTION
This is a deprecated call which is not present in the `feature_flags_v2` code.

This fixes a crash in mixed-version clusters where `feature_flags_v2` can't be enabled, but the `is_enabled` callback is still called for all feature flags, not just those exposing the old function with an arity of 3.