### PR TITLE
Update feature flags for mixed version tests

### DIFF
--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -258,7 +258,7 @@ def rabbitmq_integration_suite(
         data = data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",
-            "RABBITMQ_FEATURE_FLAGS": "",
+            "RABBITMQ_FEATURE_FLAGS": "quorum_queue,implicit_default_bindings,virtual_host_metadata,maintenance_mode_status,user_limits",
             "RABBITMQ_RUN": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/rabbitmq-for-tests-run".format(package),
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),


### PR DESCRIPTION
These feature flags are now required and we want to start nodes with them enabled instead of no feature flags at all.

Should not be backported to v3.10.x or other branches.