### PR TITLE
Bazel: Set `$RABBITMQ_FEATURE_FLAGS` to the list of required flags in 3.11.0

### DIFF
--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -258,7 +258,18 @@ def rabbitmq_integration_suite(
         data = data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",
-            "RABBITMQ_FEATURE_FLAGS": "",
+            # The feature flags listed below are required. This means they must
+            # be enabled in mixed-version testing before even starting cluster
+            # because newer node don't have the corresponding
+            # compatibility/migration code.
+            #
+            # Starting from 3.11.0:
+            #   quorum_queue
+            #   implicit_default_bindings
+            #   virtual_host_metadata
+            #   maintenance_mode_status
+            #   user_limits
+            "RABBITMQ_FEATURE_FLAGS": "quorum_queue,implicit_default_bindings,virtual_host_metadata,maintenance_mode_status,user_limits",
             "RABBITMQ_RUN": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/rabbitmq-for-tests-run".format(package),
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),


### PR DESCRIPTION
It was set to the empty string before to make sure no feature flags were enabled out-of-the-box when starting a new RabbitMQ node.

With 3.11.0, several of them will become required and their corresponding compatibility and migration code goes away. Therefore older nodes must have them enabled in order to cluster successfully.

This change is only useful in 3.11.x. It must not be backported to older release branches.