### PR TITLE
HTTP API: allow for setting a few extra security-related response headers

### DIFF
--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -307,7 +307,7 @@ end}.
 
 
 %%
-%% CORS
+%% CORS (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 %%
 
 {mapping, "management.cors.allow_origins", "rabbitmq_management.cors_allow_origins", [
@@ -370,6 +370,50 @@ fun(Conf) ->
         Value     -> Value
     end
 end}.
+
+%% X-Content-Type-Options (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
+
+{mapping, "management.headers.content_type_options", "rabbitmq_management.headers.content_type_options", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_management.headers.content_type_options",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.headers.content_type_options", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+%% X-XSS-Protection (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
+
+{mapping, "management.headers.xss_protection", "rabbitmq_management.headers.xss_protection", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_management.headers.xss_protection",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.headers.xss_protection", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+
+%% X-Frame-Options (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options)
+
+{mapping, "management.headers.frame_options", "rabbitmq_management.headers.frame_options", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_management.headers.frame_options",
+fun(Conf) ->
+    case cuttlefish:conf_get("management.headers.content_type_options", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
 
 %% OAuth 2/SSO access only
 

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -408,7 +408,7 @@ end}.
 
 {translation, "rabbitmq_management.headers.frame_options",
 fun(Conf) ->
-    case cuttlefish:conf_get("management.headers.content_type_options", Conf, undefined) of
+    case cuttlefish:conf_get("management.headers.frame_options", Conf, undefined) of
         undefined -> cuttlefish:unset();
         Value     -> Value
     end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_headers.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_headers.erl
@@ -12,6 +12,10 @@
 -export([set_common_permission_headers/2]).
 -export([set_cors_headers/2, set_hsts_headers/2, set_csp_headers/2]).
 
+-define(X_CONTENT_TYPE_OPTIONS_HEADER, <<"X-Content-Type-Options">>).
+-define(X_FRAME_OPTIONS_HEADER, <<"X-Frame-Options">>).
+-define(X_XSS_PROTECTION_HEADER, <<"X-XSS-Protection">>).
+
 %%
 %% API
 %%
@@ -25,10 +29,35 @@ set_hsts_headers(ReqData, _Module) ->
 set_csp_headers(ReqData, _Module) ->
     rabbit_mgmt_csp:set_headers(ReqData).
 
+set_content_type_options_header(ReqData, _Module) ->
+    maybe_set_known_configured_header(ReqData, content_type_options, ?X_CONTENT_TYPE_OPTIONS_HEADER).
+
+set_xss_protection_header(ReqData, _Module) ->
+    maybe_set_known_configured_header(ReqData, xss_protection, ?X_XSS_PROTECTION_HEADER).
+
+set_frame_options_header(ReqData, _Module) ->
+    maybe_set_known_configured_header(ReqData, frame_options, ?X_FRAME_OPTIONS_HEADER).
+
+maybe_set_known_configured_header(ReqData, AppEnvKey, HeaderName) ->
+    case application:get_env(rabbitmq_management, headers) of
+        undefined      -> ReqData;
+        {ok, Proplist} ->
+            case proplists:get_value(AppEnvKey, Proplist) of
+                undefined -> ReqData;
+                Value     ->
+                    cowboy_req:set_resp_header(HeaderName,
+                                               rabbit_data_coercion:to_binary(Value),
+                                               ReqData)
+            end
+    end.
+
 set_common_permission_headers(ReqData0, EndpointModule) ->
     lists:foldl(fun(Fun, ReqData) ->
                         Fun(ReqData, EndpointModule)
                 end, ReqData0,
                [fun set_csp_headers/2,
                 fun set_hsts_headers/2,
-                fun set_cors_headers/2]).
+                fun set_cors_headers/2,
+                fun set_content_type_options_header/2,
+                fun set_xss_protection_header/2,
+                fun set_frame_options_header/2]).

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -435,6 +435,37 @@
   ], [rabbitmq_management]
  },
 
+ %%
+ %% X-Xss-Protection
+ %%
+
+ {headers_xss_protection_case1,
+  "management.headers.xss_protection = DENY",
+  [
+   {rabbitmq_management, [
+                          {headers, [
+                            {xss_protection, "DENY"}
+                          ]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {csp_and_hsts_and_content_type_options_combined,
+  "management.csp.policy = default-src 'self' *.mailsite.com; img-src *
+   management.hsts.policy = max-age=31536000; includeSubDomains
+   management.headers.xss_protection = DENY",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src 'self' *.mailsite.com; img-src *"},
+                          {strict_transport_security, "max-age=31536000; includeSubDomains"},
+
+                          {headers, [
+                            {xss_protection, "DENY"}
+                          ]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
 
  %%
  %% Legacy listener configuration

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -404,6 +404,37 @@
   ], [rabbitmq_management]
  },
 
+ %%
+ %% X-Content-Type-Options
+ %%
+
+ {headers_content_type_options_case1,
+  "management.headers.content_type_options = nosniff",
+  [
+   {rabbitmq_management, [
+                          {headers, [
+                            {content_type_options, "nosniff"}
+                          ]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {csp_and_hsts_and_content_type_options_combined,
+  "management.csp.policy = default-src 'self' *.mailsite.com; img-src *
+   management.hsts.policy = max-age=31536000; includeSubDomains
+   management.headers.content_type_options = nosniff",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src 'self' *.mailsite.com; img-src *"},
+                          {strict_transport_security, "max-age=31536000; includeSubDomains"},
+
+                          {headers, [
+                            {content_type_options, "nosniff"}
+                          ]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
 
  %%
  %% Legacy listener configuration

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -440,11 +440,11 @@
  %%
 
  {headers_xss_protection_case1,
-  "management.headers.xss_protection = DENY",
+  "management.headers.xss_protection = 1; mode=block",
   [
    {rabbitmq_management, [
                           {headers, [
-                            {xss_protection, "DENY"}
+                            {xss_protection, "1; mode=block"}
                           ]}
                          ]}
   ], [rabbitmq_management]
@@ -453,14 +453,14 @@
  {csp_and_hsts_and_content_type_options_combined,
   "management.csp.policy = default-src 'self' *.mailsite.com; img-src *
    management.hsts.policy = max-age=31536000; includeSubDomains
-   management.headers.xss_protection = DENY",
+   management.headers.xss_protection = 1; mode=block",
   [
    {rabbitmq_management, [
                           {content_security_policy, "default-src 'self' *.mailsite.com; img-src *"},
                           {strict_transport_security, "max-age=31536000; includeSubDomains"},
 
                           {headers, [
-                            {xss_protection, "DENY"}
+                            {xss_protection, "1; mode=block"}
                           ]}
                          ]}
   ], [rabbitmq_management]

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -436,7 +436,7 @@
  },
 
  %%
- %% X-Xss-Protection
+ %% X-XSS-Protection
  %%
 
  {headers_xss_protection_case1,
@@ -450,7 +450,7 @@
   ], [rabbitmq_management]
  },
 
- {csp_and_hsts_and_content_type_options_combined,
+ {csp_and_hsts_and_xss_protection_combined,
   "management.csp.policy = default-src 'self' *.mailsite.com; img-src *
    management.hsts.policy = max-age=31536000; includeSubDomains
    management.headers.xss_protection = 1; mode=block",
@@ -461,6 +461,37 @@
 
                           {headers, [
                             {xss_protection, "1; mode=block"}
+                          ]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ %%
+ %% X-Frame-Options
+ %%
+
+ {headers_frame_options_case1,
+  "management.headers.frame_options = DENY",
+  [
+   {rabbitmq_management, [
+                          {headers, [
+                            {frame_options, "DENY"}
+                          ]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {csp_and_hsts_and_frame_options_combined,
+  "management.csp.policy = default-src 'self' *.mailsite.com; img-src *
+   management.hsts.policy = max-age=31536000; includeSubDomains
+   management.headers.frame_options = DENY",
+  [
+   {rabbitmq_management, [
+                          {content_security_policy, "default-src 'self' *.mailsite.com; img-src *"},
+                          {strict_transport_security, "max-age=31536000; includeSubDomains"},
+
+                          {headers, [
+                            {frame_options, "DENY"}
                           ]}
                          ]}
   ], [rabbitmq_management]


### PR DESCRIPTION
## Proposed Changes

HTTP API: allow for setting a few extra security-related response headers.
The headers are configurable via `rabbitmq.conf`:

``` ini
management.headers.content_type_options = nosniff
management.headers.xss_protection = 1; mode=block
management.headers.frame_options = DENY
```

## How to Test

Start a RabbitMQ node built from source using the following `rabbitmq.conf`:

``` ini
management.hsts.policy = max-age=31536000; includeSubDomains
management.csp.policy = default-src 'self'; script-src 'self' 'unsafe-eval'

management.headers.content_type_options = nosniff
management.headers.xss_protection = 1; mode=block
management.headers.frame_options = DENY
```

``` shell
bazel run broker RABBITMQ_ENABLED_PLUGINS=rabbitmq_management RABBITMQ_CONFIG_FILE=/path/to/RabbitMQ/configs/management.security_headers.conf --config=local
```

Then inspect the headers on a response:

``` shell
curl -i -u guest:guest localhost:15672/api/overview
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #5320)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Closes #5320.