### PR TITLE
Fix rabbit_index_route inconsistencies

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1053,6 +1053,9 @@ suites = [
         PACKAGE,
         name = "direct_exchange_routing_v2_SUITE",
         size = "medium",
+        additional_beam = [
+            ":quorum_queue_utils",
+        ],
     ),
 ]
 


### PR DESCRIPTION
Prior to this commit, when bindings were deleted while enabling feature
flag `direct_exchange_routing_v2` - specifically **after**
`rabbit_binding:populate_index_route_table/0` ran and **before** the feature
flags controller changed the feature state from `state_changing` to `enabled` -
some bindings were incorrectly present in table `rabbit_index_route`.

This commit fixes this issue.

If the state is `state_changing`, bindings must be deleted when the
table already got created.

(Somewhat unexpectedly) checking for table existence within a Mnesia
transaction can return `true` although the subsequent Mnesia table operation
will fail with `{no_exists, rabbit_index_route}`.

Therefore, a lock on the schema table must be set when checking for
table existence.
(Mnesia itself creates a write lock on the schema table when creating a
table, see https://github.com/erlang/otp/blob/09c601fa2183d4c545791ebcd68f869a5ab912a4/lib/mnesia/src/mnesia_schema.erl#L1525 )

An alternative fix would have been to catch `{no_exists,
rabbit_index_route}` outside the Mnesia transaction, i.e. in all the callers of
the `rabbit_binding:remove...` functions and then retry the `rabbit_binding:remove...` function.

This PR should go only into master (and 3.11).