### PR TITLE
adjust test function in stream queue test

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2335,16 +2335,8 @@ receive_batch_min_offset(Ch, N, M) ->
               exit({missing_offset, N})
     end.
 
-receive_batch(Ch, N, M) when N >= M ->
-    receive
-        {#'basic.deliver'{delivery_tag = DeliveryTag},
-         #amqp_msg{props = #'P_basic'{headers = [{<<"x-stream-offset">>, long, N}]}}} ->
-            ok = amqp_channel:cast(Ch, #'basic.ack'{delivery_tag = DeliveryTag,
-                                                    multiple     = false})
-    after 60000 ->
-              flush(),
-              exit({missing_offset, N})
-    end;
+receive_batch(_Ch, N, M) when N > M ->
+    ok;
 receive_batch(Ch, N, M) ->
     receive
         {_,


### PR DESCRIPTION
Misunderstood a test function clause previously. This should reduce / eliminate test flakiness in the `consumer_from_last` test in rabbit_stream_queue_SUITE