### PR TITLE
Mixed Version Testing uses bytecode compiled for test (in bazel)

### DIFF
--- a/.github/workflows/secondary-umbrella.yaml
+++ b/.github/workflows/secondary-umbrella.yaml
@@ -1,0 +1,97 @@
+name: Generate Mixed Version Testing Artifacts
+on:
+  workflow_dispatch:
+jobs:
+  package-generic-unix:
+    name: package-generic-unix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - erlang_major: "24"
+          tag: v3.8.27
+        - erlang_major: "24"
+          tag: v3.9.13
+        - erlang_major: "24"
+          tag: v3.10.6
+    timeout-minutes: 20
+    steps:
+    - name: Checkout Repository (Latest to get updated patches)
+      uses: actions/checkout@v3
+      with:
+        path: latest
+
+    - name: Checkout Repository (Secondary Umbrella tag)
+      uses: actions/checkout@v3
+      with:
+        path: secondary-umbrella
+        ref: ${{ matrix.tag }}
+
+    - name: Apply Patch
+      working-directory: secondary-umbrella
+      run: |
+        patch -p1 < ${{ github.workspace }}/latest/bazel/secondary-umbrella.patch
+        git diff
+
+    - name: Mount Bazel Cache
+      uses: actions/cache@v3.0.5
+      with:
+        path: "/home/runner/repo-cache/"
+        key: repo-cache-secondary-umbrella
+
+    - name: Configure Bazel
+      working-directory: secondary-umbrella
+      run: |
+        if [ -n "${{ secrets.BUILDBUDDY_API_KEY }}" ]; then
+        cat << EOF >> user.bazelrc
+          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
+        EOF
+        fi
+        cat << EOF >> user.bazelrc
+          build:buildbuddy --build_metadata=ROLE=CI
+          build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
+          build:buildbuddy --remote_instance_name=buildbuddy-io/buildbuddy/ci-secondary-umbrella
+          build:buildbuddy --repository_cache=/home/runner/repo-cache/
+          build:buildbuddy --color=yes
+          build:buildbuddy --disk_cache=
+
+          build:buildbuddy --remote_download_toplevel
+        EOF
+
+        bazelisk info release
+
+    - name: Build
+      working-directory: secondary-umbrella
+      run: |
+        TAG=${{ matrix.tag }}
+        VERSION=${TAG#v}
+        sed -i"_orig" -E "/APP_VERSION/ s/3\.[0-9]+\.[0-9]+/${VERSION}/" rabbitmq.bzl
+        bazelisk build :package-generic-unix \
+          --config=rbe-${{ matrix.erlang_major }} \
+          --verbose_failures
+
+    - name: Rename the Artifact
+      working-directory: secondary-umbrella
+      run: |
+        OUTPUT_DIR=${{ github.workspace }}/output
+        mkdir ${OUTPUT_DIR}
+        cp \
+          bazel-bin/package-generic-unix.tar.xz \
+          ${OUTPUT_DIR}/package-generic-unix-for-mixed-version-testing-${{ matrix.tag }}.tar.xz
+
+    - name: Upload the archive to S3
+      uses: jakejarvis/s3-sync-action@v0.5.1
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
+        SOURCE_DIR: output
+        DEST_DIR: secondary-umbrellas
+
+    - name: Confirm public access
+      run: |
+        curl -LO https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/package-generic-unix-for-mixed-version-testing-${{ matrix.tag }}.tar.xz

--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -28,7 +28,7 @@ def secondary_umbrella():
         name = "rabbitmq-server-generic-unix-3.10",
         build_file = "@//:BUILD.package_generic_unix",
         patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-        sha256 = "11651575d9c1b6b1803a41b5a37ad437abfb883fb7415500f98695f99943a83d",
+        sha256 = "d8cb9d3d851ced368dd070e21535bc8e90f6f2b8d206dd5b4fd7f3a8180ea03c",
         strip_prefix = "rabbitmq_server-3.10.6",
-        urls = ["https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.10.6/rabbitmq-server-generic-unix-3.10.6.tar.xz"],
+        urls = ["https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/package-generic-unix-for-mixed-version-testing-v3.10.6.tar.xz"],
     )

--- a/bazel/secondary-umbrella.patch
+++ b/bazel/secondary-umbrella.patch
@@ -1,0 +1,13 @@
+diff --git a/rabbitmq.bzl b/rabbitmq.bzl
+index 85f9a2d790..08c2bc957e 100644
+--- a/rabbitmq.bzl
++++ b/rabbitmq.bzl
+@@ -28,6 +28,8 @@ STARTS_BACKGROUND_BROKER_TAG = "starts-background-broker"
+ MIXED_VERSION_CLUSTER_TAG = "mixed-version-cluster"
+ 
+ RABBITMQ_ERLC_OPTS = DEFAULT_ERLC_OPTS + [
++    "-DTEST=1",
++    "+nowarn_export_all",
+     "-DINSTR_MOD=gm",
+ ]
+ 

--- a/deps/rabbitmq_cli/test/fixtures/plugins/plugins_with_version_requirements/mock_rabbitmq_plugin_for_3_8-0.1.0/ebin/mock_rabbitmq_plugin_for_3_8.app
+++ b/deps/rabbitmq_cli/test/fixtures/plugins/plugins_with_version_requirements/mock_rabbitmq_plugin_for_3_8-0.1.0/ebin/mock_rabbitmq_plugin_for_3_8.app
@@ -6,5 +6,5 @@
 	{applications, [kernel,stdlib,rabbit]},
 	{mod, {mock_rabbitmq_plugins_01_app, []}},
 	{env, []},
-	{broker_version_requirements, ["3.8.0", "3.9.0", "3.10.0"]}
+	{broker_version_requirements, ["3.8.0", "3.9.0", "3.10.0", "3.11.0"]}
 ]}.

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -41,7 +41,7 @@ RABBITMQ_DIALYZER_OPTS = [
     "-Wunmatched_returns",
 ]
 
-APP_VERSION = "3.10.0"
+APP_VERSION = "3.11.0"
 
 BROKER_VERSION_REQUIREMENTS_ANY = """
 	{broker_version_requirements, []}
@@ -177,8 +177,8 @@ def broker_for_integration_suites(extra_plugins = []):
     rabbitmq_home(
         name = "broker-for-tests-home",
         plugins = [
-            "//deps/rabbit:erlang_app",
-            ":erlang_app",
+            "//deps/rabbit:test_erlang_app",
+            ":test_erlang_app",
         ] + extra_plugins,
         testonly = True,
     )


### PR DESCRIPTION
## Proposed Changes

This introduces a manual github actions workflow that produces special "package-generic-unix-*" archives with code compiled for test, and places them on S3 in a public bucket. This allows the current mixed version testing workflow in bazel (which is archive based) to use these archive and call code wrapped in `-ifdef(TEST)` and similar, as was the case when mixed version testing was performed with Make.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

When the rabbitmq version used for mixed version testing is updated, the value must be changed in `secondary-umbrella.yaml`, pushed to master, and run to produce the new archive. After that `bazel/bzlmod/secondary_umbrella.bzl` can be updated to make use of it, on whatever branch necessary.
