### PR TITLE
Bump the rabbitmq version on this branch to 3.12.0 (bazel)

### DIFF
--- a/deps/rabbitmq_cli/test/fixtures/plugins/plugins_with_version_requirements/mock_rabbitmq_plugin_for_3_8-0.1.0/ebin/mock_rabbitmq_plugin_for_3_8.app
+++ b/deps/rabbitmq_cli/test/fixtures/plugins/plugins_with_version_requirements/mock_rabbitmq_plugin_for_3_8-0.1.0/ebin/mock_rabbitmq_plugin_for_3_8.app
@@ -6,5 +6,5 @@
 	{applications, [kernel,stdlib,rabbit]},
 	{mod, {mock_rabbitmq_plugins_01_app, []}},
 	{env, []},
-	{broker_version_requirements, ["3.8.0", "3.9.0", "3.10.0", "3.11.0"]}
+	{broker_version_requirements, ["3.9.0", "3.10.0", "3.11.0", "3.12.0"]}
 ]}.

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -41,7 +41,7 @@ RABBITMQ_DIALYZER_OPTS = [
     "-Wunmatched_returns",
 ]
 
-APP_VERSION = "3.11.0"
+APP_VERSION = "3.12.0"
 
 BROKER_VERSION_REQUIREMENTS_ANY = """
 	{broker_version_requirements, []}


### PR DESCRIPTION
To reduce cache misses, the bazel build uses a hard coded version. A correct value is injected in releases.

However, it's still helpful to have something reasonable when one is looking at logs from tests, especially mixed version tests.

Should not be backported, as the release branches already have reasonable values.