### PR TITLE
ctl add_vhost: check if relevant feature flags are enabled

### DIFF
--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -13,6 +13,7 @@
          init/0,
          close/1,
          discover/1,
+         feature_flag_name/1,
          default/0,
          is_enabled/1,
          is_compatible/4,
@@ -223,13 +224,22 @@
 -callback notify_decorators(amqqueue:amqqueue()) ->
     ok.
 
-%% TODO: this should be controlled by a registry that is populated on boot
+%% TODO: should this use a registry that's populated on boot?
 discover(<<"quorum">>) ->
     rabbit_quorum_queue;
 discover(<<"classic">>) ->
     rabbit_classic_queue;
 discover(<<"stream">>) ->
     rabbit_stream_queue.
+
+feature_flag_name(<<"quorum">>) ->
+    quorum_queue;
+feature_flag_name(<<"classic">>) ->
+    undefined;
+feature_flag_name(<<"stream">>) ->
+    stream_queue;
+feature_flag_name(_) ->
+    undefined.
 
 default() ->
     rabbit_classic_queue.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/feature_flags.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/feature_flags.ex
@@ -5,10 +5,30 @@
 ## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Core.FeatureFlags do
+  alias RabbitMQ.CLI.Core.ExitCodes
 
   #
   # API
   #
+
+  def is_enabled_remotely(node_name, feature_flag) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :is_enabled, [feature_flag]) do
+      true  -> true
+      false -> false
+      {:error, _} = error -> error
+    end
+  end
+
+  def assert_feature_flag_enabled(node_name, feature_flag, success_fun) do
+    case is_enabled_remotely(node_name, feature_flag) do
+      true  ->
+        success_fun.()
+      false ->
+        {:error, ExitCodes.exit_dataerr(), "The #{feature_flag} feature flag is not enabled on the target node"}
+      {:error, _} = error ->
+        error
+    end
+  end
 
   def feature_flag_lines(feature_flags) do
     feature_flags

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
-  alias RabbitMQ.CLI.Core.{DocGuide, ErrorCodes, FeatureFlags, Helpers}
+  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, FeatureFlags, Helpers}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -44,7 +44,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   def run([vhost], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
   end
-
+  def output({:error, :invalid_queue_type}, _opts) do
+    {:error, ExitCodes.exit_usage, "Unsupported default queue type"}
+  end
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "add_vhost <vhost> [--description <description> --tags \"<tag1>,<tag2>,<...>\" --default-queue-type <quorum|classic|stream>]"


### PR DESCRIPTION
This adds extra CLI command-level validations for #5305: if the respective queue type feature flag (e.g. `quorum_queue`) is not enabled, specifying `--default-queue-type` would fail with an error.