### PR TITLE
CQv1: Fix failure to recover messages in rare cases

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -320,7 +320,7 @@ suites = [
         PACKAGE,
         name = "classic_queue_prop_SUITE",
         size = "large",
-        shard_count = 4,
+        shard_count = 5,
         sharding_method = "case",
         deps = [
             "@proper//:erlang_app",

--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -1127,7 +1127,7 @@ queue_index_walker_reader(#resource{ virtual_host = VHost } = Name, Gatherer) ->
     _ = [queue_index_walker_segment(filename:join(Dir, F), Gatherer) || F <- SegmentFiles],
     %% When there are files belonging to the v1 index, we go through
     %% the v1 index walker function as well.
-    case rabbit_file:wildcard(".*\\.idx", Dir) of
+    case rabbit_file:wildcard(".*\\.(idx|jif)", Dir) of
         [_|_] ->
             %% This function will call gatherer:finish/1, we do not
             %% need to call it here.


### PR DESCRIPTION
When a full recovery was done it was possible to lose messages
for v1 queues when the queues only had a journal file and no
segment files.

In practice it should be a rare event because it requires the
queue (or maybe the node) to crash first and then the vhost or
the node to be restarted gracefully.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Other notes

This introduces the first regression test for the property suite.
I plan to do more of that for future fixes when I have an easy
to reproduce test case.

Edit: .... and I opened on the wrong account, again. Sorry about that.