### PR TITLE
Prevent global:sync/0 from being stuck when hostname resolution is not available early on boot

### DIFF
--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -268,7 +268,7 @@ register_globally() ->
        "Feature flags: [global sync] @ ~s",
        [node()],
        #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-    ok = global:sync(),
+    ok = rabbit_node_monitor:global_sync(),
     ?LOG_DEBUG(
        "Feature flags: [global register] @ ~s",
        [node()],

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -276,13 +276,13 @@ pause_if_all_down_guard(PreferredNodes, LastNodes, LastState) ->
 %% state, causing global:sync/0 to never return.
 %%
 %%     1. A process is spawned.
-%%     2. If after 15", global:sync() didn't return, the "global"
+%%     2. If after 10", global:sync() didn't return, the "global"
 %%        state is parsed.
 %%     3. If it detects that a sync is blocked for more than 10",
 %%        the process sends fake nodedown/nodeup events to the two
 %%        nodes involved (one local, one remote).
 %%     4. Both "global" instances restart their synchronisation.
-%%     5. globao:sync() finally returns.
+%%     5. global:sync() finally returns.
 %%
 %% FIXME: Remove this workaround, once we got rid of the change to
 %% "dist_auto_connect" and fixed the bugs uncovered.
@@ -297,13 +297,13 @@ workaround_global_hang() ->
     receive
         global_sync_done ->
             ok
-    after 10000 ->
+    after 10_000 ->
             find_blocked_global_peers()
     end.
 
 find_blocked_global_peers() ->
     Snapshot1 = snapshot_global_dict(),
-    timer:sleep(10000),
+    timer:sleep(10_000),
     Snapshot2 = snapshot_global_dict(),
     find_blocked_global_peers1(Snapshot2, Snapshot1).
 
@@ -324,8 +324,8 @@ find_blocked_global_peers1([], _) ->
 unblock_global_peer(PeerNode) ->
     ThisNode = node(),
     PeerState = rpc:call(PeerNode, sys, get_status, [global_name_server]),
-    logger:info(
-      "Global hang workaround: global state on ~s seems broken~n"
+    logger:debug(
+      "Global hang workaround: global state on ~s seems inconsistent~n"
       " * Peer global state:  ~p~n"
       " * Local global state: ~p~n"
       "Faking nodedown/nodeup between ~s and ~s",


### PR DESCRIPTION
Prior to this PR, `global:sync/0` gets sometimes stuck when either performing a rolling update on Kubernetes or when creating a new RabbitMQ cluster on Kubernetes.

When performing a rolling update, the node being booted will be stuck in:
```
2022-07-26 10:49:58.891896+00:00 [debug] <0.226.0> == Plugins (prelaunch phase) ==
2022-07-26 10:49:58.891908+00:00 [debug] <0.226.0> Setting plugins up
2022-07-26 10:49:58.920915+00:00 [debug] <0.226.0> Loading the following plugins: [cowlib,cowboy,rabbitmq_web_dispatch,
2022-07-26 10:49:58.920915+00:00 [debug] <0.226.0>                                 rabbitmq_management_agent,amqp_client,
2022-07-26 10:49:58.920915+00:00 [debug] <0.226.0>                                 rabbitmq_management,quantile_estimator,
2022-07-26 10:49:58.920915+00:00 [debug] <0.226.0>                                 prometheus,rabbitmq_peer_discovery_common,
2022-07-26 10:49:58.920915+00:00 [debug] <0.226.0>                                 accept,rabbitmq_peer_discovery_k8s,
2022-07-26 10:49:58.920915+00:00 [debug] <0.226.0>                                 rabbitmq_prometheus]
2022-07-26 10:49:58.926373+00:00 [debug] <0.226.0> Feature flags: REFRESHING after applications load...
2022-07-26 10:49:58.926416+00:00 [debug] <0.372.0> Feature flags: registering controller globally before proceeding with task: refresh_after_app_load
2022-07-26 10:49:58.926450+00:00 [debug] <0.372.0> Feature flags: [global sync] @ rabbit@r1-server-3.r1-nodes.default
```

During cluster creation, an example log of global:sync/0 being stuck can be found in bullet point 2 of
https://github.com/rabbitmq/rabbitmq-server/pull/5331#pullrequestreview-1050715029.

When global:sync/0 is stuck, it never receives a message in line
https://github.com/erlang/otp/blob/bd05b07f973f11d73c4fc77d59b69f212f121c2d/lib/kernel/src/global.erl#L2942.

This issue can be observed in both `kind` and GKE.

`kind` uses CoreDNS, GKE uses kubedns.

CoreDNS does not resolve the hostname of RabbitMQ and its peers
correctly for up to 30 seconds after node startup.
This is because the default cache value of CoreDNS is 30 seconds and
CoreDNS has a bug described in
https://github.com/kubernetes/kubernetes/issues/92559

global:sync/0 is known to be buggy "in the presence of network failures"
unless the kernel parameter `prevent_overlapping_partitions` is set.

When either:
1. setting CoreDNS cache value to 1 second (see
https://github.com/rabbitmq/rabbitmq-server/issues/5322#issuecomment-1195826135
on how to set this value), or
2. setting the kernel parameter `prevent_overlapping_partitions` to `true`

rolling updates do NOT get stuck anymore.

This means we are hitting here a combination of:
1. Kubernetes DNS bug not updating DNS caches promptly for headless
   services with `publishNotReadyAddresses: true`, and
2. Erlang bug which causes global:sync/0 to hang forever in the presence
   of network failures.

The Erlang bug is fixed by setting `prevent_overlapping_partitions` to `true` (default in Erlang/OTP 25).

In RabbitMQ however, we explicitly set `prevent_overlapping_partitions`
to `false` because other issues may arise if we set this paramter to
`true`.

To resolve this issue of global:sync/0 being stuck, we can just
call function rabbit_node_monitor:global_sync/0 which provides a
workaround.

With this commit applied, rolling updates are not stuck anymore and we
see in the debug log the workaround sometimes being applied.