### PR TITLE
Set kernel param prevent_overlapping_partitions to true

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -24,7 +24,7 @@ setup(Context) ->
     %% TODO: Check if directories/files are inside Mnesia dir.
 
     ok = set_default_config(),
-    ok = disable_kernel_overlapping_partitions(),
+    ok = enable_kernel_overlapping_partitions(),
 
     AdditionalConfigFiles = find_additional_config_files(Context),
     AdvancedConfigFile = find_actual_advanced_config_file(Context),
@@ -575,8 +575,7 @@ get_input_iodevice() ->
             end
     end.
 
-disable_kernel_overlapping_partitions() ->
-    %% This new "fixed" behavior seriously affects our own partition handling,
-    %% and potentially even libraries such as Aten and Ra,
-    %% so disable this to be forward-compatible with Erlang 25
-    application:set_env(kernel, prevent_overlapping_partitions, false).
+enable_kernel_overlapping_partitions() ->
+    %% Kernel parameter prevent_overlapping_partitions got introduced
+    %% in Erlang 24.3 and is set to `true` by default in Erlang 25.
+    application:set_env(kernel, prevent_overlapping_partitions, true).

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -81,7 +81,7 @@ start_rabbitmq_server() {
         ${RABBITMQ_SERVER_START_ARGS} \
         -syslog logger '[]' \
         -syslog syslog_error_logger false \
-        -kernel prevent_overlapping_partitions false \
+        -kernel prevent_overlapping_partitions true \
         "$@"
 }
 

--- a/deps/rabbit/scripts/rabbitmq-server.bat
+++ b/deps/rabbit/scripts/rabbitmq-server.bat
@@ -70,7 +70,7 @@ if "!RABBITMQ_ALLOW_INPUT!"=="" (
 !RABBITMQ_SERVER_START_ARGS! ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
--kernel prevent_overlapping_partitions false ^
+-kernel prevent_overlapping_partitions true ^
 !STAR!
 
 if ERRORLEVEL 1 (

--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -200,7 +200,7 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 !RABBITMQ_DIST_ARG! ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
--kernel prevent_overlapping_partitions false ^
+-kernel prevent_overlapping_partitions true ^
 !STARVAR!
 
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:\=\\!

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -268,7 +268,7 @@ register_globally() ->
        "Feature flags: [global sync] @ ~s",
        [node()],
        #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-    ok = rabbit_node_monitor:global_sync(),
+    ok = global:sync(),
     ?LOG_DEBUG(
        "Feature flags: [global register] @ ~s",
        [node()],

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -84,8 +84,7 @@ init() ->
     %% We intuitively expect the global name server to be synced when
     %% Mnesia is up. In fact that's not guaranteed to be the case -
     %% let's make it so.
-    ok = rabbit_node_monitor:global_sync(),
-    ok.
+    ok = global:sync().
 
 init_with_lock() ->
     {Retries, Timeout} = rabbit_peer_discovery:locking_retry_timeout(),


### PR DESCRIPTION
This kernel parameter got introduced in Erlang 24.3.
It is set to `false` by default in Erlang 24.
It is set to `true` by default in Erlang 25.

**This commit requires Erlang >= 24.3.**

As described in commit message https://github.com/rabbitmq/rabbitmq-server/commit/4bf78d822d7496e03061119f4cb07c0b306e4c03 setting this flag to `true` will prevent `global:sync/0` from hanging in the presence of network failures.

Instead of relying on our own workaround of `global:sync/0` being stuck introduced in https://github.com/rabbitmq/rabbitmq-server/commit/9fcb31f348590a74fd526333cf881cfbe27241e6 let us instead rely on the official Erlang fix that comes by setting `prevent_overloapping_partitions` to true.

**We want this commit only in `master`.**