### PR TITLE
Drop Erlang 23 from Actions test matrix (in 3.12.x/master, 3.11.x)

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -20,10 +20,10 @@ jobs:
   # For example, for Git commit SHA '111aaa' and branch name 'main' and maximum supported Erlang major version '24',
   # the following tags will be pushed to Dockerhub:
   #
-  # * 111aaa-otp-min (image OTP 23)
-  # * main-otp-min (image OTP 23)
-  # * 111aaa-otp-max (image OTP 24)
-  # * main-otp-max (image OTP 24)
+  # * 111aaa-otp-min (image OTP 24)
+  # * main-otp-min (image OTP 24)
+  # * 111aaa-otp-max (image OTP 25)
+  # * main-otp-max (image OTP 25)
 
   build-publish-dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "23"
+        - "24"
         include:
-        - erlang_version: "23"
+        - erlang_version: "24"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:
@@ -48,9 +48,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "23"
+        - "24"
         include:
-        - erlang_version: "23"
+        - erlang_version: "24"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         erlang_major:
-        - "23"
         - "24"
         #! - "25"
     timeout-minutes: 120
@@ -79,8 +78,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "23"
-          elixir_version: 1.10.4
         - erlang_version: "24"
           elixir_version: 1.12.3
         #! - erlang_version: "25"

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -11,8 +11,6 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-        - erlang_version: "23.3"
-          name_suffix: '_23'
         - erlang_version: "24.3"
           name_suffix: '_24'
         - erlang_version: "25.0"


### PR DESCRIPTION
we still use it for the 3.8.x mixed version umbrella,
for now.