### PR TITLE
Require Erlang 24.3

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
@@ -6,8 +6,8 @@
 
 -export([check/1]).
 
--define(OTP_MINIMUM, "23.2").
--define(ERTS_MINIMUM, "11.1").
+-define(OTP_MINIMUM, "24.3").
+-define(ERTS_MINIMUM, "12.3").
 
 check(_Context) ->
     ?LOG_DEBUG(

--- a/deps/rabbitmq_ct_helpers/tools/terraform/direct-vms/templates/setup-erlang.sh
+++ b/deps/rabbitmq_ct_helpers/tools/terraform/direct-vms/templates/setup-erlang.sh
@@ -34,12 +34,13 @@ readonly erlang_cookie='${erlang_cookie}'
 readonly debian_codename="$${distribution#debian-*}"
 
 case "$erlang_version" in
-  24.*)
+
+  26.*)
     if test -z "$erlang_git_ref"; then
       erlang_git_ref='master'
     fi
     ;;
-  23.*|22.*|21.*|20.*|19.3)
+  25.*|24.*|23.*|22.*|21.*|20.*|19.3)
     readonly erlang_package_version="1:$erlang_version-1"
     ;;
   R16B03)


### PR DESCRIPTION
We expect that 3.11 will require Erlang 25.0 but this would do for now. Per discussion with the team.