### PR TITLE
Exclude a QQ test from mixed version testing in v3.10.x and v3.9.x

### DIFF
--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -226,7 +226,7 @@ init_per_group(Group, Config) ->
                                    Config2, maintenance_mode_status),
                             case IsMixed of
                                 true  -> ok;
-                                fasel ->
+                                false ->
                                     ok = rabbit_ct_broker_helpers:enable_feature_flag(
                                             Config2, virtual_host_metadata)
                             end,

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -224,8 +224,12 @@ init_per_group(Group, Config) ->
                             timer:sleep(ClusterSize * 1000),
                             ok = rabbit_ct_broker_helpers:enable_feature_flag(
                                    Config2, maintenance_mode_status),
-                            ok = rabbit_ct_broker_helpers:enable_feature_flag(
-                                   Config2, virtual_host_metadata),
+                            case IsMixed of
+                                true  -> ok;
+                                fasel ->
+                                    ok = rabbit_ct_broker_helpers:enable_feature_flag(
+                                            Config2, virtual_host_metadata)
+                            end,
                             Config2;
                         Skip ->
                             end_per_group(Group, Config2),
@@ -709,6 +713,14 @@ vhost_with_quorum_queue_is_deleted(Config) ->
     ok.
 
 vhost_with_default_queue_type_declares_quorum_queue(Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "vhost_with_default_queue_type_declares_quorum_queue isn't mixed version reliable"};
+        false ->
+            vhost_with_default_queue_type_declares_quorum_queue0(Config)
+    end.
+
+vhost_with_default_queue_type_declares_quorum_queue0(Config) ->
     Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     VHost = atom_to_binary(?FUNCTION_NAME, utf8),
     QName = atom_to_binary(?FUNCTION_NAME, utf8),


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-server/pull/5305 was only really meant to be by a certain
kind of user who can be assumed to have all feature flags enabled.