### PR TITLE
Require Erlang 24.2 (ERTS 12.2)

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -15,10 +15,10 @@ jobs:
   # For example, for Git commit SHA '111aaa' and branch name 'main' and maximum supported Erlang major version '24',
   # the following tags will be pushed to Dockerhub:
   #
-  # * 111aaa-otp-min (image OTP 23)
-  # * main-otp-min (image OTP 23)
-  # * 111aaa-otp-max (image OTP 24)
-  # * main-otp-max (image OTP 24)
+  # * 111aaa-otp-min (image OTP 24)
+  # * main-otp-min (image OTP 24)
+  # * 111aaa-otp-max (image OTP 25)
+  # * main-otp-max (image OTP 25)
 
   build-publish-dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "23"
+        - "24"
         include:
-        - erlang_version: "23"
+        - erlang_version: "24"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:
@@ -48,9 +48,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "23"
+        - "24"
         include:
-        - erlang_version: "23"
+        - erlang_version: "24"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         erlang_major:
-        - "23"
         - "24"
         #! - "25"
     timeout-minutes: 120
@@ -75,8 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "23"
-          elixir_version: 1.10.4
         - erlang_version: "24"
           elixir_version: 1.12.3
         #! - erlang_version: "25"

--- a/.github/workflows/update-rbe-images.yaml
+++ b/.github/workflows/update-rbe-images.yaml
@@ -11,11 +11,8 @@ jobs:
       max-parallel: 1
       matrix:
         erlang_version:
-        - "23.3"
         - "24.3"
         include:
-        - erlang_version: "23.3"
-          short_version: "23"
         - erlang_version: "24.3"
           short_version: "24"
     timeout-minutes: 10

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
@@ -6,8 +6,8 @@
 
 -export([check/1]).
 
--define(OTP_MINIMUM, "23.2").
--define(ERTS_MINIMUM, "11.1").
+-define(OTP_MINIMUM, "24.2").
+-define(ERTS_MINIMUM, "12.2").
 
 check(_Context) ->
     ?LOG_DEBUG(


### PR DESCRIPTION
Erlang 23 has reached EOL on July 31st, 2022.