### PR TITLE
Revert "Set kernel param prevent_overlapping_partitions to true"

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -24,7 +24,7 @@ setup(Context) ->
     %% TODO: Check if directories/files are inside Mnesia dir.
 
     ok = set_default_config(),
-    ok = enable_kernel_overlapping_partitions(),
+    ok = disable_kernel_overlapping_partitions(),
 
     AdditionalConfigFiles = find_additional_config_files(Context),
     AdvancedConfigFile = find_actual_advanced_config_file(Context),
@@ -575,7 +575,8 @@ get_input_iodevice() ->
             end
     end.
 
-enable_kernel_overlapping_partitions() ->
-    %% Kernel parameter prevent_overlapping_partitions got introduced
-    %% in Erlang 24.3 and is set to `true` by default in Erlang 25.
-    application:set_env(kernel, prevent_overlapping_partitions, true).
+disable_kernel_overlapping_partitions() ->
+    %% This new "fixed" behavior seriously affects our own partition handling,
+    %% and potentially even libraries such as Aten and Ra,
+    %% so disable this to be forward-compatible with Erlang 25
+    application:set_env(kernel, prevent_overlapping_partitions, false).

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -81,7 +81,7 @@ start_rabbitmq_server() {
         ${RABBITMQ_SERVER_START_ARGS} \
         -syslog logger '[]' \
         -syslog syslog_error_logger false \
-        -kernel prevent_overlapping_partitions true \
+        -kernel prevent_overlapping_partitions false \
         "$@"
 }
 

--- a/deps/rabbit/scripts/rabbitmq-server.bat
+++ b/deps/rabbit/scripts/rabbitmq-server.bat
@@ -70,7 +70,7 @@ if "!RABBITMQ_ALLOW_INPUT!"=="" (
 !RABBITMQ_SERVER_START_ARGS! ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
--kernel prevent_overlapping_partitions true ^
+-kernel prevent_overlapping_partitions false ^
 !STAR!
 
 if ERRORLEVEL 1 (

--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -200,7 +200,7 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 !RABBITMQ_DIST_ARG! ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
--kernel prevent_overlapping_partitions true ^
+-kernel prevent_overlapping_partitions false ^
 !STARVAR!
 
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:\=\\!

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -268,7 +268,7 @@ register_globally() ->
        "Feature flags: [global sync] @ ~s",
        [node()],
        #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-    ok = global:sync(),
+    ok = rabbit_node_monitor:global_sync(),
     ?LOG_DEBUG(
        "Feature flags: [global register] @ ~s",
        [node()],

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -84,7 +84,8 @@ init() ->
     %% We intuitively expect the global name server to be synced when
     %% Mnesia is up. In fact that's not guaranteed to be the case -
     %% let's make it so.
-    ok = global:sync().
+    ok = rabbit_node_monitor:global_sync(),
+    ok.
 
 init_with_lock() ->
     {Retries, Timeout} = rabbit_peer_discovery:locking_retry_timeout(),

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -19,6 +19,7 @@
 -export([notify_node_up/0, notify_joined_cluster/0, notify_left_cluster/1]).
 -export([partitions/0, partitions/1, status/1, subscribe/1]).
 -export([pause_partition_guard/0]).
+-export([global_sync/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
@@ -266,6 +267,75 @@ pause_if_all_down_guard(PreferredNodes, LastNodes, LastState) ->
                           NewState}),
                      NewState
     end.
+
+%%----------------------------------------------------------------------------
+%% "global" hang workaround.
+%%----------------------------------------------------------------------------
+
+%% This code works around a possible inconsistency in the "global"
+%% state, causing global:sync/0 to never return.
+%%
+%%     1. A process is spawned.
+%%     2. If after 10", global:sync() didn't return, the "global"
+%%        state is parsed.
+%%     3. If it detects that a sync is blocked for more than 10",
+%%        the process sends fake nodedown/nodeup events to the two
+%%        nodes involved (one local, one remote).
+%%     4. Both "global" instances restart their synchronisation.
+%%     5. global:sync() finally returns.
+%%
+%% FIXME: Remove this workaround, once we got rid of the change to
+%% "dist_auto_connect" and fixed the bugs uncovered.
+
+global_sync() ->
+    Pid = spawn(fun workaround_global_hang/0),
+    ok = global:sync(),
+    Pid ! global_sync_done,
+    ok.
+
+workaround_global_hang() ->
+    receive
+        global_sync_done ->
+            ok
+    after 10_000 ->
+            find_blocked_global_peers()
+    end.
+
+find_blocked_global_peers() ->
+    Snapshot1 = snapshot_global_dict(),
+    timer:sleep(10_000),
+    Snapshot2 = snapshot_global_dict(),
+    find_blocked_global_peers1(Snapshot2, Snapshot1).
+
+snapshot_global_dict() ->
+    {status, _, _, [Dict | _]} = sys:get_status(global_name_server),
+    [E || {{sync_tag_his, _}, _} = E <- Dict].
+
+find_blocked_global_peers1([{{sync_tag_his, Peer}, _} = Item | Rest],
+  OlderSnapshot) ->
+    case lists:member(Item, OlderSnapshot) of
+        true  -> unblock_global_peer(Peer);
+        false -> ok
+    end,
+    find_blocked_global_peers1(Rest, OlderSnapshot);
+find_blocked_global_peers1([], _) ->
+    ok.
+
+unblock_global_peer(PeerNode) ->
+    ThisNode = node(),
+    PeerState = rpc:call(PeerNode, sys, get_status, [global_name_server]),
+    logger:debug(
+      "Global hang workaround: global state on ~s seems inconsistent~n"
+      " * Peer global state:  ~p~n"
+      " * Local global state: ~p~n"
+      "Faking nodedown/nodeup between ~s and ~s",
+      [PeerNode, PeerState, sys:get_status(global_name_server),
+       PeerNode, ThisNode]),
+    {global_name_server, ThisNode} ! {nodedown, PeerNode},
+    {global_name_server, PeerNode} ! {nodedown, ThisNode},
+    {global_name_server, ThisNode} ! {nodeup, PeerNode},
+    {global_name_server, PeerNode} ! {nodeup, ThisNode},
+    ok.
 
 %%----------------------------------------------------------------------------
 %% gen_server callbacks


### PR DESCRIPTION
This reverts commit 8070344a38b5d3efb2e6687c73e0a163c12bd5aa (https://github.com/rabbitmq/rabbitmq-server/pull/5442).

We learnt during the last 6 days on master branch that RabbitMQ - as
of today - is not compatible with kernel parameter
`prevent_overlapping_partitions` set to `true`.

RabbitMQ explicitly disconnects node in at least two places:
1. `rabbit_node_monitor` to "promote" a partial network partition
to a full partition, and
2. `rabbit_mnesia` after a node reset to disconnect it from the
rest of the cluster.
There is no atomicity in the way we disconnect several nodes,
because it's a simple loop. Therefore, remote nodes may/will detect
disconnection at different times obviously. In global's new
behavior behind `prevent_overlapping_partitions`, our attempt to
disconnect all nodes in `rabbit_mnesia` creates a partial network
partition from global's point of view, leading to a complete
disconnection of the cluster.

For example, test
```
make ct-clustering_management t=cluster_size_3:join_and_part_cluster
```
was flaky and demonstrates the 2nd bullet point above where RabbitMQ
interfering with Erlang distribution conflicts with global's
`prevent_overlapping_partitions`.
When RabbitMQ resets a node, its last step is to loop over
clustered nodes and disconnect from them one at a time.
In this test with a 3-node cluster where we reset node A:
1. Node A instructs node B and C to remove node A from their view
   of the cluster
2. Node A disconnects from node B
3. global on node B get a nodedow event for node A, but node C is
   still connected to node A
4. global on node B concludes there is a network partition and
   disconnect from node A and node C
At this point, each node is on its own.
Nothing in RabbitMQ tries to restore the connection between
nodes B and C.

The correct path forward is:
1. Get rid of Mnesia replacing it with Khepri.
2. Once mirrored classic queues are removed, get rid of `rabbit_node_monitor`.
3. Have a clear and consistent view of the nodes comprising a RabbitMQ Cluster:
   In other words, do not use different sources of truths like `nodes()`,
   Mnesia, Ra clusters, global monitor at different places in the code.

For the time being we live with `prevent_overlapping_partitions` set to `false`
and with the workaround for `global:sync/0` being stuck introduced in
https://github.com/rabbitmq/rabbitmq-server/commit/9fcb31f348590a74fd526333cf881cfbe27241e6