### PR TITLE
Fix stream creation on validation failure

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -223,11 +223,11 @@ handle_call({create, VirtualHost, Reference, Arguments, Username},
                             rabbit_log:info("Error while creating ~p stream, "
                                             ++ M,
                                             [Reference]),
-                            {error, validation_failed};
+                            {reply, {error, validation_failed}, State};
                         E ->
                             rabbit_log:warning("Error while creating ~p stream, ~p",
                                                [Reference, E]),
-                            {error, validation_failed}
+                            {reply, {error, validation_failed}, State}
                     end
             end;
         error ->


### PR DESCRIPTION
Expect a regular gen_server return tuple, not just the
return code.

Regression introduced when backporting a change, v3.9.x creates
the stream directly in the gen_server call, other branches
delegates to inner functions.