### PR TITLE
rabbit_stream_queue flake improvement

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -543,6 +543,8 @@ delete_last_replica(Config) ->
     ?assertEqual(ok,
                  rpc:call(Server0, rabbit_stream_queue, delete_replica,
                           [<<"/">>, Q, Server1])),
+
+    check_leader_and_replicas(Config, [Server0, Server2], members),
     ?assertEqual(ok,
                  rpc:call(Server0, rabbit_stream_queue, delete_replica,
                           [<<"/">>, Q, Server2])),


### PR DESCRIPTION
By waiting for the first remove_replica command to complete we
may reduce the likelyhood of this test flaking.
