### PR TITLE
Force gc while importing definitions

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -421,6 +421,8 @@ apply_defs(Map, ActingUser, SuccessFun) when is_function(SuccessFun) ->
         ok
     catch {error, E} -> {error, E};
           exit:E     -> {error, E}
+    after
+        rabbit_runtime:gc_all_processes()
     end.
 
 -spec apply_defs(Map :: #{atom() => any()},
@@ -456,6 +458,8 @@ apply_defs(Map, ActingUser, SuccessFun, VHost) when is_function(SuccessFun); is_
         SuccessFun()
     catch {error, E} -> {error, format(E)};
           exit:E     -> {error, format(E)}
+    after
+        rabbit_runtime:gc_all_processes()
     end.
 
 -spec apply_defs(Map :: #{atom() => any()},
@@ -492,9 +496,18 @@ apply_defs(Map, ActingUser, SuccessFun, ErrorFun, VHost) ->
         SuccessFun()
     catch {error, E} -> ErrorFun(format(E));
           exit:E     -> ErrorFun(format(E))
+    after
+        rabbit_runtime:gc_all_processes()
     end.
 
 sequential_for_all(Category, ActingUser, Definitions, Fun) ->
+    try
+        sequential_for_all0(Category, ActingUser, Definitions, Fun)
+    after
+        rabbit_runtime:gc_all_processes()
+    end.
+
+sequential_for_all0(Category, ActingUser, Definitions, Fun) ->
     case maps:get(rabbit_data_coercion:to_atom(Category), Definitions, undefined) of
         undefined -> ok;
         List      ->
@@ -509,12 +522,26 @@ sequential_for_all(Category, ActingUser, Definitions, Fun) ->
     end.
 
 sequential_for_all(Name, ActingUser, Definitions, VHost, Fun) ->
+    try
+        sequential_for_all0(Name, ActingUser, Definitions, VHost, Fun)
+    after
+        rabbit_runtime:gc_all_processes()
+    end.
+
+sequential_for_all0(Name, ActingUser, Definitions, VHost, Fun) ->
     case maps:get(rabbit_data_coercion:to_atom(Name), Definitions, undefined) of
         undefined -> ok;
         List      -> [Fun(VHost, atomize_keys(M), ActingUser) || M <- List, is_map(M)]
     end.
 
 concurrent_for_all(Category, ActingUser, Definitions, Fun) ->
+    try
+        concurrent_for_all0(Category, ActingUser, Definitions, Fun)
+    after
+        rabbit_runtime:gc_all_processes()
+    end.
+
+concurrent_for_all0(Category, ActingUser, Definitions, Fun) ->
     case maps:get(rabbit_data_coercion:to_atom(Category), Definitions, undefined) of
         undefined -> ok;
         List      ->
@@ -529,6 +556,13 @@ concurrent_for_all(Category, ActingUser, Definitions, Fun) ->
     end.
 
 concurrent_for_all(Name, ActingUser, Definitions, VHost, Fun) ->
+    try
+        concurrent_for_all0(Name, ActingUser, Definitions, VHost, Fun)
+    after
+        rabbit_runtime:gc_all_processes()
+    end.
+
+concurrent_for_all0(Name, ActingUser, Definitions, VHost, Fun) ->
     case maps:get(rabbit_data_coercion:to_atom(Name), Definitions, undefined) of
         undefined -> ok;
         List      ->


### PR DESCRIPTION
When gc is forced the memory release is faster after the import has finished.
For the new metadata store in Khepri, the extra gcs after importing
each type of definitions also releases a noticeable amount of memory.
It should be harmless for the mnesia store.

As suggested by @michaelklishin, part of https://github.com/rabbitmq/rabbitmq-server/issues/5515

## Types of Changes
- [x] Bug fix (non-breaking change part of the issue #5515)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

