### PR TITLE
Ensure that strings from external sources eventually end up as utf-8 encoded binaries

### DIFF
--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -206,7 +206,7 @@ shutdown_func(Reason) ->
     end.
 
 write_pid_file(#{pid_file := PidFile}) ->
-    ?LOG_DEBUG("Writing PID file: ~s", [PidFile]),
+    ?LOG_DEBUG("Writing PID file: ~ts", [PidFile]),
     case filelib:ensure_dir(PidFile) of
         ok ->
             OSPid = os:getpid(),
@@ -215,13 +215,13 @@ write_pid_file(#{pid_file := PidFile}) ->
                     ok;
                 {error, Reason} = Error ->
                     ?LOG_WARNING(
-                      "Failed to write PID file \"~s\": ~s",
+                      "Failed to write PID file \"~ts\": ~ts",
                       [PidFile, file:format_error(Reason)]),
                     Error
             end;
         {error, Reason} = Error ->
             ?LOG_WARNING(
-              "Failed to create PID file \"~s\" directory: ~s",
+              "Failed to create PID file \"~ts\" directory: ~ts",
               [PidFile, file:format_error(Reason)]),
             Error
     end;
@@ -229,10 +229,10 @@ write_pid_file(_) ->
     ok.
 
 remove_pid_file(#{pid_file := PidFile, keep_pid_file_on_exit := true}) ->
-    ?LOG_DEBUG("Keeping PID file: ~s", [PidFile]),
+    ?LOG_DEBUG("Keeping PID file: ~ts", [PidFile]),
     ok;
 remove_pid_file(#{pid_file := PidFile}) ->
-    ?LOG_DEBUG("Deleting PID file: ~s", [PidFile]),
+    ?LOG_DEBUG("Deleting PID file: ~ts", [PidFile]),
     _ = file:delete(PidFile),
     ok;
 remove_pid_file(_) ->

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -57,7 +57,7 @@ setup(Context) ->
                       config_advanced_file => AdvancedConfigFile};
                 undefined when AdvancedConfigFile =/= undefined ->
                     ?LOG_WARNING(
-                      "Using RABBITMQ_ADVANCED_CONFIG_FILE: ~s",
+                      "Using RABBITMQ_ADVANCED_CONFIG_FILE: ~ts",
                       [AdvancedConfigFile],
                       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                     Config = load_cuttlefish_config_file(Context,
@@ -72,7 +72,7 @@ setup(Context) ->
                       config_advanced_file => undefined}
             end,
     ?LOG_DEBUG(
-      "Saving config state to application env: ~p", [State],
+      "Saving config state to application env: ~tp", [State],
       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     store_config_state(State).
 
@@ -158,7 +158,7 @@ find_actual_main_config_file(#{main_config_file := File}) ->
                               "config files exist.",
                               #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                             ?LOG_WARNING(
-                              "Using the old format config file: ~s",
+                              "Using the old format config file: ~ts",
                               [OldFormatFile],
                               #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                             ?LOG_WARNING(
@@ -342,7 +342,7 @@ list_schemas_in_app(App) ->
                    case code:priv_dir(App) of
                        {error, bad_name} ->
                            ?LOG_DEBUG(
-                             "  [ ] ~s (no readable priv dir)", [App],
+                             "  [ ] ~ts (no readable priv dir)", [App],
                              #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                            [];
                        PrivDir ->
@@ -351,7 +351,7 @@ list_schemas_in_app(App) ->
                    end;
                Reason1 ->
                    ?LOG_DEBUG(
-                     "  [ ] ~s (failed to load application: ~p)",
+                     "  [ ] ~ts (failed to load application: ~tp)",
                      [App, Reason1],
                      #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                    []
@@ -366,14 +366,14 @@ list_schemas_in_app(App) ->
 do_list_schemas_in_app(App, SchemaDir) ->
     case erl_prim_loader:list_dir(SchemaDir) of
         {ok, Files} ->
-            ?LOG_DEBUG("  [x] ~s", [App],
+            ?LOG_DEBUG("  [x] ~ts", [App],
                        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
             [filename:join(SchemaDir, File)
              || [C | _] = File <- Files,
                 C =/= $.];
         error ->
             ?LOG_DEBUG(
-              "  [ ] ~s (no readable schema dir)", [App],
+              "  [ ] ~ts (no readable schema dir)", [App],
               #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
             []
     end.
@@ -391,7 +391,7 @@ override_with_advanced_config(Config, AdvancedConfigFile) ->
         {ok, OtherTerms} ->
             ?LOG_ERROR(
               "Failed to load advanced configuration file \"~ts\", "
-              "incorrect format: ~p",
+              "incorrect format: ~tp",
               [AdvancedConfigFile, OtherTerms],
               #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
             throw({error, failed_to_parse_advanced_configuration_file});
@@ -406,7 +406,7 @@ override_with_advanced_config(Config, AdvancedConfigFile) ->
 apply_erlang_term_based_config([{_, []} | Rest]) ->
     apply_erlang_term_based_config(Rest);
 apply_erlang_term_based_config([{App, Vars} | Rest]) ->
-    ?LOG_DEBUG("  Applying configuration for '~s':", [App],
+    ?LOG_DEBUG("  Applying configuration for '~ts':", [App],
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     ok = apply_app_env_vars(App, Vars),
     apply_erlang_term_based_config(Rest);
@@ -421,16 +421,16 @@ apply_app_env_vars(_, []) ->
     ok.
 
 log_app_env_var(password = Var, _) ->
-    ?LOG_DEBUG("    - ~s = ********", [Var],
+    ?LOG_DEBUG("    - ~ts = ********", [Var],
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH});
 log_app_env_var(Var, Value) when is_list(Value) ->
     %% To redact sensitive entries,
     %% e.g. {password,"********"} for stream replication over TLS
     Redacted = redact_env_var(Value),
-    ?LOG_DEBUG("    - ~s = ~p", [Var, Redacted],
+    ?LOG_DEBUG("    - ~ts = ~tp", [Var, Redacted],
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH});
 log_app_env_var(Var, Value) ->
-    ?LOG_DEBUG("    - ~s = ~p", [Var, Value],
+    ?LOG_DEBUG("    - ~ts = ~tp", [Var, Value],
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}).
 
 redact_env_var(Value) when is_list(Value) ->
@@ -470,7 +470,7 @@ decrypt_app(App, [{Key, Value} | Tail], Algo) ->
                         Algo1;
                     {NewValue, Algo1} ->
                         ?LOG_DEBUG(
-                          "Value of `~s` decrypted", [Key],
+                          "Value of `~ts` decrypted", [Key],
                           #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                         ok = application:set_env(App, Key, NewValue,
                                                  [{persistent, true}]),

--- a/deps/rabbit/src/rabbit_access_control.erl
+++ b/deps/rabbit/src/rabbit_access_control.erl
@@ -163,7 +163,7 @@ check_vhost_access(User = #user{username       = Username,
                             Mod:check_vhost_access(
                               auth_user(User, Impl), VHostPath, FullAuthzContext)
                 end,
-                Mod, "access to vhost '~s' refused for user '~s'",
+                Mod, "access to vhost '~ts' refused for user '~s'",
                 [VHostPath, Username], not_allowed);
          (_, Else) ->
               Else

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -430,7 +430,7 @@ rebalance(Type, VhostSpec, QueueSpec) ->
     maybe_rebalance(get_rebalance_lock(self()), Type, VhostSpec, QueueSpec).
 
 maybe_rebalance({true, Id}, Type, VhostSpec, QueueSpec) ->
-    rabbit_log:info("Starting queue rebalance operation: '~s' for vhosts matching '~s' and queues matching '~s'",
+    rabbit_log:info("Starting queue rebalance operation: '~s' for vhosts matching '~ts' and queues matching '~s'",
                     [Type, VhostSpec, QueueSpec]),
     Running = rabbit_maintenance:filter_out_drained_nodes_consistent_read(rabbit_nodes:all_running()),
     NumRunning = length(Running),

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1826,14 +1826,14 @@ log_delete_exclusive({ConPid, _ConRef}, State) ->
 log_delete_exclusive(ConPid, #q{ q = Q }) ->
     Resource = amqqueue:get_name(Q),
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_log_queue:debug("Deleting exclusive queue '~s' in vhost '~s' " ++
+    rabbit_log_queue:debug("Deleting exclusive queue '~s' in vhost '~ts' " ++
                            "because its declaring connection ~p was closed",
                            [QName, VHost, ConPid]).
 
 log_auto_delete(Reason, #q{ q = Q }) ->
     Resource = amqqueue:get_name(Q),
     #resource{ name = QName, virtual_host = VHost } = Resource,
-    rabbit_log_queue:debug("Deleting auto-delete queue '~s' in vhost '~s' " ++
+    rabbit_log_queue:debug("Deleting auto-delete queue '~s' in vhost '~ts' " ++
                            Reason,
                            [QName, VHost]).
 

--- a/deps/rabbit/src/rabbit_amqqueue_sup_sup.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_sup_sup.erl
@@ -65,7 +65,7 @@ start_for_vhost(VHost) ->
         %% we can get here if a vhost is added and removed concurrently
         %% e.g. some integration tests do it
         {error, {no_such_vhost, VHost}} ->
-            rabbit_log:error("Failed to start a queue process supervisor for vhost ~s: vhost no longer exists!",
+            rabbit_log:error("Failed to start a queue process supervisor for vhost ~ts: vhost no longer exists!",
                              [VHost]),
             {error, {no_such_vhost, VHost}}
     end.
@@ -78,7 +78,7 @@ stop_for_vhost(VHost) ->
             ok = supervisor2:delete_child(VHostSup, rabbit_amqqueue_sup_sup);
         %% see start/1
         {error, {no_such_vhost, VHost}} ->
-            rabbit_log:error("Failed to stop a queue process supervisor for vhost ~s: vhost no longer exists!",
+            rabbit_log:error("Failed to stop a queue process supervisor for vhost ~ts: vhost no longer exists!",
                              [VHost]),
             ok
     end.

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -954,8 +954,8 @@ handle_exception(Reason, State = #ch{cfg = #conf{protocol = Protocol,
     case rabbit_binary_generator:map_exception(Channel, Reason, Protocol) of
         {Channel, CloseMethod} ->
             rabbit_log_channel:error(
-                "Channel error on connection ~p (~s, vhost: '~s',"
-                " user: '~s'), channel ~p:~n~s",
+                "Channel error on connection ~p (~ts, vhost: '~ts',"
+                " user: '~ts'), channel ~p:~n~ts",
                 [ConnPid, ConnName, VHost, User#user.username,
                  Channel, format_soft_error(Reason)]),
             ok = rabbit_writer:send_command(WriterPid, CloseMethod),
@@ -1109,7 +1109,7 @@ check_vhost_queue_limit(#resource{name = QueueName}, VHost) ->
   case rabbit_vhost_limit:is_over_queue_limit(VHost) of
     false         -> ok;
     {true, Limit} -> precondition_failed("cannot declare queue '~s': "
-                               "queue limit in vhost '~s' (~p) is reached",
+                               "queue limit in vhost '~ts' (~p) is reached",
                                [QueueName, VHost, Limit])
 
   end.

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -96,14 +96,14 @@ delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_classic(Q) ->
             #resource{name = Name, virtual_host = Vhost} = amqqueue:get_name(Q1),
             case IfEmpty of
                 true ->
-                    rabbit_log:error("Queue ~s in vhost ~s has its master node down and "
+                    rabbit_log:error("Queue ~s in vhost ~ts has its master node down and "
                                      "no mirrors available or eligible for promotion. "
                                      "The queue may be non-empty. "
                                      "Refusing to force-delete.",
                                      [Name, Vhost]),
                     {error, not_empty};
                 false ->
-                    rabbit_log:warning("Queue ~s in vhost ~s has its master node is down and "
+                    rabbit_log:warning("Queue ~s in vhost ~ts has its master node is down and "
                                        "no mirrors available or eligible for promotion. "
                                        "Forcing queue deletion.",
                                        [Name, Vhost]),
@@ -141,7 +141,7 @@ recover(VHost, Queues) ->
                                  not lists:member(amqqueue:get_name(Q), RecoveredNames)],
             {RecoveredQs, FailedQueues};
         {error, Reason} ->
-            rabbit_log:error("Failed to start queue supervisor for vhost '~s': ~s", [VHost, Reason]),
+            rabbit_log:error("Failed to start queue supervisor for vhost '~ts': ~s", [VHost, Reason]),
             throw({error, Reason})
     end.
 

--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -265,7 +265,7 @@ recover(#resource{ virtual_host = VHost, name = QueueName } = Name, Terms,
             State = recover_segments(State0, Terms, IsMsgStoreClean,
                                      ContainsCheckFun, OnSyncFun, OnSyncMsgFun,
                                      CountersRef, Context),
-            rabbit_log:warning("Queue ~s in vhost ~s dropped ~b/~b/~b persistent messages "
+            rabbit_log:warning("Queue ~s in vhost ~ts dropped ~b/~b/~b persistent messages "
                                "and ~b transient messages after unclean shutdown",
                                [QueueName, VHost,
                                 counters:get(CountersRef, ?RECOVER_DROPPED_PERSISTENT_PER_VHOST),
@@ -445,7 +445,7 @@ recover_segment(State, ContainsCheckFun, StoreState0, CountersRef, Fd,
 recover_index_v1_clean(State0 = #qi{ queue_name = Name }, Terms, IsMsgStoreClean,
                        ContainsCheckFun, OnSyncFun, OnSyncMsgFun) ->
     #resource{virtual_host = VHost, name = QName} = Name,
-    rabbit_log:info("Converting queue ~s in vhost ~s from v1 to v2 after clean shutdown", [QName, VHost]),
+    rabbit_log:info("Converting queue ~s in vhost ~ts from v1 to v2 after clean shutdown", [QName, VHost]),
     {_, _, V1State} = rabbit_queue_index:recover(Name, Terms, IsMsgStoreClean,
                                                  ContainsCheckFun, OnSyncFun, OnSyncMsgFun,
                                                  convert),
@@ -454,7 +454,7 @@ recover_index_v1_clean(State0 = #qi{ queue_name = Name }, Terms, IsMsgStoreClean
     %% share code with dirty recovery.
     CountersRef = counters:new(?RECOVER_COUNTER_SIZE, []),
     State = recover_index_v1_common(State0, V1State, CountersRef),
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b total messages from v1 to v2",
+    rabbit_log:info("Queue ~s in vhost ~ts converted ~b total messages from v1 to v2",
                     [QName, VHost, counters:get(CountersRef, ?RECOVER_COUNT)]),
     State.
 
@@ -462,7 +462,7 @@ recover_index_v1_dirty(State0 = #qi{ queue_name = Name }, Terms, IsMsgStoreClean
                        ContainsCheckFun, OnSyncFun, OnSyncMsgFun,
                        CountersRef) ->
     #resource{virtual_host = VHost, name = QName} = Name,
-    rabbit_log:info("Converting queue ~s in vhost ~s from v1 to v2 after unclean shutdown", [QName, VHost]),
+    rabbit_log:info("Converting queue ~s in vhost ~ts from v1 to v2 after unclean shutdown", [QName, VHost]),
     %% We ignore the count and bytes returned here because we cannot trust
     %% rabbit_queue_index: it has a bug that may lead to more bytes being
     %% returned than it really has.
@@ -473,7 +473,7 @@ recover_index_v1_dirty(State0 = #qi{ queue_name = Name }, Terms, IsMsgStoreClean
                                                  ContainsCheckFun, OnSyncFun, OnSyncMsgFun,
                                                  convert),
     State = recover_index_v1_common(State0, V1State, CountersRef),
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b total messages from v1 to v2",
+    rabbit_log:info("Queue ~s in vhost ~ts converted ~b total messages from v1 to v2",
                     [QName, VHost, counters:get(CountersRef, ?RECOVER_COUNT)]),
     State.
 

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -126,31 +126,31 @@ handle_cast({vhost_deleted, Details}) ->
     %% Schedule vhost entry deletion, allowing time for connections to close
     _ = timer:apply_after(?TRACKING_EXECUTION_TIMEOUT, ?MODULE,
             delete_tracked_connection_vhost_entry, [VHost]),
-    rabbit_log_connection:info("Closing all connections in vhost '~s' because it's being deleted", [VHost]),
+    rabbit_log_connection:info("Closing all connections in vhost '~ts' because it's being deleted", [VHost]),
     shutdown_tracked_items(
         rabbit_connection_tracking:list(VHost),
-        rabbit_misc:format("vhost '~s' is deleted", [VHost]));
+        rabbit_misc:format("vhost '~ts' is deleted", [VHost]));
 %% Note: under normal circumstances this will be called immediately
 %% after the vhost_deleted above. Therefore we should be careful about
 %% what we log and be more defensive.
 handle_cast({vhost_down, Details}) ->
     VHost = pget(name, Details),
     Node = pget(node, Details),
-    rabbit_log_connection:info("Closing all connections in vhost '~s' on node '~s'"
+    rabbit_log_connection:info("Closing all connections in vhost '~ts' on node '~ts'"
                                " because the vhost is stopping",
                                [VHost, Node]),
     shutdown_tracked_items(
         rabbit_connection_tracking:list_on_node(Node, VHost),
-        rabbit_misc:format("vhost '~s' is down", [VHost]));
+        rabbit_misc:format("vhost '~ts' is down", [VHost]));
 handle_cast({user_deleted, Details}) ->
     Username = pget(name, Details),
     %% Schedule user entry deletion, allowing time for connections to close
     _ = timer:apply_after(?TRACKING_EXECUTION_TIMEOUT, ?MODULE,
             delete_tracked_connection_user_entry, [Username]),
-    rabbit_log_connection:info("Closing all connections from user '~s' because it's being deleted", [Username]),
+    rabbit_log_connection:info("Closing all connections from user '~ts' because it's being deleted", [Username]),
     shutdown_tracked_items(
         rabbit_connection_tracking:list_of_user(Username),
-        rabbit_misc:format("user '~s' is deleted", [Username]));
+        rabbit_misc:format("user '~ts' is deleted", [Username]));
 %% A node had been deleted from the cluster.
 handle_cast({node_deleted, Details}) ->
     case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
@@ -158,7 +158,7 @@ handle_cast({node_deleted, Details}) ->
             ok;
         false ->
             Node = pget(node, Details),
-            rabbit_log_connection:info("Node '~s' was removed from the cluster, deleting its connection tracking tables...", [Node]),
+            rabbit_log_connection:info("Node '~ts' was removed from the cluster, deleting its connection tracking tables...", [Node]),
             delete_tracked_connections_table_for_node(Node),
             delete_per_vhost_tracked_connections_table_for_node(Node),
             delete_per_user_tracked_connections_table_for_node(Node)
@@ -411,18 +411,18 @@ delete_per_user_tracked_connections_table_for_node(Node) ->
 -spec tracked_connection_table_name_for(node()) -> atom().
 
 tracked_connection_table_name_for(Node) ->
-    list_to_atom(rabbit_misc:format("tracked_connection_on_node_~s", [Node])).
+    list_to_atom(rabbit_misc:format("tracked_connection_on_node_~ts", [Node])).
 
 -spec tracked_connection_per_vhost_table_name_for(node()) -> atom().
 
 tracked_connection_per_vhost_table_name_for(Node) ->
-    list_to_atom(rabbit_misc:format("tracked_connection_per_vhost_on_node_~s", [Node])).
+    list_to_atom(rabbit_misc:format("tracked_connection_per_vhost_on_node_~ts", [Node])).
 
 -spec tracked_connection_per_user_table_name_for(node()) -> atom().
 
 tracked_connection_per_user_table_name_for(Node) ->
     list_to_atom(rabbit_misc:format(
-        "tracked_connection_table_per_user_on_node_~s", [Node])).
+        "tracked_connection_table_per_user_on_node_~ts", [Node])).
 
 -spec get_all_tracked_connection_table_names_for_node(node()) -> [atom()].
 

--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -141,8 +141,8 @@ is_vhost_alive(VHost, {Username, _Password}, Pid) ->
         false ->
             rabbit_log_connection:error(
                 "Error on Direct connection ~p~n"
-                "access to vhost '~s' refused for user '~s': "
-                "vhost '~s' is down",
+                "access to vhost '~ts' refused for user '~s': "
+                "vhost '~ts' is down",
                 [Pid, VHost, PrintedUsername, VHost]),
             false
     end.
@@ -157,7 +157,7 @@ is_over_vhost_connection_limit(VHost, {Username, _Password}, Pid) ->
         {true, Limit} ->
             rabbit_log_connection:error(
                 "Error on Direct connection ~p~n"
-                "access to vhost '~s' refused for user '~s': "
+                "access to vhost '~ts' refused for user '~s': "
                 "vhost connection limit (~p) is reached",
                 [Pid, VHost, PrintedUsername, Limit]),
             true
@@ -165,7 +165,7 @@ is_over_vhost_connection_limit(VHost, {Username, _Password}, Pid) ->
         throw:{error, {no_such_vhost, VHost}} ->
             rabbit_log_connection:error(
                 "Error on Direct connection ~p~n"
-                "vhost ~s not found", [Pid, VHost]),
+                "vhost ~ts not found", [Pid, VHost]),
             true
     end.
 

--- a/deps/rabbit/src/rabbit_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_disk_monitor.erl
@@ -192,7 +192,7 @@ handle_info({'EXIT', Port, Reason}, #state{port=Port}=State) ->
     {stop, {port_died, Reason}, State#state{port=not_used}};
 
 handle_info(Info, State) ->
-    rabbit_log:debug("~p unhandled msg: ~p", [?MODULE, Info]),
+    rabbit_log:debug("~tp unhandled msg: ~tp", [?MODULE, Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->
@@ -207,22 +207,25 @@ code_change(_OldVsn, State, _Extra) ->
 
 start_portprogram() ->
     Args = ["-s", "rabbit_disk_monitor"],
-    Opts = [stderr_to_stdout, stream, {args, Args}],
+    Opts = [stream, stderr_to_stdout, {args, Args}],
     erlang:open_port({spawn_executable, "/bin/sh"}, Opts).
 
 run_port_cmd(Cmd0, Port) ->
     %% Insert a carriage return, ^M or ASCII 13, after the command,
     %% to indicate end of output
-    Cmd = io_lib:format("(~s\n) </dev/null; echo \"\^M\"\n", [Cmd0]),
-    Port ! {self(), {command, [Cmd, 10]}}, % The 10 at the end is a newline
+    Cmd1 = io_lib:format("~ts < /dev/null; echo \"\^M\"~n", [Cmd0]),
+    Cmd2 = rabbit_data_coercion:to_utf8_binary(Cmd1),
+    Port ! {self(), {command, [Cmd2, 10]}}, % The 10 at the end is a newline
     get_reply(Port, []).
 
 get_reply(Port, O) ->
     receive
         {Port, {data, N}} ->
             case newline(N, O) of
-                {ok, Str} -> Str;
-                {more, Acc} -> get_reply(Port, Acc)
+                {ok, Str} ->
+                    Str;
+                {more, Acc} ->
+                    get_reply(Port, Acc)
             end;
         {'EXIT', Port, Reason} ->
             exit({port_died, Reason})
@@ -266,7 +269,7 @@ set_max_check_interval(MaxInterval, State) ->
 set_disk_limits(State, Limit0) ->
     Limit = interpret_limit(Limit0),
     State1 = State#state { limit = Limit },
-    rabbit_log:info("Disk free limit set to ~pMB",
+    rabbit_log:info("Disk free limit set to ~bMB",
                     [trunc(Limit / 1000000)]),
     ets:insert(?ETS_NAME, {disk_free_limit, Limit}),
     internal_update(State1).
@@ -294,10 +297,10 @@ internal_update(State = #state{limit   = Limit,
 get_disk_free(Dir, {unix, Sun}, Port)
   when Sun =:= sunos; Sun =:= sunos4; Sun =:= solaris ->
     Df = find_cmd("df"),
-    parse_free_unix(run_port_cmd(Df ++ " -k " ++ Dir, Port));
+    parse_free_unix(run_port_cmd(Df ++ " -k '" ++ Dir ++ "'", Port));
 get_disk_free(Dir, {unix, _}, Port) ->
     Df = find_cmd("df"),
-    parse_free_unix(run_port_cmd(Df ++ " -kP " ++ Dir, Port));
+    parse_free_unix(run_port_cmd(Df ++ " -kP '" ++ Dir ++ "'", Port));
 get_disk_free(Dir, {win32, _}, not_used) ->
     % Dir:
     % "c:/Users/username/AppData/Roaming/RabbitMQ/db/rabbit2@username-z01-mnesia"
@@ -305,7 +308,7 @@ get_disk_free(Dir, {win32, _}, not_used) ->
         error ->
             rabbit_log:warning("Expected the mnesia directory absolute "
                                "path to start with a drive letter like "
-                               "'C:'. The path is: '~p'", [Dir]),
+                               "'C:'. The path is: '~tp'", [Dir]),
             {ok, Free} = win32_get_disk_free_dir(Dir),
             Free;
         DriveLetter ->
@@ -392,14 +395,14 @@ interpret_limit(Absolute) ->
     case rabbit_resource_monitor_misc:parse_information_unit(Absolute) of
         {ok, ParsedAbsolute} -> ParsedAbsolute;
         {error, parse_error} ->
-            rabbit_log:error("Unable to parse disk_free_limit value ~p",
+            rabbit_log:error("Unable to parse disk_free_limit value ~tp",
                              [Absolute]),
             ?DEFAULT_DISK_FREE_LIMIT
     end.
 
 emit_update_info(StateStr, CurrentFree, Limit) ->
     rabbit_log:info(
-      "Free disk space is ~s. Free bytes: ~p. Limit: ~p",
+      "Free disk space is ~s. Free bytes: ~b. Limit: ~b",
       [StateStr, CurrentFree, Limit]).
 
 start_timer(State) ->
@@ -431,7 +434,7 @@ enable(#state{dir = Dir,
             start_timer(set_disk_limits(State, Limit));
         Err ->
             rabbit_log:error("Free disk space monitor encountered an error "
-                             "(e.g. failed to parse output from OS tools): ~p, retries left: ~b",
+                             "(e.g. failed to parse output from OS tools): ~tp, retries left: ~b",
                             [Err, Retries]),
             erlang:send_after(Interval, self(), try_enable),
             State#state{enabled = false}
@@ -450,6 +453,6 @@ run_os_cmd(Cmd) ->
             CmdResult
     after 5000 ->
         exit(CmdPid, kill),
-        rabbit_log:error("Command timed out: '~s'", [Cmd]),
+        rabbit_log:error("Command timed out: '~ts'", [Cmd]),
         {error, timeout}
     end.

--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -131,11 +131,11 @@ setup_proc(
     case declare_exchange(Config) of
         ok ->
             ?LOG_INFO(
-               "Logging to exchange '~s' in vhost '~s' ready", [Name, VHost],
+               "Logging to exchange '~s' in vhost '~ts' ready", [Name, VHost],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL});
         error ->
             ?LOG_DEBUG(
-               "Logging to exchange '~s' in vhost '~s' not ready, "
+               "Logging to exchange '~s' in vhost '~ts' not ready, "
                "trying again in ~b second(s)",
                [Name, VHost, ?DECL_EXCHANGE_INTERVAL_SECS],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
@@ -155,14 +155,14 @@ declare_exchange(
                         Exchange, topic, true, false, true, [],
                         ?INTERNAL_USER),
         ?LOG_DEBUG(
-           "Declared exchange '~s' in vhost '~s'",
+           "Declared exchange '~s' in vhost '~ts'",
            [Name, VHost],
            #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
         ok
     catch
         Class:Reason ->
             ?LOG_DEBUG(
-               "Could not declare exchange '~s' in vhost '~s', "
+               "Could not declare exchange '~s' in vhost '~ts', "
                "reason: ~0p:~0p",
                [Name, VHost, Class, Reason],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
@@ -176,6 +176,6 @@ unconfigure_exchange(
     Pid ! stop,
     rabbit_exchange:delete(Exchange, false, ?INTERNAL_USER),
     ?LOG_INFO(
-       "Logging to exchange '~s' in vhost '~s' disabled",
+       "Logging to exchange '~s' in vhost '~ts' disabled",
        [Name, VHost],
        #{domain => ?RMQLOG_DOMAIN_GLOBAL}).

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -991,7 +991,7 @@ terminate(_Reason, State = #msstate { index_state         = IndexState,
                                       flying_ets          = FlyingEts,
                                       clients             = Clients,
                                       dir                 = Dir }) ->
-    rabbit_log:info("Stopping message store for directory '~s'", [Dir]),
+    rabbit_log:info("Stopping message store for directory '~ts'", [Dir]),
     %% stop the gc first, otherwise it could be working and we pull
     %% out the ets tables from under it.
     ok = rabbit_msg_store_gc:stop(GCPid),
@@ -1006,7 +1006,7 @@ terminate(_Reason, State = #msstate { index_state         = IndexState,
         ok           -> ok;
         {error, FSErr} ->
             rabbit_log:error("Unable to store file summary"
-                             " for vhost message store for directory ~p~n"
+                             " for vhost message store for directory ~tp~n"
                              "Error: ~p",
                              [Dir, FSErr])
     end,
@@ -1016,11 +1016,11 @@ terminate(_Reason, State = #msstate { index_state         = IndexState,
     case store_recovery_terms([{client_refs, maps:keys(Clients)},
                                {index_module, IndexModule}], Dir) of
         ok           ->
-            rabbit_log:info("Message store for directory '~s' is stopped", [Dir]),
+            rabbit_log:info("Message store for directory '~ts' is stopped", [Dir]),
             ok;
         {error, RTErr} ->
             rabbit_log:error("Unable to save message store recovery terms"
-                             " for directory ~p~nError: ~p",
+                             " for directory ~tp~nError: ~p",
                              [Dir, RTErr])
     end,
     State3 #msstate { index_state         = undefined,
@@ -1773,7 +1773,7 @@ build_index(false, {MsgRefDeltaGen, MsgRefDeltaGenInit},
 build_index_worker(Gatherer, State = #msstate { dir = Dir },
                    Left, File, Files) ->
     FileName = filenum_to_name(File),
-    rabbit_log:debug("Rebuilding message location index from ~p (~B file(s) remaining)",
+    rabbit_log:debug("Rebuilding message location index from ~ts (~B file(s) remaining)",
                      [form_filename(Dir, FileName), length(Files)]),
     {ok, Messages, FileSize} =
         scan_file_for_valid_messages(Dir, FileName),

--- a/deps/rabbit/src/rabbit_prelaunch_logging.erl
+++ b/deps/rabbit/src/rabbit_prelaunch_logging.erl
@@ -521,7 +521,7 @@ configure_logger(Context) ->
     %% IDs are assigned to handlers.
     Handlers = create_logger_handlers_conf(LogConfig4),
     ?LOG_DEBUG(
-       "Logging: logger handlers:~n  ~p", [Handlers],
+       "Logging: logger handlers:~n  ~tp", [Handlers],
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
 
     %% We can now install the new handlers. The function takes care of

--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -697,7 +697,7 @@ init_dirty(CleanShutdown, ContainsCheckFun, State, Context) ->
                 %% the process of converting from v2 to v1.
                 [_|_] ->
                     #resource{virtual_host = VHost, name = QName} = State2#qistate.queue_name,
-                    rabbit_log:info("Queue ~s in vhost ~s recovered ~b total messages before resuming convert",
+                    rabbit_log:info("Queue ~s in vhost ~ts recovered ~b total messages before resuming convert",
                                     [QName, VHost, Count]),
                     CountersRef = counters:new(?RECOVER_COUNTER_SIZE, []),
                     State3 = recover_index_v2_dirty(State2, ContainsCheckFun, CountersRef),
@@ -715,14 +715,14 @@ recover_index_v2_dirty(State0 = #qistate { queue_name = Name,
                                            on_sync_msg = OnSyncMsgFun },
                        ContainsCheckFun, CountersRef) ->
     #resource{virtual_host = VHost, name = QName} = Name,
-    rabbit_log:info("Converting queue ~s in vhost ~s from v2 to v1 after unclean shutdown", [QName, VHost]),
+    rabbit_log:info("Converting queue ~s in vhost ~ts from v2 to v1 after unclean shutdown", [QName, VHost]),
     %% We cannot use the counts/bytes because some messages may be in both
     %% the v1 and v2 indexes after a crash.
     {_, _, V2State} = rabbit_classic_queue_index_v2:recover(Name, non_clean_shutdown, true,
                                                             ContainsCheckFun, OnSyncFun, OnSyncMsgFun,
                                                             convert),
     State = recover_index_v2_common(State0, V2State, CountersRef),
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b total messages from v2 to v1",
+    rabbit_log:info("Queue ~s in vhost ~ts converted ~b total messages from v2 to v1",
                     [QName, VHost, counters:get(CountersRef, ?RECOVER_COUNT)]),
     State.
 

--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -44,25 +44,25 @@ all_ra_systems() ->
 ensure_ra_system_started(RaSystem) ->
     RaSystemConfig = get_config(RaSystem),
     ?LOG_DEBUG(
-       "Starting Ra system called \"~s\" with configuration:~n~p",
+       "Starting Ra system called \"~ts\" with configuration:~n~tp",
        [RaSystem, RaSystemConfig],
        #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
     case ra_system:start(RaSystemConfig) of
         {ok, _} ->
             ?LOG_DEBUG(
-               "Ra system \"~s\" ready",
+               "Ra system \"~ts\" ready",
                [RaSystem],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
             ok;
         {error, {already_started, _}} ->
             ?LOG_DEBUG(
-               "Ra system \"~s\" ready",
+               "Ra system \"~ts\" ready",
                [RaSystem],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
             ok;
         Error ->
             ?LOG_ERROR(
-               "Failed to start Ra system \"~s\": ~p",
+               "Failed to start Ra system \"~ts\": ~tp",
                [RaSystem, Error],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
             throw(Error)

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -357,11 +357,11 @@ start_connection(Parent, HelperSup, Deb, Sock) ->
             %% connection was closed cleanly by the client
             #v1{connection = #connection{user  = #user{username = Username},
                                          vhost = VHost}} ->
-                rabbit_log_connection:info("closing AMQP connection ~p (~s, vhost: '~s', user: '~s')",
+                rabbit_log_connection:info("closing AMQP connection ~p (~ts, vhost: '~ts', user: '~ts')",
                     [self(), dynamic_connection_name(Name), VHost, Username]);
             %% just to be more defensive
             _ ->
-                rabbit_log_connection:info("closing AMQP connection ~p (~s)",
+                rabbit_log_connection:info("closing AMQP connection ~p (~ts)",
                     [self(), dynamic_connection_name(Name)])
             end
     catch
@@ -417,7 +417,7 @@ log_connection_exception(Severity, Name, {connection_closed_abruptly,
                                           #v1{connection = #connection{user  = #user{username = Username},
                                                                        vhost = VHost}}}) ->
     log_connection_exception_with_severity(Severity,
-        "closing AMQP connection ~p (~s, vhost: '~s', user: '~s'):~nclient unexpectedly closed TCP connection",
+        "closing AMQP connection ~p (~ts, vhost: '~ts', user: '~ts'):~nclient unexpectedly closed TCP connection",
         [self(), Name, VHost, Username]);
 %% when client abruptly closes connection before connection.open/authentication/authorization
 %% succeeded, don't log username and vhost as 'none'
@@ -746,8 +746,8 @@ wait_for_channel_termination(N, TimerRef,
                     wait_for_channel_termination(N-1, TimerRef, State1);
                 {_, uncontrolled} ->
                     rabbit_log_connection:error(
-                        "Error on AMQP connection ~p (~s, vhost: '~s',"
-                        " user: '~s', state: ~p), channel ~p:"
+                        "Error on AMQP connection ~p (~ts, vhost: '~ts',"
+                        " user: '~ts', state: ~tp), channel ~p:"
                         "error while terminating:~n~p",
                         [self(), ConnName, VHost, User#user.username,
                          CS, Channel, Reason]),
@@ -788,8 +788,8 @@ log_hard_error(#v1{connection_state = CS,
                                    user  = User,
                                    vhost = VHost}}, Channel, Reason) ->
     rabbit_log_connection:error(
-        "Error on AMQP connection ~p (~s, vhost: '~s',"
-        " user: '~s', state: ~p), channel ~p:~n ~s",
+        "Error on AMQP connection ~p (~s, vhost: '~ts',"
+        " user: '~ts', state: ~tp), channel ~tp:~n ~ts",
         [self(), ConnName, VHost, User#user.username, CS, Channel, format_hard_error(Reason)]).
 
 handle_exception(State = #v1{connection_state = closed}, Channel, Reason) ->
@@ -1248,7 +1248,7 @@ handle_method0(#'connection.open'{virtual_host = VHost},
     maybe_emit_stats(State1),
     rabbit_log_connection:info(
         "connection ~p (~s): "
-        "user '~s' authenticated and granted access to vhost '~s'",
+        "user '~s' authenticated and granted access to vhost '~ts'",
         [self(), dynamic_connection_name(ConnName), Username, VHost]),
     State1;
 handle_method0(#'connection.close'{}, State) when ?IS_RUNNING(State) ->
@@ -1315,8 +1315,8 @@ is_vhost_alive(VHostPath, User) ->
         true  -> ok;
         false ->
             rabbit_misc:protocol_error(internal_error,
-                            "access to vhost '~s' refused for user '~s': "
-                            "vhost '~s' is down",
+                            "access to vhost '~ts' refused for user '~s': "
+                            "vhost '~ts' is down",
                             [VHostPath, User#user.username, VHostPath])
     end.
 
@@ -1324,12 +1324,12 @@ is_over_vhost_connection_limit(VHostPath, User) ->
     try rabbit_vhost_limit:is_over_connection_limit(VHostPath) of
         false         -> ok;
         {true, Limit} -> rabbit_misc:protocol_error(not_allowed,
-                            "access to vhost '~s' refused for user '~s': "
+                            "access to vhost '~ts' refused for user '~s': "
                             "connection limit (~p) is reached",
                             [VHostPath, User#user.username, Limit])
     catch
         throw:{error, {no_such_vhost, VHostPath}} ->
-            rabbit_misc:protocol_error(not_allowed, "vhost ~s not found", [VHostPath])
+            rabbit_misc:protocol_error(not_allowed, "vhost ~ts not found", [VHostPath])
     end.
 
 is_over_user_connection_limit(#user{username = Username}) ->

--- a/deps/rabbit/src/rabbit_recovery_terms.erl
+++ b/deps/rabbit/src/rabbit_recovery_terms.erl
@@ -44,7 +44,7 @@ start(VHost) ->
         %% we can get here if a vhost is added and removed concurrently
         %% e.g. some integration tests do it
         {error, {no_such_vhost, VHost}} ->
-            rabbit_log:error("Failed to start a recovery terms manager for vhost ~s: vhost no longer exists!",
+            rabbit_log:error("Failed to start a recovery terms manager for vhost ~ts: vhost no longer exists!",
                              [VHost])
     end,
     ok.
@@ -60,7 +60,7 @@ stop(VHost) ->
             end;
         %% see start/1
         {error, {no_such_vhost, VHost}} ->
-            rabbit_log:error("Failed to stop a recovery terms manager for vhost ~s: vhost no longer exists!",
+            rabbit_log:error("Failed to stop a recovery terms manager for vhost ~ts: vhost no longer exists!",
                              [VHost]),
 
             ok
@@ -86,7 +86,7 @@ clear(VHost) ->
         dets:delete_all_objects(VHost)
     %% see start/1
     catch _:badarg ->
-            rabbit_log:error("Failed to clear recovery terms for vhost ~s: table no longer exists!",
+            rabbit_log:error("Failed to clear recovery terms for vhost ~ts: table no longer exists!",
                              [VHost]),
             ok
     end,
@@ -221,7 +221,7 @@ flush(VHost) ->
         dets:sync(VHost)
     %% see clear/1
     catch _:badarg ->
-            rabbit_log:error("Failed to sync recovery terms table for vhost ~s: the table no longer exists!",
+            rabbit_log:error("Failed to sync recovery terms table for vhost ~ts: the table no longer exists!",
                              [VHost]),
             ok
     end.
@@ -234,7 +234,7 @@ close_table(VHost) ->
         ok = dets:close(VHost)
     %% see clear/1
     catch _:badarg ->
-            rabbit_log:error("Failed to close recovery terms table for vhost ~s: the table no longer exists!",
+            rabbit_log:error("Failed to close recovery terms table for vhost ~ts: the table no longer exists!",
                              [VHost]),
             ok
     end.

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -100,7 +100,7 @@ parse_set_global(Name, String, ActingUser) ->
 
 set_global(Name, Term, ActingUser)  ->
     NameAsAtom = rabbit_data_coercion:to_atom(Name),
-    rabbit_log:debug("Setting global parameter '~s' to ~p", [NameAsAtom, Term]),
+    rabbit_log:debug("Setting global parameter '~ts' to ~tp", [NameAsAtom, Term]),
     mnesia_update(NameAsAtom, Term),
     event_notify(parameter_set, none, global, [{name,  NameAsAtom},
                                                {value, Term},
@@ -121,8 +121,8 @@ set_any(VHost, Component, Name, Term, User) ->
     end.
 
 set_any0(VHost, Component, Name, Term, User) ->
-    rabbit_log:debug("Asked to set or update runtime parameter '~s' in vhost '~s' "
-                     "for component '~s', value: ~p",
+    rabbit_log:debug("Asked to set or update runtime parameter '~ts' in vhost '~ts' "
+                     "for component '~ts', value: ~tp",
                      [Name, VHost, Component, Term]),
     case lookup_component(Component) of
         {ok, Mod} ->
@@ -418,7 +418,7 @@ lookup_component(Component) ->
     case rabbit_registry:lookup_module(
            runtime_parameter, rabbit_data_coercion:to_atom(Component)) of
         {error, not_found} -> {errors,
-                               [{"component ~s not found", [Component]}]};
+                               [{"component ~ts not found", [Component]}]};
         {ok, Module}       -> {ok, Module}
     end.
 

--- a/deps/rabbit/src/rabbit_trace.erl
+++ b/deps/rabbit/src/rabbit_trace.erl
@@ -76,10 +76,10 @@ tap_out({#resource{name = QName, virtual_host = VHost},
 start(VHost) ->
     case lists:member(VHost, vhosts_with_tracing_enabled()) of
         true  ->
-            rabbit_log:info("Tracing is already enabled for vhost '~s'", [VHost]),
+            rabbit_log:info("Tracing is already enabled for vhost '~ts'", [VHost]),
             ok;
         false ->
-            rabbit_log:info("Enabling tracing for vhost '~s'", [VHost]),
+            rabbit_log:info("Enabling tracing for vhost '~ts'", [VHost]),
             update_config(fun (VHosts) ->
                             lists:usort([VHost | VHosts])
                           end)
@@ -90,10 +90,10 @@ start(VHost) ->
 stop(VHost) ->
     case lists:member(VHost, vhosts_with_tracing_enabled()) of
         true  ->
-            rabbit_log:info("Disabling tracing for vhost '~s'", [VHost]),
+            rabbit_log:info("Disabling tracing for vhost '~ts'", [VHost]),
             update_config(fun (VHosts) -> VHosts -- [VHost] end);
         false ->
-            rabbit_log:info("Tracing is already disabled for vhost '~s'", [VHost]),
+            rabbit_log:info("Tracing is already disabled for vhost '~ts'", [VHost]),
             ok
     end.
 

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -522,7 +522,7 @@ stop(VHost) ->
     ok = rabbit_classic_queue_index_v2:stop(VHost).
 
 start_msg_store(VHost, Refs, StartFunState) when is_list(Refs); Refs == undefined ->
-    rabbit_log:info("Starting message stores for vhost '~s'", [VHost]),
+    rabbit_log:info("Starting message stores for vhost '~ts'", [VHost]),
     do_start_msg_store(VHost, ?TRANSIENT_MSG_STORE, undefined, ?EMPTY_START_FUN_STATE),
     do_start_msg_store(VHost, ?PERSISTENT_MSG_STORE, Refs, StartFunState),
     ok.
@@ -530,13 +530,13 @@ start_msg_store(VHost, Refs, StartFunState) when is_list(Refs); Refs == undefine
 do_start_msg_store(VHost, Type, Refs, StartFunState) ->
     case rabbit_vhost_msg_store:start(VHost, Type, Refs, StartFunState) of
         {ok, _} ->
-            rabbit_log:info("Started message store of type ~s for vhost '~s'", [abbreviated_type(Type), VHost]);
+            rabbit_log:info("Started message store of type ~s for vhost '~ts'", [abbreviated_type(Type), VHost]);
         {error, {no_such_vhost, VHost}} = Err ->
-            rabbit_log:error("Failed to start message store of type ~s for vhost '~s': the vhost no longer exists!",
+            rabbit_log:error("Failed to start message store of type ~s for vhost '~ts': the vhost no longer exists!",
                              [Type, VHost]),
             exit(Err);
         {error, Error} ->
-            rabbit_log:error("Failed to start message store of type ~s for vhost '~s': ~p",
+            rabbit_log:error("Failed to start message store of type ~s for vhost '~ts': ~p",
                              [Type, VHost, Error]),
             exit({error, Error})
     end.
@@ -1150,7 +1150,7 @@ convert_from_v1_to_v2(State0 = #vqstate{ index_mod   = rabbit_queue_index,
                                          store_state = V2Store0 }) ->
     {QueueName, MsgIdxOnDiskFun, MsgAndIdxOnDiskFun} = rabbit_queue_index:init_args(V1Index),
     #resource{virtual_host = VHost, name = QName} = QueueName,
-    rabbit_log:info("Converting running queue ~s in vhost ~s from v1 to v2", [QName, VHost]),
+    rabbit_log:info("Converting running queue ~ts in vhost ~ts from v1 to v2", [QName, VHost]),
     State = convert_from_v1_to_v2_in_memory(State0),
     V2Index0 = rabbit_classic_queue_index_v2:init_for_conversion(QueueName, MsgIdxOnDiskFun, MsgAndIdxOnDiskFun),
     %% We do not need to init the v2 per-queue store because we already did so in the queue init.
@@ -1163,7 +1163,7 @@ convert_from_v1_to_v2(State0 = #vqstate{ index_mod   = rabbit_queue_index,
                                                     fun (_, FunState) -> {write, FunState} end),
     %% We have already deleted segments files but not the journal.
     rabbit_queue_index:delete_journal(V1Index),
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b total messages from v1 to v2",
+    rabbit_log:info("Queue ~ts in vhost ~ts converted ~b total messages from v1 to v2",
                     [QName, VHost, counters:get(CountersRef, ?CONVERT_COUNT)]),
     State#vqstate{ index_mod   = rabbit_classic_queue_index_v2,
                    index_state = V2Index,
@@ -1273,7 +1273,7 @@ convert_from_v1_to_v2_loop(QueueName, V1Index0, V2Index0, V2Store0,
     %% Log some progress to keep the user aware of what's going on, as moving
     %% embedded messages can take quite some time.
     #resource{virtual_host = VHost, name = Name} = QueueName,
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b messages from v1 to v2",
+    rabbit_log:info("Queue ~ts in vhost ~ts converted ~b messages from v1 to v2",
                     [Name, VHost, length(Messages)]),
     convert_from_v1_to_v2_loop(QueueName, V1Index, V2Index, V2Store, Counters, UpSeqId, HiSeqId, SkipFun).
 
@@ -1284,7 +1284,7 @@ convert_from_v2_to_v1(State0 = #vqstate{ index_mod   = rabbit_classic_queue_inde
                                          index_state = V2Index }) ->
     {QueueName, MsgIdxOnDiskFun, MsgAndIdxOnDiskFun} = rabbit_classic_queue_index_v2:init_args(V2Index),
     #resource{virtual_host = VHost, name = QName} = QueueName,
-    rabbit_log:info("Converting running queue ~s in vhost ~s from v2 to v1", [QName, VHost]),
+    rabbit_log:info("Converting running queue ~ts in vhost ~ts from v2 to v1", [QName, VHost]),
     State = convert_from_v2_to_v1_in_memory(State0),
     %% We may have read from the per-queue store state and opened FDs.
     #vqstate{ store_state = V2Store0 } = State,
@@ -1296,7 +1296,7 @@ convert_from_v2_to_v1(State0 = #vqstate{ index_mod   = rabbit_classic_queue_inde
                                                     LoSeqId, HiSeqId,
                                                     %% Write all messages.
                                                     fun (_, FunState) -> {write, FunState} end),
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b total messages from v2 to v1",
+    rabbit_log:info("Queue ~ts in vhost ~ts converted ~b total messages from v2 to v1",
                     [QName, VHost, counters:get(CountersRef, ?CONVERT_COUNT)]),
     %% We have already closed the v2 index/store FDs when deleting the files.
     State#vqstate{ index_mod   = rabbit_queue_index,
@@ -1441,7 +1441,7 @@ convert_from_v2_to_v1_loop(QueueName, V1Index0, V2Index0, V2Store0,
     %% Log some progress to keep the user aware of what's going on, as moving
     %% embedded messages can take quite some time.
     #resource{virtual_host = VHost, name = Name} = QueueName,
-    rabbit_log:info("Queue ~s in vhost ~s converted ~b messages from v2 to v1",
+    rabbit_log:info("Queue ~ts in vhost ~ts converted ~b messages from v2 to v1",
                     [Name, VHost, length(Messages)]),
     convert_from_v2_to_v1_loop(QueueName, V1Index, V2Index, V2Store, Counters, UpSeqId, HiSeqId, SkipFun).
 
@@ -3451,7 +3451,7 @@ migrate_queue({QueueName = #resource{virtual_host = VHost, name = Name},
                RecoveryTerm},
               OldStore, NewStore) ->
     log_upgrade_verbose(
-        "Migrating messages in queue ~s in vhost ~s to per-vhost message store",
+        "Migrating messages in queue ~ts in vhost ~ts to per-vhost message store",
         [Name, VHost]),
     OldStoreClient = get_global_store_client(OldStore),
     NewStoreClient = get_per_vhost_store_client(QueueName, NewStore),
@@ -3479,7 +3479,7 @@ migrate_queue({QueueName = #resource{virtual_host = VHost, name = Name},
                                                {persistent_ref, NewClientRef}),
             rabbit_queue_index:update_recovery_term(QueueName, NewRecoveryTerm)
     end,
-    log_upgrade_verbose("Finished migrating queue ~s in vhost ~s", [Name, VHost]),
+    log_upgrade_verbose("Finished migrating queue ~ts in vhost ~ts", [Name, VHost]),
     {QueueName, NewClientRef}.
 
 migrate_message(MsgId, OldC, NewC) ->

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -52,7 +52,7 @@ recover() ->
 
 recover(VHost) ->
     VHostDir = msg_store_dir_path(VHost),
-    rabbit_log:info("Making sure data directory '~ts' for vhost '~s' exists",
+    rabbit_log:info("Making sure data directory '~ts' for vhost '~ts' exists",
                     [VHostDir, VHost]),
     VHostStubFile = filename:join(VHostDir, ".vhost"),
     ok = rabbit_file:ensure_dir(VHostStubFile),
@@ -64,7 +64,7 @@ recover(VHost) ->
     {Time, ok} = timer:tc(fun() ->
                                   rabbit_binding:recover(rabbit_exchange:recover(VHost), QNames)
                           end),
-    rabbit_log:debug("rabbit_binding:recover/2 for vhost ~s completed in ~fs", [VHost, Time/1000000]),
+    rabbit_log:debug("rabbit_binding:recover/2 for vhost ~ts completed in ~fs", [VHost, Time/1000000]),
 
     ok = rabbit_amqqueue:start(Recovered),
     %% Start queue mirrors.
@@ -95,7 +95,7 @@ ensure_config_file(VHost) ->
                 _ ->
                     ?LEGACY_INDEX_SEGMENT_ENTRY_COUNT
             end,
-            rabbit_log:info("Setting segment_entry_count for vhost '~s' with ~b queues to '~b'",
+            rabbit_log:info("Setting segment_entry_count for vhost '~ts' with ~b queues to '~b'",
                             [VHost, length(QueueDirs), SegmentEntryCount]),
             file:write_file(Path, io_lib:format(
                 "%% This file is auto-generated! Edit at your own risk!~n"
@@ -124,8 +124,8 @@ parse_tags(<<"">>) ->
 parse_tags([]) ->
     [];
 parse_tags(Val) when is_binary(Val) ->
-    SVal = rabbit_data_coercion:to_list(Val),
-    [trim_tag(Tag) || Tag <- re:split(SVal, ",", [{return, list}])];
+    ValUnicode = rabbit_data_coercion:to_unicode_charlist(Val),
+    [trim_tag(Tag) || Tag <- re:split(ValUnicode, ",", [unicode, {return, list}])];
 parse_tags(Val) when is_list(Val) ->
     case hd(Val) of
       Bin when is_binary(Bin) ->
@@ -136,7 +136,8 @@ parse_tags(Val) when is_list(Val) ->
         [trim_tag(Tag) || Tag <- Val];
       Int when is_integer(Int) ->
         %% this is a string/charlist
-        [trim_tag(Tag) || Tag <- re:split(Val, ",", [{return, list}])]
+        ValUnicode = rabbit_data_coercion:to_unicode_charlist(Val),
+        [trim_tag(Tag) || Tag <- re:split(ValUnicode, ",", [unicode, {return, list}])]
     end.
 
 -spec add(vhost:name(), rabbit_types:username()) ->
@@ -186,9 +187,9 @@ do_add(Name, Metadata, ActingUser) ->
 
     case Description of
         undefined ->
-            rabbit_log:info("Adding vhost '~s' without a description", [Name]);
+            rabbit_log:info("Adding vhost '~ts' without a description", [Name]);
         Description ->
-            rabbit_log:info("Adding vhost '~s' (description: '~s', tags: ~p)",
+            rabbit_log:info("Adding vhost '~ts' (description: '~ts', tags: ~tp)",
                             [Name, Description, Tags])
     end,
     VHost = rabbit_misc:execute_mnesia_transaction(
@@ -196,7 +197,7 @@ do_add(Name, Metadata, ActingUser) ->
                   case mnesia:wread({rabbit_vhost, Name}) of
                       [] ->
                         Row = vhost:new(Name, [], Metadata),
-                        rabbit_log:debug("Inserting a virtual host record ~p", [Row]),
+                        rabbit_log:debug("Inserting a virtual host record ~tp", [Row]),
                         ok = mnesia:write(rabbit_vhost, Row, write),
                         Row;
                       %% the vhost already exists
@@ -209,7 +210,7 @@ do_add(Name, Metadata, ActingUser) ->
               (VHost1, false) ->
                   [begin
                     Resource = rabbit_misc:r(Name, exchange, ExchangeName),
-                    rabbit_log:debug("Will declare an exchange ~p", [Resource]),
+                    rabbit_log:debug("Will declare an exchange ~tp", [Resource]),
                     _ = rabbit_exchange:declare(Resource, Type, true, false, Internal, [], ActingUser)
                   end || {ExchangeName, Type, Internal} <-
                           [{<<"">>,                   direct,  false},
@@ -231,7 +232,7 @@ do_add(Name, Metadata, ActingUser) ->
                                     {tags, Tags}]),
             ok;
         {error, Reason} ->
-            Msg = rabbit_misc:format("failed to set up vhost '~s': ~p",
+            Msg = rabbit_misc:format("failed to set up vhost '~ts': ~tp",
                                      [Name, Reason]),
             {error, Msg}
     end.
@@ -245,7 +246,7 @@ update(Name, Description, Tags, ActingUser) ->
                           {error, {no_such_vhost, Name}};
                       [VHost0] ->
                           VHost = vhost:merge_metadata(VHost0, #{description => Description, tags => Tags}),
-                          rabbit_log:debug("Updating a virtual host record ~p", [VHost]),
+                          rabbit_log:debug("Updating a virtual host record ~tp", [VHost]),
                           ok = mnesia:write(rabbit_vhost, VHost, write),
                           rabbit_event:notify(vhost_updated, info(VHost)
                                 ++ [{user_who_performed_action, ActingUser},
@@ -264,7 +265,7 @@ delete(VHost, ActingUser) ->
     %% process, which in turn results in further mnesia actions and
     %% eventually the termination of that process. Exchange deletion causes
     %% notifications which must be sent outside the TX
-    rabbit_log:info("Deleting vhost '~s'", [VHost]),
+    rabbit_log:info("Deleting vhost '~ts'", [VHost]),
     %% Clear the permissions first to prohibit new incoming connections when deleting a vhost
     rabbit_misc:execute_mnesia_transaction(
           with(VHost, fun () -> clear_permissions(VHost, ActingUser) end)),
@@ -300,7 +301,7 @@ put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
       Other       -> Other
     end,
     ParsedTags = parse_tags(Tags),
-    rabbit_log:debug("Parsed tags ~p to ~p", [Tags, ParsedTags]),
+    rabbit_log:debug("Parsed tags ~tp to ~tp", [Tags, ParsedTags]),
     Result = case exists(Name) of
                  true  ->
                      update(Name, Description, ParsedTags, Username);
@@ -397,16 +398,16 @@ vhost_down(VHost) ->
 
 delete_storage(VHost) ->
     VhostDir = msg_store_dir_path(VHost),
-    rabbit_log:info("Deleting message store directory for vhost '~s' at '~s'", [VHost, VhostDir]),
+    rabbit_log:info("Deleting message store directory for vhost '~ts' at '~ts'", [VHost, VhostDir]),
     %% Message store should be closed when vhost supervisor is closed.
     case rabbit_file:recursive_delete([VhostDir]) of
         ok                   -> ok;
         {error, {_, enoent}} ->
             %% a concurrent delete did the job for us
-            rabbit_log:warning("Tried to delete storage directories for vhost '~s', it failed with an ENOENT", [VHost]),
+            rabbit_log:warning("Tried to delete storage directories for vhost '~ts', it failed with an ENOENT", [VHost]),
             ok;
         Other                ->
-            rabbit_log:warning("Tried to delete storage directories for vhost '~s': ~p", [VHost, Other]),
+            rabbit_log:warning("Tried to delete storage directories for vhost '~ts': ~tp", [VHost, Other]),
             Other
     end.
 
@@ -523,20 +524,20 @@ update_tags(VHostName, Tags, ActingUser) ->
         R = rabbit_misc:execute_mnesia_transaction(fun() ->
             update_tags(VHostName, ConvertedTags)
         end),
-        rabbit_log:info("Successfully set tags for virtual host '~s' to ~p", [VHostName, ConvertedTags]),
+        rabbit_log:info("Successfully set tags for virtual host '~ts' to ~tp", [VHostName, ConvertedTags]),
         rabbit_event:notify(vhost_tags_set, [{name, VHostName},
                                              {tags, ConvertedTags},
                                              {user_who_performed_action, ActingUser}]),
         R
     catch
         throw:{error, {no_such_vhost, _}} = Error ->
-            rabbit_log:warning("Failed to set tags for virtual host '~s': the virtual host does not exist", [VHostName]),
+            rabbit_log:warning("Failed to set tags for virtual host '~ts': the virtual host does not exist", [VHostName]),
             throw(Error);
         throw:Error ->
-            rabbit_log:warning("Failed to set tags for virtual host '~s': ~p", [VHostName, Error]),
+            rabbit_log:warning("Failed to set tags for virtual host '~ts': ~tp", [VHostName, Error]),
             throw(Error);
         exit:Error ->
-            rabbit_log:warning("Failed to set tags for virtual host '~s': ~p", [VHostName, Error]),
+            rabbit_log:warning("Failed to set tags for virtual host '~ts': ~tp", [VHostName, Error]),
             exit(Error)
     end.
 
@@ -587,8 +588,13 @@ config_file_path(VHost) ->
     filename:join(VHostDir, ".config").
 
 -spec trim_tag(list() | binary() | atom()) -> atom().
-trim_tag(Val) ->
-    rabbit_data_coercion:to_atom(string:trim(rabbit_data_coercion:to_list(Val))).
+trim_tag(Val) when is_atom(Val) ->
+    trim_tag(rabbit_data_coercion:to_binary(Val));
+trim_tag(Val) when is_list(Val) ->
+    trim_tag(rabbit_data_coercion:to_utf8_binary(Val));
+trim_tag(Val) when is_binary(Val) ->
+    ValTrimmed = string:trim(Val),
+    rabbit_data_coercion:to_atom(ValTrimmed).
 
 %%----------------------------------------------------------------------------
 
@@ -602,7 +608,7 @@ i(tags, VHost) -> vhost:get_tags(VHost);
 i(default_queue_type, VHost) -> vhost:get_default_queue_type(VHost);
 i(metadata, VHost) -> vhost:get_metadata(VHost);
 i(Item, VHost)     ->
-  rabbit_log:error("Don't know how to compute a virtual host info item '~s' for virtual host '~p'", [Item, VHost]),
+  rabbit_log:error("Don't know how to compute a virtual host info item '~ts' for virtual host '~tp'", [Item, VHost]),
   throw({bad_argument, Item}).
 
 -spec info(vhost:vhost() | vhost:name()) -> rabbit_types:infos().

--- a/deps/rabbit/src/rabbit_vhost_msg_store.erl
+++ b/deps/rabbit/src/rabbit_vhost_msg_store.erl
@@ -25,7 +25,7 @@ start(VHost, Type, ClientRefs, StartupFunState) when is_list(ClientRefs);
         %% we can get here if a vhost is added and removed concurrently
         %% e.g. some integration tests do it
         {error, {no_such_vhost, VHost}} = E ->
-            rabbit_log:error("Failed to start a message store for vhost ~s: vhost no longer exists!",
+            rabbit_log:error("Failed to start a message store for vhost ~ts: vhost no longer exists!",
                              [VHost]),
             E
     end.
@@ -37,7 +37,7 @@ stop(VHost, Type) ->
             ok = supervisor2:delete_child(VHostSup, Type);
         %% see start/4
         {error, {no_such_vhost, VHost}} ->
-            rabbit_log:error("Failed to stop a message store for vhost ~s: vhost no longer exists!",
+            rabbit_log:error("Failed to stop a message store for vhost ~ts: vhost no longer exists!",
                              [VHost]),
 
             ok

--- a/deps/rabbit/src/rabbit_vhost_process.erl
+++ b/deps/rabbit/src/rabbit_vhost_process.erl
@@ -37,7 +37,7 @@ start_link(VHost) ->
 
 init([VHost]) ->
     process_flag(trap_exit, true),
-    rabbit_log:debug("Recovering data for VHost ~p", [VHost]),
+    rabbit_log:debug("Recovering data for VHost ~ts", [VHost]),
     try
         %% Recover the vhost data and save it to vhost registry.
         ok = rabbit_vhost:recover(VHost),

--- a/deps/rabbit/src/rabbit_vhost_sup_sup.erl
+++ b/deps/rabbit/src/rabbit_vhost_sup_sup.erl
@@ -78,8 +78,8 @@ stop_and_delete_vhost(VHost) ->
             case is_process_alive(WrapperPid) of
                 false -> ok;
                 true  ->
-                    rabbit_log:info("Stopping vhost supervisor ~p"
-                                    " for vhost '~s'",
+                    rabbit_log:info("Stopping vhost supervisor ~tp"
+                                    " for vhost '~ts'",
                                     [VHostSupPid, VHost]),
                     case supervisor2:terminate_child(?MODULE, WrapperPid) of
                         ok ->
@@ -100,9 +100,9 @@ stop_and_delete_vhost(VHost, Node) ->
     case rabbit_misc:rpc_call(Node, rabbit_vhost_sup_sup, stop_and_delete_vhost, [VHost]) of
         ok -> ok;
         {badrpc, RpcErr} ->
-            rabbit_log:error("Failed to stop and delete a vhost ~p"
-                             " on node ~p."
-                             " Reason: ~p",
+            rabbit_log:error("Failed to stop and delete a vhost ~tp"
+                             " on node ~tp."
+                             " Reason: ~tp",
                              [VHost, Node, RpcErr]),
             {error, RpcErr}
     end.
@@ -113,7 +113,7 @@ init_vhost(VHost) ->
         {ok, _} -> ok;
         {error, {already_started, _}} ->
             rabbit_log:warning(
-                "Attempting to start an already started vhost '~s'.",
+                "Attempting to start an already started vhost '~ts'.",
                 [VHost]),
             ok;
         {error, {no_such_vhost, VHost}} ->
@@ -122,15 +122,15 @@ init_vhost(VHost) ->
             case vhost_restart_strategy() of
                 permanent ->
                     rabbit_log:error(
-                        "Unable to initialize vhost data store for vhost '~s'."
-                        " Reason: ~p",
+                        "Unable to initialize vhost data store for vhost '~ts'."
+                        " Reason: ~tp",
                         [VHost, Reason]),
                     throw({error, Reason});
                 transient ->
                     rabbit_log:warning(
-                        "Unable to initialize vhost data store for vhost '~s'."
+                        "Unable to initialize vhost data store for vhost '~ts'."
                         " The vhost will be stopped for this node. "
-                        " Reason: ~p",
+                        " Reason: ~tp",
                         [VHost, Reason]),
                     ok
             end

--- a/deps/rabbit_common/src/rabbit_data_coercion.erl
+++ b/deps/rabbit_common/src/rabbit_data_coercion.erl
@@ -9,6 +9,7 @@
 
 -export([to_binary/1, to_list/1, to_atom/1, to_integer/1, to_proplist/1, to_map/1]).
 -export([to_atom/2, atomize_keys/1, to_list_of_binaries/1]).
+-export([to_utf8_binary/1, to_unicode_charlist/1]).
 
 -spec to_binary(Val :: binary() | list() | atom() | integer()) -> binary().
 to_binary(Val) when is_list(Val)     -> list_to_binary(Val);
@@ -47,7 +48,6 @@ to_proplist(Val) when is_map(Val) -> maps:to_list(Val).
 to_map(Val) when is_map(Val) -> Val;
 to_map(Val) when is_list(Val) -> maps:from_list(Val).
 
-
 -spec atomize_keys(Val :: map() | list()) -> map() | list().
 atomize_keys(Val) when is_list(Val) ->
   [{to_atom(K), V} || {K, V} <- Val];
@@ -65,4 +65,32 @@ to_list_of_binaries(Value) ->
            [Bin];
       Other ->
            [to_binary(Other)]
+    end.
+
+-spec to_utf8_binary(Val) -> Result when
+      Val :: unicode:latin1_chardata() | unicode:chardata() | unicode:external_chardata(),
+      Result :: binary()
+              | {error, binary(), RestData}
+              | {incomplete, binary(), binary()},
+      RestData :: unicode:latin1_chardata() | unicode:chardata() | unicode:external_chardata().
+to_utf8_binary(Val) ->
+    case unicode:characters_to_binary(Val, utf8) of
+        {error, _, _} ->
+            unicode:characters_to_binary(Val, latin1);
+        UnicodeValue ->
+            UnicodeValue
+    end.
+
+-spec to_unicode_charlist(Data) -> Result when
+      Data :: unicode:latin1_chardata() | unicode:chardata() | unicode:external_chardata(),
+      Result :: list()
+              | {error, list(), RestData}
+              | {incomplete, list(), binary()},
+      RestData :: unicode:latin1_chardata() | unicode:chardata() | unicode:external_chardata().
+to_unicode_charlist(Val) ->
+    case unicode:characters_to_list(Val, utf8) of
+        {error, _, _} ->
+            unicode:characters_to_list(Val, latin1);
+        UnicodeValue ->
+            UnicodeValue
     end.

--- a/deps/rabbit_common/src/rabbit_env.erl
+++ b/deps/rabbit_common/src/rabbit_env.erl
@@ -260,7 +260,7 @@ log_process_env() ->
     ?LOG_DEBUG("Process environment:"),
     lists:foreach(
       fun({Var, Value}) ->
-              ?LOG_DEBUG("  - ~s = ~ts", [Var, Value])
+              ?LOG_DEBUG("  - ~ts = ~ts", [Var, Value])
       end, lists:sort(env_vars())).
 
 log_context(Context) ->
@@ -268,7 +268,7 @@ log_context(Context) ->
     lists:foreach(
       fun(Key) ->
               Value = maps:get(Key, Context),
-              ?LOG_DEBUG("  - ~s: ~p", [Key, Value])
+              ?LOG_DEBUG("  - ~ts: ~tp", [Key, Value])
       end,
       lists:sort(maps:keys(Context))).
 
@@ -278,7 +278,7 @@ context_to_app_env_vars(Context) ->
       #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     Fun = fun({App, Param, Value}) ->
                   ?LOG_DEBUG(
-                     "  - ~s:~s = ~p", [App, Param, Value],
+                     "  - ~ts:~ts = ~tp", [App, Param, Value],
                      #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                   ok = application:set_env(
                          App, Param, Value, [{persistent, true}])
@@ -444,18 +444,17 @@ make_path(BundleDir, [Bundle|Tail], Res) ->
             %% Second try with archive
             Ext = archive_extension(),
             Base = filename:basename(Bundle, Ext),
-            Ebin2 = filename:join([BundleDir, Base ++ Ext, Base, "ebin"]),
+            Ebin2 = normalize_path(BundleDir, Base ++ Ext, Base, "ebin"),
             Ebins =
                 case split_base(Base) of
                     {AppName,_} ->
-                        Ebin3 = filename:join([BundleDir, Base ++ Ext,
-                                               AppName, "ebin"]),
+                        Ebin3 = normalize_path(BundleDir, Base ++ Ext, AppName, "ebin"),
                         [Ebin3, Ebin2, Dir];
                     _ ->
                         [Ebin2, Dir]
                 end,
             case try_ebin_dirs(Ebins) of
-                {ok,FoundEbin} ->
+                {ok, FoundEbin} ->
                     make_path(BundleDir, Tail, [FoundEbin|Res]);
                 error ->
                     make_path(BundleDir, Tail, Res)
@@ -514,7 +513,10 @@ nodename_type(Context) ->
 
 nodename(#{nodename_type := NameType} = Context) ->
     LongHostname = net_adm:localhost(),
-    ShortHostname = re:replace(LongHostname, "\\..*$", "", [{return, list}]),
+    RE = "\\..*$",
+    Replacement = "",
+    Options = [unicode, {return, list}],
+    ShortHostname = re:replace(LongHostname, RE, Replacement, Options),
     case get_prefixed_env_var("RABBITMQ_NODENAME") of
         false when NameType =:= shortnames ->
             Nodename = rabbit_nodes_common:make({"rabbit", ShortHostname}),
@@ -563,11 +565,12 @@ split_nodename(#{nodename := Nodename} = Context) ->
 
 config_base_dir(#{os_type := {unix, _},
                   sys_prefix := SysPrefix} = Context) ->
-    Dir = filename:join([SysPrefix, "etc", "rabbitmq"]),
+    Dir = normalize_path(SysPrefix, "etc", "rabbitmq"),
     update_context(Context, config_base_dir, Dir);
 config_base_dir(#{os_type := {win32, _},
-                  rabbitmq_base := Dir} = Context) ->
-    update_context(Context, config_base_dir, Dir).
+                  rabbitmq_base := Dir0} = Context) ->
+    Dir1 = normalize_path(Dir0),
+    update_context(Context, config_base_dir, Dir1).
 
 main_config_file(Context) ->
     case get_prefixed_env_var("RABBITMQ_CONFIG_FILE") of
@@ -580,7 +583,7 @@ main_config_file(Context) ->
     end.
 
 get_default_main_config_file(#{config_base_dir := ConfigBaseDir}) ->
-    filename:join(ConfigBaseDir, "rabbitmq").
+    normalize_path(ConfigBaseDir, "rabbitmq").
 
 additional_config_files(Context) ->
     case get_prefixed_env_var("RABBITMQ_CONFIG_FILES") of
@@ -595,7 +598,7 @@ additional_config_files(Context) ->
     end.
 
 get_default_additional_config_files(#{config_base_dir := ConfigBaseDir}) ->
-    filename:join([ConfigBaseDir, "conf.d", "*.conf"]).
+    normalize_path(ConfigBaseDir, "conf.d", "*.conf").
 
 advanced_config_file(Context) ->
     case get_prefixed_env_var("RABBITMQ_ADVANCED_CONFIG_FILE") of
@@ -608,7 +611,7 @@ advanced_config_file(Context) ->
     end.
 
 get_default_advanced_config_file(#{config_base_dir := ConfigBaseDir}) ->
-    filename:join(ConfigBaseDir, "advanced.config").
+    normalize_path(ConfigBaseDir, "advanced.config").
 
 %% -------------------------------------------------------------------
 %%
@@ -699,11 +702,11 @@ log_base_dir(#{os_type := OSType} = Context) ->
     case {get_prefixed_env_var("RABBITMQ_LOG_BASE"), OSType} of
         {false, {unix, _}} ->
             #{sys_prefix := SysPrefix} = Context,
-            Dir = filename:join([SysPrefix, "var", "log", "rabbitmq"]),
+            Dir = normalize_path(SysPrefix, "var", "log", "rabbitmq"),
             update_context(Context, log_base_dir, Dir, default);
         {false, {win32, _}} ->
             #{rabbitmq_base := RabbitmqBase} = Context,
-            Dir = filename:join([RabbitmqBase, "log"]),
+            Dir = normalize_path(RabbitmqBase, "log"),
             update_context(Context, log_base_dir, Dir, default);
         {Value, _} ->
             Dir = normalize_path(Value),
@@ -714,8 +717,8 @@ main_log_file(#{nodename := Nodename,
                 log_base_dir := LogBaseDir} = Context) ->
     case get_prefixed_env_var("RABBITMQ_LOGS") of
         false ->
-            File= filename:join(LogBaseDir,
-                                atom_to_list(Nodename) ++ ".log"),
+            LogFileName = atom_to_list(Nodename) ++ ".log",
+            File= normalize_path(LogBaseDir, LogFileName),
             update_context(Context, main_log_file, File, default);
         "-"  = Value ->
             update_context(Context, main_log_file, Value, environment);
@@ -734,8 +737,8 @@ upgrade_log_file(#{nodename := Nodename,
                    log_base_dir := LogBaseDir} = Context) ->
     case get_prefixed_env_var("RABBITMQ_UPGRADE_LOG") of
         false ->
-            File = filename:join(LogBaseDir,
-                                 atom_to_list(Nodename) ++ "_upgrade.log"),
+            UpgradeLogFileName = atom_to_list(Nodename) ++ "_upgrade.log",
+            File = normalize_path(LogBaseDir, UpgradeLogFileName),
             update_context(Context, upgrade_log_file, File, default);
         Value ->
             File = normalize_path(Value),
@@ -833,7 +836,7 @@ get_default_mnesia_base_dir(#{data_dir := DataDir} = Context) ->
                    #{os_type := {unix, _}}  -> "mnesia";
                    #{os_type := {win32, _}} -> "db"
                end,
-    filename:join(DataDir, Basename).
+    normalize_path(DataDir, Basename).
 
 mnesia_dir(#{from_remote_node := Remote} = Context) ->
     case get_prefixed_env_var("RABBITMQ_MNESIA_DIR") of
@@ -874,12 +877,12 @@ get_default_mnesia_dir(#{os_type := {unix, _},
                          nodename := Nodename,
                          mnesia_base_dir := MnesiaBaseDir})
   when MnesiaBaseDir =/= undefined ->
-    filename:join(MnesiaBaseDir, atom_to_list(Nodename));
+    normalize_path(MnesiaBaseDir, atom_to_list(Nodename));
 get_default_mnesia_dir(#{os_type := {win32, _},
                          nodename := Nodename,
                          mnesia_base_dir := MnesiaBaseDir})
   when MnesiaBaseDir =/= undefined ->
-    filename:join(MnesiaBaseDir, atom_to_list(Nodename) ++ "-mnesia").
+    normalize_path(MnesiaBaseDir, atom_to_list(Nodename) ++ "-mnesia").
 
 %% -------------------------------------------------------------------
 %%
@@ -890,7 +893,7 @@ get_default_mnesia_dir(#{os_type := {win32, _},
 quorum_queue_dir(#{mnesia_dir := MnesiaDir} = Context) ->
     case get_prefixed_env_var("RABBITMQ_QUORUM_DIR") of
         false when MnesiaDir =/= undefined ->
-            Dir = filename:join(MnesiaDir, "quorum"),
+            Dir = normalize_path(MnesiaDir, "quorum"),
             update_context(Context, quorum_queue_dir, Dir, default);
         false when MnesiaDir =:= undefined ->
             update_context(Context, quorum_queue_dir, undefined, default);
@@ -908,7 +911,7 @@ quorum_queue_dir(#{mnesia_dir := MnesiaDir} = Context) ->
 stream_queue_dir(#{mnesia_dir := MnesiaDir} = Context) ->
     case get_prefixed_env_var("RABBITMQ_STREAM_DIR") of
         false when MnesiaDir =/= undefined ->
-            Dir = filename:join(MnesiaDir, "stream"),
+            Dir = normalize_path(MnesiaDir, "stream"),
             update_context(Context, stream_queue_dir, Dir, default);
         false when MnesiaDir =:= undefined ->
             update_context(Context, stream_queue_dir, undefined, default);
@@ -931,8 +934,8 @@ pid_file(#{mnesia_base_dir := MnesiaBaseDir,
            nodename := Nodename} = Context) ->
     case get_prefixed_env_var("RABBITMQ_PID_FILE") of
         false when MnesiaBaseDir =/= undefined ->
-            File = filename:join(MnesiaBaseDir,
-                                 atom_to_list(Nodename) ++ ".pid"),
+            PidFileName = atom_to_list(Nodename) ++ ".pid",
+            File = normalize_path(MnesiaBaseDir, PidFileName),
             update_context(Context, pid_file, File, default);
         false when MnesiaBaseDir =:= undefined ->
             update_context(Context, pid_file, undefined, default);
@@ -973,8 +976,8 @@ feature_flags_file_from_env(#{mnesia_base_dir := MnesiaBaseDir,
                               nodename := Nodename} = Context) ->
     case get_env_var("RABBITMQ_FEATURE_FLAGS_FILE") of
         false ->
-            File = filename:join(MnesiaBaseDir,
-                                 atom_to_list(Nodename) ++ "-feature_flags"),
+            FeatureFlagsFileName = atom_to_list(Nodename) ++ "-feature_flags",
+            File = normalize_path(MnesiaBaseDir, FeatureFlagsFileName),
             update_context(Context, feature_flags_file, File, default);
         Value ->
             File = normalize_path(Value),
@@ -1090,8 +1093,7 @@ get_default_plugins_path_from_env(#{os_type := OSType}) ->
     PluginsDir = rabbit_common_mod_location_to_plugins_dir(ThisModDir),
     case {OSType, PluginsDir} of
         {{unix, _}, "/usr/lib/rabbitmq/" ++ _} ->
-            UserPluginsDir = filename:join(
-                               ["/", "usr", "lib", "rabbitmq", "plugins"]),
+            UserPluginsDir = normalize_path("/", "usr", "lib", "rabbitmq", "plugins"),
             UserPluginsDir ++ ":" ++ PluginsDir;
         _ ->
             PluginsDir
@@ -1111,32 +1113,26 @@ get_default_plugins_path_from_node(Remote) ->
 rabbit_common_mod_location_to_plugins_dir(ModDir) ->
     case filename:basename(ModDir) of
         "ebin" ->
-            case filelib:is_dir(ModDir) of
+            case is_dir(ModDir) of
                 false ->
                     %% rabbit_common in the plugin's .ez archive.
-                    filename:dirname(
-                      filename:dirname(
-                        filename:dirname(ModDir)));
+                    filename:dirname(filename:dirname(filename:dirname(ModDir)));
                 true ->
                     %% rabbit_common in the plugin's directory.
-                    filename:dirname(
-                      filename:dirname(ModDir))
+                    filename:dirname(filename:dirname(ModDir))
             end;
         _ ->
             %% rabbit_common in the CLI escript.
-            filename:join(
-              filename:dirname(
-                filename:dirname(ModDir)),
-              "plugins")
+            PluginsBaseDir = filename:dirname(filename:dirname(ModDir)),
+            normalize_path(PluginsBaseDir, "plugins")
     end.
 
 plugins_expand_dir(#{mnesia_base_dir := MnesiaBaseDir,
                      nodename := Nodename} = Context) ->
     case get_prefixed_env_var("RABBITMQ_PLUGINS_EXPAND_DIR") of
         false when MnesiaBaseDir =/= undefined ->
-            Dir = filename:join(
-                    MnesiaBaseDir,
-                    atom_to_list(Nodename) ++ "-plugins-expand"),
+            PluginsExpandDirName = atom_to_list(Nodename) ++ "-plugins-expand",
+            Dir = normalize_path(MnesiaBaseDir, PluginsExpandDirName),
             update_context(Context, plugins_expand_dir, Dir, default);
         false when MnesiaBaseDir =:= undefined ->
             update_context(Context, plugins_expand_dir, undefined, default);
@@ -1169,7 +1165,7 @@ enabled_plugins_file_from_env(Context) ->
     end.
 
 get_default_enabled_plugins_file(#{config_base_dir := ConfigBaseDir}) ->
-    filename:join(ConfigBaseDir, "enabled_plugins").
+    normalize_path(ConfigBaseDir, "enabled_plugins").
 
 enabled_plugins_file_from_node(#{from_remote_node := Remote} = Context) ->
     Ret = query_remote(Remote,
@@ -1283,9 +1279,8 @@ sys_prefix(Context) ->
 rabbitmq_base(#{os_type := {win32, _}} = Context) ->
     case get_env_var("RABBITMQ_BASE") of
         false ->
-            AppData = normalize_path(get_env_var("APPDATA")),
-            Dir = filename:join(AppData, "RabbitMQ"),
-            update_context(Context, rabbitmq_base, Dir, default);
+            AppDataDir = normalize_path(get_env_var("APPDATA"), "RabbitMQ"),
+            update_context(Context, rabbitmq_base, AppDataDir, default);
         Value ->
             Dir = normalize_path(Value),
             update_context(Context, rabbitmq_base, Dir, environment)
@@ -1295,7 +1290,7 @@ rabbitmq_base(Context) ->
 
 data_dir(#{os_type := {unix, _},
            sys_prefix := SysPrefix} = Context) ->
-    Dir = filename:join([SysPrefix, "var", "lib", "rabbitmq"]),
+    Dir = normalize_path(SysPrefix, "var", "lib", "rabbitmq"),
     update_context(Context, data_dir, Dir);
 data_dir(#{os_type := {win32, _},
            rabbitmq_base := RabbitmqBase} = Context) ->
@@ -1437,10 +1432,10 @@ motd_file_from_env(Context) ->
 
 get_default_motd_file(#{os_type := {unix, _},
                         config_base_dir := ConfigBaseDir}) ->
-    filename:join(ConfigBaseDir, "motd");
+    normalize_path(ConfigBaseDir, "motd");
 get_default_motd_file(#{os_type := {win32, _},
                         config_base_dir := ConfigBaseDir}) ->
-    filename:join(ConfigBaseDir, "motd.txt").
+    normalize_path(ConfigBaseDir, "motd.txt").
 
 motd_file_from_node(#{from_remote_node := Remote} = Context) ->
     Ret = (catch query_remote(Remote, rabbit, motd_file, [])),
@@ -1518,8 +1513,7 @@ load_conf_env_file(#{os_type := {unix, _},
     {ConfEnvFile, Origin} =
     case get_prefixed_env_var("RABBITMQ_CONF_ENV_FILE") of
         false ->
-            File = filename:join(
-                     [SysPrefix, "etc", "rabbitmq", "rabbitmq-env.conf"]),
+            File = normalize_path(SysPrefix, "etc", "rabbitmq", "rabbitmq-env.conf"),
             {File, default};
         Value ->
             {normalize_path(Value), environment}
@@ -1553,7 +1547,7 @@ load_conf_env_file(#{os_type := {win32, _},
     {ConfEnvFile, Origin} =
     case get_prefixed_env_var("RABBITMQ_CONF_ENV_FILE") of
         false ->
-            File = filename:join([RabbitmqBase, "rabbitmq-env-conf.bat"]),
+            File = normalize_path(RabbitmqBase, "rabbitmq-env-conf.bat"),
             {File, default};
         Value ->
             {normalize_path(Value), environment}
@@ -1627,15 +1621,13 @@ do_load_conf_env_file(#{os_type := {unix, _}} = Context, Sh, ConfEnvFile) ->
 
     #{sys_prefix := SysPrefix,
       rabbitmq_home := RabbitmqHome} = Context,
-    MainConfigFile = re:replace(
-                       get_default_main_config_file(Context),
-                       "\\.(conf|config)$", "", [{return, list}]),
+    MainConfigFileNoExt = get_main_config_file_without_extension(Context),
 
     %% The variables below are those the `CONF_ENV_FILE` file can expect.
     Env = [
            {"SYS_PREFIX", SysPrefix},
            {"RABBITMQ_HOME", RabbitmqHome},
-           {"CONFIG_FILE", MainConfigFile},
+           {"CONFIG_FILE", MainConfigFileNoExt},
            {"ADVANCED_CONFIG_FILE", get_default_advanced_config_file(Context)},
            {"MNESIA_BASE", get_default_mnesia_base_dir(Context)},
            {"ENABLED_PLUGINS_FILE", get_default_enabled_plugins_file(Context)},
@@ -1644,18 +1636,18 @@ do_load_conf_env_file(#{os_type := {unix, _}} = Context, Sh, ConfEnvFile) ->
           ],
 
     Args = ["-ex", "-c", Script],
-    Opts = [{args, Args},
-            {env, Env},
-            binary,
-            use_stdio,
-            stderr_to_stdout,
-            exit_status],
+    Opts = [{args, Args}, {env, Env},
+            binary, use_stdio, stderr_to_stdout, exit_status],
     Port = erlang:open_port({spawn_executable, Sh}, Opts),
     collect_conf_env_file_output(Context, Port, Marker, <<>>);
-do_load_conf_env_file(#{os_type := {win32, _}} = Context, Cmd, ConfEnvFile) ->
+do_load_conf_env_file(#{os_type := {win32, _}} = Context, Cmd, ConfEnvFile0) ->
+    ConfEnvFile1 = string:trim(ConfEnvFile0, both, "\"'"),
+    ConfEnvFile2 = normalize_path(ConfEnvFile1),
+    ConfEnvFile3 = rabbit_data_coercion:to_utf8_binary(ConfEnvFile2),
+
     %% rabbitmq/rabbitmq-common#392
     ?LOG_DEBUG(
-       "Executing $RABBITMQ_CONF_ENV_FILE: ~ts", [ConfEnvFile],
+       "Executing $RABBITMQ_CONF_ENV_FILE: ~ts", [ConfEnvFile3],
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
 
     %% The script below executes the `CONF_ENV_FILE` file, then it shows a
@@ -1667,19 +1659,16 @@ do_load_conf_env_file(#{os_type := {win32, _}} = Context, Cmd, ConfEnvFile) ->
     %% Arguments are split into a list of strings to support a filename with
     %% whitespaces in the path.
     Marker = vars_list_marker(),
-    ConfEnvFileNoQuotes = string:trim(ConfEnvFile, both, "\"'"),
 
     #{rabbitmq_base := RabbitmqBase,
       rabbitmq_home := RabbitmqHome} = Context,
-    MainConfigFile = re:replace(
-                       get_default_main_config_file(Context),
-                       "\\.(conf|config)$", "", [{return, list}]),
+    MainConfigFileNoExt = get_main_config_file_without_extension(Context),
 
     %% The variables below are those the `CONF_ENV_FILE` file can expect.
     Env = [
            {"RABBITMQ_BASE", RabbitmqBase},
            {"RABBITMQ_HOME", RabbitmqHome},
-           {"CONFIG_FILE", MainConfigFile},
+           {"CONFIG_FILE", MainConfigFileNoExt},
            {"ADVANCED_CONFIG_FILE", get_default_advanced_config_file(Context)},
            {"MNESIA_BASE", get_default_mnesia_base_dir(Context)},
            {"ENABLED_PLUGINS_FILE", get_default_enabled_plugins_file(Context)},
@@ -1687,22 +1676,52 @@ do_load_conf_env_file(#{os_type := {win32, _}} = Context, Cmd, ConfEnvFile) ->
            {"CONF_ENV_FILE_PHASE", "rabbtimq-prelaunch"}
           ],
 
-    Args = ["/Q", "/C", ConfEnvFileNoQuotes, "&&", "echo", Marker, "&&", "set"],
-    Opts = [{args, Args},
-            {env, Env},
-            hide,
-            binary,
-            stderr_to_stdout,
-            exit_status],
-    Port = erlang:open_port({spawn_executable, Cmd}, Opts),
-    collect_conf_env_file_output(Context, Port, "\"" ++ Marker ++ "\" ", <<>>).
+    TempBatchFileContent = [<<"@echo off\r\n">>,
+                            <<"chcp 65001 >nul\r\n">>,
+                            <<"call \"">>, ConfEnvFile3, <<"\" && echo ">>, Marker, <<" && set\r\n">>],
+    TempPath = get_temp_path_win32(),
+    TempBatchFileName = rabbit_misc:format("rabbitmq-env-conf-runner-~s.bat", [os:getpid()]),
+    TempBatchFilePath = normalize_path(TempPath, TempBatchFileName),
+    ok = file:write_file(TempBatchFilePath, TempBatchFileContent),
+    try
+        Args = ["/Q", "/C", TempBatchFilePath],
+        Opts = [{args, Args}, {env, Env},
+                hide, binary, stderr_to_stdout, exit_status],
+        Port = erlang:open_port({spawn_executable, Cmd}, Opts),
+        collect_conf_env_file_output(Context, Port, Marker, <<>>)
+    after
+        file:delete(TempBatchFilePath)
+    end.
+
+get_main_config_file_without_extension(Context) ->
+    DefaultMainConfigFile = get_default_main_config_file(Context),
+    RE = "\\.(conf|config)$",
+    Replacement = "",
+    Options = [unicode, {return, list}],
+    re:replace(DefaultMainConfigFile, RE, Replacement, Options).
+
+get_temp_path_win32() ->
+    % https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
+    EnvVars = ["TMP", "TEMP", "USERPROFILE"],
+    Fallback = normalize_path(os:getenv("SystemRoot", "C:/Windows"), "Temp"),
+    F = fun(E) ->
+                case os:getenv(E) of
+                    false -> false;
+                    Var -> {is_dir(Var), Var}
+                end
+        end,
+    case lists:filtermap(F, EnvVars) of
+        [] ->
+            Fallback;
+        TmpDirs when is_list(TmpDirs) ->
+            hd(TmpDirs)
+    end.
 
 vars_list_marker() ->
     % Note:
     % The following can't have any spaces in the text or it will not work on
     % win32. See rabbitmq/rabbitmq-server#5471
-    rabbit_misc:format(
-      "-----VARS-PID-~s-----", [os:getpid()]).
+    rabbit_misc:format("-----VARS-PID-~s-----", [os:getpid()]).
 
 collect_conf_env_file_output(Context, Port, Marker, Output) ->
     receive
@@ -1712,22 +1731,25 @@ collect_conf_env_file_output(Context, Port, Marker, Output) ->
                 0 -> parse_conf_env_file_output(Context, Marker, Lines);
                 _ -> Context
             end;
-        {Port, {data, Chunk}} ->
+        {Port, {data, Chunk}} when is_binary(Chunk) ->
+            UnicodeChunk = unicode:characters_to_list(Chunk),
             collect_conf_env_file_output(
-              Context, Port, Marker, [Output, Chunk])
+              Context, Port, Marker, [Output, UnicodeChunk]);
+        {Port, {data, Chunk}} ->
+            rabbit_log:warning("~p unexpected non-binary chunk in "
+                               "conf env file output: ~p~n", [?MODULE, Chunk])
     end.
 
-post_port_cmd_output(#{os_type := {OSType, _}}, Output, ExitStatus) ->
+post_port_cmd_output(#{os_type := {OSType, _}}, UnicodeOutput, ExitStatus) ->
     ?LOG_DEBUG(
        "$RABBITMQ_CONF_ENV_FILE exit status: ~b",
        [ExitStatus],
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
-    DecodedOutput = unicode:characters_to_list(Output),
     LineSep = case OSType of
                   win32 -> "\r\n";
                   _     -> "\n"
               end,
-    Lines = string:split(string:trim(DecodedOutput), LineSep, all),
+    Lines = string:split(string:trim(UnicodeOutput), LineSep, all),
     ?LOG_DEBUG(
        "$RABBITMQ_CONF_ENV_FILE output:~n~ts",
        [string:join([io_lib:format("  ~ts", [Line]) || Line <- Lines], "\n")],
@@ -1752,7 +1774,7 @@ parse_conf_env_file_output1(Context, Lines) ->
               case IsUsed andalso not IsSet of
                   true ->
                       ?LOG_DEBUG(
-                         "$RABBITMQ_CONF_ENV_FILE: re-exporting variable $~s",
+                         "$RABBITMQ_CONF_ENV_FILE: re-exporting variable $~ts",
                          [Var],
                          #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
                       os:putenv(Var, maps:get(Var, Vars));
@@ -2009,10 +2031,25 @@ value_is_yes(Value) when is_list(Value) orelse is_binary(Value) ->
 value_is_yes(_) ->
     false.
 
+normalize_path(P0, P1, P2, P3, P4) ->
+    P01 = filename:join(P0, P1),
+    normalize_path(P01, P2, P3, P4).
+
+normalize_path(P0, P1, P2, P3) ->
+    P01 = filename:join(P0, P1),
+    normalize_path(P01, P2, P3).
+
+normalize_path(P0, P1, P2) ->
+    P01 = filename:join(P0, P1),
+    normalize_path(P01, P2).
+
+normalize_path(P0, P1) ->
+    normalize_path(filename:join(P0, P1)).
+
 normalize_path("" = Path) ->
     Path;
 normalize_path(Path) ->
-    filename:join(filename:split(Path)).
+    unicode:characters_to_list(filename:join(filename:split(Path))).
 
 this_module_dir() ->
     File = code:which(?MODULE),
@@ -2063,8 +2100,8 @@ setup_dist_for_remote_query(#{from_remote_node := {Remote, _}} = Context,
             Context;
         Error ->
             logger:error(
-              "rabbit_env: Failed to setup distribution (as ~s) to "
-              "query node ~s: ~p",
+              "rabbit_env: Failed to setup distribution (as ~ts) to "
+              "query node ~ts: ~p",
               [Nodename, Remote, Error]),
             setup_dist_for_remote_query(Context,
                                         NamePart, HostPart, NameType,

--- a/deps/rabbit_common/src/rabbit_json.erl
+++ b/deps/rabbit_common/src/rabbit_json.erl
@@ -11,12 +11,11 @@
 	 encode/1, encode/2, try_encode/1, try_encode/2]).
 
 -define(DEFAULT_DECODE_OPTIONS, #{}).
-
+-define(DEFAULT_ENCODE_OPTIONS, #{}).
 
 -spec decode(iodata()) -> thoas:json_term().
 decode(JSON) ->
     decode(JSON, ?DEFAULT_DECODE_OPTIONS).
-
 
 -spec decode(iodata(), thoas:decode_options()) -> thoas:json_term().
 decode(JSON, Opts) ->
@@ -25,62 +24,59 @@ decode(JSON, Opts) ->
         {error, _Error} -> error({error, {failed_to_decode_json, JSON}})
     end.
 
-
 -spec try_decode(iodata()) -> {ok, thoas:json_term()} |
 				     {error, Reason :: term()}.
 try_decode(JSON) ->
     try_decode(JSON, ?DEFAULT_DECODE_OPTIONS).
-
 
 -spec try_decode(iodata(), thoas:decode_options()) ->
 			{ok, thoas:json_term()} | {error, Reason :: term()}.
 try_decode(JSON, Opts) ->
     try
         {ok, decode(JSON, Opts)}
-    catch error: Reason ->
+    catch error:Reason ->
         {error, Reason}
     end.
 
 -spec encode(thoas:json_term()) -> iodata().
 encode(Term) ->
-    encode(Term, []).
+    encode(Term, ?DEFAULT_ENCODE_OPTIONS).
 
 -spec encode(thoas:json_term(), thoas:encode_options()) -> iodata().
-encode(Term, []) ->
-    thoas:encode(fixup_terms(Term));
 encode(Term, Opts) ->
-    thoas:encode(fixup_terms(Term), Opts).
+    %% Fixup for JSON encoding
+    %% * Transforms any Funs into strings
+    %% See rabbit_mgmt_format:format_nulls/1
+    F = fun(V) when is_function(V) ->
+                rabbit_data_coercion:to_binary(V);
+            (V) -> V
+        end,
+    thoas:encode(fixup_terms(Term, F), Opts).
 
 -spec try_encode(thoas:json_term()) -> {ok, iodata()} |
 				     {error, Reason :: term()}.
 try_encode(Term) ->
-    try_encode(Term, []).
+    try_encode(Term, ?DEFAULT_ENCODE_OPTIONS).
 
 -spec try_encode(thoas:json_term(), thoas:decode_options()) ->
 			{ok, iodata()} | {error, Reason :: term()}.
 try_encode(Term, Opts) ->
     try
         {ok, encode(Term, Opts)}
-    catch error: Reason ->
+    catch error:Reason ->
 	    {error, Reason}
     end.
 
-%% Fixup for JSON encoding. Transforms any Funs into strings
-%% See rabbit_mgmt_format:format_nulls/1
-fixup_terms(Items) when is_list(Items) ->
-    [fixup_item(Pair) || Pair <- Items];
-fixup_terms(Item) ->
-    fixup_item(Item).
+fixup_terms(Items, FixupFun) when is_list(Items) ->
+    [fixup_item(Pair, FixupFun) || Pair <- Items];
+fixup_terms(Item, FixupFun) ->
+    fixup_item(Item, FixupFun).
 
-fixup_item({Key, Value}) when is_function(Value) ->
-    {Key, rabbit_data_coercion:to_binary(Value)};
-fixup_item({Key, Value}) when is_list(Value) ->
-    {Key, fixup_terms(Value)};
-fixup_item({Key, Value}) ->
-    {Key, Value};
-fixup_item([{_K, _V} | _T] = L) ->
-    fixup_terms(L);
-fixup_item(Value) when is_function(Value) ->
-    rabbit_data_coercion:to_binary(Value);
-fixup_item(Value) ->
-    Value.
+fixup_item({Key, Value}, FixupFun) when is_list(Value) ->
+    {Key, fixup_terms(Value, FixupFun)};
+fixup_item({Key, Value}, FixupFun) ->
+    {Key, FixupFun(Value)};
+fixup_item([{_K, _V} | _T] = L, FixupFun) ->
+    fixup_terms(L, FixupFun);
+fixup_item(Value, FixupFun) ->
+    FixupFun(Value).

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -449,9 +449,9 @@ r_arg(VHostPath, Kind, Table, Key) ->
     end.
 
 rs(#resource{virtual_host = VHostPath, kind = topic, name = Name}) ->
-    format("'~s' in vhost '~s'", [Name, VHostPath]);
+    format("'~s' in vhost '~ts'", [Name, VHostPath]);
 rs(#resource{virtual_host = VHostPath, kind = Kind, name = Name}) ->
-    format("~s '~s' in vhost '~s'", [Kind, Name, VHostPath]).
+    format("~s '~s' in vhost '~ts'", [Kind, Name, VHostPath]).
 
 enable_cover() -> enable_cover(["."]).
 

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -714,7 +714,7 @@ send_to_new_1_0_session(Channel, Frame, State) ->
             put({ch_fr_pid, ChFrPid}, {channel, Channel}),
             rabbit_log_connection:info(
                         "AMQP 1.0 connection ~p: "
-                        "user '~s' authenticated and granted access to vhost '~s'",
+                        "user '~s' authenticated and granted access to vhost '~ts'",
                         [self(), User#user.username, vhost(Hostname)]),
             ok = rabbit_amqp1_0_session:process_frame(ChFrPid, Frame);
         {error, {not_allowed, _}} ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_nodes.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_nodes.erl
@@ -12,7 +12,6 @@
 -export([variances/2]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
--include_lib("rabbit_common/include/rabbit.hrl").
 
 %%--------------------------------------------------------------------
 

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
@@ -240,7 +240,7 @@ i(sockets_used, State) ->
 i(sockets_total, State) ->
     {State, proplists:get_value(sockets_limit, file_handle_cache:info([sockets_limit]))};
 i(os_pid, State) ->
-    {State, list_to_binary(os:getpid())};
+    {State, rabbit_data_coercion:to_utf8_binary(os:getpid())};
 i(mem_used, State) ->
     {State, vm_memory_monitor:get_process_memory()};
 i(mem_calculation_strategy, State) ->
@@ -273,11 +273,11 @@ i(rates_mode, State) ->
 i(exchange_types, State) ->
     {State, list_registry_plugins(exchange)};
 i(log_files, State) ->
-    {State, [list_to_binary(F) || F <- rabbit:log_locations()]};
+    {State, [rabbit_data_coercion:to_utf8_binary(F) || F <- rabbit:log_locations()]};
 i(db_dir, State) ->
-    {State, list_to_binary(rabbit_mnesia:dir())};
+    {State, rabbit_data_coercion:to_utf8_binary(rabbit_mnesia:dir())};
 i(config_files, State) ->
-    {State, [list_to_binary(F) || F <- rabbit:config_files()]};
+    {State, [rabbit_data_coercion:to_utf8_binary(F) || F <- rabbit:config_files()]};
 i(net_ticktime, State) ->
     {State, net_kernel:get_net_ticktime()};
 i(persister_stats, State) ->
@@ -334,11 +334,11 @@ registry_plugin_enabled(Desc, Fun) ->
 
 format_application({Application, Description, Version}) ->
     [{name, Application},
-     {description, list_to_binary(Description)},
-     {version, list_to_binary(Version)}].
+     {description, rabbit_data_coercion:to_utf8_binary(Description)},
+     {version, rabbit_data_coercion:to_utf8_binary(Version)}].
 
 set_plugin_name(Name, Module) ->
-    [{name, list_to_binary(atom_to_list(Name))} |
+    [{name, atom_to_binary(Name, utf8)} |
      proplists:delete(name, Module:description())].
 
 persister_stats(#state{fhc_stats = FHC}) ->
@@ -373,8 +373,8 @@ rabbit_web_dispatch_registry_list_all() ->
     end.
 
 format_context({Path, Description, Rest}) ->
-    [{description, list_to_binary(Description)},
-     {path,        list_to_binary("/" ++ Path)} |
+    [{description, rabbit_data_coercion:to_utf8_binary(Description)},
+     {path,        rabbit_data_coercion:to_utf8_binary("/" ++ Path)} |
      format_mochiweb_option_list(Rest)].
 
 format_mochiweb_option_list(C) ->
@@ -383,9 +383,9 @@ format_mochiweb_option_list(C) ->
 format_mochiweb_option(ssl_opts, V) ->
     format_mochiweb_option_list(V);
 format_mochiweb_option(_K, V) ->
-    case io_lib:printable_list(V) of
-        true  -> list_to_binary(V);
-        false -> list_to_binary(rabbit_misc:format("~w", [V]))
+    case io_lib:printable_unicode_list(V) of
+        true  -> rabbit_data_coercion:to_utf8_binary(V);
+        false -> rabbit_data_coercion:to_utf8_binary(rabbit_misc:format("~w", [V]))
     end.
 
 %%--------------------------------------------------------------------

--- a/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DeleteShovelCommand.erl
+++ b/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DeleteShovelCommand.erl
@@ -58,7 +58,7 @@ merge_defaults(A, Opts) ->
     {A, maps:merge(#{vhost => <<"/">>}, Opts)}.
 
 banner([Name], #{vhost := VHost}) ->
-    erlang:list_to_binary(io_lib:format("Deleting shovel ~s in vhost ~s",
+    erlang:list_to_binary(io_lib:format("Deleting shovel ~s in vhost ~ts",
                                         [Name, VHost])).
 
 run([Name], #{node := Node, vhost := VHost}) ->

--- a/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
@@ -367,7 +367,7 @@ reset_pending(State = #{dest := Dest}) ->
 
 make_conn_and_chan([], {VHost, Name} = _ShovelName) ->
     rabbit_log:error(
-          "Shovel '~s' in vhost '~s' has no more URIs to try for connection",
+          "Shovel '~s' in vhost '~ts' has no more URIs to try for connection",
           [Name, VHost]),
     erlang:error(failed_to_connect_using_provided_uris);
 make_conn_and_chan([], ShovelName) ->
@@ -401,7 +401,7 @@ do_make_conn_and_chan(URIs, ShovelName) ->
 
 log_connection_failure(Reason, URI, {VHost, Name} = _ShovelName) ->
     rabbit_log:error(
-          "Shovel '~s' in vhost '~s' failed to connect (URI: ~s): ~s",
+          "Shovel '~s' in vhost '~ts' failed to connect (URI: ~s): ~s",
       [Name, VHost, amqp_uri:remove_credentials(URI), human_readable_connection_error(Reason)]);
 log_connection_failure(Reason, URI, ShovelName) ->
     rabbit_log:error(

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
@@ -78,7 +78,7 @@ delete_resource(ReqData, #context{user = #user{username = Username}}=Context) ->
                             %% We must distinguish between a delete and restart
                             case is_restart(ReqData) of
                                 true ->
-                                    rabbit_log:info("Asked to restart shovel '~s' in vhost '~s' on node '~s'", [Name, VHost, Node]),
+                                    rabbit_log:info("Asked to restart shovel '~s' in vhost '~ts' on node '~s'", [Name, VHost, Node]),
                                     case rpc:call(Node, rabbit_shovel_util, restart_shovel, [VHost, Name], ?SHOVEL_CALLS_TIMEOUT_MS) of
                                         ok -> true;
                                         {_, Msg} -> rabbit_log:error(Msg),
@@ -86,7 +86,7 @@ delete_resource(ReqData, #context{user = #user{username = Username}}=Context) ->
                                     end;
 
                                 _ ->
-                                    rabbit_log:info("Asked to delete shovel '~s' in vhost '~s' on node '~s'", [Name, VHost, Node]),
+                                    rabbit_log:info("Asked to delete shovel '~s' in vhost '~ts' on node '~s'", [Name, VHost, Node]),
                                     case rpc:call(Node, rabbit_shovel_util, delete_shovel, [VHost, Name, Username], ?SHOVEL_CALLS_TIMEOUT_MS) of
                                         ok -> true;
                                         {_, Msg} -> rabbit_log:error(Msg),


### PR DESCRIPTION
This is necessary since `cmd.exe` uses ISO-8859-1 encoding and directories can have latin1 characters, like `RabbitMQ Sérvér`

Follow-up to #5486

Sort-of depends on https://github.com/rabbitmq/ra/pull/305

Discovered by @dumbbell