### PR TITLE
Add platforms repo to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,11 @@ bazel_dep(
 )
 
 bazel_dep(
+    name = "platforms",
+    version = "0.0.5",
+)
+
+bazel_dep(
     name = "rules_cc",
     version = "0.0.1",
 )


### PR DESCRIPTION
As necessitated by https://github.com/rabbitmq/rbe-erlang-platform/pull/24
