### PR TITLE
Adopt latest rabbitmq-server-buildenv:linux-rbe for RBE

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -48,7 +48,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "rbe",
-    commit = "3dea2dea9721349ba06938a34e52d683e04e975b",  # linux-rbe branch
+    commit = "e96d11e9b2ca5bc7e7256957e718d268ddf3be35",  # linux-rbe branch
     remote = "https://github.com/rabbitmq/rbe-erlang-platform.git",
 )
 


### PR DESCRIPTION
Automated changes created by https://github.com/rabbitmq/rabbitmq-server/actions/runs/2886895755 using the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
Source workflow: ``