### PR TITLE
Check for vhost's existence every 5 seconds

### DIFF
--- a/deps/rabbit/src/rabbit_vhost_process.erl
+++ b/deps/rabbit/src/rabbit_vhost_process.erl
@@ -23,7 +23,7 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
--define(TICKTIME_RATIO, 4).
+-define(VHOST_CHECK_INTERVAL, 5000).
 
 -behaviour(gen_server2).
 -export([start_link/1]).
@@ -42,8 +42,7 @@ init([VHost]) ->
         %% Recover the vhost data and save it to vhost registry.
         ok = rabbit_vhost:recover(VHost),
         rabbit_vhost_sup_sup:save_vhost_process(VHost, self()),
-        Interval = interval(),
-        timer:send_interval(Interval, check_vhost),
+        timer:send_interval(?VHOST_CHECK_INTERVAL, check_vhost),
         true = erlang:garbage_collect(),
         {ok, VHost}
     catch _:Reason:Stacktrace ->
@@ -87,6 +86,3 @@ terminate(_, _VHost) ->
 
 code_change(_OldVsn, VHost, _Extra) ->
     {ok, VHost}.
-
-interval() ->
-    application:get_env(kernel, net_ticktime, 60000) * ?TICKTIME_RATIO.


### PR DESCRIPTION
This fixes a few years old bug where a value meant to be interpreted as
seconds was passed to `timer:send_interval/2`, which interpreted it as
milliseconds. That led to checking for each vhost's existence a few
times per second, which is excessive. There is no clearly good value,
but a few seconds seems reasonable for the unlikely event of a vhost
crash.