### PR TITLE
Fix duplicate credit grant in quorum queue

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1681,7 +1681,7 @@ increase_credit(_Meta, #consumer{cfg = #consumer_cfg{lifetime = auto,
 increase_credit(#{machine_version := MachineVersion},
                 #consumer{cfg = #consumer_cfg{credit_mode = {simple_prefetch, MaxCredit}},
                           credit = Current}, Credit)
-  when MachineVersion >= 3, MaxCredit > 0 ->
+  when MachineVersion >= 3 andalso MaxCredit > 0 ->
     min(MaxCredit, Current + Credit);
 increase_credit(_Meta, #consumer{credit = Current}, Credit) ->
     Current + Credit.

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -270,7 +270,7 @@ apply(#{index := Idx} = Meta,
             Header = update_header(delivery_count, fun incr/1, 1, Header0),
             State0 = add_bytes_return(Header, State00),
             Con = Con0#consumer{checked_out = maps:remove(MsgId, Checked0),
-                                credit = increase_credit(Con0, 1)},
+                                credit = increase_credit(Meta, Con0, 1)},
             State1 = State0#?MODULE{ra_indexes = rabbit_fifo_index:delete(OldIdx, Indexes0),
                                     messages = lqueue:in(?MSG(Idx, Header), Messages),
                                     enqueue_count = EnqCount + 1},
@@ -444,7 +444,8 @@ apply(#{index := Idx}, #garbage_collection{}, State) ->
     update_smallest_raft_index(Idx, ok, State, [{aux, garbage_collection}]);
 apply(Meta, {timeout, expire_msgs}, State) ->
     checkout(Meta, State, State, []);
-apply(#{system_time := Ts} = Meta, {down, Pid, noconnection},
+apply(#{system_time := Ts, machine_version := MachineVersion} = Meta,
+      {down, Pid, noconnection},
       #?MODULE{consumers = Cons0,
                cfg = #cfg{consumer_strategy = single_active},
                waiting_consumers = Waiting0,
@@ -459,10 +460,15 @@ apply(#{system_time := Ts} = Meta, {down, Pid, noconnection},
                           %% and checked out messages should be returned
                           Effs = consumer_update_active_effects(
                                    S0, Cid, C0, false, suspected_down, E0),
-                          Checked = C0#consumer.checked_out,
-                          Credit = increase_credit(C0, maps:size(Checked)),
-                          {St, Effs1} = return_all(Meta, S0, Effs,
-                                                   Cid, C0#consumer{credit = Credit}),
+                          C1 = case MachineVersion of
+                                   V when V >= 3 ->
+                                       C0;
+                                   2 ->
+                                       Checked = C0#consumer.checked_out,
+                                       Credit = increase_credit(Meta, C0, maps:size(Checked)),
+                                       C0#consumer{credit = Credit}
+                               end,
+                          {St, Effs1} = return_all(Meta, S0, Effs, Cid, C1),
                           %% if the consumer was cancelled there is a chance it got
                           %% removed when returning hence we need to be defensive here
                           Waiting = case St#?MODULE.consumers of
@@ -492,7 +498,8 @@ apply(#{system_time := Ts} = Meta, {down, Pid, noconnection},
                     end, Enqs0),
     Effects = [{monitor, node, Node} | Effects1],
     checkout(Meta, State0, State#?MODULE{enqueuers = Enqs}, Effects);
-apply(#{system_time := Ts} = Meta, {down, Pid, noconnection},
+apply(#{system_time := Ts, machine_version := MachineVersion} = Meta,
+      {down, Pid, noconnection},
       #?MODULE{consumers = Cons0,
                enqueuers = Enqs0} = State0) ->
     %% A node has been disconnected. This doesn't necessarily mean that
@@ -510,9 +517,14 @@ apply(#{system_time := Ts} = Meta, {down, Pid, noconnection},
           fun({_, P} = Cid, #consumer{checked_out = Checked0,
                                       status = up} = C0,
               {St0, Eff}) when node(P) =:= Node ->
-                  Credit = increase_credit(C0, map_size(Checked0)),
-                  C = C0#consumer{status = suspected_down,
-                                  credit = Credit},
+                  C = case MachineVersion of
+                          V when V >= 3 ->
+                              C0#consumer{status = suspected_down};
+                          2 ->
+                              Credit = increase_credit(Meta, C0, map_size(Checked0)),
+                              C0#consumer{status = suspected_down,
+                                          credit = Credit}
+                      end,
                   {St, Eff0} = return_all(Meta, St0, Eff, Cid, C),
                   Eff1 = consumer_update_active_effects(St, Cid, C, false,
                                                         suspected_down, Eff0),
@@ -933,11 +945,12 @@ get_checked_out(Cid, From, To, #?MODULE{consumers = Consumers}) ->
     end.
 
 -spec version() -> pos_integer().
-version() -> 2.
+version() -> 3.
 
 which_module(0) -> rabbit_fifo_v0;
 which_module(1) -> rabbit_fifo_v1;
-which_module(2) -> ?MODULE.
+which_module(2) -> ?MODULE;
+which_module(3) -> ?MODULE.
 
 -define(AUX, aux_v2).
 
@@ -1579,17 +1592,21 @@ maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg, Effects0,
             {duplicate, State0, Effects0}
     end.
 
-return(#{index := IncomingRaftIdx} = Meta, ConsumerId, Returned,
-       Effects0, State0) ->
+return(#{index := IncomingRaftIdx, machine_version := MachineVersion} = Meta,
+       ConsumerId, Returned, Effects0, State0) ->
     {State1, Effects1} = maps:fold(
                            fun(MsgId, Msg, {S0, E0}) ->
                                    return_one(Meta, MsgId, Msg, S0, E0, ConsumerId)
                            end, {State0, Effects0}, Returned),
     State2 =
         case State1#?MODULE.consumers of
-            #{ConsumerId := Con0} ->
-                Con = Con0#consumer{credit = increase_credit(Con0,
-                                                             map_size(Returned))},
+            #{ConsumerId := Con}
+              when MachineVersion >= 3 ->
+                update_or_remove_sub(Meta, ConsumerId, Con, State1);
+            #{ConsumerId := Con0}
+              when MachineVersion =:= 2 ->
+                Credit = increase_credit(Meta, Con0, map_size(Returned)),
+                Con = Con0#consumer{credit = Credit},
                 update_or_remove_sub(Meta, ConsumerId, Con, State1);
             _ ->
                 State1
@@ -1608,7 +1625,7 @@ complete(Meta, ConsumerId, [DiscardedMsgId],
             SettledSize = get_header(size, Hdr),
             Indexes = rabbit_fifo_index:delete(Idx, Indexes0),
             Con = Con0#consumer{checked_out = Checked,
-                                credit = increase_credit(Con0, 1)},
+                                credit = increase_credit(Meta, Con0, 1)},
             State1 = update_or_remove_sub(Meta, ConsumerId, Con, State0),
             State1#?MODULE{ra_indexes = Indexes,
                            msg_bytes_checkout = BytesCheckout - SettledSize,
@@ -1634,22 +1651,28 @@ complete(Meta, ConsumerId, DiscardedMsgIds,
             end, {0, Checked0, Indexes0}, DiscardedMsgIds),
     Len = map_size(Checked0) - map_size(Checked),
     Con = Con0#consumer{checked_out = Checked,
-                        credit = increase_credit(Con0, Len)},
+                        credit = increase_credit(Meta, Con0, Len)},
     State1 = update_or_remove_sub(Meta, ConsumerId, Con, State0),
     State1#?MODULE{ra_indexes = Indexes,
                    msg_bytes_checkout = BytesCheckout - SettledSize,
                    messages_total = Tot - Len}.
 
-increase_credit(#consumer{cfg = #consumer_cfg{lifetime = once},
-                          credit = Credit}, _) ->
+increase_credit(_Meta, #consumer{cfg = #consumer_cfg{lifetime = once},
+                                 credit = Credit}, _) ->
     %% once consumers cannot increment credit
     Credit;
-increase_credit(#consumer{cfg = #consumer_cfg{lifetime = auto,
-                                              credit_mode = credited},
-                          credit = Credit}, _) ->
+increase_credit(_Meta, #consumer{cfg = #consumer_cfg{lifetime = auto,
+                                                     credit_mode = credited},
+                                 credit = Credit}, _) ->
     %% credit_mode: `credited' also doesn't automatically increment credit
     Credit;
-increase_credit(#consumer{credit = Current}, Credit) ->
+increase_credit(#{machine_version := MachineVersion},
+                #consumer{cfg = #consumer_cfg{meta = #{prefetch := Prefetch},
+                                              credit_mode = simple_prefetch},
+                          credit = Current}, Credit)
+  when MachineVersion >= 3, Prefetch > 0 ->
+    min(Prefetch, Current + Credit);
+increase_credit(_Meta, #consumer{credit = Current}, Credit) ->
     Current + Credit.
 
 complete_and_checkout(#{index := IncomingRaftIdx} = Meta, MsgIds, ConsumerId,
@@ -1753,14 +1776,15 @@ get_header(Key, Header)
   when is_map(Header) andalso is_map_key(size, Header) ->
     maps:get(Key, Header, undefined).
 
-return_one(Meta, MsgId, Msg0,
+return_one(#{machine_version := MachineVersion} = Meta,
+           MsgId, Msg0,
            #?MODULE{returns = Returns,
                     consumers = Consumers,
                     dlx = DlxState0,
                     cfg = #cfg{delivery_limit = DeliveryLimit,
                                dead_letter_handler = DLH}} = State0,
            Effects0, ConsumerId) ->
-    #consumer{checked_out = Checked} = Con0 = maps:get(ConsumerId, Consumers),
+    #consumer{checked_out = Checked0} = Con0 = maps:get(ConsumerId, Consumers),
     Msg = update_msg_header(delivery_count, fun incr/1, 1, Msg0),
     Header = get_msg_header(Msg),
     case get_header(delivery_count, Header) of
@@ -1770,7 +1794,14 @@ return_one(Meta, MsgId, Msg0,
             State = complete(Meta, ConsumerId, [MsgId], Con0, State1),
             {State, DlxEffects ++ Effects0};
         _ ->
-            Con = Con0#consumer{checked_out = maps:remove(MsgId, Checked)},
+            Checked = maps:remove(MsgId, Checked0),
+            Con = case MachineVersion of
+                      V when V >= 3 ->
+                          Con0#consumer{checked_out = Checked,
+                                        credit = increase_credit(Meta, Con0, 1)};
+                      2 ->
+                          Con0#consumer{checked_out = Checked}
+                  end,
             {add_bytes_return(
                Header,
                State0#?MODULE{consumers = Consumers#{ConsumerId => Con},
@@ -2353,12 +2384,14 @@ notify_decorators_effect(QName, MaxActivePriority, IsEmpty) ->
     {mod_call, rabbit_quorum_queue, spawn_notify_decorators,
      [QName, consumer_state_changed, [MaxActivePriority, IsEmpty]]}.
 
-convert(To, To, State0) ->
-    State0;
-convert(0, To, State0) ->
-    convert(1, To, rabbit_fifo_v1:convert_v0_to_v1(State0));
-convert(1, To, State0) ->
-    convert(2, To, convert_v1_to_v2(State0)).
+convert(To, To, State) ->
+    State;
+convert(0, To, State) ->
+    convert(1, To, rabbit_fifo_v1:convert_v0_to_v1(State));
+convert(1, To, State) ->
+    convert(2, To, convert_v1_to_v2(State));
+convert(2, To, State) ->
+    convert(3, To, State).
 
 smallest_raft_index(#?MODULE{messages = Messages,
                              ra_indexes = Indexes,

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -66,7 +66,11 @@
 -type consumer_id() :: {consumer_tag(), pid()}.
 %% The entity that receives messages. Uniquely identifies a consumer.
 
--type credit_mode() :: simple_prefetch | credited.
+-type credit_mode() :: credited |
+                        %% machine_version 2
+                        simple_prefetch |
+                        %% machine_version 3
+                        {simple_prefetch, MaxCredit :: non_neg_integer()}.
 %% determines how credit is replenished
 
 -type checkout_spec() :: {once | auto, Num :: non_neg_integer(),
@@ -102,7 +106,7 @@
          %% or returned.
          %% credited: credit can only be changed by receiving a consumer_credit
          %% command: `{consumer_credit, ReceiverDeliveryCount, Credit}'
-         credit_mode = simple_prefetch :: credit_mode(), % part of snapshot data
+         credit_mode :: credit_mode(), % part of snapshot data
          lifetime = once :: once | auto,
          priority = 0 :: non_neg_integer()}).
 

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -21,18 +21,20 @@
 
 all() ->
     [
-     {group, tests}
+     {group, machine_version_2},
+     {group, machine_version_3}
     ].
 
 
 %% replicate eunit like test resultion
 all_tests() ->
-    [F || {F, _} <- ?MODULE:module_info(functions),
+    [F || {F, 1} <- ?MODULE:module_info(functions),
           re:run(atom_to_list(F), "_test$") /= nomatch].
 
 groups() ->
     [
-     {tests, [], all_tests()}
+     {machine_version_2, [], all_tests()},
+     {machine_version_3, [], all_tests()}
     ].
 
 init_per_suite(Config) ->
@@ -41,8 +43,10 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_group(_Group, Config) ->
-    Config.
+init_per_group(machine_version_2, Config) ->
+    [{machine_version, 2} | Config];
+init_per_group(machine_version_3, Config) ->
+    [{machine_version, 3} | Config].
 
 end_per_group(_Group, _Config) ->
     ok.
@@ -87,13 +91,13 @@ test_init(Name) ->
                                            atom_to_binary(Name, utf8)),
            release_cursor_interval => 0}).
 
-enq_enq_checkout_test(_) ->
+enq_enq_checkout_test(C) ->
     Cid = {<<"enq_enq_checkout_test">>, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
-    {State2, _} = enq(2, 2, second, State1),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
+    {State2, _} = enq(C, 2, 2, second, State1),
     ?assertEqual(2, rabbit_fifo:query_messages_total(State2)),
     {_State3, _, Effects} =
-        apply(meta(3),
+        apply(meta(C, 3),
               rabbit_fifo:make_checkout(Cid, {once, 2, simple_prefetch}, #{}),
               State2),
     ct:pal("~p", [Effects]),
@@ -101,45 +105,45 @@ enq_enq_checkout_test(_) ->
     ?ASSERT_EFF({log, [1,2], _Fun, _Local}, Effects),
     ok.
 
-credit_enq_enq_checkout_settled_credit_test(_) ->
+credit_enq_enq_checkout_settled_credit_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
-    {State2, _} = enq(2, 2, second, State1),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
+    {State2, _} = enq(C, 2, 2, second, State1),
     {State3, _, Effects} =
-        apply(meta(3), rabbit_fifo:make_checkout(Cid, {auto, 1, credited}, #{}), State2),
+        apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, {auto, 1, credited}, #{}), State2),
     ?ASSERT_EFF({monitor, _, _}, Effects),
     ?ASSERT_EFF({log, [1], _Fun, _Local}, Effects),
     %% settle the delivery this should _not_ result in further messages being
     %% delivered
-    {State4, SettledEffects} = settle(Cid, 4, 1, State3),
+    {State4, SettledEffects} = settle(C, Cid, 4, 1, State3),
     ?assertEqual(false, lists:any(fun ({log, _, _, _}) ->
                                           true;
                                       (_) -> false
                                   end, SettledEffects)),
     %% granting credit (3) should deliver the second msg if the receivers
     %% delivery count is (1)
-    {State5, CreditEffects} = credit(Cid, 5, 1, 1, false, State4),
+    {State5, CreditEffects} = credit(C, Cid, 5, 1, 1, false, State4),
     % ?debugFmt("CreditEffects  ~p ~n~p", [CreditEffects, State4]),
     ?ASSERT_EFF({log, [2], _, _}, CreditEffects),
-    {_State6, FinalEffects} = enq(6, 3, third, State5),
+    {_State6, FinalEffects} = enq(C, 6, 3, third, State5),
     ?assertEqual(false, lists:any(fun ({log, _, _, _}) ->
                                           true;
                                       (_) -> false
                                   end, FinalEffects)),
     ok.
 
-credit_with_drained_test(_) ->
+credit_with_drained_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
     State0 = test_init(test),
     %% checkout with a single credit
     {State1, _, _} =
-        apply(meta(1), rabbit_fifo:make_checkout(Cid, {auto, 1, credited},#{}),
+        apply(meta(C, 1), rabbit_fifo:make_checkout(Cid, {auto, 1, credited},#{}),
               State0),
     ?assertMatch(#rabbit_fifo{consumers = #{Cid := #consumer{credit = 1,
                                                        delivery_count = 0}}},
                  State1),
     {State, Result, _} =
-         apply(meta(3), rabbit_fifo:make_credit(Cid, 0, 5, true), State1),
+         apply(meta(C, 3), rabbit_fifo:make_credit(Cid, 0, 5, true), State1),
     ?assertMatch(#rabbit_fifo{consumers = #{Cid := #consumer{credit = 0,
                                                        delivery_count = 5}}},
                  State),
@@ -148,231 +152,231 @@ credit_with_drained_test(_) ->
                            Result),
     ok.
 
-credit_and_drain_test(_) ->
+credit_and_drain_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
-    {State2, _} = enq(2, 2, second, State1),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
+    {State2, _} = enq(C, 2, 2, second, State1),
     %% checkout without any initial credit (like AMQP 1.0 would)
     {State3, _, CheckEffs} =
-        apply(meta(3), rabbit_fifo:make_checkout(Cid, {auto, 0, credited}, #{}),
+        apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, {auto, 0, credited}, #{}),
               State2),
 
     ?ASSERT_NO_EFF({log, _, _, _}, CheckEffs),
     {State4, {multi, [{send_credit_reply, 0},
                       {send_drained, {?FUNCTION_NAME, 2}}]},
-    Effects} = apply(meta(4), rabbit_fifo:make_credit(Cid, 4, 0, true), State3),
+    Effects} = apply(meta(C, 4), rabbit_fifo:make_credit(Cid, 4, 0, true), State3),
     ?assertMatch(#rabbit_fifo{consumers = #{Cid := #consumer{credit = 0,
                                                              delivery_count = 4}}},
                  State4),
 
     ?ASSERT_EFF({log, [1, 2], _, _}, Effects),
-    {_State5, EnqEffs} = enq(5, 2, third, State4),
+    {_State5, EnqEffs} = enq(C, 5, 2, third, State4),
     ?ASSERT_NO_EFF({log, _, _, _}, EnqEffs),
     ok.
 
 
 
-enq_enq_deq_test(_) ->
+enq_enq_deq_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
-    {State2, _} = enq(2, 2, second, State1),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
+    {State2, _} = enq(C, 2, 2, second, State1),
     % get returns a reply value
     % NumReady = 1,
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, first),
     {_State3, _,
      [{log, [1], Fun},
       {monitor, _, _}]} =
-        apply(meta(3), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
+        apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
               State2),
     ct:pal("Out ~p", [Fun([Msg1])]),
     ok.
 
-enq_enq_deq_deq_settle_test(_) ->
+enq_enq_deq_deq_settle_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
-    {State2, _} = enq(2, 2, second, State1),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
+    {State2, _} = enq(C, 2, 2, second, State1),
     % get returns a reply value
     {State3, '$ra_no_reply',
      [{log, [1], _},
       {monitor, _, _}]} =
-        apply(meta(3), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
+        apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
               State2),
     {_State4, {dequeue, empty}} =
-        apply(meta(4), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
+        apply(meta(C, 4), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
               State3),
     ok.
 
-enq_enq_checkout_get_settled_test(_) ->
+enq_enq_checkout_get_settled_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
     % get returns a reply value
     {State2, _, Effs} =
-        apply(meta(3), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}),
+        apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}),
               State1),
     ?ASSERT_EFF({log, [1], _}, Effs),
     ?assertEqual(0, rabbit_fifo:query_messages_total(State2)),
     ok.
 
-checkout_get_empty_test(_) ->
+checkout_get_empty_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
     State = test_init(test),
     {_State2, {dequeue, empty}, _} =
-        apply(meta(1), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), State),
+        apply(meta(C, 1), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), State),
     ok.
 
-untracked_enq_deq_test(_) ->
+untracked_enq_deq_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
     State0 = test_init(test),
-    {State1, _, _} = apply(meta(1),
+    {State1, _, _} = apply(meta(C, 1),
                            rabbit_fifo:make_enqueue(undefined, undefined, first),
                            State0),
     {_State2, _, Effs} =
-        apply(meta(3), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State1),
+        apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State1),
     ?ASSERT_EFF({log, [1], _}, Effs),
     ok.
 
-enq_expire_deq_test(_) ->
+enq_expire_deq_test(C) ->
     Conf = #{name => ?FUNCTION_NAME,
              queue_resource => rabbit_misc:r(<<"/">>, queue, <<"test">>),
              msg_ttl => 0},
     S0 = rabbit_fifo:init(Conf),
     Msg = #basic_message{content = #content{properties = none,
                                             payload_fragments_rev = []}},
-    {S1, ok, _} = apply(meta(1, 100), rabbit_fifo:make_enqueue(self(), 1, Msg), S0),
+    {S1, ok, _} = apply(meta(C, 1, 100), rabbit_fifo:make_enqueue(self(), 1, Msg), S0),
     Cid = {?FUNCTION_NAME, self()},
     {_S2, {dequeue, empty}, Effs} =
-        apply(meta(2, 101), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), S1),
+        apply(meta(C, 2, 101), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), S1),
     ?ASSERT_EFF({mod_call, rabbit_global_counters, messages_dead_lettered,
                  [expired, rabbit_quorum_queue, disabled, 1]}, Effs),
     ok.
 
-enq_expire_enq_deq_test(_) ->
+enq_expire_enq_deq_test(C) ->
     S0 = test_init(test),
     %% Msg1 and Msg2 get enqueued in the same millisecond,
     %% but only Msg1 expires immediately.
     Msg1 = #basic_message{content = #content{properties = #'P_basic'{expiration = <<"0">>},
                                              payload_fragments_rev = [<<"msg1">>]}},
     Enq1 = rabbit_fifo:make_enqueue(self(), 1, Msg1),
-    {S1, ok, _} = apply(meta(1, 100), Enq1, S0),
+    {S1, ok, _} = apply(meta(C, 1, 100), Enq1, S0),
     Msg2 = #basic_message{content = #content{properties = none,
                                              payload_fragments_rev = [<<"msg2">>]}},
     Enq2 = rabbit_fifo:make_enqueue(self(), 2, Msg2),
-    {S2, ok, _} = apply(meta(2, 100), Enq2, S1),
+    {S2, ok, _} = apply(meta(C, 2, 100), Enq2, S1),
     Cid = {?FUNCTION_NAME, self()},
     {_S3, _, Effs} =
-        apply(meta(3, 101), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), S2),
+        apply(meta(C, 3, 101), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), S2),
     {log, [2], Fun} = get_log_eff(Effs),
     [{reply, _From,
       {wrap_reply, {dequeue, {_MsgId, _HeaderMsg}, ReadyMsgCount}}}] = Fun([Enq2]),
     ?assertEqual(0, ReadyMsgCount).
 
-enq_expire_deq_enq_enq_deq_deq_test(_) ->
+enq_expire_deq_enq_enq_deq_deq_test(C) ->
     S0 = test_init(test),
     Msg1 = #basic_message{content = #content{properties = #'P_basic'{expiration = <<"0">>},
                                              payload_fragments_rev = [<<"msg1">>]}},
-    {S1, ok, _} = apply(meta(1, 100), rabbit_fifo:make_enqueue(self(), 1, Msg1), S0),
-    {S2, {dequeue, empty}, _} = apply(meta(2, 101),
+    {S1, ok, _} = apply(meta(C, 1, 100), rabbit_fifo:make_enqueue(self(), 1, Msg1), S0),
+    {S2, {dequeue, empty}, _} = apply(meta(C, 2, 101),
                                       rabbit_fifo:make_checkout({c1, self()}, {dequeue, unsettled}, #{}), S1),
-    {S3, _} = enq(3, 2, msg2, S2),
-    {S4, _} = enq(4, 3, msg3, S3),
+    {S3, _} = enq(C, 3, 2, msg2, S2),
+    {S4, _} = enq(C, 4, 3, msg3, S3),
     {S5, '$ra_no_reply',
      [{log, [3], _},
       {monitor, _, _}]} =
-    apply(meta(5), rabbit_fifo:make_checkout({c2, self()}, {dequeue, unsettled}, #{}), S4),
+    apply(meta(C, 5), rabbit_fifo:make_checkout({c2, self()}, {dequeue, unsettled}, #{}), S4),
     {_S6, '$ra_no_reply',
      [{log, [4], _},
       {monitor, _, _}]} =
-    apply(meta(6), rabbit_fifo:make_checkout({c3, self()}, {dequeue, unsettled}, #{}), S5).
+    apply(meta(C, 6), rabbit_fifo:make_checkout({c3, self()}, {dequeue, unsettled}, #{}), S5).
 
-release_cursor_test(_) ->
+release_cursor_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, _} = enq(1, 1, first,  test_init(test)),
-    {State2, _} = enq(2, 2, second, State1),
-    {State3, _} = check(Cid, 3, 10, State2),
+    {State1, _} = enq(C, 1, 1, first,  test_init(test)),
+    {State2, _} = enq(C, 2, 2, second, State1),
+    {State3, _} = check(C, Cid, 3, 10, State2),
     % no release cursor effect at this point
-    {State4, _} = settle(Cid, 4, 1, State3),
-    {_Final, Effects1} = settle(Cid, 5, 0, State4),
+    {State4, _} = settle(C, Cid, 4, 1, State3),
+    {_Final, Effects1} = settle(C, Cid, 5, 0, State4),
     % empty queue forwards release cursor all the way
     ?ASSERT_EFF({release_cursor, 5, _}, Effects1),
     ok.
 
-checkout_enq_settle_test(_) ->
+checkout_enq_settle_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
-    {State1, [{monitor, _, _} | _]} = check(Cid, 1, test_init(test)),
-    {State2, Effects0} = enq(2, 1,  first, State1),
+    {State1, [{monitor, _, _} | _]} = check(C, Cid, 1, test_init(test)),
+    {State2, Effects0} = enq(C, 2, 1,  first, State1),
     %% TODO: this should go back to a send_msg effect after optimisation
     % ?ASSERT_EFF({log, [2], _, _}, Effects0),
     ?ASSERT_EFF({send_msg, _,
                  {delivery, ?FUNCTION_NAME,
                   [{0, {_, first}}]}, _},
                 Effects0),
-    {State3, _} = enq(3, 2, second, State2),
-    {_, _Effects} = settle(Cid, 4, 0, State3),
+    {State3, _} = enq(C, 3, 2, second, State2),
+    {_, _Effects} = settle(C, Cid, 4, 0, State3),
     % the release cursor is the smallest raft index that does not
     % contribute to the state of the application
     % ?ASSERT_EFF({release_cursor, 2, _}, Effects),
     ok.
 
-duplicate_enqueue_test(_) ->
+duplicate_enqueue_test(C) ->
     Cid = {<<"duplicate_enqueue_test">>, self()},
-    {State1, [ {monitor, _, _} | _]} = check_n(Cid, 5, 5, test_init(test)),
-    {State2, Effects2} = enq(2, 1, first, State1),
+    {State1, [ {monitor, _, _} | _]} = check_n(C, Cid, 5, 5, test_init(test)),
+    {State2, Effects2} = enq(C, 2, 1, first, State1),
     % ?ASSERT_EFF({log, [2], _, _}, Effects2),
     ?ASSERT_EFF({send_msg, _, {delivery, _, [{_, {_, first}}]}, _}, Effects2),
-    {_State3, Effects3} = enq(3, 1, first, State2),
+    {_State3, Effects3} = enq(C, 3, 1, first, State2),
     ?ASSERT_NO_EFF({log, [_], _, _}, Effects3),
     ok.
 
-return_test(_) ->
+return_test(C) ->
     Cid = {<<"cid">>, self()},
     Cid2 = {<<"cid2">>, self()},
-    {State0, _} = enq(1, 1, msg, test_init(test)),
-    {State1, _} = check_auto(Cid, 2, State0),
-    {State2, _} = check_auto(Cid2, 3, State1),
-    {State3, _, _} = apply(meta(4), rabbit_fifo:make_return(Cid, [0]), State2),
-    ?assertMatch(#{Cid := #consumer{checked_out = C}} when map_size(C) == 0,
-                                                           State3#rabbit_fifo.consumers),
+    {State0, _} = enq(C, 1, 1, msg, test_init(test)),
+    {State1, _} = check_auto(C, Cid, 2, State0),
+    {State2, _} = check_auto(C, Cid2, 3, State1),
+    {State3, _, _} = apply(meta(C, 4), rabbit_fifo:make_return(Cid, [0]), State2),
+    ?assertMatch(#{Cid := #consumer{checked_out = C1}} when map_size(C1) == 0,
+                                                            State3#rabbit_fifo.consumers),
     ?assertMatch(#{Cid2 := #consumer{checked_out = C2}} when map_size(C2) == 1,
-                                                           State3#rabbit_fifo.consumers),
+                                                             State3#rabbit_fifo.consumers),
     ok.
 
-return_dequeue_delivery_limit_test(_) ->
+return_dequeue_delivery_limit_test(C) ->
     Init = init(#{name => test,
                   queue_resource => rabbit_misc:r("/", queue,
                                                   atom_to_binary(test, utf8)),
                   max_in_memory_length => 0,
                   release_cursor_interval => 0,
                   delivery_limit => 1}),
-    {State0, _} = enq(1, 1, msg, Init),
+    {State0, _} = enq(C, 1, 1, msg, Init),
 
     Cid = {<<"cid">>, self()},
     Cid2 = {<<"cid2">>, self()},
 
     Msg = rabbit_fifo:make_enqueue(self(), 1, msg),
-    {State1, {MsgId1, _}} = deq(2, Cid, unsettled, Msg, State0),
-    {State2, _, _} = apply(meta(4), rabbit_fifo:make_return(Cid, [MsgId1]),
+    {State1, {MsgId1, _}} = deq(C, 2, Cid, unsettled, Msg, State0),
+    {State2, _, _} = apply(meta(C, 4), rabbit_fifo:make_return(Cid, [MsgId1]),
                            State1),
 
-    {State3, {MsgId2, _}} = deq(2, Cid2, unsettled, Msg, State2),
-    {State4, _, _} = apply(meta(4), rabbit_fifo:make_return(Cid2, [MsgId2]),
+    {State3, {MsgId2, _}} = deq(C, 2, Cid2, unsettled, Msg, State2),
+    {State4, _, _} = apply(meta(C, 4), rabbit_fifo:make_return(Cid2, [MsgId2]),
                            State3),
     ?assertMatch(#{num_messages := 0}, rabbit_fifo:overview(State4)),
     ok.
 
-return_non_existent_test(_) ->
+return_non_existent_test(C) ->
     Cid = {<<"cid">>, self()},
-    {State0, _} = enq(1, 1, second, test_init(test)),
+    {State0, _} = enq(C, 1, 1, second, test_init(test)),
     % return non-existent
-    {_State2, _} = apply(meta(3), rabbit_fifo:make_return(Cid, [99]), State0),
+    {_State2, _} = apply(meta(C, 3), rabbit_fifo:make_return(Cid, [99]), State0),
     ok.
 
-return_checked_out_test(_) ->
+return_checked_out_test(C) ->
     Cid = {<<"cid">>, self()},
-    {State0, _} = enq(1, 1, first, test_init(test)),
+    {State0, _} = enq(C, 1, 1, first, test_init(test)),
     {State1, [_Monitor,
               {log, [1], Fun, _}
               | _ ]
-    } = check_auto(Cid, 2, State0),
+    } = check_auto(C, Cid, 2, State0),
 
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, first),
 
@@ -382,10 +386,10 @@ return_checked_out_test(_) ->
              {log, [1], _, _}
              % {send_msg, _, {delivery, _, [{_, _}]}, _},
             ]} =
-        apply(meta(3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
+        apply(meta(C, 3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
     ok.
 
-return_checked_out_limit_test(_) ->
+return_checked_out_limit_test(C) ->
     Cid = {<<"cid">>, self()},
     Init = init(#{name => test,
                   queue_resource => rabbit_misc:r("/", queue,
@@ -394,123 +398,123 @@ return_checked_out_limit_test(_) ->
                   max_in_memory_length => 0,
                   delivery_limit => 1}),
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, first),
-    {State0, _} = enq(1, 1, first, Init),
+    {State0, _} = enq(C, 1, 1, first, Init),
     {State1, [_Monitor,
               {log, [1], Fun1, _}
-              | _ ]} = check_auto(Cid, 2, State0),
+              | _ ]} = check_auto(C, Cid, 2, State0),
     [{send_msg, _, {delivery, _, [{MsgId, _}]}, _}] = Fun1([Msg1]),
     % returning immediately checks out the same message again
     {State2, ok, [
                   {log, [1], Fun2, _}
                  ]} =
-        apply(meta(3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
+        apply(meta(C, 3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
     [{send_msg, _, {delivery, _, [{MsgId2, _}]}, _}] = Fun2([Msg1]),
     {#rabbit_fifo{} = State, ok, _} =
-        apply(meta(4), rabbit_fifo:make_return(Cid, [MsgId2]), State2),
+        apply(meta(C, 4), rabbit_fifo:make_return(Cid, [MsgId2]), State2),
     ?assertEqual(0, rabbit_fifo:query_messages_total(State)),
     ok.
 
-return_auto_checked_out_test(_) ->
+return_auto_checked_out_test(C) ->
     Cid = {<<"cid">>, self()},
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, first),
-    {State00, _} = enq(1, 1, first, test_init(test)),
-    {State0, _} = enq(2, 2, second, State00),
+    {State00, _} = enq(C, 1, 1, first, test_init(test)),
+    {State0, _} = enq(C, 2, 2, second, State00),
     % it first active then inactive as the consumer took on but cannot take
     % any more
     {State1, [_Monitor,
               {log, [1], Fun1, _}
-             ]} = check_auto(Cid, 2, State0),
+             ]} = check_auto(C, Cid, 2, State0),
     [{send_msg, _, {delivery, _, [{MsgId, _}]}, _}] = Fun1([Msg1]),
     % return should include another delivery
-    {_State2, _, Effects} = apply(meta(3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
+    {_State2, _, Effects} = apply(meta(C, 3), rabbit_fifo:make_return(Cid, [MsgId]), State1),
     [{log, [1], Fun2, _} | _] = Effects,
 
     [{send_msg, _, {delivery, _, [{_MsgId2, {#{delivery_count := 1}, first}}]}, _}]
     = Fun2([Msg1]),
     ok.
 
-cancelled_checkout_empty_queue_test(_) ->
+cancelled_checkout_empty_queue_test(C) ->
     Cid = {<<"cid">>, self()},
-    {State1, _} = check_auto(Cid, 2, test_init(test)),
+    {State1, _} = check_auto(C, Cid, 2, test_init(test)),
     % cancelled checkout should clear out service_queue also, else we'd get a
     % build up of these
-    {State2, _, Effects} = apply(meta(3), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
+    {State2, _, Effects} = apply(meta(C, 3), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
     ?assertEqual(0, map_size(State2#rabbit_fifo.consumers)),
     ?assertEqual(0, priority_queue:len(State2#rabbit_fifo.service_queue)),
     ?ASSERT_EFF({release_cursor, _, _}, Effects),
     ok.
 
-cancelled_checkout_out_test(_) ->
+cancelled_checkout_out_test(C) ->
     Cid = {<<"cid">>, self()},
-    {State00, _} = enq(1, 1, first, test_init(test)),
-    {State0, _} = enq(2, 2, second, State00),
-    {State1, _} = check_auto(Cid, 3, State0),%% prefetch of 1
+    {State00, _} = enq(C, 1, 1, first, test_init(test)),
+    {State0, _} = enq(C, 2, 2, second, State00),
+    {State1, _} = check_auto(C, Cid, 3, State0),%% prefetch of 1
     % cancelled checkout should not return pending messages to queue
-    {State2, _, _} = apply(meta(4), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
+    {State2, _, _} = apply(meta(C, 4), rabbit_fifo:make_checkout(Cid, cancel, #{}), State1),
     ?assertEqual(1, lqueue:len(State2#rabbit_fifo.messages)),
     ?assertEqual(0, lqueue:len(State2#rabbit_fifo.returns)),
     ?assertEqual(0, priority_queue:len(State2#rabbit_fifo.service_queue)),
 
     {State3, {dequeue, empty}} =
-        apply(meta(5), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State2),
+        apply(meta(C, 5), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State2),
     %% settle
     {State4, ok, _} =
-        apply(meta(6), rabbit_fifo:make_settle(Cid, [0]), State3),
+        apply(meta(C, 6), rabbit_fifo:make_settle(Cid, [0]), State3),
 
     {_State, _, [{log, [2], _Fun} | _]} =
-        apply(meta(7), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State4),
+        apply(meta(C, 7), rabbit_fifo:make_checkout(Cid, {dequeue, settled}, #{}), State4),
     ok.
 
-down_with_noproc_consumer_returns_unsettled_test(_) ->
+down_with_noproc_consumer_returns_unsettled_test(C) ->
     Cid = {<<"down_consumer_returns_unsettled_test">>, self()},
-    {State0, _} = enq(1, 1, second, test_init(test)),
-    {State1, [{monitor, process, Pid} | _]} = check(Cid, 2, State0),
-    {State2, _, _} = apply(meta(3), {down, Pid, noproc}, State1),
-    {_State, Effects} = check(Cid, 4, State2),
+    {State0, _} = enq(C, 1, 1, second, test_init(test)),
+    {State1, [{monitor, process, Pid} | _]} = check(C, Cid, 2, State0),
+    {State2, _, _} = apply(meta(C, 3), {down, Pid, noproc}, State1),
+    {_State, Effects} = check(C, Cid, 4, State2),
     ?ASSERT_EFF({monitor, process, _}, Effects),
     ok.
 
-down_with_noconnection_marks_suspect_and_node_is_monitored_test(_) ->
+down_with_noconnection_marks_suspect_and_node_is_monitored_test(C) ->
     Pid = spawn(fun() -> ok end),
     Cid = {<<"down_with_noconnect">>, Pid},
     Self = self(),
     Node = node(Pid),
-    {State0, Effects0} = enq(1, 1, second, test_init(test)),
+    {State0, Effects0} = enq(C, 1, 1, second, test_init(test)),
     ?ASSERT_EFF({monitor, process, P}, P =:= Self, Effects0),
-    {State1, Effects1} = check_auto(Cid, 2, State0),
+    {State1, Effects1} = check_auto(C, Cid, 2, State0),
     #consumer{credit = 0} = maps:get(Cid, State1#rabbit_fifo.consumers),
     ?ASSERT_EFF({monitor, process, P}, P =:= Pid, Effects1),
     % monitor both enqueuer and consumer
     % because we received a noconnection we now need to monitor the node
-    {State2a, _, _} = apply(meta(3), {down, Pid, noconnection}, State1),
+    {State2a, _, _} = apply(meta(C, 3), {down, Pid, noconnection}, State1),
     #consumer{credit = 1,
               checked_out = Ch,
               status = suspected_down} = maps:get(Cid, State2a#rabbit_fifo.consumers),
     ?assertEqual(#{}, Ch),
     %% validate consumer has credit
-    {State2, _, Effects2} = apply(meta(3), {down, Self, noconnection}, State2a),
+    {State2, _, Effects2} = apply(meta(C, 3), {down, Self, noconnection}, State2a),
     ?ASSERT_EFF({monitor, node, _}, Effects2),
     ?assertNoEffect({demonitor, process, _}, Effects2),
     % when the node comes up we need to retry the process monitors for the
     % disconnected processes
-    {State3, _, Effects3} = apply(meta(3), {nodeup, Node}, State2),
+    {State3, _, Effects3} = apply(meta(C, 3), {nodeup, Node}, State2),
     #consumer{status = up} = maps:get(Cid, State3#rabbit_fifo.consumers),
     % try to re-monitor the suspect processes
     ?ASSERT_EFF({monitor, process, P}, P =:= Pid, Effects3),
     ?ASSERT_EFF({monitor, process, P}, P =:= Self, Effects3),
     ok.
 
-down_with_noconnection_returns_unack_test(_) ->
+down_with_noconnection_returns_unack_test(C) ->
     Pid = spawn(fun() -> ok end),
     Cid = {<<"down_with_noconnect">>, Pid},
     Msg = rabbit_fifo:make_enqueue(self(), 1, second),
-    {State0, _} = enq(1, 1, second, test_init(test)),
+    {State0, _} = enq(C, 1, 1, second, test_init(test)),
     ?assertEqual(1, lqueue:len(State0#rabbit_fifo.messages)),
     ?assertEqual(0, lqueue:len(State0#rabbit_fifo.returns)),
-    {State1, {_, _}} = deq(2, Cid, unsettled, Msg, State0),
+    {State1, {_, _}} = deq(C, 2, Cid, unsettled, Msg, State0),
     ?assertEqual(0, lqueue:len(State1#rabbit_fifo.messages)),
     ?assertEqual(0, lqueue:len(State1#rabbit_fifo.returns)),
-    {State2a, _, _} = apply(meta(3), {down, Pid, noconnection}, State1),
+    {State2a, _, _} = apply(meta(C, 3), {down, Pid, noconnection}, State1),
     ?assertEqual(0, lqueue:len(State2a#rabbit_fifo.messages)),
     ?assertEqual(1, lqueue:len(State2a#rabbit_fifo.returns)),
     ?assertMatch(#consumer{checked_out = Ch,
@@ -519,27 +523,27 @@ down_with_noconnection_returns_unack_test(_) ->
                         maps:get(Cid, State2a#rabbit_fifo.consumers)),
     ok.
 
-down_with_noproc_enqueuer_is_cleaned_up_test(_) ->
+down_with_noproc_enqueuer_is_cleaned_up_test(C) ->
     State00 = test_init(test),
     Pid = spawn(fun() -> ok end),
-    {State0, _, Effects0} = apply(meta(1), rabbit_fifo:make_enqueue(Pid, 1, first), State00),
+    {State0, _, Effects0} = apply(meta(C, 1), rabbit_fifo:make_enqueue(Pid, 1, first), State00),
     ?ASSERT_EFF({monitor, process, _}, Effects0),
-    {State1, _, _} = apply(meta(3), {down, Pid, noproc}, State0),
+    {State1, _, _} = apply(meta(C, 3), {down, Pid, noproc}, State0),
     % ensure there are no enqueuers
     ?assert(0 =:= maps:size(State1#rabbit_fifo.enqueuers)),
     ok.
 
-discarded_message_without_dead_letter_handler_is_removed_test(_) ->
+discarded_message_without_dead_letter_handler_is_removed_test(C) ->
     Cid = {<<"completed_consumer_yields_demonitor_effect_test">>, self()},
-    {State0, _} = enq(1, 1, first, test_init(test)),
-    {State1, Effects1} = check_n(Cid, 2, 10, State0),
+    {State0, _} = enq(C, 1, 1, first, test_init(test)),
+    {State1, Effects1} = check_n(C, Cid, 2, 10, State0),
     ?ASSERT_EFF({log, [1], _Fun, _}, Effects1),
-    {_State2, _, Effects2} = apply(meta(1),
+    {_State2, _, Effects2} = apply(meta(C, 1),
                                    rabbit_fifo:make_discard(Cid, [0]), State1),
     ?ASSERT_NO_EFF({log, [1], _Fun, _}, Effects2),
     ok.
 
-discarded_message_with_dead_letter_handler_emits_log_effect_test(_) ->
+discarded_message_with_dead_letter_handler_emits_log_effect_test(C) ->
     Cid = {<<"cid1">>, self()},
     State00 = init(#{name => test,
                      queue_resource => rabbit_misc:r(<<"/">>, queue, <<"test">>),
@@ -547,10 +551,10 @@ discarded_message_with_dead_letter_handler_emits_log_effect_test(_) ->
                      dead_letter_handler =>
                      {at_most_once, {somemod, somefun, [somearg]}}}),
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, first),
-    {State0, _} = enq(1, 1, first, State00),
-    {State1, Effects1} = check_n(Cid, 2, 10, State0),
+    {State0, _} = enq(C, 1, 1, first, State00),
+    {State1, Effects1} = check_n(C, Cid, 2, 10, State0),
     ?ASSERT_EFF({log, [1], _, _}, Effects1),
-    {_State2, _, Effects2} = apply(meta(1), rabbit_fifo:make_discard(Cid, [0]), State1),
+    {_State2, _, Effects2} = apply(meta(C, 1), rabbit_fifo:make_discard(Cid, [0]), State1),
     % assert mod call effect with appended reason and message
     {value, {log, [1], Fun}} = lists:search(fun (E) -> element(1, E) == log end,
                                             Effects2),
@@ -561,7 +565,7 @@ get_log_eff(Effs) ->
     {value, Log} = lists:search(fun (E) -> element(1, E) == log end, Effs),
     Log.
 
-mixed_send_msg_and_log_effects_are_correctly_ordered_test(_) ->
+mixed_send_msg_and_log_effects_are_correctly_ordered_test(C) ->
     Cid = {cid(?FUNCTION_NAME), self()},
     State00 = init(#{name => test,
                      queue_resource => rabbit_misc:r(<<"/">>, queue, <<"test">>),
@@ -571,11 +575,11 @@ mixed_send_msg_and_log_effects_are_correctly_ordered_test(_) ->
                       {somemod, somefun, [somearg]}}}),
     %% enqueue two messages
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, first),
-    {State0, _} = enq(1, 1, first, State00),
+    {State0, _} = enq(C, 1, 1, first, State00),
     Msg2 = rabbit_fifo:make_enqueue(self(), 2, snd),
-    {State1, _} = enq(2, 2, snd, State0),
+    {State1, _} = enq(C, 2, 2, snd, State0),
 
-    {_State2, Effects1} = check_n(Cid, 3, 10, State1),
+    {_State2, Effects1} = check_n(C, Cid, 3, 10, State1),
     ct:pal("Effects ~w", [Effects1]),
     {log, [1, 2], Fun, _} = get_log_eff(Effects1),
     [{send_msg, _, {delivery, _Cid, [{0,{0,first}},{1,{0,snd}}]},
@@ -588,17 +592,17 @@ mixed_send_msg_and_log_effects_are_correctly_ordered_test(_) ->
     ?ASSERT_NO_EFF({send_msg, _, _, _}, Effects1),
     ok.
 
-tick_test(_) ->
+tick_test(C) ->
     Cid = {<<"c">>, self()},
     Cid2 = {<<"c2">>, self()},
 
     Msg1 = rabbit_fifo:make_enqueue(self(), 1, <<"fst">>),
     Msg2 = rabbit_fifo:make_enqueue(self(), 2, <<"snd">>),
-    {S0, _} = enq(1, 1, <<"fst">>, test_init(?FUNCTION_NAME)),
-    {S1, _} = enq(2, 2, <<"snd">>, S0),
-    {S2, {MsgId, _}} = deq(3, Cid, unsettled, Msg1, S1),
-    {S3, {_, _}} = deq(4, Cid2, unsettled, Msg2, S2),
-    {S4, _, _} = apply(meta(5), rabbit_fifo:make_return(Cid, [MsgId]), S3),
+    {S0, _} = enq(C, 1, 1, <<"fst">>, test_init(?FUNCTION_NAME)),
+    {S1, _} = enq(C, 2, 2, <<"snd">>, S0),
+    {S2, {MsgId, _}} = deq(C, 3, Cid, unsettled, Msg1, S1),
+    {S3, {_, _}} = deq(C, 4, Cid2, unsettled, Msg2, S2),
+    {S4, _, _} = apply(meta(C, 5), rabbit_fifo:make_return(Cid, [MsgId]), S3),
 
     [{mod_call, rabbit_quorum_queue, handle_tick,
       [#resource{},
@@ -608,7 +612,7 @@ tick_test(_) ->
     ok.
 
 
-delivery_query_returns_deliveries_test(_) ->
+delivery_query_returns_deliveries_test(C) ->
     Tag = atom_to_binary(?FUNCTION_NAME, utf8),
     Cid = {Tag, self()},
     Commands = [
@@ -620,15 +624,15 @@ delivery_query_returns_deliveries_test(_) ->
               ],
     Indexes = lists:seq(1, length(Commands)),
     Entries = lists:zip(Indexes, Commands),
-    {State, _Effects} = run_log(test_init(help), Entries),
+    {State, _Effects} = run_log(C, test_init(help), Entries),
     % 3 deliveries are returned
     [{0, {_, _}}] = rabbit_fifo:get_checked_out(Cid, 0, 0, State),
     [_, _, _] = rabbit_fifo:get_checked_out(Cid, 1, 3, State),
     ok.
 
-duplicate_delivery_test(_) ->
-    {State0, _} = enq(1, 1, first, test_init(test)),
-    {#rabbit_fifo{messages = Messages} = State, _} = enq(2, 1, first, State0),
+duplicate_delivery_test(C) ->
+    {State0, _} = enq(C, 1, 1, first, test_init(test)),
+    {#rabbit_fifo{messages = Messages} = State, _} = enq(C, 2, 1, first, State0),
     ?assertEqual(1, rabbit_fifo:query_messages_total(State)),
     ?assertEqual(1, lqueue:len(Messages)),
     ok.
@@ -657,13 +661,13 @@ state_enter_file_handle_other_reservation_test(_) ->
       Effects),
     ok.
 
-state_enter_monitors_and_notifications_test(_) ->
+state_enter_monitors_and_notifications_test(C) ->
     Oth = spawn(fun () -> ok end),
-    {State0, _} = enq(1, 1, first, test_init(test)),
+    {State0, _} = enq(C, 1, 1, first, test_init(test)),
     Cid = {<<"adf">>, self()},
     OthCid = {<<"oth">>, Oth},
-    {State1, _} = check(Cid, 2, State0),
-    {State, _} = check(OthCid, 3, State1),
+    {State1, _} = check(C, Cid, 2, State0),
+    {State, _} = check(C, OthCid, 3, State1),
     Self = self(),
     Effects = rabbit_fifo:state_enter(leader, State),
 
@@ -681,26 +685,26 @@ state_enter_monitors_and_notifications_test(_) ->
     ?ASSERT_EFF({monitor, process, _}, Effects),
     ok.
 
-purge_test(_) ->
+purge_test(C) ->
     Cid = {<<"purge_test">>, self()},
-    {State1, _} = enq(1, 1, first, test_init(test)),
-    {State2, {purge, 1}, _} = apply(meta(2), rabbit_fifo:make_purge(), State1),
-    {State3, _} = enq(3, 2, second, State2),
+    {State1, _} = enq(C, 1, 1, first, test_init(test)),
+    {State2, {purge, 1}, _} = apply(meta(C, 2), rabbit_fifo:make_purge(), State1),
+    {State3, _} = enq(C, 3, 2, second, State2),
     % get returns a reply value
     {_State4, _, Effs} =
-        apply(meta(4), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), State3),
+        apply(meta(C, 4), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}), State3),
     ?ASSERT_EFF({log, [3], _}, Effs),
     ok.
 
-purge_with_checkout_test(_) ->
+purge_with_checkout_test(C) ->
     Cid = {<<"purge_test">>, self()},
-    {State0, _} = check_auto(Cid, 1, test_init(?FUNCTION_NAME)),
-    {State1, _} = enq(2, 1, <<"first">>, State0),
-    {State2, _} = enq(3, 2, <<"second">>, State1),
+    {State0, _} = check_auto(C, Cid, 1, test_init(?FUNCTION_NAME)),
+    {State1, _} = enq(C, 2, 1, <<"first">>, State0),
+    {State2, _} = enq(C, 3, 2, <<"second">>, State1),
     %% assert message bytes are non zero
     ?assert(State2#rabbit_fifo.msg_bytes_checkout > 0),
     ?assert(State2#rabbit_fifo.msg_bytes_enqueue > 0),
-    {State3, {purge, 1}, _} = apply(meta(2), rabbit_fifo:make_purge(), State2),
+    {State3, {purge, 1}, _} = apply(meta(C, 2), rabbit_fifo:make_purge(), State2),
     ?assert(State2#rabbit_fifo.msg_bytes_checkout > 0),
     ?assertEqual(0, State3#rabbit_fifo.msg_bytes_enqueue),
     ?assertEqual(1, rabbit_fifo:query_messages_total(State3)),
@@ -708,20 +712,20 @@ purge_with_checkout_test(_) ->
     ?assertEqual(1, maps:size(Checked)),
     ok.
 
-down_noproc_returns_checked_out_in_order_test(_) ->
+down_noproc_returns_checked_out_in_order_test(C) ->
     S0 = test_init(?FUNCTION_NAME),
     %% enqueue 100
     S1 = lists:foldl(fun (Num, FS0) ->
-                         {FS, _} = enq(Num, Num, Num, FS0),
+                         {FS, _} = enq(C, Num, Num, Num, FS0),
                          FS
                      end, S0, lists:seq(1, 100)),
     ?assertEqual(100, lqueue:len(S1#rabbit_fifo.messages)),
     Cid = {<<"cid">>, self()},
-    {S2, _} = check(Cid, 101, 1000, S1),
+    {S2, _} = check(C, Cid, 101, 1000, S1),
     #consumer{checked_out = Checked} = maps:get(Cid, S2#rabbit_fifo.consumers),
     ?assertEqual(100, maps:size(Checked)),
     %% simulate down
-    {S, _, _} = apply(meta(102), {down, self(), noproc}, S2),
+    {S, _, _} = apply(meta(C, 102), {down, self(), noproc}, S2),
     Returns = lqueue:to_list(S#rabbit_fifo.returns),
     ?assertEqual(100, length(Returns)),
     ?assertEqual(0, maps:size(S#rabbit_fifo.consumers)),
@@ -729,20 +733,20 @@ down_noproc_returns_checked_out_in_order_test(_) ->
     ?assertEqual(lists:sort(Returns), Returns),
     ok.
 
-down_noconnection_returns_checked_out_test(_) ->
+down_noconnection_returns_checked_out_test(C) ->
     S0 = test_init(?FUNCTION_NAME),
     NumMsgs = 20,
     S1 = lists:foldl(fun (Num, FS0) ->
-                         {FS, _} = enq(Num, Num, Num, FS0),
+                         {FS, _} = enq(C, Num, Num, Num, FS0),
                          FS
                      end, S0, lists:seq(1, NumMsgs)),
     ?assertEqual(NumMsgs, lqueue:len(S1#rabbit_fifo.messages)),
     Cid = {<<"cid">>, self()},
-    {S2, _} = check(Cid, 101, 1000, S1),
+    {S2, _} = check(C, Cid, 101, 1000, S1),
     #consumer{checked_out = Checked} = maps:get(Cid, S2#rabbit_fifo.consumers),
     ?assertEqual(NumMsgs, maps:size(Checked)),
     %% simulate down
-    {S, _, _} = apply(meta(102), {down, self(), noconnection}, S2),
+    {S, _, _} = apply(meta(C, 102), {down, self(), noconnection}, S2),
     Returns = lqueue:to_list(S#rabbit_fifo.returns),
     ?assertEqual(NumMsgs, length(Returns)),
     ?assertMatch(#consumer{checked_out = Ch}
@@ -752,7 +756,7 @@ down_noconnection_returns_checked_out_test(_) ->
     ?assertEqual(lists:sort(Returns), Returns),
     ok.
 
-single_active_consumer_basic_get_test(_) ->
+single_active_consumer_basic_get_test(C) ->
     Cid = {?FUNCTION_NAME, self()},
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
@@ -761,24 +765,24 @@ single_active_consumer_basic_get_test(_) ->
                     single_active_consumer_on => true}),
     ?assertEqual(single_active, State0#rabbit_fifo.cfg#cfg.consumer_strategy),
     ?assertEqual(0, map_size(State0#rabbit_fifo.consumers)),
-    {State1, _} = enq(1, 1, first, State0),
+    {State1, _} = enq(C, 1, 1, first, State0),
     {_State, {error, {unsupported, single_active_consumer}}} =
-        apply(meta(2), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
+        apply(meta(C, 2), rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
               State1),
     ok.
 
-single_active_consumer_revive_test(_) ->
+single_active_consumer_revive_test(C) ->
     S0 = init(#{name => ?FUNCTION_NAME,
                 queue_resource => rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
                 single_active_consumer_on => true}),
     Cid1 = {<<"one">>, self()},
     Cid2 = {<<"two">>, self()},
-    {S1, _} = check_auto(Cid1, 1, S0),
-    {S2, _} = check_auto(Cid2, 2, S1),
-    {S3, _} = enq(3, 1, first, S2),
+    {S1, _} = check_auto(C, Cid1, 1, S0),
+    {S2, _} = check_auto(C, Cid2, 2, S1),
+    {S3, _} = enq(C, 3, 1, first, S2),
     %% cancel the active consumer whilst it has a message pending
-    {S4, _, _} = rabbit_fifo:apply(meta(4), make_checkout(Cid1, cancel, #{}), S3),
-    {S5, _} = check_auto(Cid1, 5, S4),
+    {S4, _, _} = rabbit_fifo:apply(meta(C, 4), make_checkout(Cid1, cancel, #{}), S3),
+    {S5, _} = check_auto(C, Cid1, 5, S4),
 
     ct:pal("S5 ~p", [S5]),
     ?assertEqual(1, rabbit_fifo:query_messages_checked_out(S5)),
@@ -791,12 +795,12 @@ single_active_consumer_revive_test(_) ->
     ?assertEqual(1, map_size(Up)),
 
     %% settle message and ensure it is handled correctly
-    {S6, _} = settle(Cid1, 6, 0, S5),
+    {S6, _} = settle(C, Cid1, 6, 0, S5),
     ?assertEqual(0, rabbit_fifo:query_messages_checked_out(S6)),
     ?assertEqual(0, rabbit_fifo:query_messages_total(S6)),
 
     %% requeue message and check that is handled
-    {S6b, _} = return(Cid1, 6, 0, S5),
+    {S6b, _} = return(C, Cid1, 6, 0, S5),
     ?assertEqual(1, rabbit_fifo:query_messages_checked_out(S6b)),
     ?assertEqual(1, rabbit_fifo:query_messages_total(S6b)),
     %%
@@ -807,16 +811,16 @@ single_active_consumer_revive_test(_) ->
     %% MULTI checkout should not result in multiple waiting
     ok.
 
-single_active_consumer_revive_2_test(_) ->
+single_active_consumer_revive_2_test(C) ->
     S0 = init(#{name => ?FUNCTION_NAME,
                 queue_resource => rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
                 single_active_consumer_on => true}),
     Cid1 = {<<"one">>, self()},
-    {S1, _} = check_auto(Cid1, 1, S0),
-    {S2, _} = enq(3, 1, first, S1),
+    {S1, _} = check_auto(C, Cid1, 1, S0),
+    {S2, _} = enq(C, 3, 1, first, S1),
     %% cancel the active consumer whilst it has a message pending
-    {S3, _, _} = rabbit_fifo:apply(meta(4), make_checkout(Cid1, cancel, #{}), S2),
-    {S4, _} = check_auto(Cid1, 5, S3),
+    {S3, _, _} = rabbit_fifo:apply(meta(C, 4), make_checkout(Cid1, cancel, #{}), S2),
+    {S4, _} = check_auto(C, Cid1, 5, S3),
     ?assertEqual(1, rabbit_fifo:query_consumer_count(S4)),
     ?assertEqual(0, length(rabbit_fifo:query_waiting_consumers(S4))),
     ?assertEqual(1, rabbit_fifo:query_messages_total(S4)),
@@ -824,7 +828,7 @@ single_active_consumer_revive_2_test(_) ->
 
     ok.
 
-single_active_consumer_test(_) ->
+single_active_consumer_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -836,7 +840,7 @@ single_active_consumer_test(_) ->
     % adding some consumers
     AddConsumer = fun(CTag, State) ->
                           {NewState, _, _} = apply(
-                                               meta(1),
+                                               meta(C, 1),
                                                make_checkout({CTag, self()},
                                                              {once, 1, simple_prefetch},
                                                              #{}),
@@ -859,7 +863,7 @@ single_active_consumer_test(_) ->
     ?assertNotEqual(false, lists:keyfind(C4, 1, rabbit_fifo:query_waiting_consumers(State1))),
 
     % cancelling a waiting consumer
-    {State2, _, Effects1} = apply(meta(2),
+    {State2, _, Effects1} = apply(meta(C, 2),
                                   make_checkout(C3, cancel, #{}),
                                   State1),
     % the active consumer should still be in place
@@ -871,10 +875,10 @@ single_active_consumer_test(_) ->
     ?assertNotEqual(false, lists:keyfind(C4, 1, rabbit_fifo:query_waiting_consumers(State2))),
     % there are some effects to unregister the consumer
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C3, Effects1),
+                 cancel_consumer_handler, [_, Con]}, Con == C3, Effects1),
 
     % cancelling the active consumer
-    {State3, _, Effects2} = apply(meta(3),
+    {State3, _, Effects2} = apply(meta(C, 3),
                                   make_checkout(C1, cancel, #{}),
                                   State2),
     % the second registered consumer is now the active one
@@ -887,12 +891,12 @@ single_active_consumer_test(_) ->
     %% should have a cancel consumer handler mod_call effect and
     %% an active new consumer effect
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C1, Effects2),
+                 cancel_consumer_handler, [_, Con]}, Con == C1, Effects2),
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
                  update_consumer_handler, _}, Effects2),
 
     % cancelling the active consumer
-    {State4, _, Effects3} = apply(meta(4),
+    {State4, _, Effects3} = apply(meta(C, 4),
                                   make_checkout(C2, cancel, #{}),
                                   State3),
     % the last waiting consumer became the active one
@@ -903,12 +907,12 @@ single_active_consumer_test(_) ->
     % there are some effects to unregister the consumer and
     % to update the new active one (metrics)
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C2, Effects3),
+                 cancel_consumer_handler, [_, Con]}, Con == C2, Effects3),
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
                  update_consumer_handler, _}, Effects3),
 
     % cancelling the last consumer
-    {State5, _, Effects4} = apply(meta(5),
+    {State5, _, Effects4} = apply(meta(C, 5),
                                   make_checkout(C4, cancel, #{}),
                                   State4),
     % no active consumer anymore
@@ -921,7 +925,7 @@ single_active_consumer_test(_) ->
 
     ok.
 
-single_active_consumer_cancel_consumer_when_channel_is_down_test(_) ->
+single_active_consumer_cancel_consumer_when_channel_is_down_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
         queue_resource => rabbit_misc:r("/", queue,
             atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -939,7 +943,7 @@ single_active_consumer_cancel_consumer_when_channel_is_down_test(_) ->
     % adding some consumers
     AddConsumer = fun({CTag, ChannelId}, State) ->
         {NewState, _, _} = apply(
-            meta(1),
+            meta(C, 1),
             make_checkout({CTag, ChannelId}, {once, 1, simple_prefetch}, #{}),
             State),
         NewState
@@ -947,7 +951,7 @@ single_active_consumer_cancel_consumer_when_channel_is_down_test(_) ->
     State1 = lists:foldl(AddConsumer, State0, Consumers),
 
     % the channel of the active consumer goes down
-    {State2, _, Effects} = apply(meta(2), {down, Pid1, noproc}, State1),
+    {State2, _, Effects} = apply(meta(C, 2), {down, Pid1, noproc}, State1),
     % fell back to another consumer
     ?assertEqual(1, map_size(State2#rabbit_fifo.consumers)),
     % there are still waiting consumers
@@ -955,42 +959,42 @@ single_active_consumer_cancel_consumer_when_channel_is_down_test(_) ->
     % effects to unregister the consumer and
     % to update the new active one (metrics) are there
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C1, Effects),
+                 cancel_consumer_handler, [_, Con]}, Con == C1, Effects),
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
                  update_consumer_handler, _}, Effects),
 
     % the channel of the active consumer and a waiting consumer goes down
-    {State3, _, Effects2} = apply(meta(3), {down, Pid2, noproc}, State2),
+    {State3, _, Effects2} = apply(meta(C, 3), {down, Pid2, noproc}, State2),
     % fell back to another consumer
     ?assertEqual(1, map_size(State3#rabbit_fifo.consumers)),
     % no more waiting consumer
     ?assertEqual(0, length(rabbit_fifo:query_waiting_consumers(State3))),
     % effects to cancel both consumers of this channel + effect to update the new active one (metrics)
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C2, Effects2),
+                 cancel_consumer_handler, [_, Con]}, Con == C2, Effects2),
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C3, Effects2),
+                 cancel_consumer_handler, [_, Con]}, Con == C3, Effects2),
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
                  update_consumer_handler, _}, Effects2),
 
     % the last channel goes down
-    {State4, _, Effects3} = apply(meta(4), {down, Pid3, doesnotmatter}, State3),
+    {State4, _, Effects3} = apply(meta(C, 4), {down, Pid3, doesnotmatter}, State3),
     % no more consumers
     ?assertEqual(0, map_size(State4#rabbit_fifo.consumers)),
     ?assertEqual(0, length(rabbit_fifo:query_waiting_consumers(State4))),
     % there is an effect to unregister the consumer + queue inactive effect
     ?ASSERT_EFF({mod_call, rabbit_quorum_queue,
-                 cancel_consumer_handler, [_, C]}, C == C4, Effects3),
+                 cancel_consumer_handler, [_, Con]}, Con == C4, Effects3),
 
     ok.
 
-single_active_returns_messages_on_noconnection_test(_) ->
+single_active_returns_messages_on_noconnection_test(C) ->
     R = rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => R,
                     release_cursor_interval => 0,
                     single_active_consumer_on => true}),
-    Meta = meta(1),
+    Meta = meta(C, 1),
     Nodes = [n1],
     ConsumerIds = [{_, DownPid}] =
         [begin
@@ -1004,28 +1008,29 @@ single_active_returns_messages_on_noconnection_test(_) ->
                        {Acc, _, _} =
                            apply(Meta,
                                  make_checkout(CId,
-                                               {once, 1, simple_prefetch}, #{}),
+                                               {auto, 1, simple_prefetch}, #{}),
                                  Acc0),
                        Acc
                end, State0, ConsumerIds),
-    {State2, _} = enq(4, 1, msg1, State1),
+    {State2, _} = enq(C, 4, 1, msg1, State1),
     % simulate node goes down
-    {State3, _, _} = apply(meta(5), {down, DownPid, noconnection}, State2),
+    {State3, _, _} = apply(meta(C, 5), {down, DownPid, noconnection}, State2),
     %% assert the consumer is up
     ?assertMatch([_], lqueue:to_list(State3#rabbit_fifo.returns)),
-    ?assertMatch([{_, #consumer{checked_out = Checked}}]
+    ?assertMatch([{_, #consumer{checked_out = Checked,
+                                credit = 1}}]
                  when map_size(Checked) == 0,
                       rabbit_fifo:query_waiting_consumers(State3)),
 
     ok.
 
-single_active_consumer_replaces_consumer_when_down_noconnection_test(_) ->
+single_active_consumer_replaces_consumer_when_down_noconnection_test(C) ->
     R = rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => R,
                     release_cursor_interval => 0,
                     single_active_consumer_on => true}),
-    Meta = meta(1),
+    Meta = meta(C, 1),
     Nodes = [n1, n2, node()],
     ConsumerIds = [C1 = {_, DownPid}, C2, _C3] =
     [begin
@@ -1048,10 +1053,10 @@ single_active_consumer_replaces_consumer_when_down_noconnection_test(_) ->
     ?assertMatch(#{C1 := #consumer{status = up}},
                  State1a#rabbit_fifo.consumers),
 
-    {State1, _} = enq(10, 1, msg, State1a),
+    {State1, _} = enq(C, 10, 1, msg, State1a),
 
     % simulate node goes down
-    {State2, _, _} = apply(meta(5), {down, DownPid, noconnection}, State1),
+    {State2, _, _} = apply(meta(C, 5), {down, DownPid, noconnection}, State1),
 
     %% assert a new consumer is in place and it is up
     ?assertMatch([{C2, #consumer{status = up,
@@ -1060,12 +1065,12 @@ single_active_consumer_replaces_consumer_when_down_noconnection_test(_) ->
                         maps:to_list(State2#rabbit_fifo.consumers)),
 
     %% the disconnected consumer has been returned to waiting
-    ?assert(lists:any(fun ({C,_}) -> C =:= C1 end,
+    ?assert(lists:any(fun ({Con,_}) -> Con =:= C1 end,
                       rabbit_fifo:query_waiting_consumers(State2))),
     ?assertEqual(2, length(rabbit_fifo:query_waiting_consumers(State2))),
 
     % simulate node comes back up
-    {State3, _, _} = apply(meta(2), {nodeup, node(DownPid)}, State2),
+    {State3, _, _} = apply(meta(C, 2), {nodeup, node(DownPid)}, State2),
 
     %% the consumer is still active and the same as before
     ?assertMatch([{C2, #consumer{status = up}}],
@@ -1077,13 +1082,13 @@ single_active_consumer_replaces_consumer_when_down_noconnection_test(_) ->
                   end, rabbit_fifo:query_waiting_consumers(State3)),
     ok.
 
-single_active_consumer_all_disconnected_test(_) ->
+single_active_consumer_all_disconnected_test(C) ->
     R = rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => R,
                     release_cursor_interval => 0,
                     single_active_consumer_on => true}),
-    Meta = meta(1),
+    Meta = meta(C, 1),
     Nodes = [n1, n2],
     ConsumerIds = [C1 = {_, C1Pid}, C2 = {_, C2Pid}] =
     [begin
@@ -1106,14 +1111,14 @@ single_active_consumer_all_disconnected_test(_) ->
     ?assertMatch(#{C1 := #consumer{status = up}}, State1#rabbit_fifo.consumers),
 
     % simulate node goes down
-    {State2, _, _} = apply(meta(5), {down, C1Pid, noconnection}, State1),
+    {State2, _, _} = apply(meta(C, 5), {down, C1Pid, noconnection}, State1),
     %% assert the consumer fails over to the consumer on n2
     ?assertMatch(#{C2 := #consumer{status = up}}, State2#rabbit_fifo.consumers),
-    {State3, _, _} = apply(meta(6), {down, C2Pid, noconnection}, State2),
+    {State3, _, _} = apply(meta(C, 6), {down, C2Pid, noconnection}, State2),
     %% assert these no active consumer after both nodes are maked as down
     ?assertMatch([], maps:to_list(State3#rabbit_fifo.consumers)),
     %% n2 comes back
-    {State4, _, _} = apply(meta(7), {nodeup, node(C2Pid)}, State3),
+    {State4, _, _} = apply(meta(C, 7), {nodeup, node(C2Pid)}, State3),
     %% ensure n2 is the active consumer as this node as been registered
     %% as up again
     ?assertMatch([{{<<"ctag_n2">>, _}, #consumer{status = up,
@@ -1121,7 +1126,7 @@ single_active_consumer_all_disconnected_test(_) ->
                  maps:to_list(State4#rabbit_fifo.consumers)),
     ok.
 
-single_active_consumer_state_enter_leader_include_waiting_consumers_test(_) ->
+single_active_consumer_state_enter_leader_include_waiting_consumers_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource =>
                     rabbit_misc:r("/", queue,
@@ -1134,7 +1139,7 @@ single_active_consumer_state_enter_leader_include_waiting_consumers_test(_) ->
     Pid2 = spawn(DummyFunction),
     Pid3 = spawn(DummyFunction),
 
-    Meta = meta(1),
+    Meta = meta(C, 1),
     % adding some consumers
     AddConsumer = fun({CTag, ChannelId}, State) ->
         {NewState, _, _} = apply(
@@ -1152,7 +1157,7 @@ single_active_consumer_state_enter_leader_include_waiting_consumers_test(_) ->
     %% 1 effect for file handle reservation
     ?assertEqual(2 * 3 + 1 + 1 + 1, length(Effects)).
 
-single_active_consumer_state_enter_eol_include_waiting_consumers_test(_) ->
+single_active_consumer_state_enter_eol_include_waiting_consumers_test(C) ->
     Resource = rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => Resource,
@@ -1164,7 +1169,7 @@ single_active_consumer_state_enter_eol_include_waiting_consumers_test(_) ->
     Pid2 = spawn(DummyFunction),
     Pid3 = spawn(DummyFunction),
 
-    Meta = meta(1),
+    Meta = meta(C, 1),
     % adding some consumers
     AddConsumer = fun({CTag, ChannelId}, State) ->
         {NewState, _, _} = apply(
@@ -1184,7 +1189,7 @@ single_active_consumer_state_enter_eol_include_waiting_consumers_test(_) ->
     %% 1 effect for eol to handle rabbit_fifo_usage entries
     ?assertEqual(5, length(Effects)).
 
-query_consumers_test(_) ->
+query_consumers_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1194,7 +1199,7 @@ query_consumers_test(_) ->
     % adding some consumers
     AddConsumer = fun(CTag, State) ->
                           {NewState, _, _} = apply(
-                                               meta(1),
+                                               meta(C, 1),
                                                make_checkout({CTag, self()},
                                                              {once, 1, simple_prefetch}, #{}),
                                                State),
@@ -1222,13 +1227,13 @@ query_consumers_test(_) ->
         end
               end, [], Consumers2).
 
-query_consumers_when_single_active_consumer_is_on_test(_) ->
+query_consumers_when_single_active_consumer_is_on_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
                     release_cursor_interval => 0,
                     single_active_consumer_on => true}),
-    Meta = meta(1),
+    Meta = meta(C, 1),
     % adding some consumers
     AddConsumer = fun(CTag, State) ->
                     {NewState, _, _} = apply(
@@ -1255,7 +1260,7 @@ query_consumers_when_single_active_consumer_is_on_test(_) ->
                   end
               end, [], Consumers).
 
-active_flag_updated_when_consumer_suspected_unsuspected_test(_) ->
+active_flag_updated_when_consumer_suspected_unsuspected_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
         queue_resource => rabbit_misc:r("/", queue,
             atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1271,7 +1276,7 @@ active_flag_updated_when_consumer_suspected_unsuspected_test(_) ->
     AddConsumer = fun({CTag, ChannelId}, State) ->
                           {NewState, _, _} =
                           apply(
-                            meta(1),
+                            meta(C, 1),
                             rabbit_fifo:make_checkout({CTag, ChannelId},
                                                       {once, 1, simple_prefetch},
                                                       #{}),
@@ -1281,16 +1286,16 @@ active_flag_updated_when_consumer_suspected_unsuspected_test(_) ->
     State1 = lists:foldl(AddConsumer, State0,
         [{<<"ctag1">>, Pid1}, {<<"ctag2">>, Pid2}, {<<"ctag3">>, Pid2}, {<<"ctag4">>, Pid3}]),
 
-    {State2, _, Effects2} = apply(meta(3),
+    {State2, _, Effects2} = apply(meta(C, 3),
                                     {down, Pid1, noconnection}, State1),
     % 1 effect to update the metrics of each consumer (they belong to the same node), 1 more effect to monitor the node, 1 more decorators effect
     ?assertEqual(4 + 1, length(Effects2)),
 
-    {_, _, Effects3} = apply(meta(4), {nodeup, node(self())}, State2),
+    {_, _, Effects3} = apply(meta(C, 4), {nodeup, node(self())}, State2),
     % for each consumer: 1 effect to update the metrics, 1 effect to monitor the consumer PID, 1 more decorators effect
     ?assertEqual(4 + 4, length(Effects3)).
 
-active_flag_not_updated_when_consumer_suspected_unsuspected_and_single_active_consumer_is_on_test(_) ->
+active_flag_not_updated_when_consumer_suspected_unsuspected_and_single_active_consumer_is_on_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                                                     atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1305,7 +1310,7 @@ active_flag_not_updated_when_consumer_suspected_unsuspected_and_single_active_co
     % adding some consumers
     AddConsumer = fun({CTag, ChannelId}, State) ->
                           {NewState, _, _} = apply(
-                                               meta(1),
+                                               meta(C, 1),
                                                make_checkout({CTag, ChannelId},
                                                              {once, 1, simple_prefetch}, #{}),
             State),
@@ -1315,15 +1320,15 @@ active_flag_not_updated_when_consumer_suspected_unsuspected_and_single_active_co
                          [{<<"ctag1">>, Pid1}, {<<"ctag2">>, Pid2},
                           {<<"ctag3">>, Pid2}, {<<"ctag4">>, Pid3}]),
 
-    {State2, _, Effects2} = apply(meta(2), {down, Pid1, noconnection}, State1),
+    {State2, _, Effects2} = apply(meta(C, 2), {down, Pid1, noconnection}, State1),
     % one monitor and one consumer status update (deactivated)
     ?assertEqual(2, length(Effects2)),
 
-    {_, _, Effects3} = apply(meta(3), {nodeup, node(self())}, State2),
+    {_, _, Effects3} = apply(meta(C, 3), {nodeup, node(self())}, State2),
     % for each consumer: 1 effect to monitor the consumer PID
     ?assertEqual(5, length(Effects3)).
 
-single_active_cancelled_with_unacked_test(_) ->
+single_active_cancelled_with_unacked_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1333,10 +1338,10 @@ single_active_cancelled_with_unacked_test(_) ->
     C1 = {<<"ctag1">>, self()},
     C2 = {<<"ctag2">>, self()},
     % adding some consumers
-    AddConsumer = fun(C, S0) ->
+    AddConsumer = fun(Con, S0) ->
                           {S, _, _} = apply(
-                                        meta(1),
-                                        make_checkout(C,
+                                        meta(C, 1),
+                                        make_checkout(Con,
                                                       {auto, 1, simple_prefetch},
                                                       #{}),
                                         S0),
@@ -1345,11 +1350,11 @@ single_active_cancelled_with_unacked_test(_) ->
     State1 = lists:foldl(AddConsumer, State0, [C1, C2]),
 
     %% enqueue 2 messages
-    {State2, _Effects2} = enq(3, 1, msg1, State1),
-    {State3, _Effects3} = enq(4, 2, msg2, State2),
+    {State2, _Effects2} = enq(C, 3, 1, msg1, State1),
+    {State3, _Effects3} = enq(C, 4, 2, msg2, State2),
     %% one should be checked ou to C1
     %% cancel C1
-    {State4, _, _} = apply(meta(5),
+    {State4, _, _} = apply(meta(C, 5),
                            make_checkout(C1, cancel, #{}),
                            State3),
     %% C2 should be the active consumer
@@ -1364,9 +1369,9 @@ single_active_cancelled_with_unacked_test(_) ->
     ?assertMatch([], rabbit_fifo:query_waiting_consumers(State4)),
 
     %% Ack both messages
-    {State5, _Effects5} = settle(C1, 1, 0, State4),
+    {State5, _Effects5} = settle(C, C1, 1, 0, State4),
     %% C1 should now be cancelled
-    {State6, _Effects6} = settle(C2, 2, 0, State5),
+    {State6, _Effects6} = settle(C, C2, 2, 0, State5),
 
     %% C2 should remain
     ?assertMatch(#{C2 := #consumer{status = up}},
@@ -1377,7 +1382,7 @@ single_active_cancelled_with_unacked_test(_) ->
     ?assertMatch([], rabbit_fifo:query_waiting_consumers(State6)),
     ok.
 
-single_active_with_credited_test(_) ->
+single_active_with_credited_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1387,10 +1392,10 @@ single_active_with_credited_test(_) ->
     C1 = {<<"ctag1">>, self()},
     C2 = {<<"ctag2">>, self()},
     % adding some consumers
-    AddConsumer = fun(C, S0) ->
+    AddConsumer = fun(Con, S0) ->
                           {S, _, _} = apply(
-                                        meta(1),
-                                        make_checkout(C,
+                                        meta(C, 1),
+                                        make_checkout(Con,
                                                       {auto, 0, credited},
                                                       #{}),
                                         S0),
@@ -1400,9 +1405,9 @@ single_active_with_credited_test(_) ->
 
     %% add some credit
     C1Cred = rabbit_fifo:make_credit(C1, 5, 0, false),
-    {State2, _, _Effects2} = apply(meta(3), C1Cred, State1),
+    {State2, _, _Effects2} = apply(meta(C, 3), C1Cred, State1),
     C2Cred = rabbit_fifo:make_credit(C2, 4, 0, false),
-    {State3, _} = apply(meta(4), C2Cred, State2),
+    {State3, _} = apply(meta(C, 4), C2Cred, State2),
     %% both consumers should have credit
     ?assertMatch(#{C1 := #consumer{credit = 5}},
                  State3#rabbit_fifo.consumers),
@@ -1411,7 +1416,7 @@ single_active_with_credited_test(_) ->
     ok.
 
 
-register_enqueuer_test(_) ->
+register_enqueuer_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1420,22 +1425,22 @@ register_enqueuer_test(_) ->
                     overflow_strategy => reject_publish}),
     %% simply registering should be ok when we're below limit
     Pid1 = test_util:fake_pid(node()),
-    {State1, ok, [_]} = apply(meta(1), make_register_enqueuer(Pid1), State0),
+    {State1, ok, [_]} = apply(meta(C, 1), make_register_enqueuer(Pid1), State0),
 
-    {State2, ok, _} = apply(meta(2), rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
+    {State2, ok, _} = apply(meta(C, 2), rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
     %% register another enqueuer shoudl be ok
     Pid2 = test_util:fake_pid(node()),
-    {State3, ok, [_]} = apply(meta(3), make_register_enqueuer(Pid2), State2),
+    {State3, ok, [_]} = apply(meta(C, 3), make_register_enqueuer(Pid2), State2),
 
-    {State4, ok, _} = apply(meta(4), rabbit_fifo:make_enqueue(Pid1, 2, two), State3),
-    {State5, ok, Efx} = apply(meta(5), rabbit_fifo:make_enqueue(Pid1, 3, three), State4),
+    {State4, ok, _} = apply(meta(C, 4), rabbit_fifo:make_enqueue(Pid1, 2, two), State3),
+    {State5, ok, Efx} = apply(meta(C, 5), rabbit_fifo:make_enqueue(Pid1, 3, three), State4),
     % ct:pal("Efx ~p", [Efx]),
     %% validate all registered enqueuers are notified of overflow state
     ?ASSERT_EFF({send_msg, P, {queue_status, reject_publish}, [ra_event]}, P == Pid1, Efx),
     ?ASSERT_EFF({send_msg, P, {queue_status, reject_publish}, [ra_event]}, P == Pid2, Efx),
 
     %% this time, registry should return reject_publish
-    {State6, reject_publish, [_]} = apply(meta(6), make_register_enqueuer(
+    {State6, reject_publish, [_]} = apply(meta(C, 6), make_register_enqueuer(
                                                      test_util:fake_pid(node())), State5),
     ?assertMatch(#{num_enqueuers := 3}, rabbit_fifo:overview(State6)),
 
@@ -1443,13 +1448,13 @@ register_enqueuer_test(_) ->
     Pid3 = test_util:fake_pid(node()),
     %% remove two messages this should make the queue fall below the 0.8 limit
     {State7, _, Efx7} =
-        apply(meta(7),
+        apply(meta(C, 7),
               rabbit_fifo:make_checkout({<<"a">>, Pid3}, {dequeue, settled}, #{}),
               State6),
     ?ASSERT_EFF({log, [_], _}, Efx7),
     % ct:pal("Efx7 ~p", [_Efx7]),
     {State8, _, Efx8} =
-        apply(meta(8),
+        apply(meta(C, 8),
               rabbit_fifo:make_checkout({<<"a">>, Pid3}, {dequeue, settled}, #{}),
               State7),
     ?ASSERT_EFF({log, [_], _}, Efx8),
@@ -1458,7 +1463,7 @@ register_enqueuer_test(_) ->
     ?ASSERT_EFF({send_msg, P, {queue_status, go}, [ra_event]}, P == Pid1, Efx8),
     ?ASSERT_EFF({send_msg, P, {queue_status, go}, [ra_event]}, P == Pid2, Efx8),
     {_State9, _, Efx9} =
-        apply(meta(9),
+        apply(meta(C, 9),
               rabbit_fifo:make_checkout({<<"a">>, Pid3}, {dequeue, settled}, #{}),
               State8),
     ?ASSERT_EFF({log, [_], _}, Efx9),
@@ -1466,7 +1471,7 @@ register_enqueuer_test(_) ->
     ?ASSERT_NO_EFF({send_msg, P, go, [ra_event]}, P == Pid2, Efx9),
     ok.
 
-reject_publish_purge_test(_) ->
+reject_publish_purge_test(C) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
@@ -1475,17 +1480,17 @@ reject_publish_purge_test(_) ->
                     overflow_strategy => reject_publish}),
     %% simply registering should be ok when we're below limit
     Pid1 = test_util:fake_pid(node()),
-    {State1, ok, [_]} = apply(meta(1), make_register_enqueuer(Pid1), State0),
-    {State2, ok, _} = apply(meta(2), rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
-    {State3, ok, _} = apply(meta(3), rabbit_fifo:make_enqueue(Pid1, 2, two), State2),
-    {State4, ok, Efx} = apply(meta(4), rabbit_fifo:make_enqueue(Pid1, 3, three), State3),
+    {State1, ok, [_]} = apply(meta(C, 1), make_register_enqueuer(Pid1), State0),
+    {State2, ok, _} = apply(meta(C, 2), rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
+    {State3, ok, _} = apply(meta(C, 3), rabbit_fifo:make_enqueue(Pid1, 2, two), State2),
+    {State4, ok, Efx} = apply(meta(C, 4), rabbit_fifo:make_enqueue(Pid1, 3, three), State3),
     % ct:pal("Efx ~p", [Efx]),
     ?ASSERT_EFF({send_msg, P, {queue_status, reject_publish}, [ra_event]}, P == Pid1, Efx),
-    {_State5, {purge, 3}, Efx1} = apply(meta(5), rabbit_fifo:make_purge(), State4),
+    {_State5, {purge, 3}, Efx1} = apply(meta(C, 5), rabbit_fifo:make_purge(), State4),
     ?ASSERT_EFF({send_msg, P, {queue_status, go}, [ra_event]}, P == Pid1, Efx1),
     ok.
 
-reject_publish_applied_after_limit_test(_) ->
+reject_publish_applied_after_limit_test(C) ->
     QName = rabbit_misc:r("/", queue, atom_to_binary(?FUNCTION_NAME, utf8)),
     InitConf = #{name => ?FUNCTION_NAME,
                  max_in_memory_length => 0,
@@ -1494,10 +1499,10 @@ reject_publish_applied_after_limit_test(_) ->
     State0 = init(InitConf),
     %% simply registering should be ok when we're below limit
     Pid1 = test_util:fake_pid(node()),
-    {State1, ok, [_]} = apply(meta(1), make_register_enqueuer(Pid1), State0),
-    {State2, ok, _} = apply(meta(2), rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
-    {State3, ok, _} = apply(meta(3), rabbit_fifo:make_enqueue(Pid1, 2, two), State2),
-    {State4, ok, Efx} = apply(meta(4), rabbit_fifo:make_enqueue(Pid1, 3, three), State3),
+    {State1, ok, [_]} = apply(meta(C, 1), make_register_enqueuer(Pid1), State0),
+    {State2, ok, _} = apply(meta(C, 2), rabbit_fifo:make_enqueue(Pid1, 1, one), State1),
+    {State3, ok, _} = apply(meta(C, 3), rabbit_fifo:make_enqueue(Pid1, 2, two), State2),
+    {State4, ok, Efx} = apply(meta(C, 4), rabbit_fifo:make_enqueue(Pid1, 3, three), State3),
     % ct:pal("Efx ~p", [Efx]),
     ?ASSERT_NO_EFF({send_msg, P, {queue_status, reject_publish}, [ra_event]}, P == Pid1, Efx),
     %% apply new config
@@ -1508,13 +1513,13 @@ reject_publish_applied_after_limit_test(_) ->
              max_in_memory_length => 0,
              dead_letter_handler => undefined
             },
-    {State5, ok, Efx1} = apply(meta(5), rabbit_fifo:make_update_config(Conf), State4),
+    {State5, ok, Efx1} = apply(meta(C, 5), rabbit_fifo:make_update_config(Conf), State4),
     ?ASSERT_EFF({send_msg, P, {queue_status, reject_publish}, [ra_event]}, P == Pid1, Efx1),
     Pid2 = test_util:fake_pid(node()),
-    {_State6, reject_publish, _} = apply(meta(1), make_register_enqueuer(Pid2), State5),
+    {_State6, reject_publish, _} = apply(meta(C, 1), make_register_enqueuer(Pid2), State5),
     ok.
 
-purge_nodes_test(_) ->
+purge_nodes_test(C) ->
     Node = purged@node,
     ThisNode = node(),
     EnqPid = test_util:fake_pid(Node),
@@ -1527,14 +1532,14 @@ purge_nodes_test(_) ->
                     queue_resource => rabbit_misc:r("/", queue,
                         atom_to_binary(?FUNCTION_NAME, utf8)),
                     single_active_consumer_on => false}),
-    {State1, _, _} = apply(meta(1),
+    {State1, _, _} = apply(meta(C, 1),
                            rabbit_fifo:make_enqueue(EnqPid, 1, msg1),
                            State0),
-    {State2, _, _} = apply(meta(2),
+    {State2, _, _} = apply(meta(C, 2),
                            rabbit_fifo:make_enqueue(EnqPid2, 1, msg2),
                            State1),
-    {State3, _} = check(Cid, 3, 1000, State2),
-    {State4, _, _} = apply(meta(4),
+    {State3, _} = check(C, Cid, 3, 1000, State2),
+    {State4, _, _} = apply(meta(C, 4),
                            {down, EnqPid, noconnection},
                            State3),
     ?assertMatch(
@@ -1543,7 +1548,7 @@ purge_nodes_test(_) ->
           [ThisNode, Node]
          ]}] , rabbit_fifo:tick(1, State4)),
     %% assert there are both enqueuers and consumers
-    {State, _, _} = apply(meta(5),
+    {State, _, _} = apply(meta(C, 5),
                           rabbit_fifo:make_purge_nodes([Node]),
                           State4),
 
@@ -1560,22 +1565,23 @@ purge_nodes_test(_) ->
          ]}] , rabbit_fifo:tick(1, State)),
     ok.
 
-meta(Idx) ->
-    meta(Idx, 0).
+meta(Config, Idx) ->
+    meta(Config, Idx, 0).
 
-meta(Idx, Timestamp) ->
-    #{index => Idx,
+meta(Config, Idx, Timestamp) ->
+    #{machine_version => ?config(machine_version, Config),
+      index => Idx,
       term => 1,
       system_time => Timestamp,
       from => {make_ref(), self()}}.
 
-enq(Idx, MsgSeq, Msg, State) ->
+enq(Config, Idx, MsgSeq, Msg, State) ->
     strip_reply(
-        rabbit_fifo:apply(meta(Idx), rabbit_fifo:make_enqueue(self(), MsgSeq, Msg), State)).
+        rabbit_fifo:apply(meta(Config, Idx), rabbit_fifo:make_enqueue(self(), MsgSeq, Msg), State)).
 
-deq(Idx, Cid, Settlement, Msg, State0) ->
+deq(Config, Idx, Cid, Settlement, Msg, State0) ->
     {State, _, Effs} =
-        apply(meta(Idx),
+        apply(meta(Config, Idx),
               rabbit_fifo:make_checkout(Cid, {dequeue, Settlement}, #{}),
               State0),
     {value, {log, [_Idx], Fun}} = lists:search(fun(E) -> element(1, E) == log end, Effs),
@@ -1584,46 +1590,46 @@ deq(Idx, Cid, Settlement, Msg, State0) ->
 
     {State, {MsgId, Msg}}.
 
-check_n(Cid, Idx, N, State) ->
+check_n(Config, Cid, Idx, N, State) ->
     strip_reply(
-      apply(meta(Idx),
+      apply(meta(Config, Idx),
             rabbit_fifo:make_checkout(Cid, {auto, N, simple_prefetch}, #{}),
             State)).
 
-check(Cid, Idx, State) ->
+check(Config, Cid, Idx, State) ->
     strip_reply(
-      apply(meta(Idx),
+      apply(meta(Config, Idx),
             rabbit_fifo:make_checkout(Cid, {once, 1, simple_prefetch}, #{}),
             State)).
 
-check_auto(Cid, Idx, State) ->
+check_auto(Config, Cid, Idx, State) ->
     strip_reply(
-      apply(meta(Idx),
+      apply(meta(Config, Idx),
             rabbit_fifo:make_checkout(Cid, {auto, 1, simple_prefetch}, #{}),
             State)).
 
-check(Cid, Idx, Num, State) ->
+check(Config, Cid, Idx, Num, State) ->
     strip_reply(
-      apply(meta(Idx),
+      apply(meta(Config, Idx),
             rabbit_fifo:make_checkout(Cid, {auto, Num, simple_prefetch}, #{}),
             State)).
 
-settle(Cid, Idx, MsgId, State) ->
-    strip_reply(apply(meta(Idx), rabbit_fifo:make_settle(Cid, [MsgId]), State)).
+settle(Config, Cid, Idx, MsgId, State) ->
+    strip_reply(apply(meta(Config, Idx), rabbit_fifo:make_settle(Cid, [MsgId]), State)).
 
-return(Cid, Idx, MsgId, State) ->
-    strip_reply(apply(meta(Idx), rabbit_fifo:make_return(Cid, [MsgId]), State)).
+return(Config, Cid, Idx, MsgId, State) ->
+    strip_reply(apply(meta(Config, Idx), rabbit_fifo:make_return(Cid, [MsgId]), State)).
 
-credit(Cid, Idx, Credit, DelCnt, Drain, State) ->
-    strip_reply(apply(meta(Idx), rabbit_fifo:make_credit(Cid, Credit, DelCnt, Drain),
+credit(Config, Cid, Idx, Credit, DelCnt, Drain, State) ->
+    strip_reply(apply(meta(Config, Idx), rabbit_fifo:make_credit(Cid, Credit, DelCnt, Drain),
                       State)).
 
 strip_reply({State, _, Effects}) ->
     {State, Effects}.
 
-run_log(InitState, Entries) ->
+run_log(Config, InitState, Entries) ->
     lists:foldl(fun ({Idx, E}, {Acc0, Efx0}) ->
-                        case apply(meta(Idx), E, Acc0) of
+                        case apply(meta(Config, Idx), E, Acc0) of
                             {Acc, _, Efx} when is_list(Efx) ->
                                 {Acc, Efx0 ++ Efx};
                             {Acc, _, Efx}  ->
@@ -1657,12 +1663,12 @@ aux_test(_) ->
 
 %% machine version conversion test
 
-machine_version_test(_) ->
+machine_version_test(C) ->
     V0 = rabbit_fifo_v0,
     S0 = V0:init(#{name => ?FUNCTION_NAME,
                    queue_resource => rabbit_misc:r(<<"/">>, queue, <<"test">>)}),
     Idx = 1,
-    {#rabbit_fifo{}, ok, _} = apply(meta(Idx), {machine_version, 0, 2}, S0),
+    {#rabbit_fifo{}, ok, _} = apply(meta(C, Idx), {machine_version, 0, 2}, S0),
 
     Cid = {atom_to_binary(?FUNCTION_NAME, utf8), self()},
     Entries = [
@@ -1676,19 +1682,19 @@ machine_version_test(_) ->
                   consumers = #{Cid := #consumer{cfg = #consumer_cfg{priority = 0}}},
                   service_queue = S,
                   messages = Msgs}, ok,
-     [_|_]} = apply(meta(Idx),
+     [_|_]} = apply(meta(C, Idx),
                     {machine_version, 0, 2}, S1),
     %% validate message conversion to lqueue
     ?assertEqual(1, lqueue:len(Msgs)),
     ?assert(priority_queue:is_queue(S)),
     ok.
 
-machine_version_waiting_consumer_test(_) ->
+machine_version_waiting_consumer_test(C) ->
     V0 = rabbit_fifo_v0,
     S0 = V0:init(#{name => ?FUNCTION_NAME,
                    queue_resource => rabbit_misc:r(<<"/">>, queue, <<"test">>)}),
     Idx = 1,
-    {#rabbit_fifo{}, ok, _} = apply(meta(Idx), {machine_version, 0, 2}, S0),
+    {#rabbit_fifo{}, ok, _} = apply(meta(C, Idx), {machine_version, 0, 2}, S0),
 
     Cid = {atom_to_binary(?FUNCTION_NAME, utf8), self()},
     Entries = [
@@ -1701,7 +1707,7 @@ machine_version_waiting_consumer_test(_) ->
     {#rabbit_fifo{enqueuers = #{Self := #enqueuer{}},
                   consumers = #{Cid := #consumer{cfg = #consumer_cfg{priority = 0}}},
                   service_queue = S,
-                  messages = Msgs}, ok, _} = apply(meta(Idx),
+                  messages = Msgs}, ok, _} = apply(meta(C, Idx),
                                                     {machine_version, 0, 2}, S1),
     %% validate message conversion to lqueue
     ?assertEqual(0, lqueue:len(Msgs)),
@@ -1709,7 +1715,7 @@ machine_version_waiting_consumer_test(_) ->
     ?assertEqual(1, priority_queue:len(S)),
     ok.
 
-queue_ttl_test(_) ->
+queue_ttl_test(C) ->
     QName = rabbit_misc:r(<<"/">>, queue, <<"test">>),
     Conf = #{name => ?FUNCTION_NAME,
              queue_resource => QName,
@@ -1723,11 +1729,11 @@ queue_ttl_test(_) ->
         = rabbit_fifo:tick(Now + 1000, S0),
     %% adding a consumer should not ever trigger deletion
     Cid = {<<"cid1">>, self()},
-    {S1, _} = check_auto(Cid, 1, S0),
+    {S1, _} = check_auto(C, Cid, 1, S0),
     [{mod_call, _, handle_tick, _}] = rabbit_fifo:tick(Now, S1),
     [{mod_call, _, handle_tick, _}] = rabbit_fifo:tick(Now + 1000, S1),
     %% cancelling the consumer should then
-    {S2, _, _} = apply(meta(2, Now),
+    {S2, _, _} = apply(meta(C, 2, Now),
                        rabbit_fifo:make_checkout(Cid, cancel, #{}), S1),
     %% last_active should have been reset when consumer was cancelled
     %% last_active = 2500
@@ -1737,7 +1743,7 @@ queue_ttl_test(_) ->
         = rabbit_fifo:tick(Now + 2500, S2),
 
     %% Same for downs
-    {S2D, _, _} = apply(meta(2, Now),
+    {S2D, _, _} = apply(meta(C, 2, Now),
                         {down, self(), noconnection}, S1),
     %% last_active should have been reset when consumer was cancelled
     %% last_active = 2500
@@ -1748,7 +1754,7 @@ queue_ttl_test(_) ->
 
     %% dequeue should set last applied
     {S1Deq, {dequeue, empty}, _} =
-        apply(meta(2, Now),
+        apply(meta(C, 2, Now),
               rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
               S0),
 
@@ -1758,17 +1764,17 @@ queue_ttl_test(_) ->
         = rabbit_fifo:tick(Now + 2500, S1Deq),
     %% Enqueue message,
     Msg = rabbit_fifo:make_enqueue(self(), 1, msg1),
-    {E1, _, _} = apply(meta(2, Now), Msg, S0),
+    {E1, _, _} = apply(meta(C, 2, Now), Msg, S0),
     Deq = {<<"deq1">>, self()},
     {E2, _, Effs2} =
-        apply(meta(3, Now),
+        apply(meta(C, 3, Now),
               rabbit_fifo:make_checkout(Deq, {dequeue, unsettled}, #{}),
               E1),
 
     {log, [2], Fun2} = get_log_eff(Effs2),
     [{reply, _From,
       {wrap_reply, {dequeue, {MsgId, _}, _}}}] = Fun2([Msg]),
-    {E3, _, _} = apply(meta(3, Now + 1000),
+    {E3, _, _} = apply(meta(C, 3, Now + 1000),
                        rabbit_fifo:make_settle(Deq, [MsgId]), E2),
     [{mod_call, _, handle_tick, _}] = rabbit_fifo:tick(Now + 1500, E3),
     %% but now it should be deleted
@@ -1777,7 +1783,7 @@ queue_ttl_test(_) ->
 
     ok.
 
-queue_ttl_with_single_active_consumer_test(_) ->
+queue_ttl_with_single_active_consumer_test(C) ->
     QName = rabbit_misc:r(<<"/">>, queue, <<"test">>),
     Conf = #{name => ?FUNCTION_NAME,
              queue_resource => QName,
@@ -1792,11 +1798,11 @@ queue_ttl_with_single_active_consumer_test(_) ->
         = rabbit_fifo:tick(Now + 1000, S0),
     %% adding a consumer should not ever trigger deletion
     Cid = {<<"cid1">>, self()},
-    {S1, _} = check_auto(Cid, 1, S0),
+    {S1, _} = check_auto(C, Cid, 1, S0),
     [{mod_call, _, handle_tick, _}] = rabbit_fifo:tick(Now, S1),
     [{mod_call, _, handle_tick, _}] = rabbit_fifo:tick(Now + 1000, S1),
     %% cancelling the consumer should then
-    {S2, _, _} = apply(meta(2, Now),
+    {S2, _, _} = apply(meta(C, 2, Now),
                        rabbit_fifo:make_checkout(Cid, cancel, #{}), S1),
     %% last_active should have been reset when consumer was cancelled
     %% last_active = 2500
@@ -1806,7 +1812,7 @@ queue_ttl_with_single_active_consumer_test(_) ->
         = rabbit_fifo:tick(Now + 2500, S2),
 
     %% Same for downs
-    {S2D, _, _} = apply(meta(2, Now),
+    {S2D, _, _} = apply(meta(C, 2, Now),
                         {down, self(), noconnection}, S1),
     %% last_active should have been reset when consumer was cancelled
     %% last_active = 2500
@@ -1817,11 +1823,11 @@ queue_ttl_with_single_active_consumer_test(_) ->
 
     ok.
 
-query_peek_test(_) ->
+query_peek_test(C) ->
     State0 = test_init(test),
     ?assertEqual({error, no_message_at_pos}, rabbit_fifo:query_peek(1, State0)),
-    {State1, _} = enq(1, 1, first, State0),
-    {State2, _} = enq(2, 2, second, State1),
+    {State1, _} = enq(C, 1, 1, first, State0),
+    {State2, _} = enq(C, 2, 2, second, State1),
     ?assertMatch({ok, [1 | _]}, rabbit_fifo:query_peek(1, State1)),
     ?assertEqual({error, no_message_at_pos}, rabbit_fifo:query_peek(2, State1)),
     ?assertMatch({ok, [1 | _]}, rabbit_fifo:query_peek(1, State2)),
@@ -1829,42 +1835,42 @@ query_peek_test(_) ->
     ?assertEqual({error, no_message_at_pos}, rabbit_fifo:query_peek(3, State2)),
     ok.
 
-checkout_priority_test(_) ->
+checkout_priority_test(C) ->
     Cid = {<<"checkout_priority_test">>, self()},
     Pid = spawn(fun () -> ok end),
     Cid2 = {<<"checkout_priority_test2">>, Pid},
     Args = [{<<"x-priority">>, long, 1}],
     {S1, _, _} =
-        apply(meta(3),
+        apply(meta(C, 3),
               rabbit_fifo:make_checkout(Cid, {once, 2, simple_prefetch},
                                         #{args => Args}),
               test_init(test)),
     {S2, _, _} =
-        apply(meta(3),
+        apply(meta(C, 3),
               rabbit_fifo:make_checkout(Cid2, {once, 2, simple_prefetch},
                                         #{args => []}),
               S1),
-    {S3, E3} = enq(1, 1, first, S2),
+    {S3, E3} = enq(C, 1, 1, first, S2),
     ct:pal("E3 ~p ~p", [E3, self()]),
     ?ASSERT_EFF({send_msg, P, {delivery, _, _}, _}, P == self(), E3),
-    {S4, E4} = enq(2, 2, second, S3),
+    {S4, E4} = enq(C, 2, 2, second, S3),
     ?ASSERT_EFF({send_msg, P, {delivery, _, _}, _}, P == self(), E4),
-    {_S5, E5} = enq(3, 3, third, S4),
+    {_S5, E5} = enq(C, 3, 3, third, S4),
     ?ASSERT_EFF({send_msg, P, {delivery, _, _}, _}, P == Pid, E5),
     ok.
 
-empty_dequeue_should_emit_release_cursor_test(_) ->
+empty_dequeue_should_emit_release_cursor_test(C) ->
     State0 = test_init(?FUNCTION_NAME),
     Cid = {<<"basic.get1">>, self()},
     {_State, {dequeue, empty}, Effects} =
-        apply(meta(2, 1234),
+        apply(meta(C, 2, 1234),
               rabbit_fifo:make_checkout(Cid, {dequeue, unsettled}, #{}),
               State0),
 
     ?ASSERT_EFF({release_cursor, _, _}, Effects),
     ok.
 
-expire_message_should_emit_release_cursor_test(_) ->
+expire_message_should_emit_release_cursor_test(C) ->
     Conf = #{name => ?FUNCTION_NAME,
              queue_resource => rabbit_misc:r(<<"/">>, queue, <<"test">>),
              release_cursor_interval => 0,
@@ -1872,8 +1878,8 @@ expire_message_should_emit_release_cursor_test(_) ->
     S0 = rabbit_fifo:init(Conf),
     Msg = #basic_message{content = #content{properties = none,
                                             payload_fragments_rev = []}},
-    {S1, ok, _} = apply(meta(1, 100), rabbit_fifo:make_enqueue(self(), 1, Msg), S0),
-    {_S, ok, Effs} = apply(meta(2, 101),
+    {S1, ok, _} = apply(meta(C, 1, 100), rabbit_fifo:make_enqueue(self(), 1, Msg), S0),
+    {_S, ok, Effs} = apply(meta(C, 2, 101),
                            rabbit_fifo:make_enqueue(self(), 2, Msg),
                            S1),
     ?ASSERT_EFF({release_cursor, 1, _}, Effs),


### PR DESCRIPTION
Prior to this commit, when a consumer NACKed a message with requeue=true
(resulting in a Ra #return{} command) and that message got
dropped or dead-lettered (for example because the delivery-limit
was exceeded), that consumer got too many credits granted,
which could lead to exceeding (and therefore violating) the
configured Prefetch value.
The consumer got credit granted twice: 1. for completing the message
and 2. for returning the message.

This bug has existed since 3.8. It got reported in
* https://groups.google.com/g/rabbitmq-users/c/iMcX0oXzURQ
* https://rabbitmq.slack.com/archives/C1EDN83PA/p1661257750373939

From now on, credit for a consumer is increased in only 3 places:

* a message is completed, or
* a message is returned, or
* a message is requeued using the new #requeue{} Ra command (when
delivery-limit is not configured)

Furthermore, this commit also fixes a somewhat related bug:
When a consumer with checked out messages gets cancelled, and
a new consumer subscribes with the same consumer ID and on the same channel
but with a lower Prefetch value, that new consumer's Prefetch value was
not always respected. This commit fixes this issue by ensuring that
the credit in simple_prefetch mode does not exceed the consumer
Prefetch value.

We cannot backport to v3.9.x because that branch uses rabbit_fifo Ra machine version 1.
Let's only backport to 3.11.