### PR TITLE
connection/channel tracking refactorings

### DIFF
--- a/deps/rabbit/src/rabbit_channel_tracking.erl
+++ b/deps/rabbit/src/rabbit_channel_tracking.erl
@@ -418,7 +418,7 @@ get_tracked_channels_by_connection_pid(ConnPid) ->
     end.
 
 get_tracked_channels_by_connection_pid_ets(ConnPid) ->
-    rabbit_tracking:match_tracked_items_ets(
+    rabbit_tracking:match_tracked_items_local(
         ?TRACKED_CHANNEL_TABLE,
         #tracked_channel{connection = ConnPid, _ = '_'}).
 

--- a/deps/rabbit/src/rabbit_channel_tracking.erl
+++ b/deps/rabbit/src/rabbit_channel_tracking.erl
@@ -33,6 +33,11 @@
          ensure_tracked_tables_for_this_node/0,
          delete_tracked_channel_user_entry/1]).
 
+%% All nodes (that support the `tracking_records_in_ets' feature) must
+%% export this function with the same spec, as they are called via
+%% RPC from other nodes. (Their implementation can differ.)
+-export([count_local_tracked_items_of_user/1]).
+
 -export([migrate_tracking_records/0]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
@@ -223,9 +228,13 @@ count_tracked_items_in(Type) ->
     end.
 
 count_tracked_items_in_ets({user, Username}) ->
-    rabbit_tracking:count_tracked_items_ets(
-      ?TRACKED_CHANNEL_TABLE_PER_USER, Username,
-      "channels of user").
+    rabbit_tracking:count_on_all_nodes(
+      ?MODULE, count_local_tracked_items_of_user, [Username],
+      ["channels of user ", Username]).
+
+-spec count_local_tracked_items_of_user(rabbit_types:username()) -> non_neg_integer().
+count_local_tracked_items_of_user(Username) ->
+    rabbit_tracking:read_ets_counter(?TRACKED_CHANNEL_TABLE_PER_USER, Username).
 
 count_tracked_items_in_mnesia({user, Username}) ->
     rabbit_tracking:count_tracked_items_mnesia(


### PR DESCRIPTION
## Proposed Changes

These commits meant to be included in the same versions where feature flag `tracking_records_in_ets` exists (I assume starting with 3.11) (piggy backing that great work)

Two commits reduce the number of RPC calls. Commit "Refactor rabbit_(connection|channel)_tracking:count_tracking_items_in_ets" only changes what function is called via RPC in order to make future refactoring easier.

The `erpc` module was introduced in OTP 23, no earlier OTP versions are supported by any RabbitMQ version that support upgrading to 3.11, so it was deemed safe to use it.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
