### PR TITLE
mqtt_processor: Get local port from already available adapter_info

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -148,7 +148,7 @@ process_request(?CONNECT,
                                     {ok, Corr} ->
                                         RetainerPid = rabbit_mqtt_retainer_sup:child_for_vhost(VHost),
                                         link(Conn),
-                                    {ok, Ch} = amqp_connection:open_channel(Conn),
+                                        {ok, Ch} = amqp_connection:open_channel(Conn),
                                         link(Ch),
                                         amqp_channel:enable_delivery_flow_control(Ch),
                                         Prefetch = rabbit_mqtt_util:env(prefetch),

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -578,11 +578,10 @@ process_login(_UserBin, _PassBin, _ProtoVersion,
     connack_dup_auth;
 process_login(UserBin, PassBin, ProtoVersion,
               #proc_state{channels     = {undefined, undefined},
-                          socket       = Sock,
                           adapter_info = AdapterInfo,
                           ssl_login_name = SslLoginName,
                           peer_addr    = Addr}) ->
-    {ok, {_, _, _, ToPort}} = rabbit_net:socket_ends(Sock, inbound),
+    ToPort = AdapterInfo#amqp_adapter_info.port,
     {VHostPickedUsing, {VHost, UsernameBin}} = get_vhost(UserBin, SslLoginName, ToPort),
     rabbit_log_connection:debug(
         "MQTT vhost picked using ~s",


### PR DESCRIPTION
## Proposed Changes

This replaces `rabbit_net:socket_ends/2` which also tries to fetch peer
host and port. Fetching peer can return an error if the socket is
already closed (which used to crash the mqtt connection process). This
can happen after a resource alarm, when the processing of CONNECT frame
was delayed and the client closes the connection meanwhile.

```
** Reason for termination ==
** {{badmatch,{error,einval}},
    [{rabbit_mqtt_processor,process_login,4,
                            [{file,"rabbit_mqtt_processor.erl"},{line,585}]},
     {rabbit_mqtt_processor,process_request,3,
                            [{file,"rabbit_mqtt_processor.erl"},{line,143}]},
     {rabbit_mqtt_processor,process_frame,2,
                            [{file,"rabbit_mqtt_processor.erl"},{line,69}]},
     {rabbit_mqtt_reader,process_received_bytes,2,
                         [{file,"src/rabbit_mqtt_reader.erl"},{line,307}]},
```

Now the logs look as follows:
```
 [info] <0.303.0> vm_memory_high_watermark set. Memory used:130613248 allowed:171

 [debug] <0.871.0> MQTT accepting TCP connection <0.871.0> (127.0.0.1:53503 -> 127.0.0.1:21005)

 [info] <0.303.0> vm_memory_high_watermark clear. Memory used:130334720 allowed:6871947673

 [debug] <0.871.0> Received a CONNECT, client ID: "simpleClient" (expanded to "simpleClient"), username: undefined, clean session: true, protocol version: 3, keepalive: 90
 [debug] <0.871.0> MQTT vhost picked using plugin configuration or default
 [warning] <0.871.0> AMQP 0-9-1 client call timeout was 70000 ms, is updated to a safe effective value of 130000 ms
 [debug] <0.879.0> User 'guest' authenticated successfully by backend rabbit_auth_backend_internal
 [error] <0.871.0> MQTT: a socket write failed, the socket might already be closed
 [debug] <0.871.0> Failed to write to socket #Port<0.60>, error: badarg, frame: {mqtt_frame,
 [debug] <0.871.0>                                                               {mqtt_frame_fixed,
 [debug] <0.871.0>                                                                2,0,0,0},
 [debug] <0.871.0>                                                               {mqtt_frame_connack,
 [debug] <0.871.0>                                                                false,0},
 [debug] <0.871.0>                                                               undefined}
 [info] <0.871.0> accepting MQTT connection <0.871.0> (127.0.0.1:53503 -> 127.0.0.1:21005, client id: simpleClient)
 [info] <0.871.0> MQTT connection "127.0.0.1:53503 -> 127.0.0.1:21005" will terminate because peer closed TCP connection
 [debug] <0.871.0> MQTT: about to send will message (if any) on connection "127.0.0.1:53503 -> 127.0.0.1:21005"
 [debug] <0.906.0> Closing all channels from connection '127.0.0.1:53503 -> 127.0.0.1:21005' because it has been closed
```

Note: that the old behaviour had some benefits of failing fast, avoiding some administrative steps that are not necessary for an already closed connection (like registering client id with raft). However I think this "check" was rather implicit and accidental. Firstly the connection can get closed at every step and it does not make sense to check the connection before every function call. If such a check is deemed useful (makes sense when the connection is unblocked) I am happy to add one with an explicit comment.
 
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
