### PR TITLE
Exclude OCI targets from wildcards like `bazel test //... ...`

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -242,7 +242,8 @@ jobs:
         run: |
           ERLANG_HOME="$(dirname $(dirname $(which erl)))"
           ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
-          bazelisk test //packaging/docker-image:all \
+          OCI_TESTS=$(bazel query 'tests(//packaging/docker-image/...)')
+          bazelisk test ${OCI_TESTS} \
             --config=buildbuddy
 
       - name: Load

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -48,12 +48,14 @@ download_pkgs(
     name = "otp_pkgs",
     image_tar = "@ubuntu2004//image",
     packages = BUILD_DEPS_PACKAGES,
+    tags = ["manual"],
 )
 
 download_pkgs(
     name = "rabbitmq_pkgs",
     image_tar = "@ubuntu2004//image",
     packages = REQUIRED_PACKAGES + CONVENIENCE_PACKAGES,
+    tags = ["manual"],
 )
 
 install_pkgs(
@@ -62,6 +64,7 @@ install_pkgs(
     installables_tar = ":otp_pkgs.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "otp_pkgs_image",
+    tags = ["manual"],
 )
 
 install_pkgs(
@@ -70,6 +73,7 @@ install_pkgs(
     installables_tar = ":rabbitmq_pkgs.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "rabbitmq_pkgs_image",
+    tags = ["manual"],
 )
 
 container_layer(
@@ -81,6 +85,7 @@ container_layer(
     files = [
         "build_install_openssh.sh",
     ],
+    tags = ["manual"],
     tars = [
         "@openssl-1.1.1g//file",
     ],
@@ -90,6 +95,7 @@ container_image(
     name = "openssl_source",
     base = ":otp_pkgs_image",
     layers = [":openssl_source_layer"],
+    tags = ["manual"],
 )
 
 container_run_and_commit_layer(
@@ -99,6 +105,7 @@ container_run_and_commit_layer(
         "rm /usr/local/src/build_install_openssh.sh",
     ],
     image = ":openssl_source.tar",
+    tags = ["manual"],
 )
 
 container_image(
@@ -111,6 +118,7 @@ container_image(
     layers = [
         ":openssl_layer",
     ],
+    tags = ["manual"],
     tars = select({
         "@rules_erlang//platforms:erlang_23": ["@otp_src_23//file"],
         "@rules_erlang//platforms:erlang_24": ["@otp_src_24//file"],
@@ -126,6 +134,7 @@ container_run_and_commit_layer(
         "rm /usr/local/src/build_install_otp.sh",
     ],
     image = ":otp_source.tar",
+    tags = ["manual"],
 )
 
 container_layer(
@@ -136,6 +145,7 @@ container_layer(
         "docker-entrypoint.sh",
         "install_rabbitmq.sh",
     ],
+    tags = ["manual"],
     tars = [
         "//:package-generic-unix",
     ],
@@ -157,6 +167,7 @@ container_image(
         ":otp_layer",
         ":rabbitmq_tarball_layer",
     ],
+    tags = ["manual"],
 )
 
 container_run_and_commit_layer(
@@ -166,6 +177,7 @@ container_run_and_commit_layer(
         "rm /opt/install_rabbitmq.sh",
     ],
     image = ":rabbitmq_tarball.tar",
+    tags = ["manual"],
 )
 
 C_UTF8 = "C.UTF-8"
@@ -210,6 +222,7 @@ container_image(
         "15674/tcp",  # web-stomp
         "15670/tcp",  # examples
     ],
+    tags = ["manual"],
     volumes = [
         RABBITMQ_DATA_DIR,
     ],
@@ -221,6 +234,7 @@ container_image(
 container_image(
     name = "openssl_install_wrapper",
     base = ":otp_source",
+    tags = ["manual"],
 )
 
 container_image(
@@ -229,6 +243,7 @@ container_image(
     layers = [
         ":otp_layer",
     ],
+    tags = ["manual"],
 )
 
 # Tests
@@ -237,19 +252,28 @@ container_test(
     name = "openssl_test",
     configs = ["//packaging/docker-image/test_configs:openssl_ubuntu.yaml"],
     image = ":openssl_install_wrapper",
-    tags = ["docker"],
+    tags = [
+        "docker",
+        "manual",
+    ],
 )
 
 container_test(
     name = "otp_test",
     configs = ["//packaging/docker-image/test_configs:otp_ubuntu.yaml"],
     image = ":otp_install_wrapper",
-    tags = ["docker"],
+    tags = [
+        "docker",
+        "manual",
+    ],
 )
 
 container_test(
     name = "rabbitmq_test",
     configs = ["//packaging/docker-image/test_configs:rabbitmq_ubuntu.yaml"],
     image = ":rabbitmq",
-    tags = ["docker"],
+    tags = [
+        "docker",
+        "manual",
+    ],
 )


### PR DESCRIPTION
## Proposed Changes

This tags all of the bazel targets under `//packaging/docker-image/..` as manual, meaning they will not run unless named specifically.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

To run the container tests, they must be requested specifically, e.g. `bazel test //packaging/docker-image:rabbitmq_test`.