### PR TITLE
Avoid crash when client disconnects before server handles MQTT CONNECT

### DIFF
--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -19,6 +19,7 @@ groups() ->
     [
       {non_parallel_tests, [], [
                                 block,
+                                block_connack_timeout,
                                 handle_invalid_frames,
                                 stats,
                                 quorum_session_false,
@@ -120,6 +121,53 @@ block(Config) ->
                                     <<"Blocked">>]),
 
     emqttc:disconnect(C).
+
+block_connack_timeout(Config) ->
+    P = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    Ports0 = rpc(Config, erlang, ports, []),
+
+    ok = rpc(Config, vm_memory_monitor, set_vm_memory_high_watermark, [0.00000001]),
+    %% Let connection block.
+    timer:sleep(100),
+
+    %% We can still connect via TCP, but CONNECT frame will not be processed on the server.
+    {ok, Client} = emqttc:start_link([{host, "localhost"},
+                                      {port, P},
+                                      {client_id, <<"simpleClient">>},
+                                      {proto_ver, 3},
+                                      {logger, info},
+                                      {connack_timeout, 1}]),
+    timer:sleep(100),
+
+    Ports = rpc(Config, erlang, ports, []),
+    %% Server creates 1 new port to handle our MQTT connection.
+    [NewPort] = Ports -- Ports0,
+    {connected, MqttReader} = rpc(Config, erlang, port_info, [NewPort, connected]),
+    MqttReaderMRef = monitor(process, MqttReader),
+
+    unlink(Client),
+    ClientMRef = monitor(process, Client),
+    receive
+        {'DOWN', ClientMRef, process, Client, {shutdown, connack_timeout}} ->
+            ok
+    after 2000 ->
+              ct:fail("missing connack_timeout in client")
+    end,
+
+    %% Unblock connection. CONNECT frame will be processed on the server.
+    rpc(Config, vm_memory_monitor, set_vm_memory_high_watermark, [0.4]),
+
+    receive
+        {'DOWN', MqttReaderMRef, process, MqttReader, {shutdown, peername_not_known}} ->
+            %% We expect that MQTT reader process exits with reason peername_not_known
+            %% because our client already disconnected.
+            ok
+    after 2000 ->
+              ct:fail("missing peername_not_known from server")
+    end,
+    %% Ensure that our client is not registered.
+    [] = rpc(Config, rabbit_mqtt_collector, list, []),
+    ok.
 
 handle_invalid_frames(Config) ->
     N = rpc(Config, ets, info, [connection_metrics, size]),

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -158,8 +158,8 @@ block_connack_timeout(Config) ->
     rpc(Config, vm_memory_monitor, set_vm_memory_high_watermark, [0.4]),
 
     receive
-        {'DOWN', MqttReaderMRef, process, MqttReader, {shutdown, peername_not_known}} ->
-            %% We expect that MQTT reader process exits with reason peername_not_known
+        {'DOWN', MqttReaderMRef, process, MqttReader, {shutdown, {socket_ends, einval}}} ->
+            %% We expect that MQTT reader process exits (without crashing)
             %% because our client already disconnected.
             ok
     after 2000 ->


### PR DESCRIPTION
This is a follow-up of https://github.com/rabbitmq/rabbitmq-server/pull/5615.
Work was done by @gomoripeti.

In case of a resource alarm, the server accepts incoming TCP
connections, but does not read from the socket.
When a client connects during a resource alarm, the MQTT CONNECT frame
is therefore not processed.

While the resource alarm is ongoing, the client might time out waiting
on a CONNACK MQTT packet.

When the resource alarm clears on the server, the MQTT CONNECT frame
gets processed.

Prior to this commit, this results in the following crash on the server:
```
** Reason for termination ==
** {{badmatch,{error,einval}},
    [{rabbit_mqtt_processor,process_login,4,
                            [{file,"rabbit_mqtt_processor.erl"},{line,585}]},
     {rabbit_mqtt_processor,process_request,3,
                            [{file,"rabbit_mqtt_processor.erl"},{line,143}]},
     {rabbit_mqtt_processor,process_frame,2,
                            [{file,"rabbit_mqtt_processor.erl"},{line,69}]},
     {rabbit_mqtt_reader,process_received_bytes,2,
                         [{file,"src/rabbit_mqtt_reader.erl"},{line,307}]},
```

After this commit, the server just logs:
```
[error] <0.905.0> MQTT protocol error on connection 127.0.0.1:62207 -> 127.0.0.1:1883: {socket_ends,
[error] <0.905.0>                                                                       einval}
```

In case the client already disconnected, we want the server to bail out
early, i.e. not authenticating and registering the client at all
since that can be expensive when many clients connected while the
resource alarm was ongoing.

To detect whether the client disconnected, we rely on `inet:peername/1`
which will return an error when the peer is not connected anymore.

Ideally we could use some better mechanism for detecting whether the
client disconnected.

The MQTT reader does receive a `{tcp_closed, Socket}` message once the
socket becomes active. However, we don't really want to read frames
ahead (i.e. ahead of the received CONNECT frame), one reason being that:

> Clients are allowed to send further Control Packets immediately
> after sending a CONNECT Packet; Clients need not wait for a CONNACK Packet
> to arrive from the Server.

Setting socket option `show_econnreset` does not help either because the client
closes the connection normally.