### PR TITLE
Controllable way to ignore supervisor2 error reports

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -256,6 +256,10 @@ ifdef DEBUG_FF
 RMQ_ERLC_OPTS += -DDEBUG_QUORUM_QUEUE_FF=true
 endif
 
+ifdef TRACE_SUPERVISOR2
+RMQ_ERLC_OPTS += -DTRACE_SUPERVISOR2=true
+endif
+
 ifndef USE_PROPER_QC
 # PropEr needs to be installed for property checking
 # http://proper.softlab.ntua.gr/

--- a/deps/rabbit_common/BUILD.bazel
+++ b/deps/rabbit_common/BUILD.bazel
@@ -138,6 +138,9 @@ suites = [
     rabbitmq_suite(
         name = "supervisor2_SUITE",
         size = "small",
+        additional_srcs = [
+            "test/test_event_handler.erl",
+        ],
     ),
     rabbitmq_suite(
         name = "unit_priority_queue_SUITE",

--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -81,7 +81,7 @@
 
 -include_lib("kernel/include/logger.hrl").
 
--ifdef(TRACE_SUP2).
+-ifdef(TRACE_SUPERVISOR2).
 -define(TRACE_SUPERVISOR2_ERROR_LOG(ERROR, CHILD, SUP_NAME, LOGGED),
         rabbit_event:notify(supervisor2_error_report,
            [{supervisor, SUP_NAME},

--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -81,17 +81,36 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-ifdef(TRACE_SUP2).
+-define(TRACE_SUPERVISOR2_ERROR_LOG(SUP_PID, ERROR, CHILD, SUP_NAME, LOGGED),
+        rabbit_event:notify(supervisor2_error_report,
+           [{supervisor, SUP_NAME},
+            {errorContext, ERROR},
+            {offender,extract_child(CHILD)},
+            {logged, LOGGED},
+            {timestamp, os:system_time(milli_seconds)}])).
+-else.
+-define(TRACE_SUPERVISOR2_ERROR_LOG(SUP_PID, ERROR, CHILD, SUP_NAME, LOGGED), ok).
+-endif.
+
 -define(report_error(Error, Reason, Child, SupName),
-        ?LOG_ERROR(#{label=>{supervisor,Error},
-                     report=>[{supervisor,SupName},
-                              {errorContext,Error},
-                              {reason,Reason},
-                              {offender,extract_child(Child)}]},
-                   #{domain=>[otp,sasl],
-                     report_cb=>fun logger:format_otp_report/1,
-                     logger_formatter=>#{title=>"SUPERVISOR REPORT"},
-                     error_logger=>#{tag=>error_report,
-                                     type=>supervisor_report}})).
+        case lists:member(Error, rabbit_misc:get_env(rabbit, ignore_supervisor2_error_reports, [])) of
+            false ->
+                ?TRACE_SUPERVISOR2_ERROR_LOG(self(), Error, Child, SupName, true),
+                ?LOG_ERROR(#{label=>{supervisor,Error},
+                             report=>[{supervisor,SupName},
+                                      {errorContext,Error},
+                                      {reason,Reason},
+                                      {offender,extract_child(Child)}]},
+                           #{domain=>[otp,sasl],
+                             report_cb=>fun logger:format_otp_report/1,
+                             logger_formatter=>#{title=>"SUPERVISOR REPORT"},
+                             error_logger=>#{tag=>error_report,
+                                             type=>supervisor_report}});
+            true ->
+                ?TRACE_SUPERVISOR2_ERROR_LOG(self(), Error, Child, SupName, false),
+                ok
+        end).
 
 %%--------------------------------------------------------------------------
 

--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -82,7 +82,7 @@
 -include_lib("kernel/include/logger.hrl").
 
 -ifdef(TRACE_SUP2).
--define(TRACE_SUPERVISOR2_ERROR_LOG(SUP_PID, ERROR, CHILD, SUP_NAME, LOGGED),
+-define(TRACE_SUPERVISOR2_ERROR_LOG(ERROR, CHILD, SUP_NAME, LOGGED),
         rabbit_event:notify(supervisor2_error_report,
            [{supervisor, SUP_NAME},
             {errorContext, ERROR},
@@ -90,13 +90,13 @@
             {logged, LOGGED},
             {timestamp, os:system_time(milli_seconds)}])).
 -else.
--define(TRACE_SUPERVISOR2_ERROR_LOG(SUP_PID, ERROR, CHILD, SUP_NAME, LOGGED), ok).
+-define(TRACE_SUPERVISOR2_ERROR_LOG(ERROR, CHILD, SUP_NAME, LOGGED), ok).
 -endif.
 
 -define(report_error(Error, Reason, Child, SupName),
         case lists:member(Error, rabbit_misc:get_env(rabbit, ignore_supervisor2_error_reports, [])) of
             false ->
-                ?TRACE_SUPERVISOR2_ERROR_LOG(self(), Error, Child, SupName, true),
+                ?TRACE_SUPERVISOR2_ERROR_LOG(Error, Child, SupName, true),
                 ?LOG_ERROR(#{label=>{supervisor,Error},
                              report=>[{supervisor,SupName},
                                       {errorContext,Error},
@@ -108,7 +108,7 @@
                              error_logger=>#{tag=>error_report,
                                              type=>supervisor_report}});
             true ->
-                ?TRACE_SUPERVISOR2_ERROR_LOG(self(), Error, Child, SupName, false),
+                ?TRACE_SUPERVISOR2_ERROR_LOG(Error, Child, SupName, false),
                 ok
         end).
 

--- a/deps/rabbit_common/test/supervisor2_SUITE.erl
+++ b/deps/rabbit_common/test/supervisor2_SUITE.erl
@@ -10,10 +10,11 @@
 -behaviour(supervisor2).
 
 -include_lib("common_test/include/ct.hrl").
+-include("rabbit.hrl").
 
 -compile(export_all).
 
-all() -> [intrinsic, delayed_restart].
+all() -> [intrinsic, delayed_restart, ignore_error_reports].
 
 intrinsic(_Config) ->
     false = process_flag(trap_exit, true),
@@ -38,6 +39,31 @@ delayed_restart(_Config) ->
 
     Args1 = {one_for_one, {permanent, DelayInSeconds}, Intensity},
     {passed, _} = with_sup(Args1, fun test_supervisor_delayed_restart/1).
+
+ignore_error_reports(_Config) ->
+    {ok, _Pid} = rabbit_event:start_link(),
+    gen_event:add_handler(rabbit_event, test_event_handler, []),
+
+    DelayInSeconds = 1,
+    Intensity = 1,
+
+    application:set_env(rabbit, ignore_supervisor2_error_reports, [child_terminated, shutdown_error]),
+    Args0 = {simple_one_for_one, {permanent, DelayInSeconds}, Intensity},
+    F0 = fun(SupPid) ->
+        {ok, _ChildPid} =
+            supervisor2:start_child(SupPid, []),
+        test_supervisor_ignore_error_reports(SupPid, false)
+    end,
+    {passed, _} = with_sup(Args0, F0),
+
+    application:set_env(rabbit, ignore_supervisor2_error_reports, [unknown_error]),
+    Args1 = {simple_one_for_one, {permanent, DelayInSeconds}, Intensity},
+    F1 = fun(SupPid) ->
+        {ok, _ChildPid} =
+            supervisor2:start_child(SupPid, []),
+        test_supervisor_ignore_error_reports(SupPid, true)
+    end,
+    {passed, _} = with_sup(Args1, F1).
 
 test_supervisor_intrinsic(SupPid) ->
     ok = ping_child(SupPid),
@@ -68,6 +94,56 @@ test_supervisor_delayed_restart(SupPid) ->
     ok = timer:sleep(1010),
     ok = ping_child(SupPid),
     passed.
+
+-ifdef(TRACE_SUP2).
+test_supervisor_ignore_error_reports(SupPid, IsLogged = false) ->
+    ok = ping_child(SupPid),
+
+    ok = exit_child(SupPid, abnormal),
+    ok = timer:sleep(100),
+    ok = ping_child(SupPid),
+
+    ok = verify_error_events(SupPid, IsLogged),
+
+    ok = test_event_handler:reset(),
+    {ok, []} = test_event_handler:get_events(),
+
+    passed;
+test_supervisor_ignore_error_reports(SupPid, IsLogged = true) ->
+    ok = ping_child(SupPid),
+
+    ok = exit_child(SupPid, abnormal),
+    ok = timer:sleep(100),
+    ok = ping_child(SupPid),
+
+    ok = verify_error_events(SupPid, IsLogged),
+
+    ok = test_event_handler:reset(),
+    {ok, []} = test_event_handler:get_events(),
+
+    passed.
+
+-else.
+test_supervisor_ignore_error_reports(SupPid, _IsLogged) ->
+    ok = ping_child(SupPid),
+
+    ok = exit_child(SupPid, abnormal),
+    ok = timer:sleep(100),
+    ok = ping_child(SupPid),
+
+    {ok, []} = test_event_handler:get_events(),
+
+    passed.
+-endif.
+
+verify_error_events(SupPid, IsLogged) ->
+    {ok, [#event{type = supervisor2_error_report, props = Details} | _]} = test_event_handler:get_events(),
+
+    IsLogged = rabbit_misc:pget(logged, Details),
+    child_terminated = rabbit_misc:pget(errorContext, Details),
+    {SupPid, ?MODULE} = rabbit_misc:pget(supervisor, Details),
+
+    ok.
 
 with_sup({RestartStrategy, Restart, Intensity}, Fun) ->
     {ok, SupPid} = supervisor2:start_link(?MODULE, [RestartStrategy, Restart, Intensity]),

--- a/deps/rabbit_common/test/supervisor2_SUITE.erl
+++ b/deps/rabbit_common/test/supervisor2_SUITE.erl
@@ -63,7 +63,10 @@ ignore_error_reports(_Config) ->
             supervisor2:start_child(SupPid, []),
         test_supervisor_ignore_error_reports(SupPid, true)
     end,
-    {passed, _} = with_sup(Args1, F1).
+    Result = {passed, _} = with_sup(Args1, F1),
+    ok = gen_event:stop(rabbit_event),
+
+    Result.
 
 test_supervisor_intrinsic(SupPid) ->
     ok = ping_child(SupPid),

--- a/deps/rabbit_common/test/supervisor2_SUITE.erl
+++ b/deps/rabbit_common/test/supervisor2_SUITE.erl
@@ -95,7 +95,7 @@ test_supervisor_delayed_restart(SupPid) ->
     ok = ping_child(SupPid),
     passed.
 
--ifdef(TRACE_SUP2).
+-ifdef(TRACE_SUPERVISOR2).
 test_supervisor_ignore_error_reports(SupPid, IsLogged = false) ->
     ok = ping_child(SupPid),
 

--- a/deps/rabbit_common/test/test_event_handler.erl
+++ b/deps/rabbit_common/test/test_event_handler.erl
@@ -1,0 +1,52 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2020-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(test_event_handler).
+
+-behaviour(gen_event).
+
+-export([get_events/0, reset/0]).
+
+-export([init/1, handle_call/2, handle_event/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+
+%%
+%% API
+%%
+get_events() ->
+    gen_event:call(rabbit_event, ?MODULE, get_events).
+
+reset() ->
+    gen_event:call(rabbit_event, ?MODULE, reset).
+
+%%
+%% Callbacks
+%%
+init([]) ->
+    {ok, []}.
+
+handle_event(Event = #event{type = supervisor2_error_report}, State) ->
+    {ok, [Event | State]};
+handle_event(_Event, State) ->
+    {ok, State}.
+
+handle_call(get_events, State) ->
+    {ok, {ok, State}, State};
+handle_call(reset, _State) ->
+    {ok, ok, []}.
+
+handle_info(_Info, State) ->
+    {ok, State}.
+
+terminate(_Arg, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/deps/rabbit_common/test/test_event_handler.erl
+++ b/deps/rabbit_common/test/test_event_handler.erl
@@ -14,7 +14,7 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2,
          terminate/2, code_change/3]).
 
--include_lib("rabbit_common/include/rabbit.hrl").
+-include("rabbit.hrl").
 
 
 %%


### PR DESCRIPTION
## Proposed Changes

Error reports generated by supervisor2 based processes for informative purposes
not adding much use on the monitoring end can be quite a lot, e.g. the common one
being channel processes resulting in unclean shutdown_error logs such as below:

```
<0.23599.129> supervisor: {<0.23599.129>,rabbit_channel_sup_sup}, errorContext: shutdown_error, reason: shutdown, offender: [{nb_children,1}, {id,channel_sup}, {mfargs,{rabbit_channel_sup,start_link,[]}}, {restart_type,temporary}, {shutdown,infinity}, {child_type,supervisor}]
```

We need a means to control this, as such logs are making their way to 3rd party
monitoring tools and end up impacting things like costs, network use, etc. This
change allows us to filter out specific supervisor2 based error reports through
application config. The plan is to be able to configure this in the `advanced.config`
file, specifying a list of `supervisor2` error contexts to be ignored for logging, as
follows:

```
{rabbit, [
   {ignore_supervisor2_error_reports, [shutdown_error, child_terminated]}
]}
```

There's also an event generated, if a `TRACE_SUP2` macro is provided at compile
time (this also used for testing and asserting the expected behaviour/events).

These error reports have been raised elsewhere: https://github.com/rabbitmq/rabbitmq-server/issues/2124 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
