### PR TITLE
Use OTP 24.3.4.4 to build docker images using make

### DIFF
--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -34,8 +34,8 @@ endif
 IMAGE_TAG_1 ?= $(subst +,-,$(VERSION))
 endif
 
-OTP_VERSION ?= 24.0.2
-OTP_SHA256 ?= 4abca2cda7fc962ad65575e5ed834dd69c745e7e637f92cfd49f384a281d0f18
+OTP_VERSION ?= 24.3.4.4
+OTP_SHA256 ?= b127aba77c4754904c642cf93f9b4b6667507ac31e8419b3131ed815e1f6827c
 REPO ?= pivotalrabbitmq/rabbitmq
 SKIP_PGP_VERIFY ?= false
 PGP_KEYSERVER ?= pgpkeys.eu


### PR DESCRIPTION
## Proposed Changes

Latest RabbitMQ requires OTP VERSION >=24.3 however the dockerfile used by `make docker-image` uses 24.0.2. This means that any built RabbitMQ image fails to start. 

The suggested change is to bump it up to 24.3.4.4.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI
