### PR TITLE
Upgrade MQTT Erlang client

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,8 +100,20 @@ erlang_app(
 )
 
 erlang_package.git_package(
-    repository = "rabbitmq/emqttc",
-    branch = "remove-logging",
+    name = "emqtt",
+    repository = "ansd/emqtt",
+    commit = "f6d7ddd391890f4db5f77c775e83cf0ffe3d2d76",
+    build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlang_app(
+    app_name = "emqtt",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+        "-DBUILD_WITHOUT_QUIC",
+    ],
+)
+""",
 )
 
 erlang_package.hex_package(
@@ -277,7 +289,7 @@ use_repo(
     "ct_helper",
     "cuttlefish",
     "eetcd",
-    "emqttc",
+    "emqtt",
     "gen_batch_server",
     "gun",
     "inet_tcp_proxy_dist",

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -105,7 +105,7 @@ suites = [
         ],
         flaky = True,
         runtime_deps = [
-            "@emqttc//:erlang_app",
+            "@emqtt//:erlang_app",
         ],
     ),
     rabbitmq_integration_suite(
@@ -114,14 +114,14 @@ suites = [
         size = "large",
         flaky = True,
         runtime_deps = [
-            "@emqttc//:erlang_app",
+            "@emqtt//:erlang_app",
         ],
     ),
     rabbitmq_integration_suite(
         PACKAGE,
         name = "command_SUITE",
         runtime_deps = [
-            "@emqttc//:erlang_app",
+            "@emqtt//:erlang_app",
         ],
     ),
     rabbitmq_integration_suite(
@@ -153,14 +153,14 @@ suites = [
         PACKAGE,
         name = "reader_SUITE",
         runtime_deps = [
-            "@emqttc//:erlang_app",
+            "@emqtt//:erlang_app",
         ],
     ),
     rabbitmq_integration_suite(
         PACKAGE,
         name = "retainer_SUITE",
         runtime_deps = [
-            "@emqttc//:erlang_app",
+            "@emqtt//:erlang_app",
         ],
     ),
     rabbitmq_suite(

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -31,11 +31,15 @@ define PROJECT_APP_EXTRA_KEYS
 	{broker_version_requirements, []}
 endef
 
+# We do not need QUIC as dependency of emqtt.
+BUILD_WITHOUT_QUIC=1
+export BUILD_WITHOUT_QUIC
+
 DEPS = ranch rabbit_common rabbit amqp_client ra
-TEST_DEPS = emqttc ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_emqttc = git https://github.com/rabbitmq/emqttc.git remove-logging
+dep_emqtt = git https://github.com/ansd/emqtt.git f6d7ddd391890f4db5f77c775e83cf0ffe3d2d76
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -74,22 +74,6 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
         ],
     )
 
-    http_archive(
-        name = "emqttc",
-        urls = ["https://github.com/rabbitmq/emqttc/archive/remove-logging.zip"],
-        strip_prefix = "emqttc-remove-logging",
-        build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
-
-erlang_app(
-    app_name = "emqttc",
-    erlc_opts = [
-        "+warn_export_all",
-        "+warn_unused_import",
-    ],
-)
-""",
-    )
-
     hex_pm_erlang_app(
         name = "enough",
         version = "0.1.0",
@@ -214,6 +198,10 @@ sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.baze
         name = "redbug",
         version = "2.0.7",
         sha256 = "3624feb7a4b78fd9ae0e66cc3158fe7422770ad6987a1ebf8df4d3303b1c4b0c",
+        erlc_opts = [
+            "+deterministic",
+            "+debug_info",
+        ],
     )
 
     hex_pm_erlang_app(
@@ -248,6 +236,25 @@ sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.baze
         deps = [
             "@enough//:erlang_app",
         ],
+    )
+
+    github_erlang_app(
+        name = "emqtt",
+        org = "ansd",
+        repo = "emqtt",
+        version = "f6d7ddd391890f4db5f77c775e83cf0ffe3d2d76",
+        ref = "f6d7ddd391890f4db5f77c775e83cf0ffe3d2d76",
+        build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+erlang_app(
+    app_name = "emqtt",
+    erlc_opts = [
+        "+deterministic",
+        "+debug_info",
+        "-DBUILD_WITHOUT_QUIC",
+    ],
+)
+""",
     )
 
 RA_INJECT_GIT_VERSION = """


### PR DESCRIPTION
The `rabbitmq_mqtt` tests used an outdated (> 4 years old) MQTT Erlang client fork: https://github.com/rabbitmq/emqttc/tree/remove-logging
This commit upgrades the client to the latest version. Therefore, we can delete our outdated fork.

Until https://github.com/emqx/emqtt/pull/169 is merged, we use a new fork https://github.com/ansd/emqtt