### PR TITLE
Updates for latest rules_erlang

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,10 @@ build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-regist
 build --incompatible_strict_action_env
 build --local_test_jobs=1
 
+build --flag_alias=erlang_home=@rules_erlang//:erlang_home
+build --flag_alias=erlang_version=@rules_erlang//:erlang_version
+build --flag_alias=elixir_home=//:elixir_home
+
 build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
 build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
@@ -26,25 +30,26 @@ build:rbe --jobs=50
 build:rbe --crosstool_top=@rbe//cc:toolchain
 build:rbe --extra_toolchains=@rbe//config:cc-toolchain
 
-build:rbe --host_platform=@rbe//config:platform
+build:rbe --host_platform=//bazel/platforms:erlang_internal_platform
 
 build:rbe --host_cpu=k8
 build:rbe --cpu=k8
 
 build:rbe-23 --config=rbe
-build:rbe-23 --platforms=//bazel/platforms:erlang_23_platform
-build:rbe-23 --extra_execution_platforms=//bazel/platforms:erlang_23_platform
+build:rbe-23 --platforms=//bazel/platforms:erlang_linux_23_platform
 
 build:rbe-24 --config=rbe
-build:rbe-24 --platforms=//bazel/platforms:erlang_24_platform
-build:rbe-24 --extra_execution_platforms=//bazel/platforms:erlang_24_platform
+build:rbe-24 --platforms=//bazel/platforms:erlang_linux_24_platform
 
 build:rbe-25 --config=rbe
-build:rbe-25 --platforms=//bazel/platforms:erlang_25_platform
-build:rbe-25 --extra_execution_platforms=//bazel/platforms:erlang_25_platform
+build:rbe-25 --platforms=//bazel/platforms:erlang_linux_25_platform
 
-build:local --platforms=//bazel/platforms:erlang_external_platform
-build:local --extra_execution_platforms=//bazel/platforms:erlang_external_platform
+# no-op config so that --config=local does not error
+build:local --color=auto
+
+# having bzlmod enabled seems to interfere with docker toolchain resolution,
+# so we set this flag
+build --@io_bazel_rules_docker//transitions:enable=false
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -86,44 +86,27 @@ jobs:
 
       - name: Further Configure Bazel
         run: |
-          ERLANG_HOME="$(dirname $(dirname $(which erl)))"
           ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
           cat << EOF >> user.bazelrc
-            build --@rules_erlang//:erlang_version=${{ matrix.otp_major }}
-            build --@rules_erlang//:erlang_home=${ERLANG_HOME}
-            build --//:elixir_home=${ELIXIR_HOME}
-            build --platforms=//bazel/platforms:erlang_external_platform
-            build --extra_execution_platforms=//bazel/platforms:erlang_external_platform
+            build --elixir_home=${ELIXIR_HOME}
           EOF
-
-      - name: Set the correct erlang source tar for the container
-        run: |
-          sudo npm install --global --silent @bazel/buildozer
-
-          buildozer 'set tars ["@otp_src_${{ matrix.otp_major }}//file"]' \
-            //packaging/docker-image:otp_source
-
-          git diff
 
       - name: Build
         run: |
-          ERLANG_HOME="$(dirname $(dirname $(which erl)))"
-          ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
+          export ERLANG_HOME="$(dirname $(dirname $(which erl)))"
           bazelisk build //packaging/docker-image:rabbitmq \
             --config=buildbuddy
 
       - name: Test
         run: |
-          ERLANG_HOME="$(dirname $(dirname $(which erl)))"
-          ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
+          export ERLANG_HOME="$(dirname $(dirname $(which erl)))"
           OCI_TESTS=$(bazel query 'tests(//packaging/docker-image/...)')
           bazelisk test ${OCI_TESTS} \
             --config=buildbuddy
 
       - name: Load
         run: |
-          ERLANG_HOME="$(dirname $(dirname $(which erl)))"
-          ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
+          export ERLANG_HOME="$(dirname $(dirname $(which erl)))"
           bazelisk run //packaging/docker-image:rabbitmq \
             --config=buildbuddy
 

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -111,8 +111,6 @@ jobs:
           build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
           build --@rules_erlang//:erlang_home=${ERLANG_HOME}
           build --//:elixir_home=${ELIXIR_HOME}
-          build --platforms=//bazel/platforms:erlang_external_platform
-          build --extra_execution_platforms=//bazel/platforms:erlang_external_platform
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -52,8 +52,6 @@ jobs:
           build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
           build --@rules_erlang//:erlang_home="${ERL_PATH/\/bin\/erl/}"
           build --//:elixir_home="${IEX_PATH/\/bin\/iex/}"
-          build --platforms=//bazel/platforms:erlang_external_platform
-          build --extra_execution_platforms=//bazel/platforms:erlang_external_platform
         EOF
 
         bazelisk info release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,8 +113,6 @@ jobs:
           build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
           build --@rules_erlang//:erlang_home=${ERLANG_HOME}
           build --//:elixir_home=${ELIXIR_HOME}
-          build --platforms=//bazel/platforms:erlang_external_platform
-          build --extra_execution_platforms=//bazel/platforms:erlang_external_platform
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
         - erlang_version: "25.0"
-          name_suffix: '_25'
+          name: '25'
     timeout-minutes: 10
     steps:
     - name: CHECKOUT REPOSITORY
@@ -63,17 +63,19 @@ jobs:
       run: |
         sudo npm install --global --silent @bazel/buildozer
 
-        LINE=$(grep -n 'name_suffix = "${{ matrix.name_suffix }}",' bazel/toolchains/BUILD.bazel | awk -F  ":" '{print $1}')
-        LINE=$(($LINE-1))
+        OLD_SHA="$(cat MODULE.bazel | buildozer 'print sha256' -:${{ matrix.name }})"
+        OLD_VERSION="$(cat MODULE.bazel | buildozer 'print version' -:${{ matrix.name }})"
 
-        buildozer 'set sha256 "${{ steps.fetch-version.outputs.SHA }}"' \
-          //bazel/toolchains:%${LINE} || test $? -eq 3
-        buildozer 'set version "${{ steps.fetch-version.outputs.VERSION }}"' \
-          //bazel/toolchains:%${LINE} || test $? -eq 3
+        echo "$(cat MODULE.bazel | buildozer 'set sha256 "${{ steps.fetch-version.outputs.SHA }}"' -:${{ matrix.name }})" > MODULE.bazel
+        echo "$(cat MODULE.bazel | buildozer 'set version "${{ steps.fetch-version.outputs.VERSION }}"' -:${{ matrix.name }})" > MODULE.bazel
 
-        echo "$(cat WORKSPACE | buildozer 'set downloaded_file_path "OTP-${{ steps.fetch-version.outputs.VERSION }}.tar.gz"' -:otp_src${{ matrix.name_suffix }})" > WORKSPACE
-        echo "$(cat WORKSPACE | buildozer 'set urls ["https://github.com/erlang/otp/archive/OTP-${{ steps.fetch-version.outputs.VERSION }}.tar.gz"]' -:otp_src${{ matrix.name_suffix }})" > WORKSPACE
-        echo "$(cat WORKSPACE | buildozer 'set sha256 "${{ steps.fetch-version.outputs.SHA2 }}"' -:otp_src${{ matrix.name_suffix }})" > WORKSPACE
+        echo "$(cat WORKSPACE | buildozer 'set downloaded_file_path "OTP-${{ steps.fetch-version.outputs.VERSION }}.tar.gz"' -:otp_src_${{ matrix.name }})" > WORKSPACE
+        echo "$(cat WORKSPACE | buildozer 'set urls ["https://github.com/erlang/otp/archive/OTP-${{ steps.fetch-version.outputs.VERSION }}.tar.gz"]' -:otp_src_${{ matrix.name }})" > WORKSPACE
+        echo "$(cat WORKSPACE | buildozer 'set sha256 "${{ steps.fetch-version.outputs.SHA2 }}"' -:otp_src_${{ matrix.name }})" > WORKSPACE
+
+        sed -i"_orig" "s/${OLD_SHA}/${{ steps.fetch-version.outputs.SHA }}" WORKSPACE
+        sed -i"_orig" "s/${OLD_VERSION}/${{ steps.fetch-version.outputs.VERSION }}" WORKSPACE
+        rm *_orig
 
         set -x
         git diff

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ load(":rabbitmq.bzl", "all_plugins")
 exports_files([
     "scripts/bazel/rabbitmq-run.sh",
     "scripts/bazel/rabbitmq-run.bat",
+    "release-notes",
 ])
 
 config_setting(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,54 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.5.0",
+    version = "3.6.3",
+)
+
+erlang_config = use_extension(
+    "@rules_erlang//bzlmod:extensions.bzl",
+    "erlang_config",
+)
+
+erlang_config.internal_erlang_from_github_release(
+    name = "23",
+    sha256 = "e3ecb3ac2cc549ab90cd9f8921eaebc8613f4d5c89972a3987e5a762d5a2df08",
+    version = "23.3.4.16",
+)
+
+erlang_config.internal_erlang_from_github_release(
+    name = "24",
+    sha256 = "86dddc0de486acc320ed7557f12033af0b5045205290ee4926aa931b3d8b3ab2",
+    version = "24.3.4.4",
+)
+
+erlang_config.internal_erlang_from_github_release(
+    name = "25",
+    sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
+    version = "25.0.4",
+)
+
+erlang_config.internal_erlang_from_http_archive(
+    name = "git_master",
+    strip_prefix = "otp-master",
+    url = "https://github.com/erlang/otp/archive/refs/heads/master.tar.gz",
+    version = "master",
+)
+
+use_repo(
+    erlang_config,
+    "erlang_config",
+)
+
+register_toolchains(
+    "@erlang_config//external:toolchain",
+    "@erlang_config//23:toolchain",
+    "@erlang_config//24:toolchain",
+    "@erlang_config//25:toolchain",
+    "@erlang_config//git_master:toolchain",
+    "//bazel/toolchains:elixir_toolchain_external",
+    "//bazel/toolchains:elixir_toolchain_1_10",
+    "//bazel/toolchains:elixir_toolchain_1_12",
+    "//bazel/toolchains:elixir_toolchain_1_13",
 )
 
 erlang_package = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -112,22 +112,50 @@ git_repository(
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.2.0",
+    tag = "3.6.3",
 )
 
 load(
     "@rules_erlang//:rules_erlang.bzl",
+    "erlang_config",
+    "internal_erlang_from_github_release",
+    "internal_erlang_from_http_archive",
     "rules_erlang_dependencies",
+)
+
+erlang_config(
+    internal_erlang_configs = [
+        internal_erlang_from_github_release(
+            name = "23",
+            sha256 = "e3ecb3ac2cc549ab90cd9f8921eaebc8613f4d5c89972a3987e5a762d5a2df08",
+            version = "23.3.4.16",
+        ),
+        internal_erlang_from_github_release(
+            name = "24",
+            sha256 = "86dddc0de486acc320ed7557f12033af0b5045205290ee4926aa931b3d8b3ab2",
+            version = "24.3.4.4",
+        ),
+        internal_erlang_from_github_release(
+            name = "25",
+            sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
+            version = "25.0.4",
+        ),
+        internal_erlang_from_http_archive(
+            name = "git_master",
+            strip_prefix = "otp-master",
+            url = "https://github.com/erlang/otp/archive/refs/heads/master.tar.gz",
+            version = "master",
+        ),
+    ],
 )
 
 rules_erlang_dependencies()
 
+load("@erlang_config//:defaults.bzl", "register_defaults")
+
+register_defaults()
+
 register_toolchains(
-    "//bazel/toolchains:erlang_toolchain_external",
-    "//bazel/toolchains:erlang_toolchain_23",
-    "//bazel/toolchains:erlang_toolchain_24",
-    "//bazel/toolchains:erlang_toolchain_25",
-    "//bazel/toolchains:erlang_toolchain_git_master",
     "//bazel/toolchains:elixir_toolchain_external",
     "//bazel/toolchains:elixir_toolchain_1_10",
     "//bazel/toolchains:elixir_toolchain_1_12",

--- a/bazel/elixir/elixir.bzl
+++ b/bazel/elixir/elixir.bzl
@@ -9,13 +9,8 @@ load(
 )
 
 def elixir_toolchain_external():
-    elixir_constraint = Label("//bazel/platforms:elixir_external")
-
     elixir_external(
         name = "external_elixir_installation_ref",
-        target_compatible_with = [
-            elixir_constraint,
-        ],
     )
 
     elixir_toolchain(
@@ -26,33 +21,27 @@ def elixir_toolchain_external():
     native.toolchain(
         name = "elixir_toolchain_external",
         exec_compatible_with = [
-            elixir_constraint,
+            Label("@erlang_config//:erlang_external"),
         ],
         target_compatible_with = [
-            elixir_constraint,
+            Label("//bazel/platforms:elixir_external"),
         ],
         toolchain = ":elixir_external",
         toolchain_type = Label("//bazel/elixir:toolchain_type"),
         visibility = ["//visibility:public"],
     )
 
-    return elixir_constraint
-
 def elixir_toolchain_from_http_archive(
         name_suffix = "",
-        version = None,
         url = None,
         strip_prefix = None,
         sha256 = None,
-        elixir_constraint = None):
+        elixir_constraints = None):
     elixir_build(
         name = "elixir_build{}".format(name_suffix),
         url = url,
         strip_prefix = strip_prefix,
         sha256 = sha256,
-        target_compatible_with = [
-            elixir_constraint,
-        ],
     )
 
     elixir_toolchain(
@@ -63,11 +52,9 @@ def elixir_toolchain_from_http_archive(
     native.toolchain(
         name = "elixir_toolchain{}".format(name_suffix),
         exec_compatible_with = [
-            elixir_constraint,
+            Label("@erlang_config//:erlang_internal"),
         ],
-        target_compatible_with = [
-            elixir_constraint,
-        ],
+        target_compatible_with = elixir_constraints,
         toolchain = ":elixir{}".format(name_suffix),
         toolchain_type = Label("//bazel/elixir:toolchain_type"),
         visibility = ["//visibility:public"],
@@ -78,13 +65,14 @@ def elixir_toolchain_from_github_release(
         version = None,
         sha256 = None):
     [major, minor, patch] = version.split(".")
-    elixir_constraint = Label("//bazel/platforms:elixir_{}_{}".format(major, minor))
+    elixir_constraints = [
+        Label("//bazel/platforms:elixir_{}_{}".format(major, minor)),
+    ]
     url = "https://github.com/elixir-lang/elixir/archive/refs/tags/v{}.tar.gz".format(version)
     elixir_toolchain_from_http_archive(
         name_suffix = name_suffix,
         url = url,
         strip_prefix = "elixir-{}".format(version),
         sha256 = sha256,
-        elixir_constraint = elixir_constraint,
+        elixir_constraints = elixir_constraints,
     )
-    return elixir_constraint

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -2,13 +2,9 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-constraint_value(
-    name = "erlang_git_master",
-    constraint_setting = "@rules_erlang//platforms:erlang_major_version",
-)
-
 constraint_setting(
     name = "elixir_version",
+    default_constraint_value = ":elixir_external",
 )
 
 constraint_value(
@@ -37,45 +33,44 @@ constraint_value(
 )
 
 platform(
-    name = "erlang_external_platform",
+    name = "erlang_internal_platform",
     constraint_values = [
-        "@rules_erlang//platforms:erlang_external",
-        ":elixir_external",
+        "@erlang_config//:erlang_internal",
     ],
-    parents = ["@local_config_platform//:host"],
+    parents = ["@rbe//config:platform"],
 )
 
 platform(
-    name = "erlang_23_platform",
+    name = "erlang_linux_23_platform",
     constraint_values = [
-        "@rules_erlang//platforms:erlang_23",
+        "@erlang_config//:erlang_23",
         ":elixir_1_10",
     ],
     parents = ["@rbe//config:platform"],
 )
 
 platform(
-    name = "erlang_24_platform",
+    name = "erlang_linux_24_platform",
     constraint_values = [
-        "@rules_erlang//platforms:erlang_24",
+        "@erlang_config//:erlang_24",
         ":elixir_1_12",
     ],
     parents = ["@rbe//config:platform"],
 )
 
 platform(
-    name = "erlang_25_platform",
+    name = "erlang_linux_25_platform",
     constraint_values = [
-        "@rules_erlang//platforms:erlang_25",
+        "@erlang_config//:erlang_25",
         ":elixir_1_14",
     ],
     parents = ["@rbe//config:platform"],
 )
 
 platform(
-    name = "erlang_git_master_platform",
+    name = "erlang_linux_git_master_platform",
     constraint_values = [
-        ":erlang_git_master",
+        "@erlang_config//:erlang_git_master",
         ":elixir_1_14",
     ],
     parents = ["@rbe//config:platform"],

--- a/bazel/toolchains/BUILD.bazel
+++ b/bazel/toolchains/BUILD.bazel
@@ -1,40 +1,7 @@
 load(
-    "@rules_erlang//tools:erlang.bzl",
-    "erlang_toolchain_external",
-    "erlang_toolchain_from_github_release",
-    "erlang_toolchain_from_http_archive",
-)
-load(
     "//bazel/elixir:elixir.bzl",
     "elixir_toolchain_external",
     "elixir_toolchain_from_github_release",
-)
-
-erlang_toolchain_external()
-
-erlang_toolchain_from_github_release(
-    name_suffix = "_23",
-    sha256 = "e3ecb3ac2cc549ab90cd9f8921eaebc8613f4d5c89972a3987e5a762d5a2df08",
-    version = "23.3.4.16",
-)
-
-erlang_toolchain_from_github_release(
-    name_suffix = "_24",
-    sha256 = "0b57d49e62958350676e8f32a39008d420dca4bc20f2d7e38c0671ab2ba62f14",
-    version = "24.3.4.5",
-)
-
-erlang_toolchain_from_github_release(
-    name_suffix = "_25",
-    sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
-    version = "25.0.4",
-)
-
-erlang_toolchain_from_http_archive(
-    erlang_constraint = "//bazel/platforms:erlang_git_master",
-    name_suffix = "_git_master",
-    strip_prefix = "otp-master",
-    url = "https://github.com/erlang/otp/archive/refs/heads/master.tar.gz",
 )
 
 elixir_toolchain_external()

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -1,4 +1,8 @@
 load(
+    "@bazel_skylib//lib:selects.bzl",
+    "selects",
+)
+load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
     "container_layer",
@@ -108,6 +112,30 @@ container_run_and_commit_layer(
     tags = ["manual"],
 )
 
+selects.config_setting_group(
+    name = "erlang_23_internal",
+    match_all = [
+        "@erlang_config//:erlang_internal",
+        "@erlang_config//:erlang_23",
+    ],
+)
+
+selects.config_setting_group(
+    name = "erlang_24_internal",
+    match_all = [
+        "@erlang_config//:erlang_internal",
+        "@erlang_config//:erlang_24",
+    ],
+)
+
+selects.config_setting_group(
+    name = "erlang_25_internal",
+    match_all = [
+        "@erlang_config//:erlang_internal",
+        "@erlang_config//:erlang_25",
+    ],
+)
+
 container_image(
     name = "otp_source",
     base = ":otp_pkgs_image",
@@ -120,10 +148,10 @@ container_image(
     ],
     tags = ["manual"],
     tars = select({
-        "@rules_erlang//platforms:erlang_23": ["@otp_src_23//file"],
-        "@rules_erlang//platforms:erlang_24": ["@otp_src_24//file"],
-        "@rules_erlang//platforms:erlang_25": ["@otp_src_25//file"],
-        "@rules_erlang//platforms:erlang_external": ["@otp_src_25//file"],
+        ":erlang_23_internal": ["@otp_src_23//file"],
+        ":erlang_24_internal": ["@otp_src_24//file"],
+        ":erlang_25_internal": ["@otp_src_25//file"],
+        "//conditions:default": ["@otp_src_25//file"],
     }),
 )
 

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -1,6 +1,4 @@
-build:local --@rules_erlang//:erlang_home=/Users/rabbitmq/kerl/25.0
-build:local --@rules_erlang//:erlang_version=25.0
-build:local --//:elixir_home=/Users/rabbitmq/.kiex/elixirs/elixir-1.14.0/lib/elixir
+build --elixir_home=/Users/rabbitmq/.kiex/elixirs/elixir-1.14.0/lib/elixir
 
 # rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS
 # sandbox (https://github.com/bazelbuild/bazel/issues/7448)
@@ -16,9 +14,3 @@ build:buildbuddy --experimental_strict_action_env
 build --flaky_test_attempts=1
 
 build:buildbuddy --remote_header=x-buildbuddy-api-key=YOUR_API_KEY
-
-# cross compile for linux (if on macOS) with rbe
-# build:rbe --host_cpu=k8
-# build:rbe --cpu=k8
-
-build --@io_bazel_rules_docker//transitions:enable=false


### PR DESCRIPTION
The latest rules_erlang provides greater auto-configuration than the previous, now optionally generating a `@erlang_config` repository for simplified config and the elimiation of the need for `--config=local`, and greater reusability of erlang platform definitions in general