### PR TITLE
rabbit_definitions: Apply default-queue-type logic to imported queues

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -731,10 +731,22 @@ add_queue_int(Queue, Name, ActingUser) ->
         true ->
             ok;
         false ->
+            VHostName = maps:get(vhost, Queue, undefined),
+            AutoDelete = maps:get(auto_delete, Queue, false),
+            DurableDeclare = maps:get(durable, Queue, true),
+            ExclusiveDeclare = maps:get(exclusive, Queue, false),
+
+            Args0 = args(maps:get(arguments, Queue, undefined)),
+            Args1 = rabbit_amqqueue:augment_declare_args(VHostName,
+                                                         DurableDeclare,
+                                                         ExclusiveDeclare,
+                                                         AutoDelete,
+                                                         Args0),
+
             rabbit_amqqueue:declare(Name,
-                                    maps:get(durable, Queue, undefined),
-                                    maps:get(auto_delete, Queue, undefined),
-                                    args(maps:get(arguments, Queue, undefined)),
+                                    DurableDeclare,
+                                    AutoDelete,
+                                    Args1,
                                     none,
                                     ActingUser)
     end.


### PR DESCRIPTION
## Background
The default-queue-type property on a vhost was added recently in #5305 to aid a workflow for converting to quorum queues. The core logic of that change was applying some special logic which injects `x-queue-type` into `arguments` on a queue when it is declared.

## The issue
I've noticed that this logic isn't applied when queues are imported into a vhost. This is particularly important when importing queues into vhosts which have a default queue type assigned and the imported queue information does not specify a queue type. The imported definition can be missing a queue type for two reasons:

1. The source broker is older than `x-queue-type` has been a concept
2. The metadata has been modified to strip this queue type to facilitate a Quorum Queue migration - possible/desirable if we know that the queue was declared without any `x-queue-type` argument.

The steps to reproduce this issue are:

1. Start a rabbitmq broker without this patch
2. Create a vhost with a default queue type of `quorum`: `rabbitmqctl add_vhost vhost-dqt --default-queue-type quorum`
3. Import a queue to this vhost: `echo '{"queues":[{"name": "test-queue", "durable": true, "auto_delete": false, "vhost": "vhost-dqt"}]}' > defs.json && rabbitmqctl import_definitions defs.json`
     1. Notice that the queue is actually created as a classic queue
4. Start an amqp application which declares this queue with the same arguments
     1. Notice that the amqp application's declaration fails with incompatible arguments: `"PRECONDITION_FAILED - inequivalent arg 'x-queue-type' for queue 'test-queue' in vhost 'vhost-dqt': received the value 'quorum' of type 'longstr' but current is none")`

## The change
This PR extends the import logic to apply this same `x-queue-type` adjustment.

There is quite a bit of code in rabbit_channel.erl for `queue.declare` which isn't applied to queues being imported. But I think this logic is the only part which would make sense to share between import and AMQP (or otherwise) `queue.declare`.

When running through the exact same steps as above, the queue is declared with the correct `default-queue-type` and the AMQP client is able to declare the queue.

Although I think this change fixes the issue - I'm opening this PR as a conversation starter to validate I'm on the right lines for where to fix this. Any & all feedback appreciated.