### PR TITLE
Handle error during shovel topology setup gracefully

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_behaviour.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_behaviour.erl
@@ -152,6 +152,8 @@ nack(Tag, Multi, #{source := #{module := Mod}} = State) ->
     Mod:nack(Tag, Multi, State).
 
 %% Common functions
+
+%% Count down until we stop publishing in on-confirm mode
 decr_remaining_unacked(State = #{source := #{remaining_unacked := unlimited}}) ->
     State;
 decr_remaining_unacked(State = #{source := #{remaining_unacked := 0}}) ->
@@ -159,6 +161,7 @@ decr_remaining_unacked(State = #{source := #{remaining_unacked := 0}}) ->
 decr_remaining_unacked(State = #{source := #{remaining_unacked := N} = Src}) ->
     State#{source => Src#{remaining_unacked =>  N - 1}}.
 
+%% Count down until we shut down in all modes
 decr_remaining(_N, State = #{source := #{remaining := unlimited}}) ->
     State;
 decr_remaining(N, State = #{source := #{remaining := M} = Src,

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -15,16 +15,11 @@
 %% for testing purposes
 -export([get_connection_name/1]).
 
--include_lib("amqp_client/include/amqp_client.hrl").
 -include("rabbit_shovel.hrl").
 
--record(state, {inbound_conn, inbound_ch, outbound_conn, outbound_ch,
-                name, type, config, inbound_uri, outbound_uri, unacked,
-                remaining, %% [1]
-                remaining_unacked}). %% [2]
-
-%% [1] Counts down until we shut down in all modes
-%% [2] Counts down until we stop publishing in on-confirm mode
+-record(state, {name :: binary() | {rabbit_types:vhost(), binary()},
+                type :: static | dynamic,
+                config :: rabbit_shovel_behaviour:state()}).
 
 start_link(Type, Name, Config) ->
     ShovelParameter = rabbit_shovel_util:get_shovel_parameter(Name),


### PR DESCRIPTION
## Proposed Changes

Eg. when the source exchange does not exist the source channel is closed during `queue.bind`, this used to cause the shovel to crash.
With this change the shovel is restarted gracefully, the same way as when eg the source queue is deleted during operation.

This is just a cosmetic change to avoid one crash log which might look scary at first.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
