### PR TITLE
Fix dialyzer warning due to renamed type in OTP 21.3

### DIFF
--- a/deps/amqp10_client/README.md
+++ b/deps/amqp10_client/README.md
@@ -35,7 +35,7 @@ The `connection_config` map contains various configuration properties.
       % the dns name of the target host
       % required by some vendors such as Azure ServiceBus
       hostname => binary(),
-      tls_opts => {secure_port, [ssl:ssl_option()]}, % optional
+      tls_opts => {secure_port, [ssl:tls_option()]}, % optional
       notify => pid(), % Pid to receive protocol notifications. Set to self() if not provided
       max_frame_size => non_neg_integer(), % incoming max frame size
       idle_time_out => non_neg_integer(), % heartbeat
@@ -50,7 +50,7 @@ The `connection_config` map contains various configuration properties.
 ### TLS
 
 TLS is enabled by setting the `tls_opts` connection configuration property.
-Currently the only valid value is `{secure_port, [ssl_option]}` where the port
+Currently the only valid value is `{secure_port, [tls_option]}` where the port
 specified only accepts TLS. It is possible that tls negotiation as described
 in the amqp 1.0 protocol will be supported in the future. If no value is provided
 for `tls_opt` then a plain socket will be used.

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -60,7 +60,7 @@
       addresses => [address()],
       address => address(),
       port => inet:port_number(),
-      tls_opts => {secure_port, [ssl:ssl_option()]},
+      tls_opts => {secure_port, [ssl:tls_option()]},
       notify => pid() | none, % the pid to send connection events to
       notify_when_opened => pid() | none,
       notify_when_closed => pid() | none,


### PR DESCRIPTION
## Proposed Changes

This change prevents dialyzer warning:
```
:0:unknown_type
Unknown type: :ssl.ssl_option/0.
```
The ssl:ssl_option() type was renamed to ssl:tls_option() in this commit: https://github.com/erlang/otp/commit/e042afe54727ae490d47eae47c6d9a210f04dd47 which was merged in OTP 21.3 in March 2019. 

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
