### PR TITLE
Require Erlang/OTP 25.0 (3.11 and 3.12/main only)

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -19,13 +19,13 @@ jobs:
   # This job will build one docker image per supported Erlang major version.
   # Each image will have two tags (one containing the Git commit SHA, one containing the branch name).
   #
-  # For example, for Git commit SHA '111aaa' and branch name 'main' and maximum supported Erlang major version '24',
+  # For example, for Git commit SHA '111aaa' and branch name 'main' and maximum supported Erlang major version '26',
   # the following tags will be pushed to Dockerhub:
   #
-  # * 111aaa-otp-min (image OTP 24)
-  # * main-otp-min (image OTP 24)
-  # * 111aaa-otp-max (image OTP 25)
-  # * main-otp-max (image OTP 25)
+  # * 111aaa-otp-min (image OTP 25)
+  # * main-otp-min (image OTP 25)
+  # * 111aaa-otp-max (image OTP 26)
+  # * main-otp-max (image OTP 26)
 
   build-publish-dev:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
           # Source of truth for OTP versions (min & max): https://www.rabbitmq.com/which-erlang.html
           include:
           - image_tag_suffix: otp-min
-            otp_major: 24
+            otp_major: 25
           - image_tag_suffix: otp-max
             otp_major: 25
     steps:
@@ -171,7 +171,7 @@ jobs:
       matrix:
         include:
           - image_tag_suffix: otp-min-bazel
-            otp_major: 24
+            otp_major: 25
           - image_tag_suffix: otp-max-bazel
             otp_major: 25
     steps:

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "24"
+        - "25"
         include:
-        - erlang_version: "24"
+        - erlang_version: "25"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:
@@ -48,9 +48,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "24"
+        - "25"
         include:
-        - erlang_version: "24"
+        - erlang_version: "25"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:

--- a/.github/workflows/secondary-umbrella.yaml
+++ b/.github/workflows/secondary-umbrella.yaml
@@ -45,7 +45,7 @@ jobs:
                  "+{parse_transform,lager_transform}",
                  "+{lager_extra_sinks,[" + ",".join(_LAGER_EXTRA_SINKS) + "]}",
              ]
-        - erlang_major: "24"
+        - erlang_major: "25"
           tag: v3.9.13
           patch: |
             diff --git a/rabbitmq.bzl b/rabbitmq.bzl
@@ -64,8 +64,8 @@ jobs:
 
              RABBITMQ_TEST_ERLC_OPTS = DEFAULT_TEST_ERLC_OPTS + [
                  "+nowarn_export_all",
-        - erlang_major: "24"
-          tag: v3.10.6
+        - erlang_major: "25"
+          tag: v3.10.7
           patch: |
             diff --git a/MODULE.bazel b/MODULE.bazel
             index bbc541b766..9290f13053 100644

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         erlang_major:
-        - "24"
         - "25"
     timeout-minutes: 120
     steps:
@@ -77,10 +76,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - erlang_version: "24"
-          elixir_version: 1.12.3
         - erlang_version: "25"
-          elixir_version: 1.13.4
+          elixir_version: 1.14.0
     timeout-minutes: 60
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -11,10 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "24"
-          elixir_version: 1.12.3
         - erlang_version: "25"
-          elixir_version: 1.13.4
+          elixir_version: 1.14.0
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         erlang_major:
-        - "24"
         - "25"
     timeout-minutes: 120
     steps:
@@ -79,10 +78,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "24"
-          elixir_version: 1.12.3
-        #! - erlang_version: "25"
-        #!   elixir_version: 1.13.4
+        - erlang_version: "25"
+          elixir_version: 1.14.0
     timeout-minutes: 60
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "24.3"
-          name_suffix: '_24'
         - erlang_version: "25.0"
           name_suffix: '_25'
     timeout-minutes: 10

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
@@ -6,8 +6,8 @@
 
 -export([check/1]).
 
--define(OTP_MINIMUM, "24.3").
--define(ERTS_MINIMUM, "12.3").
+-define(OTP_MINIMUM, "25.0").
+-define(ERTS_MINIMUM, "13.0").
 
 check(_Context) ->
     ?LOG_DEBUG(

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -11,7 +11,7 @@ defmodule RabbitMQCtl.MixfileBase do
     [
       app: :rabbitmqctl,
       version: "3.12.0-dev",
-      elixir: ">= 1.10.4 and < 1.15.0",
+      elixir: ">= 1.13.4 and < 1.15.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       escript: [main_module: RabbitMQCtl,

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -1,6 +1,6 @@
-build:local --@rules_erlang//:erlang_home=/Users/rabbitmq/kerl/24.0
-build:local --@rules_erlang//:erlang_version=24.0
-build:local --//:elixir_home=/Users/rabbitmq/.kiex/elixirs/elixir-1.12.0/lib/elixir
+build:local --@rules_erlang//:erlang_home=/Users/rabbitmq/kerl/25.0
+build:local --@rules_erlang//:erlang_version=25.0
+build:local --//:elixir_home=/Users/rabbitmq/.kiex/elixirs/elixir-1.14.0/lib/elixir
 
 # rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS
 # sandbox (https://github.com/bazelbuild/bazel/issues/7448)


### PR DESCRIPTION
So that we can be sure that the JIT is available for both amd64
and arm64 users, and we benefit from all the latest compiler and runtime
optimization work.