### PR TITLE
Ignore failure of optional step in OCI github actions workflow

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -85,6 +85,7 @@ jobs:
 
       - name: Save the package as a workflow artifact
         uses: actions/upload-artifact@v3
+        continue-on-error: true
         with:
           name: package-generic-unix-${{ steps.load-info.outputs.otp }}.tar.xz
           path: ${{ steps.resolve-artifact-path.outputs.ARTIFACT_PATH }}


### PR DESCRIPTION
The `upload-artifact` step fails in the OCI workflow