### PR TITLE
Point emqtt test dependency to emqx

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -148,8 +148,8 @@ erlang_app(
 
 erlang_package.git_package(
     name = "emqtt",
-    repository = "ansd/emqtt",
-    commit = "68683689546b081c1cd5efeaa897b619e581fe29",
+    repository = "emqx/emqtt",
+    tag = "1.7.0-rc.2",
     build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 
 erlang_app(

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -39,7 +39,7 @@ DEPS = ranch rabbit_common rabbit amqp_client ra
 TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_emqtt = git https://github.com/ansd/emqtt.git 68683689546b081c1cd5efeaa897b619e581fe29
+dep_emqtt = git https://github.com/emqx/emqtt.git 1.7.0-rc.2
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -238,10 +238,10 @@ sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.baze
 
     github_erlang_app(
         name = "emqtt",
-        org = "ansd",
+        org = "emqx",
         repo = "emqtt",
-        version = "68683689546b081c1cd5efeaa897b619e581fe29",
-        ref = "68683689546b081c1cd5efeaa897b619e581fe29",
+        version = "1.7.0-rc.2",
+        ref = "1.7.0-rc.2",
         build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 
 erlang_app(


### PR DESCRIPTION
Given that https://github.com/emqx/emqtt/pull/169 has been merged and a new tag has been set on https://github.com/emqx/emqtt, we do not need the fork https://github.com/ansd/emqtt anymore.