### PR TITLE
Elixir build: tar on macOS does not support --transform

### DIFF
--- a/bazel/elixir/elixir_build.bzl
+++ b/bazel/elixir/elixir_build.bzl
@@ -70,7 +70,6 @@ ABS_RELEASE_DIR=$PWD/{release_path}
 ABS_VERSION_FILE=$PWD/{version_file}
 
 tar --extract \\
-    --transform 's/{strip_prefix}//' \\
     --file {archive_path} \\
     --directory $ABS_BUILD_DIR
 


### PR DESCRIPTION
We do not need `--transform` as far as I can tell. Elixir's Make target does not require any suffixes to be stripped off of paths.

This change makes `bazel build` functional again on a macOS with XCode 14 and a `user.bazelrc` that targets Elixir 1.14.