### PR TITLE
Mark the rbe repo as a dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -362,6 +362,7 @@ use_repo(
 rbe = use_extension(
     "//bazel/bzlmod:extensions.bzl",
     "rbe",
+    dev_dependency = True,
 )
 
 rbe.git_repository(


### PR DESCRIPTION
So that bazel modules depending on rabbitmq-server can define their own without conflicts