### PR TITLE
Handle managment path_prefix on oidc init

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -4,14 +4,15 @@ var _management_logger;
 
 function oauth_initialize_if_required() {
     rabbit_port = window.location.port ? ":" +  window.location.port : ""
-    rabbit_base_uri = window.location.protocol + "//" + window.location.hostname + rabbit_port
+    rabbit_path_prefix = window.location.pathname.replace(/\/+$/, "")
+    rabbit_base_uri = window.location.protocol + "//" + window.location.hostname + rabbit_port + rabbit_path_prefix
 
     var request = new XMLHttpRequest();
-    request.open('GET', rabbit_base_uri + '/api/auth', false);
+    request.open("GET", rabbit_base_uri + "/api/auth", false);
     request.send(null);
     if (request.status === 200) {
         return oauth_initialize(JSON.parse(request.responseText));
-    }else {
+    } else {
         return { "enabled" : false };
     }
 
@@ -64,7 +65,7 @@ function oauth_initialize(authSettings) {
         scope: authSettings.oauth_scopes, // for uaa we may need to include <resource-server-id>.*
         resource: authSettings.oauth_resource_id,
         redirect_uri: rabbit_base_uri + "/js/oidc-oauth/login-callback.html",
-        post_logout_redirect_uri: rabbit_base_uri ,
+        post_logout_redirect_uri: rabbit_base_uri,
 
         automaticSilentRenew: true,
         revokeAccessTokenOnSignout: true,
@@ -78,7 +79,7 @@ function oauth_initialize(authSettings) {
       // This is required for old versions of UAA because the newer ones do expose
       // the end_session_endpoint on the oidc discovery endpoint, .a.k.a. metadataUrl
       oidcSettings.metadataSeed = {
-        end_session_endpoint: authSettings.oauth_provider_url + '/logout.do'
+        end_session_endpoint: authSettings.oauth_provider_url + "/logout.do"
       }
     }
     oidc.Log.setLevel(oidc.Log.DEBUG);
@@ -135,7 +136,7 @@ function oauth_initiateLogin() {
     });
 }
 function oauth_redirectToHome(oauth) {
-  set_auth_pref(oauth.user_name + ':' + oauth.access_token);
+  set_auth_pref(oauth.user_name + ":" + oauth.access_token);
   location.href = "/"
 }
 function oauth_redirectToLogin(error) {


### PR DESCRIPTION
## Proposed Changes
When RabbitMQ Management plugin works with `management.path_prefix` oidc helper ignores that path. When another service works on same domain and sent code 200 from 'api/auth' all logic crashed on `JSON.parse` (In my case `/api/auth` served SPA page). Anyway, request to API outside `path_prefix` doesn't look like correct behavior

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I have not run tests for this project, as I am not familiar with erlang, and the request to `/rabbitmq/api/auth` returns a specific response (`{"oauth_enabled":false}`), which indicates that the api actually works according to `management.path_prefix "/rabbitmq"`

The quotes have been replaced by the majority principle for file uniformity.
