### PR TITLE
Add option for wildcard certificates to auth_backend_http docs

### DIFF
--- a/deps/rabbitmq_auth_backend_http/README.md
+++ b/deps/rabbitmq_auth_backend_http/README.md
@@ -149,6 +149,11 @@ configure the plugin to use a CA and client certificate/key pair using the `rabb
 
 It is recommended to use TLS for authentication and enable peer verification.
 
+### Wildcard Certificates
+
+If the certificate of your Web Server should be matched against a wildcard certificate in your `cacertfile`, the following option must be added to the `ssl_options`:
+
+    {customize_hostname_check, [{match_fun,public_key:pkix_verify_hostname_match_fun(https)}]}
 
 ## Debugging
 


### PR DESCRIPTION
## Proposed Changes

I am using the auth_backend_http plugin in a Kubernetes environment. I my environment the `cacertfile` provided by the cluster included wildcard certificates, where validation for the auth backend web servier certificate required an additional setting to be successful. This PR adds this setting to the relevant documentation.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
