### PR TITLE
Add erlang 25.1 to github actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,7 +42,13 @@ build:rbe-24 --config=rbe
 build:rbe-24 --platforms=//bazel/platforms:erlang_linux_24_platform
 
 build:rbe-25 --config=rbe
-build:rbe-25 --platforms=//bazel/platforms:erlang_linux_25_platform
+build:rbe-25 --platforms=//bazel/platforms:erlang_linux_25_1_platform
+
+build:rbe-25_0 --config=rbe
+build:rbe-25_0 --platforms=//bazel/platforms:erlang_linux_25_0_platform
+
+build:rbe-25_1 --config=rbe
+build:rbe-25_1 --platforms=//bazel/platforms:erlang_linux_25_1_platform
 
 # no-op config so that --config=local does not error
 build:local --color=auto

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -34,9 +34,9 @@ jobs:
       matrix:
         include:
           - image_tag_suffix: otp-min-bazel
-            otp_major: 25
+            otp_version_id: 25_0
           - image_tag_suffix: otp-max-bazel
-            otp_major: 25
+            otp_version_id: 25_1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
         id: load-info
         run: |
           bazelisk build :otp_version :elixir_version \
-            --config=rbe-${{ matrix.otp_major }}
+            --config=rbe-${{ matrix.otp_version_id }}
           echo "::set-output name=otp::$(cat bazel-bin/otp_version.txt)"
           echo "::set-output name=elixir::$(cat bazel-bin/elixir_version.txt)"
 

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        erlang_major:
-        - "25"
+        otp_version_id:
+        - "25_1"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -66,7 +66,7 @@ jobs:
         sudo sysctl -w net.ipv4.tcp_keepalive_time=60
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
-          --config=rbe-${{ matrix.erlang_major }} \
+          --config=rbe-${{ matrix.otp_version_id }} \
           --test_tag_filters=mixed-version-cluster,-exclusive,-aws,-docker \
           --build_tests_only \
           --verbose_failures
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - erlang_version: "25"
+        - erlang_version: "25.1"
           elixir_version: 1.14.0
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -27,11 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - "25"
+        - "25.1"
         browser:
         - chrome
         include:
-        - erlang_version: "25"
+        - erlang_version: "25.1"
           elixir_version: 1.13.4
     env:
       SELENIUM_DIR: deps/rabbitmq_management/selenium

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "25"
+        - erlang_version: "25.1"
           elixir_version: 1.14.0
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        erlang_major:
-        - "25"
+        otp_version_id:
+        - 25_1
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -67,7 +67,7 @@ jobs:
         sudo sysctl -w net.ipv4.tcp_keepalive_time=60
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
-          --config=rbe-${{ matrix.erlang_major }} \
+          --config=rbe-${{ matrix.otp_version_id }} \
           --test_tag_filters=-exclusive,-aws,-docker,-mixed-version-cluster \
           --build_tests_only \
           --verbose_failures
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "25"
+        - erlang_version: "25.1"
           elixir_version: 1.14.0
     timeout-minutes: 60
     steps:

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -15,9 +15,9 @@ jobs:
         - erlang_version: "24.3"
           name: '24'
         - erlang_version: "25.0"
-          name: '25'
-        #! - erlang_version: "25.1"
-        #!   name: '25'
+          name: '25_0'
+        - erlang_version: "25.1"
+          name: '25_1'
     timeout-minutes: 10
     steps:
     - name: CHECKOUT REPOSITORY

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,9 +46,15 @@ erlang_config.internal_erlang_from_github_release(
 )
 
 erlang_config.internal_erlang_from_github_release(
-    name = "25",
+    name = "25_0",
     sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
     version = "25.0.4",
+)
+
+erlang_config.internal_erlang_from_github_release(
+    name = "25_1",
+    sha256 = "a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31",
+    version = "25.1",
 )
 
 erlang_config.internal_erlang_from_http_archive(
@@ -101,7 +107,8 @@ register_toolchains(
     "@erlang_config//external:toolchain",
     "@erlang_config//23:toolchain",
     "@erlang_config//24:toolchain",
-    "@erlang_config//25:toolchain",
+    "@erlang_config//25_0:toolchain",
+    "@erlang_config//25_1:toolchain",
     "@erlang_config//git_master:toolchain",
     "@elixir_config//external:toolchain",
     "@elixir_config//1_10:toolchain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,9 +136,14 @@ erlang_config(
             version = "24.3.4.5",
         ),
         internal_erlang_from_github_release(
-            name = "25",
+            name = "25_0",
             sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
             version = "25.0.4",
+        ),
+        internal_erlang_from_github_release(
+            name = "25_1",
+            sha256 = "a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31",
+            version = "25.1",
         ),
         internal_erlang_from_http_archive(
             name = "git_master",

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -30,9 +30,18 @@ platform(
 )
 
 platform(
-    name = "erlang_linux_25_platform",
+    name = "erlang_linux_25_0_platform",
     constraint_values = [
-        "@erlang_config//:erlang_25",
+        "@erlang_config//:erlang_25_0",
+        "@elixir_config//:elixir_1_14",
+    ],
+    parents = ["@rbe//config:platform"],
+)
+
+platform(
+    name = "erlang_linux_25_1_platform",
+    constraint_values = [
+        "@erlang_config//:erlang_25_1",
         "@elixir_config//:elixir_1_14",
     ],
     parents = ["@rbe//config:platform"],


### PR DESCRIPTION
otp-min for OCI images is now 25.0, and otp-max is 25.1

Also use 25.1 for general testing