### PR TITLE
Introduce new feature flag to avoid сhannel exceptions when delivering to CQs post #5105

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -103,6 +103,14 @@
                              {?MODULE, tracking_records_in_ets_post_enable}}
      }}).
 
+-rabbit_feature_flag(
+   {classic_queue_type_delivery_support,
+    #{desc          => "Bug fix for classic queue deliveries using mixed versions",
+      doc_url       => "https://github.com/rabbitmq/rabbitmq-server/issues/5931",
+      stability     => stable,
+      depends_on    => [stream_queue]
+     }}).
+
 %% -------------------------------------------------------------------
 %% Direct exchange routing v2.
 %% -------------------------------------------------------------------

--- a/deps/rabbitmq_management/test/clustering_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_SUITE.erl
@@ -18,6 +18,7 @@
 -import(rabbit_mgmt_test_util, [http_get/2, http_put/4, http_delete/3]).
 -import(rabbit_misc, [pget/2]).
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 all() ->
@@ -252,6 +253,9 @@ queue_on_other_node(Config) ->
     ok.
 
 queue_with_multiple_consumers(Config) ->
+    ok = rabbit_ct_broker_helpers:enable_feature_flag(Config, stream_queue),
+    %% this may not be supported in mixed mode
+    _ = rabbit_ct_broker_helpers:enable_feature_flag(Config, classic_queue_type_delivery_support),
     {ok, Chan} = amqp_connection:open_channel(?config(conn, Config)),
     Q = <<"multi-consumer-queue1">>,
     _ = queue_declare(Chan, Q),


### PR DESCRIPTION
When a delivery or credit_reply is sent from a node running 3.11.0 or 3.10.8 to an older node.

Fixes #5931 
