### PR TITLE
Standardize CLI formatting with mix format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,11 @@ cd deps/rabbitmq_cli
 mix format
 ```
 
-Running `make` in `deps/rabbitmq_cli` will validate the CLI formatting and issue any necessary warnings.
+Running `make` will validate the CLI formatting and issue any necessary warnings. Alternatively, run the format checker in the `deps/rabbitmq_cli` directory:
+
+```
+mix format --check-formatted
+```
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The process is fairly standard:
  * Fork the repository or repositories you plan on contributing to
  * Run `make`
  * Create a branch with a descriptive name in the relevant repositories
- * Make your changes, run tests, commit with a [descriptive message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
+ * Make your changes, run tests, ensure correct code formatting, commit with a [descriptive message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
  * Submit a filled out and signed [Contributor Agreement](https://cla.pivotal.io/) if needed (see below)
  * Be patient. We will get to your pull request eventually
@@ -42,6 +42,17 @@ make ct-cluster_rename t=cluster_size_3:partial_one_by_one
 ```
 
 Test output is in the `logs/` subdirectory.
+
+## Formatting the RabbitMQ CLI
+
+The RabbitMQ CLI uses the standard [Elixir code formatter](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html). To ensure correct code formatting of the CLI:
+
+```
+cd deps/rabbitmq_cli
+mix format
+```
+
+Running `make` in `deps/rabbitmq_cli` will validate the CLI formatting and issue any necessary warnings.
 
 ## Code of Conduct
 

--- a/deps/rabbitmq_cli/.formatter.exs
+++ b/deps/rabbitmq_cli/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/deps/rabbitmq_cli/config/config.exs
+++ b/deps/rabbitmq_cli/config/config.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
@@ -25,7 +24,7 @@ use Mix.Config
 #
 # Or configure a 3rd-party app:
 #
-config :logger, [level: :warn, console: [device: :standard_error]]
+config :logger, level: :warn, console: [device: :standard_error]
 #
 
 # It is also possible to import configuration files, relative to this

--- a/deps/rabbitmq_cli/config/config.exs
+++ b/deps/rabbitmq_cli/config/config.exs
@@ -6,7 +6,7 @@
 
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/auto_complete.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/auto_complete.ex
@@ -28,6 +28,7 @@ defmodule RabbitMQ.CLI.AutoComplete do
   def suggest_command(_cmd_name, empty) when empty == %{} do
     nil
   end
+
   def suggest_command(typed, module_map) do
     suggestion =
       module_map
@@ -40,6 +41,7 @@ defmodule RabbitMQ.CLI.AutoComplete do
     case suggestion do
       {cmd, distance} when distance >= @jaro_distance_limit ->
         {:suggest, cmd}
+
       _ ->
         nil
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/command_behaviour.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/command_behaviour.ex
@@ -48,7 +48,11 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback scopes() :: [atom()] | nil
   @callback description() :: String.t()
   @callback help_section() :: String.t()
-  @callback usage_additional() :: String.t() | [String.t()] | nonempty_list(pair_of_strings()) | [{String.t(), String.t()}]
+  @callback usage_additional() ::
+              String.t()
+              | [String.t()]
+              | nonempty_list(pair_of_strings())
+              | [{String.t(), String.t()}]
   @callback usage_doc_guides() :: String.t() | [String.t()]
   ## Erlang distribution control
   ## :cli - default rabbitmqctl generated node name
@@ -57,46 +61,93 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback distribution(map()) :: :cli | :none | {:fun, (map() -> :ok | {:error, any()})}
 
   defmacro defcmd(map) do
-    usage_q = case map[:usage] do
-      nil -> :ok
-      usage ->
-        quote do def usage(), do: unquote(usage) end
-    end
-    scopes_q = case map[:scopes] do
-      nil -> :ok
-      scopes ->
-        quote do def scopes(), do: unquote(scopes) end
-    end
-    description_q = case map[:description] do
-      nil -> :ok
-      description ->
-        quote do def description(), do: unquote(description) end
-    end
-    help_section_q = case map[:help_section] do
-      nil -> :ok
-      help_section ->
-        quote do def help_section(), do: unquote(help_section) end
-    end
-    usage_additional_q = case map[:usage_additional] do
-      nil -> :ok
-      usage_additional ->
-        quote do def usage_additional(), do: unquote(usage_additional) end
-    end
-    formatter_q = case map[:formatter] do
-      nil -> :ok
-      formatter ->
-        quote do def formatter(), do: unquote(formatter) end
-    end
-    switches_q = case map[:switches] do
-      nil -> :ok
-      switches ->
-        quote do def switches(), do: unquote(switches) end
-    end
-    aliases_q = case map[:aliases] do
-      nil -> :ok
-      aliases ->
-        quote do def aliases(), do: unquote(aliases) end
-    end
+    usage_q =
+      case map[:usage] do
+        nil ->
+          :ok
+
+        usage ->
+          quote do
+            def usage(), do: unquote(usage)
+          end
+      end
+
+    scopes_q =
+      case map[:scopes] do
+        nil ->
+          :ok
+
+        scopes ->
+          quote do
+            def scopes(), do: unquote(scopes)
+          end
+      end
+
+    description_q =
+      case map[:description] do
+        nil ->
+          :ok
+
+        description ->
+          quote do
+            def description(), do: unquote(description)
+          end
+      end
+
+    help_section_q =
+      case map[:help_section] do
+        nil ->
+          :ok
+
+        help_section ->
+          quote do
+            def help_section(), do: unquote(help_section)
+          end
+      end
+
+    usage_additional_q =
+      case map[:usage_additional] do
+        nil ->
+          :ok
+
+        usage_additional ->
+          quote do
+            def usage_additional(), do: unquote(usage_additional)
+          end
+      end
+
+    formatter_q =
+      case map[:formatter] do
+        nil ->
+          :ok
+
+        formatter ->
+          quote do
+            def formatter(), do: unquote(formatter)
+          end
+      end
+
+    switches_q =
+      case map[:switches] do
+        nil ->
+          :ok
+
+        switches ->
+          quote do
+            def switches(), do: unquote(switches)
+          end
+      end
+
+    aliases_q =
+      case map[:aliases] do
+        nil ->
+          :ok
+
+        aliases ->
+          quote do
+            def aliases(), do: unquote(aliases)
+          end
+      end
 
     quote do
       unquote(usage_q)
@@ -129,6 +180,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
           :rabbitmqctl -> :other
           plugin -> {:plugin, plugin}
         end
+
       section ->
         section
     end
@@ -159,9 +211,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   end
 
   def validate_execution_environment(cmd, args, options) do
-    Helpers.apply_if_exported(cmd,
-                              :validate_execution_environment, [args, options],
-                              :ok)
+    Helpers.apply_if_exported(cmd, :validate_execution_environment, [args, options], :ok)
   end
 
   def distribution(cmd, options) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/alarms.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/alarms.ex
@@ -54,9 +54,11 @@ defmodule RabbitMQ.CLI.Core.Alarms do
   def alarm_type(val) when is_atom(val) do
     val
   end
+
   def alarm_type({:resource_limit, val, _node}) do
     val
   end
+
   def alarm_type({{:resource_limit, val, _node}, []}) do
     val
   end
@@ -64,6 +66,7 @@ defmodule RabbitMQ.CLI.Core.Alarms do
   def alarm_maps(xs) do
     Enum.map(xs, &alarm_map/1)
   end
+
   def alarm_map(:file_descriptor_limit) do
     %{
       type: :resource_limit,
@@ -71,6 +74,7 @@ defmodule RabbitMQ.CLI.Core.Alarms do
       node: node()
     }
   end
+
   def alarm_map({{:resource_limit, resource, node}, _}) do
     %{
       type: :resource_limit,
@@ -78,6 +82,7 @@ defmodule RabbitMQ.CLI.Core.Alarms do
       node: node
     }
   end
+
   def alarm_map({:resource_limit, resource, node}) do
     %{
       type: :resource_limit,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
@@ -189,6 +189,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
         |> to_snake_case
         |> String.to_atom()
         |> List.wrap()
+
       scopes ->
         scopes
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/feature_flags.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/feature_flags.ex
@@ -13,7 +13,7 @@ defmodule RabbitMQ.CLI.Core.FeatureFlags do
 
   def is_enabled_remotely(node_name, feature_flag) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :is_enabled, [feature_flag]) do
-      true  -> true
+      true -> true
       false -> false
       {:error, _} = error -> error
     end
@@ -21,10 +21,13 @@ defmodule RabbitMQ.CLI.Core.FeatureFlags do
 
   def assert_feature_flag_enabled(node_name, feature_flag, success_fun) do
     case is_enabled_remotely(node_name, feature_flag) do
-      true  ->
+      true ->
         success_fun.()
+
       false ->
-        {:error, ExitCodes.exit_dataerr(), "The #{feature_flag} feature flag is not enabled on the target node"}
+        {:error, ExitCodes.exit_dataerr(),
+         "The #{feature_flag} feature flag is not enabled on the target node"}
+
       {:error, _} = error ->
         error
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/helpers.ex
@@ -19,7 +19,7 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   def normalise_node(name, node_name_type) do
     case NodeName.create(name, node_name_type) do
       {:ok, node_name} -> node_name
-      other            -> other
+      other -> other
     end
   end
 
@@ -27,9 +27,11 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   def normalise_node_option(options) do
     node_opt = Config.get_option(:node, options)
     longnames_opt = Config.get_option(:longnames, options)
+
     case NodeName.create(node_opt, longnames_opt) do
       {:error, _} = err ->
         err
+
       {:ok, val} ->
         {:ok, Map.put(options, :node, val)}
     end
@@ -38,10 +40,12 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   def normalise_node_option(nil, _, _) do
     nil
   end
+
   def normalise_node_option(node_opt, longnames_opt, options) do
     case NodeName.create(node_opt, longnames_opt) do
       {:error, _} = err ->
         err
+
       {:ok, val} ->
         {:ok, Map.put(options, :node, val)}
     end
@@ -50,6 +54,7 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   def case_insensitive_format(%{format: format} = opts) do
     %{opts | format: String.downcase(format)}
   end
+
   def case_insensitive_format(opts), do: opts
 
   def nodes_in_cluster(node, timeout \\ :infinity) do
@@ -116,17 +121,17 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   end
 
   def atomize_values(map, keys) do
-    Enum.reduce(map, %{},
-                fn({k, v}, acc) ->
-                  case Enum.member?(keys, k) do
-                    false -> Map.put(acc, k, v)
-                    true  -> Map.put(acc, k, DataCoercion.to_atom(v))
-                  end
-                end)
+    Enum.reduce(map, %{}, fn {k, v}, acc ->
+      case Enum.member?(keys, k) do
+        false -> Map.put(acc, k, v)
+        true -> Map.put(acc, k, DataCoercion.to_atom(v))
+      end
+    end)
   end
 
   def apply_if_exported(mod, fun, args, default) do
     Code.ensure_loaded(mod)
+
     case function_exported?(mod, fun, length(args)) do
       true -> apply(mod, fun, args)
       false -> default

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/input.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/input.ex
@@ -8,18 +8,20 @@ defmodule RabbitMQ.CLI.Core.Input do
   alias RabbitMQ.CLI.Core.Config
 
   def consume_single_line_string_with_prompt(prompt, opts) do
-    val = case Config.output_less?(opts) do
-      true  ->
-        IO.read(:stdio, :line)
-      false ->
-        IO.puts(prompt)
-        IO.read(:stdio, :line)
-    end
+    val =
+      case Config.output_less?(opts) do
+        true ->
+          IO.read(:stdio, :line)
+
+        false ->
+          IO.puts(prompt)
+          IO.read(:stdio, :line)
+      end
 
     case val do
       :eof -> :eof
-      ""   -> :eof
-      s    -> String.trim(s)
+      "" -> :eof
+      s -> String.trim(s)
     end
   end
 
@@ -28,8 +30,8 @@ defmodule RabbitMQ.CLI.Core.Input do
 
     case val do
       :eof -> :eof
-      ""   -> :eof
-      s    -> String.trim(s)
+      "" -> :eof
+      s -> String.trim(s)
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/log_files.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/log_files.ex
@@ -5,29 +5,35 @@
 ## Copyright (c) 2019-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Core.LogFiles do
-  @spec get_log_locations(atom, integer | :infinity) :: [String.t] | {:badrpc, term}
+  @spec get_log_locations(atom, integer | :infinity) :: [String.t()] | {:badrpc, term}
   def get_log_locations(node_name, timeout) do
-    case :rabbit_misc.rpc_call(node_name,
-                               :rabbit, :log_locations, [],
-                               timeout) do
-      {:badrpc, _} = error -> error;
+    case :rabbit_misc.rpc_call(node_name, :rabbit, :log_locations, [], timeout) do
+      {:badrpc, _} = error -> error
       list -> Enum.map(list, &to_string/1)
     end
   end
 
   @spec get_default_log_location(atom, integer | :infinity) ::
-    {:ok, String.t} | {:badrpc, term} | {:error, term}
+          {:ok, String.t()} | {:badrpc, term} | {:error, term}
   def get_default_log_location(node_name, timeout) do
     case get_log_locations(node_name, timeout) do
-      {:badrpc, _} = error -> error;
-      [] -> {:error, "No log files configured on the node"};
+      {:badrpc, _} = error ->
+        error
+
+      [] ->
+        {:error, "No log files configured on the node"}
+
       [first_log | _] = log_locations ->
         case get_log_config_file_location(node_name, timeout) do
-          {:badrpc, _} = error -> error;
-          nil      -> {:ok, first_log};
+          {:badrpc, _} = error ->
+            error
+
+          nil ->
+            {:ok, first_log}
+
           location ->
             case Enum.member?(log_locations, location) do
-              true  -> {:ok, to_string(location)};
+              true -> {:ok, to_string(location)}
               false -> {:ok, first_log}
             end
         end
@@ -35,14 +41,18 @@ defmodule RabbitMQ.CLI.Core.LogFiles do
   end
 
   defp get_log_config_file_location(node_name, timeout) do
-    case :rabbit_misc.rpc_call(node_name,
-                               :application, :get_env, [:rabbit, :log, :none],
-                               timeout) do
-      {:badrpc, _} = error -> error;
-      :none      -> nil;
+    case :rabbit_misc.rpc_call(node_name, :application, :get_env, [:rabbit, :log, :none], timeout) do
+      {:badrpc, _} = error ->
+        error
+
+      :none ->
+        nil
+
       log_config ->
         case log_config[:file] do
-          nil -> nil;
+          nil ->
+            nil
+
           file_config ->
             file_config[:file]
         end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
@@ -32,6 +32,7 @@ defmodule RabbitMQ.CLI.Core.Memory do
   def compute_relative_values(all_pairs) when is_map(all_pairs) do
     compute_relative_values(Enum.into(all_pairs, []))
   end
+
   def compute_relative_values(all_pairs) do
     num_pairs = Keyword.delete(all_pairs, :strategy)
     # Includes RSS, allocated and runtime-used ("erlang") values.
@@ -56,21 +57,27 @@ defmodule RabbitMQ.CLI.Core.Memory do
   def formatted_watermark(val) when is_float(val) do
     %{relative: val}
   end
+
   def formatted_watermark({:relative, val}) when is_float(val) do
     %{relative: val}
   end
+
   def formatted_watermark(:infinity) do
     %{relative: 1.0}
   end
+
   def formatted_watermark({:absolute, val}) do
     %{absolute: parse_watermark(val)}
   end
+
   def formatted_watermark(val) when is_integer(val) do
     %{absolute: parse_watermark(val)}
   end
+
   def formatted_watermark(val) when is_bitstring(val) do
     %{absolute: parse_watermark(val)}
   end
+
   def formatted_watermark(val) when is_list(val) do
     %{absolute: parse_watermark(val)}
   end
@@ -78,21 +85,24 @@ defmodule RabbitMQ.CLI.Core.Memory do
   def parse_watermark({:absolute, n}) do
     case IU.parse(n) do
       {:ok, parsed} -> parsed
-      err           -> err
+      err -> err
     end
   end
+
   def parse_watermark(n) when is_bitstring(n) do
     case IU.parse(n) do
       {:ok, parsed} -> parsed
-      err           -> err
+      err -> err
     end
   end
+
   def parse_watermark(n) when is_list(n) do
     case IU.parse(n) do
       {:ok, parsed} -> parsed
-      err           -> err
+      err -> err
     end
   end
+
   def parse_watermark(n) when is_float(n) or is_integer(n) do
     n
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/networking.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/networking.ex
@@ -10,14 +10,15 @@ defmodule RabbitMQ.CLI.Core.Networking do
   @spec address_family(String.t() | atom() | charlist() | binary()) :: address_family()
   def address_family(value) do
     val = RabbitMQ.CLI.Core.DataCoercion.to_atom(value)
+
     case val do
-      :inet  -> :inet
+      :inet -> :inet
       :inet4 -> :inet
       :inet6 -> :inet6
-      :ipv4  -> :inet
-      :ipv6  -> :inet6
-      :IPv4  -> :inet
-      :IPv6  -> :inet6
+      :ipv4 -> :inet
+      :ipv6 -> :inet6
+      :IPv4 -> :inet
+      :IPv6 -> :inet6
     end
   end
 
@@ -25,14 +26,15 @@ defmodule RabbitMQ.CLI.Core.Networking do
   def valid_address_family?(value) when is_atom(value) do
     valid_address_family?(to_string(value))
   end
-  def valid_address_family?("inet"),  do: true
+
+  def valid_address_family?("inet"), do: true
   def valid_address_family?("inet4"), do: true
   def valid_address_family?("inet6"), do: true
-  def valid_address_family?("ipv4"),  do: true
-  def valid_address_family?("ipv6"),  do: true
-  def valid_address_family?("IPv4"),  do: true
-  def valid_address_family?("IPv6"),  do: true
-  def valid_address_family?(_other),  do: false
+  def valid_address_family?("ipv4"), do: true
+  def valid_address_family?("ipv6"), do: true
+  def valid_address_family?("IPv4"), do: true
+  def valid_address_family?("IPv6"), do: true
+  def valid_address_family?(_other), do: false
 
   @spec format_address(:inet.ip_address()) :: String.t()
   def format_address(addr) do
@@ -46,28 +48,37 @@ defmodule RabbitMQ.CLI.Core.Networking do
 
   @spec inetrc_map(nonempty_list()) :: map()
   def inetrc_map(list) do
-    Enum.reduce(list, %{},
-      fn hosts, acc when is_list(hosts) ->
-           Map.put(acc, "hosts", host_resolution_map(hosts))
-         {k, v}, acc when k == :domain or k == :resolv_conf or k == :hosts_file ->
-           Map.put(acc, to_string(k), to_string(v))
-         {k, v}, acc when is_list(v) when k == :search or k == :lookup ->
-           Map.put(acc, to_string(k), Enum.join(Enum.map(v, &to_string/1), ", "))
-         {k, v}, acc when is_integer(v) ->
-           Map.put(acc, to_string(k), v)
-         {k, v, v2}, acc when is_tuple(v) when k == :nameserver or k == :nameservers or k == :alt_nameserver ->
-           Map.put(acc, to_string(k), "#{:inet.ntoa(v)}:#{v2}")
-         {k, v}, acc when is_tuple(v) when k == :nameserver or k == :nameservers or k == :alt_nameserver ->
-           Map.put(acc, to_string(k), to_string(:inet.ntoa(v)))
-         {k, v}, acc ->
-           Map.put(acc, to_string(k), to_string(v))
-      end)
+    Enum.reduce(list, %{}, fn
+      hosts, acc when is_list(hosts) ->
+        Map.put(acc, "hosts", host_resolution_map(hosts))
+
+      {k, v}, acc when k == :domain or k == :resolv_conf or k == :hosts_file ->
+        Map.put(acc, to_string(k), to_string(v))
+
+      {k, v}, acc when is_list(v) when k == :search or k == :lookup ->
+        Map.put(acc, to_string(k), Enum.join(Enum.map(v, &to_string/1), ", "))
+
+      {k, v}, acc when is_integer(v) ->
+        Map.put(acc, to_string(k), v)
+
+      {k, v, v2}, acc
+      when is_tuple(v)
+      when k == :nameserver or k == :nameservers or k == :alt_nameserver ->
+        Map.put(acc, to_string(k), "#{:inet.ntoa(v)}:#{v2}")
+
+      {k, v}, acc
+      when is_tuple(v)
+      when k == :nameserver or k == :nameservers or k == :alt_nameserver ->
+        Map.put(acc, to_string(k), to_string(:inet.ntoa(v)))
+
+      {k, v}, acc ->
+        Map.put(acc, to_string(k), to_string(v))
+    end)
   end
 
   def host_resolution_map(hosts) do
-    Enum.reduce(hosts, %{},
-        fn {:host, address, hosts}, acc ->
-          Map.put(acc, to_string(:inet.ntoa(address)), Enum.map(hosts, &to_string/1))
-        end)
+    Enum.reduce(hosts, %{}, fn {:host, address, hosts}, acc ->
+      Map.put(acc, to_string(:inet.ntoa(address)), Enum.map(hosts, &to_string/1))
+    end)
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/parser.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/parser.ex
@@ -70,19 +70,22 @@ defmodule RabbitMQ.CLI.Core.Parser do
         {[_alias_command_name | cmd_arguments], cmd_options, cmd_invalid} =
           parse_alias(input, command_name, alias_module, alias_content, options)
 
-        {alias_module, command_name, cmd_arguments, Helpers.atomize_values(cmd_options, @atomized_options), cmd_invalid}
+        {alias_module, command_name, cmd_arguments,
+         Helpers.atomize_values(cmd_options, @atomized_options), cmd_invalid}
 
       command_module when is_atom(command_module) ->
         {[^command_name | cmd_arguments], cmd_options, cmd_invalid} =
           parse_command_specific(input, command_module, options)
 
-        {command_module, command_name, cmd_arguments, Helpers.atomize_values(cmd_options, @atomized_options), cmd_invalid}
+        {command_module, command_name, cmd_arguments,
+         Helpers.atomize_values(cmd_options, @atomized_options), cmd_invalid}
     end
   end
 
   def command_suggestion(_cmd_name, empty) when empty == %{} do
     nil
   end
+
   def command_suggestion(typed, module_map) do
     RabbitMQ.CLI.AutoComplete.suggest_command(typed, module_map)
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/platform.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/platform.ex
@@ -14,7 +14,7 @@ defmodule RabbitMQ.CLI.Core.Platform do
 
   def line_separator() do
     case :os.type() do
-      {:unix, _}  -> "\n"
+      {:unix, _} -> "\n"
       {:win32, _} -> "\r\n"
     end
   end
@@ -22,15 +22,19 @@ defmodule RabbitMQ.CLI.Core.Platform do
   def os_name({:unix, :linux}) do
     "Linux"
   end
+
   def os_name({:unix, :darwin}) do
     "macOS"
   end
+
   def os_name({:unix, :freebsd}) do
     "FreeBSD"
   end
+
   def os_name({:unix, name}) do
-    name |> to_string |> String.capitalize
+    name |> to_string |> String.capitalize()
   end
+
   def os_name({:win32, _}) do
     "Windows"
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
@@ -9,7 +9,6 @@ defmodule RabbitMQ.CLI.Core.Validators do
   alias RabbitMQ.CLI.Core.Helpers
   import RabbitMQ.CLI.Core.{CodePath, Paths}
 
-
   def chain([validator | rest], args) do
     case apply(validator, args) do
       :ok -> chain(rest, args)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/version.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/version.ex
@@ -11,14 +11,14 @@ defmodule RabbitMQ.CLI.Core.Version do
     to_string(:rabbit_misc.version())
   end
 
-
   def remote_version(node_name) do
     remote_version(node_name, @default_timeout)
   end
+
   def remote_version(node_name, timeout) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_misc, :version, [], timeout) do
       {:badrpc, _} = err -> err
-      val                -> val
+      val -> val
     end
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -15,9 +15,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def validate(args, _) when length(args) < 1, do: {:validation_failure, :not_enough_args}
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
+
   def validate(["", _], _) do
     {:validation_failure, {:bad_argument, "user cannot be an empty string"}}
   end
+
   def validate([_, _], _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
@@ -28,15 +30,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
     # Credential validators can be used to require passwords of a certain length
     # or following a certain pattern. This is a core server responsibility. MK.
     case Input.infer_password("Password: ", opts) do
-      :eof     -> {:error, :not_enough_args}
-      password -> :rabbit_misc.rpc_call(
-                    node_name,
-                    :rabbit_auth_backend_internal,
-                    :add_user,
-                    [username, password, Helpers.cli_acting_user()]
-                  )
+      :eof ->
+        {:error, :not_enough_args}
+
+      password ->
+        :rabbit_misc.rpc_call(
+          node_name,
+          :rabbit_auth_backend_internal,
+          :add_user,
+          [username, password, Helpers.cli_acting_user()]
+        )
     end
   end
+
   def run([username, password], %{node: node_name}) do
     :rabbit_misc.rpc_call(
       node_name,
@@ -49,28 +55,38 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def output({:error, :not_enough_args}, _) do
     {:error, ExitCodes.exit_dataerr(), "Password is not provided via argument or stdin"}
   end
+
   def output({:error, {:user_already_exists, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} already exists"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} already exists"}}
   end
+
   def output({:error, {:user_already_exists, username}}, _) do
     {:error, ExitCodes.exit_software(), "User \"#{username}\" already exists"}
   end
+
   def output(:ok, %{formatter: "json", node: node_name}) do
     m = %{
-      "status"  => "ok",
-      "node"    => node_name,
-      "message" => "Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more."
+      "status" => "ok",
+      "node" => node_name,
+      "message" =>
+        "Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more."
     }
+
     {:ok, m}
   end
+
   def output(:ok, opts) do
     case output_less?(opts) do
       true ->
         :ok
+
       false ->
-        {:ok, "Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more."}
+        {:ok,
+         "Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more."}
     end
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "add_user <username> <password>"
@@ -78,7 +94,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def usage_additional() do
     [
       ["<username>", "Self-explanatory"],
-      ["<password>", "Password this user will authenticate with. Use a blank string to disable password-based authentication."]
+      [
+        "<password>",
+        "Password this user will authenticate with. Use a blank string to disable password-based authentication."
+      ]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -9,54 +9,84 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: [description: :string,
-                       tags: :string,
-                       default_queue_type: :string]
+  def switches(), do: [description: :string, tags: :string, default_queue_type: :string]
   def aliases(), do: [d: :description]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{description: "", tags: ""}, opts)}
   end
+
   use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([vhost], %{node: node_name, description: desc, tags: tags, default_queue_type: default_qt}) do
-    meta = %{description: desc,
-             tags: parse_tags(tags),
-             default_queue_type: default_qt}
+  def run([vhost], %{
+        node: node_name,
+        description: desc,
+        tags: tags,
+        default_queue_type: default_qt
+      }) do
+    meta = %{description: desc, tags: parse_tags(tags), default_queue_type: default_qt}
     # check if the respective feature flag is enabled
     case default_qt do
       "quorum" ->
-        FeatureFlags.assert_feature_flag_enabled(node_name, :quorum_queue, fn () ->
-          :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, meta, Helpers.cli_acting_user()])
+        FeatureFlags.assert_feature_flag_enabled(node_name, :quorum_queue, fn ->
+          :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
+            vhost,
+            meta,
+            Helpers.cli_acting_user()
+          ])
         end)
+
       "stream" ->
-        FeatureFlags.assert_feature_flag_enabled(node_name, :stream_queue, fn () ->
-          :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, meta, Helpers.cli_acting_user()])
+        FeatureFlags.assert_feature_flag_enabled(node_name, :stream_queue, fn ->
+          :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
+            vhost,
+            meta,
+            Helpers.cli_acting_user()
+          ])
         end)
+
       _ ->
-        :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, meta, Helpers.cli_acting_user()])
+        :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
+          vhost,
+          meta,
+          Helpers.cli_acting_user()
+        ])
     end
   end
+
   def run([vhost], %{node: node_name, description: desc, tags: tags}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, desc, tags, Helpers.cli_acting_user()])
+    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
+      vhost,
+      desc,
+      tags,
+      Helpers.cli_acting_user()
+    ])
   end
+
   def run([vhost], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
   end
+
   def output({:error, :invalid_queue_type}, _opts) do
-    {:error, ExitCodes.exit_usage, "Unsupported default queue type"}
+    {:error, ExitCodes.exit_usage(), "Unsupported default queue type"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
-  def usage, do: "add_vhost <vhost> [--description <description> --tags \"<tag1>,<tag2>,<...>\" --default-queue-type <quorum|classic|stream>]"
+  def usage,
+    do:
+      "add_vhost <vhost> [--description <description> --tags \"<tag1>,<tag2>,<...>\" --default-queue-type <quorum|classic|stream>]"
 
   def usage_additional() do
     [
       ["<vhost>", "Virtual host name"],
       ["--description <description>", "Virtual host description"],
       ["--tags <tags>", "Command separated list of tags"],
-      ["--default-queue-type <quorum|classic|stream>", "Queue type to use if no type is explicitly provided by the client"]
+      [
+        "--default-queue-type <quorum|classic|stream>",
+        "Queue type to use if no type is explicitly provided by the client"
+      ]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
@@ -24,15 +24,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
     # Credential validators can be used to require passwords of a certain length
     # or following a certain pattern. This is a core server responsibility. MK.
     case Input.infer_password("Password: ", opts) do
-      :eof     -> {:error, :not_enough_args}
-      password -> :rabbit_misc.rpc_call(
-                    node_name,
-                    :rabbit_access_control,
-                    :check_user_pass_login,
-                    [user, password]
-                  )
+      :eof ->
+        {:error, :not_enough_args}
+
+      password ->
+        :rabbit_misc.rpc_call(
+          node_name,
+          :rabbit_access_control,
+          :check_user_pass_login,
+          [user, password]
+        )
     end
   end
+
   def run([user, password], %{node: node_name}) do
     :rabbit_misc.rpc_call(
       node_name,
@@ -59,18 +63,21 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
 
   def help_section(), do: :user_management
 
-  def description(), do: "Attempts to authenticate a user. Exits with a non-zero code if authentication fails."
+  def description(),
+    do: "Attempts to authenticate a user. Exits with a non-zero code if authentication fails."
 
   def banner([username | _], _), do: "Authenticating user \"#{username}\" ..."
 
   def output({:error, :not_enough_args}, _) do
     {:error, ExitCodes.exit_software(), "Password is not provided via argument or stdin"}
   end
+
   def output({:refused, user, msg, args}, _) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_dataerr(),
      "Error: failed to authenticate user \"#{user}\"\n" <>
        to_string(:io_lib.format(msg, args))}
   end
+
   def output({:ok, _user}, _) do
     {:ok, "Success"}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/autocomplete_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/autocomplete_command.ex
@@ -26,11 +26,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AutocompleteCommand do
   def run(args, %{script_name: script_name}) do
     {:stream, RabbitMQ.CLI.AutoComplete.complete(script_name, args)}
   end
+
   def run(args, opts) do
     script_name = Config.get_system_option(:script_name, opts)
 
     {:stream, RabbitMQ.CLI.AutoComplete.complete(script_name, args)}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage() do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/await_online_nodes_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/await_online_nodes_command.ex
@@ -37,9 +37,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitOnlineNodesCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def banner([count], %{node: node_name, timeout: timeout}) when is_number(timeout) do
-    "Will wait for at least #{count} nodes to join the cluster of #{node_name}. Timeout: #{
-      trunc(timeout / 1000)
-    } seconds."
+    "Will wait for at least #{count} nodes to join the cluster of #{node_name}. Timeout: #{trunc(timeout / 1000)} seconds."
   end
 
   def banner([count], %{node: node_name, timeout: _timeout}) do
@@ -52,7 +50,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitOnlineNodesCommand do
 
   def usage_additional() do
     [
-      ["<count>", "how many cluster members must be up in order for this command to exit. When <count> is 1, always exits immediately."]
+      [
+        "<count>",
+        "how many cluster members must be up in order for this command to exit. When <count> is 1, always exits immediately."
+      ]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -24,15 +24,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
     # Credential validators can be used to require passwords of a certain length
     # or following a certain pattern. This is a core server responsibility. MK.
     case Input.infer_password("Password: ", opts) do
-      :eof -> {:error, :not_enough_args}
-      password -> :rabbit_misc.rpc_call(
-                    node_name,
-                    :rabbit_auth_backend_internal,
-                    :change_password,
-                    [username, password, Helpers.cli_acting_user()]
-                  )
+      :eof ->
+        {:error, :not_enough_args}
+
+      password ->
+        :rabbit_misc.rpc_call(
+          node_name,
+          :rabbit_auth_backend_internal,
+          :change_password,
+          [username, password, Helpers.cli_acting_user()]
+        )
     end
   end
+
   def run([username, password], %{node: node_name}) do
     :rabbit_misc.rpc_call(
       node_name,
@@ -45,12 +49,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
   def output({:error, :not_enough_args}, _) do
     {:error, ExitCodes.exit_software(), "Password is not provided via argument or stdin"}
   end
+
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exists"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exists"}}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User \"#{username}\" does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "change_password <username> <password>"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
@@ -25,17 +25,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand do
   end
 
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "Virtual host #{vhost} does not exist"}}
+    {:error,
+     %{
+       "result" => "error",
+       "node" => node_name,
+       "message" => "Virtual host #{vhost} does not exist"
+     }}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User #{username} does not exist"}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, _) do
     {:error, "Virtual host #{vhost} does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "clear_permissions [--vhost <vhost>] <username>"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
@@ -44,17 +44,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearTopicPermissionsCommand do
   end
 
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "Virtual host #{vhost} does not exist"}}
+    {:error,
+     %{
+       "result" => "error",
+       "node" => node_name,
+       "message" => "Virtual host #{vhost} does not exist"
+     }}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User #{username} does not exist"}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, _) do
     {:error, "Virtual host #{vhost} does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "clear_topic_permissions [--vhost <vhost>] <username> [<exchange>]"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/clear_user_limits_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/clear_user_limits_command.ex
@@ -45,6 +45,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearUserLimitsCommand do
   def banner([username, "all"], %{}) do
     "Clearing all limits for user \"#{username}\" ..."
   end
+
   def banner([username, limit_type], %{}) do
     "Clearing \"#{limit_type}\" limit for user \"#{username}\" ..."
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_all_connections_command.ex
@@ -62,18 +62,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand do
         per_connection_delay: delay,
         limit: limit
       }) do
-        run(args, %{
-              node: node_name,
-              vhost: nil,
-              global: global_opt,
-              per_connection_delay: delay,
-              limit: limit
-            })
+    run(args, %{
+      node: node_name,
+      vhost: nil,
+      global: global_opt,
+      per_connection_delay: delay,
+      limit: limit
+    })
   end
 
   def output({:stream, stream}, _opts) do
     {:stream, Stream.filter(stream, fn x -> x != :ok end)}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def banner([explanation], %{node: node_name, global: true}) do
@@ -108,7 +109,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand do
 
   def help_section(), do: :operations
 
-  def description(), do: "Instructs the broker to close all connections for the specified vhost or entire RabbitMQ node"
+  def description(),
+    do:
+      "Instructs the broker to close all connections for the specified vhost or entire RabbitMQ node"
 
   #
   # Implementation

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
@@ -40,7 +40,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseConnectionCommand do
 
   def help_section(), do: :operations
 
-  def description(), do: "Instructs the broker to close the connection associated with the Erlang process id"
+  def description(),
+    do: "Instructs the broker to close the connection associated with the Erlang process id"
 
   def banner([pid, explanation], _), do: "Closing connection #{pid}, reason: #{explanation}..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -19,16 +19,22 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
       iterations: :integer
     ]
   end
+
   @atomized_keys [:cipher, :hash]
 
   def distribution(_), do: :none
 
   def merge_defaults(args, opts) do
-    with_defaults = Map.merge(%{
-         cipher: :rabbit_pbe.default_cipher(),
-         hash: :rabbit_pbe.default_hash(),
-         iterations: :rabbit_pbe.default_iterations()
-       }, opts)
+    with_defaults =
+      Map.merge(
+        %{
+          cipher: :rabbit_pbe.default_cipher(),
+          hash: :rabbit_pbe.default_hash(),
+          iterations: :rabbit_pbe.default_iterations()
+        },
+        opts
+      )
+
     {args, Helpers.atomize_values(with_defaults, @atomized_keys)}
   end
 
@@ -60,7 +66,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
 
   def run([value], %{cipher: cipher, hash: hash, iterations: iterations} = opts) do
     case Input.consume_single_line_string_with_prompt("Passphrase: ", opts) do
-      :eof -> {:error, :not_enough_args}
+      :eof ->
+        {:error, :not_enough_args}
+
       passphrase ->
         try do
           term_value = Helpers.evaluate_input_as_term(value)
@@ -69,6 +77,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
             case term_value do
               {:encrypted, _} = encrypted ->
                 encrypted
+
               _ ->
                 {:encrypted, term_value}
             end
@@ -91,6 +100,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
         case term_value do
           {:encrypted, _} = encrypted ->
             encrypted
+
           _ ->
             {:encrypted, term_value}
         end
@@ -110,7 +120,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
     "Decrypting value..."
   end
 
-  def usage, do: "decode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
+  def usage,
+    do: "decode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
 
   def usage_additional() do
     [

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
@@ -23,11 +23,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteUserCommand do
   end
 
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exists"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exists"}}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User \"#{username}\" does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "delete_user <username>"
@@ -46,7 +49,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteUserCommand do
 
   def help_section(), do: :user_management
 
-  def description(), do: "Removes a user from the internal database. Has no effect on users provided by external backends such as LDAP"
+  def description(),
+    do:
+      "Removes a user from the internal database. Has no effect on users provided by external backends such as LDAP"
 
   def banner([arg], _), do: "Deleting user \"#{arg}\" ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_feature_flag_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_feature_flag_command.ex
@@ -4,15 +4,17 @@
 ##
 ## Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.EnableFeatureFlagCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate([], _), do: {:validation_failure, :not_enough_args}
-  def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
-  def validate([""], _), do: {:validation_failure, {:bad_argument, "feature_flag cannot be an empty string."}}
+  def validate([_ | _] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
+
+  def validate([""], _),
+    do: {:validation_failure, {:bad_argument, "feature_flag cannot be an empty string."}}
+
   def validate([_], _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
@@ -22,37 +24,45 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnableFeatureFlagCommand do
       # Server does not support feature flags, consider none are available.
       # See rabbitmq/rabbitmq-cli#344 for context. MK.
       {:badrpc, {:EXIT, {:undef, _}}} -> {:error, :unsupported}
-      {:badrpc, _} = err    -> err
-      other                 -> other
+      {:badrpc, _} = err -> err
+      other -> other
     end
   end
 
   def run([feature_flag], %{node: node_name}) do
-    case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :enable, [String.to_atom(feature_flag)]) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :enable, [
+           String.to_atom(feature_flag)
+         ]) do
       # Server does not support feature flags, consider none are available.
       # See rabbitmq/rabbitmq-cli#344 for context. MK.
       {:badrpc, {:EXIT, {:undef, _}}} -> {:error, :unsupported}
-      {:badrpc, _} = err    -> err
-      other                 -> other
+      {:badrpc, _} = err -> err
+      other -> other
     end
   end
 
   def output({:error, :unsupported}, %{node: node_name}) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage, "This feature flag is not supported by node #{node_name}"}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(),
+     "This feature flag is not supported by node #{node_name}"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "enable_feature_flag <all | feature_flag>"
 
   def usage_additional() do
-  [
-    ["<feature_flag>", "name of the feature flag to enable, or \"all\" to enable all supported flags"]
-  ]
-end
+    [
+      [
+        "<feature_flag>",
+        "name of the feature flag to enable, or \"all\" to enable all supported flags"
+      ]
+    ]
+  end
 
   def help_section(), do: :feature_flags
 
-  def description(), do: "Enables a feature flag or all supported feature flags on the target node"
+  def description(),
+    do: "Enables a feature flag or all supported feature flags on the target node"
 
   def banner(["all"], _), do: "Enabling all feature flags ..."
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -17,16 +17,22 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
       iterations: :integer
     ]
   end
+
   @atomized_keys [:cipher, :hash]
 
   def distribution(_), do: :none
 
   def merge_defaults(args, opts) do
-    with_defaults = Map.merge(%{
-         cipher: :rabbit_pbe.default_cipher(),
-         hash: :rabbit_pbe.default_hash(),
-         iterations: :rabbit_pbe.default_iterations()
-       }, opts)
+    with_defaults =
+      Map.merge(
+        %{
+          cipher: :rabbit_pbe.default_cipher(),
+          hash: :rabbit_pbe.default_hash(),
+          iterations: :rabbit_pbe.default_iterations()
+        },
+        opts
+      )
+
     {args, Helpers.atomize_values(with_defaults, @atomized_keys)}
   end
 
@@ -52,14 +58,22 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
 
   def run([], %{cipher: cipher, hash: hash, iterations: iterations} = opts) do
     case Input.consume_single_line_string_with_prompt("Value to encode: ", opts) do
-      :eof  -> {:error, :not_enough_args}
+      :eof ->
+        {:error, :not_enough_args}
+
       value ->
         case Input.consume_single_line_string_with_prompt("Passphrase: ", opts) do
-          :eof  -> {:error, :not_enough_args}
+          :eof ->
+            {:error, :not_enough_args}
+
           passphrase ->
             try do
               term_value = Helpers.evaluate_input_as_term(value)
-              result = {:encrypted, _} = :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+
+              result =
+                {:encrypted, _} =
+                :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+
               {:ok, result}
             catch
               _, _ ->
@@ -71,11 +85,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
 
   def run([value], %{cipher: cipher, hash: hash, iterations: iterations} = opts) do
     case Input.consume_single_line_string_with_prompt("Passphrase: ", opts) do
-      :eof -> {:error, :not_enough_args}
+      :eof ->
+        {:error, :not_enough_args}
+
       passphrase ->
         try do
           term_value = Helpers.evaluate_input_as_term(value)
-          result = {:encrypted, _} = :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+
+          result =
+            {:encrypted, _} =
+            :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+
           {:ok, result}
         catch
           _, _ ->
@@ -87,7 +107,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   def run([value, passphrase], %{cipher: cipher, hash: hash, iterations: iterations}) do
     try do
       term_value = Helpers.evaluate_input_as_term(value)
-      result = {:encrypted, _} = :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+
+      result =
+        {:encrypted, _} =
+        :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+
       {:ok, result}
     catch
       _, _ ->
@@ -101,7 +125,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     "Encrypting value ..."
   end
 
-  def usage, do: "encode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
+  def usage,
+    do: "encode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
 
   def usage_additional() do
     [

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/environment_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/environment_command.ex
@@ -32,7 +32,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Displays the name and value of each variable in the application environment for each running application"
+  def description(),
+    do:
+      "Displays the name and value of each variable in the application environment for each running application"
 
   def banner(_, %{node: node_name}), do: "Application environment of node #{node_name} ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/eval_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/eval_command.ex
@@ -29,7 +29,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
 
   def run([], %{node: node_name} = opts) do
     case Input.consume_multiline_string() do
-      :eof -> {:error, :not_enough_args}
+      :eof ->
+        {:error, :not_enough_args}
+
       expr ->
         case ErlEval.parse_expr(expr) do
           {:ok, parsed} ->
@@ -37,13 +39,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
 
             case :rabbit_misc.rpc_call(node_name, :erl_eval, :exprs, [parsed, bindings]) do
               {:value, value, _} -> {:ok, value}
-              err                -> err
+              err -> err
             end
 
-          {:error, msg} -> {:error, msg}
+          {:error, msg} ->
+            {:error, msg}
         end
     end
   end
+
   def run([expr | arguments], %{node: node_name} = opts) do
     case ErlEval.parse_expr(expr) do
       {:ok, parsed} ->
@@ -51,19 +55,23 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
 
         case :rabbit_misc.rpc_call(node_name, :erl_eval, :exprs, [parsed, bindings]) do
           {:value, value, _} -> {:ok, value}
-          err                -> err
+          err -> err
         end
 
-      {:error, msg} -> {:error, msg}
+      {:error, msg} ->
+        {:error, msg}
     end
   end
 
   def output({:error, :not_enough_args}, _) do
-    {:error, ExitCodes.exit_dataerr(), "Expression to evaluate is not provided via argument or stdin"}
+    {:error, ExitCodes.exit_dataerr(),
+     "Expression to evaluate is not provided via argument or stdin"}
   end
+
   def output({:error, msg}, _) do
     {:error, ExitCodes.exit_dataerr(), "Evaluation failed: #{msg}"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/eval_file_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/eval_file_command.ex
@@ -24,13 +24,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalFileCommand do
     case File.read(file_path) do
       {:ok, expr} ->
         case ErlEval.parse_expr(expr) do
-          {:ok, _}      -> :ok
+          {:ok, _} -> :ok
           {:error, err} -> {:validation_failure, err}
         end
+
       {:error, :enoent} ->
         {:validation_failure, "File #{file_path} does not exist"}
+
       {:error, :eacces} ->
         {:validation_failure, "Insufficient permissions to read file #{file_path}"}
+
       {:error, err} ->
         {:validation_failure, err}
     end
@@ -38,15 +41,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalFileCommand do
 
   def run([file_path], opts) do
     case File.read(file_path) do
-      {:ok, expr}   -> EvalCommand.run([expr], opts)
+      {:ok, expr} -> EvalCommand.run([expr], opts)
       {:error, err} -> {:error, err}
     end
-
   end
 
   def output({:error, msg}, _) do
     {:error, ExitCodes.exit_dataerr(), "Evaluation failed: #{msg}"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
@@ -69,7 +72,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalFileCommand do
 
   def help_section(), do: :operations
 
-  def description(), do: "Evaluates a file that contains a snippet of Erlang code on the target node"
+  def description(),
+    do: "Evaluates a file that contains a snippet of Erlang code on the target node"
 
   def banner(_, _), do: nil
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -51,7 +51,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
 
   def help_section(), do: :cluster_management
 
-  def description(), do: "Forces node to start even if it cannot contact or rejoin any of its previously known peers"
+  def description(),
+    do:
+      "Forces node to start even if it cannot contact or rejoin any of its previously known peers"
 
   def banner(_, _), do: nil
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_gc_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_gc_command.ex
@@ -29,7 +29,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceGcCommand do
 
   def help_section(), do: :operations
 
-  def description, do: "Makes all Erlang processes on the target node perform/schedule a full sweep garbage collection"
+  def description,
+    do:
+      "Makes all Erlang processes on the target node perform/schedule a full sweep garbage collection"
 
-  def banner([], %{node: node_name}), do: "Will ask all processes on node #{node_name} to schedule a full sweep GC"
+  def banner([], %{node: node_name}),
+    do: "Will ask all processes on node #{node_name} to schedule a full sweep GC"
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -19,7 +19,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
 
   def output({:error, :mnesia_unexpectedly_running}, %{node: node_name}) do
     {:error, ExitCodes.exit_software(),
-              RabbitMQ.CLI.DefaultOutput.mnesia_running_error(node_name)}
+     RabbitMQ.CLI.DefaultOutput.mnesia_running_error(node_name)}
   end
 
   use RabbitMQ.CLI.DefaultOutput

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -60,6 +60,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
   def run([_target_dir], _opts) do
     :ok
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "hipe_compile <directory>"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
@@ -12,8 +12,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
   def merge_defaults(["-"] = args, opts) do
     {args, Map.merge(%{format: "json", silent: true}, Helpers.case_insensitive_format(opts))}
   end
+
   def merge_defaults(args, opts) do
-    {args, Map.merge(%{format: "json", skip_if_unchanged: false}, Helpers.case_insensitive_format(opts))}
+    {args,
+     Map.merge(%{format: "json", skip_if_unchanged: false}, Helpers.case_insensitive_format(opts))}
   end
 
   def switches(), do: [timeout: :integer, format: :string, skip_if_unchanged: :boolean]
@@ -23,63 +25,86 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
       when format != "json" and format != "JSON" and format != "erlang" do
     {:validation_failure, {:bad_argument, "Format should be either json or erlang"}}
   end
+
   def validate(args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end
+
   def validate([path], _) do
-    case File.exists?(path, [raw: true]) do
-      true  -> :ok
+    case File.exists?(path, raw: true) do
+      true -> :ok
       false -> {:validation_failure, {:bad_argument, "File #{path} does not exist"}}
     end
   end
+
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, format: format, timeout: timeout}) do
     case IO.read(:stdio, :all) do
-      :eof -> {:error, :not_enough_args}
-      bin  ->
+      :eof ->
+        {:error, :not_enough_args}
+
+      bin ->
         case deserialise(bin, format) do
           {:error, error} ->
-            {:error, ExitCodes.exit_dataerr(), "Failed to deserialise input (format: #{human_friendly_format(format)}) (error: #{inspect(error)})"}
+            {:error, ExitCodes.exit_dataerr(),
+             "Failed to deserialise input (format: #{human_friendly_format(format)}) (error: #{inspect(error)})"}
+
           {:ok, map} ->
             skip? = Map.get(map, :skip_if_unchanged, false)
-            fun = case skip? do
-              true  -> :import_parsed_with_hashing
-              false -> :import_parsed
-            end
+
+            fun =
+              case skip? do
+                true -> :import_parsed_with_hashing
+                false -> :import_parsed
+              end
+
             :rabbit_misc.rpc_call(node_name, :rabbit_definitions, fun, [map], timeout)
         end
     end
   end
+
   def run([path], %{node: node_name, format: format, timeout: timeout}) do
     abs_path = Path.absname(path)
 
     case File.read(abs_path) do
       {:ok, ""} ->
         {:error, ExitCodes.exit_dataerr(), "File #{path} is zero-sized"}
+
       {:ok, bin} ->
         case deserialise(bin, format) do
           {:error, error} ->
-            {:error, ExitCodes.exit_dataerr(), "Failed to deserialise input (format: #{human_friendly_format(format)}) (error: #{inspect(error)})"}
+            {:error, ExitCodes.exit_dataerr(),
+             "Failed to deserialise input (format: #{human_friendly_format(format)}) (error: #{inspect(error)})"}
+
           {:ok, map} ->
             skip? = Map.get(map, :skip_if_unchanged, false)
-            fun = case skip? do
-              true  -> :import_parsed_with_hashing
-              false -> :import_parsed
-            end
+
+            fun =
+              case skip? do
+                true -> :import_parsed_with_hashing
+                false -> :import_parsed
+              end
+
             :rabbit_misc.rpc_call(node_name, :rabbit_definitions, fun, [map], timeout)
         end
-      {:error, :enoent}  ->
+
+      {:error, :enoent} ->
         {:error, ExitCodes.exit_dataerr(), "Parent directory or file #{path} does not exist"}
+
       {:error, :enotdir} ->
         {:error, ExitCodes.exit_dataerr(), "Parent directory of file #{path} is not a directory"}
+
       {:error, :eacces} ->
-        {:error, ExitCodes.exit_dataerr(), "No permissions to read from file #{path} or its parent directory"}
+        {:error, ExitCodes.exit_dataerr(),
+         "No permissions to read from file #{path} or its parent directory"}
+
       {:error, :eisdir} ->
         {:error, ExitCodes.exit_dataerr(), "Path #{path} is a directory"}
-      {:error, err}     ->
+
+      {:error, err} ->
         {:error, ExitCodes.exit_dataerr(), "Could not read from file #{path}: #{err}"}
     end
   end
@@ -87,24 +112,34 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
   def output(:ok, %{node: node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "node" => node_name}}
   end
+
   def output(:ok, opts) do
     case Config.output_less?(opts) do
-      true  -> :ok
-      false -> {:ok, "Successfully started definition import. " <>
-                     "This process is asynchronous and can take some time.\n"}
+      true ->
+        :ok
+
+      false ->
+        {:ok,
+         "Successfully started definition import. " <>
+           "This process is asynchronous and can take some time.\n"}
     end
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def printer(), do: RabbitMQ.CLI.Printers.StdIORaw
 
-  def usage, do: "import_definitions <file_path | \"-\"> [--format <json | erlang>] [--skip-if-unchanged]"
+  def usage,
+    do: "import_definitions <file_path | \"-\"> [--format <json | erlang>] [--skip-if-unchanged]"
 
   def usage_additional() do
     [
       ["[file]", "Local file path to import from. If omitted will be read from standard input"],
       ["--format", "input format to use: json or erlang"],
-      ["--skip-if-unchanged", "Avoids repetitive definition imports when file contents are unchanged. Target node must be configured accordingly"]
+      [
+        "--skip-if-unchanged",
+        "Avoids repetitive definition imports when file contents are unchanged. Target node must be configured accordingly"
+      ]
     ]
   end
 
@@ -121,6 +156,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
   def banner([], %{format: fmt}) do
     "Importing definitions in #{human_friendly_format(fmt)} from standard input ..."
   end
+
   def banner([path], %{format: fmt}) do
     "Importing definitions in #{human_friendly_format(fmt)} from a file at \"#{path}\" ..."
   end
@@ -136,8 +172,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
   defp deserialise(bin, "erlang") do
     try do
       {:ok, :erlang.binary_to_term(bin)}
-    rescue e in ArgumentError ->
-      {:error, e.message}
+    rescue
+      e in ArgumentError ->
+        {:error, e.message}
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -77,8 +77,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
   def usage_additional() do
     [
       ["<existing_cluster_member>", "Existing cluster member (node) to join"],
-      ["--disc", "new node should be a disk one (stores its schema on disk). Highly recommended, used by default."],
-      ["--ram", "new node should be a RAM one (stores schema in RAM). Not recommended. Consult clustering doc guides first."]
+      [
+        "--disc",
+        "new node should be a disk one (stores its schema on disk). Highly recommended, used by default."
+      ],
+      [
+        "--ram",
+        "new node should be a RAM one (stores schema in RAM). Not recommended. Consult clustering doc guides first."
+      ]
     ]
   end
 
@@ -91,5 +97,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
 
   def help_section(), do: :cluster_management
 
-  def description(), do: "Instructs the node to become a member of the cluster that the specified node is in"
+  def description(),
+    do: "Instructs the node to become a member of the cluster that the specified node is in"
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -43,9 +43,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
     Helpers.with_nodes_in_cluster(node_name, fn nodes ->
       RpcStream.receive_list_items_with_fun(
         node_name,
-        [{:rabbit_amqqueue,
-        :emit_consumers_all,
-        [nodes, vhost]}],
+        [{:rabbit_amqqueue, :emit_consumers_all, [nodes, vhost]}],
         timeout,
         info_keys,
         Kernel.length(nodes),
@@ -91,15 +89,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
 
   def fill_consumer_active_fields({items, {chunk, :continue}}) do
     {Enum.map(items, fn item ->
-                          case Keyword.has_key?(item, :active) do
-                            true ->
-                              item
-                            false ->
-                              Keyword.drop(item, [:arguments])
-                                ++ [active: true, activity_status: :up]
-                                ++ [arguments: Keyword.get(item, :arguments, [])]
-                          end
-                        end), {chunk, :continue}}
+       case Keyword.has_key?(item, :active) do
+         true ->
+           item
+
+         false ->
+           Keyword.drop(item, [:arguments]) ++
+             [active: true, activity_status: :up] ++
+             [arguments: Keyword.get(item, :arguments, [])]
+       end
+     end), {chunk, :continue}}
   end
 
   def fill_consumer_active_fields(v) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_feature_flags_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_feature_flags_command.ex
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ListFeatureFlagsCommand do
   alias RabbitMQ.CLI.Core.{DocGuide, Validators}
   alias RabbitMQ.CLI.Ctl.InfoKeys
@@ -41,15 +40,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListFeatureFlagsCommand do
     )
   end
 
-  def run([_|_] = args, %{node: node_name, timeout: timeout}) do
+  def run([_ | _] = args, %{node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_ff_extra, :cli_info, [], timeout) do
       # Server does not support feature flags, consider none are available.
       # See rabbitmq/rabbitmq-cli#344 for context. MK.
       {:badrpc, {:EXIT, {:undef, _}}} -> []
-      {:badrpc, _} = err    -> err
-      val                   -> filter_by_arg(val, args)
+      {:badrpc, _} = err -> err
+      val -> filter_by_arg(val, args)
     end
-
   end
 
   def banner(_, _), do: "Listing feature flags ..."
@@ -81,13 +79,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListFeatureFlagsCommand do
     ff_info
   end
 
-  defp filter_by_arg(ff_info, [_|_] = args) when is_list(ff_info) do
+  defp filter_by_arg(ff_info, [_ | _] = args) when is_list(ff_info) do
     symbol_args = InfoKeys.prepare_info_keys(args)
-    Enum.map(ff_info,
-      fn(ff) ->
+
+    Enum.map(
+      ff_info,
+      fn ff ->
         symbol_args
-        |> Enum.filter(fn(arg) -> ff[arg] != nil end)
-        |> Enum.map(fn(arg) -> {arg, ff[arg]} end)
+        |> Enum.filter(fn arg -> ff[arg] != nil end)
+        |> Enum.map(fn arg -> {arg, ff[arg]} end)
       end
     )
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -26,12 +26,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
             leader members online)a
 
   def description(), do: "Lists queues and their properties"
-  def usage(), do: "list_queues [--vhost <vhost>] [--online] [--offline] [--local] [--no-table-headers] [<column>, ...]"
+
+  def usage(),
+    do:
+      "list_queues [--vhost <vhost>] [--online] [--offline] [--local] [--no-table-headers] [<column>, ...]"
+
   def scopes(), do: [:ctl, :diagnostics]
-  def switches(), do: [offline: :boolean,
-                       online: :boolean,
-                       local: :boolean,
-                       timeout: :integer]
+  def switches(), do: [offline: :boolean, online: :boolean, local: :boolean, timeout: :integer]
   def aliases(), do: [t: :timeout]
 
   def info_keys(), do: @info_keys

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
@@ -85,11 +85,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
     [
       ["<column>", "must be one of " <> Enum.join(Enum.sort(@info_keys), ", ")],
       ["--local", "only return queues hosted on the target node"],
-      ["--queue-timeout <milliseconds>", "per-queue timeout to use when checking for responsiveness"]
+      [
+        "--queue-timeout <milliseconds>",
+        "per-queue timeout to use when checking for responsiveness"
+      ]
     ]
   end
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Tests queues to respond within timeout. Lists those which did not respond"
+  def description(),
+    do: "Tests queues to respond within timeout. Lists those which did not respond"
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_user_limits_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_user_limits_command.ex
@@ -43,7 +43,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserLimitsCommand do
   end
 
   def run([], %{node: node_name, user: username}) do
-    case :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :get_user_limits, [username]) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :get_user_limits, [
+           username
+         ]) do
       :undefined ->
         {:error, {:no_such_user, username}}
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -70,9 +70,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
   end
 
   def help_section(), do: :deprecated
+
   def description() do
     "DEPRECATED. Performs intrusive, opinionated health checks on a fully booted node. " <>
-    "See https://www.rabbitmq.com/monitoring.html#health-checks instead"
+      "See https://www.rabbitmq.com/monitoring.html#health-checks instead"
   end
 
   def banner(_, %{node: node_name, timeout: timeout}) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/ping_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/ping_command.ex
@@ -62,6 +62,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PingCommand do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software(),
      "Error: timed out while waiting for a response from #{node_name}."}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage() do
@@ -76,12 +77,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PingCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it"
+  def description(),
+    do:
+      "Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it"
 
   def banner([], %{node: node_name, timeout: timeout}) when is_number(timeout) do
-    "Will ping #{node_name}. This only checks if the OS process is running and registered with epmd. Timeout: #{
-      timeout
-    } ms."
+    "Will ping #{node_name}. This only checks if the OS process is running and registered with epmd. Timeout: #{timeout} ms."
   end
 
   def banner([], %{node: node_name, timeout: _timeout}) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/report_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/report_command.ex
@@ -6,6 +6,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
   alias RabbitMQ.CLI.Core.DocGuide
+
   alias RabbitMQ.CLI.Ctl.Commands.{
     ClusterStatusCommand,
     EnvironmentCommand,
@@ -20,6 +21,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
     ListQueuesCommand,
     StatusCommand
   }
+
   alias RabbitMQ.CLI.Diagnostics.Commands.{
     CommandLineArgumentsCommand,
     OsEnvCommand
@@ -73,8 +75,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
               run_command(ListPermissionsCommand, [], opts),
               run_command(ListPoliciesCommand, [], opts),
               run_command(ListGlobalParametersCommand, [], opts),
-              run_command(ListParametersCommand, [], opts),
-
+              run_command(ListParametersCommand, [], opts)
             ]
           end)
 
@@ -96,7 +97,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Generate a server status report containing a concatenation of all server status information for support purposes"
+  def description(),
+    do:
+      "Generate a server status report containing a concatenation of all server status information for support purposes"
 
   def banner(_, %{node: node_name}), do: "Reporting server status of node #{node_name} ..."
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -34,7 +34,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
 
   def help_section(), do: :node_management
 
-  def description(), do: "Instructs a RabbitMQ node to leave the cluster and return to its virgin state"
+  def description(),
+    do: "Instructs a RabbitMQ node to leave the cluster and return to its virgin state"
 
   def banner(_, %{node: node_name}), do: "Resetting node #{node_name} ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/resume_listeners_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/resume_listeners_command.ex
@@ -21,7 +21,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResumeListenersCommand do
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name, timeout: timeout}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_maintenance, :resume_all_client_listeners, [], timeout)
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_maintenance,
+      :resume_all_client_listeners,
+      [],
+      timeout
+    )
   end
 
   use RabbitMQ.CLI.DefaultOutput
@@ -36,10 +42,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResumeListenersCommand do
 
   def help_section(), do: :operations
 
-  def description(), do: "Resumes client connection listeners making them accept client connections again"
+  def description(),
+    do: "Resumes client connection listeners making them accept client connections again"
 
   def banner(_, %{node: node_name}) do
-    "Will resume client connection listeners on node #{node_name}. "
-    <> "The node will now accept client connections"
+    "Will resume client connection listeners on node #{node_name}. " <>
+      "The node will now accept client connections"
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
@@ -20,6 +20,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RotateLogsCommand do
       "This command does not rotate logs anymore [deprecated]"
     }
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "rotate_logs"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
@@ -14,9 +14,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetGlobalParameterCommand do
   def validate(args, _) when length(args) < 2 do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 2 do
     {:validation_failure, :too_many_args}
   end
+
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_log_level_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_log_level_command.ex
@@ -26,6 +26,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetLogLevelCommand do
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end
@@ -36,7 +37,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetLogLevelCommand do
         :ok
 
       false ->
-        {:error, "level #{level} is not supported. Try one of debug, info, warning, error, critical, none"}
+        {:error,
+         "level #{level} is not supported. Try one of debug, info, warning, error, critical, none"}
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
@@ -54,10 +54,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
   def usage_additional() do
     [
       ["<name>", "policy name (identifier)"],
-      ["<pattern>", "a regular expression pattern that will be used to match queue, exchanges, etc"],
+      [
+        "<pattern>",
+        "a regular expression pattern that will be used to match queue, exchanges, etc"
+      ],
       ["<definition>", "policy definition (arguments). Must be a valid JSON document"],
       ["--priority <priority>", "policy priority"],
-      ["--apply-to <queues | exchanges | all>", "policy should only apply to queues, exchanges, or all entities (both of the above)"]
+      [
+        "--apply-to <queues | exchanges | all>",
+        "policy should only apply to queues, exchanges, or all entities (both of the above)"
+      ]
     ]
   end
 
@@ -69,11 +75,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
 
   def help_section(), do: :policies
 
-  def description(), do: "Sets an operator policy that overrides a subset of arguments in user policies"
+  def description(),
+    do: "Sets an operator policy that overrides a subset of arguments in user policies"
 
   def banner([name, pattern, definition], %{vhost: vhost, priority: priority}) do
-    "Setting operator policy override \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{
-      priority
-    }\" for vhost \"#{vhost}\" ..."
+    "Setting operator policy override \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{priority}\" for vhost \"#{vhost}\" ..."
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
@@ -61,8 +61,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
   def description(), do: "Sets a runtime parameter."
 
   def banner([component_name, name, value], %{vhost: vhost}) do
-    "Setting runtime parameter \"#{name}\" for component \"#{component_name}\" to \"#{value}\" in vhost \"#{
-      vhost
-    }\" ..."
+    "Setting runtime parameter \"#{name}\" for component \"#{component_name}\" to \"#{value}\" in vhost \"#{vhost}\" ..."
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
@@ -39,17 +39,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
   end
 
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "Virtual host #{vhost} does not exist"}}
+    {:error,
+     %{
+       "result" => "error",
+       "node" => node_name,
+       "message" => "Virtual host #{vhost} does not exist"
+     }}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User #{username} does not exist"}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, _) do
     {:error, "Virtual host #{vhost} does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "set_permissions [--vhost <vhost>] <username> <conf> <write> <read>"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
@@ -18,12 +18,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) < 3 do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 3 do
     {:validation_failure, :too_many_args}
   end
+
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
@@ -51,10 +54,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
   def usage_additional() do
     [
       ["<name>", "policy name (identifier)"],
-      ["<pattern>", "regular expression pattern that will be used to match queues, exchanges, etc"],
+      [
+        "<pattern>",
+        "regular expression pattern that will be used to match queues, exchanges, etc"
+      ],
       ["<definition>", "policy definition (arguments). Must be a valid JSON document"],
       ["--priority <priority>", "policy priority"],
-      ["--apply-to <queues | exchanges | all>", "policy should only apply to queues, exchanges, or all entities (both of the above)"]
+      [
+        "--apply-to <queues | exchanges | all>",
+        "policy should only apply to queues, exchanges, or all entities (both of the above)"
+      ]
     ]
   end
 
@@ -69,8 +78,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
   def description(), do: "Sets or updates a policy"
 
   def banner([name, pattern, definition], %{vhost: vhost, priority: priority}) do
-    "Setting policy \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{
-      priority
-    }\" for vhost \"#{vhost}\" ..."
+    "Setting policy \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{priority}\" for vhost \"#{vhost}\" ..."
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
@@ -16,9 +16,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
   def validate(args, _) when length(args) < 4 do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 4 do
     {:validation_failure, :too_many_args}
   end
+
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
@@ -33,17 +35,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
   end
 
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exist"}}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "Virtual host #{vhost} does not exist"}}
+    {:error,
+     %{
+       "result" => "error",
+       "node" => node_name,
+       "message" => "Virtual host #{vhost} does not exist"
+     }}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User #{username} does not exist"}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, _) do
     {:error, "Virtual host #{vhost} does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
@@ -14,6 +14,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
@@ -28,11 +29,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
   end
 
   def output({:error, {:no_such_user, username}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exists"}}
+    {:error,
+     %{"result" => "error", "node" => node_name, "message" => "User #{username} does not exists"}}
   end
+
   def output({:error, {:no_such_user, username}}, _) do
     {:error, ExitCodes.exit_nouser(), "User \"#{username}\" does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "set_user_tags <username> <tag> [...]"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_vhost_tags_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_vhost_tags_command.ex
@@ -14,25 +14,37 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostTagsCommand do
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([vhost | tags], %{node: node_name}) do
     case :rabbit_misc.rpc_call(
-      node_name, :rabbit_vhost, :update_tags, [vhost, tags, Helpers.cli_acting_user()]) do
-      {:error, _}  = err -> err
+           node_name,
+           :rabbit_vhost,
+           :update_tags,
+           [vhost, tags, Helpers.cli_acting_user()]
+         ) do
+      {:error, _} = err -> err
       {:badrpc, _} = err -> err
-      _                  -> :ok
+      _ -> :ok
     end
   end
 
   def output({:error, {:no_such_vhost, vhost}}, %{node: node_name, formatter: "json"}) do
-    {:error, %{"result" => "error", "node" => node_name, "message" => "Virtual host \"#{vhost}\" does not exists"}}
+    {:error,
+     %{
+       "result" => "error",
+       "node" => node_name,
+       "message" => "Virtual host \"#{vhost}\" does not exists"
+     }}
   end
+
   def output({:error, {:no_such_vhost, vhost}}, _) do
     {:error, ExitCodes.exit_dataerr(), "Virtual host \"#{vhost}\" does not exist"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "set_vhost_tags <vhost> <tag> [...]"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
@@ -112,7 +112,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
   def usage_doc_guides() do
     [
       DocGuide.alarms(),
-      DocGuide.memory_use(),
+      DocGuide.memory_use()
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
@@ -19,7 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StartAppCommand do
 
   def help_section(), do: :node_management
 
-  def description(), do: "Starts the RabbitMQ application but leaves the runtime (Erlang VM) running"
+  def description(),
+    do: "Starts the RabbitMQ application but leaves the runtime (Erlang VM) running"
 
   def banner(_, %{node: node_name}), do: "Starting node #{node_name} ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -55,12 +55,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
 
   def usage_additional() do
     [
-      ["<pidfile>", "node PID file path to monitor. To avoid using a PID file, use 'rabbitmqctl shutdown'"],
+      [
+        "<pidfile>",
+        "node PID file path to monitor. To avoid using a PID file, use 'rabbitmqctl shutdown'"
+      ],
       ["--idempotent", "return success if target node is not running (cannot be contacted)"]
     ]
   end
 
-  def description(), do: "Stops RabbitMQ and its runtime (Erlang VM). Requires a local node pid file path to monitor progress."
+  def description(),
+    do:
+      "Stops RabbitMQ and its runtime (Erlang VM). Requires a local node pid file path to monitor progress."
 
   def help_section(), do: :node_management
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/suspend_listeners_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/suspend_listeners_command.ex
@@ -22,7 +22,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SuspendListenersCommand do
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name, timeout: timeout}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_maintenance, :suspend_all_client_listeners, [], timeout)
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_maintenance,
+      :suspend_all_client_listeners,
+      [],
+      timeout
+    )
   end
 
   use RabbitMQ.CLI.DefaultOutput
@@ -37,10 +43,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SuspendListenersCommand do
 
   def help_section(), do: :operations
 
-  def description(), do: "Suspends client connection listeners so that no new client connections are accepted"
+  def description(),
+    do: "Suspends client connection listeners so that no new client connections are accepted"
 
   def banner(_, %{node: node_name}) do
-    "Will suspend client connection listeners on node #{node_name}. "
-    <> "The node will no longer accept client connections!"
+    "Will suspend client connection listeners on node #{node_name}. " <>
+      "The node will no longer accept client connections!"
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
@@ -46,7 +46,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SyncQueueCommand do
 
   def help_section(), do: :replication
 
-  def description(), do: "Instructs a mirrored queue with unsynchronised mirrors (follower replicas) to synchronise them"
+  def description(),
+    do:
+      "Instructs a mirrored queue with unsynchronised mirrors (follower replicas) to synchronise them"
 
   def banner([queue], %{vhost: vhost, node: _node}) do
     "Synchronising queue '#{queue}' in vhost '#{vhost}' ..."

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -13,9 +13,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
   use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
-  def run([seed_node], options=%{node: node_name}) do
+  def run([seed_node], options = %{node: node_name}) do
     long_or_short_names = Config.get_option(:longnames, options)
     seed_node_normalised = Helpers.normalise_node(seed_node, long_or_short_names)
+
     :rabbit_misc.rpc_call(
       node_name,
       :rabbit_mnesia,
@@ -42,7 +43,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
 
   def help_section(), do: :cluster_management
 
-  def description(), do: "Instructs a cluster member node to sync the list of known cluster members from <seed_node>"
+  def description(),
+    do:
+      "Instructs a cluster member node to sync the list of known cluster members from <seed_node>"
 
   def banner([seed_node], %{node: node_name}) do
     "Will seed #{node_name} from #{seed_node} on next start"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/version_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/version_command.ex
@@ -21,13 +21,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.VersionCommand do
   def run([], %{formatter: "json"}) do
     {:ok, %{version: Version.local_version()}}
   end
+
   def run([], %{formatter: "csv"}) do
     row = [version: Version.local_version()]
     {:ok, [row]}
   end
+
   def run([], _opts) do
     {:ok, Version.local_version()}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def help_section, do: :help

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -35,6 +35,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   def validate_execution_environment([], %{pid: _} = opts) do
     Validators.rabbit_is_loaded([], opts)
   end
+
   def validate_execution_environment([_pid_file], opts) do
     Validators.rabbit_is_loaded([], opts)
   end
@@ -102,7 +103,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
 
   def help_section(), do: :node_management
 
-  def description(), do: "Waits for RabbitMQ node startup by monitoring a local PID file. See also 'rabbitmqctl await_online_nodes'"
+  def description(),
+    do:
+      "Waits for RabbitMQ node startup by monitoring a local PID file. See also 'rabbitmqctl await_online_nodes'"
 
   #
   # Implementation
@@ -253,7 +256,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
               {pid, _} ->
                 case check_distribution(pid, node_name) do
                   :ok -> {:ok, pid}
-                  _   -> {:error, :loop}
+                  _ -> {:error, :loop}
                 end
             end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/default_output.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/default_output.ex
@@ -28,10 +28,13 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output(:ok, %{node: node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "node" => node_name}}
   end
+
   defp normalize_output(:ok, _opts), do: :ok
+
   defp normalize_output({:ok, value}, %{node: node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "node" => node_name, "value" => value}}
   end
+
   defp normalize_output({:ok, _} = input, _opts), do: input
   defp normalize_output({:stream, _} = input, _opts), do: input
   defp normalize_output({:badrpc_multi, _, _} = input, _opts), do: {:error, input}
@@ -40,25 +43,30 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output({:badrpc, {:timeout, _n}} = input, _opts), do: {:error, input}
   defp normalize_output({:badrpc, {:timeout, _n, _msg}} = input, _opts), do: {:error, input}
   defp normalize_output({:badrpc, {:EXIT, reason}}, _opts), do: {:error, reason}
+
   defp normalize_output({:error, exit_code, string}, _opts) when is_integer(exit_code) do
     {:error, exit_code, to_string(string)}
   end
+
   defp normalize_output({:error, format, args}, _opts)
        when (is_list(format) or is_binary(format)) and is_list(args) do
     {:error, to_string(:rabbit_misc.format(format, args))}
   end
+
   defp normalize_output({:error, _} = input, _opts), do: input
+
   defp normalize_output({:error_string, string}, _opts) do
     {:error, to_string(string)}
   end
+
   defp normalize_output(unknown, _opts) when is_atom(unknown), do: {:error, unknown}
   defp normalize_output({unknown, _} = input, _opts) when is_atom(unknown), do: {:error, input}
   defp normalize_output(result, _opts) when not is_atom(result), do: {:ok, result}
 
-  
   defp format_output({:error, _} = result) do
     result
   end
+
   defp format_output({:error, _, _} = result) do
     result
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/alarms_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/alarms_command.ex
@@ -67,7 +67,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.AlarmsCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists resource alarms (local or cluster-wide) in effect on the target node"
+  def description(),
+    do: "Lists resource alarms (local or cluster-wide) in effect on the target node"
 
   def usage, do: "alarms"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/certificates_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/certificates_command.ex
@@ -49,7 +49,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CertificatesCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Displays certificates (public keys) for every listener on target node that is configured to use TLS"
+  def description(),
+    do:
+      "Displays certificates (public keys) for every listener on target node that is configured to use TLS"
 
   def banner(_, %{node: node_name}), do: "Certificates of node #{node_name} ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_alarms_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_alarms_command.ex
@@ -76,7 +76,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckAlarmsCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Health check that exits with a non-zero code if the target node reports any alarms, local or cluster-wide."
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if the target node reports any alarms, local or cluster-wide."
 
   def usage, do: "check_alarms"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_certificate_expiration_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_certificate_expiration_command.ex
@@ -20,15 +20,18 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckCertificateExpirationCommand do
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}
   end
+
   def validate(_, %{unit: unit}) do
     case TU.known_unit?(unit) do
       true ->
         :ok
 
       false ->
-        {:validation_failure, "unit '#{unit}' is not supported. Please use one of: days, weeks, months, years"}
+        {:validation_failure,
+         "unit '#{unit}' is not supported. Please use one of: days, weeks, months, years"}
     end
   end
+
   def validate(_, _), do: :ok
 
   def run([], %{node: node_name, unit: unit, within: within, timeout: timeout}) do
@@ -45,10 +48,12 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckCertificateExpirationCommand do
       xs when is_list(xs) ->
         listeners = listeners_on(xs, node_name)
         seconds = TU.convert(within, unit)
-        Enum.reduce(listeners, [], fn (listener, acc) -> case listener_expiring_within(listener, seconds) do
-                                                           false -> acc
-                                                           expiring -> [expiring | acc]
-                                                         end
+
+        Enum.reduce(listeners, [], fn listener, acc ->
+          case listener_expiring_within(listener, seconds) do
+            false -> acc
+            expiring -> [expiring | acc]
+          end
         end)
     end
   end
@@ -63,7 +68,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckCertificateExpirationCommand do
   end
 
   def output(listeners, %{formatter: "json"}) do
-    {:error, :check_failed, %{"result" => "error", "expired" => Enum.map(listeners, &expired_listener_map/1)}}
+    {:error, :check_failed,
+     %{"result" => "error", "expired" => Enum.map(listeners, &expired_listener_map/1)}}
   end
 
   def output(listeners, %{}) do
@@ -73,6 +79,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckCertificateExpirationCommand do
   def unit_label(1, unit) do
     unit |> String.slice(0..-2)
   end
+
   def unit_label(_within, unit) do
     unit
   end
@@ -82,7 +89,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckCertificateExpirationCommand do
   def usage_additional() do
     [
       ["<period>", "period of time to check. Default is four (weeks)."],
-      ["<unit>", "time unit for the period, can be days, weeks, months, years. Default is weeks."],
+      ["<unit>", "time unit for the period, can be days, weeks, months, years. Default is weeks."]
     ]
   end
 
@@ -95,7 +102,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckCertificateExpirationCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Checks the expiration date on the certificates for every listener configured to use TLS"
+  def description(),
+    do: "Checks the expiration date on the certificates for every listener configured to use TLS"
 
-  def banner(_, %{node: node_name}), do: "Checking certificate expiration on node #{node_name} ..."
+  def banner(_, %{node: node_name}),
+    do: "Checking certificate expiration on node #{node_name} ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_local_alarms_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_local_alarms_command.ex
@@ -75,7 +75,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckLocalAlarmsCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Health check that exits with a non-zero code if the target node reports any local alarms"
+  def description(),
+    do: "Health check that exits with a non-zero code if the target node reports any local alarms"
 
   def usage, do: "check_local_alarms"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
@@ -15,6 +15,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
 
   import RabbitMQ.CLI.Diagnostics.Helpers,
     only: [check_listener_connectivity: 3]
+
   import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
   import RabbitMQ.CLI.Core.Listeners
 
@@ -87,7 +88,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
     {:error, Enum.join(lines, line_separator())}
   end
 
-  def description(), do: "Basic TCP connectivity health check for each listener's port on the target node"
+  def description(),
+    do: "Basic TCP connectivity health check for each listener's port on the target node"
 
   def help_section(), do: :observability_and_health_checks
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_listener_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_listener_command.ex
@@ -65,14 +65,16 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortListenerCommand do
   def output({false, port, listeners}, %{node: node_name}) do
     ports = Enum.map(listeners, fn %{port: p} -> p end) |> Enum.sort() |> Enum.join(", ")
 
-    {:error,  :check_failed,
+    {:error, :check_failed,
      "No listener for port #{port} is active on node #{node_name}. " <>
        "Found listeners that use the following ports: #{ports}"}
   end
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Health check that exits with a non-zero code if target node does not have an active listener for given port"
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if target node does not have an active listener for given port"
 
   def usage, do: "check_port_listener <port>"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_protocol_listener_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_protocol_listener_command.ex
@@ -80,7 +80,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckProtocolListenerCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Health check that exits with a non-zero code if target node does not have an active listener for given protocol"
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if target node does not have an active listener for given protocol"
 
   def usage, do: "check_protocol_listener <protocol>"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_running_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_running_command.ex
@@ -36,7 +36,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckRunningCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Health check that exits with a non-zero code if the RabbitMQ app on the target node is not running"
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if the RabbitMQ app on the target node is not running"
 
   def usage, do: "check_running"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -13,15 +13,14 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
     {args, Map.merge(%{all: false, format: "openssl"}, Helpers.case_insensitive_format(opts))}
   end
 
-  def switches(), do: [timeout: :integer,
-                       format: :string,
-                       all: :boolean]
+  def switches(), do: [timeout: :integer, format: :string, all: :boolean]
   def aliases(), do: [t: :timeout]
 
   def validate(_, %{format: format})
       when format != "openssl" and format != "erlang" and format != "map" do
     {:validation_failure, {:bad_argument, "Format should be either openssl, erlang or map"}}
   end
+
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}
   end
@@ -29,27 +28,33 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
   def validate(_, _), do: :ok
 
   def run([], %{node: node_name, timeout: timeout, format: format} = opts) do
-    {mod, function} = case format do
-      "openssl" -> {:rabbit_ssl, :cipher_suites_openssl};
-      "erlang"  -> {:rabbit_ssl, :cipher_suites_erlang};
-      "map"     -> {:rabbit_ssl, :cipher_suites}
-    end
-    args = case opts do
-      %{all: true} -> [:all];
-      %{}          -> [:default]
-    end
+    {mod, function} =
+      case format do
+        "openssl" -> {:rabbit_ssl, :cipher_suites_openssl}
+        "erlang" -> {:rabbit_ssl, :cipher_suites_erlang}
+        "map" -> {:rabbit_ssl, :cipher_suites}
+      end
+
+    args =
+      case opts do
+        %{all: true} -> [:all]
+        %{} -> [:default]
+      end
+
     :rabbit_misc.rpc_call(node_name, mod, function, args, timeout)
   end
 
   use RabbitMQ.CLI.DefaultOutput
 
-  def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in OpenSSL format"
+  def banner([], %{format: "openssl"}), do: "Listing available cipher suites in OpenSSL format"
   def banner([], %{format: "erlang"}), do: "Listing available cipher suites in Erlang term format"
   def banner([], %{format: "map"}), do: "Listing available cipher suites in map format"
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists cipher suites enabled by default. To list all available cipher suites, add the --all argument."
+  def description(),
+    do:
+      "Lists cipher suites enabled by default. To list all available cipher suites, add the --all argument."
 
   def usage, do: "cipher_suites [--format <openssl | erlang | map>] [--all]"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/command_line_arguments_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/command_line_arguments_command.ex
@@ -15,11 +15,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CommandLineArgumentsCommand do
   def validate(_, %{formatter: "json"}) do
     {:validation_failure, :unsupported_formatter}
   end
+
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :init, :get_arguments, [])
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
@@ -35,7 +37,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CommandLineArgumentsCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Displays target node's command-line arguments and flags as reported by the runtime"
+  def description(),
+    do: "Displays target node's command-line arguments and flags as reported by the runtime"
 
   def banner(_, %{node: node_name}), do: "Command line arguments of node #{node_name} ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/disable_auth_attempt_source_tracking_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/disable_auth_attempt_source_tracking_command.ex
@@ -13,9 +13,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.DisableAuthAttemptSourceTrackingComm
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :application, :set_env,
-      [:rabbit, :track_auth_attempt_source, :false])
+    :rabbit_misc.rpc_call(node_name, :application, :set_env, [
+      :rabbit,
+      :track_auth_attempt_source,
+      false
+    ])
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "disable_track_auth_attempt_source"
@@ -29,7 +33,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.DisableAuthAttemptSourceTrackingComm
 
   def help_section(), do: :configuration
 
-  def description(), do: "Disables the tracking of peer IP address and username of authentication attempts"
+  def description(),
+    do: "Disables the tracking of peer IP address and username of authentication attempts"
 
   def banner([], _), do: "Disabling authentication attempt source tracking ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/enable_auth_attempt_source_tracking_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/enable_auth_attempt_source_tracking_command.ex
@@ -13,8 +13,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.EnableAuthAttemptSourceTrackingComma
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :application, :set_env,
-      [:rabbit, :track_auth_attempt_source, :true])
+    :rabbit_misc.rpc_call(node_name, :application, :set_env, [
+      :rabbit,
+      :track_auth_attempt_source,
+      true
+    ])
   end
 
   use RabbitMQ.CLI.DefaultOutput
@@ -30,7 +33,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.EnableAuthAttemptSourceTrackingComma
 
   def help_section(), do: :configuration
 
-  def description(), do: "Enables the tracking of peer IP address and username of authentication attempts"
+  def description(),
+    do: "Enables the tracking of peer IP address and username of authentication attempts"
 
   def banner([], _), do: "Enabling authentication attempt source tracking ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
@@ -13,19 +13,22 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieHashCommand do
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_data_coercion.to_binary(
-      :rabbit_misc.rpc_call(node_name, :rabbit_nodes_common, :cookie_hash, [], timeout))
+      :rabbit_misc.rpc_call(node_name, :rabbit_nodes_common, :cookie_hash, [], timeout)
+    )
   end
 
   def output(result, %{formatter: "json"}) do
     {:ok, %{"result" => "ok", "value" => result}}
   end
+
   def output(result, _options) when is_bitstring(result) do
     {:ok, result}
   end
 
   def help_section(), do: :configuration
 
-  def description(), do: "Displays a hash of the Erlang cookie (shared secret) used by the target node"
+  def description(),
+    do: "Displays a hash of the Erlang cookie (shared secret) used by the target node"
 
   def usage, do: "erlang_cookie_hash"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
@@ -19,22 +19,30 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
     switch_cookie = opts[:erlang_cookie]
     home_dir = get_home_dir()
     cookie_file_path = Path.join(home_dir, ".erlang.cookie")
-    cookie_file_stat = case File.stat(Path.join(home_dir, ".erlang.cookie")) do
-      {:error, :enoent} -> nil
-      {:ok, value}     -> value
-    end
-    cookie_file_type = case cookie_file_stat do
-      nil   -> nil
-      value -> value.type
-    end
-    cookie_file_access = case cookie_file_stat do
-      nil   -> nil
-      value -> value.access
-    end
-    cookie_file_size = case cookie_file_stat do
-      nil   -> nil
-      value -> value.size
-    end
+
+    cookie_file_stat =
+      case File.stat(Path.join(home_dir, ".erlang.cookie")) do
+        {:error, :enoent} -> nil
+        {:ok, value} -> value
+      end
+
+    cookie_file_type =
+      case cookie_file_stat do
+        nil -> nil
+        value -> value.type
+      end
+
+    cookie_file_access =
+      case cookie_file_stat do
+        nil -> nil
+        value -> value.access
+      end
+
+    cookie_file_size =
+      case cookie_file_stat do
+        nil -> nil
+        value -> value.size
+      end
 
     %{
       os_env_cookie_set: System.get_env("RABBITMQ_ERLANG_COOKIE") != nil,
@@ -66,7 +74,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
       "Cookie file exists? #{result[:cookie_file_exists]}",
       "Cookie file type: #{result[:cookie_file_type] || "(n/a)"}",
       "Cookie file access: #{result[:cookie_file_access] || "(n/a)"}",
-      "Cookie file size: #{result[:cookie_file_size] || "(n/a)"}",
+      "Cookie file size: #{result[:cookie_file_size] || "(n/a)"}"
     ]
 
     switch_lines = [
@@ -106,11 +114,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
   """
   def get_home_dir() do
     homedrive = System.get_env("HOMEDRIVE")
-    homepath  = System.get_env("HOMEPATH")
+    homepath = System.get_env("HOMEPATH")
 
     case {homedrive != nil, homepath != nil} do
       {true, true} -> "#{homedrive}#{homepath}"
-      _            -> System.get_env("HOME")
+      _ -> System.get_env("HOME")
     end
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
@@ -10,6 +10,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   def switches() do
     [details: :boolean, offline: :boolean, timeout: :integer]
   end
+
   def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
@@ -21,29 +22,31 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   def run([], %{details: details, offline: true}) do
     case details do
       true ->
-        :rabbit_data_coercion.to_binary(
-          :rabbit_misc.otp_system_version())
+        :rabbit_data_coercion.to_binary(:rabbit_misc.otp_system_version())
 
       false ->
-        :rabbit_data_coercion.to_binary(
-          :rabbit_misc.platform_and_version())
+        :rabbit_data_coercion.to_binary(:rabbit_misc.platform_and_version())
     end
   end
+
   def run([], %{node: node_name, timeout: timeout, details: details}) do
     case details do
       true ->
         :rabbit_data_coercion.to_binary(
-          :rabbit_misc.rpc_call(node_name, :rabbit_misc, :otp_system_version, [], timeout))
+          :rabbit_misc.rpc_call(node_name, :rabbit_misc, :otp_system_version, [], timeout)
+        )
 
       false ->
-      :rabbit_data_coercion.to_binary(
-        :rabbit_misc.rpc_call(node_name, :rabbit_misc, :platform_and_version, [], timeout))
+        :rabbit_data_coercion.to_binary(
+          :rabbit_misc.rpc_call(node_name, :rabbit_misc, :platform_and_version, [], timeout)
+        )
     end
   end
 
   def output(result, %{formatter: "json"}) do
     {:ok, %{"result" => "ok", "value" => result}}
   end
+
   def output(result, _opts) when is_bitstring(result) do
     {:ok, result}
   end
@@ -66,6 +69,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   def banner([], %{offline: true}) do
     "CLI Erlang/OTP version ..."
   end
+
   def banner([], %{node: node_name}) do
     "Asking node #{node_name} for its Erlang/OTP version..."
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/is_booting_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/is_booting_command.ex
@@ -20,16 +20,20 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.IsBootingCommand do
       "result" => true,
       "message" => "RabbitMQ on node #{node_name} is booting"
     }
+
     {:ok, m}
   end
 
   def output(false, %{node: node_name, formatter: "json"}) do
     m = %{
       "result" => false,
-      "message" => "RabbitMQ on node #{node_name} is fully booted (check with is_running), stopped or has not started booting yet"
+      "message" =>
+        "RabbitMQ on node #{node_name} is fully booted (check with is_running), stopped or has not started booting yet"
     }
+
     {:ok, m}
   end
+
   def output(true, %{node: node_name}) do
     {:ok, "RabbitMQ on node #{node_name} is booting"}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/is_running_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/is_running_command.ex
@@ -18,19 +18,28 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.IsRunningCommand do
   end
 
   def output(true, %{node: node_name, formatter: "json"}) do
-    {:ok, %{"result" => true, "message" => "RabbitMQ on node #{node_name} is fully booted and running"}}
+    {:ok,
+     %{"result" => true, "message" => "RabbitMQ on node #{node_name} is fully booted and running"}}
   end
+
   def output(false, %{node: node_name, formatter: "json"}) do
     {:ok,
-     %{"result" => false, "message" => "RabbitMQ on node #{node_name} is not running or has not fully booted yet (check with is_booting)"}}
+     %{
+       "result" => false,
+       "message" =>
+         "RabbitMQ on node #{node_name} is not running or has not fully booted yet (check with is_booting)"
+     }}
   end
+
   def output(true, %{node: node_name}) do
     {:ok, "RabbitMQ on node #{node_name} is fully booted and running"}
   end
+
   def output(false, %{node: node_name}) do
     {:ok,
      "RabbitMQ on node #{node_name} is not running or has not fully booted yet (check with is_booting)"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def help_section(), do: :observability_and_health_checks

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/list_node_auth_attempt_stats_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/list_node_auth_attempt_stats_command.ex
@@ -26,30 +26,45 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ListNodeAuthAttemptStatsCommand do
 
   def run([], %{node: node_name, timeout: timeout, by_source: by_source}) do
     case by_source do
-      :true ->
+      true ->
         :rabbit_misc.rpc_call(
-          node_name, :rabbit_core_metrics, :get_auth_attempts_by_source, [], timeout)
-      :false ->
+          node_name,
+          :rabbit_core_metrics,
+          :get_auth_attempts_by_source,
+          [],
+          timeout
+        )
+
+      false ->
         :rabbit_misc.rpc_call(
-          node_name, :rabbit_core_metrics, :get_auth_attempts, [], timeout)
+          node_name,
+          :rabbit_core_metrics,
+          :get_auth_attempts,
+          [],
+          timeout
+        )
     end
   end
 
   def output([], %{node: node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "node" => node_name, "attempts" => []}}
   end
-  def output([], %{node: node_name})  do
+
+  def output([], %{node: node_name}) do
     {:ok, "Node #{node_name} reported no authentication attempt stats"}
   end
+
   def output(rows, %{node: node_name, formatter: "json"}) do
     maps = Enum.map(rows, &Map.new/1)
+
     {:ok,
      %{
-       "result"   => "ok",
-       "node"     => node_name,
+       "result" => "ok",
+       "node" => node_name,
        "attempts" => maps
      }}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "list_node_auth_attempts [--by-source]"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
@@ -23,25 +23,29 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand do
 
   def run([], %{node: node_name, timeout: timeout, all: all}) do
     case all do
-      true  -> LogFiles.get_log_locations(node_name, timeout);
+      true -> LogFiles.get_log_locations(node_name, timeout)
       false -> LogFiles.get_default_log_location(node_name, timeout)
     end
   end
 
   def output({:ok, location}, %{node: node_name, formatter: "json"}) do
-    {:ok, %{
-      "result" => "ok",
-      "node_name" => node_name,
-      "paths"  => [location]
-    }}
+    {:ok,
+     %{
+       "result" => "ok",
+       "node_name" => node_name,
+       "paths" => [location]
+     }}
   end
+
   def output(locations, %{node: node_name, formatter: "json"}) do
-    {:ok, %{
-      "result" => "ok",
-      "node_name" => node_name,
-      "paths"  => locations
-    }}
+    {:ok,
+     %{
+       "result" => "ok",
+       "node_name" => node_name,
+       "paths" => locations
+     }}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def help_section(), do: :configuration

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/log_tail_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/log_tail_command.ex
@@ -13,20 +13,21 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand do
   alias RabbitMQ.CLI.Core.LogFiles
 
   def switches, do: [number: :integer, timeout: :integer]
-  def aliases, do: ['N': :number, t: :timeout]
+  def aliases, do: [N: :number, t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{number: 50}, opts)}
   end
+
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name, timeout: timeout, number: n}) do
     case LogFiles.get_default_log_location(node_name, timeout) do
       {:ok, file} ->
-        :rabbit_misc.rpc_call(node_name,
-                              :rabbit_log_tail, :tail_n_lines, [file, n],
-                              timeout)
-      error -> error
+        :rabbit_misc.rpc_call(node_name, :rabbit_log_tail, :tail_n_lines, [file, n], timeout)
+
+      error ->
+        error
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
@@ -19,7 +19,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Detects Erlang processes (\"lightweight threads\") potentially not making progress on the target node"
+  def description(),
+    do:
+      "Detects Erlang processes (\"lightweight threads\") potentially not making progress on the target node"
 
   def usage, do: "maybe_stuck"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -68,7 +68,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
   def usage_additional() do
     [
       ["--unit <bytes | mb | gb>", "byte multiple (bytes, megabytes, gigabytes) to use"],
-      ["--formatter <json | csv | erlang>", "alternative formatter to use, JSON, CSV or Erlang terms"]
+      [
+        "--formatter <json | csv | erlang>",
+        "alternative formatter to use, JSON, CSV or Erlang terms"
+      ]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -15,16 +15,15 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
     {args, Map.merge(%{interval: 5}, opts)}
   end
 
-
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name, interval: interval}) do
     case :observer_cli.start(node_name, [{:interval, interval * 1000}]) do
       # See zhongwencool/observer_cli#54
-      {:badrpc, _} = err   -> err
-      {:error, _} = err    -> err
+      {:badrpc, _} = err -> err
+      {:error, _} = err -> err
       {:error, _, _} = err -> err
-      :ok   -> {:ok, "Disconnected from #{node_name}."}
+      :ok -> {:ok, "Disconnected from #{node_name}."}
       :quit -> {:ok, "Disconnected from #{node_name}."}
       other -> other
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/os_env_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/os_env_command.ex
@@ -22,34 +22,47 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.OsEnvCommand do
 
   def run([], %{node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_env, :get_used_env_vars, [], timeout) do
-      {:error, _} = err -> err
-      {:error, _, _} = err -> err
+      {:error, _} = err ->
+        err
+
+      {:error, _, _} = err ->
+        err
+
       xs when is_list(xs) ->
         # convert keys and values to binaries (Elixir strings)
         xs
-        |> Enum.map(fn {k, v} -> {:rabbit_data_coercion.to_binary(k), :rabbit_data_coercion.to_binary(v)} end)
-        |> :maps.from_list
-      other -> other
+        |> Enum.map(fn {k, v} ->
+          {:rabbit_data_coercion.to_binary(k), :rabbit_data_coercion.to_binary(v)}
+        end)
+        |> :maps.from_list()
+
+      other ->
+        other
     end
   end
 
   def output([], %{formatter: fmt}) when fmt == "csv" or fmt == "erlang" do
     {:ok, []}
   end
+
   def output([], %{node: node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "node" => node_name, "variables" => []}}
   end
+
   def output([], %{node: node_name}) do
     {:ok, "Node #{node_name} reported no relevant environment variables."}
   end
+
   def output(vars, %{node: node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "node" => node_name, "variables" => vars}}
   end
+
   def output(vars, %{formatter: "csv"}) do
-    {:stream, [Enum.map(vars, fn({k, v}) -> [variable: k, value: v] end)]}
+    {:stream, [Enum.map(vars, fn {k, v} -> [variable: k, value: v] end)]}
   end
+
   def output(vars, _opts) do
-    lines = Enum.map(vars, fn({k, v}) -> "#{k}=#{v}" end) |> Enum.join(line_separator())
+    lines = Enum.map(vars, fn {k, v} -> "#{k}=#{v}" end) |> Enum.join(line_separator())
     {:ok, lines}
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
@@ -15,9 +15,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.RemoteShellCommand do
     Process.flag(:trap_exit, true)
     user_drv = :user_drv.start(['tty_sl -c -e', {node_name, :shell, :start, []}])
     Process.link(user_drv)
+
     receive do
-        {'EXIT', _user_drv, _} ->
-            {:ok, "Disconnected from #{node_name}."}
+      {'EXIT', _user_drv, _} ->
+        {:ok, "Disconnected from #{node_name}."}
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/resolver_info_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/resolver_info_command.ex
@@ -30,6 +30,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolverInfoCommand do
   def run([], %{offline: true}) do
     Networking.inetrc_map(:inet.get_rc())
   end
+
   def run([], %{node: node_name, timeout: timeout, offline: false}) do
     case :rabbit_misc.rpc_call(node_name, :inet, :get_rc, [], timeout) do
       {:error, _} = err -> err
@@ -40,12 +41,14 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolverInfoCommand do
   end
 
   def output(info, %{node: node_name, formatter: "json"}) do
-    {:ok, %{
-      "result"   => "ok",
-      "node"     => node_name,
-      "resolver" => info
-    }}
+    {:ok,
+     %{
+       "result" => "ok",
+       "node" => node_name,
+       "resolver" => info
+     }}
   end
+
   def output(info, _opts) do
     main_section = [
       "#{bright("Runtime Hostname Resolver (inetrc) Settings")}\n",
@@ -54,13 +57,16 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolverInfoCommand do
       "Resolver conf file: #{info["resolv_conf"]}",
       "Cache size: #{info["cache_size"]}"
     ]
-    hosts_section = [
-      "\n#{bright("inetrc File Host Entries")}\n"
-    ] ++ case info["hosts"] do
-      []  -> ["(none)"]
-      nil -> ["(none)"]
-      hs  -> Enum.reduce(hs, [], fn {k, v}, acc -> ["#{k} #{Enum.join(v, ", ")}" | acc] end)
-    end
+
+    hosts_section =
+      [
+        "\n#{bright("inetrc File Host Entries")}\n"
+      ] ++
+        case info["hosts"] do
+          [] -> ["(none)"]
+          nil -> ["(none)"]
+          hs -> Enum.reduce(hs, [], fn {k, v}, acc -> ["#{k} #{Enum.join(v, ", ")}" | acc] end)
+        end
 
     lines = main_section ++ hosts_section
 
@@ -73,11 +79,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolverInfoCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Displays effective hostname resolver (inetrc) configuration on target node"
+  def description(),
+    do: "Displays effective hostname resolver (inetrc) configuration on target node"
 
   def banner(_, %{node: node_name, offline: false}) do
     "Asking node #{node_name} for its effective hostname resolver (inetrc) configuration..."
   end
+
   def banner(_, %{offline: true}) do
     "Displaying effective hostname resolver (inetrc) configuration used by CLI tools..."
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats_command.ex
@@ -46,7 +46,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.RuntimeThreadStatsCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Provides a breakdown of runtime thread activity stats on the target node"
+  def description(),
+    do: "Provides a breakdown of runtime thread activity stats on the target node"
 
   def usage, do: "runtime_thread_stats [--sample-interval <interval>]"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
@@ -13,12 +13,14 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ServerVersionCommand do
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_data_coercion.to_binary(
-      :rabbit_misc.rpc_call(node_name, :rabbit_misc, :version, [], timeout))
+      :rabbit_misc.rpc_call(node_name, :rabbit_misc, :version, [], timeout)
+    )
   end
 
   def output(result, %{formatter: "json"}) do
     {:ok, %{"result" => "ok", "value" => result}}
   end
+
   def output(result, _options) when is_bitstring(result) do
     {:ok, result}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/tls_versions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/tls_versions_command.ex
@@ -31,7 +31,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.TlsVersionsCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists TLS versions supported (but not necessarily allowed) on the target node"
+  def description(),
+    do: "Lists TLS versions supported (but not necessarily allowed) on the target node"
 
   def usage, do: "tls_versions"
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -6,15 +6,16 @@
 
 defmodule RabbitMQ.CLI.Diagnostics.Helpers do
   def test_connection(hostname, port, timeout) do
-      case :gen_tcp.connect(hostname, port, [], timeout) do
-          {:error, _} -> :gen_tcp.connect(hostname, port, [:inet6], timeout)
-          r -> r
-      end
+    case :gen_tcp.connect(hostname, port, [], timeout) do
+      {:error, _} -> :gen_tcp.connect(hostname, port, [:inet6], timeout)
+      r -> r
+    end
   end
 
   def check_port_connectivity(port, node_name, timeout) do
     regex = Regex.recompile!(~r/^(.+)@/)
     hostname = Regex.replace(regex, to_string(node_name), "") |> to_charlist
+
     try do
       case test_connection(hostname, port, timeout) do
         {:error, _} ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatter_behaviour.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatter_behaviour.ex
@@ -28,14 +28,16 @@ defmodule RabbitMQ.CLI.FormatterBehaviour do
   def module_name(nil) do
     nil
   end
+
   def module_name(formatter) do
-    mod = formatter |> String.downcase |> Macro.camelize
+    mod = formatter |> String.downcase() |> Macro.camelize()
     Module.safe_concat("RabbitMQ.CLI.Formatters", mod)
   end
 
   def machine_readable?(nil) do
     false
   end
+
   def machine_readable?(formatter) do
     Helpers.apply_if_exported(module_name(formatter), :machine_readable?, [], false)
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/formatter_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/formatter_helpers.ex
@@ -33,7 +33,6 @@ defmodule RabbitMQ.CLI.Formatters.FormatterHelpers do
   def proplist?([]), do: true
   def proplist?(_other), do: false
 
-
   defmacro is_u8(x) do
     quote do
       unquote(x) >= 0 and unquote(x) <= 255

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
@@ -16,6 +16,7 @@ defmodule RabbitMQ.CLI.Formatters.Json do
   def format_output(output, opts) when is_bitstring(output) do
     format_output(%{"message" => output}, opts)
   end
+
   def format_output(output, _opts) do
     {:ok, json} = JSON.encode(keys_to_atoms(output))
     json
@@ -29,7 +30,7 @@ defmodule RabbitMQ.CLI.Formatters.Json do
         fn
           [first | _] = element ->
             case FormatterHelpers.proplist?(first) or is_map(first) do
-              true  -> element
+              true -> element
               false -> [element]
             end
 
@@ -54,11 +55,16 @@ defmodule RabbitMQ.CLI.Formatters.Json do
   end
 
   def keys_to_atoms(enum) do
-    Enum.map(enum,
-             fn({k, v}) when is_binary(k) or is_list(k) ->
-                 {String.to_atom(k), v}
-               (other) -> other
-             end)
+    Enum.map(
+      enum,
+      fn
+        {k, v} when is_binary(k) or is_list(k) ->
+          {String.to_atom(k), v}
+
+        other ->
+          other
+      end
+    )
   end
 
   def format_element(val, separator, options) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json_stream.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json_stream.ex
@@ -29,6 +29,7 @@ defmodule RabbitMQ.CLI.Formatters.JsonStream do
     # we just emit the empty string as the last value for the stream in this case
     ""
   end
+
   def format_output(output, _opts) do
     {:ok, json} = JSON.encode(keys_to_atoms(output))
     json
@@ -41,7 +42,7 @@ defmodule RabbitMQ.CLI.Formatters.JsonStream do
         fn
           [first | _] = element ->
             case FormatterHelpers.proplist?(first) or is_map(first) do
-              true  -> element
+              true -> element
               false -> [element]
             end
 
@@ -60,11 +61,16 @@ defmodule RabbitMQ.CLI.Formatters.JsonStream do
   end
 
   def keys_to_atoms(enum) do
-    Enum.map(enum,
-             fn({k, v}) when is_binary(k) or is_list(k) ->
-                 {String.to_atom(k), v}
-               (other) -> other
-             end)
+    Enum.map(
+      enum,
+      fn
+        {k, v} when is_binary(k) or is_list(k) ->
+          {String.to_atom(k), v}
+
+        other ->
+          other
+      end
+    )
   end
 
   def format_element(val, options) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -162,9 +162,11 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
   defp legend(_, :minimal, _) do
     []
   end
+
   defp legend(_, _, %{quiet: true}) do
     []
   end
+
   defp legend(_, _, %{silent: true}) do
     []
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
@@ -12,76 +12,120 @@ defmodule RabbitMQ.CLI.Formatters.PrettyTable do
   require Record
   import Record
 
-  defrecord :table , extract(:table,
-    from_lib: "stdout_formatter/include/stdout_formatter.hrl")
-  defrecord :cell, extract(:cell,
-    from_lib: "stdout_formatter/include/stdout_formatter.hrl")
-  defrecord :paragraph, extract(:paragraph,
-    from_lib: "stdout_formatter/include/stdout_formatter.hrl")
+  defrecord :table,
+            extract(:table,
+              from_lib: "stdout_formatter/include/stdout_formatter.hrl"
+            )
+
+  defrecord :cell,
+            extract(:cell,
+              from_lib: "stdout_formatter/include/stdout_formatter.hrl"
+            )
+
+  defrecord :paragraph,
+            extract(:paragraph,
+              from_lib: "stdout_formatter/include/stdout_formatter.hrl"
+            )
 
   def format_stream(stream, _opts) do
     # Flatten for list_consumers
-    entries_with_keys = Stream.flat_map(stream,
-      fn([first | _] = element) ->
-        case FormatterHelpers.proplist?(first) or is_map(first) do
-          true  -> element;
-          false -> [element]
+    entries_with_keys =
+      Stream.flat_map(
+        stream,
+        fn
+          [first | _] = element ->
+            case FormatterHelpers.proplist?(first) or is_map(first) do
+              true -> element
+              false -> [element]
+            end
+
+          other ->
+            [other]
         end
-        (other) ->
-          [other]
-      end)
+      )
       |> Enum.to_list()
 
     # Use stdout_formatter library to format the table.
     case entries_with_keys do
       [first_entry | _] ->
-        col_headers = Stream.map(first_entry,
-          fn({key, _}) ->
-            cell(content: key, props: %{:title => true})
-          end)
+        col_headers =
+          Stream.map(
+            first_entry,
+            fn {key, _} ->
+              cell(content: key, props: %{:title => true})
+            end
+          )
           |> Enum.to_list()
-        rows = Stream.map(entries_with_keys,
-          fn(element) ->
-            Stream.map(element,
-              fn({_, value}) ->
-                cell(content: value, props: %{})
-              end)
+
+        rows =
+          Stream.map(
+            entries_with_keys,
+            fn element ->
+              Stream.map(
+                element,
+                fn {_, value} ->
+                  cell(content: value, props: %{})
+                end
+              )
               |> Enum.to_list()
-          end)
+            end
+          )
           |> Enum.to_list()
-        ret = :stdout_formatter.to_string(
-          table(
-            rows: [col_headers | rows],
-            props: %{:cell_padding => {0, 1}}))
-        [to_string ret]
+
+        ret =
+          :stdout_formatter.to_string(
+            table(
+              rows: [col_headers | rows],
+              props: %{:cell_padding => {0, 1}}
+            )
+          )
+
+        [to_string(ret)]
+
       [] ->
         entries_with_keys
     end
   end
 
   def format_output(output, _opts) do
-    format = case is_binary(output) do
-      true  -> "~s"
-      false -> "~p"
-    end
-    ret = :stdout_formatter.to_string(
-      table(
-        rows: [
-          [cell(content: "Output", props: %{:title => true})],
-          [cell(
-            content: paragraph(content: output,
-            props: %{:format => format}))]],
-        props: %{:cell_padding => {0, 1}}))
-    to_string ret
+    format =
+      case is_binary(output) do
+        true -> "~s"
+        false -> "~p"
+      end
+
+    ret =
+      :stdout_formatter.to_string(
+        table(
+          rows: [
+            [cell(content: "Output", props: %{:title => true})],
+            [
+              cell(
+                content:
+                  paragraph(
+                    content: output,
+                    props: %{:format => format}
+                  )
+              )
+            ]
+          ],
+          props: %{:cell_padding => {0, 1}}
+        )
+      )
+
+    to_string(ret)
   end
 
   def format_value(value) do
     case is_binary(value) do
-      true  -> value
-      false -> case is_atom(value) do
-        true  -> to_string(value)
-        false -> inspect(value)
-      end
+      true ->
+        value
+
+      false ->
+        case is_atom(value) do
+          true -> to_string(value)
+          false -> inspect(value)
+        end
     end
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -109,8 +109,14 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
   def usage_additional() do
     [
       ["<plugin1> [ <plugin2>]", "names of plugins to disable separated by a space"],
-      ["--online", "contact target node to disable the plugins. Changes are applied immediately."],
-      ["--offline", "update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted."],
+      [
+        "--online",
+        "contact target node to disable the plugins. Changes are applied immediately."
+      ],
+      [
+        "--offline",
+        "update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted."
+      ],
       ["--all", "disable all currently enabled plugins"]
     ]
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -79,8 +79,14 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
     [
       ["<plugin1> [ <plugin2>]", "names of plugins to enable separated by a space"],
       ["--online", "contact target node to enable the plugins. Changes are applied immediately."],
-      ["--offline", "update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted."],
-      ["--all", "enable all available plugins. Not recommended as some plugins may conflict or otherwise be incompatible!"]
+      [
+        "--offline",
+        "update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted."
+      ],
+      [
+        "--all",
+        "enable all available plugins. Not recommended as some plugins may conflict or otherwise be incompatible!"
+      ]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
@@ -99,7 +99,10 @@ defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
   def usage_additional() do
     [
       ["<plugin1> [ <plugin2>]", "names of plugins to check separated by a space"],
-      ["--online", "contact target node to perform the check. Requires the node to be running and reachable."],
+      [
+        "--online",
+        "contact target node to perform the check. Requires the node to be running and reachable."
+      ],
       ["--offline", "check enabled plugins file directly without contacting target node."]
     ]
   end
@@ -120,7 +123,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Health check that exits with a non-zero code if provided plugins are not enabled on target node"
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if provided plugins are not enabled on target node"
 
   #
   # Implementation

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -114,7 +114,10 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
     [
       ["<pattern>", "only list plugins that match a regular expression pattern"],
       ["--verbose", "output more information"],
-      ["--minimal", "only print plugin names. Most useful in compbination with --silent and --enabled."],
+      [
+        "--minimal",
+        "only print plugin names. Most useful in compbination with --silent and --enabled."
+      ],
       ["--enabled", "only list enabled plugins"],
       ["--implicitly-enabled", "include plugins enabled as dependencies of other plugins"]
     ]

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -66,9 +66,15 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
 
   def usage_additional() do
     [
-      ["<plugin1> [ <plugin2>]", "names of plugins to enable separated by a space. All other plugins will be disabled."],
+      [
+        "<plugin1> [ <plugin2>]",
+        "names of plugins to enable separated by a space. All other plugins will be disabled."
+      ],
       ["--online", "contact target node to enable the plugins. Changes are applied immediately."],
-      ["--offline", "update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted."]
+      [
+        "--offline",
+        "update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted."
+      ]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/error_output.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/error_output.ex
@@ -12,9 +12,7 @@ defmodule RabbitMQ.CLI.Plugins.ErrorOutput do
     quote do
       def output({:error, {:enabled_plugins_mismatch, cli_path, node_path}}, opts) do
         {:error, ExitCodes.exit_dataerr(),
-         "Could not update enabled plugins file at #{cli_path}: target node #{opts[:node]} uses a different path (#{
-           node_path
-         })"}
+         "Could not update enabled plugins file at #{cli_path}: target node #{opts[:node]} uses a different path (#{node_path})"}
       end
 
       def output({:error, {:cannot_read_enabled_plugins_file, path, :eacces}}, _opts) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/printer_behaviour.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/printer_behaviour.ex
@@ -14,8 +14,9 @@ defmodule RabbitMQ.CLI.PrinterBehaviour do
   def module_name(nil) do
     nil
   end
+
   def module_name(printer) do
-    mod = printer |> String.downcase |> Macro.camelize
+    mod = printer |> String.downcase() |> Macro.camelize()
     String.to_atom("RabbitMQ.CLI.Printers." <> mod)
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
@@ -19,6 +19,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommand do
         :infinity -> @default_timeout
         other -> other
       end
+
     {args, Map.merge(%{vhost: "/", timeout: timeout}, opts)}
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/check_if_node_is_mirror_sync_critical_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/check_if_node_is_mirror_sync_critical_command.ex
@@ -25,66 +25,88 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsMirrorSyncCriticalCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
-    case :rabbit_misc.rpc_call(node_name,
-           :rabbit_nodes, :is_single_node_cluster, [], timeout) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :is_single_node_cluster, [], timeout) do
       # if target node is the only one in the cluster, the check makes little sense
       # and false positives can be misleading
-      true  -> {:ok, :single_node_cluster}
+      true ->
+        {:ok, :single_node_cluster}
+
       false ->
-        case :rabbit_misc.rpc_call(node_name,
-                                    :rabbit_amqqueue, :list_local_mirrored_classic_without_synchronised_mirrors_for_cli, [], timeout) do
+        case :rabbit_misc.rpc_call(
+               node_name,
+               :rabbit_amqqueue,
+               :list_local_mirrored_classic_without_synchronised_mirrors_for_cli,
+               [],
+               timeout
+             ) do
           [] -> {:ok, []}
           qs when is_list(qs) -> {:ok, qs}
           other -> other
         end
-      other -> other
+
+      other ->
+        other
     end
   end
 
   def output({:ok, :single_node_cluster}, %{formatter: "json"}) do
-    {:ok, %{
-      "result"  => "ok",
-      "message" => "Target node seems to be the only one in a single node cluster, the check does not apply"
-    }}
+    {:ok,
+     %{
+       "result" => "ok",
+       "message" =>
+         "Target node seems to be the only one in a single node cluster, the check does not apply"
+     }}
   end
+
   def output({:ok, []}, %{formatter: "json"}) do
     {:ok, %{"result" => "ok"}}
   end
+
   def output({:ok, :single_node_cluster}, %{silent: true}) do
     {:ok, :check_passed}
   end
+
   def output({:ok, []}, %{silent: true}) do
     {:ok, :check_passed}
   end
+
   def output({:ok, :single_node_cluster}, %{node: node_name}) do
-    {:ok, "Node #{node_name} seems to be the only one in a single node cluster, the check does not apply"}
+    {:ok,
+     "Node #{node_name} seems to be the only one in a single node cluster, the check does not apply"}
   end
+
   def output({:ok, []}, %{node: node_name}) do
-    {:ok, "Node #{node_name} reported no classic mirrored queues without online synchronised mirrors"}
+    {:ok,
+     "Node #{node_name} reported no classic mirrored queues without online synchronised mirrors"}
   end
+
   def output({:ok, qs}, %{node: node_name, formatter: "json"}) when is_list(qs) do
     {:error, :check_failed,
      %{
        "result" => "error",
        "queues" => qs,
-       "message" => "Node #{node_name} reported local classic mirrored queues without online synchronised mirrors"
+       "message" =>
+         "Node #{node_name} reported local classic mirrored queues without online synchronised mirrors"
      }}
   end
+
   def output({:ok, qs}, %{silent: true}) when is_list(qs) do
     {:error, :check_failed}
   end
+
   def output({:ok, qs}, %{node: node_name}) when is_list(qs) do
     lines = queue_lines(qs, node_name)
 
     {:error, :check_failed, Enum.join(lines, line_separator())}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def help_section(), do: :observability_and_health_checks
 
   def description() do
     "Health check that exits with a non-zero code if there are classic mirrored queues " <>
-    "without online synchronised mirrors (queues that would potentially lose data if the target node is shut down)"
+      "without online synchronised mirrors (queues that would potentially lose data if the target node is shut down)"
   end
 
   def usage, do: "check_if_node_is_mirror_sync_critical"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/grow_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/grow_command.ex
@@ -10,16 +10,14 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  defp default_opts, do: %{vhost_pattern: ".*",
-                           queue_pattern: ".*",
-                           errors_only: false}
+  defp default_opts, do: %{vhost_pattern: ".*", queue_pattern: ".*", errors_only: false}
 
   def switches(),
     do: [
-    vhost_pattern: :string,
-    queue_pattern: :string,
-    errors_only: :boolean
-  ]
+      vhost_pattern: :string,
+      queue_pattern: :string,
+      errors_only: :boolean
+    ]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(default_opts(), opts)}
@@ -32,40 +30,57 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
   def validate(args, _) when length(args) > 2 do
     {:validation_failure, :too_many_args}
   end
+
   def validate([_, s], _) do
-   case s do
-     "all" -> :ok
-     "even" -> :ok
-     _ ->
-       {:validation_failure, "strategy '#{s}' is not recognised."}
-   end
+    case s do
+      "all" ->
+        :ok
+
+      "even" ->
+        :ok
+
+      _ ->
+        {:validation_failure, "strategy '#{s}' is not recognised."}
+    end
   end
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([node, strategy], %{node: node_name,
-                              vhost_pattern: vhost_pat,
-                              queue_pattern: queue_pat,
-                              errors_only: errors_only}) do
-        case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :grow, [
-          to_atom(node),
-          vhost_pat,
-          queue_pat,
-          to_atom(strategy)]) do
-      {:error, _}  = error -> error;
-      {:badrpc, _} = error -> error;
+  def run([node, strategy], %{
+        node: node_name,
+        vhost_pattern: vhost_pat,
+        queue_pattern: queue_pat,
+        errors_only: errors_only
+      }) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :grow, [
+           to_atom(node),
+           vhost_pat,
+           queue_pat,
+           to_atom(strategy)
+         ]) do
+      {:error, _} = error ->
+        error
+
+      {:badrpc, _} = error ->
+        error
+
       results when errors_only ->
         for {{:resource, vhost, _kind, name}, {:errors, _, _} = res} <- results,
-        do: [{:vhost, vhost},
-             {:name, name},
-             {:size, format_size res},
-             {:result, format_result res}]
+            do: [
+              {:vhost, vhost},
+              {:name, name},
+              {:size, format_size(res)},
+              {:result, format_result(res)}
+            ]
+
       results ->
         for {{:resource, vhost, _kind, name}, res} <- results,
-        do: [{:vhost, vhost},
-             {:name, name},
-             {:size, format_size res},
-             {:result, format_result res}]
+            do: [
+              {:vhost, vhost},
+              {:name, name},
+              {:size, format_size(res)},
+              {:result, format_result(res)}
+            ]
     end
   end
 
@@ -73,12 +88,16 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
-  def usage, do: "grow <node> <all | even> [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
+  def usage,
+    do: "grow <node> <all | even> [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
 
   def usage_additional do
     [
       ["<node>", "node name to place replicas on"],
-      ["<all | even>", "add a member for all matching queues or just those whose membership count is an even number"],
+      [
+        "<all | even>",
+        "add a member for all matching queues or just those whose membership count is an even number"
+      ],
       ["--queue-pattern <pattern>", "regular expression to match queue names"],
       ["--vhost-pattern <pattern>", "regular expression to match virtual host names"],
       ["--errors-only", "only list queues which reported an error"]
@@ -93,7 +112,9 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
 
   def help_section, do: :cluster_management
 
-  def description, do: "Grows quorum queue clusters by adding a member (replica) on the specified node for all matching queues"
+  def description,
+    do:
+      "Grows quorum queue clusters by adding a member (replica) on the specified node for all matching queues"
 
   def banner([node, strategy], _) do
     "Growing #{strategy} quorum queues on #{node}..."
@@ -106,10 +127,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
   defp format_size({:ok, size}) do
     size
   end
+
   defp format_size({:error, _size, :timeout}) do
     # the actual size is uncertain here
     "?"
   end
+
   defp format_size({:error, size, _}) do
     size
   end
@@ -117,10 +140,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
   defp format_result({:ok, _size}) do
     "ok"
   end
+
   defp format_result({:error, _size, :timeout}) do
     "error: the operation timed out and may not have been completed"
   end
+
   defp format_result({:error, _size, err}) do
-    :io.format "error: ~W", [err, 10]
+    :io.format("error: ~W", [err, 10])
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/peek_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/peek_command.ex
@@ -17,32 +17,40 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommand do
   def validate(args, _) when length(args) < 2 do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 2 do
     {:validation_failure, :too_many_args}
   end
+
   def validate([_, raw_pos], _) do
-    pos = case Integer.parse(raw_pos) do
-      {n, _} -> n
-      :error -> :error
-      _      -> :error
-    end
+    pos =
+      case Integer.parse(raw_pos) do
+        {n, _} -> n
+        :error -> :error
+        _ -> :error
+      end
 
     invalid_pos = {:validation_failure, "position value must be a positive integer"}
+
     case pos do
-      :error            -> invalid_pos
-      num when num < 1  -> invalid_pos
+      :error -> invalid_pos
+      num when num < 1 -> invalid_pos
       num when num >= 1 -> :ok
     end
   end
+
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([name, pos] = _args, %{node: node_name, vhost: vhost}) do
     {pos, _} = Integer.parse(pos)
+
     case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :peek, [vhost, name, pos]) do
       {:error, :classic_queue_not_supported} ->
         {:error, "Cannot peek into a classic queue"}
+
       {:ok, msg} ->
         {:ok, msg}
+
       err ->
         err
     end
@@ -55,6 +63,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommand do
        "message" => "Target queue was not found in virtual host '#{vhost}'"
      }}
   end
+
   def output({:error, :no_message_at_pos}, %{formatter: "json"}) do
     {:error,
      %{
@@ -62,6 +71,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommand do
        "message" => "Target queue does not have a message at that position"
      }}
   end
+
   def output({:error, error}, %{formatter: "json"}) do
     {:error,
      %{
@@ -69,19 +79,24 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommand do
        "message" => "Failed to perform the operation: #{error}"
      }}
   end
+
   def output({:error, :not_found}, %{vhost: vhost}) do
     {:error, "Target queue was not found in virtual host '#{vhost}'"}
   end
+
   def output({:error, :no_message_at_pos}, _) do
     {:error, "Target queue does not have a message at that position"}
   end
+
   def output({:ok, msg}, %{formatter: "json"}) do
     {:ok, %{"result" => "ok", "message" => Enum.into(msg, %{})}}
   end
+
   def output({:ok, msg}, _) do
-    res = Enum.map(msg, fn {k,v} -> [{"keys", k}, {"values", v}] end)
+    res = Enum.map(msg, fn {k, v} -> [{"keys", k}, {"values", v}] end)
     {:stream, res}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.PrettyTable
@@ -92,8 +107,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommand do
 
   def usage_additional do
     [
-      ["<queue>", "Name of the queue",
-       "<position>", "Position in the queue, starts at 1"]
+      ["<queue>", "Name of the queue", "<position>", "Position in the queue, starts at 1"]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/rebalance_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/rebalance_command.ex
@@ -16,14 +16,13 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
     "quorum"
   ]
 
-  defp default_opts, do: %{vhost_pattern: ".*",
-                           queue_pattern: ".*"}
+  defp default_opts, do: %{vhost_pattern: ".*", queue_pattern: ".*"}
 
   def switches(),
     do: [
-    vhost_pattern: :string,
-    queue_pattern: :string
-  ]
+      vhost_pattern: :string,
+      queue_pattern: :string
+    ]
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
@@ -34,6 +33,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end
@@ -48,16 +48,16 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
     end
   end
 
-  def run([type], %{node: node_name,
-                vhost_pattern: vhost_pat,
-                queue_pattern: queue_pat}) do
+  def run([type], %{node: node_name, vhost_pattern: vhost_pat, queue_pattern: queue_pat}) do
     arg = String.to_atom(type)
     :rabbit_misc.rpc_call(node_name, :rabbit_amqqueue, :rebalance, [arg, vhost_pat, queue_pat])
   end
 
   def formatter(), do: RabbitMQ.CLI.Formatters.PrettyTable
 
-  def usage, do: "rebalance < all | classic | quorum > [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
+  def usage,
+    do:
+      "rebalance < all | classic | quorum > [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
 
   def usage_additional do
     [
@@ -75,17 +75,21 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
 
   def help_section, do: :cluster_management
 
-  def description, do: "Re-balances leaders of replicated queues across up-and-running cluster nodes"
+  def description,
+    do: "Re-balances leaders of replicated queues across up-and-running cluster nodes"
 
   def banner([:all], _) do
     "Re-balancing leaders of all replicated queues..."
   end
+
   def banner([:classic], _) do
     "Re-balancing leaders of replicated (mirrored, non-exclusive) classic queues..."
   end
+
   def banner([:quorum], _) do
     "Re-balancing leaders of quorum queues..."
   end
+
   def banner([type], _) do
     "Re-balancing leaders of #{type} queues..."
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/reclaim_quorum_memory_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/reclaim_quorum_memory_command.ex
@@ -31,6 +31,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.ReclaimQuorumMemoryCommand do
        "message" => "Target queue was not found in virtual host '#{vhost}'"
      }}
   end
+
   def output({:error, error}, %{formatter: "json"}) do
     {:error,
      %{
@@ -38,9 +39,11 @@ defmodule RabbitMQ.CLI.Queues.Commands.ReclaimQuorumMemoryCommand do
        "message" => "Failed to perform the operation: #{error}"
      }}
   end
+
   def output({:error, :not_found}, %{vhost: vhost}) do
     {:error, "Target queue was not found in virtual host '#{vhost}'"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage() do
@@ -62,7 +65,9 @@ defmodule RabbitMQ.CLI.Queues.Commands.ReclaimQuorumMemoryCommand do
 
   def help_section(), do: :operations
 
-  def description(), do: "Flushes quorum queue processes WAL, performs a full sweep GC on all of its local Erlang processes"
+  def description(),
+    do:
+      "Flushes quorum queue processes WAL, performs a full sweep GC on all of its local Erlang processes"
 
   def banner([name], %{}),
     do: "Will flush Raft WAL of quorum queue #{name} ..."

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/shrink_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/shrink_command.ex
@@ -23,20 +23,29 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommand do
 
   def run([node], %{node: node_name, errors_only: errs}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :shrink_all, [to_atom(node)]) do
-      {:error, _}  = error -> error;
-      {:badrpc, _} = error -> error;
+      {:error, _} = error ->
+        error
+
+      {:badrpc, _} = error ->
+        error
+
       results when errs ->
         for {{:resource, vhost, _kind, name}, {:error, _, _} = res} <- results,
-        do: [{:vhost, vhost},
-             {:name, name},
-             {:size, format_size(res)},
-             {:result, format_result(res)}]
+            do: [
+              {:vhost, vhost},
+              {:name, name},
+              {:size, format_size(res)},
+              {:result, format_result(res)}
+            ]
+
       results ->
         for {{:resource, vhost, _kind, name}, res} <- results,
-        do: [{:vhost, vhost},
-             {:name, name},
-             {:size, format_size(res)},
-             {:result, format_result(res)}]
+            do: [
+              {:vhost, vhost},
+              {:name, name},
+              {:size, format_size(res)},
+              {:result, format_result(res)}
+            ]
     end
   end
 
@@ -65,7 +74,8 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommand do
 
   def help_section, do: :cluster_management
 
-  def description, do: "Shrinks quorum queue clusters by removing any members (replicas) on the given node."
+  def description,
+    do: "Shrinks quorum queue clusters by removing any members (replicas) on the given node."
 
   #
   # Implementation
@@ -74,10 +84,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommand do
   defp format_size({:ok, size}) do
     size
   end
+
   defp format_size({:error, _size, :timeout}) do
     # the actual size is uncertain here
     "?"
   end
+
   defp format_size({:error, size, _}) do
     size
   end
@@ -85,13 +97,16 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommand do
   defp format_result({:ok, _size}) do
     "ok"
   end
+
   defp format_result({:error, _size, :last_node}) do
     "error: the last node cannot be removed"
   end
+
   defp format_result({:error, _size, :timeout}) do
     "error: the operation timed out and may not have been completed"
   end
+
   defp format_result({:error, _size, err}) do
-    :io.format "error: ~W", [err, 10]
+    :io.format("error: ~W", [err, 10])
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/delete_replica_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/delete_replica_command.ex
@@ -31,6 +31,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.DeleteReplicaCommand do
 
       {:error, :last_stream_member} ->
         {:error, "Cannot delete the last member of a stream"}
+
       other ->
         other
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/set_stream_retention_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/set_stream_retention_policy_command.ex
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Streams.Commands.SetStreamRetentionPolicyCommand do
   alias RabbitMQ.CLI.Core.DocGuide
 
@@ -17,9 +16,9 @@ defmodule RabbitMQ.CLI.Streams.Commands.SetStreamRetentionPolicyCommand do
 
   def run([name, retention_policy], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :set_retention_policy, [
-          name,
-          vhost,
-          retention_policy
+      name,
+      vhost,
+      retention_policy
     ])
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/stream_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/stream_status_command.ex
@@ -17,7 +17,7 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
   use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([name] = _args, %{node: node_name, vhost: vhost, tracking: :false}) do
+  def run([name] = _args, %{node: node_name, vhost: vhost, tracking: false}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :status, [vhost, name]) do
       {:error, :classic_queue_not_supported} ->
         {:error, "Cannot get stream status of a classic queue"}
@@ -29,7 +29,8 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommand do
         other
     end
   end
-  def run([name] = _args, %{node: node_name, vhost: vhost, tracking: :true}) do
+
+  def run([name] = _args, %{node: node_name, vhost: vhost, tracking: true}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :tracking_status, [vhost, name]) do
       {:error, :classic_queue_not_supported} ->
         {:error, "Cannot get stream status of a classic queue"}

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/time_unit.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/time_unit.ex
@@ -44,5 +44,4 @@ defmodule RabbitMQ.CLI.TimeUnit do
   defp do_convert(time, "years") do
     time * @years_seconds
   end
-
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/await_online_synchronized_mirror_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/await_online_synchronized_mirror_command.ex
@@ -26,41 +26,69 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineSynchronizedMirrorCommand do
     {args, Map.put(opts, :timeout, timeout)}
   end
 
-
   def run([], %{node: node_name, timeout: timeout}) do
     rpc_timeout = timeout + 500
+
     case :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :is_single_node_cluster, [], rpc_timeout) do
       # if target node is the only one in the cluster, the command makes little sense
       # and false positives can be misleading
-      true  -> {:ok, :single_node_cluster}
-      false ->
-        case :rabbit_misc.rpc_call(node_name, :rabbit_upgrade_preparation, :await_online_synchronised_mirrors, [timeout], rpc_timeout) do
-          {:error, _} = err -> err
-          {:error, _, _} = err -> err
-          {:badrpc, _} = err -> err
+      true ->
+        {:ok, :single_node_cluster}
 
-          true  -> :ok
-          false -> {:error, "time is up, no synchronised mirror came online for at least some classic mirrored queues"}
+      false ->
+        case :rabbit_misc.rpc_call(
+               node_name,
+               :rabbit_upgrade_preparation,
+               :await_online_synchronised_mirrors,
+               [timeout],
+               rpc_timeout
+             ) do
+          {:error, _} = err ->
+            err
+
+          {:error, _, _} = err ->
+            err
+
+          {:badrpc, _} = err ->
+            err
+
+          true ->
+            :ok
+
+          false ->
+            {:error,
+             "time is up, no synchronised mirror came online for at least some classic mirrored queues"}
         end
-      other -> other
+
+      other ->
+        other
     end
   end
 
   def output({:ok, :single_node_cluster}, %{formatter: "json"}) do
-    {:ok, %{
-      "result"  => "ok",
-      "message" => "Target node seems to be the only one in a single node cluster, the check does not apply"
-    }}
+    {:ok,
+     %{
+       "result" => "ok",
+       "message" =>
+         "Target node seems to be the only one in a single node cluster, the check does not apply"
+     }}
   end
+
   def output({:error, msg}, %{node: node_name, formatter: "json"}) do
     {:error, %{"result" => "error", "node" => node_name, "message" => msg}}
   end
+
   def output({:ok, :single_node_cluster}, opts) do
     case output_less?(opts) do
-      true  -> :ok;
-      false -> {:ok, "Target node seems to be the only one in a single node cluster, the command does not apply"}
+      true ->
+        :ok
+
+      false ->
+        {:ok,
+         "Target node seems to be the only one in a single node cluster, the command does not apply"}
     end
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "await_online_synchronized_mirror"
@@ -76,10 +104,10 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineSynchronizedMirrorCommand do
 
   def description() do
     "Waits for all classic mirrored queues hosted on the target node to have at least one synchronized mirror online. " <>
-    "This makes sure that if target node is shut down, there will be an up-to-date mirror to promote."
+      "This makes sure that if target node is shut down, there will be an up-to-date mirror to promote."
   end
 
   def banner([], %{timeout: timeout}) do
-    "Will wait for a synchronised mirror be online for all classic mirrored queues for #{round(timeout/1000)} seconds..."
+    "Will wait for a synchronised mirror be online for all classic mirrored queues for #{round(timeout / 1000)} seconds..."
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/drain_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/drain_command.ex
@@ -25,14 +25,16 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.DrainCommand do
     case :rabbit_misc.rpc_call(node_name, :rabbit_maintenance, :drain, [], timeout) do
       # Server does not support maintenance mode
       {:badrpc, {:EXIT, {:undef, _}}} -> {:error, :unsupported}
-      {:badrpc, _} = err    -> err
-      other                 -> other
+      {:badrpc, _} = err -> err
+      other -> other
     end
   end
 
   def output({:error, :unsupported}, %{node: node_name}) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage, "Maintenance mode is not supported by node #{node_name}"}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(),
+     "Maintenance mode is not supported by node #{node_name}"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "drain"
@@ -45,10 +47,12 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.DrainCommand do
 
   def help_section(), do: :upgrade
 
-  def description(), do: "Puts the node in maintenance mode. Such nodes will not serve any client traffic or host any primary queue replicas"
+  def description(),
+    do:
+      "Puts the node in maintenance mode. Such nodes will not serve any client traffic or host any primary queue replicas"
 
   def banner(_, %{node: node_name}) do
-    "Will put node #{node_name} into maintenance mode. "
-    <> "The node will no longer serve any client traffic!"
+    "Will put node #{node_name} into maintenance mode. " <>
+      "The node will no longer serve any client traffic!"
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/post_upgrade_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/post_upgrade_command.ex
@@ -33,7 +33,6 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.PostUpgradeCommand do
 
   def banner([], _) do
     "Executing post upgrade tasks...\n" <>
-    "Rebalancing queue masters..."
+      "Rebalancing queue masters..."
   end
-
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/revive_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/revive_command.ex
@@ -27,14 +27,16 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.ReviveCommand do
     case :rabbit_misc.rpc_call(node_name, :rabbit_maintenance, :revive, [], timeout) do
       # Server does not support maintenance mode
       {:badrpc, {:EXIT, {:undef, _}}} -> {:error, :unsupported}
-      {:badrpc, _} = err    -> err
-      other                 -> other
+      {:badrpc, _} = err -> err
+      other -> other
     end
   end
 
   def output({:error, :unsupported}, %{node: node_name}) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage, "Maintenance mode is not supported by node #{node_name}"}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(),
+     "Maintenance mode is not supported by node #{node_name}"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "revive"
@@ -47,10 +49,12 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.ReviveCommand do
 
   def help_section(), do: :upgrade
 
-  def description(), do: "Puts the node out of maintenance and into regular operating mode. Such nodes will again serve client traffic and host primary queue replicas"
+  def description(),
+    do:
+      "Puts the node out of maintenance and into regular operating mode. Such nodes will again serve client traffic and host primary queue replicas"
 
   def banner(_, %{node: node_name}) do
-    "Will put node #{node_name} back into regular operating mode. "
-    <> "The node will again serve client traffic and host primary queue replicas."
+    "Will put node #{node_name} back into regular operating mode. " <>
+      "The node will again serve client traffic and host primary queue replicas."
   end
 end

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -185,18 +185,21 @@ defmodule RabbitMQCtl.MixfileBase do
         "deps.compile"
       ],
       make_app: [
+        "format --check-formatted",
         "compile",
         "escript.build"
       ],
       make_all: [
         "deps.get",
         "deps.compile",
+        "format --check-formatted",
         "compile",
         "escript.build"
       ],
       make_all_in_src_archive: [
         "deps.get --only prod",
         "deps.compile",
+        "format --check-formatted",
         "compile",
         "escript.build"
       ]

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -12,11 +12,9 @@ defmodule RabbitMQCtl.MixfileBase do
       app: :rabbitmqctl,
       version: "3.12.0-dev",
       elixir: ">= 1.13.4 and < 1.15.0",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
-      escript: [main_module: RabbitMQCtl,
-                emu_args: "-hidden",
-                path: "escript/rabbitmqctl"],
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      escript: [main_module: RabbitMQCtl, emu_args: "-hidden", path: "escript/rabbitmqctl"],
       deps: deps(),
       aliases: aliases(),
       xref: [
@@ -47,55 +45,62 @@ defmodule RabbitMQCtl.MixfileBase do
           :stdout_formatter
         ]
       ]
-   ]
+    ]
   end
 
   # Configuration for the OTP application
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger],
-     env: [scopes: ['rabbitmq-plugins': :plugins,
-                    rabbitmqctl: :ctl,
-                    'rabbitmq-diagnostics': :diagnostics,
-                    'rabbitmq-queues': :queues,
-                    'rabbitmq-streams': :streams,
-                    'rabbitmq-upgrade': :upgrade,
-                    'rabbitmq-tanzu': :tanzu
-     ]]
+    [
+      applications: [:logger],
+      env: [
+        scopes: [
+          "rabbitmq-plugins": :plugins,
+          rabbitmqctl: :ctl,
+          "rabbitmq-diagnostics": :diagnostics,
+          "rabbitmq-queues": :queues,
+          "rabbitmq-streams": :streams,
+          "rabbitmq-upgrade": :upgrade,
+          "rabbitmq-tanzu": :tanzu
+        ]
+      ]
     ]
-    |> add_modules(Mix.env)
+    |> add_modules(Mix.env())
   end
-
 
   defp add_modules(app, :test) do
     # There are issues with building a package without this line ¯\_(ツ)_/¯
-    Mix.Project.get
-    path = Mix.Project.compile_path
+    Mix.Project.get()
+    path = Mix.Project.compile_path()
     mods = modules_from(Path.wildcard("#{path}/*.beam"))
-    test_modules = [RabbitMQ.CLI.Ctl.Commands.DuckCommand,
-                    RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand,
-                    RabbitMQ.CLI.Ctl.Commands.UglyDucklingCommand,
-                    RabbitMQ.CLI.Plugins.Commands.StorkCommand,
-                    RabbitMQ.CLI.Plugins.Commands.HeronCommand,
-                    RabbitMQ.CLI.Custom.Commands.CrowCommand,
-                    RabbitMQ.CLI.Custom.Commands.RavenCommand,
-                    RabbitMQ.CLI.Seagull.Commands.SeagullCommand,
-                    RabbitMQ.CLI.Seagull.Commands.PacificGullCommand,
-                    RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
-                    RabbitMQ.CLI.Seagull.Commands.HermannGullCommand,
-                    RabbitMQ.CLI.Wolf.Commands.CanisLupusCommand,
-                    RabbitMQ.CLI.Wolf.Commands.CanisLatransCommand,
-                    RabbitMQ.CLI.Wolf.Commands.CanisAureusCommand
-                  ]
-    [{:modules, mods ++ test_modules |> Enum.sort} | app]
+
+    test_modules = [
+      RabbitMQ.CLI.Ctl.Commands.DuckCommand,
+      RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand,
+      RabbitMQ.CLI.Ctl.Commands.UglyDucklingCommand,
+      RabbitMQ.CLI.Plugins.Commands.StorkCommand,
+      RabbitMQ.CLI.Plugins.Commands.HeronCommand,
+      RabbitMQ.CLI.Custom.Commands.CrowCommand,
+      RabbitMQ.CLI.Custom.Commands.RavenCommand,
+      RabbitMQ.CLI.Seagull.Commands.SeagullCommand,
+      RabbitMQ.CLI.Seagull.Commands.PacificGullCommand,
+      RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
+      RabbitMQ.CLI.Seagull.Commands.HermannGullCommand,
+      RabbitMQ.CLI.Wolf.Commands.CanisLupusCommand,
+      RabbitMQ.CLI.Wolf.Commands.CanisLatransCommand,
+      RabbitMQ.CLI.Wolf.Commands.CanisAureusCommand
+    ]
+
+    [{:modules, (mods ++ test_modules) |> Enum.sort()} | app]
   end
+
   defp add_modules(app, _) do
     app
   end
 
   defp modules_from(beams) do
-    Enum.map beams, &(&1 |> Path.basename |> Path.rootname(".beam") |> String.to_atom)
+    Enum.map(beams, &(&1 |> Path.basename() |> Path.rootname(".beam") |> String.to_atom()))
   end
 
   # Dependencies can be Hex packages:
@@ -123,51 +128,52 @@ defmodule RabbitMQCtl.MixfileBase do
       {:csv, "~> 2.4.0"},
       {:stdout_formatter, "~> 0.2.3"},
       {:observer_cli, "~> 1.7.3"},
-
       {:amqp, "~> 2.1.0", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:temp, "~> 0.4", only: :test},
       {:x509, "~> 0.7", only: :test}
     ]
 
-    rabbitmq_deps = case System.get_env("DEPS_DIR") do
-      nil ->
-        # rabbitmq_cli is built as a standalone Elixir application.
-        [
-          {:rabbit_common, "~> 3.8.0"},
-          {:amqp_client, "~> 3.8.0", only: :test}
-        ]
-      deps_dir ->
-        # rabbitmq_cli is built as part of RabbitMQ.
+    rabbitmq_deps =
+      case System.get_env("DEPS_DIR") do
+        nil ->
+          # rabbitmq_cli is built as a standalone Elixir application.
+          [
+            {:rabbit_common, "~> 3.8.0"},
+            {:amqp_client, "~> 3.8.0", only: :test}
+          ]
 
-        # Mix is confused by any `rebar.{config,lock}` we might have left in
-        # `rabbit_common` or `amqp_client`. So just remove those files to be
-        # safe, as they are generated when we publish to Hex.pm only.
-        for dir <- ["rabbit_common", "amqp_client"] do
-          for file <- ["rebar.config", "rebar.lock"] do
-            File.rm(Path.join([deps_dir, dir, file]))
+        deps_dir ->
+          # rabbitmq_cli is built as part of RabbitMQ.
+
+          # Mix is confused by any `rebar.{config,lock}` we might have left in
+          # `rabbit_common` or `amqp_client`. So just remove those files to be
+          # safe, as they are generated when we publish to Hex.pm only.
+          for dir <- ["rabbit_common", "amqp_client"] do
+            for file <- ["rebar.config", "rebar.lock"] do
+              File.rm(Path.join([deps_dir, dir, file]))
+            end
           end
-        end
 
-        make_cmd = System.get_env("MAKE", "make")
-        is_bazel = System.get_env("IS_BAZEL") != nil
+          make_cmd = System.get_env("MAKE", "make")
+          is_bazel = System.get_env("IS_BAZEL") != nil
 
-        [
-          {
-            :rabbit_common,
-            path: Path.join(deps_dir, "rabbit_common"),
-            compile: (if is_bazel, do: false, else: make_cmd),
-            override: true
-          },
-          {
-            :amqp_client,
-            path: Path.join(deps_dir, "amqp_client"),
-            compile: (if is_bazel, do: false, else: make_cmd),
-            override: true,
-            only: :test
-          },
-        ]
-    end
+          [
+            {
+              :rabbit_common,
+              path: Path.join(deps_dir, "rabbit_common"),
+              compile: if(is_bazel, do: false, else: make_cmd),
+              override: true
+            },
+            {
+              :amqp_client,
+              path: Path.join(deps_dir, "amqp_client"),
+              compile: if(is_bazel, do: false, else: make_cmd),
+              override: true,
+              only: :test
+            }
+          ]
+      end
 
     elixir_deps ++ rabbitmq_deps
   end
@@ -176,24 +182,24 @@ defmodule RabbitMQCtl.MixfileBase do
     [
       make_deps: [
         "deps.get",
-        "deps.compile",
+        "deps.compile"
       ],
       make_app: [
         "compile",
-        "escript.build",
+        "escript.build"
       ],
       make_all: [
         "deps.get",
         "deps.compile",
         "compile",
-        "escript.build",
+        "escript.build"
       ],
       make_all_in_src_archive: [
         "deps.get --only prod",
         "deps.compile",
         "compile",
-        "escript.build",
-      ],
+        "escript.build"
+      ]
     ]
   end
 end

--- a/deps/rabbitmq_cli/test/core/args_processing_test.exs
+++ b/deps/rabbitmq_cli/test/core/args_processing_test.exs
@@ -22,12 +22,13 @@ defmodule ArgsProcessingTest do
 
   defp all_commands() do
     RabbitMQ.CLI.Core.CommandModules.load_commands(:all, %{})
-    |> Map.values
+    |> Map.values()
   end
 
   defp line_filter([_, description]) do
     Regex.match?(~r/must be one of/, description)
   end
+
   defp line_filter(line) do
     Regex.match?(~r/must be one of/, line)
   end
@@ -44,8 +45,10 @@ defmodule ArgsProcessingTest do
 
   test "defaults are merged with positinal args", _context do
     commands = all_commands()
-    Enum.each(commands,
-      fn(command) ->
+
+    Enum.each(
+      commands,
+      fn command ->
         command.merge_defaults([], %{})
         command.merge_defaults(["arg"], %{})
         command.merge_defaults(["two", "args"], %{})
@@ -53,7 +56,8 @@ defmodule ArgsProcessingTest do
 
         command.merge_defaults([], %{unknown: "option"})
         command.merge_defaults(["arg"], %{unknown: "option"})
-      end)
+      end
+    )
   end
 
   # this test parses info keys mentioned in the usage_additional section
@@ -61,19 +65,26 @@ defmodule ArgsProcessingTest do
   # or a mix of commas and spaces
   test "comma-separated info items are supported", context do
     commands = list_commands()
-    Enum.each(commands, fn(command) ->
-      items_usage = case command.usage_additional() do
-        # find the line with info items, ignore the rest
-        list when is_list(list) ->
-          # list items can be strings or pairs
-          Enum.filter(list, &line_filter/1) |> List.first |> Enum.join(" ")
-        string ->
-          string
-      end
+
+    Enum.each(commands, fn command ->
+      items_usage =
+        case command.usage_additional() do
+          # find the line with info items, ignore the rest
+          list when is_list(list) ->
+            # list items can be strings or pairs
+            Enum.filter(list, &line_filter/1) |> List.first() |> Enum.join(" ")
+
+          string ->
+            string
+        end
+
       # info_item, info_item2, …
-      case Regex.run(~r/.*one of (.*)$/, items_usage, [capture: :all_but_first]) do
-        nil          ->
-          throw "Command #{command} does not list info items in usage_additional or the format has changed. Output: #{items_usage}"
+      case Regex.run(~r/.*one of (.*)$/, items_usage, capture: :all_but_first) do
+        nil ->
+          throw(
+            "Command #{command} does not list info items in usage_additional or the format has changed. Output: #{items_usage}"
+          )
+
         [info_items] ->
           :ok = command.validate([info_items], context[:opts])
           :ok = command.validate(String.split(info_items, " "), context[:opts])

--- a/deps/rabbitmq_cli/test/core/auto_complete_test.exs
+++ b/deps/rabbitmq_cli/test/core/auto_complete_test.exs
@@ -4,16 +4,17 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AutoCompleteTest do
   use ExUnit.Case, async: false
 
   @subject RabbitMQ.CLI.AutoComplete
 
-
   test "Auto-completes a command" do
     ["canis_aureus", "canis_latrans", "canis_lupus"] = @subject.complete("rabbitmqctl", ["canis"])
-    ["canis_aureus", "canis_latrans", "canis_lupus"] = @subject.complete("rabbitmqctl", ["canis_"])
+
+    ["canis_aureus", "canis_latrans", "canis_lupus"] =
+      @subject.complete("rabbitmqctl", ["canis_"])
+
     ["canis_latrans", "canis_lupus"] = @subject.complete("rabbitmqctl", ["canis_l"])
     ["canis_latrans"] = @subject.complete("rabbitmqctl", ["canis_la"])
     ["canis_aureus"] = @subject.complete("rabbitmqctl", ["canis_a"])
@@ -38,11 +39,13 @@ defmodule AutoCompleteTest do
     scopes = Application.get_env(:rabbitmqctl, :scopes)
     scopes_with_wolf = Keyword.put(scopes, :rabbitmq_wolf, :wolf)
     Application.put_env(:rabbitmqctl, :scopes, scopes_with_wolf)
-    on_exit(fn() ->
+
+    on_exit(fn ->
       Application.put_env(:rabbitmqctl, :scopes, scopes)
     end)
 
-    ["canis_aureus", "canis_latrans", "canis_lupus"] = @subject.complete("rabbitmq_wolf", ["canis"])
+    ["canis_aureus", "canis_latrans", "canis_lupus"] =
+      @subject.complete("rabbitmq_wolf", ["canis"])
   end
 
   test "Auto-completes scoped command with --script-name flag" do
@@ -54,10 +57,10 @@ defmodule RabbitMQ.CLI.Wolf.Commands.CanisLupusCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["canis_lupus"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
   def switches(), do: [colour: :string, dingo: :boolean, dog: :boolean]
   def scopes, do: [:ctl, :wolf]
 end
@@ -66,10 +69,10 @@ defmodule RabbitMQ.CLI.Wolf.Commands.CanisLatransCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["canis_latrans"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
   def scopes, do: [:ctl, :wolf]
 end
 
@@ -77,9 +80,9 @@ defmodule RabbitMQ.CLI.Wolf.Commands.CanisAureusCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["canis_aureus"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
   def scopes, do: [:ctl, :wolf]
 end

--- a/deps/rabbitmq_cli/test/core/command_modules_test.exs
+++ b/deps/rabbitmq_cli/test/core/command_modules_test.exs
@@ -15,17 +15,18 @@ defmodule CommandModulesTest do
       set_scope(:none)
       Application.put_env(:rabbitmqctl, :commands, nil)
     end)
+
     :ok
   end
 
   test "command modules has existing commands" do
     assert @subject.load_commands(:all, %{})["duck"] ==
-      RabbitMQ.CLI.Ctl.Commands.DuckCommand
+             RabbitMQ.CLI.Ctl.Commands.DuckCommand
   end
 
   test "command with multiple underscores shows up in map" do
     assert @subject.load_commands(:all, %{})["gray_goose"] ==
-      RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand
+             RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand
   end
 
   test "command modules does not have non-existent commands" do
@@ -98,7 +99,6 @@ defmodule CommandModulesTest do
 
     # SeagullCommand has scopes() defined as [:plugins, :custom]
     assert custom_commands["seagull"] == RabbitMQ.CLI.Seagull.Commands.SeagullCommand
-
   end
 
   ## ------------------- commands/0 tests --------------------
@@ -123,25 +123,24 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DuckCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["duck"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 defmodule RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["gray_goose"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 defmodule RabbitMQ.CLI.Ctl.Commands.UglyDucklingCommand do
 end
-
 
 # Mock command modules for Plugins
 
@@ -149,20 +148,20 @@ defmodule RabbitMQ.CLI.Plugins.Commands.StorkCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["stork"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 defmodule RabbitMQ.CLI.Plugins.Commands.HeronCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["heron"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 # Mock command modules for Custom
@@ -171,32 +170,30 @@ defmodule RabbitMQ.CLI.Custom.Commands.CrowCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["crow"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
-  def scopes(), do: [:custom, ]
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
+  def scopes(), do: [:custom]
 end
 
 defmodule RabbitMQ.CLI.Custom.Commands.RavenCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["raven"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 defmodule RabbitMQ.CLI.Seagull.Commands.SeagullCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["seagull"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
   def scopes(), do: [:plugins, :custom]
 end
-
-

--- a/deps/rabbitmq_cli/test/core/default_output_test.exs
+++ b/deps/rabbitmq_cli/test/core/default_output_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule DefaultOutputTest do
   use ExUnit.Case, async: false
 
@@ -14,15 +13,19 @@ defmodule DefaultOutputTest do
 
   test "ok with message is passed as is" do
     assert match?({:ok, :message}, ExampleCommand.output({:ok, :message}, %{}))
-    assert match?({:ok, {:complex, "message"}}, ExampleCommand.output({:ok, {:complex, "message"}}, %{}))
+
+    assert match?(
+             {:ok, {:complex, "message"}},
+             ExampleCommand.output({:ok, {:complex, "message"}}, %{})
+           )
   end
 
   test "enumerable is passed as stream" do
     assert match?({:stream, 'list'}, ExampleCommand.output({:ok, 'list'}, %{}))
     assert match?({:stream, 'list'}, ExampleCommand.output('list', %{}))
 
-    assert match?({:stream, [1,2,3]}, ExampleCommand.output({:ok, [1,2,3]}, %{}))
-    assert match?({:stream, [1,2,3]}, ExampleCommand.output([1,2,3], %{}))
+    assert match?({:stream, [1, 2, 3]}, ExampleCommand.output({:ok, [1, 2, 3]}, %{}))
+    assert match?({:stream, [1, 2, 3]}, ExampleCommand.output([1, 2, 3], %{}))
 
     stream = Stream.timer(10000)
     assert match?({:stream, ^stream}, ExampleCommand.output({:ok, stream}, %{}))
@@ -30,11 +33,9 @@ defmodule DefaultOutputTest do
   end
 
   test "badrpc is an error" do
-    {:error, {:badrpc, :nodedown}} =
-      ExampleCommand.output({:badrpc, :nodedown}, %{})
+    {:error, {:badrpc, :nodedown}} = ExampleCommand.output({:badrpc, :nodedown}, %{})
 
-    {:error, {:badrpc, :timeout}} =
-      ExampleCommand.output({:badrpc, :timeout}, %{})
+    {:error, {:badrpc, :timeout}} = ExampleCommand.output({:badrpc, :timeout}, %{})
   end
 
   test "unknown atom is error" do
@@ -50,8 +51,10 @@ defmodule DefaultOutputTest do
   end
 
   test "error_string is converted to string" do
-    assert match?({:error, "I am charlist"},
-                  ExampleCommand.output({:error_string, 'I am charlist'}, %{}))
+    assert match?(
+             {:error, "I am charlist"},
+             ExampleCommand.output({:error_string, 'I am charlist'}, %{})
+           )
   end
 
   test "error is formatted" do
@@ -71,25 +74,30 @@ defmodule DefaultOutputTest do
   end
 
   test "custom output function can be defined" do
-    assert {:error, 125, "Non standard"} == ExampleCommandWithCustomOutput.output(:non_standard_output, %{})
+    assert {:error, 125, "Non standard"} ==
+             ExampleCommandWithCustomOutput.output(:non_standard_output, %{})
   end
 
   test "default output works even if custom output is defined" do
     assert :ok == ExampleCommandWithCustomOutput.output(:ok, %{})
-    assert {:ok, {:complex, "message"}} == ExampleCommandWithCustomOutput.output({:ok, {:complex, "message"}}, %{})
 
-    assert {:stream, [1,2,3]} == ExampleCommandWithCustomOutput.output({:ok, [1,2,3]}, %{})
-    assert {:stream, [1,2,3]} == ExampleCommandWithCustomOutput.output([1,2,3], %{})
+    assert {:ok, {:complex, "message"}} ==
+             ExampleCommandWithCustomOutput.output({:ok, {:complex, "message"}}, %{})
+
+    assert {:stream, [1, 2, 3]} == ExampleCommandWithCustomOutput.output({:ok, [1, 2, 3]}, %{})
+    assert {:stream, [1, 2, 3]} == ExampleCommandWithCustomOutput.output([1, 2, 3], %{})
 
     assert {:error, {:badrpc, :nodedown}} ==
-      ExampleCommandWithCustomOutput.output({:badrpc, :nodedown}, %{})
+             ExampleCommandWithCustomOutput.output({:badrpc, :nodedown}, %{})
+
     assert {:error, {:badrpc, :timeout}} ==
-      ExampleCommandWithCustomOutput.output({:badrpc, :timeout}, %{})
+             ExampleCommandWithCustomOutput.output({:badrpc, :timeout}, %{})
 
     error = %{i: [am: "arbitrary", error: 1]}
     {:error, ^error} = ExampleCommandWithCustomOutput.output({:error, error}, %{})
 
-    assert {:error, "I am string"} == ExampleCommandWithCustomOutput.output({:error_string, "I am string"}, %{})
+    assert {:error, "I am string"} ==
+             ExampleCommandWithCustomOutput.output({:error_string, "I am string"}, %{})
 
     val = "foo"
     assert match?({:ok, ^val}, ExampleCommandWithCustomOutput.output(val, %{}))
@@ -110,5 +118,6 @@ defmodule ExampleCommandWithCustomOutput do
   def output(:non_standard_output, _) do
     {:error, 125, "Non standard"}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 end

--- a/deps/rabbitmq_cli/test/core/distribution_test.exs
+++ b/deps/rabbitmq_cli/test/core/distribution_test.exs
@@ -19,12 +19,14 @@ defmodule DistributionTest do
       :net_kernel.stop()
       System.delete_env("RABBITMQ_ERLANG_COOKIE")
     end)
+
     try do
       :nocookie = Node.get_cookie()
     catch
       # one of net_kernel processes is not running ¯\_(ツ)_/¯
       :exit, _ -> :ok
     end
+
     System.put_env("RABBITMQ_ERLANG_COOKIE", "mycookie")
     opts = %{}
     Distribution.start(opts)
@@ -35,12 +37,14 @@ defmodule DistributionTest do
     on_exit(fn ->
       :net_kernel.stop()
     end)
+
     try do
       :nocookie = Node.get_cookie()
     catch
       # one of net_kernel processes is not running ¯\_(ツ)_/¯
       :exit, _ -> :ok
     end
+
     opts = %{erlang_cookie: :mycookie}
     Distribution.start(opts)
     :mycookie = Node.get_cookie()

--- a/deps/rabbitmq_cli/test/core/helpers_test.exs
+++ b/deps/rabbitmq_cli/test/core/helpers_test.exs
@@ -14,7 +14,7 @@ defmodule HelpersTest do
   ## --------------------- get_rabbit_hostname()/0 tests -------------------------
 
   test "RabbitMQ hostname is properly formed" do
-    assert Helpers.get_rabbit_hostname() |> Atom.to_string =~ ~r/rabbit@\w+/
+    assert Helpers.get_rabbit_hostname() |> Atom.to_string() =~ ~r/rabbit@\w+/
   end
 
   ## ------------------- memory_unit* tests --------------------
@@ -24,21 +24,23 @@ defmodule HelpersTest do
   end
 
   test "an invalid number fails " do
-    assert memory_unit_absolute("lots", "gigantibytes") == {:bad_argument, ["lots", "gigantibytes"]}
+    assert memory_unit_absolute("lots", "gigantibytes") ==
+             {:bad_argument, ["lots", "gigantibytes"]}
+
     assert memory_unit_absolute(-1, "gigantibytes") == {:bad_argument, [-1, "gigantibytes"]}
   end
 
   test "valid number and unit returns a valid result  " do
-      assert memory_unit_absolute(10, "k") == 10240
-      assert memory_unit_absolute(10, "kiB") == 10240
-      assert memory_unit_absolute(10, "M") == 10485760
-      assert memory_unit_absolute(10, "MiB") == 10485760
-      assert memory_unit_absolute(10, "G") == 10737418240
-      assert memory_unit_absolute(10, "GiB")== 10737418240
-      assert memory_unit_absolute(10, "kB")== 10000
-      assert memory_unit_absolute(10, "MB")== 10000000
-      assert memory_unit_absolute(10, "GB")== 10000000000
-      assert memory_unit_absolute(10, "")  == 10
+    assert memory_unit_absolute(10, "k") == 10240
+    assert memory_unit_absolute(10, "kiB") == 10240
+    assert memory_unit_absolute(10, "M") == 10_485_760
+    assert memory_unit_absolute(10, "MiB") == 10_485_760
+    assert memory_unit_absolute(10, "G") == 10_737_418_240
+    assert memory_unit_absolute(10, "GiB") == 10_737_418_240
+    assert memory_unit_absolute(10, "kB") == 10000
+    assert memory_unit_absolute(10, "MB") == 10_000_000
+    assert memory_unit_absolute(10, "GB") == 10_000_000_000
+    assert memory_unit_absolute(10, "") == 10
   end
 
   ## ------------------- Helpers.normalise_node_option tests --------------------
@@ -118,12 +120,14 @@ defmodule HelpersTest do
   test "locate plugin with version number in filename" do
     plugins_directory_03 = fixture_plugins_path("plugins-subdirectory-03")
     rabbitmq_home = :rabbit_misc.rpc_call(node(), :code, :lib_dir, [:rabbit])
-    opts = %{plugins_dir: to_string(plugins_directory_03),
-             rabbitmq_home: rabbitmq_home}
+    opts = %{plugins_dir: to_string(plugins_directory_03), rabbitmq_home: rabbitmq_home}
 
     desc = 'A mock RabbitMQ plugin to be used in tests'
     vsn = '0.1.0'
-    assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_03, desc, vsn}) == false
+
+    assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_03, desc, vsn}) ==
+             false
+
     require_rabbit_and_plugins(opts)
     Application.load(:mock_rabbitmq_plugins_03)
     assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_03, desc, vsn})
@@ -132,15 +136,16 @@ defmodule HelpersTest do
   test "locate plugin without version number in filename" do
     plugins_directory_04 = fixture_plugins_path("plugins-subdirectory-04")
     rabbitmq_home = :rabbit_misc.rpc_call(node(), :code, :lib_dir, [:rabbit])
-    opts = %{plugins_dir: to_string(plugins_directory_04),
-             rabbitmq_home: rabbitmq_home}
+    opts = %{plugins_dir: to_string(plugins_directory_04), rabbitmq_home: rabbitmq_home}
 
     desc = 'A mock RabbitMQ plugin to be used in tests'
     vsn = 'rolling'
-    assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_04, desc, vsn}) == false
+
+    assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_04, desc, vsn}) ==
+             false
+
     require_rabbit_and_plugins(opts)
     Application.load(:mock_rabbitmq_plugins_04)
     assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_04, desc, vsn})
   end
-
 end

--- a/deps/rabbitmq_cli/test/core/information_unit_test.exs
+++ b/deps/rabbitmq_cli/test/core/information_unit_test.exs
@@ -4,20 +4,23 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule InformationUnitTest do
   use ExUnit.Case, async: true
 
   alias RabbitMQ.CLI.InformationUnit, as: IU
 
   test "bytes, MB, GB, TB are known units" do
-    Enum.each(["bytes", "mb", "MB", "gb", "GB", "tb", "TB"],
-              fn x -> assert IU.known_unit?(x) end)
+    Enum.each(
+      ["bytes", "mb", "MB", "gb", "GB", "tb", "TB"],
+      fn x -> assert IU.known_unit?(x) end
+    )
   end
 
   test "glip-glops, millibars, gold pressed latinum bars and looney and are not known units" do
-    Enum.each(["glip-glops", "millibars", "gold pressed latinum bars", "looney"],
-              fn x -> assert not IU.known_unit?(x) end)
+    Enum.each(
+      ["glip-glops", "millibars", "gold pressed latinum bars", "looney"],
+      fn x -> assert not IU.known_unit?(x) end
+    )
   end
 
   test "conversion to bytes" do
@@ -27,18 +30,18 @@ defmodule InformationUnitTest do
   end
 
   test "conversion to MB" do
-    assert IU.convert(1000000, "mb") == 1.0
-    assert IU.convert(9500000, "mb") == 9.5
-    assert IU.convert(97893000, "mb") == 97.893
-    assert IU.convert(978930000, "mb") == 978.93
+    assert IU.convert(1_000_000, "mb") == 1.0
+    assert IU.convert(9_500_000, "mb") == 9.5
+    assert IU.convert(97_893_000, "mb") == 97.893
+    assert IU.convert(978_930_000, "mb") == 978.93
   end
 
   test "conversion to GB" do
-    assert IU.convert(978930000, "gb") == 0.9789
+    assert IU.convert(978_930_000, "gb") == 0.9789
 
-    assert IU.convert(1000000000, "gb") == 1.0
-    assert IU.convert(9500000000, "gb") == 9.5
-    assert IU.convert(97893000000, "gb") == 97.893
-    assert IU.convert(978930000000, "gb") == 978.93
+    assert IU.convert(1_000_000_000, "gb") == 1.0
+    assert IU.convert(9_500_000_000, "gb") == 9.5
+    assert IU.convert(97_893_000_000, "gb") == 97.893
+    assert IU.convert(978_930_000_000, "gb") == 978.93
   end
 end

--- a/deps/rabbitmq_cli/test/core/json_stream_test.exs
+++ b/deps/rabbitmq_cli/test/core/json_stream_test.exs
@@ -10,15 +10,16 @@ defmodule JsonStreamTest do
   @formatter RabbitMQ.CLI.Formatters.JsonStream
 
   test "format_output map with atom keys is converted to JSON object" do
-    assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) == "{\"a\":\"apple\",\"b\":\"beer\"}"
+    assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) ==
+             "{\"a\":\"apple\",\"b\":\"beer\"}"
   end
 
   test "format_output map with binary keys is converted to JSON object" do
-    assert @formatter.format_output(%{"a" => :apple, "b" => :beer}, %{}) == "{\"a\":\"apple\",\"b\":\"beer\"}"
+    assert @formatter.format_output(%{"a" => :apple, "b" => :beer}, %{}) ==
+             "{\"a\":\"apple\",\"b\":\"beer\"}"
   end
 
   test "format_output empty binary is converted to empty JSON array" do
     assert @formatter.format_output("", %{}) == ""
   end
-
 end

--- a/deps/rabbitmq_cli/test/core/listeners_test.exs
+++ b/deps/rabbitmq_cli/test/core/listeners_test.exs
@@ -11,52 +11,64 @@ defmodule CoreListenersTest do
   import RabbitCommon.Records
 
   test "listener record translation to a map" do
-    assert listener_map(listener(node: :rabbit@mercurio,
-                        protocol: :stomp,
-                        ip_address: {0,0,0,0,0,0,0,0},
-                        port: 61613)) ==
-      %{
-        interface: "[::]",
-        node: :rabbit@mercurio,
-        port: 61613,
-        protocol: :stomp,
-        purpose: "STOMP"
-      }
+    assert listener_map(
+             listener(
+               node: :rabbit@mercurio,
+               protocol: :stomp,
+               ip_address: {0, 0, 0, 0, 0, 0, 0, 0},
+               port: 61613
+             )
+           ) ==
+             %{
+               interface: "[::]",
+               node: :rabbit@mercurio,
+               port: 61613,
+               protocol: :stomp,
+               purpose: "STOMP"
+             }
   end
 
   test "[human-readable] protocol labels" do
     assert protocol_label(:amqp) == "AMQP 0-9-1 and AMQP 1.0"
-    assert protocol_label(:'amqp/ssl') == "AMQP 0-9-1 and AMQP 1.0 over TLS"
+    assert protocol_label(:"amqp/ssl") == "AMQP 0-9-1 and AMQP 1.0 over TLS"
     assert protocol_label(:mqtt) == "MQTT"
-    assert protocol_label(:'mqtt/ssl') == "MQTT over TLS"
+    assert protocol_label(:"mqtt/ssl") == "MQTT over TLS"
     assert protocol_label(:stomp) == "STOMP"
-    assert protocol_label(:'stomp/ssl') == "STOMP over TLS"
+    assert protocol_label(:"stomp/ssl") == "STOMP over TLS"
     assert protocol_label(:http) == "HTTP API"
     assert protocol_label(:https) == "HTTP API over TLS (HTTPS)"
-    assert protocol_label(:'https/web-stomp') == "STOMP over WebSockets and TLS (HTTPS)"
-    assert protocol_label(:'https/web-mqtt') == "MQTT over WebSockets and TLS (HTTPS)"
+    assert protocol_label(:"https/web-stomp") == "STOMP over WebSockets and TLS (HTTPS)"
+    assert protocol_label(:"https/web-mqtt") == "MQTT over WebSockets and TLS (HTTPS)"
 
-    assert protocol_label(:'http/prometheus') == "Prometheus exporter API over HTTP"
-    assert protocol_label(:'https/prometheus') == "Prometheus exporter API over TLS (HTTPS)"
+    assert protocol_label(:"http/prometheus") == "Prometheus exporter API over HTTP"
+    assert protocol_label(:"https/prometheus") == "Prometheus exporter API over TLS (HTTPS)"
   end
 
   test "listener expiring within" do
     validityInDays = 10
     validity = X509.Certificate.Validity.days_from_now(validityInDays)
     ca_key = X509.PrivateKey.new_ec(:secp256r1)
-    ca = X509.Certificate.self_signed(ca_key,
-      "/C=US/ST=CA/L=San Francisco/O=Megacorp/CN=Megacorp Intermediate CA",
-      template: :root_ca,
-      validity: validity
-    )
+
+    ca =
+      X509.Certificate.self_signed(
+        ca_key,
+        "/C=US/ST=CA/L=San Francisco/O=Megacorp/CN=Megacorp Intermediate CA",
+        template: :root_ca,
+        validity: validity
+      )
+
     pem = X509.Certificate.to_pem(ca)
 
     opts = [{:certfile, {:pem, pem}}, {:cacertfile, {:pem, pem}}]
-    listener = listener(node: :rabbit@mercurio,
-      protocol: :stomp,
-      ip_address: {0,0,0,0,0,0,0,0},
-      port: 61613,
-      opts: opts)
+
+    listener =
+      listener(
+        node: :rabbit@mercurio,
+        protocol: :stomp,
+        ip_address: {0, 0, 0, 0, 0, 0, 0, 0},
+        port: 61613,
+        opts: opts
+      )
 
     assert not listener_expiring_within(listener, 86400 * (validityInDays - 5))
     assert listener_expiring_within(listener, 86400 * (validityInDays + 5))

--- a/deps/rabbitmq_cli/test/core/os_pid_test.exs
+++ b/deps/rabbitmq_cli/test/core/os_pid_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule OsPidTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -19,36 +18,48 @@ defmodule OsPidTest do
     test "with a valid pid file returns an integer value" do
       path = fixture_file_path("valid_pidfile.pid")
 
-      assert (File.exists?(path) and File.regular?(path))
+      assert File.exists?(path) and File.regular?(path)
       assert @subject.read_pid_from_file(path, false) == 13566
     end
 
     test "with a valid pid file that includes spaces returns an integer value" do
       path = fixture_file_path("valid_pidfile_with_spaces.pid")
 
-      assert (File.exists?(path) and File.regular?(path))
+      assert File.exists?(path) and File.regular?(path)
       assert @subject.read_pid_from_file(path, false) == 83777
     end
 
     test "with an empty file" do
       path = fixture_file_path("empty_pidfile.pid")
 
-      assert (File.exists?(path) and File.regular?(path))
-      assert match?({:error, :could_not_read_pid_from_file, _}, @subject.read_pid_from_file(path, false))
+      assert File.exists?(path) and File.regular?(path)
+
+      assert match?(
+               {:error, :could_not_read_pid_from_file, _},
+               @subject.read_pid_from_file(path, false)
+             )
     end
 
     test "with a non-empty file full of garbage (that doesn't parse)" do
       path = fixture_file_path("invalid_pidfile.pid")
 
-      assert (File.exists?(path) and File.regular?(path))
-      assert match?({:error, :could_not_read_pid_from_file, _}, @subject.read_pid_from_file(path, false))
+      assert File.exists?(path) and File.regular?(path)
+
+      assert match?(
+               {:error, :could_not_read_pid_from_file, _},
+               @subject.read_pid_from_file(path, false)
+             )
     end
 
     test "with a file that does not exist" do
       path = fixture_file_path("pidfile_that_does_not_exist_128787df8s7f8%4&^.pid")
 
       assert !File.exists?(path)
-      assert match?({:error, :could_not_read_pid_from_file, _}, @subject.read_pid_from_file(path, false))
+
+      assert match?(
+               {:error, :could_not_read_pid_from_file, _},
+               @subject.read_pid_from_file(path, false)
+             )
     end
   end
 end

--- a/deps/rabbitmq_cli/test/core/parser_test.exs
+++ b/deps/rabbitmq_cli/test/core/parser_test.exs
@@ -9,10 +9,10 @@ defmodule RabbitMQ.CLI.Seagull.Commands.HerringGullCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["herring_gull"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
   def switches(), do: [herring: :string, garbage: :boolean]
   def aliases(), do: [h: :herring, g: :garbage]
 end
@@ -21,20 +21,20 @@ defmodule RabbitMQ.CLI.Seagull.Commands.PacificGullCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["pacific_gull"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 defmodule RabbitMQ.CLI.Seagull.Commands.HermannGullCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def usage(), do: ["hermann_gull"]
-  def validate(_,_), do: :ok
-  def merge_defaults(_,_), do: {[], %{}}
-  def banner(_,_), do: ""
-  def run(_,_), do: :ok
+  def validate(_, _), do: :ok
+  def merge_defaults(_, _), do: {[], %{}}
+  def banner(_, _), do: ""
+  def run(_, _), do: :ok
 end
 
 defmodule ParserTest do
@@ -48,9 +48,11 @@ defmodule ParserTest do
     Code.ensure_loaded(RabbitMQ.CLI.Seagull.Commands.HerringGullCommand)
     Code.ensure_loaded(RabbitMQ.CLI.Seagull.Commands.PacificGullCommand)
     set_scope(:seagull)
+
     on_exit(fn ->
       set_scope(:none)
     end)
+
     :ok
   end
 
@@ -67,51 +69,52 @@ defmodule ParserTest do
   end
 
   test "no commands, no options (empty array)" do
-    assert @subject.parse_global([]) == {[],%{}, []}
+    assert @subject.parse_global([]) == {[], %{}, []}
   end
 
   test "one arity 1 command, one double-dash quiet flag" do
     assert @subject.parse_global(["sandwich", "pastrami", "--quiet"]) ==
-      {["sandwich", "pastrami"], %{quiet: true}, []}
+             {["sandwich", "pastrami"], %{quiet: true}, []}
   end
 
   test "one arity 1 command, one single-dash quiet flag" do
     assert @subject.parse_global(["sandwich", "pastrami", "-q"]) ==
-      {["sandwich", "pastrami"], %{quiet: true}, []}
+             {["sandwich", "pastrami"], %{quiet: true}, []}
   end
 
   test "one arity 1 command, one double-dash silent flag" do
     assert @subject.parse_global(["sandwich", "pastrami", "--silent"]) ==
-      {["sandwich", "pastrami"], %{silent: true}, []}
+             {["sandwich", "pastrami"], %{silent: true}, []}
   end
 
   test "one arity 1 command, one single-dash silent flag" do
     assert @subject.parse_global(["sandwich", "pastrami", "-s"]) ==
-      {["sandwich", "pastrami"], %{silent: true}, []}
+             {["sandwich", "pastrami"], %{silent: true}, []}
   end
 
   test "one arity 0 command, one single-dash node option" do
     assert @subject.parse_global(["sandwich", "-n", "rabbitmq@localhost"]) ==
-      {["sandwich"], %{node: :rabbitmq@localhost}, []}
+             {["sandwich"], %{node: :rabbitmq@localhost}, []}
   end
 
   test "one arity 1 command, one single-dash node option" do
     assert @subject.parse_global(["sandwich", "pastrami", "-n", "rabbitmq@localhost"]) ==
-      {["sandwich", "pastrami"], %{node: :rabbitmq@localhost}, []}
+             {["sandwich", "pastrami"], %{node: :rabbitmq@localhost}, []}
   end
 
   test "one arity 1 command, one single-dash node option and one quiet flag" do
     assert @subject.parse_global(["sandwich", "pastrami", "-n", "rabbitmq@localhost", "--quiet"]) ==
-      {["sandwich", "pastrami"], %{node: :rabbitmq@localhost, quiet: true}, []}
+             {["sandwich", "pastrami"], %{node: :rabbitmq@localhost, quiet: true}, []}
   end
 
   test "single-dash node option before command" do
     assert @subject.parse_global(["-n", "rabbitmq@localhost", "sandwich", "pastrami"]) ==
-      {["sandwich", "pastrami"], %{node: :rabbitmq@localhost}, []}
+             {["sandwich", "pastrami"], %{node: :rabbitmq@localhost}, []}
   end
 
   test "no commands, one double-dash node option" do
-    assert @subject.parse_global(["--node=rabbitmq@localhost"]) == {[], %{node: :rabbitmq@localhost}, []}
+    assert @subject.parse_global(["--node=rabbitmq@localhost"]) ==
+             {[], %{node: :rabbitmq@localhost}, []}
   end
 
   test "no commands, one single-dash -p option" do
@@ -121,175 +124,197 @@ defmodule ParserTest do
   test "global parse treats command-specific arguments as invalid (ignores them)" do
     command_line = ["seagull", "--herring", "atlantic", "-g", "-p", "my_vhost"]
     {args, options, invalid} = @subject.parse_global(command_line)
+
     assert {args, options, invalid} ==
-      {["seagull", "atlantic"], %{vhost: "my_vhost"}, [{"--herring", nil}, {"-g", nil}]}
+             {["seagull", "atlantic"], %{vhost: "my_vhost"}, [{"--herring", nil}, {"-g", nil}]}
   end
 
   test "global parse treats command-specific arguments that are separated by an equals sign as invalid (ignores them)" do
     command_line = ["seagull", "--herring=atlantic", "-g", "-p", "my_vhost"]
     {args, options, invalid} = @subject.parse_global(command_line)
+
     assert {args, options, invalid} ==
-      {["seagull"], %{vhost: "my_vhost"}, [{"--herring", nil}, {"-g", nil}]}
+             {["seagull"], %{vhost: "my_vhost"}, [{"--herring", nil}, {"-g", nil}]}
   end
 
   test "command-specific parse recognizes command switches" do
     command_line = ["seagull", "--herring", "atlantic", "-g", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse_command_specific(command_line, command) ==
-      {["seagull"], %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+             {["seagull"], %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
   end
 
   test "command-specific parse recognizes command switches that are separated by an equals sign" do
     command_line = ["seagull", "--herring=atlantic", "-g", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse_command_specific(command_line, command) ==
-      {["seagull"], %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+             {["seagull"], %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
   end
 
   test "command-specific switches and aliases are optional" do
     command_line = ["seagull", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+
     assert @subject.parse_command_specific(command_line, command) ==
-      {["seagull"], %{vhost: "my_vhost"}, []}
+             {["seagull"], %{vhost: "my_vhost"}, []}
   end
 
   test "--timeout can be specified before command" do
     # for backwards compatibility
-    assert @subject.parse_global(["-n", "rabbitmq@localhost", "--timeout", "5", "sandwich", "pastrami"]) ==
-      {["sandwich", "pastrami"], %{node: :rabbitmq@localhost, timeout: 5}, []}
+    assert @subject.parse_global([
+             "-n",
+             "rabbitmq@localhost",
+             "--timeout",
+             "5",
+             "sandwich",
+             "pastrami"
+           ]) ==
+             {["sandwich", "pastrami"], %{node: :rabbitmq@localhost, timeout: 5}, []}
   end
 
   test "-t can be specified before command" do
     # for backwards compatibility
     assert @subject.parse_global(["-n", "rabbitmq@localhost", "-t", "5", "sandwich", "pastrami"]) ==
-      {["sandwich", "pastrami"], %{node: :rabbitmq@localhost, timeout: 5}, []}
+             {["sandwich", "pastrami"], %{node: :rabbitmq@localhost, timeout: 5}, []}
   end
 
   test "parse/1 returns command name" do
     command_line = ["pacific_gull", "fly", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
+             {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
   end
 
   test "parse/1 returns command name when a global flag comes before the command" do
     command_line = ["-p", "my_vhost", "pacific_gull", "fly"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
+             {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
   end
 
   test "parse/1 returns command name when a global flag separated by an equals sign comes before the command" do
     command_line = ["-p=my_vhost", "pacific_gull", "fly"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
+             {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
   end
 
   test "parse/1 returns :no_command when given an empty argument list" do
     command_line = ["-p", "my_vhost"]
+
     assert @subject.parse(command_line) ==
-      {:no_command, "", [], %{vhost: "my_vhost"}, []}
+             {:no_command, "", [], %{vhost: "my_vhost"}, []}
   end
 
   test "parse/1 returns :no_command and command name when command isn't known" do
     command_line = ["atlantic_gull", "-p", "my_vhost"]
+
     assert @subject.parse(command_line) ==
-      {:no_command, "atlantic_gull", [], %{vhost: "my_vhost"}, []}
+             {:no_command, "atlantic_gull", [], %{vhost: "my_vhost"}, []}
   end
 
   test "parse/1 returns :no command if command-specific options come before the command" do
     command_line = ["--herring", "atlantic", "herring_gull", "-p", "my_vhost"]
+
     assert @subject.parse(command_line) ==
-      {:no_command, "atlantic", ["herring_gull"],
-       %{vhost: "my_vhost"}, [{"--herring", nil}]}
+             {:no_command, "atlantic", ["herring_gull"], %{vhost: "my_vhost"},
+              [{"--herring", nil}]}
   end
 
   test "parse/1 returns command name if a global option comes before the command" do
     command_line = ["-p", "my_vhost", "herring_gull"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "herring_gull", [], %{vhost: "my_vhost"}, []}
+             {command, "herring_gull", [], %{vhost: "my_vhost"}, []}
   end
 
   test "parse/1 returns command name if multiple global options come before the command" do
     command_line = ["-p", "my_vhost", "-q", "-n", "rabbit@test", "herring_gull"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "herring_gull", [], %{vhost: "my_vhost", node: :rabbit@test, quiet: true}, []}
+             {command, "herring_gull", [], %{vhost: "my_vhost", node: :rabbit@test, quiet: true},
+              []}
   end
 
   test "parse/1 returns command name if multiple global options separated by an equals sign come before the command" do
     command_line = ["-p=my_vhost", "-q", "--node=rabbit@test", "herring_gull"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "herring_gull", [], %{vhost: "my_vhost", node: :rabbit@test, quiet: true}, []}
+             {command, "herring_gull", [], %{vhost: "my_vhost", node: :rabbit@test, quiet: true},
+              []}
   end
 
   test "parse/1 returns command with command specific options" do
-    command_line = ["herring_gull", "--herring", "atlantic",
-                    "-g", "fly", "-p", "my_vhost"]
+    command_line = ["herring_gull", "--herring", "atlantic", "-g", "fly", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "herring_gull", ["fly"],
-       %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+             {command, "herring_gull", ["fly"],
+              %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
   end
 
   test "parse/1 returns command with command specific options that are separated by an equals sign" do
-    command_line = ["herring_gull", "--herring=atlantic",
-                    "-g", "fly", "-p=my_vhost"]
+    command_line = ["herring_gull", "--herring=atlantic", "-g", "fly", "-p=my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "herring_gull", ["fly"],
-       %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+             {command, "herring_gull", ["fly"],
+              %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
   end
 
   test "parse/1 expands command-defined aliases" do
     command_line = ["herring_gull", "fly", "-g"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+
     assert @subject.parse(command_line) ==
-      {command, "herring_gull", ["fly"], %{garbage: true}, []}
+             {command, "herring_gull", ["fly"], %{garbage: true}, []}
   end
 
   test "parse/1 returns invalid/extra options for command" do
-    command_line = ["pacific_gull", "fly",
-                    "--herring", "atlantic",
-                    "-p", "my_vhost"]
+    command_line = ["pacific_gull", "fly", "--herring", "atlantic", "-p", "my_vhost"]
     pacific_gull = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+
     assert @subject.parse(command_line) ==
-      {pacific_gull, "pacific_gull", ["fly", "atlantic"],
-       %{vhost: "my_vhost"},
-       [{"--herring", nil}]}
+             {pacific_gull, "pacific_gull", ["fly", "atlantic"], %{vhost: "my_vhost"},
+              [{"--herring", nil}]}
   end
 
   test "parse/1 suggests similar command" do
     # One letter difference
     assert @subject.parse(["pacific_gulf"]) ==
-      {{:suggest, "pacific_gull"}, "pacific_gulf", [], %{}, []}
+             {{:suggest, "pacific_gull"}, "pacific_gulf", [], %{}, []}
 
     # One letter missing
     assert @subject.parse(["pacific_gul"]) ==
-      {{:suggest, "pacific_gull"}, "pacific_gul", [], %{}, []}
+             {{:suggest, "pacific_gull"}, "pacific_gul", [], %{}, []}
 
     # One letter extra
     assert @subject.parse(["pacific_gulll"]) ==
-      {{:suggest, "pacific_gull"}, "pacific_gulll", [], %{}, []}
+             {{:suggest, "pacific_gull"}, "pacific_gulll", [], %{}, []}
 
     # Five letter difference
     assert @subject.parse(["pacifistcatl"]) ==
-      {{:suggest, "pacific_gull"}, "pacifistcatl", [], %{}, []}
+             {{:suggest, "pacific_gull"}, "pacifistcatl", [], %{}, []}
 
     # Five letters missing
     assert @subject.parse(["pacific"]) ==
-      {{:suggest, "pacific_gull"}, "pacific", [], %{}, []}
+             {{:suggest, "pacific_gull"}, "pacific", [], %{}, []}
 
     # Closest to similar
     assert @subject.parse(["herrdog_gull"]) ==
-      {{:suggest, "herring_gull"}, "herrdog_gull", [], %{}, []}
+             {{:suggest, "herring_gull"}, "herrdog_gull", [], %{}, []}
 
     # Closest to similar
     assert @subject.parse(["hermaug_gull"]) ==
-      {{:suggest, "hermann_gull"}, "hermaug_gull", [], %{}, []}
+             {{:suggest, "hermann_gull"}, "hermaug_gull", [], %{}, []}
   end
 
   @tag cd: "fixtures"
@@ -306,64 +331,52 @@ defmodule ParserTest do
 
     aliases_file_name = "aliases.ini"
     File.write(aliases_file_name, aliases)
-    on_exit(fn() ->
+
+    on_exit(fn ->
       File.rm(aliases_file_name)
     end)
 
     assert @subject.parse(["larus_pacificus", "--aliases-file", aliases_file_name]) ==
-      {RabbitMQ.CLI.Seagull.Commands.PacificGullCommand,
-       "larus_pacificus",
-       [],
-       %{aliases_file: aliases_file_name},
-       []}
+             {RabbitMQ.CLI.Seagull.Commands.PacificGullCommand, "larus_pacificus", [],
+              %{aliases_file: aliases_file_name}, []}
 
     assert @subject.parse(["gull_with_herring", "--aliases-file", aliases_file_name]) ==
-      {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
-       "gull_with_herring",
-       [],
-       %{aliases_file: aliases_file_name, herring: "atlantic"},
-       []}
+             {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand, "gull_with_herring", [],
+              %{aliases_file: aliases_file_name, herring: "atlantic"}, []}
 
     assert @subject.parse(["flying_gull", "--aliases-file", aliases_file_name]) ==
-      {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
-       "flying_gull",
-       ["fly"],
-       %{aliases_file: aliases_file_name},
-       []}
+             {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand, "flying_gull", ["fly"],
+              %{aliases_file: aliases_file_name}, []}
 
     assert @subject.parse(["garbage_gull", "--aliases-file", aliases_file_name]) ==
-      {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
-       "garbage_gull",
-       [],
-       %{aliases_file: aliases_file_name, garbage: true},
-       []}
+             {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand, "garbage_gull", [],
+              %{aliases_file: aliases_file_name, garbage: true}, []}
 
     assert @subject.parse(["complex_gull", "--aliases-file", aliases_file_name]) ==
-      {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
-       "complex_gull",
-       ["eat"],
-       %{aliases_file: aliases_file_name, garbage: true, herring: "pacific", formatter: "erlang"},
-       []}
+             {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand, "complex_gull", ["eat"],
+              %{
+                aliases_file: aliases_file_name,
+                garbage: true,
+                herring: "pacific",
+                formatter: "erlang"
+              }, []}
 
     assert @subject.parse(["invalid_gull", "--aliases-file", aliases_file_name]) ==
-      {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
-       "invalid_gull",
-       [],
-       %{aliases_file: aliases_file_name},
-       [{"--invalid", nil}]}
+             {RabbitMQ.CLI.Seagull.Commands.HerringGullCommand, "invalid_gull", [],
+              %{aliases_file: aliases_file_name}, [{"--invalid", nil}]}
 
     assert @subject.parse(["unknown_gull", "--aliases-file", aliases_file_name]) ==
-      {:no_command, "unknown_gull", [], %{aliases_file: aliases_file_name}, []}
+             {:no_command, "unknown_gull", [], %{aliases_file: aliases_file_name}, []}
 
     File.rm(aliases_file_name)
 
-
-    assert capture_io(:stderr,
-      fn ->
-        assert @subject.parse(["larus_pacificus", "--aliases-file", aliases_file_name]) ==
-          {:no_command, "larus_pacificus", [], %{aliases_file: aliases_file_name}, []}
-      end) =~ "Error reading aliases file"
-
+    assert capture_io(
+             :stderr,
+             fn ->
+               assert @subject.parse(["larus_pacificus", "--aliases-file", aliases_file_name]) ==
+                        {:no_command, "larus_pacificus", [], %{aliases_file: aliases_file_name},
+                         []}
+             end
+           ) =~ "Error reading aliases file"
   end
-
 end

--- a/deps/rabbitmq_cli/test/core/rpc_stream_test.exs
+++ b/deps/rabbitmq_cli/test/core/rpc_stream_test.exs
@@ -7,88 +7,165 @@ defmodule RpcStreamTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-
     :ok
-
   end
 
   test "emit empty list" do
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list, [[]], :infinity, []])
+    items =
+      receive_list_items_to_list([Kernel.node(), TestHelper, :emit_list, [[]], :infinity, []])
 
     assert [] == items
   end
 
   test "emit list without filters" do
-    list  = [:one, :two, :three]
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list, [list], :infinity, []])
+    list = [:one, :two, :three]
+
+    items =
+      receive_list_items_to_list([Kernel.node(), TestHelper, :emit_list, [list], :infinity, []])
 
     assert list == items
   end
 
-
   test "emit list with filters" do
     list = [[one: 1, two: 2, three: 3], [one: 11, two: 12, three: 13]]
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list, [list], :infinity, [:one, :two]])
+
+    items =
+      receive_list_items_to_list([
+        Kernel.node(),
+        TestHelper,
+        :emit_list,
+        [list],
+        :infinity,
+        [:one, :two]
+      ])
 
     assert [[one: 1, two: 2], [one: 11, two: 12]] == items
   end
 
   test "emit list of lists with filters" do
-    list = [[[one: 1, two: 2, three: 3], [one: 11, two: 12, three: 13]],
-            [[one: 21, two: 22, three: 23], [one: 31, two: 32, three: 33]]]
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list, [list], :infinity, [:one, :two]])
+    list = [
+      [[one: 1, two: 2, three: 3], [one: 11, two: 12, three: 13]],
+      [[one: 21, two: 22, three: 23], [one: 31, two: 32, three: 33]]
+    ]
 
-    assert [[[one: 1, two: 2], [one: 11, two: 12]], [[one: 21, two: 22], [one: 31, two: 32]]] == items
+    items =
+      receive_list_items_to_list([
+        Kernel.node(),
+        TestHelper,
+        :emit_list,
+        [list],
+        :infinity,
+        [:one, :two]
+      ])
+
+    assert [[[one: 1, two: 2], [one: 11, two: 12]], [[one: 21, two: 22], [one: 31, two: 32]]] ==
+             items
   end
 
   test "emission timeout 0 return badrpc" do
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list, [[]], 0, []])
+    items = receive_list_items_to_list([Kernel.node(), TestHelper, :emit_list, [[]], 0, []])
 
     assert [{:badrpc, {:timeout, 0.0}}] == items
   end
 
   test "emission timeout return badrpc with timeout value in seconds" do
-    timeout_fun = fn(x) -> :timer.sleep(1000); x end
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list_map, [[1,2,3], timeout_fun], 100, []])
+    timeout_fun = fn x ->
+      :timer.sleep(1000)
+      x
+    end
+
+    items =
+      receive_list_items_to_list([
+        Kernel.node(),
+        TestHelper,
+        :emit_list_map,
+        [[1, 2, 3], timeout_fun],
+        100,
+        []
+      ])
+
     assert [{:badrpc, {:timeout, 0.1}}] == items
   end
 
   test "emission timeout in progress return badrpc with timeout value in seconds as last element" do
-    timeout_fun = fn(x) -> :timer.sleep(100); x end
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list_map, [[1,2,3], timeout_fun], 150, []])
+    timeout_fun = fn x ->
+      :timer.sleep(100)
+      x
+    end
+
+    items =
+      receive_list_items_to_list([
+        Kernel.node(),
+        TestHelper,
+        :emit_list_map,
+        [[1, 2, 3], timeout_fun],
+        150,
+        []
+      ])
+
     assert [1, {:badrpc, {:timeout, 0.15}}] == items
   end
 
   test "parallel emission do not mix values" do
-    {:ok, agent} = Agent.start_link(fn() -> :init end)
-    list1  = [:one, :two, :three]
-    list2  = [:dog, :cat, :pig]
+    {:ok, agent} = Agent.start_link(fn -> :init end)
+    list1 = [:one, :two, :three]
+    list2 = [:dog, :cat, :pig]
     # Adding timeout to make sure emissions are executed in parallel
-    timeout_fun = fn(x) -> :timer.sleep(10); x end
-    Agent.update(agent,
-                 fn(:init) ->
-                   receive_list_items_to_list([Kernel.node, TestHelper, :emit_list_map, [list2, timeout_fun], :infinity, []])
-                 end)
-    items1 = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list_map, [list1, timeout_fun], :infinity, []])
-    items2 = Agent.get(agent, fn(x) -> x end)
+    timeout_fun = fn x ->
+      :timer.sleep(10)
+      x
+    end
+
+    Agent.update(
+      agent,
+      fn :init ->
+        receive_list_items_to_list([
+          Kernel.node(),
+          TestHelper,
+          :emit_list_map,
+          [list2, timeout_fun],
+          :infinity,
+          []
+        ])
+      end
+    )
+
+    items1 =
+      receive_list_items_to_list([
+        Kernel.node(),
+        TestHelper,
+        :emit_list_map,
+        [list1, timeout_fun],
+        :infinity,
+        []
+      ])
+
+    items2 = Agent.get(agent, fn x -> x end)
 
     assert items1 == list1
     assert items2 == list2
   end
 
   test "can receive from multiple emission sources in parallel" do
-    list1  = [:one, :two, :three]
-    list2  = [:dog, :cat, :pig]
-    items = receive_list_items_to_list([Kernel.node, TestHelper, :emit_list_multiple_sources, [list1, list2], :infinity, []], 2)
+    list1 = [:one, :two, :three]
+    list2 = [:dog, :cat, :pig]
+
+    items =
+      receive_list_items_to_list(
+        [Kernel.node(), TestHelper, :emit_list_multiple_sources, [list1, list2], :infinity, []],
+        2
+      )
+
     assert Kernel.length(list1 ++ list2) == Kernel.length(items)
     assert MapSet.new(list1 ++ list2) == MapSet.new(items)
   end
 
   def receive_list_items_to_list(args, chunks \\ 1) do
     res = Kernel.apply(RpcStream, :receive_list_items, args ++ [chunks])
+
     case Enumerable.impl_for(res) do
-      nil -> res;
-      _   -> Enum.to_list(res)
+      nil -> res
+      _ -> Enum.to_list(res)
     end
   end
 end

--- a/deps/rabbitmq_cli/test/core/table_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/core/table_formatter_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule TableFormatterTest do
   use ExUnit.Case, async: false
 
@@ -12,35 +11,79 @@ defmodule TableFormatterTest do
 
   test "format_output tab-separates map values" do
     assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) == ["a\tb", "apple\tbeer"]
-    assert @formatter.format_output(%{a: :apple, b: :beer, c: 1}, %{}) == ["a\tb\tc", "apple\tbeer\t1"]
-    assert @formatter.format_output(%{a: "apple", b: 'beer', c: 1}, %{}) == ["a\tb\tc", "apple\t\"beer\"\t1"]
+
+    assert @formatter.format_output(%{a: :apple, b: :beer, c: 1}, %{}) == [
+             "a\tb\tc",
+             "apple\tbeer\t1"
+           ]
+
+    assert @formatter.format_output(%{a: "apple", b: 'beer', c: 1}, %{}) == [
+             "a\tb\tc",
+             "apple\t\"beer\"\t1"
+           ]
   end
 
   test "format_output tab-separates keyword values" do
     assert @formatter.format_output([a: :apple, b: :beer], %{}) == ["a\tb", "apple\tbeer"]
-    assert @formatter.format_output([a: :apple, b: :beer, c: 1], %{}) == ["a\tb\tc", "apple\tbeer\t1"]
-    assert @formatter.format_output([a: "apple", b: 'beer', c: 1], %{}) == ["a\tb\tc", "apple\t\"beer\"\t1"]
+
+    assert @formatter.format_output([a: :apple, b: :beer, c: 1], %{}) == [
+             "a\tb\tc",
+             "apple\tbeer\t1"
+           ]
+
+    assert @formatter.format_output([a: "apple", b: 'beer', c: 1], %{}) == [
+             "a\tb\tc",
+             "apple\t\"beer\"\t1"
+           ]
   end
 
   test "format_stream tab-separates map values" do
-    assert @formatter.format_stream([%{a: :apple, b: :beer, c: 1},
-                                     %{a: "aadvark", b: 'bee', c: 2}], %{})
-           |> Enum.to_list ==
-           ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
+    assert @formatter.format_stream(
+             [%{a: :apple, b: :beer, c: 1}, %{a: "aadvark", b: 'bee', c: 2}],
+             %{}
+           )
+           |> Enum.to_list() ==
+             ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
   end
 
   test "format_stream tab-separates keyword values" do
-    assert @formatter.format_stream([[a: :apple, b: :beer, c: 1],
-                                     [a: "aadvark", b: 'bee', c: 2]], %{})
-           |> Enum.to_list ==
-           ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
+    assert @formatter.format_stream(
+             [[a: :apple, b: :beer, c: 1], [a: "aadvark", b: 'bee', c: 2]],
+             %{}
+           )
+           |> Enum.to_list() ==
+             ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
   end
 
   test "format_output formats non-string values with inspect recursively" do
-    assert @formatter.format_output(%{a: :apple, b: "beer", c: {:carp, "fish"}, d: [door: :way], e: %{elk: "horn", for: :you}}, %{}) ==
-        ["a\tb\tc\td\te", "apple\tbeer\t{carp, fish}\t[{door, way}]\t\#{elk => horn, for => you}"]
+    assert @formatter.format_output(
+             %{
+               a: :apple,
+               b: "beer",
+               c: {:carp, "fish"},
+               d: [door: :way],
+               e: %{elk: "horn", for: :you}
+             },
+             %{}
+           ) ==
+             [
+               "a\tb\tc\td\te",
+               "apple\tbeer\t{carp, fish}\t[{door, way}]\t\#{elk => horn, for => you}"
+             ]
 
-    assert @formatter.format_output(%{a: :apple, b: "beer", c: {:carp, {:small, :fish}}, d: [door: {:way, "big"}], e: %{elk: [horn: :big]}}, %{}) ==
-        ["a\tb\tc\td\te", "apple\tbeer\t{carp, {small, fish}}\t[{door, {way, big}}]\t\#{elk => [{horn, big}]}"]
+    assert @formatter.format_output(
+             %{
+               a: :apple,
+               b: "beer",
+               c: {:carp, {:small, :fish}},
+               d: [door: {:way, "big"}],
+               e: %{elk: [horn: :big]}
+             },
+             %{}
+           ) ==
+             [
+               "a\tb\tc\td\te",
+               "apple\tbeer\t{carp, {small, fish}}\t[{door, {way, big}}]\t\#{elk => [{horn, big}]}"
+             ]
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/add_user_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_user_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AddUserCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -28,7 +27,7 @@ defmodule AddUserCommandTest do
 
   test "validate: too many positional arguments fails" do
     assert @command.validate(["user", "password", "extra"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: two arguments passes" do
@@ -41,7 +40,10 @@ defmodule AddUserCommandTest do
 
   @tag user: "", password: "password"
   test "validate: an empty username fails", context do
-    assert match?({:validation_failure, {:bad_argument, _}}, @command.validate([context[:user], context[:password]], context[:opts]))
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([context[:user], context[:password]], context[:opts])
+           )
   end
 
   # Blank passwords are currently allowed, they make sense
@@ -62,20 +64,23 @@ defmodule AddUserCommandTest do
   @tag user: "someone", password: "password"
   test "run: default case completes successfully", context do
     assert @command.run([context[:user], context[:password]], context[:opts]) == :ok
-    assert list_users() |> Enum.count(fn(record) -> record[:user] == context[:user] end) == 1
+    assert list_users() |> Enum.count(fn record -> record[:user] == context[:user] end) == 1
   end
 
   @tag user: "someone", password: "password"
   test "run: adding an existing user returns an error", context do
     add_user(context[:user], context[:password])
-    assert @command.run([context[:user], context[:password]], context[:opts]) == {:error, {:user_already_exists, context[:user]}}
-    assert list_users() |> Enum.count(fn(record) -> record[:user] == context[:user] end) == 1
+
+    assert @command.run([context[:user], context[:password]], context[:opts]) ==
+             {:error, {:user_already_exists, context[:user]}}
+
+    assert list_users() |> Enum.count(fn record -> record[:user] == context[:user] end) == 1
   end
 
   @tag user: "someone", password: "password"
   test "banner", context do
-    assert @command.banner([context[:user], context[:password]], context[:opts])
-      =~ ~r/Adding user \"#{context[:user]}\" \.\.\./
+    assert @command.banner([context[:user], context[:password]], context[:opts]) =~
+             ~r/Adding user \"#{context[:user]}\" \.\.\./
   end
 
   @tag user: "someone"

--- a/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AddVhostCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -33,20 +32,30 @@ defmodule AddVhostCommandTest do
   test "validate: one argument passes validation" do
     assert @command.validate(["new-vhost"], %{}) == :ok
     assert @command.validate(["new-vhost"], %{description: "Used by team A"}) == :ok
-    assert @command.validate(["new-vhost"], %{description: "Used by team A for QA purposes", tags: "qa,team-a"}) == :ok
-    assert @command.validate(["new-vhost"], %{description: "Used by team A for QA purposes", tags: "qa,team-a", default_queue_type: "quorum"}) == :ok
+
+    assert @command.validate(["new-vhost"], %{
+             description: "Used by team A for QA purposes",
+             tags: "qa,team-a"
+           }) == :ok
+
+    assert @command.validate(["new-vhost"], %{
+             description: "Used by team A for QA purposes",
+             tags: "qa,team-a",
+             default_queue_type: "quorum"
+           }) == :ok
   end
 
   @tag vhost: @vhost
   test "run: passing a valid vhost name to a running RabbitMQ node succeeds", context do
     assert @command.run([context[:vhost]], context[:opts]) == :ok
-    assert list_vhosts() |> Enum.count(fn(record) -> record[:name] == context[:vhost] end) == 1
+    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 1
   end
 
   @tag vhost: ""
-  test "run: passing an empty string for vhost name with a running RabbitMQ node still succeeds", context do
+  test "run: passing an empty string for vhost name with a running RabbitMQ node still succeeds",
+       context do
     assert @command.run([context[:vhost]], context[:opts]) == :ok
-    assert list_vhosts() |> Enum.count(fn(record) -> record[:name] == context[:vhost] end) == 1
+    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 1
   end
 
   test "run: attempt to use an unreachable node returns a nodedown" do
@@ -55,15 +64,15 @@ defmodule AddVhostCommandTest do
   end
 
   test "run: adding the same host twice is idempotent", context do
-    add_vhost context[:vhost]
+    add_vhost(context[:vhost])
 
     assert @command.run([context[:vhost]], context[:opts]) == :ok
-    assert list_vhosts() |> Enum.count(fn(record) -> record[:name] == context[:vhost] end) == 1
+    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 1
   end
 
   @tag vhost: @vhost
   test "banner", context do
-    assert @command.banner([context[:vhost]], context[:opts])
-      =~ ~r/Adding vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([context[:vhost]], context[:opts]) =~
+             ~r/Adding vhost \"#{context[:vhost]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/authenticate_user_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/authenticate_user_command_test.exs
@@ -4,13 +4,12 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AuthenticateUserCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands. AuthenticateUserCommand
-  @user     "user1"
+  @command RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand
+  @user "user1"
   @password "password"
 
   setup_all do
@@ -31,7 +30,7 @@ defmodule AuthenticateUserCommandTest do
 
   test "validate: too many positional arguments fails" do
     assert @command.validate(["user", "password", "extra"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: one argument passes" do
@@ -54,28 +53,34 @@ defmodule AuthenticateUserCommandTest do
 
   @tag user: @user, password: "treachery"
   test "run: a valid username and invalid password returns refused", context do
-    assert {:refused, _, _, _} = @command.run([context[:user], context[:password]], context[:opts])
+    assert {:refused, _, _, _} =
+             @command.run([context[:user], context[:password]], context[:opts])
   end
 
   @tag user: "interloper", password: @password
   test "run: an invalid username returns refused", context do
-    assert {:refused, _, _, _} = @command.run([context[:user], context[:password]], context[:opts])
+    assert {:refused, _, _, _} =
+             @command.run([context[:user], context[:password]], context[:opts])
   end
 
   @tag user: @user, password: @password
   test "banner", context do
-    assert @command.banner([context[:user], context[:password]], context[:opts])
-      =~ ~r/Authenticating user/
-    assert @command.banner([context[:user], context[:password]], context[:opts])
-      =~ ~r/"#{context[:user]}"/
+    assert @command.banner([context[:user], context[:password]], context[:opts]) =~
+             ~r/Authenticating user/
+
+    assert @command.banner([context[:user], context[:password]], context[:opts]) =~
+             ~r/"#{context[:user]}"/
   end
 
   test "output: refused error", context do
     user = "example_user"
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_dataerr
-    assert match?({:error, ^exit_code,
-                   "Error: failed to authenticate user \"example_user\"\n" <>
-                   "Unable to foo"},
-                  @command.output({:refused, user, "Unable to ~s", ["foo"]}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_dataerr()
+
+    assert match?(
+             {:error, ^exit_code,
+              "Error: failed to authenticate user \"example_user\"\n" <>
+                "Unable to foo"},
+             @command.output({:refused, user, "Unable to ~s", ["foo"]}, context[:opts])
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/autocomplete_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/autocomplete_command_test.exs
@@ -4,17 +4,17 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AutocompleteCommandTest do
   use ExUnit.Case, async: true
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.AutocompleteCommand
   setup do
-    {:ok, opts: %{
-      script_name: "rabbitmqctl",
-      node: get_rabbit_hostname()
-    }}
+    {:ok,
+     opts: %{
+       script_name: "rabbitmqctl",
+       node: get_rabbit_hostname()
+     }}
   end
 
   test "shows up in help" do

--- a/deps/rabbitmq_cli/test/ctl/await_online_nodes_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/await_online_nodes_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AwaitOnlineNodesCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -32,13 +31,12 @@ defmodule AwaitOnlineNodesCommandTest do
   end
 
   test "run: a call to an unreachable RabbitMQ node returns a nodedown" do
-    opts   = %{node: :jake@thedog, timeout: 200}
+    opts = %{node: :jake@thedog, timeout: 200}
     assert match?({:badrpc, _}, @command.run(["1"], opts))
   end
 
   test "banner", context do
-    assert @command.banner(["1"], context[:opts])
-      =~ ~r/Will wait for at least 1 nodes to join the cluster of #{context[:opts][:node]}. Timeout: 300 seconds./
+    assert @command.banner(["1"], context[:opts]) =~
+             ~r/Will wait for at least 1 nodes to join the cluster of #{context[:opts][:node]}. Timeout: 300 seconds./
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/await_startup_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/await_startup_command_test.exs
@@ -30,7 +30,7 @@ defmodule AwaitStartupCommandTest do
 
   test "validate: with extra arguments returns an arg count error", context do
     assert @command.validate(["extra"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: request to a non-existent node returns a badrpc" do

--- a/deps/rabbitmq_cli/test/ctl/cancel_sync_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/cancel_sync_command_test.exs
@@ -25,25 +25,26 @@ defmodule CancelSyncQueueCommandTest do
   end
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname(),
-      vhost: @vhost
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       vhost: @vhost
+     }}
   end
 
   test "validate: specifying no queue name is reported as an error", context do
     assert @command.validate([], context[:opts]) ==
-      {:validation_failure, :not_enough_args}
+             {:validation_failure, :not_enough_args}
   end
 
   test "validate: specifying two queue names is reported as an error", context do
     assert @command.validate(["q1", "q2"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: specifying three queue names is reported as an error", context do
     assert @command.validate(["q1", "q2", "q3"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: specifying one queue name succeeds", context do

--- a/deps/rabbitmq_cli/test/ctl/change_cluster_node_type_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/change_cluster_node_type_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2016-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ChangeClusterNodeTypeCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -24,15 +23,17 @@ defmodule ChangeClusterNodeTypeCommandTest do
   end
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname()
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname()
+     }}
   end
 
   test "validate: node type of disc, disk, and ram pass validation", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["foo"], context[:opts]))
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["foo"], context[:opts])
+           )
 
     assert :ok == @command.validate(["ram"], context[:opts])
     assert :ok == @command.validate(["disc"], context[:opts])
@@ -41,44 +42,49 @@ defmodule ChangeClusterNodeTypeCommandTest do
 
   test "validate: providing no arguments fails validation", context do
     assert @command.validate([], context[:opts]) ==
-      {:validation_failure, :not_enough_args}
+             {:validation_failure, :not_enough_args}
   end
+
   test "validate: providing too many arguments fails validation", context do
     assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   # TODO
-  #test "run: change ram node to disc node", context do
-  #end
+  # test "run: change ram node to disc node", context do
+  # end
 
   # TODO
-  #test "run: change disk node to ram node", context do
-  #end
+  # test "run: change disk node to ram node", context do
+  # end
 
   test "run: request to a node with running RabbitMQ app fails", context do
-   assert match?(
-     {:error, :mnesia_unexpectedly_running},
-    @command.run(["ram"], context[:opts]))
+    assert match?(
+             {:error, :mnesia_unexpectedly_running},
+             @command.run(["ram"], context[:opts])
+           )
   end
 
   test "run: request to an unreachable node returns a badrpc", _context do
     opts = %{node: :jake@thedog, timeout: 200}
+
     assert match?(
-      {:badrpc, :nodedown},
-      @command.run(["ram"], opts))
+             {:badrpc, :nodedown},
+             @command.run(["ram"], opts)
+           )
   end
 
   test "banner", context do
     assert @command.banner(["ram"], context[:opts]) =~
-      ~r/Turning #{get_rabbit_hostname()} into a ram node/
+             ~r/Turning #{get_rabbit_hostname()} into a ram node/
   end
 
   test "output mnesia is running error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code,
-                   "Mnesia is still running on node " <> _},
-                   @command.output({:error, :mnesia_unexpectedly_running}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
 
+    assert match?(
+             {:error, ^exit_code, "Mnesia is still running on node " <> _},
+             @command.output({:error, :mnesia_unexpectedly_running}, context[:opts])
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/change_password_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/change_password_command_test.exs
@@ -10,13 +10,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ChangePasswordCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands. ChangePasswordCommand
-  @user     "user1"
+  @command RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand
+  @user "user1"
   @password "password"
 
   setup_all do
@@ -37,7 +36,7 @@ defmodule ChangePasswordCommandTest do
 
   test "validate: too many positional arguments fails" do
     assert @command.validate(["user", "password", "extra"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: two arguments passes" do
@@ -67,14 +66,16 @@ defmodule ChangePasswordCommandTest do
 
   @tag user: "interloper", password: "new_password"
   test "run: an invalid user returns an error", context do
-    assert @command.run([context[:user], context[:password]], context[:opts]) == {:error, {:no_such_user, "interloper"}}
+    assert @command.run([context[:user], context[:password]], context[:opts]) ==
+             {:error, {:no_such_user, "interloper"}}
   end
 
   @tag user: @user, password: @password
   test "banner", context do
-    assert @command.banner([context[:user], context[:password]], context[:opts])
-      =~ ~r/Changing password for user/
-    assert @command.banner([context[:user], context[:password]], context[:opts])
-      =~ ~r/"#{context[:user]}"/
+    assert @command.banner([context[:user], context[:password]], context[:opts]) =~
+             ~r/Changing password for user/
+
+    assert @command.banner([context[:user], context[:password]], context[:opts]) =~
+             ~r/"#{context[:user]}"/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_global_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_global_parameter_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearGlobalParameterCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -21,7 +20,7 @@ defmodule ClearGlobalParameterCommandTest do
 
   setup context do
     on_exit(context, fn ->
-      clear_global_parameter context[:key]
+      clear_global_parameter(context[:key])
     end)
 
     {
@@ -35,15 +34,17 @@ defmodule ClearGlobalParameterCommandTest do
   test "validate: expects a single argument" do
     assert @command.validate(["one"], %{}) == :ok
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["this is", "too many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this is", "too many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag key: @key
   test "run: when global parameter does not exist, returns an error", context do
     assert @command.run(
-      [context[:key]],
-      context[:opts]
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:key]],
+             context[:opts]
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
@@ -56,9 +57,9 @@ defmodule ClearGlobalParameterCommandTest do
     set_global_parameter(context[:key], @value)
 
     assert @command.run(
-      [context[:key]],
-      context[:opts]
-    ) == :ok
+             [context[:key]],
+             context[:opts]
+           ) == :ok
 
     assert_parameter_empty(context)
   end
@@ -67,20 +68,23 @@ defmodule ClearGlobalParameterCommandTest do
   test "banner", context do
     set_global_parameter(context[:key], @value)
 
-    s = @command.banner(
-      [context[:key]],
-      context[:opts]
-    )
+    s =
+      @command.banner(
+        [context[:key]],
+        context[:opts]
+      )
 
     assert s =~ ~r/Clearing global runtime parameter/
     assert s =~ ~r/"#{context[:key]}"/
   end
 
   defp assert_parameter_empty(context) do
-    parameter = list_global_parameters()
-                |> Enum.filter(fn(param) ->
-                    param[:key] == context[:key]
-                    end)
+    parameter =
+      list_global_parameters()
+      |> Enum.filter(fn param ->
+        param[:key] == context[:key]
+      end)
+
     assert parameter === []
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_operator_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_operator_policy_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearOperatorPolicyCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,10 +17,10 @@ defmodule ClearOperatorPolicyCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -66,16 +65,15 @@ defmodule ClearOperatorPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   test "run: an unreachable node throws a badrpc" do
     opts = %{node: :jake@thedog, vhost: "/", timeout: 200}
     assert match?({:badrpc, _}, @command.run([@key], opts))
   end
-
 
   @tag pattern: @pattern, key: @key, vhost: @vhost
   test "run: if policy exists, returns ok and removes it", context do
@@ -84,9 +82,9 @@ defmodule ClearOperatorPolicyCommandTest do
     set_operator_policy(context[:vhost], context[:key], context[:pattern], @value)
 
     assert @command.run(
-      [context[:key]],
-      vhost_opts
-    ) == :ok
+             [context[:key]],
+             vhost_opts
+           ) == :ok
 
     assert_operator_policy_does_not_exist(context)
   end
@@ -96,9 +94,9 @@ defmodule ClearOperatorPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   @tag key: @key, pattern: @pattern, value: @value, vhost: @vhost
@@ -106,22 +104,25 @@ defmodule ClearOperatorPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
     set_operator_policy(context[:vhost], context[:key], context[:pattern], @value)
 
-    s = @command.banner(
-      [context[:key]],
-      vhost_opts
-    )
+    s =
+      @command.banner(
+        [context[:key]],
+        vhost_opts
+      )
 
     assert s =~ ~r/Clearing operator policy/
     assert s =~ ~r/"#{context[:key]}"/
   end
 
   defp assert_operator_policy_does_not_exist(context) do
-    policy = context[:vhost]
-                |> list_operator_policies
-                |> Enum.filter(fn(param) ->
-                    param[:pattern] == context[:pattern] and
-                    param[:key] == context[:key]
-                    end)
+    policy =
+      context[:vhost]
+      |> list_operator_policies
+      |> Enum.filter(fn param ->
+        param[:pattern] == context[:pattern] and
+          param[:key] == context[:key]
+      end)
+
     assert policy === []
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_parameter_command_test.exs
@@ -4,14 +4,13 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearParameterCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.ClearParameterCommand
   @vhost "test1"
-  @root   "/"
+  @root "/"
   @component_name "federation-upstream"
   @key "reconnect-delay"
   @value "{\"uri\":\"amqp://127.0.0.1:5672\"}"
@@ -19,12 +18,12 @@ defmodule ClearParameterCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     enable_federation_plugin()
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -32,7 +31,7 @@ defmodule ClearParameterCommandTest do
 
   setup context do
     on_exit(context, fn ->
-      clear_parameter context[:vhost], context[:component_name], context[:key]
+      clear_parameter(context[:vhost], context[:component_name], context[:key])
     end)
 
     {
@@ -64,16 +63,15 @@ defmodule ClearParameterCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:component_name], context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:component_name], context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     opts = %{node: :jake@thedog, vhost: "/", timeout: 200}
     assert match?({:badrpc, _}, @command.run([@component_name, @key], opts))
   end
-
 
   @tag component_name: @component_name, key: @key, vhost: @vhost
   test "run: returns ok and clears parameter, if it exists", context do
@@ -82,9 +80,9 @@ defmodule ClearParameterCommandTest do
     set_parameter(context[:vhost], context[:component_name], context[:key], @value)
 
     assert @command.run(
-      [context[:component_name], context[:key]],
-      vhost_opts
-    ) == :ok
+             [context[:component_name], context[:key]],
+             vhost_opts
+           ) == :ok
 
     assert_parameter_empty(context)
   end
@@ -92,10 +90,11 @@ defmodule ClearParameterCommandTest do
   @tag component_name: "bad-component-name", key: @key, value: @value, vhost: @root
   test "run: an invalid component_name returns a 'parameter does not exist' error", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
+
     assert @command.run(
-      [context[:component_name], context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:component_name], context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
 
     assert list_parameters(context[:vhost]) == []
   end
@@ -105,9 +104,9 @@ defmodule ClearParameterCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:component_name], context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:component_name], context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   @tag component_name: @component_name, key: @key, value: @value, vhost: @vhost
@@ -115,10 +114,11 @@ defmodule ClearParameterCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
     set_parameter(context[:vhost], context[:component_name], context[:key], @value)
 
-    s = @command.banner(
-      [context[:component_name], context[:key]],
-      vhost_opts
-    )
+    s =
+      @command.banner(
+        [context[:component_name], context[:key]],
+        vhost_opts
+      )
 
     assert s =~ ~r/Clearing runtime parameter/
     assert s =~ ~r/"#{context[:key]}"/
@@ -127,12 +127,14 @@ defmodule ClearParameterCommandTest do
   end
 
   defp assert_parameter_empty(context) do
-    parameter = context[:vhost]
-                |> list_parameters
-                |> Enum.filter(fn(param) ->
-                    param[:component_name] == context[:component_name] and
-                    param[:key] == context[:key]
-                    end)
+    parameter =
+      context[:vhost]
+      |> list_parameters
+      |> Enum.filter(fn param ->
+        param[:component_name] == context[:component_name] and
+          param[:key] == context[:key]
+      end)
+
     assert parameter === []
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_password_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_password_command_test.exs
@@ -10,13 +10,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearPasswordCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands. ClearPasswordCommand
-  @user     "user1"
+  @command RabbitMQ.CLI.Ctl.Commands.ClearPasswordCommand
+  @user "user1"
   @password "password"
 
   setup_all do
@@ -34,8 +33,9 @@ defmodule ClearPasswordCommandTest do
   test "validate: argument count is correct" do
     assert @command.validate(["username"], %{}) == :ok
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+
     assert @command.validate(["username", "extra"], %{}) ==
-        {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   @tag user: @user, password: @password
@@ -51,7 +51,8 @@ defmodule ClearPasswordCommandTest do
 
   @tag user: "interloper"
   test "run: An invalid username returns a no-such-user error message", context do
-    assert @command.run([context[:user]], context[:opts]) == {:error, {:no_such_user, "interloper"}}
+    assert @command.run([context[:user]], context[:opts]) ==
+             {:error, {:no_such_user, "interloper"}}
   end
 
   @tag user: @user

--- a/deps/rabbitmq_cli/test/ctl/clear_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_permissions_command_test.exs
@@ -10,13 +10,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearPermissionsTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands. ClearPermissionsCommand
-  @user     "user1"
+  @command RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand
+  @user "user1"
   @password "password"
   @default_vhost "/"
   @specific_vhost "vhost1"
@@ -58,7 +57,8 @@ defmodule ClearPermissionsTest do
 
   @tag user: "fake_user"
   test "run: can't clear permissions for non-existing user", context do
-    assert @command.run([context[:user]], context[:opts]) == {:error, {:no_such_user, context[:user]}}
+    assert @command.run([context[:user]], context[:opts]) ==
+             {:error, {:no_such_user, context[:user]}}
   end
 
   @tag user: @user, vhost: @default_vhost
@@ -66,7 +66,7 @@ defmodule ClearPermissionsTest do
     assert @command.run([context[:user]], context[:opts]) == :ok
 
     assert list_permissions(@default_vhost)
-    |> Enum.filter(fn(record) -> record[:user] == context[:user] end) == []
+           |> Enum.filter(fn record -> record[:user] == context[:user] end) == []
   end
 
   test "run: on an invalid node, return a badrpc message" do
@@ -81,12 +81,13 @@ defmodule ClearPermissionsTest do
     assert @command.run([context[:user]], context[:opts]) == :ok
 
     assert list_permissions(context[:vhost])
-    |> Enum.filter(fn(record) -> record[:user] == context[:user] end) == []
+           |> Enum.filter(fn record -> record[:user] == context[:user] end) == []
   end
 
   @tag user: @user, vhost: "bad_vhost"
   test "run: on an invalid vhost, return no_such_vhost error", context do
-    assert @command.run([context[:user]], context[:opts]) == {:error, {:no_such_vhost, context[:vhost]}}
+    assert @command.run([context[:user]], context[:opts]) ==
+             {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag user: @user, vhost: @specific_vhost

--- a/deps/rabbitmq_cli/test/ctl/clear_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_policy_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearPolicyCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,12 +17,12 @@ defmodule ClearPolicyCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     enable_federation_plugin()
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -31,7 +30,7 @@ defmodule ClearPolicyCommandTest do
 
   setup context do
     on_exit(context, fn ->
-      clear_policy context[:vhost], context[:key]
+      clear_policy(context[:vhost], context[:key])
     end)
 
     {
@@ -68,16 +67,15 @@ defmodule ClearPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   test "run: an unreachable node throws a badrpc" do
     opts = %{node: :jake@thedog, vhost: "/", timeout: 200}
     assert match?({:badrpc, _}, @command.run([@key], opts))
   end
-
 
   @tag pattern: @pattern, key: @key, vhost: @vhost
   test "run: if policy exists, returns ok and removes it", context do
@@ -86,9 +84,9 @@ defmodule ClearPolicyCommandTest do
     set_policy(context[:vhost], context[:key], context[:pattern], @value)
 
     assert @command.run(
-      [context[:key]],
-      vhost_opts
-    ) == :ok
+             [context[:key]],
+             vhost_opts
+           ) == :ok
 
     assert_policy_does_not_exist(context)
   end
@@ -98,9 +96,9 @@ defmodule ClearPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:key]],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [context[:key]],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   @tag key: @key, pattern: @pattern, value: @value, vhost: @vhost
@@ -108,22 +106,25 @@ defmodule ClearPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
     set_policy(context[:vhost], context[:key], context[:pattern], @value)
 
-    s = @command.banner(
-      [context[:key]],
-      vhost_opts
-    )
+    s =
+      @command.banner(
+        [context[:key]],
+        vhost_opts
+      )
 
     assert s =~ ~r/Clearing policy/
     assert s =~ ~r/"#{context[:key]}"/
   end
 
   defp assert_policy_does_not_exist(context) do
-    policy = context[:vhost]
-                |> list_policies
-                |> Enum.filter(fn(param) ->
-                    param[:pattern] == context[:pattern] and
-                    param[:key] == context[:key]
-                    end)
+    policy =
+      context[:vhost]
+      |> list_policies
+      |> Enum.filter(fn param ->
+        param[:pattern] == context[:pattern] and
+          param[:key] == context[:key]
+      end)
+
     assert policy === []
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_topic_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_topic_permissions_command_test.exs
@@ -10,13 +10,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearTopicPermissionsTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands. ClearTopicPermissionsCommand
-  @user     "user1"
+  @command RabbitMQ.CLI.Ctl.Commands.ClearTopicPermissionsCommand
+  @user "user1"
   @password "password"
   @specific_vhost "vhost1"
 
@@ -38,6 +37,7 @@ defmodule ClearTopicPermissionsTest do
   setup context do
     set_topic_permissions(@user, @specific_vhost, "amq.topic", "^a", "^b")
     set_topic_permissions(@user, @specific_vhost, "topic1", "^a", "^b")
+
     {
       :ok,
       opts: %{node: get_rabbit_hostname(), vhost: context[:vhost]}
@@ -53,17 +53,21 @@ defmodule ClearTopicPermissionsTest do
     assert @command.validate(["username"], %{}) == :ok
     assert @command.validate(["username", "exchange"], %{}) == :ok
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["this is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag user: "fake_user"
   test "run: can't clear topic permissions for non-existing user", context do
-    assert @command.run([context[:user]], context[:opts]) == {:error, {:no_such_user, context[:user]}}
+    assert @command.run([context[:user]], context[:opts]) ==
+             {:error, {:no_such_user, context[:user]}}
   end
 
   @tag user: @user, vhost: "bad_vhost"
   test "run: on an invalid vhost, return no_such_vhost error", context do
-    assert @command.run([context[:user]], context[:opts]) == {:error, {:no_such_vhost, context[:vhost]}}
+    assert @command.run([context[:user]], context[:opts]) ==
+             {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag user: @user, vhost: @specific_vhost
@@ -93,15 +97,15 @@ defmodule ClearTopicPermissionsTest do
   test "banner with username only", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([context[:user]], vhost_opts)
-          =~ ~r/Clearing topic permissions for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([context[:user]], vhost_opts) =~
+             ~r/Clearing topic permissions for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
   end
 
   @tag user: @user, vhost: @specific_vhost
   test "banner with username and exchange name", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([context[:user], "amq.topic"], vhost_opts)
-          =~ ~r/Clearing topic permissions on \"amq.topic\" for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([context[:user], "amq.topic"], vhost_opts) =~
+             ~r/Clearing topic permissions on \"amq.topic\" for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_user_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_user_limits_command_test.exs
@@ -19,10 +19,10 @@ defmodule ClearUserLimitsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_user @user, @password
+    add_user(@user, @password)
 
     on_exit([], fn ->
-      delete_user @user
+      delete_user(@user)
     end)
 
     :ok
@@ -48,7 +48,9 @@ defmodule ClearUserLimitsCommandTest do
 
   test "validate: providing too many arguments fails validation" do
     assert @command.validate(["is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["this", "is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this", "is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "run: an unreachable node throws a badrpc" do
@@ -63,9 +65,9 @@ defmodule ClearUserLimitsCommandTest do
     assert get_user_limits(@user) != []
 
     assert @command.run(
-      [@user, @limittype],
-      context[:opts]
-    ) == :ok
+             [@user, @limittype],
+             context[:opts]
+           ) == :ok
 
     assert get_user_limits(@user) == %{}
   end
@@ -76,40 +78,38 @@ defmodule ClearUserLimitsCommandTest do
     assert get_user_limits(@user) != []
 
     assert @command.run(
-      [@user, "all"],
-      context[:opts]
-    ) == :ok
+             [@user, "all"],
+             context[:opts]
+           ) == :ok
 
     assert get_user_limits(@user) == %{}
   end
 
   @tag user: "bad-user"
   test "run: a non-existent user returns an error", context do
-
     assert @command.run(
-      [context[:user], @limittype],
-      context[:opts]
-    ) == {:error, {:no_such_user, "bad-user"}}
+             [context[:user], @limittype],
+             context[:opts]
+           ) == {:error, {:no_such_user, "bad-user"}}
   end
 
   test "banner: for a limit type", context do
-
-    s = @command.banner(
-      [@user, @limittype],
-      context[:opts]
-    )
+    s =
+      @command.banner(
+        [@user, @limittype],
+        context[:opts]
+      )
 
     assert s == "Clearing \"#{@limittype}\" limit for user \"#{@user}\" ..."
   end
 
   test "banner: for all", context do
-
-    s = @command.banner(
-      [@user, "all"],
-      context[:opts]
-    )
+    s =
+      @command.banner(
+        [@user, "all"],
+        context[:opts]
+      )
 
     assert s == "Clearing all limits for user \"#{@user}\" ..."
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/clear_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_vhost_limits_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClearVhostLimitsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -16,10 +15,10 @@ defmodule ClearVhostLimitsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -61,7 +60,6 @@ defmodule ClearVhostLimitsCommandTest do
     assert match?({:badrpc, _}, @command.run([], opts))
   end
 
-
   @tag vhost: @vhost
   test "run: if limits exist, returns ok and clears them", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
@@ -71,9 +69,9 @@ defmodule ClearVhostLimitsCommandTest do
     assert get_vhost_limits(context[:vhost]) != []
 
     assert @command.run(
-      [],
-      vhost_opts
-    ) == :ok
+             [],
+             vhost_opts
+           ) == :ok
 
     assert get_vhost_limits(context[:vhost]) == %{}
   end
@@ -83,21 +81,21 @@ defmodule ClearVhostLimitsCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [],
-      vhost_opts
-    ) == {:error_string, 'Parameter does not exist'}
+             [],
+             vhost_opts
+           ) == {:error_string, 'Parameter does not exist'}
   end
 
   @tag vhost: @vhost
   test "banner", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    s = @command.banner(
-      [],
-      vhost_opts
-    )
+    s =
+      @command.banner(
+        [],
+        vhost_opts
+      )
 
     assert s =~ ~r/Clearing vhost \"#{context[:vhost]}\" limits .../
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/close_all_user_connections_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/close_all_user_connections_command_test.exs
@@ -25,10 +25,11 @@ defmodule CloseAllUserConnectionsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "validate: with an invalid number of arguments returns an arg count error", context do
@@ -47,11 +48,14 @@ defmodule CloseAllUserConnectionsCommandTest do
     Application.ensure_all_started(:amqp)
     # open a localhost connection with default username
     {:ok, _conn} = AMQP.Connection.open(virtual_host: @vhost)
-    
-    await_condition(fn ->
-      conns = fetch_user_connections("guest", context)
-      length(conns) > 0
-    end, 10000)
+
+    await_condition(
+      fn ->
+        conns = fetch_user_connections("guest", context)
+        length(conns) > 0
+      end,
+      10000
+    )
 
     # make sure there is a connection to close
     conns = fetch_user_connections("guest", context)
@@ -65,16 +69,21 @@ defmodule CloseAllUserConnectionsCommandTest do
 
     # finally, make sure we can close guest's connections
     assert :ok == @command.run(["guest", "test"], context[:opts])
-    await_condition(fn ->
-      conns = fetch_user_connections("guest", context)
-      length(conns) == 0
-    end, 10000)
+
+    await_condition(
+      fn ->
+        conns = fetch_user_connections("guest", context)
+        length(conns) == 0
+      end,
+      10000
+    )
 
     conns = fetch_user_connections("guest", context)
     assert length(conns) == 0
   end
 
-  test "run: a close connections request on for a non existing user returns successfully", context do
+  test "run: a close connections request on for a non existing user returns successfully",
+       context do
     assert match?(
              :ok,
              @command.run(["yeti", "test"], context[:opts])

--- a/deps/rabbitmq_cli/test/ctl/cluster_status_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/cluster_status_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ClusterStatusCommandTest do
   use ExUnit.Case, async: false
   import TestHelper

--- a/deps/rabbitmq_cli/test/ctl/decode_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/decode_command_test.exs
@@ -9,11 +9,12 @@ defmodule DecodeCommandTest do
   @command RabbitMQ.CLI.Ctl.Commands.DecodeCommand
 
   setup _context do
-    {:ok, opts: %{
-      cipher: :rabbit_pbe.default_cipher,
-      hash: :rabbit_pbe.default_hash,
-      iterations: :rabbit_pbe.default_iterations
-    }}
+    {:ok,
+     opts: %{
+       cipher: :rabbit_pbe.default_cipher(),
+       hash: :rabbit_pbe.default_hash(),
+       iterations: :rabbit_pbe.default_iterations()
+     }}
   end
 
   test "validate: providing exactly 2 positional arguments passes", context do
@@ -21,8 +22,10 @@ defmodule DecodeCommandTest do
   end
 
   test "validate: providing no positional arguments fails", context do
-    assert match?({:validation_failure, {:not_enough_args, _}},
-                  @command.validate([], context[:opts]))
+    assert match?(
+             {:validation_failure, {:not_enough_args, _}},
+             @command.validate([], context[:opts])
+           )
   end
 
   test "validate: providing one positional argument passes", context do
@@ -30,35 +33,51 @@ defmodule DecodeCommandTest do
   end
 
   test "validate: providing three or more positional argument fails", context do
-    assert match?({:validation_failure, :too_many_args},
-                  @command.validate(["value", "secret", "incorrect"], context[:opts]))
+    assert match?(
+             {:validation_failure, :too_many_args},
+             @command.validate(["value", "secret", "incorrect"], context[:opts])
+           )
   end
 
   test "validate: hash and cipher must be supported", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{cipher: :funny_cipher}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher})
+             )
+           )
+
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{hash: :funny_hash}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{hash: :funny_hash})
+             )
+           )
+
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{cipher: :funny_cipher, hash: :funny_hash}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher, hash: :funny_hash})
+             )
+           )
+
     assert :ok == @command.validate(["value", "secret"], context[:opts])
   end
 
   test "validate: number of iterations must greater than 0", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: 0}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: 0}))
+           )
+
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: -1}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: -1}))
+           )
+
     assert :ok == @command.validate(["value", "secret"], context[:opts])
   end
 
@@ -76,19 +95,30 @@ defmodule DecodeCommandTest do
     cipher = context[:opts][:cipher]
     hash = context[:opts][:hash]
     iterations = context[:opts][:iterations]
-    output = {:encrypted, _encrypted} = :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, secret)
+
+    output =
+      {:encrypted, _encrypted} =
+      :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, secret)
 
     {:encrypted, encrypted} = output
     # decode plain value
-    assert {:ok, secret} === @command.run([format_as_erlang_term(encrypted), passphrase], context[:opts])
+    assert {:ok, secret} ===
+             @command.run([format_as_erlang_term(encrypted), passphrase], context[:opts])
+
     # decode {encrypted, ...} tuple form
-    assert {:ok, secret} === @command.run([format_as_erlang_term(output), passphrase], context[:opts])
+    assert {:ok, secret} ===
+             @command.run([format_as_erlang_term(output), passphrase], context[:opts])
 
     # wrong passphrase
-    assert match?({:error, _},
-                  @command.run([format_as_erlang_term(encrypted), "wrong/passphrase"], context[:opts]))
-    assert match?({:error, _},
-                  @command.run([format_as_erlang_term(output), "wrong passphrase"], context[:opts]))
+    assert match?(
+             {:error, _},
+             @command.run([format_as_erlang_term(encrypted), "wrong/passphrase"], context[:opts])
+           )
+
+    assert match?(
+             {:error, _},
+             @command.run([format_as_erlang_term(output), "wrong passphrase"], context[:opts])
+           )
   end
 
   defp format_as_erlang_term(value) do

--- a/deps/rabbitmq_cli/test/ctl/delete_queue_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/delete_queue_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule DeleteQueueCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -20,48 +19,51 @@ defmodule DeleteQueueCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        vhost: @vhost,
-        timeout: context[:test_timeout],
-        if_empty: false,
-        if_unused: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       vhost: @vhost,
+       timeout: context[:test_timeout],
+       if_empty: false,
+       if_unused: false
+     }}
   end
 
   test "merge_defaults: defaults can be overridden" do
-    assert @command.merge_defaults([], %{}) == {[], %{vhost: "/", if_empty: false, if_unused: false}}
+    assert @command.merge_defaults([], %{}) ==
+             {[], %{vhost: "/", if_empty: false, if_unused: false}}
+
     assert @command.merge_defaults([], %{vhost: "non_default", if_empty: true}) ==
-            {[], %{vhost: "non_default", if_empty: true, if_unused: false}}
+             {[], %{vhost: "non_default", if_empty: true, if_unused: false}}
   end
 
   test "validate: providing no queue name fails validation", context do
     assert match?(
-      {:validation_failure, :not_enough_args},
-      @command.validate([], context[:opts])
-    )
+             {:validation_failure, :not_enough_args},
+             @command.validate([], context[:opts])
+           )
   end
 
   test "validate: providing an empty queue name fails validation", context do
     assert match?(
-      {:validation_failure, {:bad_argument, "queue name cannot be an empty string"}},
-      @command.validate([""], context[:opts])
-    )
+             {:validation_failure, {:bad_argument, "queue name cannot be an empty string"}},
+             @command.validate([""], context[:opts])
+           )
   end
 
   test "validate: providing a non-blank queue name and -u succeeds", context do
     assert @command.validate(["a-queue"], %{
-      node: get_rabbit_hostname(),
-      vhost: @vhost,
-      timeout: context[:test_timeout],
-      if_unused: false
-    }) == :ok
+             node: get_rabbit_hostname(),
+             vhost: @vhost,
+             timeout: context[:test_timeout],
+             if_unused: false
+           }) == :ok
   end
 
   @tag test_timeout: 30000
   test "run: request to an existent queue on active node succeeds", context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
     on_exit(context, fn -> delete_vhost(@vhost) end)
 
     q = "foo"
@@ -81,8 +83,8 @@ defmodule DeleteQueueCommandTest do
 
   @tag test_timeout: 0
   test "run: timeout causes command to return a bad RPC", context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
     on_exit(context, fn -> delete_vhost(@vhost) end)
 
     q = "foo"
@@ -96,11 +98,13 @@ defmodule DeleteQueueCommandTest do
   end
 
   test "defaults to vhost /" do
-    assert @command.merge_defaults(["foo"], %{bar: "baz"}) == {["foo"], %{bar: "baz", vhost: "/", if_unused: false, if_empty: false}}
+    assert @command.merge_defaults(["foo"], %{bar: "baz"}) ==
+             {["foo"], %{bar: "baz", vhost: "/", if_unused: false, if_empty: false}}
   end
 
   test "validate: with extra arguments returns an arg count error" do
-    assert @command.validate(["queue-name", "extra"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["queue-name", "extra"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: with no arguments returns an arg count error" do
@@ -112,8 +116,13 @@ defmodule DeleteQueueCommandTest do
   end
 
   test "banner informs that vhost's queue is deleted" do
-    assert @command.banner(["my-q"], %{vhost: "/foo", if_empty: false, if_unused: false}) == "Deleting queue 'my-q' on vhost '/foo' ..."
-    assert @command.banner(["my-q"], %{vhost: "/foo", if_empty: true, if_unused: false}) == "Deleting queue 'my-q' on vhost '/foo' if queue is empty ..."
-    assert @command.banner(["my-q"], %{vhost: "/foo", if_empty: true, if_unused: true}) == "Deleting queue 'my-q' on vhost '/foo' if queue is empty and if queue is unused ..."
+    assert @command.banner(["my-q"], %{vhost: "/foo", if_empty: false, if_unused: false}) ==
+             "Deleting queue 'my-q' on vhost '/foo' ..."
+
+    assert @command.banner(["my-q"], %{vhost: "/foo", if_empty: true, if_unused: false}) ==
+             "Deleting queue 'my-q' on vhost '/foo' if queue is empty ..."
+
+    assert @command.banner(["my-q"], %{vhost: "/foo", if_empty: true, if_unused: true}) ==
+             "Deleting queue 'my-q' on vhost '/foo' if queue is empty and if queue is unused ..."
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/delete_user_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/delete_user_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule DeleteUserCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -36,7 +35,7 @@ defmodule DeleteUserCommandTest do
   test "run: A valid username returns ok", context do
     assert @command.run([context[:user]], context[:opts]) == :ok
 
-    assert list_users() |> Enum.count(fn(record) -> record[:user] == context[:user] end) == 0
+    assert list_users() |> Enum.count(fn record -> record[:user] == context[:user] end) == 0
   end
 
   test "run: An invalid Rabbit node returns a bad rpc message" do

--- a/deps/rabbitmq_cli/test/ctl/delete_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/delete_vhost_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule DeleteVhostCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -35,14 +34,14 @@ defmodule DeleteVhostCommandTest do
   test "run: A valid name to an active RabbitMQ node is successful", context do
     assert @command.run([context[:vhost]], context[:opts]) == :ok
 
-    assert list_vhosts() |> Enum.count(fn(record) -> record[:name] == context[:vhost] end) == 0
+    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 0
   end
 
   @tag vhost: ""
   test "run: An empty string to an active RabbitMQ node is successful", context do
     assert @command.run([context[:vhost]], context[:opts]) == :ok
 
-    assert list_vhosts() |> Enum.count(fn(record) -> record[:name] == context[:vhost] end) == 0
+    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 0
   end
 
   test "run: A call to invalid or inactive RabbitMQ node returns a nodedown" do
@@ -54,8 +53,9 @@ defmodule DeleteVhostCommandTest do
   @tag vhost: @vhost
   test "run: Deleting the same host twice results in a host not found message", context do
     @command.run([context[:vhost]], context[:opts])
+
     assert @command.run([context[:vhost]], context[:opts]) ==
-      {:error, {:no_such_vhost, context[:vhost]}}
+             {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag vhost: @vhost

--- a/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule EnableFeatureFlagCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -17,29 +16,41 @@ defmodule EnableFeatureFlagCommandTest do
 
     # Define an arbitrary feature flag for the test.
     node = get_rabbit_hostname()
+
     new_feature_flags = %{
-      @feature_flag =>
-      %{desc: "My feature flag",
+      @feature_flag => %{
+        desc: "My feature flag",
         provided_by: :EnableFeatureFlagCommandTest,
-        stability: :stable}}
-    :ok = :rabbit_misc.rpc_call(
-      node, :rabbit_feature_flags, :inject_test_feature_flags,
-      [new_feature_flags])
+        stability: :stable
+      }
+    }
+
+    :ok =
+      :rabbit_misc.rpc_call(
+        node,
+        :rabbit_feature_flags,
+        :inject_test_feature_flags,
+        [new_feature_flags]
+      )
 
     {
       :ok,
-      opts: %{node: get_rabbit_hostname()},
-      feature_flag: @feature_flag
+      opts: %{node: get_rabbit_hostname()}, feature_flag: @feature_flag
     }
   end
 
   test "validate: wrong number of arguments results in arg count errors" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["ff_from_enable_ff_testsuite", "whoops"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["ff_from_enable_ff_testsuite", "whoops"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: passing an empty string for feature_flag name is an arg error", context do
-    assert match?({:validation_failure, {:bad_argument, _}}, @command.validate([""], context[:opts]))
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([""], context[:opts])
+           )
   end
 
   test "run: passing a valid feature_flag name to a running RabbitMQ node succeeds", context do
@@ -53,19 +64,19 @@ defmodule EnableFeatureFlagCommandTest do
   end
 
   test "run: enabling the same feature flag twice is idempotent", context do
-    enable_feature_flag context[:feature_flag]
+    enable_feature_flag(context[:feature_flag])
     assert @command.run([Atom.to_string(context[:feature_flag])], context[:opts]) == :ok
     assert list_feature_flags(:enabled) |> Map.has_key?(context[:feature_flag])
   end
 
   test "run: enabling all feature flags succeeds", context do
-    enable_feature_flag context[:feature_flag]
+    enable_feature_flag(context[:feature_flag])
     assert @command.run(["all"], context[:opts]) == :ok
     assert list_feature_flags(:enabled) |> Map.has_key?(context[:feature_flag])
   end
 
   test "banner", context do
-    assert @command.banner([context[:feature_flag]], context[:opts])
-      =~ ~r/Enabling feature flag \"#{context[:feature_flag]}\" \.\.\./
+    assert @command.banner([context[:feature_flag]], context[:opts]) =~
+             ~r/Enabling feature flag \"#{context[:feature_flag]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/encode_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/encode_command_test.exs
@@ -10,11 +10,12 @@ defmodule EncodeCommandTest do
   @command RabbitMQ.CLI.Ctl.Commands.EncodeCommand
 
   setup _context do
-    {:ok, opts: %{
-      cipher: :rabbit_pbe.default_cipher,
-      hash: :rabbit_pbe.default_hash,
-      iterations: :rabbit_pbe.default_iterations
-    }}
+    {:ok,
+     opts: %{
+       cipher: :rabbit_pbe.default_cipher(),
+       hash: :rabbit_pbe.default_hash(),
+       iterations: :rabbit_pbe.default_iterations()
+     }}
   end
 
   test "validate: providing exactly 2 positional arguments passes", context do
@@ -27,35 +28,51 @@ defmodule EncodeCommandTest do
   end
 
   test "validate: providing three or more positional argument fails", context do
-    assert match?({:validation_failure, :too_many_args},
-                  @command.validate(["value", "secret", "incorrect"], context[:opts]))
+    assert match?(
+             {:validation_failure, :too_many_args},
+             @command.validate(["value", "secret", "incorrect"], context[:opts])
+           )
   end
 
   test "validate: hash and cipher must be supported", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{cipher: :funny_cipher}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher})
+             )
+           )
+
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{hash: :funny_hash}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{hash: :funny_hash})
+             )
+           )
+
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{cipher: :funny_cipher, hash: :funny_hash}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher, hash: :funny_hash})
+             )
+           )
+
     assert :ok == @command.validate(["value", "secret"], context[:opts])
   end
 
   test "validate: number of iterations must greater than 0", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: 0}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: 0}))
+           )
+
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: -1}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: -1}))
+           )
+
     assert :ok == @command.validate(["value", "secret"], context[:opts])
   end
 
@@ -79,9 +96,18 @@ defmodule EncodeCommandTest do
     {:ok, output} = @command.run([secret_as_erlang_term, passphrase], context[:opts])
     {:encrypted, encrypted} = output
     # decode plain value
-    assert secret === :rabbit_pbe.decrypt_term(cipher, hash, iterations, passphrase, {:plaintext, secret})
+    assert secret ===
+             :rabbit_pbe.decrypt_term(cipher, hash, iterations, passphrase, {:plaintext, secret})
+
     # decode {encrypted, ...} tuple form
-    assert secret === :rabbit_pbe.decrypt_term(cipher, hash, iterations, passphrase, {:encrypted, encrypted})
+    assert secret ===
+             :rabbit_pbe.decrypt_term(
+               cipher,
+               hash,
+               iterations,
+               passphrase,
+               {:encrypted, encrypted}
+             )
   end
 
   defp format_as_erlang_term(value) do

--- a/deps/rabbitmq_cli/test/ctl/environment_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/environment_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule EnvironmentCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -39,7 +38,7 @@ defmodule EnvironmentCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts])
-      =~ ~r/Application environment of node #{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Application environment of node #{get_rabbit_hostname()}/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/eval_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/eval_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule EvalCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -28,12 +27,17 @@ defmodule EvalCommandTest do
 
   test "validate: empty expression to eval fails validation" do
     assert @command.validate([""], %{}) == {:validation_failure, "Expression must not be blank"}
-    assert @command.validate(["", "foo"], %{}) == {:validation_failure, "Expression must not be blank"}
+
+    assert @command.validate(["", "foo"], %{}) ==
+             {:validation_failure, "Expression must not be blank"}
   end
 
   test "validate: syntax error in expression to eval fails validation" do
-    assert @command.validate(["foo bar"], %{}) == {:validation_failure, "syntax error before: bar"}
-    assert @command.validate(["foo bar", "foo"], %{}) == {:validation_failure, "syntax error before: bar"}
+    assert @command.validate(["foo bar"], %{}) ==
+             {:validation_failure, "syntax error before: bar"}
+
+    assert @command.validate(["foo bar", "foo"], %{}) ==
+             {:validation_failure, "syntax error before: bar"}
   end
 
   test "run: request to a non-existent node returns a badrpc", _context do
@@ -58,8 +62,8 @@ defmodule EvalCommandTest do
 
   test "run: returns stdout output", context do
     assert capture_io(fn ->
-      assert @command.run(["io:format(\"output\")."], context[:opts]) == {:ok, :ok}
-    end) == "output"
+             assert @command.run(["io:format(\"output\")."], context[:opts]) == {:ok, :ok}
+           end) == "output"
   end
 
   test "run: passes parameters to the expression as positional/numerical variables", context do
@@ -69,6 +73,6 @@ defmodule EvalCommandTest do
 
   test "run: passes globally recognised options as named variables", context do
     assert @command.run(["{_vhost, _node}."], Map.put(context[:opts], :vhost, "a-node")) ==
-      {:ok, {"a-node", context[:opts][:node]}}
+             {:ok, {"a-node", context[:opts][:node]}}
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/eval_file_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/eval_file_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule EvalFileCommandTest do
   use ExUnit.Case, async: false
   import TestHelper

--- a/deps/rabbitmq_cli/test/ctl/exec_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/exec_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ExecCommandTest do
   use ExUnit.Case, async: false
 
@@ -43,5 +42,4 @@ defmodule ExecCommandTest do
     {:ok, ^opts} = @command.run(["options"], opts)
     {:ok, 123} = @command.run(["options[:option]"], opts)
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/export_definitions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/export_definitions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ExportDefinitionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,11 +17,12 @@ defmodule ExportDefinitionsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        format: context[:format] || "json"
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       format: context[:format] || "json"
+     }}
   end
 
   test "merge_defaults: defaults to JSON for format" do
@@ -37,6 +37,7 @@ defmodule ExportDefinitionsCommandTest do
   test "merge_defaults: format is case insensitive" do
     assert @command.merge_defaults([valid_file_path()], %{format: "JSON"}) ==
              {[valid_file_path()], %{format: "json"}}
+
     assert @command.merge_defaults([valid_file_path()], %{format: "Erlang"}) ==
              {[valid_file_path()], %{format: "erlang"}}
   end
@@ -55,11 +56,13 @@ defmodule ExportDefinitionsCommandTest do
   end
 
   test "validate: unsupported format fails validation", context do
-    assert match?({:validation_failure, {:bad_argument, _}},
-                  @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "yolo"})))
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "yolo"}))
+           )
   end
 
-    test "validate: no positional arguments fails validation", context do
+  test "validate: no positional arguments fails validation", context do
     assert @command.validate([], context[:opts]) ==
              {:validation_failure, :not_enough_args}
   end
@@ -70,16 +73,21 @@ defmodule ExportDefinitionsCommandTest do
   end
 
   test "validate: supports JSON and Erlang formats", context do
-    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "json"})) == :ok
-    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "erlang"})) == :ok
+    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "json"})) ==
+             :ok
+
+    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "erlang"})) ==
+             :ok
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    result = @command.run([valid_file_path()],
-                          %{node: :jake@thedog,
-                            timeout: context[:test_timeout],
-                            format: "json"})
+    result =
+      @command.run(
+        [valid_file_path()],
+        %{node: :jake@thedog, timeout: context[:test_timeout], format: "json"}
+      )
+
     assert match?({:badrpc, _}, result)
   end
 
@@ -90,13 +98,15 @@ defmodule ExportDefinitionsCommandTest do
   end
 
   @tag format: "erlang"
-  test "run: returns a list of definitions when target is stdout and format is Erlang Terms", context do
+  test "run: returns a list of definitions when target is stdout and format is Erlang Terms",
+       context do
     {:ok, map} = @command.run(["-"], context[:opts])
     assert Map.has_key?(map, :rabbitmq_version)
   end
 
   @tag format: "json"
-  test "run: writes to a file and returns nil when target is a file and format is JSON", context do
+  test "run: writes to a file and returns nil when target is a file and format is JSON",
+       context do
     File.rm(valid_file_path())
     {:ok, nil} = @command.run([valid_file_path()], context[:opts])
 
@@ -125,7 +135,8 @@ defmodule ExportDefinitionsCommandTest do
   end
 
   @tag format: "erlang"
-  test "run: writes to a file and returns nil when target is a file and format is Erlang Terms", context do
+  test "run: writes to a file and returns nil when target is a file and format is Erlang Terms",
+       context do
     File.rm(valid_file_path())
     {:ok, nil} = @command.run([valid_file_path()], context[:opts])
 

--- a/deps/rabbitmq_cli/test/ctl/force_gc_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/force_gc_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ForceGcCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -26,7 +25,6 @@ defmodule ForceGcCommandTest do
   setup do
     {:ok, opts: %{node: get_rabbit_hostname(), timeout: 200}}
   end
-
 
   test "merge_defaults: merge not defaults" do
     assert @command.merge_defaults([], %{}) == {[], %{}}

--- a/deps/rabbitmq_cli/test/ctl/force_reset_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/force_reset_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ForceResetCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -32,9 +31,9 @@ defmodule ForceResetCommandTest do
   end
 
   test "run: force reset request to an active node with a stopped rabbit app succeeds", context do
-    add_vhost "some_vhost"
+    add_vhost("some_vhost")
     # ensure the vhost really does exist
-    assert vhost_exists? "some_vhost"
+    assert vhost_exists?("some_vhost")
     stop_rabbitmq_app()
     assert :ok == @command.run([], context[:opts])
     start_rabbitmq_app()
@@ -43,10 +42,10 @@ defmodule ForceResetCommandTest do
   end
 
   test "run: reset request to an active node with a running rabbit app fails", context do
-    add_vhost "some_vhost"
-    assert vhost_exists? "some_vhost"
+    add_vhost("some_vhost")
+    assert vhost_exists?("some_vhost")
     assert match?({:error, :mnesia_unexpectedly_running}, @command.run([], context[:opts]))
-    assert vhost_exists? "some_vhost"
+    assert vhost_exists?("some_vhost")
   end
 
   test "run: request to a non-existent node returns a badrpc" do
@@ -55,14 +54,16 @@ defmodule ForceResetCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts]) =~ ~r/Forcefully resetting node #{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Forcefully resetting node #{get_rabbit_hostname()}/
   end
 
   test "output mnesia is running error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code,
-                   "Mnesia is still running on node " <> _},
-                   @command.output({:error, :mnesia_unexpectedly_running}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
 
+    assert match?(
+             {:error, ^exit_code, "Mnesia is still running on node " <> _},
+             @command.output({:error, :mnesia_unexpectedly_running}, context[:opts])
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/help_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/help_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule HelpCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -28,7 +27,7 @@ defmodule HelpCommandTest do
 
   test "validate: providing two or more position arguments fails validation" do
     assert @command.validate(["extra1", "extra2"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: prints basic usage info" do
@@ -39,38 +38,43 @@ defmodule HelpCommandTest do
   end
 
   test "run: ctl command usage info is printed if command is specified" do
-    ctl_commands = CommandModules.module_map
-    |> Enum.filter(fn({_name, command_mod}) ->
-                     to_string(command_mod) =~ ~r/^RabbitMQ\.CLI\.Ctl\.Commands/
-                   end)
-    |> Enum.map(fn({name, _}) -> name end)
+    ctl_commands =
+      CommandModules.module_map()
+      |> Enum.filter(fn {_name, command_mod} ->
+        to_string(command_mod) =~ ~r/^RabbitMQ\.CLI\.Ctl\.Commands/
+      end)
+      |> Enum.map(fn {name, _} -> name end)
 
     IO.inspect(ctl_commands)
+
     Enum.each(
       ctl_commands,
-      fn(command) ->
+      fn command ->
         assert @command.run([command], %{}) =~ ~r/#{command}/
-      end)
+      end
+    )
   end
 
   test "run prints command info" do
-    ctl_commands = CommandModules.module_map
-    |> Enum.filter(fn({_name, command_mod}) ->
-                     to_string(command_mod) =~ ~r/^RabbitMQ\.CLI\.Ctl\.Commands/
-                   end)
-    |> Enum.map(fn({name, _}) -> name end)
+    ctl_commands =
+      CommandModules.module_map()
+      |> Enum.filter(fn {_name, command_mod} ->
+        to_string(command_mod) =~ ~r/^RabbitMQ\.CLI\.Ctl\.Commands/
+      end)
+      |> Enum.map(fn {name, _} -> name end)
 
     Enum.each(
       ctl_commands,
-      fn(command) ->
+      fn command ->
         {:ok, lines} = @command.run([], %{})
         output = Enum.join(lines, "\n")
         assert output =~ ~r/\n\s+#{command}.*\n/
-      end)
+      end
+    )
   end
 
   test "run: exits with the code of OK" do
     assert @command.output({:ok, "Help string"}, %{}) ==
-      {:ok, "Help string"}
+             {:ok, "Help string"}
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/import_definitions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/import_definitions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ImportDefinitionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,11 +17,12 @@ defmodule ImportDefinitionsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        format: context[:format] || "json"
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       format: context[:format] || "json"
+     }}
   end
 
   test "merge_defaults: defaults to JSON for format" do
@@ -37,6 +37,7 @@ defmodule ImportDefinitionsCommandTest do
   test "merge_defaults: format is case insensitive" do
     assert @command.merge_defaults([valid_file_path()], %{format: "JSON"}) ==
              {[valid_file_path()], %{format: "json", skip_if_unchanged: false}}
+
     assert @command.merge_defaults([valid_file_path()], %{format: "Erlang"}) ==
              {[valid_file_path()], %{format: "erlang", skip_if_unchanged: false}}
   end
@@ -51,8 +52,10 @@ defmodule ImportDefinitionsCommandTest do
   end
 
   test "validate: unsupported format fails validation", context do
-    assert match?({:validation_failure, {:bad_argument, _}},
-                  @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "yolo"})))
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "yolo"}))
+           )
   end
 
   test "validate: more than one positional argument fails validation", context do
@@ -61,16 +64,21 @@ defmodule ImportDefinitionsCommandTest do
   end
 
   test "validate: supports JSON and Erlang formats", context do
-    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "json"})) == :ok
-    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "erlang"})) == :ok
+    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "json"})) ==
+             :ok
+
+    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "erlang"})) ==
+             :ok
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    result = @command.run([valid_file_path()],
-                          %{node: :jake@thedog,
-                            timeout: context[:test_timeout],
-                            format: "json"})
+    result =
+      @command.run(
+        [valid_file_path()],
+        %{node: :jake@thedog, timeout: context[:test_timeout], format: "json"}
+      )
+
     assert match?({:badrpc, _}, result)
   end
 
@@ -84,7 +92,11 @@ defmodule ImportDefinitionsCommandTest do
 
   @tag format: "json"
   test "run: imports definitions from a file when --skip-if-unchanged is provided", context do
-    assert :ok == @command.run([valid_file_path()], Map.merge(context[:opts], %{skip_if_unchanged: true}))
+    assert :ok ==
+             @command.run(
+               [valid_file_path()],
+               Map.merge(context[:opts], %{skip_if_unchanged: true})
+             )
 
     # clean up the state we've modified
     clear_parameter("/", "federation-upstream", "up-1")

--- a/deps/rabbitmq_cli/test/ctl/join_cluster_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/join_cluster_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2016-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule JoinClusterCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -24,49 +23,56 @@ defmodule JoinClusterCommandTest do
   end
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname(),
-      disc: true,
-      ram: false,
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       disc: true,
+       ram: false
+     }}
   end
 
   test "validate: specifying both --disc and --ram is reported as invalid", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["a"], Map.merge(context[:opts], %{disc: true, ram: true}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["a"], Map.merge(context[:opts], %{disc: true, ram: true}))
+           )
   end
+
   test "validate: specifying no target node is reported as an error", context do
     assert @command.validate([], context[:opts]) ==
-      {:validation_failure, :not_enough_args}
+             {:validation_failure, :not_enough_args}
   end
+
   test "validate: specifying multiple target nodes is reported as an error", context do
     assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   # TODO
-  #test "run: successful join as a disc node", context do
-  #end
+  # test "run: successful join as a disc node", context do
+  # end
 
   # TODO
-  #test "run: successful join as a RAM node", context do
-  #end
+  # test "run: successful join as a RAM node", context do
+  # end
 
   test "run: joining self is invalid", context do
     stop_rabbitmq_app()
+
     assert match?(
-      {:error, :cannot_cluster_node_with_itself},
-      @command.run([context[:opts][:node]], context[:opts]))
+             {:error, :cannot_cluster_node_with_itself},
+             @command.run([context[:opts][:node]], context[:opts])
+           )
+
     start_rabbitmq_app()
   end
 
   # TODO
   test "run: request to an active node fails", context do
-   assert match?(
-     {:error, :mnesia_unexpectedly_running},
-    @command.run([context[:opts][:node]], context[:opts]))
+    assert match?(
+             {:error, :mnesia_unexpectedly_running},
+             @command.run([context[:opts][:node]], context[:opts])
+           )
   end
 
   test "run: request to a non-existent node returns a badrpc", context do
@@ -76,29 +82,35 @@ defmodule JoinClusterCommandTest do
       ram: false,
       timeout: 200
     }
+
     assert match?(
-      {:badrpc, _},
-      @command.run([context[:opts][:node]], opts))
+             {:badrpc, _},
+             @command.run([context[:opts][:node]], opts)
+           )
   end
 
   test "run: joining a non-existent node returns a badrpc", context do
     stop_rabbitmq_app()
+
     assert match?(
-      {:badrpc_multi, _, [_]},
-      @command.run([:jake@thedog], context[:opts]))
+             {:badrpc_multi, _, [_]},
+             @command.run([:jake@thedog], context[:opts])
+           )
+
     start_rabbitmq_app()
   end
 
   test "banner", context do
     assert @command.banner(["a"], context[:opts]) =~
-      ~r/Clustering node #{get_rabbit_hostname()} with a/
+             ~r/Clustering node #{get_rabbit_hostname()} with a/
   end
 
   test "output mnesia is running error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code,
-                   "Mnesia is still running on node " <> _},
-                   @command.output({:error, :mnesia_unexpectedly_running}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
 
+    assert match?(
+             {:error, ^exit_code, "Mnesia is still running on node " <> _},
+             @command.output({:error, :mnesia_unexpectedly_running}, context[:opts])
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_bindings_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_bindings_command_test.exs
@@ -14,11 +14,13 @@ defmodule ListBindingsCommandTest do
   end
 
   setup context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
+
     on_exit(fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
+
     {
       :ok,
       opts: %{
@@ -30,7 +32,9 @@ defmodule ListBindingsCommandTest do
   end
 
   test "merge_defaults: adds all keys if none specificed", context do
-    default_keys = ~w(source_name source_kind destination_name destination_kind routing_key arguments)
+    default_keys =
+      ~w(source_name source_kind destination_name destination_kind routing_key arguments)
+
     declare_queue("test_queue", @vhost)
     :timer.sleep(100)
 
@@ -45,27 +49,29 @@ defmodule ListBindingsCommandTest do
 
   test "validate: returns bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: returns multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "source_name"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["source_name", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["source_kind", "oink", "source_name"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   @tag test_timeout: 0
   test "run: timeout causes command to return badrpc", context do
     assert run_command_to_list(@command, [["source_name"], context[:opts]]) ==
-      [{:badrpc, {:timeout, 0.0}}]
+             [{:badrpc, {:timeout, 0.0}}]
   end
 
   test "run: no bindings for no queues", context do
@@ -75,8 +81,9 @@ defmodule ListBindingsCommandTest do
   test "run: can filter info keys", context do
     wanted_keys = ~w(source_name destination_name routing_key)
     declare_queue("test_queue", @vhost)
+
     assert run_command_to_list(@command, [wanted_keys, context[:opts]]) ==
-            [[source_name: "", destination_name: "test_queue", routing_key: "test_queue"]]
+             [[source_name: "", destination_name: "test_queue", routing_key: "test_queue"]]
   end
 
   test "banner" do

--- a/deps/rabbitmq_cli/test/ctl/list_ciphers_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_ciphers_command_test.exs
@@ -22,8 +22,8 @@ defmodule ListCiphersCommandTest do
 
   test "run: lists ciphers", _context do
     assert match?(
-      {:ok, _},
-      @command.run([], %{})
-    )
+             {:ok, _},
+             @command.run([], %{})
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_connections_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_connections_command_test.exs
@@ -30,7 +30,8 @@ defmodule ListConnectionsCommandTest do
   end
 
   test "merge_defaults: user, peer_host, peer_port and state by default" do
-    assert @command.merge_defaults([], %{}) == {~w(user peer_host peer_port state), @default_options}
+    assert @command.merge_defaults([], %{}) ==
+             {~w(user peer_host peer_port state), @default_options}
   end
 
   test "merge_defaults: includes table headers by default", _context do
@@ -40,51 +41,54 @@ defmodule ListConnectionsCommandTest do
 
   test "validate: returns bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "peer_host"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["user", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["user", "oink", "peer_host"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   @tag test_timeout: 0
   test "run: timeout causes command to return badrpc", context do
     assert run_command_to_list(@command, [["name"], context[:opts]]) ==
-      [{:badrpc, {:timeout, 0.0}}]
+             [{:badrpc, {:timeout, 0.0}}]
   end
 
   test "run: filter single key", context do
     vhost = "/"
-    with_connection(vhost, fn(_conn) ->
+
+    with_connection(vhost, fn _conn ->
       conns = run_command_to_list(@command, [["name"], context[:opts]])
-      assert (Enum.map(conns, &Keyword.keys/1) |> Enum.uniq) == [[:name]]
-      assert Enum.any?(conns, fn(conn) -> conn[:name] != nil end)
+      assert Enum.map(conns, &Keyword.keys/1) |> Enum.uniq() == [[:name]]
+      assert Enum.any?(conns, fn conn -> conn[:name] != nil end)
     end)
   end
 
   test "run: show connection vhost", context do
     vhost = "custom_vhost"
-    add_vhost vhost
-    set_permissions @user, vhost, [".*", ".*", ".*"]
+    add_vhost(vhost)
+    set_permissions(@user, vhost, [".*", ".*", ".*"])
+
     on_exit(fn ->
-      delete_vhost vhost
+      delete_vhost(vhost)
     end)
-    with_connection(vhost, fn(_conn) ->
+
+    with_connection(vhost, fn _conn ->
       conns = run_command_to_list(@command, [["vhost"], context[:opts]])
-      assert (Enum.map(conns, &Keyword.keys/1) |> Enum.uniq) == [[:vhost]]
-      assert Enum.any?(conns, fn(conn) -> conn[:vhost] == vhost end)
+      assert Enum.map(conns, &Keyword.keys/1) |> Enum.uniq() == [[:vhost]]
+      assert Enum.any?(conns, fn conn -> conn[:vhost] == vhost end)
     end)
   end
-
-
 end

--- a/deps/rabbitmq_cli/test/ctl/list_consumers_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_consumers_command_test.exs
@@ -17,11 +17,13 @@ defmodule ListConsumersCommandTest do
   end
 
   setup context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
+
     on_exit(fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
+
     {
       :ok,
       opts: %{
@@ -34,33 +36,36 @@ defmodule ListConsumersCommandTest do
 
   test "merge_defaults: defaults can be overridden" do
     assert @command.merge_defaults([], %{}) == {@info_keys, @default_options}
-    assert @command.merge_defaults([], %{vhost: "non_default"}) == {@info_keys, %{vhost: "non_default",
-                                                                                  table_headers: true}}
+
+    assert @command.merge_defaults([], %{vhost: "non_default"}) ==
+             {@info_keys, %{vhost: "non_default", table_headers: true}}
   end
 
   test "validate: returns bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: returns multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "queue_name"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["queue_name", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["channel_pid", "oink", "queue_name"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   @tag test_timeout: 0
   test "run: zero timeout causes command to return badrpc", context do
-      assert run_command_to_list(@command, [["queue_name"], context[:opts]]) ==
-        [{:badrpc, {:timeout, 0.0}}]
+    assert run_command_to_list(@command, [["queue_name"], context[:opts]]) ==
+             [{:badrpc, {:timeout, 0.0}}]
   end
 
   test "run: no consumers for no open connections", context do
@@ -74,17 +79,23 @@ defmodule ListConsumersCommandTest do
     info_keys_s = ~w(queue_name channel_pid consumer_tag ack_required prefetch_count arguments)
     info_keys_a = Enum.map(info_keys_s, &String.to_atom/1)
     declare_queue(queue_name, @vhost)
-    with_channel(@vhost, fn(channel) ->
-      {:ok, _} = AMQP.Basic.consume(channel, queue_name, nil, [consumer_tag: consumer_tag])
+
+    with_channel(@vhost, fn channel ->
+      {:ok, _} = AMQP.Basic.consume(channel, queue_name, nil, consumer_tag: consumer_tag)
       :timer.sleep(100)
       [[consumer]] = run_command_to_list(@command, [info_keys_s, context[:opts]])
       assert info_keys_a == Keyword.keys(consumer)
       assert consumer[:consumer_tag] == consumer_tag
       assert consumer[:queue_name] == queue_name
-      assert Keyword.delete(consumer, :channel_pid) ==
-        [queue_name: queue_name, consumer_tag: consumer_tag,
-         ack_required: true, prefetch_count: 0, arguments: []]
 
+      assert Keyword.delete(consumer, :channel_pid) ==
+               [
+                 queue_name: queue_name,
+                 consumer_tag: consumer_tag,
+                 ack_required: true,
+                 prefetch_count: 0,
+                 arguments: []
+               ]
     end)
   end
 
@@ -93,17 +104,29 @@ defmodule ListConsumersCommandTest do
     queue_name2 = "test_queue2"
     declare_queue("test_queue1", @vhost)
     declare_queue("test_queue2", @vhost)
-    with_channel(@vhost, fn(channel) ->
+
+    with_channel(@vhost, fn channel ->
       {:ok, tag1} = AMQP.Basic.consume(channel, queue_name1)
       {:ok, tag2} = AMQP.Basic.consume(channel, queue_name2)
       {:ok, tag3} = AMQP.Basic.consume(channel, queue_name2)
       :timer.sleep(100)
+
       try do
-        consumers = run_command_to_list(@command, [["queue_name", "consumer_tag"], context[:opts]])
-        {[[consumer1]], [consumers2]} = Enum.split_with(consumers, fn([_]) -> true; ([_,_]) -> false end)
+        consumers =
+          run_command_to_list(@command, [["queue_name", "consumer_tag"], context[:opts]])
+
+        {[[consumer1]], [consumers2]} =
+          Enum.split_with(consumers, fn
+            [_] -> true
+            [_, _] -> false
+          end)
+
         assert [queue_name: queue_name1, consumer_tag: tag1] == consumer1
-        assert Keyword.equal?([{tag2, queue_name2}, {tag3, queue_name2}],
-          for([queue_name: q, consumer_tag: t] <- consumers2, do: {t, q}))
+
+        assert Keyword.equal?(
+                 [{tag2, queue_name2}, {tag3, queue_name2}],
+                 for([queue_name: q, consumer_tag: t] <- consumers2, do: {t, q})
+               )
       after
         AMQP.Basic.cancel(channel, tag1)
         AMQP.Basic.cancel(channel, tag2)
@@ -114,20 +137,39 @@ defmodule ListConsumersCommandTest do
 
   test "run: active and activity status fields are set properly when requested", context do
     queue_types = ["classic", "quorum"]
-    Enum.each queue_types, fn queue_type ->
+
+    Enum.each(queue_types, fn queue_type ->
       queue_name = "active-activity-status-fields-" <> queue_type
       declare_queue(queue_name, @vhost, true, false, [{"x-queue-type", :longstr, queue_type}])
       :timer.sleep(200)
-      with_channel(@vhost, fn(channel) ->
+
+      with_channel(@vhost, fn channel ->
         {:ok, tag1} = AMQP.Basic.consume(channel, queue_name)
         {:ok, tag2} = AMQP.Basic.consume(channel, queue_name)
         {:ok, tag3} = AMQP.Basic.consume(channel, queue_name)
         :timer.sleep(100)
+
         try do
-          consumers = List.first(run_command_to_list(@command, [["queue_name", "consumer_tag", "active", "activity_status"], context[:opts]]))
-          assert Keyword.equal?([{tag1, queue_name, true, :up},
-                                 {tag2, queue_name, true, :up}, {tag3, queue_name, true, :up}],
-                   for([queue_name: q, consumer_tag: t, active: a, activity_status: as] <- consumers, do: {t, q, a, as}))
+          consumers =
+            List.first(
+              run_command_to_list(@command, [
+                ["queue_name", "consumer_tag", "active", "activity_status"],
+                context[:opts]
+              ])
+            )
+
+          assert Keyword.equal?(
+                   [
+                     {tag1, queue_name, true, :up},
+                     {tag2, queue_name, true, :up},
+                     {tag3, queue_name, true, :up}
+                   ],
+                   for(
+                     [queue_name: q, consumer_tag: t, active: a, activity_status: as] <-
+                       consumers,
+                     do: {t, q, a, as}
+                   )
+                 )
         after
           AMQP.Basic.cancel(channel, tag1)
           AMQP.Basic.cancel(channel, tag2)
@@ -136,31 +178,73 @@ defmodule ListConsumersCommandTest do
           delete_queue(queue_name, @vhost)
         end
       end)
-    end
+    end)
   end
 
-  test "run: active and activity status fields are set properly when requested and single active consumer is enabled", context do
+  test "run: active and activity status fields are set properly when requested and single active consumer is enabled",
+       context do
     queue_types = ["classic", "quorum"]
-    Enum.each queue_types, fn queue_type ->
+
+    Enum.each(queue_types, fn queue_type ->
       queue_name = "single-active-consumer-" <> queue_type
-      declare_queue(queue_name, @vhost, true, false,
-        [{"x-single-active-consumer", :bool, true}, {"x-queue-type", :longstr, queue_type}])
+
+      declare_queue(queue_name, @vhost, true, false, [
+        {"x-single-active-consumer", :bool, true},
+        {"x-queue-type", :longstr, queue_type}
+      ])
+
       :timer.sleep(200)
-      with_channel(@vhost, fn(channel) ->
+
+      with_channel(@vhost, fn channel ->
         {:ok, tag1} = AMQP.Basic.consume(channel, queue_name)
         {:ok, tag2} = AMQP.Basic.consume(channel, queue_name)
         {:ok, tag3} = AMQP.Basic.consume(channel, queue_name)
         :timer.sleep(100)
+
         try do
-          consumers = List.first(run_command_to_list(@command, [["queue_name", "consumer_tag", "active", "activity_status"], context[:opts]]))
-          assert Keyword.equal?([{tag1, queue_name, true, :single_active},
-                                 {tag2, queue_name, false, :waiting}, {tag3, queue_name, false, :waiting}],
-                   for([queue_name: q, consumer_tag: t, active: a, activity_status: as] <- consumers, do: {t, q, a, as}))
+          consumers =
+            List.first(
+              run_command_to_list(@command, [
+                ["queue_name", "consumer_tag", "active", "activity_status"],
+                context[:opts]
+              ])
+            )
+
+          assert Keyword.equal?(
+                   [
+                     {tag1, queue_name, true, :single_active},
+                     {tag2, queue_name, false, :waiting},
+                     {tag3, queue_name, false, :waiting}
+                   ],
+                   for(
+                     [queue_name: q, consumer_tag: t, active: a, activity_status: as] <-
+                       consumers,
+                     do: {t, q, a, as}
+                   )
+                 )
+
           AMQP.Basic.cancel(channel, tag1)
           :timer.sleep(100)
-          consumers = List.first(run_command_to_list(@command, [["queue_name", "consumer_tag", "active", "activity_status"], context[:opts]]))
-          assert Keyword.equal?([{tag2, queue_name, true, :single_active}, {tag3, queue_name, false, :waiting}],
-                   for([queue_name: q, consumer_tag: t, active: a, activity_status: as] <- consumers, do: {t, q, a, as}))
+
+          consumers =
+            List.first(
+              run_command_to_list(@command, [
+                ["queue_name", "consumer_tag", "active", "activity_status"],
+                context[:opts]
+              ])
+            )
+
+          assert Keyword.equal?(
+                   [
+                     {tag2, queue_name, true, :single_active},
+                     {tag3, queue_name, false, :waiting}
+                   ],
+                   for(
+                     [queue_name: q, consumer_tag: t, active: a, activity_status: as] <-
+                       consumers,
+                     do: {t, q, a, as}
+                   )
+                 )
         after
           AMQP.Basic.cancel(channel, tag2)
           AMQP.Basic.cancel(channel, tag3)
@@ -168,7 +252,7 @@ defmodule ListConsumersCommandTest do
           delete_queue(queue_name, @vhost)
         end
       end)
-    end
+    end)
   end
 
   test "fill_consumer_active_fields: add missing fields if necessary" do
@@ -182,32 +266,36 @@ defmodule ListConsumersCommandTest do
       activity_status: :up,
       arguments: []
     ]
-    assert @command.fill_consumer_active_fields({[
-      consumer38
-    ], {1, :continue}}) == {[consumer38], {1, :continue}}
 
-    assert @command.fill_consumer_active_fields({[
-      [
-        queue_name: {:resource, "/", :queue, "queue2"},
-        channel_pid: "",
-        consumer_tag: "ctag2",
-        ack_required: false,
-        prefetch_count: 0,
-        arguments: []
-      ]
-    ], {1, :continue}}) == {[
-                              [
-                                queue_name: {:resource, "/", :queue, "queue2"},
-                                channel_pid: "",
-                                consumer_tag: "ctag2",
-                                ack_required: false,
-                                prefetch_count: 0,
-                                active: true,
-                                activity_status: :up,
-                                arguments: []
-                              ]
-                            ], {1, :continue}}
+    assert @command.fill_consumer_active_fields(
+             {[
+                consumer38
+              ], {1, :continue}}
+           ) == {[consumer38], {1, :continue}}
 
+    assert @command.fill_consumer_active_fields(
+             {[
+                [
+                  queue_name: {:resource, "/", :queue, "queue2"},
+                  channel_pid: "",
+                  consumer_tag: "ctag2",
+                  ack_required: false,
+                  prefetch_count: 0,
+                  arguments: []
+                ]
+              ], {1, :continue}}
+           ) ==
+             {[
+                [
+                  queue_name: {:resource, "/", :queue, "queue2"},
+                  channel_pid: "",
+                  consumer_tag: "ctag2",
+                  ack_required: false,
+                  prefetch_count: 0,
+                  active: true,
+                  activity_status: :up,
+                  arguments: []
+                ]
+              ], {1, :continue}}
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/list_exchanges_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_exchanges_command_test.exs
@@ -7,13 +7,15 @@ defmodule ListExchangesCommandTest do
   @vhost "test1"
   @user "guest"
   @default_timeout :infinity
-  @default_exchanges [{"amq.direct", :direct},
-                      {"amq.fanout", :fanout},
-                      {"amq.match", :headers},
-                      {"amq.rabbitmq.trace", :topic},
-                      {"amq.headers", :headers},
-                      {"amq.topic", :topic},
-                      {"", :direct}]
+  @default_exchanges [
+    {"amq.direct", :direct},
+    {"amq.fanout", :fanout},
+    {"amq.match", :headers},
+    {"amq.rabbitmq.trace", :topic},
+    {"amq.headers", :headers},
+    {"amq.topic", :topic},
+    {"", :direct}
+  ]
   @default_options %{vhost: "/", table_headers: true}
 
   defp default_exchange_names() do
@@ -28,11 +30,13 @@ defmodule ListExchangesCommandTest do
   end
 
   setup context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
+
     on_exit(fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
+
     {
       :ok,
       opts: %{
@@ -45,64 +49,72 @@ defmodule ListExchangesCommandTest do
   end
 
   test "merge_defaults: should include name and type when no arguments provided and add default vhost to opts" do
-    assert @command.merge_defaults([], %{})
-      == {["name", "type"], @default_options}
+    assert @command.merge_defaults([], %{}) ==
+             {["name", "type"], @default_options}
   end
 
   test "merge_defaults: defaults can be overridden" do
     assert @command.merge_defaults([], %{}) == {["name", "type"], @default_options}
-    assert @command.merge_defaults([], %{vhost: "non_default"}) == {["name", "type"], %{vhost: "non_default",
-                                                                                        table_headers: true}}
+
+    assert @command.merge_defaults([], %{vhost: "non_default"}) ==
+             {["name", "type"], %{vhost: "non_default", table_headers: true}}
   end
 
   test "validate: returns bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: returns multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "type"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["name", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["name", "oink", "type"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   @tag test_timeout: 0
   test "run: zero timeout causes command to return badrpc", context do
     assert run_command_to_list(@command, [["name"], context[:opts]]) ==
-      [{:badrpc, {:timeout, 0.0}}]
+             [{:badrpc, {:timeout, 0.0}}]
   end
 
   test "run: show default exchanges by default", context do
     assert MapSet.new(run_command_to_list(@command, [["name"], context[:opts]])) ==
-           MapSet.new(for {ex_name, _ex_type} <- @default_exchanges, do: [name: ex_name])
+             MapSet.new(for {ex_name, _ex_type} <- @default_exchanges, do: [name: ex_name])
   end
 
   test "run: default options test", context do
     exchange_name = "test_exchange"
     declare_exchange(exchange_name, @vhost)
-      assert MapSet.new(run_command_to_list(@command, [["name", "type"], context[:opts]])) ==
-        MapSet.new(
-          for({ex_name, ex_type} <- @default_exchanges, do: [name: ex_name, type: ex_type]) ++
-          [[name: exchange_name, type: :direct]])
+
+    assert MapSet.new(run_command_to_list(@command, [["name", "type"], context[:opts]])) ==
+             MapSet.new(
+               for({ex_name, ex_type} <- @default_exchanges, do: [name: ex_name, type: ex_type]) ++
+                 [[name: exchange_name, type: :direct]]
+             )
   end
 
   test "run: list multiple exchanges", context do
     declare_exchange("test_exchange_1", @vhost, :direct)
     declare_exchange("test_exchange_2", @vhost, :fanout)
-    non_default_exchanges = run_command_to_list(@command, [["name", "type"], context[:opts]])
-                            |> without_default_exchanges
+
+    non_default_exchanges =
+      run_command_to_list(@command, [["name", "type"], context[:opts]])
+      |> without_default_exchanges
+
     assert_set_equal(
       non_default_exchanges,
-      [[name: "test_exchange_1", type: :direct],
-       [name: "test_exchange_2", type: :fanout]])
+      [[name: "test_exchange_1", type: :direct], [name: "test_exchange_2", type: :fanout]]
+    )
   end
 
   def assert_set_equal(one, two) do
@@ -112,49 +124,63 @@ defmodule ListExchangesCommandTest do
   test "run: info keys filter single key", context do
     declare_exchange("test_exchange_1", @vhost)
     declare_exchange("test_exchange_2", @vhost)
-    non_default_exchanges = run_command_to_list(@command, [["name"], context[:opts]])
-                            |> without_default_exchanges
+
+    non_default_exchanges =
+      run_command_to_list(@command, [["name"], context[:opts]])
+      |> without_default_exchanges
+
     assert_set_equal(
       non_default_exchanges,
-      [[name: "test_exchange_1"],
-       [name: "test_exchange_2"]])
+      [[name: "test_exchange_1"], [name: "test_exchange_2"]]
+    )
   end
-
 
   test "run: info keys add additional keys", context do
     declare_exchange("durable_exchange", @vhost, :direct, true)
     declare_exchange("auto_delete_exchange", @vhost, :fanout, false, true)
-    non_default_exchanges = run_command_to_list(@command, [["name", "type", "durable", "auto_delete"], context[:opts]])
-                            |> without_default_exchanges
+
+    non_default_exchanges =
+      run_command_to_list(@command, [["name", "type", "durable", "auto_delete"], context[:opts]])
+      |> without_default_exchanges
+
     assert_set_equal(
       non_default_exchanges,
-      [[name: "auto_delete_exchange", type: :fanout, durable: false, auto_delete: true],
-       [name: "durable_exchange", type: :direct, durable: true, auto_delete: false]])
+      [
+        [name: "auto_delete_exchange", type: :fanout, durable: false, auto_delete: true],
+        [name: "durable_exchange", type: :direct, durable: true, auto_delete: false]
+      ]
+    )
   end
 
   test "run: specifying a vhost returns the targeted vhost exchanges", context do
     other_vhost = "other_vhost"
-    add_vhost other_vhost
+    add_vhost(other_vhost)
+
     on_exit(fn ->
-      delete_vhost other_vhost
+      delete_vhost(other_vhost)
     end)
+
     declare_exchange("test_exchange_1", @vhost)
     declare_exchange("test_exchange_2", other_vhost)
-    non_default_exchanges1 = run_command_to_list(@command, [["name"], context[:opts]])
-                             |> without_default_exchanges
 
-    non_default_exchanges2 = run_command_to_list(@command, [["name"], %{context[:opts] | :vhost => other_vhost}])
-                             |> without_default_exchanges
+    non_default_exchanges1 =
+      run_command_to_list(@command, [["name"], context[:opts]])
+      |> without_default_exchanges
+
+    non_default_exchanges2 =
+      run_command_to_list(@command, [["name"], %{context[:opts] | :vhost => other_vhost}])
+      |> without_default_exchanges
 
     assert non_default_exchanges1 == [[name: "test_exchange_1"]]
     assert non_default_exchanges2 == [[name: "test_exchange_2"]]
   end
 
   defp without_default_exchanges(xs) do
-    Enum.filter(xs,
-                fn(x) ->
-                  not Enum.member?(default_exchange_names(), x[:name])
-                end)
+    Enum.filter(
+      xs,
+      fn x ->
+        not Enum.member?(default_exchange_names(), x[:name])
+      end
+    )
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/list_feature_flags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_feature_flags_command_test.exs
@@ -18,20 +18,35 @@ defmodule ListFeatureFlagsCommandTest do
 
     # Define an arbitrary feature flag for the test.
     node = get_rabbit_hostname()
+
     new_feature_flags = %{
-      @flag1 =>
-      %{desc: "My feature flag #1",
+      @flag1 => %{
+        desc: "My feature flag #1",
         provided_by: :ListFeatureFlagsCommandTest,
-        stability: :stable},
-      @flag2 =>
-      %{desc: "My feature flag #2",
+        stability: :stable
+      },
+      @flag2 => %{
+        desc: "My feature flag #2",
         provided_by: :ListFeatureFlagsCommandTest,
-        stability: :stable}}
-    :ok = :rabbit_misc.rpc_call(
-      node, :rabbit_feature_flags, :inject_test_feature_flags,
-      [new_feature_flags])
-    :ok = :rabbit_misc.rpc_call(
-      node, :rabbit_feature_flags, :enable_all, [])
+        stability: :stable
+      }
+    }
+
+    :ok =
+      :rabbit_misc.rpc_call(
+        node,
+        :rabbit_feature_flags,
+        :inject_test_feature_flags,
+        [new_feature_flags]
+      )
+
+    :ok =
+      :rabbit_misc.rpc_call(
+        node,
+        :rabbit_feature_flags,
+        :enable_all,
+        []
+      )
 
     name_result = [
       [{:name, @flag1}],
@@ -45,8 +60,7 @@ defmodule ListFeatureFlagsCommandTest do
 
     {
       :ok,
-      name_result: name_result,
-      full_result: full_result
+      name_result: name_result, full_result: full_result
     }
   end
 
@@ -63,21 +77,23 @@ defmodule ListFeatureFlagsCommandTest do
 
   test "validate: return bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "name"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["name", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["name", "oink", "state"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   test "run: on a bad RabbitMQ node, return a badrpc" do
@@ -88,32 +104,35 @@ defmodule ListFeatureFlagsCommandTest do
   @tag test_timeout: :infinity
   test "run: with the name tag, print just the names", context do
     matches_found = @command.run(["name"], context[:opts])
-    assert Enum.all?(context[:name_result], fn(feature_name) ->
-      Enum.find(matches_found, fn(found) -> found == feature_name end)
-    end)
+
+    assert Enum.all?(context[:name_result], fn feature_name ->
+             Enum.find(matches_found, fn found -> found == feature_name end)
+           end)
   end
 
   @tag test_timeout: :infinity
   test "run: duplicate args do not produce duplicate entries", context do
     # checks to ensure that all expected feature flags are in the results
     matches_found = @command.run(["name", "name"], context[:opts])
-    assert Enum.all?(context[:name_result], fn(feature_name) ->
-      Enum.find(matches_found, fn(found) -> found == feature_name end)
-    end)
+
+    assert Enum.all?(context[:name_result], fn feature_name ->
+             Enum.find(matches_found, fn found -> found == feature_name end)
+           end)
   end
 
   @tag test_timeout: 30000
   test "run: sufficiently long timeouts don't interfere with results", context do
     matches_found = @command.run(["name", "state"], context[:opts])
-    assert Enum.all?(context[:full_result], fn(feature_name) ->
-      Enum.find(matches_found, fn(found) -> found == feature_name end)
-    end)
+
+    assert Enum.all?(context[:full_result], fn feature_name ->
+             Enum.find(matches_found, fn found -> found == feature_name end)
+           end)
   end
 
   @tag test_timeout: 0, username: "guest"
   test "run: timeout causes command to return a bad RPC", context do
     assert @command.run(["name", "state"], context[:opts]) ==
-      {:badrpc, :timeout}
+             {:badrpc, :timeout}
   end
 
   @tag test_timeout: :infinity

--- a/deps/rabbitmq_cli/test/ctl/list_hashes_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_hashes_command_test.exs
@@ -22,8 +22,8 @@ defmodule ListHashesCommandTest do
 
   test "run: lists hashes", _context do
     assert match?(
-      {:ok, _},
-      @command.run([], %{})
-    )
+             {:ok, _},
+             @command.run([], %{})
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_permissions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListPermissionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -13,18 +12,18 @@ defmodule ListPermissionsCommandTest do
 
   @vhost "test1"
   @user "guest"
-  @root   "/"
+  @root "/"
   @default_timeout :infinity
   @default_options %{vhost: "/", table_headers: true}
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
-    set_permissions @user, @vhost, ["^guest-.*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, ["^guest-.*", ".*", ".*"])
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -47,8 +46,9 @@ defmodule ListPermissionsCommandTest do
 
   test "merge_defaults: defaults can be overridden" do
     assert @command.merge_defaults([], %{}) == {[], @default_options}
-    assert @command.merge_defaults([], %{vhost: "non_default"}) == {[], %{vhost: "non_default",
-                                                                          table_headers: true}}
+
+    assert @command.merge_defaults([], %{vhost: "non_default"}) ==
+             {[], %{vhost: "non_default", table_headers: true}}
   end
 
   test "validate: invalid parameters yield an arg count error" do
@@ -64,29 +64,31 @@ defmodule ListPermissionsCommandTest do
   @tag test_timeout: @default_timeout, vhost: @vhost
   test "run: specifying a vhost returns the targeted vhost permissions", context do
     assert @command.run(
-      [],
-      Map.merge(context[:opts], %{vhost: @vhost})
-    ) == [[user: "guest", configure: "^guest-.*", write: ".*", read: ".*"]]
+             [],
+             Map.merge(context[:opts], %{vhost: @vhost})
+           ) == [[user: "guest", configure: "^guest-.*", write: ".*", read: ".*"]]
   end
 
   @tag test_timeout: 30000
   test "run: sufficiently long timeouts don't interfere with results", context do
     results = @command.run([], context[:opts])
-    Enum.all?([[user: "guest", configure: ".*", write: ".*", read: ".*"]], fn(perm) ->
-      Enum.find(results, fn(found) -> found == perm end)
+
+    Enum.all?([[user: "guest", configure: ".*", write: ".*", read: ".*"]], fn perm ->
+      Enum.find(results, fn found -> found == perm end)
     end)
   end
 
   @tag test_timeout: 0
   test "run: timeout causes command to return a bad RPC", context do
     assert @command.run([], context[:opts]) ==
-      {:badrpc, :timeout}
+             {:badrpc, :timeout}
   end
 
   @tag vhost: @root
   test "banner", context do
     ctx = Map.merge(context[:opts], %{vhost: @vhost})
-    assert @command.banner([], ctx )
-      =~ ~r/Listing permissions for vhost \"#{Regex.escape(ctx[:vhost])}\" \.\.\./
+
+    assert @command.banner([], ctx) =~
+             ~r/Listing permissions for vhost \"#{Regex.escape(ctx[:vhost])}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_policies_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_policies_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListPoliciesCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -12,7 +11,7 @@ defmodule ListPoliciesCommandTest do
   @command RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand
 
   @vhost "test1"
-  @default_vhost   "/"
+  @default_vhost "/"
   @key "federate"
   @pattern "^fed\."
   @value "{\"federation-upstream-set\":\"all\"}"
@@ -22,27 +21,26 @@ defmodule ListPoliciesCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
     enable_federation_plugin()
 
     on_exit(fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
   end
 
   setup context do
-
     on_exit(fn ->
-      clear_policy context[:vhost], context[:key]
+      clear_policy(context[:vhost], context[:key])
     end)
 
     {
       :ok,
       opts: %{
         node: get_rabbit_hostname(),
-        timeout: (context[:timeout] || :infinity),
+        timeout: context[:timeout] || :infinity,
         vhost: context[:vhost],
         apply_to: @apply_to,
         priority: 0
@@ -52,20 +50,24 @@ defmodule ListPoliciesCommandTest do
 
   test "merge_defaults: default vhost is '/'" do
     assert @command.merge_defaults([], %{}) == {[], @default_options}
-    assert @command.merge_defaults([], %{vhost: "non_default"}) == {[], %{vhost: "non_default",
-                                                                          table_headers: true}}
+
+    assert @command.merge_defaults([], %{vhost: "non_default"}) ==
+             {[], %{vhost: "non_default", table_headers: true}}
   end
 
   test "validate: providing too many arguments fails validation" do
     assert @command.validate(["many"], %{}) == {:validation_failure, :too_many_args}
     assert @command.validate(["too", "many"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["this", "is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this", "is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag key: @key, pattern: @pattern, value: @value, vhost: @vhost
   test "run: a well-formed, host-specific command returns list of policies", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
     set_policy(context[:vhost], context[:key], context[:pattern], @value)
+
     @command.run([], vhost_opts)
     |> assert_policy_list(context)
   end
@@ -79,6 +81,7 @@ defmodule ListPoliciesCommandTest do
   @tag key: @key, pattern: @pattern, value: @value, vhost: @default_vhost
   test "run: a well-formed command with no vhost runs against the default one", context do
     set_policy("/", context[:key], context[:pattern], @value)
+
     on_exit(fn ->
       clear_policy("/", context[:key])
     end)
@@ -98,25 +101,40 @@ defmodule ListPoliciesCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [],
-      vhost_opts
-    ) == {:error, {:no_such_vhost, context[:vhost]}}
+             [],
+             vhost_opts
+           ) == {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag vhost: @vhost
   test "run: when multiple policies exist in the vhost, returns them all", context do
     policies = [
-      %{vhost: @vhost, name: "some-policy", pattern: "foo", definition: "{\"federation-upstream-set\":\"all\"}", 'apply-to': "all", priority: 0},
-      %{vhost: @vhost, name: "other-policy", pattern: "bar", definition: "{\"ha-mode\":\"all\"}", 'apply-to': "all", priority: 0}
+      %{
+        vhost: @vhost,
+        name: "some-policy",
+        pattern: "foo",
+        definition: "{\"federation-upstream-set\":\"all\"}",
+        "apply-to": "all",
+        priority: 0
+      },
+      %{
+        vhost: @vhost,
+        name: "other-policy",
+        pattern: "bar",
+        definition: "{\"ha-mode\":\"all\"}",
+        "apply-to": "all",
+        priority: 0
+      }
     ]
+
     policies
-    |> Enum.map(
-        fn(%{name: name, pattern: pattern, definition: value}) ->
-          set_policy(context[:vhost], name, pattern, value)
-          on_exit(fn ->
-            clear_policy(context[:vhost], name)
-          end)
-        end)
+    |> Enum.map(fn %{name: name, pattern: pattern, definition: value} ->
+      set_policy(context[:vhost], name, pattern, value)
+
+      on_exit(fn ->
+        clear_policy(context[:vhost], name)
+      end)
+    end)
 
     pols = for policy <- @command.run([], context[:opts]), do: Map.new(policy)
 
@@ -127,18 +145,22 @@ defmodule ListPoliciesCommandTest do
   test "banner", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([], vhost_opts)
-      =~ ~r/Listing policies for vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([], vhost_opts) =~
+             ~r/Listing policies for vhost \"#{context[:vhost]}\" \.\.\./
   end
 
   # Checks each element of the first policy against the expected context values
   defp assert_policy_list(policies, context) do
     [policy | _] = policies
-    assert MapSet.new(policy) == MapSet.new([name: context[:key],
-                                             pattern: context[:pattern],
-                                             definition: context[:value],
-                                             vhost: context[:vhost],
-                                             priority: context[:opts][:priority],
-                                             "apply-to": context[:opts][:apply_to]])
+
+    assert MapSet.new(policy) ==
+             MapSet.new(
+               name: context[:key],
+               pattern: context[:pattern],
+               definition: context[:value],
+               vhost: context[:vhost],
+               priority: context[:opts][:priority],
+               "apply-to": context[:opts][:apply_to]
+             )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_queues_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_queues_command_test.exs
@@ -24,11 +24,13 @@ defmodule ListQueuesCommandTest do
   end
 
   setup context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
+
     on_exit(fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
+
     {
       :ok,
       opts: %{
@@ -49,40 +51,54 @@ defmodule ListQueuesCommandTest do
 
   test "validate: returns bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "messages"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["name", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["name", "oink", "messages"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   @tag test_timeout: 0
   test "run: timeout causes command to return badrpc", context do
     assert run_command_to_list(@command, [["name"], context[:opts]]) ==
-      [{:badrpc, {:timeout, 0.0, "Some queue(s) are unresponsive, use list_unresponsive_queues command."}}]
+             [
+               {:badrpc,
+                {:timeout, 0.0,
+                 "Some queue(s) are unresponsive, use list_unresponsive_queues command."}}
+             ]
   end
 
   @tag test_timeout: 1
-  test "run: command timeout (several thousands queues in 1ms) return badrpc with timeout value in seconds", context do
+  test "run: command timeout (several thousands queues in 1ms) return badrpc with timeout value in seconds",
+       context do
     # we assume it will take longer than 1 ms to list thousands of queues
     n = 5000
+
     for i <- 1..n do
-        declare_queue("test_queue_" <> Integer.to_string(i), @vhost)
+      declare_queue("test_queue_" <> Integer.to_string(i), @vhost)
     end
+
     assert run_command_to_list(@command, [["name"], context[:opts]]) ==
-      [{:badrpc, {:timeout, 0.001, "Some queue(s) are unresponsive, use list_unresponsive_queues command."}}]
+             [
+               {:badrpc,
+                {:timeout, 0.001,
+                 "Some queue(s) are unresponsive, use list_unresponsive_queues command."}}
+             ]
+
     for i <- 1..n do
-        delete_queue("test_queue_" <> Integer.to_string(i), @vhost)
+      delete_queue("test_queue_" <> Integer.to_string(i), @vhost)
     end
   end
 
@@ -92,18 +108,22 @@ defmodule ListQueuesCommandTest do
     publish_messages(@vhost, "test_queue_1", 3)
     declare_queue("test_queue_2", @vhost)
     publish_messages(@vhost, "test_queue_2", 1)
-    assert Keyword.equal?(run_command_to_list(@command, [["name", "messages"], context[:opts]]),
-      [[name: "test_queue_1", messages: 3],
-       [name: "test_queue_2", messages: 1]])
+
+    assert Keyword.equal?(
+             run_command_to_list(@command, [["name", "messages"], context[:opts]]),
+             [[name: "test_queue_1", messages: 3], [name: "test_queue_2", messages: 1]]
+           )
   end
 
   @tag test_timeout: 5000
   test "run: info keys filter single key", context do
     declare_queue("test_queue_1", @vhost)
     declare_queue("test_queue_2", @vhost)
-    assert Keyword.equal?(run_command_to_list(@command, [["name"], context[:opts]]),
-      [[name: "test_queue_1"],
-       [name: "test_queue_2"]])
+
+    assert Keyword.equal?(
+             run_command_to_list(@command, [["name"], context[:opts]]),
+             [[name: "test_queue_1"], [name: "test_queue_2"]]
+           )
   end
 
   @tag test_timeout: 5000
@@ -112,10 +132,17 @@ defmodule ListQueuesCommandTest do
     publish_messages(@vhost, "durable_queue", 3)
     declare_queue("auto_delete_queue", @vhost, false, true)
     publish_messages(@vhost, "auto_delete_queue", 1)
+
     assert Keyword.equal?(
-      run_command_to_list(@command, [["name", "messages", "durable", "auto_delete"], context[:opts]]),
-      [[name: "durable_queue", messages: 3, durable: true, auto_delete: false],
-       [name: "auto_delete_queue", messages: 1, durable: false, auto_delete: true]])
+             run_command_to_list(@command, [
+               ["name", "messages", "durable", "auto_delete"],
+               context[:opts]
+             ]),
+             [
+               [name: "durable_queue", messages: 3, durable: true, auto_delete: false],
+               [name: "auto_delete_queue", messages: 1, durable: false, auto_delete: true]
+             ]
+           )
   end
 
   @tag test_timeout: 5000
@@ -124,22 +151,33 @@ defmodule ListQueuesCommandTest do
     publish_messages(@vhost, "durable_queue", 3)
     declare_queue("auto_delete_queue", @vhost, false, true)
     publish_messages(@vhost, "auto_delete_queue", 1)
+
     assert Keyword.equal?(
-      run_command_to_list(@command, [["messages", "durable", "name", "auto_delete"], context[:opts]]),
-      [[messages: 3, durable: true, name: "durable_queue", auto_delete: false],
-       [messages: 1, durable: false, name: "auto_delete_queue", auto_delete: true]])
+             run_command_to_list(@command, [
+               ["messages", "durable", "name", "auto_delete"],
+               context[:opts]
+             ]),
+             [
+               [messages: 3, durable: true, name: "durable_queue", auto_delete: false],
+               [messages: 1, durable: false, name: "auto_delete_queue", auto_delete: true]
+             ]
+           )
   end
 
   @tag test_timeout: 5000
   test "run: specifying a vhost returns the targeted vhost queues", context do
     other_vhost = "other_vhost"
-    add_vhost other_vhost
+    add_vhost(other_vhost)
+
     on_exit(fn ->
-      delete_vhost other_vhost
+      delete_vhost(other_vhost)
     end)
+
     declare_queue("test_queue_1", @vhost)
     declare_queue("test_queue_2", other_vhost)
     assert run_command_to_list(@command, [["name"], context[:opts]]) == [[name: "test_queue_1"]]
-    assert run_command_to_list(@command, [["name"], %{context[:opts] | :vhost => other_vhost}]) == [[name: "test_queue_2"]]
+
+    assert run_command_to_list(@command, [["name"], %{context[:opts] | :vhost => other_vhost}]) ==
+             [[name: "test_queue_2"]]
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_topic_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_topic_permissions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListTopicPermissionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -14,7 +13,7 @@ defmodule ListTopicPermissionsCommandTest do
   @vhost "test1"
   @user "user1"
   @password "password"
-  @root   "/"
+  @root "/"
   @default_timeout :infinity
   @default_options %{vhost: "/", table_headers: true}
 
@@ -29,7 +28,7 @@ defmodule ListTopicPermissionsCommandTest do
     on_exit([], fn ->
       clear_topic_permissions(@user, @vhost)
       delete_user(@user)
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -52,8 +51,9 @@ defmodule ListTopicPermissionsCommandTest do
 
   test "merge_defaults: defaults can be overridden" do
     assert @command.merge_defaults([], %{}) == {[], @default_options}
-    assert @command.merge_defaults([], %{vhost: "non_default"}) == {[], %{vhost: "non_default",
-                                                                          table_headers: true}}
+
+    assert @command.merge_defaults([], %{vhost: "non_default"}) ==
+             {[], %{vhost: "non_default", table_headers: true}}
   end
 
   test "validate: does not expect any parameter" do
@@ -70,16 +70,18 @@ defmodule ListTopicPermissionsCommandTest do
   test "run: specifying a vhost returns the topic permissions for the targeted vhost", context do
     permissions = @command.run([], Map.merge(context[:opts], %{vhost: @vhost}))
     assert Enum.count(permissions) == 2
+
     assert Enum.sort(permissions) == [
-        [user: @user, exchange: "amq.topic", write: "^a", read: "^b"],
-        [user: @user, exchange: "topic1", write: "^a", read: "^b"]
-    ]
+             [user: @user, exchange: "amq.topic", write: "^a", read: "^b"],
+             [user: @user, exchange: "topic1", write: "^a", read: "^b"]
+           ]
   end
 
   @tag vhost: @root
   test "banner", context do
     ctx = Map.merge(context[:opts], %{vhost: @vhost})
-    assert @command.banner([], ctx )
-      =~ ~r/Listing topic permissions for vhost \"#{Regex.escape(ctx[:vhost])}\" \.\.\./
+
+    assert @command.banner([], ctx) =~
+             ~r/Listing topic permissions for vhost \"#{Regex.escape(ctx[:vhost])}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_user_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_user_limits_command_test.exs
@@ -55,21 +55,24 @@ defmodule ListUserLimitsCommandTest do
   end
 
   test "run: a well-formed user specific command returns an empty json object if there are no limits" do
-    assert @command.run([], %{node: get_rabbit_hostname(),
-                              user: @user}) == "{}"
+    assert @command.run([], %{node: get_rabbit_hostname(), user: @user}) == "{}"
   end
 
   test "run: list limits for all users", context do
     add_user(@user1, @password1)
-    on_exit(fn() ->
+
+    on_exit(fn ->
       delete_user(@user1)
     end)
+
     set_user_limits(@user, @connection_limit_defn)
     set_user_limits(@user1, @channel_limit_defn)
 
     assert Enum.sort(@command.run([], context[:opts])) ==
-           Enum.sort([[user: @user,  limits: @connection_limit_defn],
-                      [user: @user1, limits: @channel_limit_defn]])
+             Enum.sort([
+               [user: @user, limits: @connection_limit_defn],
+               [user: @user1, limits: @channel_limit_defn]
+             ])
   end
 
   test "run: list limits for a single user", context do
@@ -77,7 +80,7 @@ defmodule ListUserLimitsCommandTest do
     set_user_limits(@user, @connection_limit_defn)
 
     assert @command.run([], user_opts) ==
-           [[user: @user, limits: @connection_limit_defn]]
+             [[user: @user, limits: @connection_limit_defn]]
   end
 
   test "run: an unreachable node throws a badrpc" do
@@ -90,14 +93,15 @@ defmodule ListUserLimitsCommandTest do
   test "run: providing a non-existent user reports an error", _context do
     s = "non-existent-user"
 
-    assert @command.run([], %{node: get_rabbit_hostname(),
-                              user: s}) == {:error, {:no_such_user, s}}
+    assert @command.run([], %{node: get_rabbit_hostname(), user: s}) ==
+             {:error, {:no_such_user, s}}
   end
 
   test "banner", context do
-    assert @command.banner([], %{user: context[:user]})
-      == "Listing limits for user \"#{context[:user]}\" ..."
-    assert @command.banner([], %{global: true})
-      == "Listing limits for all users ..."
+    assert @command.banner([], %{user: context[:user]}) ==
+             "Listing limits for user \"#{context[:user]}\" ..."
+
+    assert @command.banner([], %{global: true}) ==
+             "Listing limits for all users ..."
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_user_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_user_permissions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListUserPermissionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -20,10 +19,10 @@ defmodule ListUserPermissionsCommandTest do
   setup context do
     default_result = [
       [
-        {:vhost,<<"/">>},
-        {:configure,<<".*">>},
-        {:write,<<".*">>},
-        {:read,<<".*">>}
+        {:vhost, <<"/">>},
+        {:configure, <<".*">>},
+        {:write, <<".*">>},
+        {:read, <<".*">>}
       ]
     ]
 
@@ -38,30 +37,33 @@ defmodule ListUserPermissionsCommandTest do
     }
   end
 
-## -------------------------------- Usage -------------------------------------
+  ## -------------------------------- Usage -------------------------------------
 
   test "validate: wrong number of arguments results in an arg count error" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["guest", "extra"], %{}) == {:validation_failure, :too_many_args}
   end
 
-## ------------------------------- Username -----------------------------------
+  ## ------------------------------- Username -----------------------------------
 
   @tag test_timeout: :infinity, username: "guest"
   test "run: valid user returns a list of permissions", context do
     results = @command.run([context[:username]], context[:opts])
-    assert Enum.all?(context[:result], fn(perm) ->
-      Enum.find(results, fn(found) -> found == perm end)
-    end)
+
+    assert Enum.all?(context[:result], fn perm ->
+             Enum.find(results, fn found -> found == perm end)
+           end)
   end
 
   @tag test_timeout: :infinity, username: "interloper"
   test "run: invalid user returns a no-such-user error", context do
     assert @command.run(
-      [context[:username]], context[:opts]) == context[:no_such_user]
+             [context[:username]],
+             context[:opts]
+           ) == context[:no_such_user]
   end
 
-## --------------------------------- Flags ------------------------------------
+  ## --------------------------------- Flags ------------------------------------
 
   test "run: unreachable RabbitMQ node returns a badrpc" do
     assert match?({:badrpc, _}, @command.run(["guest"], %{node: :jake@thedog, timeout: 200}))
@@ -70,22 +72,23 @@ defmodule ListUserPermissionsCommandTest do
   @tag test_timeout: 30000, username: "guest"
   test "run: long user-defined timeout doesn't interfere with operation", context do
     results = @command.run([context[:username]], context[:opts])
-    Enum.all?(context[:result], fn(perm) ->
-      Enum.find(results, fn(found) -> found == perm end)
+
+    Enum.all?(context[:result], fn perm ->
+      Enum.find(results, fn found -> found == perm end)
     end)
   end
 
   @tag test_timeout: 0, username: "guest"
   test "run: timeout causes command to return a bad RPC", context do
     assert @command.run(
-      [context[:username]],
-      context[:opts]
-    ) == context[:timeout]
+             [context[:username]],
+             context[:opts]
+           ) == context[:timeout]
   end
 
   @tag test_timeout: :infinity
   test "banner", context do
-    assert @command.banner( [context[:username]], context[:opts])
-      =~ ~r/Listing permissions for user \"#{context[:username]}\" \.\.\./
+    assert @command.banner([context[:username]], context[:opts]) =~
+             ~r/Listing permissions for user \"#{context[:username]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_user_topic_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_user_topic_permissions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListUserTopicPermissionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -35,14 +34,14 @@ defmodule ListUserTopicPermissionsCommandTest do
     }
   end
 
-## -------------------------------- Usage -------------------------------------
+  ## -------------------------------- Usage -------------------------------------
 
   test "validate: expect username argument" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["guest", "extra"], %{}) == {:validation_failure, :too_many_args}
   end
 
-## ------------------------------- Username -----------------------------------
+  ## ------------------------------- Username -----------------------------------
 
   @tag test_timeout: :infinity, username: "guest"
   test "run: valid user returns a list of topic permissions", context do
@@ -53,10 +52,12 @@ defmodule ListUserTopicPermissionsCommandTest do
   @tag test_timeout: :infinity, username: "interloper"
   test "run: invalid user returns a no-such-user error", context do
     assert @command.run(
-      [context[:username]], context[:opts]) == context[:no_such_user]
+             [context[:username]],
+             context[:opts]
+           ) == context[:no_such_user]
   end
 
-## --------------------------------- Flags ------------------------------------
+  ## --------------------------------- Flags ------------------------------------
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     opts = %{node: :jake@thedog, timeout: 200}
@@ -66,7 +67,7 @@ defmodule ListUserTopicPermissionsCommandTest do
 
   @tag test_timeout: :infinity
   test "banner", context do
-    assert @command.banner( [context[:username]], context[:opts])
-      =~ ~r/Listing topic permissions for user \"#{context[:username]}\" \.\.\./
+    assert @command.banner([context[:username]], context[:opts]) =~
+             ~r/Listing topic permissions for user \"#{context[:username]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_users_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_users_command_test.exs
@@ -4,31 +4,30 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListUsersCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.ListUsersCommand
 
-  @user     "user1"
+  @user "user1"
   @password "password"
-  @guest    "guest"
+  @guest "guest"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
     std_result = [
-      [{:user,@guest},{:tags,[:administrator]}],
-      [{:user,@user},{:tags,[]}]
+      [{:user, @guest}, {:tags, [:administrator]}],
+      [{:user, @user}, {:tags, []}]
     ]
 
     {:ok, std_result: std_result}
   end
 
   setup context do
-    add_user @user, @password
-    on_exit([], fn -> delete_user @user end)
+    add_user(@user, @password)
+    on_exit([], fn -> delete_user(@user) end)
 
     {:ok, opts: %{node: get_rabbit_hostname(), timeout: context[:test_timeout]}}
   end
@@ -41,9 +40,9 @@ defmodule ListUsersCommandTest do
   test "run: On a successful query, return an array of lists of tuples", context do
     matches_found = @command.run([], context[:opts])
 
-    assert Enum.all?(context[:std_result], fn(user) ->
-      Enum.find(matches_found, fn(found) -> found == user end)
-    end)
+    assert Enum.all?(context[:std_result], fn user ->
+             Enum.find(matches_found, fn found -> found == user end)
+           end)
   end
 
   test "run: On an invalid rabbitmq node, return a bad rpc" do
@@ -55,20 +54,20 @@ defmodule ListUsersCommandTest do
     # checks to ensure that all expected users are in the results
     matches_found = @command.run([], context[:opts])
 
-    assert Enum.all?(context[:std_result], fn(user) ->
-      Enum.find(matches_found, fn(found) -> found == user end)
-    end)
+    assert Enum.all?(context[:std_result], fn user ->
+             Enum.find(matches_found, fn found -> found == user end)
+           end)
   end
 
   @tag test_timeout: 0
   test "run: timeout causes command to return a bad RPC", context do
     assert @command.run([], context[:opts]) ==
-      {:badrpc, :timeout}
+             {:badrpc, :timeout}
   end
 
   @tag test_timeout: :infinity
   test "banner", context do
-    assert @command.banner([], context[:opts])
-      =~ ~r/Listing users \.\.\./
+    assert @command.banner([], context[:opts]) =~
+             ~r/Listing users \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_vhost_limits_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListVhostLimitsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -19,10 +18,10 @@ defmodule ListVhostLimitsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
@@ -48,36 +47,46 @@ defmodule ListVhostLimitsCommandTest do
   end
 
   test "merge_defaults: does not change defined vhost" do
-    assert match?({[], %{vhost: "test_vhost"}}, @command.merge_defaults([], %{vhost: "test_vhost"}))
+    assert match?(
+             {[], %{vhost: "test_vhost"}},
+             @command.merge_defaults([], %{vhost: "test_vhost"})
+           )
   end
 
   test "validate: providing arguments fails validation" do
     assert @command.validate(["many"], %{}) == {:validation_failure, :too_many_args}
     assert @command.validate(["too", "many"], %{}) == {:validation_failure, :too_many_args}
     assert @command.validate(["is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["this", "is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this", "is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "run: a well-formed command returns an empty list if there are no limits", context do
     assert @command.run([], context[:opts]) == []
   end
 
-  test "run: a well-formed vhost specific command returns an empty list if there are no limits", context do
+  test "run: a well-formed vhost specific command returns an empty list if there are no limits",
+       context do
     vhost_opts = Map.put(context[:opts], :vhost, @vhost)
     assert @command.run([], vhost_opts) == []
   end
 
   test "run: list limits for all vhosts", context do
     add_vhost(@vhost1)
-    on_exit(fn() ->
+
+    on_exit(fn ->
       delete_vhost(@vhost1)
     end)
+
     set_vhost_limits(@vhost, @connection_limit_defn)
     set_vhost_limits(@vhost1, @queue_limit_defn)
 
     assert Enum.sort(@command.run([], context[:opts])) ==
-           Enum.sort([[vhost: @vhost,  limits: @connection_limit_defn],
-                      [vhost: @vhost1, limits: @queue_limit_defn]])
+             Enum.sort([
+               [vhost: @vhost, limits: @connection_limit_defn],
+               [vhost: @vhost1, limits: @queue_limit_defn]
+             ])
   end
 
   test "run: list limits for a single vhost", context do
@@ -85,7 +94,7 @@ defmodule ListVhostLimitsCommandTest do
     set_vhost_limits(@vhost, @connection_limit_defn)
 
     assert @command.run([], vhost_opts) ==
-           [[vhost: @vhost, limits: @connection_limit_defn]]
+             [[vhost: @vhost, limits: @connection_limit_defn]]
   end
 
   test "run: an unreachable node throws a badrpc" do
@@ -98,14 +107,15 @@ defmodule ListVhostLimitsCommandTest do
   test "run: providing a non-existent vhost reports an error", _context do
     s = "non-existent-vhost-a9sd89"
 
-    assert @command.run([], %{node: get_rabbit_hostname(),
-                              vhost: s}) == {:error, {:no_such_vhost, s}}
+    assert @command.run([], %{node: get_rabbit_hostname(), vhost: s}) ==
+             {:error, {:no_such_vhost, s}}
   end
 
   test "banner", context do
-    assert @command.banner([], %{vhost: context[:vhost]})
-      == "Listing limits for vhost \"#{context[:vhost]}\" ..."
-    assert @command.banner([], %{global: true})
-      == "Listing limits for all vhosts ..."
+    assert @command.banner([], %{vhost: context[:vhost]}) ==
+             "Listing limits for vhost \"#{context[:vhost]}\" ..."
+
+    assert @command.banner([], %{global: true}) ==
+             "Listing limits for all vhosts ..."
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/list_vhosts_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_vhosts_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ListVhostsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -13,18 +12,18 @@ defmodule ListVhostsCommandTest do
 
   @vhost1 "test1"
   @vhost2 "test2"
-  @root   "/"
+  @root "/"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost1
-    add_vhost @vhost2
-    trace_off @root
+    add_vhost(@vhost1)
+    add_vhost(@vhost2)
+    trace_off(@root)
 
     on_exit([], fn ->
-      delete_vhost @vhost1
-      delete_vhost @vhost2
+      delete_vhost(@vhost1)
+      delete_vhost(@vhost2)
     end)
 
     name_result = [
@@ -73,21 +72,23 @@ defmodule ListVhostsCommandTest do
 
   test "validate: return bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "tracing"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["name", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["name", "oink", "tracing"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   test "run: on a bad RabbitMQ node, return a badrpc" do
@@ -100,57 +101,63 @@ defmodule ListVhostsCommandTest do
   test "run: with the name tag, print just the names", context do
     # checks to ensure that all expected vhosts are in the results
     matches_found = @command.run(["name"], context[:opts])
-    assert Enum.all?(context[:name_result], fn(vhost) ->
-      Enum.find(matches_found, fn(found) -> found == vhost end)
-    end)
+
+    assert Enum.all?(context[:name_result], fn vhost ->
+             Enum.find(matches_found, fn found -> found == vhost end)
+           end)
   end
 
   @tag test_timeout: :infinity
   test "run: with the tracing tag, print just say if tracing is on", context do
     # checks to ensure that all expected vhosts are in the results
     matches_found = @command.run(["tracing"], context[:opts])
-    assert Enum.all?(context[:tracing_result], fn(vhost) ->
-      Enum.find(matches_found, fn(found) -> found == vhost end)
-    end)
+
+    assert Enum.all?(context[:tracing_result], fn vhost ->
+             Enum.find(matches_found, fn found -> found == vhost end)
+           end)
   end
 
   @tag test_timeout: :infinity
   test "run: with name and tracing keys, print both", context do
     # checks to ensure that all expected vhosts are in the results
     matches_found = @command.run(["name", "tracing"], context[:opts])
-    assert Enum.all?(context[:full_result], fn(vhost) ->
-      Enum.find(matches_found, fn(found) -> found == vhost end)
-    end)
+
+    assert Enum.all?(context[:full_result], fn vhost ->
+             Enum.find(matches_found, fn found -> found == vhost end)
+           end)
 
     # checks to ensure that all expected vhosts are in the results
     matches_found = @command.run(["tracing", "name"], context[:opts])
-    assert Enum.all?(context[:transposed_result], fn(vhost) ->
-      Enum.find(matches_found, fn(found) -> found == vhost end)
-    end)
+
+    assert Enum.all?(context[:transposed_result], fn vhost ->
+             Enum.find(matches_found, fn found -> found == vhost end)
+           end)
   end
 
   @tag test_timeout: :infinity
   test "run: duplicate args do not produce duplicate entries", context do
     # checks to ensure that all expected vhosts are in the results
     matches_found = @command.run(["name", "name"], context[:opts])
-    assert Enum.all?(context[:name_result], fn(vhost) ->
-      Enum.find(matches_found, fn(found) -> found == vhost end)
-    end)
+
+    assert Enum.all?(context[:name_result], fn vhost ->
+             Enum.find(matches_found, fn found -> found == vhost end)
+           end)
   end
 
   @tag test_timeout: 30000
   test "run: sufficiently long timeouts don't interfere with results", context do
     # checks to ensure that all expected vhosts are in the results
     matches_found = @command.run(["name", "tracing"], context[:opts])
-    assert Enum.all?(context[:full_result], fn(vhost) ->
-      Enum.find(matches_found, fn(found) -> found == vhost end)
-    end)
+
+    assert Enum.all?(context[:full_result], fn vhost ->
+             Enum.find(matches_found, fn found -> found == vhost end)
+           end)
   end
 
   @tag test_timeout: 0, username: "guest"
   test "run: timeout causes command to return a bad RPC", context do
     assert @command.run(["name", "tracing"], context[:opts]) ==
-      {:badrpc, :timeout}
+             {:badrpc, :timeout}
   end
 
   @tag test_timeout: :infinity

--- a/deps/rabbitmq_cli/test/ctl/node_health_check_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/node_health_check_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule NodeHealthCheckCommandTest do
   use ExUnit.Case, async: false
   import TestHelper

--- a/deps/rabbitmq_cli/test/ctl/ping_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/ping_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule PingCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -48,7 +47,7 @@ defmodule PingCommandTest do
   end
 
   test "banner", context do
-    banner  = @command.banner([], context[:opts])
+    banner = @command.banner([], context[:opts])
 
     assert banner =~ ~r/Will ping/
     assert banner =~ ~r/#{get_rabbit_hostname()}/

--- a/deps/rabbitmq_cli/test/ctl/purge_queue_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/purge_queue_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule PurgeQueueCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -20,11 +19,12 @@ defmodule PurgeQueueCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        vhost: @vhost,
-        timeout: context[:test_timeout]
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       vhost: @vhost,
+       timeout: context[:test_timeout]
+     }}
   end
 
   test "merge_defaults: defaults can be overridden" do
@@ -34,8 +34,8 @@ defmodule PurgeQueueCommandTest do
 
   @tag test_timeout: 30000
   test "request to an existent queue on active node succeeds", context do
-    add_vhost @vhost
-    set_permissions @user, @vhost, [".*", ".*", ".*"]
+    add_vhost(@vhost)
+    set_permissions(@user, @vhost, [".*", ".*", ".*"])
     on_exit(context, fn -> delete_vhost(@vhost) end)
 
     q = "foo"
@@ -71,7 +71,8 @@ defmodule PurgeQueueCommandTest do
   end
 
   test "validate: with extra arguments returns an arg count error" do
-    assert @command.validate(["queue-name", "extra"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["queue-name", "extra"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: with no arguments returns an arg count error" do
@@ -83,6 +84,7 @@ defmodule PurgeQueueCommandTest do
   end
 
   test "banner informs that vhost's queue is purged" do
-    assert @command.banner(["my-q"], %{vhost: "/foo"}) == "Purging queue 'my-q' in vhost '/foo' ..."
+    assert @command.banner(["my-q"], %{vhost: "/foo"}) ==
+             "Purging queue 'my-q' in vhost '/foo' ..."
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/report_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/report_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ReportTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -23,11 +22,11 @@ defmodule ReportTest do
 
   test "validate: with extra arguments, status returns an arg count error", context do
     assert @command.validate(["extra"], context[:opts]) ==
-    {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: report request to a reachable node succeeds", context do
-    output = @command.run([], context[:opts]) |> Enum.to_list
+    output = @command.run([], context[:opts]) |> Enum.to_list()
 
     assert_stream_without_errors(output)
   end
@@ -38,7 +37,7 @@ defmodule ReportTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts])
-      =~ ~r/Reporting server status of node #{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Reporting server status of node #{get_rabbit_hostname()}/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/reset_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/reset_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ResetCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -32,21 +31,21 @@ defmodule ResetCommandTest do
   end
 
   test "run: reset request to an active node with a stopped rabbit app succeeds", context do
-    add_vhost "some_vhost"
-    #ensure the vhost really does exist
-    assert vhost_exists? "some_vhost"
+    add_vhost("some_vhost")
+    # ensure the vhost really does exist
+    assert vhost_exists?("some_vhost")
     stop_rabbitmq_app()
     assert :ok == @command.run([], context[:opts])
     start_rabbitmq_app()
-    #check that the created vhost no longer exists
+    # check that the created vhost no longer exists
     assert match?([_], list_vhosts())
   end
 
   test "run: reset request to an active node with a running rabbit app fails", context do
-    add_vhost "some_vhost"
-    assert vhost_exists? "some_vhost"
+    add_vhost("some_vhost")
+    assert vhost_exists?("some_vhost")
     assert match?({:error, :mnesia_unexpectedly_running}, @command.run([], context[:opts]))
-    assert vhost_exists? "some_vhost"
+    assert vhost_exists?("some_vhost")
   end
 
   test "run: request to a non-existent node returns a badrpc" do
@@ -59,10 +58,11 @@ defmodule ResetCommandTest do
   end
 
   test "output mnesia is running error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code,
-                   "Mnesia is still running on node " <> _},
-                   @command.output({:error, :mnesia_unexpectedly_running}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
 
+    assert match?(
+             {:error, ^exit_code, "Mnesia is still running on node " <> _},
+             @command.output({:error, :mnesia_unexpectedly_running}, context[:opts])
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/restart_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/restart_vhost_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2016-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RestartVhostCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -20,27 +19,32 @@ defmodule RestartVhostCommandTest do
   @timeout 10000
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname(),
-      vhost: @vhost,
-      timeout: @timeout
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       vhost: @vhost,
+       timeout: @timeout
+     }}
   end
 
   test "validate: specifying arguments is reported as an error", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
+
     assert @command.validate(["a", "b"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
+
     assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: request to a non-existent node returns a badrpc", _context do
     opts = %{node: :jake@thedog, vhost: @vhost, timeout: @timeout}
+
     assert match?(
-      {:badrpc, _},
-      @command.run([], opts))
+             {:badrpc, _},
+             @command.run([], opts)
+           )
   end
 
   test "banner", context do
@@ -67,11 +71,12 @@ defmodule RestartVhostCommandTest do
   #
 
   defp setup_vhosts do
-    add_vhost @vhost
+    add_vhost(@vhost)
     # give the vhost a chance to fully start and initialise
     :timer.sleep(1000)
+
     on_exit(fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
   end
 
@@ -79,15 +84,17 @@ defmodule RestartVhostCommandTest do
     case :rpc.call(node_name, :rabbit_vhost_sup_sup, :get_vhost_sup, [vhost]) do
       {:ok, sup} ->
         case :lists.keyfind(:msg_store_persistent, 1, :supervisor.which_children(sup)) do
-        {_, pid, _, _} ->
-          Process.exit(pid, :foo)
-          :timer.sleep(5000)
-          force_vhost_failure(node_name, vhost);
-        false ->
-          Process.exit(sup, :foo)
-          :timer.sleep(5000)
-          force_vhost_failure(node_name, vhost)
-        end;
+          {_, pid, _, _} ->
+            Process.exit(pid, :foo)
+            :timer.sleep(5000)
+            force_vhost_failure(node_name, vhost)
+
+          false ->
+            Process.exit(sup, :foo)
+            :timer.sleep(5000)
+            force_vhost_failure(node_name, vhost)
+        end
+
       {:error, {:vhost_supervisor_not_running, _}} ->
         :ok
     end

--- a/deps/rabbitmq_cli/test/ctl/resume_listeners_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/resume_listeners_command_test.exs
@@ -16,6 +16,7 @@ defmodule ResumeListenersCommandTest do
     resume_all_client_listeners()
 
     node_name = get_rabbit_hostname()
+
     on_exit(fn ->
       resume_all_client_listeners()
       close_all_connections(node_name)
@@ -38,7 +39,7 @@ defmodule ResumeListenersCommandTest do
 
   test "validate: with extra arguments returns an arg count error", context do
     assert @command.validate(["extra"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: request to a non-existent node returns a badrpc" do

--- a/deps/rabbitmq_cli/test/ctl/set_cluster_name_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_cluster_name_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetClusterNameCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -59,5 +58,4 @@ defmodule SetClusterNameCommandTest do
     s = @command.banner(["annoyyou"], %{})
     assert s == "Setting cluster name to annoyyou ..."
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/set_disk_free_limit_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_disk_free_limit_command_test.exs
@@ -4,14 +4,13 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetDiskFreeLimitCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand
 
-  @default_limit 1048576
+  @default_limit 1_048_576
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -21,11 +20,11 @@ defmodule SetDiskFreeLimitCommandTest do
     on_exit([], fn ->
       set_disk_free_limit(@default_limit)
     end)
-
   end
 
   setup context do
-    context[:tag] # silences warnings
+    # silences warnings
+    context[:tag]
     on_exit([], fn -> set_disk_free_limit(@default_limit) end)
 
     {:ok, opts: %{node: get_rabbit_hostname()}}
@@ -39,58 +38,59 @@ defmodule SetDiskFreeLimitCommandTest do
   @tag limit: "2097152bytes"
   test "run: an invalid string input returns a bad arg and does not change the limit", context do
     assert @command.validate([context[:limit]], context[:opts]) ==
-      {:validation_failure, :bad_argument}
+             {:validation_failure, :bad_argument}
   end
 
   test "validate: valid fractional inputs return an ok", context do
     assert @command.validate(
-      ["mem_relative", "0.0"],
-      context[:opts]
-    ) == :ok
+             ["mem_relative", "0.0"],
+             context[:opts]
+           ) == :ok
 
     assert @command.validate(
-      ["mem_relative", "0.5"],
-      context[:opts]
-    ) == :ok
+             ["mem_relative", "0.5"],
+             context[:opts]
+           ) == :ok
 
     assert @command.validate(
-      ["mem_relative", "1.8"],
-      context[:opts]
-    ) == :ok
+             ["mem_relative", "1.8"],
+             context[:opts]
+           ) == :ok
   end
 
   test "validate: a value outside the accepted range returns an error", context do
-      assert @command.validate(
-        ["mem_relative", "-1.0"],
-        context[:opts]
-      ) == {:validation_failure, :bad_argument}
+    assert @command.validate(
+             ["mem_relative", "-1.0"],
+             context[:opts]
+           ) == {:validation_failure, :bad_argument}
   end
 
   @tag fraction: "1.3"
   test "validate: a valid float string input returns ok", context do
     assert @command.validate(
-      ["mem_relative", context[:fraction]],
-      context[:opts]
-    ) == :ok
+             ["mem_relative", context[:fraction]],
+             context[:opts]
+           ) == :ok
   end
 
   @tag fraction: "1.3salt"
   test "validate: an invalid string input returns a bad argument", context do
     assert @command.validate(
-      ["mem_relative", context[:fraction]],
-      context[:opts]
-    ) == {:validation_failure, :bad_argument}
+             ["mem_relative", context[:fraction]],
+             context[:opts]
+           ) == {:validation_failure, :bad_argument}
   end
 
-## ------------------------ validate mem_relative command -------------------------------------------
+  ## ------------------------ validate mem_relative command -------------------------------------------
 
   test "validate: an invalid number of mem_relative arguments results in an arg count error" do
     assert @command.validate(["mem_relative"], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["mem_relative", 1.3, "extra"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["mem_relative", 1.3, "extra"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
-
-## ------------------------ run absolute command -------------------------------------------
+  ## ------------------------ run absolute command -------------------------------------------
 
   @tag test_timeout: 3000
   test "run: an invalid node returns a bad rpc" do
@@ -100,22 +100,24 @@ defmodule SetDiskFreeLimitCommandTest do
     assert match?({:badrpc, _}, @command.run(args, opts))
   end
 
-  @tag limit: 2097152
+  @tag limit: 2_097_152
   test "run: a valid integer input returns an ok and sets the disk free limit", context do
     assert @command.run([context[:limit]], context[:opts]) == :ok
     assert status()[:disk_free_limit] === context[:limit]
   end
 
-  @tag limit: 2097152.0
-  test "run: a valid non-fractional float input returns an ok and sets the disk free limit", context do
+  @tag limit: 2_097_152.0
+  test "run: a valid non-fractional float input returns an ok and sets the disk free limit",
+       context do
     assert @command.run([context[:limit]], context[:opts]) == :ok
     assert status()[:disk_free_limit] === round(context[:limit])
   end
 
-  @tag limit: 2097152.9
-  test "run: a valid fractional float input returns an ok and sets the disk free limit", context do
+  @tag limit: 2_097_152.9
+  test "run: a valid fractional float input returns an ok and sets the disk free limit",
+       context do
     assert @command.run([context[:limit]], context[:opts]) == :ok
-    assert status()[:disk_free_limit] === context[:limit] |> Float.floor |> round
+    assert status()[:disk_free_limit] === context[:limit] |> Float.floor() |> round
   end
 
   @tag limit: "2097152"
@@ -127,47 +129,46 @@ defmodule SetDiskFreeLimitCommandTest do
   @tag limit: "2MB"
   test "run: an valid unit string input returns an ok and changes the limit", context do
     assert @command.run([context[:limit]], context[:opts]) == :ok
-    assert status()[:disk_free_limit] === 2000000
+    assert status()[:disk_free_limit] === 2_000_000
   end
 
-## ------------------------ run relative command -------------------------------------------
+  ## ------------------------ run relative command -------------------------------------------
 
   @tag fraction: 1
   test "run: an integer input returns ok", context do
     assert @command.run(
-      ["mem_relative", context[:fraction]],
-      context[:opts]
-    ) == :ok
+             ["mem_relative", context[:fraction]],
+             context[:opts]
+           ) == :ok
   end
 
   @tag fraction: 1.1
   test "run: a factional  input returns ok", context do
     assert @command.run(
-      ["mem_relative", context[:fraction]],
-      context[:opts]
-    ) == :ok
+             ["mem_relative", context[:fraction]],
+             context[:opts]
+           ) == :ok
   end
 
-
   test "banner: returns absolute message", context do
-    assert @command.banner(["10"], context[:opts])
-      =~ ~r/Setting disk free limit on #{get_rabbit_hostname()} to 10 bytes .../
+    assert @command.banner(["10"], context[:opts]) =~
+             ~r/Setting disk free limit on #{get_rabbit_hostname()} to 10 bytes .../
 
-    assert @command.banner(["-10"], context[:opts])
-      =~ ~r/Setting disk free limit on #{get_rabbit_hostname()} to -10 bytes .../
+    assert @command.banner(["-10"], context[:opts]) =~
+             ~r/Setting disk free limit on #{get_rabbit_hostname()} to -10 bytes .../
 
-    assert @command.banner(["sandwich"], context[:opts])
-      =~ ~r/Setting disk free limit on #{get_rabbit_hostname()} to sandwich bytes .../
+    assert @command.banner(["sandwich"], context[:opts]) =~
+             ~r/Setting disk free limit on #{get_rabbit_hostname()} to sandwich bytes .../
   end
 
   test "banner: returns memory-relative message", context do
-    assert @command.banner(["mem_relative", "1.3"], context[:opts])
-      =~ ~r/Setting disk free limit on #{get_rabbit_hostname()} to 1\.3 times the total RAM \.\.\./
+    assert @command.banner(["mem_relative", "1.3"], context[:opts]) =~
+             ~r/Setting disk free limit on #{get_rabbit_hostname()} to 1\.3 times the total RAM \.\.\./
 
-    assert @command.banner(["mem_relative", "-1.3"], context[:opts])
-      =~ ~r/Setting disk free limit on #{get_rabbit_hostname()} to -1\.3 times the total RAM \.\.\./
+    assert @command.banner(["mem_relative", "-1.3"], context[:opts]) =~
+             ~r/Setting disk free limit on #{get_rabbit_hostname()} to -1\.3 times the total RAM \.\.\./
 
-    assert @command.banner(["mem_relative", "sandwich"], context[:opts])
-      =~ ~r/Setting disk free limit on #{get_rabbit_hostname()} to sandwich times the total RAM \.\.\./
+    assert @command.banner(["mem_relative", "sandwich"], context[:opts]) =~
+             ~r/Setting disk free limit on #{get_rabbit_hostname()} to sandwich times the total RAM \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/set_global_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_global_parameter_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetGlobalParameterCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -22,13 +21,13 @@ defmodule SetGlobalParameterCommandTest do
 
   setup context do
     on_exit(context, fn ->
-      clear_global_parameter context[:key]
+      clear_global_parameter(context[:key])
     end)
 
     {
       :ok,
       opts: %{
-        node: get_rabbit_hostname(),
+        node: get_rabbit_hostname()
       }
     }
   end
@@ -36,15 +35,17 @@ defmodule SetGlobalParameterCommandTest do
   test "validate: expects a key and a value" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["insufficient"], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["this is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag key: @key, value: @value
   test "run: expects a key and a value", context do
     assert @command.run(
-      [context[:key], context[:value]],
-      context[:opts]
-    ) == :ok
+             [context[:key], context[:value]],
+             context[:opts]
+           ) == :ok
 
     assert_parameter_fields(context)
   end
@@ -58,25 +59,29 @@ defmodule SetGlobalParameterCommandTest do
   @tag key: @key, value: "bad-value"
   test "run: a value that fails to parse as JSON returns a decoding error", context do
     initial = list_global_parameters()
-    assert match?({:error_string, _},
-      @command.run([context[:key], context[:value]],
-        context[:opts]))
+
+    assert match?(
+             {:error_string, _},
+             @command.run(
+               [context[:key], context[:value]],
+               context[:opts]
+             )
+           )
 
     assert list_global_parameters() == initial
   end
 
   @tag key: @key, value: @value
   test "banner", context do
-    assert @command.banner([context[:key], context[:value]], context[:opts])
-      =~ ~r/Setting global runtime parameter \"#{context[:key]}\" to \"#{context[:value]}\" \.\.\./
+    assert @command.banner([context[:key], context[:value]], context[:opts]) =~
+             ~r/Setting global runtime parameter \"#{context[:key]}\" to \"#{context[:value]}\" \.\.\./
   end
 
   # Checks each element of the first parameter against the expected context values
   defp assert_parameter_fields(context) do
-    result_param = list_global_parameters() |> List.first
+    result_param = list_global_parameters() |> List.first()
 
     assert result_param[:value] == context[:value]
     assert result_param[:name] == context[:key]
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/set_log_level_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_log_level_command_test.exs
@@ -12,9 +12,7 @@ defmodule SetLogLevelCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    {:ok,
-      log_level: "debug",
-      opts: %{node: get_rabbit_hostname()}}
+    {:ok, log_level: "debug", opts: %{node: get_rabbit_hostname()}}
   end
 
   test "validate: with a single known level succeeds", context do
@@ -26,7 +24,8 @@ defmodule SetLogLevelCommandTest do
   end
 
   test "validate: with extra arguments returns an arg count error", context do
-    assert @command.validate([context[:log_level], "whoops"], context[:opts]) == {:validation_failure, :too_many_args}
+    assert @command.validate([context[:log_level], "whoops"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "run: request to a named, active node succeeds", context do
@@ -39,6 +38,7 @@ defmodule SetLogLevelCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([context[:log_level]], context[:opts]) == "Setting log level to \"debug\" ..."
+    assert @command.banner([context[:log_level]], context[:opts]) ==
+             "Setting log level to \"debug\" ..."
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/set_operator_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_operator_policy_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetOperatorPolicyCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -12,7 +11,7 @@ defmodule SetOperatorPolicyCommandTest do
   @command RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand
 
   @vhost "test1"
-  @root   "/"
+  @root "/"
   @key "message-expiry"
   @pattern "^queue\."
   @value "{\"message-ttl\":10}"
@@ -22,17 +21,16 @@ defmodule SetOperatorPolicyCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
   end
 
   setup context do
-
     on_exit(context, fn ->
       clear_operator_policy(context[:vhost], context[:key])
     end)
@@ -54,7 +52,10 @@ defmodule SetOperatorPolicyCommandTest do
   end
 
   test "merge_defaults: does not change defined vhost" do
-    assert match?({[], %{vhost: "test_vhost"}}, @command.merge_defaults([], %{vhost: "test_vhost"}))
+    assert match?(
+             {[], %{vhost: "test_vhost"}},
+             @command.merge_defaults([], %{vhost: "test_vhost"})
+           )
   end
 
   test "merge_defaults: default apply_to is \"all\"" do
@@ -74,7 +75,8 @@ defmodule SetOperatorPolicyCommandTest do
   end
 
   test "validate: providing too many arguments fails validation" do
-    assert @command.validate(["this", "is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["this", "is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag pattern: @pattern, key: @key, value: @value, vhost: @vhost
@@ -82,9 +84,9 @@ defmodule SetOperatorPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:key], context[:pattern], context[:value]],
-      vhost_opts
-    ) == :ok
+             [context[:key], context[:pattern], context[:value]],
+             vhost_opts
+           ) == :ok
 
     assert_operator_policy_fields(context)
   end
@@ -100,16 +102,20 @@ defmodule SetOperatorPolicyCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:key], context[:pattern], context[:value]],
-      vhost_opts
-    ) == {:error, {:no_such_vhost, context[:vhost]}}
+             [context[:key], context[:pattern], context[:value]],
+             vhost_opts
+           ) == {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag pattern: @pattern, key: @key, value: "bad-value", vhost: @root
   test "run: an invalid value returns a JSON decoding error", context do
-    assert match?({:error_string, _},
-      @command.run([context[:key], context[:pattern], context[:value]],
-        context[:opts]))
+    assert match?(
+             {:error_string, _},
+             @command.run(
+               [context[:key], context[:pattern], context[:value]],
+               context[:opts]
+             )
+           )
 
     assert list_operator_policies(context[:vhost]) == []
   end
@@ -117,9 +123,11 @@ defmodule SetOperatorPolicyCommandTest do
   @tag pattern: @pattern, key: @key, value: "{\"foo\":\"bar\"}", vhost: @root
   test "run: invalid policy returns an error", context do
     assert @command.run(
-      [context[:key], context[:pattern], context[:value]],
-      context[:opts]
-    ) == {:error_string, 'Validation failed\n\n[{<<"foo">>,<<"bar">>}] are not recognised policy settings\n'}
+             [context[:key], context[:pattern], context[:value]],
+             context[:opts]
+           ) ==
+             {:error_string,
+              'Validation failed\n\n[{<<"foo">>,<<"bar">>}] are not recognised policy settings\n'}
 
     assert list_operator_policies(context[:vhost]) == []
   end
@@ -127,9 +135,9 @@ defmodule SetOperatorPolicyCommandTest do
   @tag pattern: @pattern, key: @key, value: "{}", vhost: @root
   test "run: an empty JSON object value returns an error", context do
     assert @command.run(
-      [context[:key], context[:pattern], context[:value]],
-      context[:opts]
-    ) == {:error_string, 'Validation failed\n\nno policy provided\n'}
+             [context[:key], context[:pattern], context[:value]],
+             context[:opts]
+           ) == {:error_string, 'Validation failed\n\nno policy provided\n'}
 
     assert list_operator_policies(context[:vhost]) == []
   end
@@ -138,13 +146,13 @@ defmodule SetOperatorPolicyCommandTest do
   test "banner", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([context[:key], context[:pattern], context[:value]], vhost_opts)
-      == "Setting operator policy override \"#{context[:key]}\" for pattern \"#{context[:pattern]}\" to \"#{context[:value]}\" with priority \"#{context[:opts][:priority]}\" for vhost \"#{context[:vhost]}\" \.\.\."
+    assert @command.banner([context[:key], context[:pattern], context[:value]], vhost_opts) ==
+             "Setting operator policy override \"#{context[:key]}\" for pattern \"#{context[:pattern]}\" to \"#{context[:value]}\" with priority \"#{context[:opts][:priority]}\" for vhost \"#{context[:vhost]}\" \.\.\."
   end
 
   # Checks each element of the first policy against the expected context values
   defp assert_operator_policy_fields(context) do
-    result_policy = context[:vhost] |> list_operator_policies |> List.first
+    result_policy = context[:vhost] |> list_operator_policies |> List.first()
     assert result_policy[:definition] == context[:value]
     assert result_policy[:vhost] == context[:vhost]
     assert result_policy[:pattern] == context[:pattern]

--- a/deps/rabbitmq_cli/test/ctl/set_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_permissions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetPermissionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -13,24 +12,23 @@ defmodule SetPermissionsCommandTest do
 
   @vhost "test1"
   @user "guest"
-  @root   "/"
+  @root "/"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
   end
 
   setup context do
-
     on_exit(context, fn ->
-      set_permissions context[:user], context[:vhost], [".*", ".*", ".*"]
+      set_permissions(context[:user], context[:vhost], [".*", ".*", ".*"])
     end)
 
     {
@@ -51,8 +49,12 @@ defmodule SetPermissionsCommandTest do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["insufficient"], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["not", "enough"], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["not", "quite", "enough"], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["this", "is", "way", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["not", "quite", "enough"], %{}) ==
+             {:validation_failure, :not_enough_args}
+
+    assert @command.validate(["this", "is", "way", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag user: @user, vhost: @vhost
@@ -60,11 +62,11 @@ defmodule SetPermissionsCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:user], "^#{context[:user]}-.*", ".*", ".*"],
-      vhost_opts
-    ) == :ok
+             [context[:user], "^#{context[:user]}-.*", ".*", ".*"],
+             vhost_opts
+           ) == :ok
 
-    u = Enum.find(list_permissions(context[:vhost]), fn(x) -> x[:user] == context[:user] end)
+    u = Enum.find(list_permissions(context[:vhost]), fn x -> x[:user] == context[:user] end)
     assert u[:configure] == "^#{context[:user]}-.*"
   end
 
@@ -77,9 +79,9 @@ defmodule SetPermissionsCommandTest do
   @tag user: "interloper", vhost: @root
   test "run: an invalid user returns a no-such-user error", context do
     assert @command.run(
-      [context[:user], "^#{context[:user]}-.*", ".*", ".*"],
-      context[:opts]
-    ) == {:error, {:no_such_user, context[:user]}}
+             [context[:user], "^#{context[:user]}-.*", ".*", ".*"],
+             context[:opts]
+           ) == {:error, {:no_such_user, context[:user]}}
   end
 
   @tag user: @user, vhost: "wintermute"
@@ -87,20 +89,20 @@ defmodule SetPermissionsCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:user], "^#{context[:user]}-.*", ".*", ".*"],
-      vhost_opts
-    ) == {:error, {:no_such_vhost, context[:vhost]}}
+             [context[:user], "^#{context[:user]}-.*", ".*", ".*"],
+             vhost_opts
+           ) == {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag user: @user, vhost: @root
   test "run: invalid regex patterns returns an error", context do
     assert @command.run(
-      [context[:user], "^#{context[:user]}-.*", ".*", "*"],
-      context[:opts]
-    ) == {:error, {:invalid_regexp, '*', {'nothing to repeat', 0}}}
+             [context[:user], "^#{context[:user]}-.*", ".*", "*"],
+             context[:opts]
+           ) == {:error, {:invalid_regexp, '*', {'nothing to repeat', 0}}}
 
     # asserts that the failed command didn't change anything
-    u = Enum.find(list_permissions(context[:vhost]), fn(x) -> x[:user] == context[:user] end)
+    u = Enum.find(list_permissions(context[:vhost]), fn x -> x[:user] == context[:user] end)
     assert u == [user: context[:user], configure: ".*", write: ".*", read: ".*"]
   end
 
@@ -108,7 +110,7 @@ defmodule SetPermissionsCommandTest do
   test "banner", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([context[:user], "^#{context[:user]}-.*", ".*", ".*"], vhost_opts)
-      =~ ~r/Setting permissions for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([context[:user], "^#{context[:user]}-.*", ".*", ".*"], vhost_opts) =~
+             ~r/Setting permissions for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/set_topic_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_topic_permissions_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetTopicPermissionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -13,24 +12,23 @@ defmodule SetTopicPermissionsCommandTest do
 
   @vhost "test1"
   @user "guest"
-  @root   "/"
+  @root "/"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
   end
 
   setup context do
-
     on_exit(context, fn ->
-      clear_topic_permissions context[:user], context[:vhost]
+      clear_topic_permissions(context[:user], context[:vhost])
     end)
 
     {
@@ -51,8 +49,12 @@ defmodule SetTopicPermissionsCommandTest do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["insufficient"], %{}) == {:validation_failure, :not_enough_args}
     assert @command.validate(["not", "enough"], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["still", "not", "enough"], %{}) == {:validation_failure, :not_enough_args}
-    assert @command.validate(["this", "is", "way", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["still", "not", "enough"], %{}) ==
+             {:validation_failure, :not_enough_args}
+
+    assert @command.validate(["this", "is", "way", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag user: @user, vhost: @vhost
@@ -60,9 +62,9 @@ defmodule SetTopicPermissionsCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:user], "amq.topic", "^a", "^b"],
-      vhost_opts
-    ) == :ok
+             [context[:user], "amq.topic", "^a", "^b"],
+             vhost_opts
+           ) == :ok
 
     assert List.first(list_user_topic_permissions(context[:user]))[:write] == "^a"
     assert List.first(list_user_topic_permissions(context[:user]))[:read] == "^b"
@@ -77,9 +79,9 @@ defmodule SetTopicPermissionsCommandTest do
   @tag user: "interloper", vhost: @root
   test "run: an invalid user returns a no-such-user error", context do
     assert @command.run(
-      [context[:user], "amq.topic", "^a", "^b"],
-      context[:opts]
-    ) == {:error, {:no_such_user, context[:user]}}
+             [context[:user], "amq.topic", "^a", "^b"],
+             context[:opts]
+           ) == {:error, {:no_such_user, context[:user]}}
   end
 
   @tag user: @user, vhost: "wintermute"
@@ -87,9 +89,9 @@ defmodule SetTopicPermissionsCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:user], "amq.topic", "^a", "^b"],
-      vhost_opts
-    ) == {:error, {:no_such_vhost, context[:vhost]}}
+             [context[:user], "amq.topic", "^a", "^b"],
+             vhost_opts
+           ) == {:error, {:no_such_vhost, context[:vhost]}}
 
     assert Enum.count(list_user_topic_permissions(context[:user])) == 0
   end
@@ -97,10 +99,13 @@ defmodule SetTopicPermissionsCommandTest do
   @tag user: @user, vhost: @root
   test "run: invalid regex patterns return error", context do
     n = Enum.count(list_user_topic_permissions(context[:user]))
-    {:error, {:invalid_regexp, _, _}} = @command.run(
-                                            [context[:user], "amq.topic", "[", "^b"],
-                                            context[:opts]
-                                          )
+
+    {:error, {:invalid_regexp, _, _}} =
+      @command.run(
+        [context[:user], "amq.topic", "[", "^b"],
+        context[:opts]
+      )
+
     assert Enum.count(list_user_topic_permissions(context[:user])) == n
   end
 
@@ -108,7 +113,7 @@ defmodule SetTopicPermissionsCommandTest do
   test "banner", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([context[:user], "amq.topic", "^a", "^b"], vhost_opts)
-      =~ ~r/Setting topic permissions on \"amq.topic\" for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([context[:user], "amq.topic", "^a", "^b"], vhost_opts) =~
+             ~r/Setting topic permissions on \"amq.topic\" for user \"#{context[:user]}\" in vhost \"#{context[:vhost]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
@@ -19,10 +19,10 @@ defmodule SetUserLimitsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_user @user, @password
+    add_user(@user, @password)
 
     on_exit([], fn ->
-      delete_user @user
+      delete_user(@user)
     end)
 
     :ok
@@ -53,34 +53,34 @@ defmodule SetUserLimitsCommandTest do
 
   test "validate: providing too many arguments fails validation" do
     assert @command.validate(["is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["this", "is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this", "is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "run: a well-formed, host-specific command returns okay", context do
     assert @command.run(
-      [context[:user],
-      @conn_definition],
-      context[:opts]
-    ) == :ok
+             [context[:user], @conn_definition],
+             context[:opts]
+           ) == :ok
 
     assert_limits(context, @conn_definition)
     clear_user_limits(context[:user])
 
     assert @command.run(
-      [context[:user],
-      @channel_definition],
-      context[:opts]
-    ) == :ok
+             [context[:user], @channel_definition],
+             context[:opts]
+           ) == :ok
 
     assert_limits(context, @channel_definition)
   end
 
-  test "run: a well-formed command to set both max-connections and max-channels returns okay", context do
+  test "run: a well-formed command to set both max-connections and max-channels returns okay",
+       context do
     assert @command.run(
-      [context[:user],
-      @definition],
-      context[:opts]
-    ) == :ok
+             [context[:user], @definition],
+             context[:opts]
+           ) == :ok
 
     assert_limits(context, @definition)
   end
@@ -93,37 +93,36 @@ defmodule SetUserLimitsCommandTest do
 
   @tag user: "non-existent-user"
   test "run: providing a non-existent user reports an error", context do
-
     assert @command.run(
-      [context[:user],
-      @conn_definition],
-      context[:opts]
-    ) == {:error, {:no_such_user, context[:user]}}
+             [context[:user], @conn_definition],
+             context[:opts]
+           ) == {:error, {:no_such_user, context[:user]}}
   end
 
   test "run: an invalid definition returns a JSON decoding error", context do
-    assert match?({:error_string, _},
-      @command.run(
-        [context[:user],
-        ["this_is_not_json"]],
-        context[:opts]))
+    assert match?(
+             {:error_string, _},
+             @command.run(
+               [context[:user], ["this_is_not_json"]],
+               context[:opts]
+             )
+           )
 
     assert get_user_limits(context[:user]) == %{}
   end
 
   test "run: invalid limit returns an error", context do
     assert @command.run(
-      [context[:user],
-      "{\"foo\":\"bar\"}"],
-      context[:opts]
-    ) == {:error_string, 'Unrecognised terms [{<<"foo">>,<<"bar">>}] in user-limits'}
+             [context[:user], "{\"foo\":\"bar\"}"],
+             context[:opts]
+           ) == {:error_string, 'Unrecognised terms [{<<"foo">>,<<"bar">>}] in user-limits'}
 
     assert get_user_limits(context[:user]) == %{}
   end
 
   test "banner", context do
-    assert @command.banner([context[:user], context[:conn_definition]], context[:opts])
-      == "Setting user limits to \"#{context[:conn_definition]}\" for user \"#{context[:user]}\" ..."
+    assert @command.banner([context[:user], context[:conn_definition]], context[:opts]) ==
+             "Setting user limits to \"#{context[:conn_definition]}\" for user \"#{context[:user]}\" ..."
   end
 
   #

--- a/deps/rabbitmq_cli/test/ctl/set_user_tags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_user_tags_command_test.exs
@@ -4,20 +4,19 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetUserTagsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand
 
-  @user     "user1"
+  @user "user1"
   @password "password"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_user @user, @password
+    add_user(@user, @password)
 
     on_exit([], fn ->
       delete_user(@user)
@@ -27,7 +26,8 @@ defmodule SetUserTagsCommandTest do
   end
 
   setup context do
-    context[:user] # silences warnings
+    # silences warnings
+    context[:user]
     on_exit([], fn -> set_user_tags(context[:user], []) end)
 
     {:ok, opts: %{node: get_rabbit_hostname()}}
@@ -44,16 +44,17 @@ defmodule SetUserTagsCommandTest do
   end
 
   @tag user: @user, tags: [:emperor]
-  test "run: on a single optional argument, add a flag to the user", context  do
+  test "run: on a single optional argument, add a flag to the user", context do
     @command.run(
       [context[:user] | context[:tags]],
       context[:opts]
     )
 
-    result = Enum.find(
-      list_users(),
-      fn(record) -> record[:user] == context[:user] end
-    )
+    result =
+      Enum.find(
+        list_users(),
+        fn record -> record[:user] == context[:user] end
+      )
 
     assert result[:tags] == context[:tags]
   end
@@ -61,84 +62,84 @@ defmodule SetUserTagsCommandTest do
   @tag user: "interloper", tags: [:emperor]
   test "run: when user does not exist, returns an error", context do
     assert @command.run(
-      [context[:user] | context[:tags]],
-      context[:opts]
-    ) == {:error, {:no_such_user, context[:user]}}
+             [context[:user] | context[:tags]],
+             context[:opts]
+           ) == {:error, {:no_such_user, context[:user]}}
   end
 
   @tag user: @user, tags: [:emperor, :generalissimo]
-  test "run: with multiple optional arguments, adds multiple tags", context  do
+  test "run: with multiple optional arguments, adds multiple tags", context do
     @command.run(
       [context[:user] | context[:tags]],
       context[:opts]
     )
 
-    result = Enum.find(
-      list_users(),
-      fn(record) -> record[:user] == context[:user] end
-    )
+    result =
+      Enum.find(
+        list_users(),
+        fn record -> record[:user] == context[:user] end
+      )
 
     assert result[:tags] == context[:tags]
   end
 
   @tag user: @user, tags: [:emperor]
-  test "run: without optional arguments, clears user tags", context  do
-
+  test "run: without optional arguments, clears user tags", context do
     set_user_tags(context[:user], context[:tags])
 
     @command.run([context[:user]], context[:opts])
 
-    result = Enum.find(
-      list_users(),
-      fn(record) -> record[:user] == context[:user] end
-    )
+    result =
+      Enum.find(
+        list_users(),
+        fn record -> record[:user] == context[:user] end
+      )
 
     assert result[:tags] == []
   end
 
   @tag user: @user, tags: [:emperor]
-  test "run: identical calls are idempotent", context  do
-
+  test "run: identical calls are idempotent", context do
     set_user_tags(context[:user], context[:tags])
 
     assert @command.run(
-      [context[:user] | context[:tags]],
-      context[:opts]
-    ) == :ok
+             [context[:user] | context[:tags]],
+             context[:opts]
+           ) == :ok
 
-    result = Enum.find(
-      list_users(),
-      fn(record) -> record[:user] == context[:user] end
-    )
+    result =
+      Enum.find(
+        list_users(),
+        fn record -> record[:user] == context[:user] end
+      )
 
     assert result[:tags] == context[:tags]
   end
 
   @tag user: @user, old_tags: [:emperor], new_tags: [:generalissimo]
-  test "run: overwrites existing tags", context  do
-
+  test "run: overwrites existing tags", context do
     set_user_tags(context[:user], context[:old_tags])
 
     assert @command.run(
-      [context[:user] | context[:new_tags]],
-      context[:opts]
-    ) == :ok
+             [context[:user] | context[:new_tags]],
+             context[:opts]
+           ) == :ok
 
-    result = Enum.find(
-      list_users(),
-      fn(record) -> record[:user] == context[:user] end
-    )
+    result =
+      Enum.find(
+        list_users(),
+        fn record -> record[:user] == context[:user] end
+      )
 
     assert result[:tags] == context[:new_tags]
   end
 
   @tag user: @user, tags: ["imperator"]
-  test "banner", context  do
+  test "banner", context do
     assert @command.banner(
-        [context[:user] | context[:tags]],
-        context[:opts]
-      )
-      =~ ~r/Setting tags for user \"#{context[:user]}\" to \[#{context[:tags]}\] \.\.\./
+             [context[:user] | context[:tags]],
+             context[:opts]
+           ) =~
+             ~r/Setting tags for user \"#{context[:user]}\" to \[#{context[:tags]}\] \.\.\./
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetVhostLimitsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -17,17 +16,16 @@ defmodule SetVhostLimitsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-    add_vhost @vhost
+    add_vhost(@vhost)
 
     on_exit([], fn ->
-      delete_vhost @vhost
+      delete_vhost(@vhost)
     end)
 
     :ok
   end
 
   setup context do
-
     vhost = context[:vhost] || @vhost
 
     clear_vhost_limits(vhost)
@@ -52,7 +50,10 @@ defmodule SetVhostLimitsCommandTest do
   end
 
   test "merge_defaults: does not change defined vhost" do
-    assert match?({[], %{vhost: "test_vhost"}}, @command.merge_defaults([], %{vhost: "test_vhost"}))
+    assert match?(
+             {[], %{vhost: "test_vhost"}},
+             @command.merge_defaults([], %{vhost: "test_vhost"})
+           )
   end
 
   test "validate: providing too few arguments fails validation" do
@@ -62,14 +63,16 @@ defmodule SetVhostLimitsCommandTest do
   test "validate: providing too many arguments fails validation" do
     assert @command.validate(["too", "many"], %{}) == {:validation_failure, :too_many_args}
     assert @command.validate(["is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["this", "is", "too", "many"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["this", "is", "too", "many"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "run: a well-formed, host-specific command returns okay", context do
     assert @command.run(
-      [context[:definition]],
-      context[:opts]
-    ) == :ok
+             [context[:definition]],
+             context[:opts]
+           ) == :ok
 
     assert_limits(context)
   end
@@ -85,40 +88,43 @@ defmodule SetVhostLimitsCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.run(
-      [context[:definition]],
-      vhost_opts
-    ) == {:error, {:no_such_vhost, context[:vhost]}}
+             [context[:definition]],
+             vhost_opts
+           ) == {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   test "run: an invalid definition returns a JSON decoding error", context do
-    assert match?({:error_string, _},
-      @command.run(["bad_value"], context[:opts]))
+    assert match?(
+             {:error_string, _},
+             @command.run(["bad_value"], context[:opts])
+           )
 
     assert get_vhost_limits(context[:vhost]) == %{}
   end
 
   test "run: invalid limit returns an error", context do
     assert @command.run(
-      ["{\"foo\":\"bar\"}"],
-      context[:opts]
-    ) == {:error_string, 'Validation failed\n\nUnrecognised terms [{<<"foo">>,<<"bar">>}] in limits\n'}
+             ["{\"foo\":\"bar\"}"],
+             context[:opts]
+           ) ==
+             {:error_string,
+              'Validation failed\n\nUnrecognised terms [{<<"foo">>,<<"bar">>}] in limits\n'}
 
     assert get_vhost_limits(context[:vhost]) == %{}
   end
 
   test "run: an empty JSON object definition unsets all limits for vhost", context do
-
     assert @command.run(
-      [@definition],
-      context[:opts]
-    ) == :ok
+             [@definition],
+             context[:opts]
+           ) == :ok
 
     assert_limits(context)
 
     assert @command.run(
-      ["{}"],
-      context[:opts]
-    ) == :ok
+             ["{}"],
+             context[:opts]
+           ) == :ok
 
     assert get_vhost_limits(context[:vhost]) == %{}
   end
@@ -126,8 +132,8 @@ defmodule SetVhostLimitsCommandTest do
   test "banner", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
-    assert @command.banner([context[:definition]], vhost_opts)
-      == "Setting vhost limits to \"#{context[:definition]}\" for vhost \"#{context[:vhost]}\" ..."
+    assert @command.banner([context[:definition]], vhost_opts) ==
+             "Setting vhost limits to \"#{context[:definition]}\" for vhost \"#{context[:vhost]}\" ..."
   end
 
   defp assert_limits(context) do

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_tags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_tags_command_test.exs
@@ -4,14 +4,13 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule SetVhostTagsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.SetVhostTagsCommand
 
-  @vhost    "vhost99-tests"
+  @vhost "vhost99-tests"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -43,13 +42,14 @@ defmodule SetVhostTagsCommandTest do
   end
 
   @tag vhost: @vhost
-  test "run: with a single optional argument, adds a single tag", context  do
+  test "run: with a single optional argument, adds a single tag", context do
     @command.run([context[:vhost], :qa], context[:opts])
 
-    result = Enum.find(
-      list_vhosts(),
-      fn(record) -> record[:vhost] == context[:vhost] end
-    )
+    result =
+      Enum.find(
+        list_vhosts(),
+        fn record -> record[:vhost] == context[:vhost] end
+      )
 
     assert result[:tags] == context[:tags]
   end
@@ -59,81 +59,84 @@ defmodule SetVhostTagsCommandTest do
     delete_vhost(context[:vhost])
 
     assert @command.run(
-      [context[:vhost]],
-      context[:opts]
-    ) == {:error, {:no_such_vhost, context[:vhost]}}
+             [context[:vhost]],
+             context[:opts]
+           ) == {:error, {:no_such_vhost, context[:vhost]}}
   end
 
   @tag user: @vhost, tags: [:qa, :limited]
-  test "run: with multiple optional arguments, adds multiple tags", context  do
+  test "run: with multiple optional arguments, adds multiple tags", context do
     @command.run(
       [context[:vhost] | context[:tags]],
       context[:opts]
     )
 
-    result = Enum.find(
-      list_vhosts(),
-      fn(record) -> record[:vhost] == context[:vhost] end
-    )
+    result =
+      Enum.find(
+        list_vhosts(),
+        fn record -> record[:vhost] == context[:vhost] end
+      )
 
     assert result[:tags] == context[:tags]
   end
 
   @tag user: @vhost, tags: [:qa]
-  test "run: with no optional arguments, clears virtual host tags", context  do
+  test "run: with no optional arguments, clears virtual host tags", context do
     set_vhost_tags(context[:vhost], context[:tags])
 
     @command.run([context[:vhost]], context[:opts])
 
-    result = Enum.find(
-      list_vhosts(),
-      fn(record) -> record[:vhost] == context[:vhost] end
-    )
+    result =
+      Enum.find(
+        list_vhosts(),
+        fn record -> record[:vhost] == context[:vhost] end
+      )
 
     assert result[:tags] == []
   end
 
   @tag user: @vhost, tags: [:qa]
-  test "run: identical calls are idempotent", context  do
+  test "run: identical calls are idempotent", context do
     set_vhost_tags(context[:vhost], context[:tags])
 
     assert @command.run(
-      [context[:vhost] | context[:tags]],
-      context[:opts]
-    ) == :ok
+             [context[:vhost] | context[:tags]],
+             context[:opts]
+           ) == :ok
 
-    result = Enum.find(
-      list_vhosts(),
-      fn(record) -> record[:vhost] == context[:vhost] end
-    )
+    result =
+      Enum.find(
+        list_vhosts(),
+        fn record -> record[:vhost] == context[:vhost] end
+      )
 
     assert result[:tags] == context[:tags]
   end
 
   @tag user: @vhost, old_tags: [:qa], new_tags: [:limited]
-  test "run: overwrites existing tags them", context  do
+  test "run: overwrites existing tags them", context do
     set_vhost_tags(context[:vhost], context[:old_tags])
 
     assert @command.run(
-      [context[:vhost] | context[:new_tags]],
-      context[:opts]
-    ) == :ok
+             [context[:vhost] | context[:new_tags]],
+             context[:opts]
+           ) == :ok
 
-    result = Enum.find(
-      list_vhosts(),
-      fn(record) -> record[:vhost] == context[:vhost] end
-    )
+    result =
+      Enum.find(
+        list_vhosts(),
+        fn record -> record[:vhost] == context[:vhost] end
+      )
 
     assert result[:tags] == context[:new_tags]
   end
 
   @tag user: @vhost, tags: ["abc"]
-  test "banner", context  do
+  test "banner", context do
     assert @command.banner(
-        [context[:vhost] | context[:tags]],
-        context[:opts]
-      )
-      =~ ~r/Setting tags for virtual host \"#{context[:vhost]}\" to \[#{context[:tags]}\] \.\.\./
+             [context[:vhost] | context[:tags]],
+             context[:opts]
+           ) =~
+             ~r/Setting tags for virtual host \"#{context[:vhost]}\" to \[#{context[:tags]}\] \.\.\./
   end
-
 end

--- a/deps/rabbitmq_cli/test/ctl/set_vm_memory_high_watermark_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vm_memory_high_watermark_command_test.exs
@@ -29,7 +29,9 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
 
   test "validate: a string returns an error", context do
     assert @command.validate(["sandwich"], context[:opts]) == {:validation_failure, :bad_argument}
-    assert @command.validate(["0.4sandwich"], context[:opts]) == {:validation_failure, :bad_argument}
+
+    assert @command.validate(["0.4sandwich"], context[:opts]) ==
+             {:validation_failure, :bad_argument}
   end
 
   test "validate: valid numerical value returns valid", context do
@@ -56,15 +58,21 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
   end
 
   test "validate: a negative number returns a bad argument", context do
-    assert @command.validate(["-0.1"], context[:opts]) == {:validation_failure, {:bad_argument, "The threshold should be a fraction between 0.0 and 1.0"}}
+    assert @command.validate(["-0.1"], context[:opts]) ==
+             {:validation_failure,
+              {:bad_argument, "The threshold should be a fraction between 0.0 and 1.0"}}
   end
 
   test "validate: a percentage returns a bad argument", context do
-    assert @command.validate(["40"], context[:opts]) == {:validation_failure, {:bad_argument, "The threshold should be a fraction between 0.0 and 1.0"}}
+    assert @command.validate(["40"], context[:opts]) ==
+             {:validation_failure,
+              {:bad_argument, "The threshold should be a fraction between 0.0 and 1.0"}}
   end
 
   test "validate: a value greater than 1.0 returns a bad argument", context do
-    assert @command.validate(["1.1"], context[:opts]) == {:validation_failure, {:bad_argument, "The threshold should be a fraction between 0.0 and 1.0"}}
+    assert @command.validate(["1.1"], context[:opts]) ==
+             {:validation_failure,
+              {:bad_argument, "The threshold should be a fraction between 0.0 and 1.0"}}
   end
 
   @tag test_timeout: 3000
@@ -75,7 +83,7 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
     assert match?({:badrpc, _}, @command.run(args, opts))
   end
 
-## ---------------------------- Absolute tests --------------------------------
+  ## ---------------------------- Absolute tests --------------------------------
 
   test "validate: an absolute call without an argument returns not enough args" do
     assert @command.validate(["absolute"], %{}) == {:validation_failure, :not_enough_args}
@@ -83,55 +91,65 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
 
   test "validate: an absolute call with too many arguments returns too many args" do
     assert @command.validate(["absolute", "too", "many"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: a single absolute integer return valid", context do
-    assert @command.validate(["absolute","10"], context[:opts]) == :ok
+    assert @command.validate(["absolute", "10"], context[:opts]) == :ok
   end
+
   test "run: a single absolute integer return ok", context do
-    assert @command.run(["absolute","10"], context[:opts]) == :ok
+    assert @command.run(["absolute", "10"], context[:opts]) == :ok
     assert status()[:vm_memory_high_watermark] == {:absolute, memory_unit_absolute(10, "")}
   end
 
   test "validate: a single absolute integer with an invalid memory unit fails ", context do
-    assert @command.validate(["absolute","10bytes"], context[:opts]) == {:validation_failure, {:bad_argument, "Invalid units."}}
+    assert @command.validate(["absolute", "10bytes"], context[:opts]) ==
+             {:validation_failure, {:bad_argument, "Invalid units."}}
   end
 
   test "validate: a single absolute float with a valid memory unit fails ", context do
-    assert @command.validate(["absolute","10.0MB"], context[:opts]) == {:validation_failure, {:bad_argument, "The threshold should be an integer."}}
+    assert @command.validate(["absolute", "10.0MB"], context[:opts]) ==
+             {:validation_failure, {:bad_argument, "The threshold should be an integer."}}
   end
 
   test "validate: a single absolute float with an invalid memory unit fails ", context do
-    assert @command.validate(["absolute","10.0bytes"], context[:opts]) == {:validation_failure, {:bad_argument, "The threshold should be an integer."}}
+    assert @command.validate(["absolute", "10.0bytes"], context[:opts]) ==
+             {:validation_failure, {:bad_argument, "The threshold should be an integer."}}
   end
 
   test "validate: a single absolute string fails ", context do
-    assert @command.validate(["absolute","large"], context[:opts]) == {:validation_failure, :bad_argument}
+    assert @command.validate(["absolute", "large"], context[:opts]) ==
+             {:validation_failure, :bad_argument}
   end
 
   test "validate: a single absolute string with a valid unit  fails ", context do
-    assert @command.validate(["absolute","manyGB"], context[:opts]) == {:validation_failure, :bad_argument}
+    assert @command.validate(["absolute", "manyGB"], context[:opts]) ==
+             {:validation_failure, :bad_argument}
   end
 
   test "run: a single absolute integer with memory units return ok", context do
     memory_units()
     |> Enum.each(fn mu ->
       arg = "10#{mu}"
-      assert @command.run(["absolute",arg], context[:opts]) == :ok
+      assert @command.run(["absolute", arg], context[:opts]) == :ok
       assert status()[:vm_memory_high_watermark] == {:absolute, memory_unit_absolute(10, mu)}
     end)
   end
 
   test "run: low watermark sets alarm", context do
     old_watermark = status()[:vm_memory_high_watermark]
-    on_exit(fn() ->
-      args = case old_watermark do
-        {:absolute, val} -> ["absolute", to_string(val)];
-        other            -> [to_string(other)]
-      end
+
+    on_exit(fn ->
+      args =
+        case old_watermark do
+          {:absolute, val} -> ["absolute", to_string(val)]
+          other -> [to_string(other)]
+        end
+
       @command.run(args, context[:opts])
     end)
+
     ## this will trigger an alarm
     @command.run(["absolute", "2000"], context[:opts])
 
@@ -139,24 +157,24 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
   end
 
   test "banner: absolute memory request prints info message", context do
-    assert @command.banner(["absolute", "10"], context[:opts])
-      =~ ~r/Setting memory threshold on #{get_rabbit_hostname()} to 10 bytes .../
+    assert @command.banner(["absolute", "10"], context[:opts]) =~
+             ~r/Setting memory threshold on #{get_rabbit_hostname()} to 10 bytes .../
 
-    assert @command.banner(["absolute", "-10"], context[:opts])
-      =~ ~r/Setting memory threshold on #{get_rabbit_hostname()} to -10 bytes .../
+    assert @command.banner(["absolute", "-10"], context[:opts]) =~
+             ~r/Setting memory threshold on #{get_rabbit_hostname()} to -10 bytes .../
 
-    assert @command.banner(["absolute", "sandwich"], context[:opts])
-      =~ ~r/Setting memory threshold on #{get_rabbit_hostname()} to sandwich bytes .../
+    assert @command.banner(["absolute", "sandwich"], context[:opts]) =~
+             ~r/Setting memory threshold on #{get_rabbit_hostname()} to sandwich bytes .../
   end
 
   test "banner, relative memory", context do
-    assert @command.banner(["0.7"], context[:opts])
-      =~ ~r/Setting memory threshold on #{get_rabbit_hostname()} to 0.7 .../
+    assert @command.banner(["0.7"], context[:opts]) =~
+             ~r/Setting memory threshold on #{get_rabbit_hostname()} to 0.7 .../
 
-    assert @command.banner(["-0.7"], context[:opts])
-      =~ ~r/Setting memory threshold on #{get_rabbit_hostname()} to -0.7 .../
+    assert @command.banner(["-0.7"], context[:opts]) =~
+             ~r/Setting memory threshold on #{get_rabbit_hostname()} to -0.7 .../
 
-    assert @command.banner(["sandwich"], context[:opts])
-      =~ ~r/Setting memory threshold on #{get_rabbit_hostname()} to sandwich .../
+    assert @command.banner(["sandwich"], context[:opts]) =~
+             ~r/Setting memory threshold on #{get_rabbit_hostname()} to sandwich .../
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/shutdown_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/shutdown_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ShutdownCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -30,8 +29,10 @@ defmodule ShutdownCommandTest do
   end
 
   test "validate: in wait mode, checks if local and target node hostnames match" do
-    assert match?({:validation_failure, {:unsupported_target, _}},
-                  @command.validate([], %{wait: true, node: :'rabbit@some.remote.hostname'}))
+    assert match?(
+             {:validation_failure, {:unsupported_target, _}},
+             @command.validate([], %{wait: true, node: :"rabbit@some.remote.hostname"})
+           )
   end
 
   test "validate: in wait mode, always assumes @localhost nodes are local" do

--- a/deps/rabbitmq_cli/test/ctl/start_app_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/start_app_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule StartAppCommandTest do
   use ExUnit.Case, async: false
   import TestHelper

--- a/deps/rabbitmq_cli/test/ctl/status_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/status_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule StatusCommandTest do
   use ExUnit.Case, async: false
   import TestHelper

--- a/deps/rabbitmq_cli/test/ctl/stop_app_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/stop_app_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule StopAppCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -44,6 +43,7 @@ defmodule StopAppCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts]) =~ ~r/Stopping rabbit application on node #{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Stopping rabbit application on node #{get_rabbit_hostname()}/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/stop_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/stop_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule StopCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,8 +17,7 @@ defmodule StopCommandTest do
   end
 
   setup do
-    {:ok, opts: %{node: get_rabbit_hostname(),
-                  idempotent: false}}
+    {:ok, opts: %{node: get_rabbit_hostname(), idempotent: false}}
   end
 
   test "validate accepts no arguments", context do
@@ -31,7 +29,8 @@ defmodule StopCommandTest do
   end
 
   test "validate: with extra arguments returns an arg count error", context do
-    assert @command.validate(["/path/to/pidfile.pid", "extra"], context[:opts]) == {:validation_failure, :too_many_args}
+    assert @command.validate(["/path/to/pidfile.pid", "extra"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
   end
 
   # NB: as this commands shuts down the Erlang vm it isn't really practical to test it here
@@ -47,6 +46,7 @@ defmodule StopCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts]) =~ ~r/Stopping and halting node #{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Stopping and halting node #{get_rabbit_hostname()}/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/suspend_listeners_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/suspend_listeners_command_test.exs
@@ -16,6 +16,7 @@ defmodule SuspendListenersCommandTest do
     resume_all_client_listeners()
 
     node_name = get_rabbit_hostname()
+
     on_exit(fn ->
       resume_all_client_listeners()
       close_all_connections(node_name)
@@ -38,7 +39,7 @@ defmodule SuspendListenersCommandTest do
 
   test "validate: with extra arguments returns an arg count error", context do
     assert @command.validate(["extra"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: request to a non-existent node returns a badrpc" do

--- a/deps/rabbitmq_cli/test/ctl/sync_queue_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/sync_queue_command_test.exs
@@ -25,25 +25,26 @@ defmodule SyncQueueCommandTest do
   end
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname(),
-      vhost: @vhost
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       vhost: @vhost
+     }}
   end
 
   test "validate: specifying no queue name is reported as an error", context do
     assert @command.validate([], context[:opts]) ==
-      {:validation_failure, :not_enough_args}
+             {:validation_failure, :not_enough_args}
   end
 
   test "validate: specifying two queue names is reported as an error", context do
     assert @command.validate(["q1", "q2"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: specifying three queue names is reported as an error", context do
     assert @command.validate(["q1", "q2", "q3"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: specifying one queue name succeeds", context do

--- a/deps/rabbitmq_cli/test/ctl/trace_off_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/trace_off_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule TraceOffCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -72,7 +71,7 @@ defmodule TraceOffCommandTest do
 
   @tag vhost: @default_vhost
   test "banner", context do
-    assert @command.banner([], context[:opts])
-      =~ ~r/Stopping tracing for vhost "#{context[:vhost]}" .../
+    assert @command.banner([], context[:opts]) =~
+             ~r/Stopping tracing for vhost "#{context[:vhost]}" .../
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/trace_on_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/trace_on_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule TraceOnCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -73,7 +72,7 @@ defmodule TraceOnCommandTest do
 
   @tag vhost: @default_vhost
   test "banner", context do
-    assert @command.banner([], context[:opts])
-      =~ ~r/Starting tracing for vhost "#{context[:vhost]}" .../
+    assert @command.banner([], context[:opts]) =~
+             ~r/Starting tracing for vhost "#{context[:vhost]}" .../
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/update_cluster_nodes_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_cluster_nodes_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2016-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule UpdateClusterNodesCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -24,26 +23,30 @@ defmodule UpdateClusterNodesCommandTest do
   end
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname()
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname()
+     }}
   end
 
   test "validate: providing too few arguments fails validation", context do
     assert @command.validate([], context[:opts]) ==
-      {:validation_failure, :not_enough_args}
+             {:validation_failure, :not_enough_args}
   end
 
   test "validate: providing too many arguments fails validation", context do
     assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: specifying self as seed node fails validation", context do
     stop_rabbitmq_app()
+
     assert match?(
-      {:error, :cannot_cluster_node_with_itself},
-      @command.run([context[:opts][:node]], context[:opts]))
+             {:error, :cannot_cluster_node_with_itself},
+             @command.run([context[:opts][:node]], context[:opts])
+           )
+
     start_rabbitmq_app()
   end
 
@@ -52,29 +55,35 @@ defmodule UpdateClusterNodesCommandTest do
       node: :jake@thedog,
       timeout: 200
     }
+
     assert match?(
-      {:badrpc, :nodedown},
-      @command.run([context[:opts][:node]], opts))
+             {:badrpc, :nodedown},
+             @command.run([context[:opts][:node]], opts)
+           )
   end
 
   test "run: specifying an unreachable node as seed returns a badrpc", context do
     stop_rabbitmq_app()
+
     assert match?(
-      {:badrpc_multi, _, [_]},
-      @command.run([:jake@thedog], context[:opts]))
+             {:badrpc_multi, _, [_]},
+             @command.run([:jake@thedog], context[:opts])
+           )
+
     start_rabbitmq_app()
   end
 
   test "banner", context do
     assert @command.banner(["a"], context[:opts]) =~
-      ~r/Will seed #{get_rabbit_hostname()} from a on next start/
+             ~r/Will seed #{get_rabbit_hostname()} from a on next start/
   end
 
   test "output mnesia is running error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code,
-                   "Mnesia is still running on node " <> _},
-                   @command.output({:error, :mnesia_unexpectedly_running}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
 
+    assert match?(
+             {:error, ^exit_code, "Mnesia is still running on node " <> _},
+             @command.output({:error, :mnesia_unexpectedly_running}, context[:opts])
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/version_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/version_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule VersionCommandTest do
   use ExUnit.Case
 

--- a/deps/rabbitmq_cli/test/ctl/wait_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/wait_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule WaitCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -22,11 +21,8 @@ defmodule WaitCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
     rabbitmq_home = :rabbit_misc.rpc_call(get_rabbit_hostname(), :code, :lib_dir, [:rabbit])
 
-    {:ok, opts: %{node: get_rabbit_hostname(),
-                  rabbitmq_home: rabbitmq_home,
-                  timeout: 500}}
+    {:ok, opts: %{node: get_rabbit_hostname(), rabbitmq_home: rabbitmq_home, timeout: 500}}
   end
-
 
   test "validate: cannot have both pid and pidfile", context do
     {:validation_failure, "Cannot specify both pid and pidfile"} =
@@ -34,32 +30,35 @@ defmodule WaitCommandTest do
   end
 
   test "validate: should have either pid or pidfile", context do
-    {:validation_failure, "No pid or pidfile specified"} =
-      @command.validate([], context[:opts])
+    {:validation_failure, "No pid or pidfile specified"} = @command.validate([], context[:opts])
   end
 
   test "validate: with more than one argument returns an arg count error", context do
-    assert @command.validate(["pid_file", "extra"], context[:opts]) == {:validation_failure, :too_many_args}
+    assert @command.validate(["pid_file", "extra"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "run: times out waiting for non-existent pid file", context do
-    {:error, {:timeout, _}} = @command.run(["pid_file"], context[:opts]) |> Enum.to_list |> List.last
+    {:error, {:timeout, _}} =
+      @command.run(["pid_file"], context[:opts]) |> Enum.to_list() |> List.last()
   end
 
   test "run: fails if pid process does not exist", context do
     non_existent_pid = get_non_existent_os_pid()
+
     {:error, :process_not_running} =
       @command.run([], Map.merge(context[:opts], %{pid: non_existent_pid}))
-      |> Enum.to_list
-      |> List.last
+      |> Enum.to_list()
+      |> List.last()
   end
 
   test "run: times out if unable to communicate with the node", context do
     pid = String.to_integer(System.get_pid())
+
     {:error, {:timeout, _}} =
       @command.run([], Map.merge(context[:opts], %{pid: pid, node: :nonode@nohost}))
-      |> Enum.to_list
-      |> List.last
+      |> Enum.to_list()
+      |> List.last()
   end
 
   test "run: happy path", context do
@@ -79,21 +78,30 @@ defmodule WaitCommandTest do
   end
 
   test "output: process not running error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code, "Error: process is not running."},
-                  @command.output({:error, :process_not_running}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
+
+    assert match?(
+             {:error, ^exit_code, "Error: process is not running."},
+             @command.output({:error, :process_not_running}, context[:opts])
+           )
   end
 
   test "output: garbage in pid file error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code, "Error: garbage in pid file."},
-                  @command.output({:error, {:garbage_in_pid_file, "somefile"}}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
+
+    assert match?(
+             {:error, ^exit_code, "Error: garbage in pid file."},
+             @command.output({:error, {:garbage_in_pid_file, "somefile"}}, context[:opts])
+           )
   end
 
   test "output: could not read pid error", context do
-    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software
-    assert match?({:error, ^exit_code, "Error: could not read pid. Detail: something wrong"},
-                  @command.output({:error, {:could_not_read_pid, "something wrong"}}, context[:opts]))
+    exit_code = RabbitMQ.CLI.Core.ExitCodes.exit_software()
+
+    assert match?(
+             {:error, ^exit_code, "Error: could not read pid. Detail: something wrong"},
+             @command.output({:error, {:could_not_read_pid, "something wrong"}}, context[:opts])
+           )
   end
 
   test "output: default output is fine", context do
@@ -107,7 +115,7 @@ defmodule WaitCommandTest do
 
   def get_non_existent_os_pid(pid \\ 2) do
     case :rabbit_misc.is_os_process_alive(to_charlist(pid)) do
-      true  -> get_non_existent_os_pid(pid + 1)
+      true -> get_non_existent_os_pid(pid + 1)
       false -> pid
     end
   end

--- a/deps/rabbitmq_cli/test/diagnostics/alarms_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/alarms_command_test.exs
@@ -24,10 +24,11 @@ defmodule AlarmsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -44,7 +45,10 @@ defmodule AlarmsCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: when target node has no alarms in effect, returns an empty list", context do
@@ -55,9 +59,11 @@ defmodule AlarmsCommandTest do
 
   test "run: when target node has an alarm in effect, returns it", context do
     old_watermark = status()[:vm_memory_high_watermark]
-    on_exit(fn() ->
+
+    on_exit(fn ->
       set_vm_memory_high_watermark(old_watermark)
     end)
+
     # 2000 bytes will trigger an alarm
     set_vm_memory_high_watermark({:absolute, 2000})
 

--- a/deps/rabbitmq_cli/test/diagnostics/check_alarms_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_alarms_command_test.exs
@@ -24,10 +24,11 @@ defmodule CheckAlarmsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -44,7 +45,10 @@ defmodule CheckAlarmsCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when target node has no alarms in effect, returns an empty list", context do
@@ -55,9 +59,11 @@ defmodule CheckAlarmsCommandTest do
 
   test "run: when target node has an alarm in effect, returns it", context do
     old_watermark = status()[:vm_memory_high_watermark]
-    on_exit(fn() ->
+
+    on_exit(fn ->
       set_vm_memory_high_watermark(old_watermark)
     end)
+
     # 2000 bytes will trigger an alarm
     set_vm_memory_high_watermark({:absolute, 2000})
 
@@ -66,7 +72,6 @@ defmodule CheckAlarmsCommandTest do
 
     set_vm_memory_high_watermark(old_watermark)
   end
-
 
   test "output: when target node has no alarms in effect, returns a success", context do
     assert [] == status()[:alarms]
@@ -85,17 +90,18 @@ defmodule CheckAlarmsCommandTest do
           ],
           [
             :file_descriptor_limit,
-            {{:resource_limit, :disk,   :hare@warp10},   []},
-            {{:resource_limit, :memory, :hare@warp10},   []},
-            {{:resource_limit, :disk,   :rabbit@warp10}, []},
+            {{:resource_limit, :disk, :hare@warp10}, []},
+            {{:resource_limit, :memory, :hare@warp10}, []},
+            {{:resource_limit, :disk, :rabbit@warp10}, []},
             {{:resource_limit, :memory, :rabbit@warp10}, []}
           ]
         ] do
-        assert match?({:error, _, _}, @command.output(input, context[:opts]))
+      assert match?({:error, _, _}, @command.output(input, context[:opts]))
     end
   end
 
-  test "output: when target node has an alarm in effect and --silent is passed, returns a silent failure", _context do
+  test "output: when target node has an alarm in effect and --silent is passed, returns a silent failure",
+       _context do
     for input <- [
           [
             :file_descriptor_limit
@@ -106,13 +112,13 @@ defmodule CheckAlarmsCommandTest do
           ],
           [
             :file_descriptor_limit,
-            {{:resource_limit, :disk,   :hare@warp10},   []},
-            {{:resource_limit, :memory, :hare@warp10},   []},
-            {{:resource_limit, :disk,   :rabbit@warp10}, []},
+            {{:resource_limit, :disk, :hare@warp10}, []},
+            {{:resource_limit, :memory, :hare@warp10}, []},
+            {{:resource_limit, :disk, :rabbit@warp10}, []},
             {{:resource_limit, :memory, :rabbit@warp10}, []}
           ]
         ] do
-        assert {:error, :check_failed} == @command.output(input, %{silent: true})
+      assert {:error, :check_failed} == @command.output(input, %{silent: true})
     end
   end
 end

--- a/deps/rabbitmq_cli/test/diagnostics/check_local_alarms_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_local_alarms_command_test.exs
@@ -24,10 +24,11 @@ defmodule CheckLocalAlarmsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -44,7 +45,10 @@ defmodule CheckLocalAlarmsCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when target node has no alarms in effect, returns an empty list", context do
@@ -55,9 +59,11 @@ defmodule CheckLocalAlarmsCommandTest do
 
   test "run: when target node has a local alarm in effect, returns it", context do
     old_watermark = status()[:vm_memory_high_watermark]
-    on_exit(fn() ->
+
+    on_exit(fn ->
       set_vm_memory_high_watermark(old_watermark)
     end)
+
     # 2000 bytes will trigger an alarm
     set_vm_memory_high_watermark({:absolute, 2000})
 
@@ -81,16 +87,17 @@ defmodule CheckLocalAlarmsCommandTest do
           ],
           [
             :file_descriptor_limit,
-            {{:resource_limit, :disk,   get_rabbit_hostname()}, []},
+            {{:resource_limit, :disk, get_rabbit_hostname()}, []},
             {{:resource_limit, :memory, get_rabbit_hostname()}, []}
           ]
         ] do
-        assert match?({:error, _}, @command.output(input, context[:opts]))
+      assert match?({:error, _}, @command.output(input, context[:opts]))
     end
   end
 
   # note: it's run/2 that filters out non-local alarms
-  test "output: when target node has an alarm in effect and --silent is passed, returns a silent failure", _context do
+  test "output: when target node has an alarm in effect and --silent is passed, returns a silent failure",
+       _context do
     for input <- [
           [
             :file_descriptor_limit
@@ -101,11 +108,11 @@ defmodule CheckLocalAlarmsCommandTest do
           ],
           [
             :file_descriptor_limit,
-            {{:resource_limit, :disk,   get_rabbit_hostname()}, []},
+            {{:resource_limit, :disk, get_rabbit_hostname()}, []},
             {{:resource_limit, :memory, get_rabbit_hostname()}, []}
           ]
         ] do
-        assert {:error, :check_failed} == @command.output(input, %{silent: true})
+      assert {:error, :check_failed} == @command.output(input, %{silent: true})
     end
   end
 end

--- a/deps/rabbitmq_cli/test/diagnostics/check_port_connectivity_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_port_connectivity_command_test.exs
@@ -17,10 +17,11 @@ defmodule CheckPortConnectivityCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: provides a default timeout" do
@@ -37,13 +38,15 @@ defmodule CheckPortConnectivityCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: tries to connect to every inferred active listener", context do
     assert match?({true, _}, @command.run([], context[:opts]))
   end
-
 
   test "output: when all connections succeeded, returns a success", context do
     assert match?({:ok, _}, @command.output({true, []}, context[:opts]))
@@ -51,9 +54,10 @@ defmodule CheckPortConnectivityCommandTest do
 
   # note: it's run/2 that filters out non-local alarms
   test "output: when target node has a local alarm in effect, returns a failure", context do
-    failure = {:listener, :rabbit@mercurio, :lolz, 'mercurio',
-                  {0, 0, 0, 0, 0, 0, 0, 0}, 7761613,
-                  [backlog: 128, nodelay: true]}
+    failure =
+      {:listener, :rabbit@mercurio, :lolz, 'mercurio', {0, 0, 0, 0, 0, 0, 0, 0}, 7_761_613,
+       [backlog: 128, nodelay: true]}
+
     assert match?({:error, _}, @command.output({false, [failure]}, context[:opts]))
   end
 end

--- a/deps/rabbitmq_cli/test/diagnostics/check_port_listener_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_port_listener_command_test.exs
@@ -17,10 +17,11 @@ defmodule CheckPortListenerCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -41,7 +42,10 @@ defmodule CheckPortListenerCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([61613], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([61613], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when a listener for the protocol is active, returns a success", context do

--- a/deps/rabbitmq_cli/test/diagnostics/check_protocol_listener_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_protocol_listener_command_test.exs
@@ -17,10 +17,11 @@ defmodule CheckProtocolListenerCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -41,7 +42,10 @@ defmodule CheckProtocolListenerCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run(["stomp"], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run(["stomp"], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when a listener for the protocol is active, returns a success", context do
@@ -54,7 +58,8 @@ defmodule CheckProtocolListenerCommandTest do
     end
   end
 
-  test "run: when a listener for the protocol is not active or unknown, returns an error", context do
+  test "run: when a listener for the protocol is not active or unknown, returns an error",
+       context do
     assert match?({false, _, _}, @command.run(["non-existent-proto"], context[:opts]))
   end
 

--- a/deps/rabbitmq_cli/test/diagnostics/check_running_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_running_command_test.exs
@@ -23,10 +23,11 @@ defmodule CheckRunningCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -43,7 +44,10 @@ defmodule CheckRunningCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when the RabbitMQ app is booted and started, returns true", context do

--- a/deps/rabbitmq_cli/test/diagnostics/check_virtual_hosts_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_virtual_hosts_command_test.exs
@@ -17,10 +17,11 @@ defmodule CheckVirtualHostsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: is a no-op" do
@@ -37,7 +38,10 @@ defmodule CheckVirtualHostsCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "output: when all virtual hosts are reported as up, returns a success", context do

--- a/deps/rabbitmq_cli/test/diagnostics/cipher_suites_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/cipher_suites_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule CipherSuitesCommandTest do
   use ExUnit.Case
   import TestHelper
@@ -18,12 +17,13 @@ defmodule CipherSuitesCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        format: context[:format] || "openssl",
-        all: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       format: context[:format] || "openssl",
+       all: false
+     }}
   end
 
   test "merge_defaults: defaults to the OpenSSL format" do
@@ -31,8 +31,12 @@ defmodule CipherSuitesCommandTest do
   end
 
   test "merge_defaults: format is case insensitive" do
-    assert @command.merge_defaults([], %{format: "OpenSSL"}) == {[], %{format: "openssl", all: false}}
-    assert @command.merge_defaults([], %{format: "Erlang"}) == {[], %{format: "erlang", all: false}}
+    assert @command.merge_defaults([], %{format: "OpenSSL"}) ==
+             {[], %{format: "openssl", all: false}}
+
+    assert @command.merge_defaults([], %{format: "Erlang"}) ==
+             {[], %{format: "erlang", all: false}}
+
     assert @command.merge_defaults([], %{format: "Map"}) == {[], %{format: "map", all: false}}
   end
 
@@ -41,7 +45,8 @@ defmodule CipherSuitesCommandTest do
   end
 
   test "validate: treats positional arguments as a failure", context do
-    assert @command.validate(["extra-arg"], context[:opts]) == {:validation_failure, :too_many_args}
+    assert @command.validate(["extra-arg"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: treats empty positional arguments and default switches as a success", context do
@@ -56,13 +61,16 @@ defmodule CipherSuitesCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag format: "openssl"
   test "run: returns a list of cipher suites in OpenSSL format", context do
     res = @command.run([], context[:opts])
-    for cipher <- res, do: assert true == is_list(cipher)
+    for cipher <- res, do: assert(true == is_list(cipher))
     # the list is long and its values are environment-specific,
     # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
@@ -72,7 +80,7 @@ defmodule CipherSuitesCommandTest do
   test "run: returns a list of cipher suites in erlang format", context do
     res = @command.run([], context[:opts])
 
-    for cipher <- res, do: assert true = is_tuple(cipher)
+    for cipher <- res, do: assert(true = is_tuple(cipher))
     # the list is long and its values are environment-specific,
     # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
@@ -81,7 +89,7 @@ defmodule CipherSuitesCommandTest do
   @tag format: "map"
   test "run: returns a list of cipher suites in map format", context do
     res = @command.run([], context[:opts])
-    for cipher <- res, do: assert true = is_map(cipher)
+    for cipher <- res, do: assert(true = is_map(cipher))
     # the list is long and its values are environment-specific,
     # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
@@ -97,5 +105,4 @@ defmodule CipherSuitesCommandTest do
     assert length(all_suites) > length(default_suites)
     assert length(default_suites -- all_suites) == 0
   end
-
 end

--- a/deps/rabbitmq_cli/test/diagnostics/command_line_arguments_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/command_line_arguments_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule CommandLineArgumentsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -21,13 +20,14 @@ defmodule CommandLineArgumentsCommandTest do
     {:ok, opts: %{node: get_rabbit_hostname(), timeout: :infinity}}
   end
 
-  test "validate: with extra arguments, command line arguments returns an arg count error", context do
+  test "validate: with extra arguments, command line arguments returns an arg count error",
+       context do
     assert @command.validate(["extra"], context[:opts]) ==
-    {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "run: command line arguments request to a reachable node succeeds", context do
-    output = @command.run([], context[:opts]) |> Enum.to_list
+    output = @command.run([], context[:opts]) |> Enum.to_list()
 
     assert_stream_without_errors(output)
   end
@@ -38,7 +38,7 @@ defmodule CommandLineArgumentsCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts])
-      =~ ~r/Command line arguments of node #{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Command line arguments of node #{get_rabbit_hostname()}/
   end
 end

--- a/deps/rabbitmq_cli/test/diagnostics/consume_event_stream_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/consume_event_stream_command_test.exs
@@ -15,7 +15,7 @@ defmodule ConsumeEventStreamCommandTest do
 
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
 
     on_exit([], fn ->
       start_rabbitmq_app()
@@ -25,18 +25,18 @@ defmodule ConsumeEventStreamCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        duration: :infinity,
-        pattern: ".*"
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       duration: :infinity,
+       pattern: ".*"
+     }}
   end
 
   test "merge_defaults: duration defaults to infinity, pattern to anything" do
-    assert @command.merge_defaults([], %{}) == {[], %{duration: :infinity,
-                                                      pattern: ".*",
-                                                      quiet: true}}
+    assert @command.merge_defaults([], %{}) ==
+             {[], %{duration: :infinity, pattern: ".*", quiet: true}}
   end
 
   test "validate: treats positional arguments as a failure" do
@@ -49,25 +49,30 @@ defmodule ConsumeEventStreamCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: consumes events for N seconds", context do
-
     stream = @command.run([], Map.merge(context[:opts], %{duration: 5}))
-    :rpc.call(get_rabbit_hostname(), :rabbit_event, :notify, [String.to_atom("event_type1"),
-                                                              [{String.to_atom("args"), 1}]])
-    :rpc.call(get_rabbit_hostname(), :rabbit_event, :notify, [String.to_atom("event_type2"),
-                                                              [{String.to_atom("pid"), self()}]])
 
+    :rpc.call(get_rabbit_hostname(), :rabbit_event, :notify, [
+      String.to_atom("event_type1"),
+      [{String.to_atom("args"), 1}]
+    ])
 
-    event1 =  Enum.find(stream, nil, fn x -> Keyword.get(x, :event, nil) == "event.type1" end)
-    event2 =  Enum.find(stream, nil, fn x -> Keyword.get(x, :event, nil) == "event.type2" end)
+    :rpc.call(get_rabbit_hostname(), :rabbit_event, :notify, [
+      String.to_atom("event_type2"),
+      [{String.to_atom("pid"), self()}]
+    ])
+
+    event1 = Enum.find(stream, nil, fn x -> Keyword.get(x, :event, nil) == "event.type1" end)
+    event2 = Enum.find(stream, nil, fn x -> Keyword.get(x, :event, nil) == "event.type2" end)
     assert event1 != nil
     assert event2 != nil
     assert Keyword.get(event1, :args, nil) == 1
     assert is_binary(Keyword.get(event2, :pid, nil))
-
   end
-
 end

--- a/deps/rabbitmq_cli/test/diagnostics/disable_auth_attempt_source_tracking_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/disable_auth_attempt_source_tracking_command_test.exs
@@ -24,12 +24,15 @@ defmodule DisbleAuthAttemptSourceTrackingCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
-    @tag test_timeout: 3000
+  @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 15000

--- a/deps/rabbitmq_cli/test/diagnostics/discover_peers_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/discover_peers_command_test.exs
@@ -24,12 +24,15 @@ defmodule DiscoverPeersCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 15000

--- a/deps/rabbitmq_cli/test/diagnostics/enable_auth_attempt_source_tracking_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/enable_auth_attempt_source_tracking_command_test.exs
@@ -24,12 +24,15 @@ defmodule EnableAuthAttemptSourceTrackingCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
-    @tag test_timeout: 3000
+  @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 15000

--- a/deps/rabbitmq_cli/test/diagnostics/erlang_cookie_hash_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/erlang_cookie_hash_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ErlangCookieHashCommandTest do
   use ExUnit.Case
   import TestHelper
@@ -18,10 +17,11 @@ defmodule ErlangCookieHashCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 5000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 5000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -46,5 +46,4 @@ defmodule ErlangCookieHashCommandTest do
     res = @command.run([], context[:opts])
     assert is_bitstring(res)
   end
-
 end

--- a/deps/rabbitmq_cli/test/diagnostics/erlang_version_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/erlang_version_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ErlangVersionCommandTest do
   use ExUnit.Case
   import TestHelper
@@ -18,12 +17,13 @@ defmodule ErlangVersionCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        details: false,
-        offline: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       details: false,
+       offline: false
+     }}
   end
 
   test "merge_defaults: defaults to remote version and abbreviated output" do
@@ -52,7 +52,10 @@ defmodule ErlangVersionCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, details: false})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, details: false}))
+           )
   end
 
   test "run: returns Erlang/OTP version on the target node", context do

--- a/deps/rabbitmq_cli/test/diagnostics/is_booting_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/is_booting_command_test.exs
@@ -23,10 +23,11 @@ defmodule IsBootingCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -43,7 +44,10 @@ defmodule IsBootingCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when the RabbitMQ app is fully booted and running, returns false", context do

--- a/deps/rabbitmq_cli/test/diagnostics/is_running_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/is_running_command_test.exs
@@ -23,10 +23,11 @@ defmodule IsRunningCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -43,7 +44,10 @@ defmodule IsRunningCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: when the RabbitMQ app is booted and started, returns true", context do

--- a/deps/rabbitmq_cli/test/diagnostics/list_network_interfaces_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/list_network_interfaces_command_test.exs
@@ -24,12 +24,15 @@ defmodule ListNetworkInterfacesCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
-    @tag test_timeout: 3000
+  @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 15000

--- a/deps/rabbitmq_cli/test/diagnostics/list_node_auth_attempt_stats_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/list_node_auth_attempt_stats_command_test.exs
@@ -24,12 +24,15 @@ defmodule ListNodeAuthAttemptStatsCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
-    @tag test_timeout: 3000
+  @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 15000

--- a/deps/rabbitmq_cli/test/diagnostics/listeners_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/listeners_command_test.exs
@@ -24,10 +24,11 @@ defmodule ListenersCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -44,20 +45,24 @@ defmodule ListenersCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: returns a list of node-local listeners", context do
     xs = @command.run([], context[:opts]) |> listener_maps
 
     assert length(xs) >= 3
+
     for p <- [5672, 61613, 25672] do
       assert Enum.any?(xs, fn %{port: port} -> port == p end)
     end
   end
 
   test "output: returns a formatted list of node-local listeners", context do
-    raw        = @command.run([],  context[:opts])
+    raw = @command.run([], context[:opts])
     {:ok, msg} = @command.output(raw, context[:opts])
 
     for p <- [5672, 61613, 25672] do
@@ -66,11 +71,12 @@ defmodule ListenersCommandTest do
   end
 
   test "output: when formatter is JSON, returns an array of listener maps", context do
-    raw        = @command.run([],  context[:opts])
+    raw = @command.run([], context[:opts])
     {:ok, doc} = @command.output(raw, Map.merge(%{formatter: "json"}, context[:opts]))
-    xs         = doc["listeners"]
+    xs = doc["listeners"]
 
     assert length(xs) >= 3
+
     for p <- [5672, 61613, 25672] do
       assert Enum.any?(xs, fn %{port: port} -> port == p end)
     end

--- a/deps/rabbitmq_cli/test/diagnostics/log_location_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/log_location_command_test.exs
@@ -15,7 +15,7 @@ defmodule LogLocationCommandTest do
 
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
 
     on_exit([], fn ->
       start_rabbitmq_app()
@@ -25,15 +25,16 @@ defmodule LogLocationCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        all: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       all: false
+     }}
   end
 
   test "merge_defaults: all is false" do
-    assert @command.merge_defaults([], %{}) == {[], %{all: :false}}
+    assert @command.merge_defaults([], %{}) == {[], %{all: false}}
   end
 
   test "validate: treats positional arguments as a failure" do
@@ -41,12 +42,15 @@ defmodule LogLocationCommandTest do
   end
 
   test "validate: treats empty positional arguments and default switches as a success" do
-    assert @command.validate([], %{all: :false}) == :ok
+    assert @command.validate([], %{all: false}) == :ok
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: prints default log location", context do
@@ -60,16 +64,21 @@ defmodule LogLocationCommandTest do
 
   test "run: shows all log locations", context do
     # This assumes default configuration
-    [logfile, upgrade_log_file | _] =
-      @command.run([], Map.merge(context[:opts], %{all: true}))
+    [logfile, upgrade_log_file | _] = @command.run([], Map.merge(context[:opts], %{all: true}))
 
     log_message = "checking the default log file when checking all"
     :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(log_message)])
     wait_for_log_message(log_message, logfile)
 
     log_message_upgrade = "checking the upgrade log file when checking all"
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_log, :log, [:upgrade, :error, to_charlist(log_message_upgrade), []])
+
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :log, [
+      :upgrade,
+      :error,
+      to_charlist(log_message_upgrade),
+      []
+    ])
+
     wait_for_log_message(log_message_upgrade, upgrade_log_file)
   end
 end

--- a/deps/rabbitmq_cli/test/diagnostics/log_tail_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/log_tail_command_test.exs
@@ -15,7 +15,7 @@ defmodule LogTailCommandTest do
 
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
 
     on_exit([], fn ->
       start_rabbitmq_app()
@@ -25,11 +25,12 @@ defmodule LogTailCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        number: 50
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       number: 50
+     }}
   end
 
   test "merge_defaults: number is 50" do
@@ -46,36 +47,48 @@ defmodule LogTailCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: shows last 50 lines from the log by default", context do
     clear_log_files()
+
     log_messages =
-      Enum.map(:lists.seq(1, 50),
-               fn(n) ->
-                 message = "Getting log tail #{n}"
-                 :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(message)])
-                 message
-               end)
+      Enum.map(
+        :lists.seq(1, 50),
+        fn n ->
+          message = "Getting log tail #{n}"
+          :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(message)])
+          message
+        end
+      )
+
     wait_for_log_message("Getting log tail 50")
     lines = @command.run([], context[:opts])
     assert Enum.count(lines) == 50
 
-    Enum.map(Enum.zip(log_messages, lines),
-             fn({message, line}) ->
-               assert String.match?(line, Regex.compile!(message))
-             end)
+    Enum.map(
+      Enum.zip(log_messages, lines),
+      fn {message, line} ->
+        assert String.match?(line, Regex.compile!(message))
+      end
+    )
   end
 
   test "run: returns N lines", context do
     ## Log a bunch of lines
-    Enum.map(:lists.seq(1, 50),
-             fn(n) ->
-               message = "More lines #{n}"
-               :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(message)])
-               message
-             end)
+    Enum.map(
+      :lists.seq(1, 50),
+      fn n ->
+        message = "More lines #{n}"
+        :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(message)])
+        message
+      end
+    )
+
     wait_for_log_message("More lines 50")
     assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 20}))) == 20
     assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 30}))) == 30
@@ -85,23 +98,27 @@ defmodule LogTailCommandTest do
   test "run: may return less than N lines if N is high", context do
     clear_log_files()
     ## Log a bunch of lines
-    Enum.map(:lists.seq(1, 100),
-             fn(n) ->
-               message = "More lines #{n}"
-               :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(message)])
-               message
-             end)
+    Enum.map(
+      :lists.seq(1, 100),
+      fn n ->
+        message = "More lines #{n}"
+        :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist(message)])
+        message
+      end
+    )
+
     wait_for_log_message("More lines 50")
     assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 50}))) == 50
     assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 200}))) < 200
   end
 
   def clear_log_files() do
-    [_|_] = logs = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
-    Enum.map(logs, fn(log) ->
+    [_ | _] = logs = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
+
+    Enum.map(logs, fn log ->
       case log do
         '<stdout>' -> :ok
-        _          -> File.write(log, "")
+        _ -> File.write(log, "")
       end
     end)
   end

--- a/deps/rabbitmq_cli/test/diagnostics/log_tail_stream_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/log_tail_stream_command_test.exs
@@ -15,7 +15,7 @@ defmodule LogTailStreamCommandTest do
 
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
 
     on_exit([], fn ->
       start_rabbitmq_app()
@@ -25,11 +25,12 @@ defmodule LogTailStreamCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        duration: :infinity
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       duration: :infinity
+     }}
   end
 
   test "merge_defaults: duration defaults to infinity" do
@@ -46,7 +47,10 @@ defmodule LogTailStreamCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: streams messages for N seconds", context do
@@ -81,16 +85,19 @@ defmodule LogTailStreamCommandTest do
   end
 
   def ensure_log_file() do
-    [log|_] = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
+    [log | _] = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
     ensure_file(log, 100)
   end
 
   def ensure_file(log, 0) do
     flunk("timed out trying to ensure the log file #{log}")
   end
+
   def ensure_file(log, attempts) do
     case File.exists?(log) do
-      true -> :ok
+      true ->
+        :ok
+
       false ->
         :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [to_charlist("Ping")])
         :timer.sleep(100)
@@ -99,8 +106,9 @@ defmodule LogTailStreamCommandTest do
   end
 
   def delete_log_files() do
-    [_|_] = logs = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
-    Enum.map(logs, fn(log) ->
+    [_ | _] = logs = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
+
+    Enum.map(logs, fn log ->
       File.rm(log)
     end)
   end

--- a/deps/rabbitmq_cli/test/diagnostics/maybe_stuck_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/maybe_stuck_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule MaybeStuckCommandTest do
   use ExUnit.Case
   import TestHelper
@@ -18,10 +17,11 @@ defmodule MaybeStuckCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 15000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 15000
+     }}
   end
 
   test "merge_defaults: returns inputs" do
@@ -38,7 +38,10 @@ defmodule MaybeStuckCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 0

--- a/deps/rabbitmq_cli/test/diagnostics/memory_breakdown_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/memory_breakdown_command_test.exs
@@ -23,19 +23,20 @@ defmodule MemoryBreakdownCommandTest do
   end
 
   setup do
-    {:ok, opts: %{
-      node: get_rabbit_hostname(),
-      timeout: 5000,
-      unit: "gb"
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: 5000,
+       unit: "gb"
+     }}
   end
 
   test "validate: specifying a positional argument fails validation", context do
     assert @command.validate(["abc"], context[:opts]) ==
-    {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
 
     assert @command.validate(["abc", "def"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: specifying no positional arguments and no options succeeds", context do
@@ -56,7 +57,8 @@ defmodule MemoryBreakdownCommandTest do
 
   test "validate: specifying glip-glops as a --unit fails validation", context do
     assert @command.validate([], Map.merge(context[:opts], %{unit: "glip-glops"})) ==
-    {:validation_failure, "unit 'glip-glops' is not supported. Please use one of: bytes, mb, gb"}
+             {:validation_failure,
+              "unit 'glip-glops' is not supported. Please use one of: bytes, mb, gb"}
   end
 
   test "run: request to a non-existent RabbitMQ node returns a nodedown" do

--- a/deps/rabbitmq_cli/test/diagnostics/observer_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/observer_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ObserverCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,11 +17,12 @@ defmodule ObserverCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        interval: 5,
-        timeout: context[:test_timeout] || 15000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       interval: 5,
+       timeout: context[:test_timeout] || 15000
+     }}
   end
 
   test "merge_defaults: injects a default interval of 5s" do

--- a/deps/rabbitmq_cli/test/diagnostics/os_env_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/os_env_command_test.exs
@@ -15,7 +15,7 @@ defmodule OsEnvCommandTest do
 
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
 
     on_exit([], fn ->
       start_rabbitmq_app()
@@ -25,11 +25,12 @@ defmodule OsEnvCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        all: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       all: false
+     }}
   end
 
   test "merge_defaults: merges no defaults" do
@@ -46,7 +47,10 @@ defmodule OsEnvCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: returns defined RabbitMQ-specific environment variables", context do
@@ -55,8 +59,8 @@ defmodule OsEnvCommandTest do
     # Only variables that are used by RABBITMQ are returned.
     # They can be prefixed with RABBITMQ_ or not, rabbit_env tries both
     # when filtering env variables down.
-    assert Enum.any?(vars, fn({k, _v}) ->
-      String.starts_with?(k, "RABBITMQ_") or String.starts_with?(k, "rabbitmq_")
-    end)
+    assert Enum.any?(vars, fn {k, _v} ->
+             String.starts_with?(k, "RABBITMQ_") or String.starts_with?(k, "rabbitmq_")
+           end)
   end
 end

--- a/deps/rabbitmq_cli/test/diagnostics/remote_shell_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/remote_shell_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RemoteShellCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,10 +17,11 @@ defmodule RemoteShellCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 15000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 15000
+     }}
   end
 
   test "merge_defaults: nothing to do" do

--- a/deps/rabbitmq_cli/test/diagnostics/resolve_hostname_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/resolve_hostname_command_test.exs
@@ -14,7 +14,8 @@ defmodule ResolveHostnameCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
+
     on_exit([], fn ->
       start_rabbitmq_app()
     end)
@@ -23,12 +24,13 @@ defmodule ResolveHostnameCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        address_family: "ipv4",
-        offline: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       address_family: "ipv4",
+       offline: false
+     }}
   end
 
   test "merge_defaults: defaults to IPv4 address family" do
@@ -40,15 +42,20 @@ defmodule ResolveHostnameCommandTest do
   end
 
   test "validate: treats positional arguments as a failure" do
-    assert @command.validate(["elixir-lang.org", "extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["elixir-lang.org", "extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: address family other than IPv4 or IPv6 fails validation" do
-    assert match?({:validation_failure, {:bad_argument, _}},
-                  @command.validate(["elixir-lang.org"], %{address_family: "ipv5"}))
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["elixir-lang.org"], %{address_family: "ipv5"})
+           )
 
-    assert match?({:validation_failure, {:bad_argument, _}},
-                  @command.validate(["elixir-lang.org"], %{address_family: "IPv5"}))
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["elixir-lang.org"], %{address_family: "IPv5"})
+           )
   end
 
   test "validate: IPv4 for address family passes validation" do
@@ -69,7 +76,7 @@ defmodule ResolveHostnameCommandTest do
 
   test "run: returns a resolution result", context do
     case @command.run(["github.com"], context[:opts]) do
-      {:ok, _hostent}     -> :ok
+      {:ok, _hostent} -> :ok
       {:error, :nxdomain} -> :ok
       other -> flunk("hostname resolution returned #{other}")
     end
@@ -77,7 +84,7 @@ defmodule ResolveHostnameCommandTest do
 
   test "run with --offline: returns a resolution result", context do
     case @command.run(["github.com"], Map.merge(context[:opts], %{offline: true})) do
-      {:ok, _hostent}     -> :ok
+      {:ok, _hostent} -> :ok
       {:error, :nxdomain} -> :ok
       other -> flunk("hostname resolution returned #{other}")
     end

--- a/deps/rabbitmq_cli/test/diagnostics/resolver_info_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/resolver_info_command_test.exs
@@ -15,7 +15,7 @@ defmodule ResolverInfoCommandTest do
 
     start_rabbitmq_app()
 
-    ExUnit.configure([max_cases: 1])
+    ExUnit.configure(max_cases: 1)
 
     on_exit([], fn ->
       start_rabbitmq_app()
@@ -25,11 +25,12 @@ defmodule ResolverInfoCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        offline: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       offline: false
+     }}
   end
 
   test "merge_defaults: defaults to offline mode" do
@@ -46,7 +47,10 @@ defmodule ResolverInfoCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100}))
+           )
   end
 
   test "run: returns host resolver (inetrc) information", context do

--- a/deps/rabbitmq_cli/test/diagnostics/runtime_thread_stats_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/runtime_thread_stats_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RuntimeThreadStatsCommandTest do
   use ExUnit.Case
   import TestHelper
@@ -18,13 +17,13 @@ defmodule RuntimeThreadStatsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 10000,
-        sample_interval: 1
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 10000,
+       sample_interval: 1
+     }}
   end
-
 
   test "validate: providing no arguments passes validation", context do
     assert @command.validate([], context[:opts]) == :ok
@@ -32,12 +31,15 @@ defmodule RuntimeThreadStatsCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 2000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   @tag test_timeout: 6000

--- a/deps/rabbitmq_cli/test/diagnostics/schema_info_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/schema_info_command_test.exs
@@ -35,32 +35,38 @@ defmodule SchemaInfoCommandTest do
 
   test "validate: returns bad_info_key on a single bad arg", context do
     assert @command.validate(["quack"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
   end
 
   test "validate: returns multiple bad args return a list of bad info key values", context do
     assert @command.validate(["quack", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+             {:validation_failure, {:bad_info_key, [:oink, :quack]}}
   end
 
   test "validate: return bad_info_key on mix of good and bad args", context do
     assert @command.validate(["quack", "cookie"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:quack]}}
+             {:validation_failure, {:bad_info_key, [:quack]}}
+
     assert @command.validate(["access_mode", "oink"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
+
     assert @command.validate(["access_mode", "oink", "name"], context[:opts]) ==
-      {:validation_failure, {:bad_info_key, [:oink]}}
+             {:validation_failure, {:bad_info_key, [:oink]}}
   end
 
   @tag test_timeout: 0
   test "run: timeout causes command to return badrpc", context do
     assert run_command_to_list(@command, [["source_name"], context[:opts]]) ==
-      {:badrpc, :timeout}
+             {:badrpc, :timeout}
   end
 
   test "run: can filter info keys", context do
     wanted_keys = ~w(name access_mode)
-    assert match?([[name: _, access_mode: _] | _], run_command_to_list(@command, [wanted_keys, context[:opts]]))
+
+    assert match?(
+             [[name: _, access_mode: _] | _],
+             run_command_to_list(@command, [wanted_keys, context[:opts]])
+           )
   end
 
   test "banner" do

--- a/deps/rabbitmq_cli/test/diagnostics/server_version_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/server_version_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule ServerVersionCommandTest do
   use ExUnit.Case
   import TestHelper
@@ -18,10 +17,11 @@ defmodule ServerVersionCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -38,7 +38,10 @@ defmodule ServerVersionCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
   test "run: returns RabbitMQ version on the target node", context do

--- a/deps/rabbitmq_cli/test/diagnostics/tls_versions_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/tls_versions_command_test.exs
@@ -17,10 +17,11 @@ defmodule TlsVersionsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "merge_defaults: is a no-op" do
@@ -37,11 +38,15 @@ defmodule TlsVersionsCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
   end
 
-  test "run when formatter is set to JSON: return a document with a list of supported TLS versions", context do
-    m  = @command.run([], Map.merge(context[:opts], %{formatter: "json"})) |> Map.new
+  test "run when formatter is set to JSON: return a document with a list of supported TLS versions",
+       context do
+    m = @command.run([], Map.merge(context[:opts], %{formatter: "json"})) |> Map.new()
     xs = Map.get(m, :available)
 
     # assert that we have a list and tlsv1.2 is included
@@ -50,7 +55,7 @@ defmodule TlsVersionsCommandTest do
   end
 
   test "run and output: return a list of supported TLS versions", context do
-    m          = @command.run([], context[:opts])
+    m = @command.run([], context[:opts])
     {:ok, res} = @command.output(m, context[:opts])
 
     # assert that we have a list and tlsv1.2 is included

--- a/deps/rabbitmq_cli/test/json_formatting.exs
+++ b/deps/rabbitmq_cli/test/json_formatting.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule JSONFormattingTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureIO
@@ -24,9 +23,12 @@ defmodule JSONFormattingTest do
 
     node = to_string(get_rabbit_hostname())
     command = ["status", "-n", node, "--formatter=json"]
-    output = capture_io(:stdio, fn ->
-      error_check(command, exit_ok())
-    end)
+
+    output =
+      capture_io(:stdio, fn ->
+        error_check(command, exit_ok())
+      end)
+
     {:ok, doc} = JSON.decode(output)
 
     assert Map.has_key?(doc, "memory")
@@ -45,9 +47,12 @@ defmodule JSONFormattingTest do
 
     node = to_string(get_rabbit_hostname())
     command = ["cluster_status", "-n", node, "--formatter=json"]
-    output = capture_io(:stdio, fn ->
-      error_check(command, exit_ok())
-    end)
+
+    output =
+      capture_io(:stdio, fn ->
+        error_check(command, exit_ok())
+      end)
+
     {:ok, doc} = JSON.decode(output)
 
     assert Enum.member?(doc["disk_nodes"], node)

--- a/deps/rabbitmq_cli/test/plugins/directories_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/directories_command_test.exs
@@ -14,33 +14,34 @@ defmodule DirectoriesCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
 
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
-    {:ok, plugins_expand_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_expand_dir])
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
+    {:ok, plugins_expand_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_expand_dir])
 
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
-    {:ok, opts: %{
-        plugins_file: plugins_file,
-        plugins_dir: plugins_dir,
-        plugins_expand_dir: plugins_expand_dir,
-        rabbitmq_home: rabbitmq_home,
+    {:ok,
+     opts: %{
+       plugins_file: plugins_file,
+       plugins_dir: plugins_dir,
+       plugins_expand_dir: plugins_expand_dir,
+       rabbitmq_home: rabbitmq_home
      }}
   end
 
   setup context do
     {
       :ok,
-      opts: Map.merge(context[:opts], %{
-              node: get_rabbit_hostname(),
-              timeout: 1000
-            })
+      opts:
+        Map.merge(context[:opts], %{
+          node: get_rabbit_hostname(),
+          timeout: 1000
+        })
     }
   end
 
@@ -58,45 +59,53 @@ defmodule DirectoriesCommandTest do
 
   test "validate: providing any arguments fails validation", context do
     assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: setting both --online and --offline to false fails validation", context do
     assert @command.validate([], Map.merge(context[:opts], %{online: false, offline: false})) ==
-      {:validation_failure, {:bad_argument, "Cannot set online and offline to false"}}
+             {:validation_failure, {:bad_argument, "Cannot set online and offline to false"}}
   end
 
   test "validate: setting both --online and --offline to true fails validation", context do
     assert @command.validate([], Map.merge(context[:opts], %{online: true, offline: true})) ==
-      {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
+             {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
   end
 
-  test "validate_execution_environment: when --offline is used, specifying a non-existent enabled_plugins_file passes validation", context do
+  test "validate_execution_environment: when --offline is used, specifying a non-existent enabled_plugins_file passes validation",
+       context do
     opts = context[:opts] |> Map.merge(%{offline: true, enabled_plugins_file: "none"})
     assert @command.validate_execution_environment([], opts) == :ok
   end
 
-  test "validate_execution_environment: when --offline is used, specifying a non-existent plugins_dir fails validation", context do
+  test "validate_execution_environment: when --offline is used, specifying a non-existent plugins_dir fails validation",
+       context do
     opts = context[:opts] |> Map.merge(%{offline: true, plugins_dir: "none"})
-    assert @command.validate_execution_environment([], opts) == {:validation_failure, :plugins_dir_does_not_exist}
+
+    assert @command.validate_execution_environment([], opts) ==
+             {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "validate_execution_environment: when --online is used, specifying a non-existent enabled_plugins_file passes validation", context do
+  test "validate_execution_environment: when --online is used, specifying a non-existent enabled_plugins_file passes validation",
+       context do
     opts = context[:opts] |> Map.merge(%{online: true, enabled_plugins_file: "none"})
     assert @command.validate_execution_environment([], opts) == :ok
   end
 
-  test "validate_execution_environment: when --online is used, specifying a non-existent plugins_dir passes validation", context do
+  test "validate_execution_environment: when --online is used, specifying a non-existent plugins_dir passes validation",
+       context do
     opts = context[:opts] |> Map.merge(%{online: true, plugins_dir: "none"})
     assert @command.validate_execution_environment([], opts) == :ok
   end
 
-
   test "run: when --online is used, lists plugin directories", context do
     opts = Map.merge(context[:opts], %{online: true})
-    dirs = %{plugins_dir: to_string(Map.get(opts, :plugins_dir)),
-             plugins_expand_dir: to_string(Map.get(opts, :plugins_expand_dir)),
-             enabled_plugins_file: to_string(Map.get(opts, :plugins_file))}
+
+    dirs = %{
+      plugins_dir: to_string(Map.get(opts, :plugins_dir)),
+      plugins_expand_dir: to_string(Map.get(opts, :plugins_expand_dir)),
+      enabled_plugins_file: to_string(Map.get(opts, :plugins_file))
+    }
 
     assert @command.run([], opts) == {:ok, dirs}
   end

--- a/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
@@ -16,24 +16,32 @@ defmodule DisablePluginsCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
 
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
-    IO.puts("plugins disable tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}")
+    IO.puts(
+      "plugins disable tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}"
+    )
 
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
-    IO.puts("plugins disable tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to")
 
-    opts = %{enabled_plugins_file: plugins_file,
-             plugins_dir: plugins_dir,
-             rabbitmq_home: rabbitmq_home,
-             online: false, offline: false,
-             all: false}
+    IO.puts(
+      "plugins disable tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
+    )
+
+    opts = %{
+      enabled_plugins_file: plugins_file,
+      plugins_dir: plugins_dir,
+      rabbitmq_home: rabbitmq_home,
+      online: false,
+      offline: false,
+      all: false
+    }
 
     on_exit(fn ->
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
@@ -43,156 +51,237 @@ defmodule DisablePluginsCommandTest do
   end
 
   setup context do
-    set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
-                        :online,
-                        get_rabbit_hostname(),
-                        context[:opts])
-
+    set_enabled_plugins(
+      [:rabbitmq_stomp, :rabbitmq_federation],
+      :online,
+      get_rabbit_hostname(),
+      context[:opts]
+    )
 
     {
       :ok,
-      opts: Map.merge(context[:opts], %{
-              node: get_rabbit_hostname(),
-              timeout: 1000
-            })
+      opts:
+        Map.merge(context[:opts], %{
+          node: get_rabbit_hostname(),
+          timeout: 1000
+        })
     }
   end
 
   test "validate: specifying both --online and --offline is reported as invalid", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["a"], Map.merge(context[:opts], %{online: true, offline: true}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["a"], Map.merge(context[:opts], %{online: true, offline: true}))
+           )
   end
 
   test "validate: not specifying plugins to enable is reported as invalid", context do
     assert match?(
-      {:validation_failure, :not_enough_args},
-      @command.validate([], Map.merge(context[:opts], %{online: true, offline: false}))
-    )
+             {:validation_failure, :not_enough_args},
+             @command.validate([], Map.merge(context[:opts], %{online: true, offline: false}))
+           )
   end
 
-  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine",
+       context do
+    assert @command.validate_execution_environment(
+             ["a"],
+             Map.merge(context[:opts], %{enabled_plugins_file: "none"})
+           ) == :ok
   end
 
-  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error",
+       context do
+    assert @command.validate_execution_environment(
+             ["a"],
+             Map.merge(context[:opts], %{plugins_dir: "none"})
+           ) ==
+             {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "node is inaccessible, writes out enabled plugins file and returns implicitly enabled plugin list", context do
+  test "node is inaccessible, writes out enabled plugins file and returns implicitly enabled plugin list",
+       context do
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
-    assert [[:rabbitmq_federation],
-            %{mode: :offline, disabled: [:rabbitmq_stomp], set: [:rabbitmq_federation]}] ==
-      Enum.to_list(test_stream)
+             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
+
+    assert [
+             [:rabbitmq_federation],
+             %{mode: :offline, disabled: [:rabbitmq_stomp], set: [:rabbitmq_federation]}
+           ] ==
+             Enum.to_list(test_stream)
+
     assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp] ==
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
-  test "in offline mode, writes out enabled plugins and reports implicitly enabled plugin list", context do
-    assert {:stream, test_stream} = @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[:rabbitmq_federation],
-            %{mode: :offline, disabled: [:rabbitmq_stomp], set: [:rabbitmq_federation]}] == Enum.to_list(test_stream)
+  test "in offline mode, writes out enabled plugins and reports implicitly enabled plugin list",
+       context do
+    assert {:stream, test_stream} =
+             @command.run(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [
+             [:rabbitmq_federation],
+             %{mode: :offline, disabled: [:rabbitmq_stomp], set: [:rabbitmq_federation]}
+           ] == Enum.to_list(test_stream)
+
     assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp] ==
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
-  test "in offline mode, removes implicitly enabled plugins when the last explicitly enabled one is removed", context do
+  test "in offline mode, removes implicitly enabled plugins when the last explicitly enabled one is removed",
+       context do
     assert {:stream, test_stream0} =
-      @command.run(["rabbitmq_federation"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[:rabbitmq_stomp],
-            %{mode: :offline, disabled: [:rabbitmq_federation], set: [:rabbitmq_stomp]}] == Enum.to_list(test_stream0)
+             @command.run(
+               ["rabbitmq_federation"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [
+             [:rabbitmq_stomp],
+             %{mode: :offline, disabled: [:rabbitmq_federation], set: [:rabbitmq_stomp]}
+           ] == Enum.to_list(test_stream0)
+
     assert {:ok, [[:rabbitmq_stomp]]} == :file.consult(context[:opts][:enabled_plugins_file])
 
     assert {:stream, test_stream1} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[],
-            %{mode: :offline, disabled: [:rabbitmq_stomp], set: []}] ==
-      Enum.to_list(test_stream1)
+             @command.run(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [[], %{mode: :offline, disabled: [:rabbitmq_stomp], set: []}] ==
+             Enum.to_list(test_stream1)
+
     assert {:ok, [[]]} = :file.consult(context[:opts][:enabled_plugins_file])
   end
 
   test "updates plugin list and stops disabled plugins", context do
-    assert {:stream, test_stream0} =
-      @command.run(["rabbitmq_stomp"], context[:opts])
-    assert [[:rabbitmq_federation],
-            %{mode: :online,
-              started: [], stopped: [:rabbitmq_stomp],
-              disabled: [:rabbitmq_stomp],
-              set: [:rabbitmq_federation]}] ==
-      Enum.to_list(test_stream0)
-    assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
-    assert [:amqp_client, :rabbitmq_federation] ==
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+    assert {:stream, test_stream0} = @command.run(["rabbitmq_stomp"], context[:opts])
 
-    assert {:stream, test_stream1} =
-      @command.run(["rabbitmq_federation"], context[:opts])
-    assert [[],
-            %{mode: :online,
-              started: [], stopped: [:rabbitmq_federation],
-              disabled: [:rabbitmq_federation],
-              set: []}] ==
-      Enum.to_list(test_stream1)
+    assert [
+             [:rabbitmq_federation],
+             %{
+               mode: :online,
+               started: [],
+               stopped: [:rabbitmq_stomp],
+               disabled: [:rabbitmq_stomp],
+               set: [:rabbitmq_federation]
+             }
+           ] ==
+             Enum.to_list(test_stream0)
+
+    assert {:ok, [[:rabbitmq_federation]]} == :file.consult(context[:opts][:enabled_plugins_file])
+
+    assert [:amqp_client, :rabbitmq_federation] ==
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+
+    assert {:stream, test_stream1} = @command.run(["rabbitmq_federation"], context[:opts])
+
+    assert [
+             [],
+             %{
+               mode: :online,
+               started: [],
+               stopped: [:rabbitmq_federation],
+               disabled: [:rabbitmq_federation],
+               set: []
+             }
+           ] ==
+             Enum.to_list(test_stream1)
+
     assert {:ok, [[]]} == :file.consult(context[:opts][:enabled_plugins_file])
-    assert Enum.empty?(Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])))
+
+    assert Enum.empty?(
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+           )
   end
 
   test "can disable multiple plugins at once", context do
-    assert {:stream, test_stream} = @command.run(["rabbitmq_stomp", "rabbitmq_federation"], context[:opts])
+    assert {:stream, test_stream} =
+             @command.run(["rabbitmq_stomp", "rabbitmq_federation"], context[:opts])
+
     [[], m0] = Enum.to_list(test_stream)
-    m1 = m0 |> Map.update!(:stopped, &Enum.sort/1)
-            |> Map.update!(:disabled, &Enum.sort/1)
+
+    m1 =
+      m0
+      |> Map.update!(:stopped, &Enum.sort/1)
+      |> Map.update!(:disabled, &Enum.sort/1)
+
     expected_list = Enum.sort([:rabbitmq_federation, :rabbitmq_stomp])
-    assert [[],
-            %{mode: :online,
-              started: [],
-              stopped: expected_list,
-              disabled: expected_list,
-              set: []}
-            ] == [[], m1]
+
+    assert [
+             [],
+             %{
+               mode: :online,
+               started: [],
+               stopped: expected_list,
+               disabled: expected_list,
+               set: []
+             }
+           ] == [[], m1]
+
     assert {:ok, [[]]} == :file.consult(context[:opts][:enabled_plugins_file])
-    assert Enum.empty?(Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])))
+
+    assert Enum.empty?(
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+           )
   end
 
   test "disabling a dependency disables all plugins that depend on it", context do
     assert {:stream, test_stream} = @command.run(["amqp_client"], context[:opts])
     [[], m0] = Enum.to_list(test_stream)
-    m1 = m0 |> Map.update!(:stopped, &Enum.sort/1)
-            |> Map.update!(:disabled, &Enum.sort/1)
+
+    m1 =
+      m0
+      |> Map.update!(:stopped, &Enum.sort/1)
+      |> Map.update!(:disabled, &Enum.sort/1)
 
     expected_list = Enum.sort([:rabbitmq_federation, :rabbitmq_stomp])
-    assert [[],
-            %{mode: :online,
-              started: [],
-              stopped: expected_list,
-              disabled: expected_list,
-              set: []}
-            ] == [[], m1]
+
+    assert [
+             [],
+             %{
+               mode: :online,
+               started: [],
+               stopped: expected_list,
+               disabled: expected_list,
+               set: []
+             }
+           ] == [[], m1]
 
     assert {:ok, [[]]} == :file.consult(context[:opts][:enabled_plugins_file])
-    assert Enum.empty?(Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])))
+
+    assert Enum.empty?(
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+           )
   end
 
   test "formats enabled plugins mismatch errors", context do
     err = {:enabled_plugins_mismatch, '/tmp/a/cli/path', '/tmp/a/server/path'}
+
     assert {:error, ExitCodes.exit_dataerr(),
-            "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"}
-      == @command.output({:error, err}, context[:opts])
+            "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"} ==
+             @command.output({:error, err}, context[:opts])
   end
 
   test "formats enabled plugins write errors", context do
     err1 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :eacces}
+
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist or permission was denied (EACCES)"} ==
-      @command.output({:error, err1}, context[:opts])
+             @command.output({:error, err1}, context[:opts])
 
     err2 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :enoent}
+
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist (ENOENT)"} ==
-      @command.output({:error, err2}, context[:opts])
+             @command.output({:error, err2}, context[:opts])
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -16,98 +16,132 @@ defmodule EnablePluginsCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
 
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
-    IO.puts("plugins enable tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}")
+    IO.puts(
+      "plugins enable tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}"
+    )
 
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
-    IO.puts("plugins enable tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to")
 
-    opts = %{enabled_plugins_file: plugins_file,
-             plugins_dir: plugins_dir,
-             rabbitmq_home: rabbitmq_home,
-             online: false, offline: false,
-             all: false}
+    IO.puts(
+      "plugins enable tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
+    )
+
+    opts = %{
+      enabled_plugins_file: plugins_file,
+      plugins_dir: plugins_dir,
+      rabbitmq_home: rabbitmq_home,
+      online: false,
+      offline: false,
+      all: false
+    }
 
     on_exit(fn ->
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
 
-
     {:ok, opts: opts}
   end
 
   setup context do
-    set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
-                        :online,
-                        get_rabbit_hostname(),
-                        context[:opts])
+    set_enabled_plugins(
+      [:rabbitmq_stomp, :rabbitmq_federation],
+      :online,
+      get_rabbit_hostname(),
+      context[:opts]
+    )
 
     {
       :ok,
-      opts: Map.merge(context[:opts], %{
-              node: get_rabbit_hostname(),
-              timeout: 1000
-            })
+      opts:
+        Map.merge(context[:opts], %{
+          node: get_rabbit_hostname(),
+          timeout: 1000
+        })
     }
   end
 
   test "validate: specifying both --online and --offline is reported as invalid", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["a"], Map.merge(context[:opts], %{online: true, offline: true}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["a"], Map.merge(context[:opts], %{online: true, offline: true}))
+           )
   end
 
   test "validate: not specifying any plugins to enable is reported as invalid", context do
     assert match?(
-      {:validation_failure, :not_enough_args},
-      @command.validate([], Map.merge(context[:opts], %{online: true, offline: false}))
-    )
+             {:validation_failure, :not_enough_args},
+             @command.validate([], Map.merge(context[:opts], %{online: true, offline: false}))
+           )
   end
 
-  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine",
+       context do
+    assert @command.validate_execution_environment(
+             ["a"],
+             Map.merge(context[:opts], %{enabled_plugins_file: "none"})
+           ) == :ok
   end
 
-  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error",
+       context do
+    assert @command.validate_execution_environment(
+             ["a"],
+             Map.merge(context[:opts], %{plugins_dir: "none"})
+           ) ==
+             {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "if node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list", context do
+  test "if node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list",
+       context do
     # Clears enabled plugins file
     set_enabled_plugins([], :offline, :nonode, context[:opts])
 
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
-    assert [[:rabbitmq_stomp],
-            %{mode: :offline, enabled: [:rabbitmq_stomp], set: [:rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream)
+             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
+
+    assert [
+             [:rabbitmq_stomp],
+             %{mode: :offline, enabled: [:rabbitmq_stomp], set: [:rabbitmq_stomp]}
+           ] ==
+             Enum.to_list(test_stream)
+
     check_plugins_enabled([:rabbitmq_stomp], context)
+
     assert [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp] ==
-           currently_active_plugins(context)
+             currently_active_plugins(context)
   end
 
-  test "in offline mode, writes enabled plugins and reports implicitly enabled plugin list", context do
+  test "in offline mode, writes enabled plugins and reports implicitly enabled plugin list",
+       context do
     # Clears enabled plugins file
     set_enabled_plugins([], :offline, :nonode, context[:opts])
 
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[:rabbitmq_stomp],
-            %{mode: :offline, enabled: [:rabbitmq_stomp], set: [:rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream)
+             @command.run(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [
+             [:rabbitmq_stomp],
+             %{mode: :offline, enabled: [:rabbitmq_stomp], set: [:rabbitmq_stomp]}
+           ] ==
+             Enum.to_list(test_stream)
+
     check_plugins_enabled([:rabbitmq_stomp], context)
+
     assert_equal_sets(
       [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp],
-      currently_active_plugins(context))
+      currently_active_plugins(context)
+    )
   end
 
   test "adds additional plugins to those already enabled", context do
@@ -115,17 +149,35 @@ defmodule EnablePluginsCommandTest do
     set_enabled_plugins([], :offline, :nonode, context[:opts])
 
     assert {:stream, test_stream0} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[:rabbitmq_stomp],
-            %{mode: :offline, enabled: [:rabbitmq_stomp], set: [:rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream0)
+             @command.run(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [
+             [:rabbitmq_stomp],
+             %{mode: :offline, enabled: [:rabbitmq_stomp], set: [:rabbitmq_stomp]}
+           ] ==
+             Enum.to_list(test_stream0)
+
     check_plugins_enabled([:rabbitmq_stomp], context)
+
     assert {:stream, test_stream1} =
-      @command.run(["rabbitmq_federation"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[:rabbitmq_federation, :rabbitmq_stomp],
-            %{mode: :offline, enabled: [:rabbitmq_federation],
-              set: [:rabbitmq_federation, :rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream1)
+             @command.run(
+               ["rabbitmq_federation"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [
+             [:rabbitmq_federation, :rabbitmq_stomp],
+             %{
+               mode: :offline,
+               enabled: [:rabbitmq_federation],
+               set: [:rabbitmq_federation, :rabbitmq_stomp]
+             }
+           ] ==
+             Enum.to_list(test_stream1)
+
     check_plugins_enabled([:rabbitmq_stomp, :rabbitmq_federation], context)
   end
 
@@ -133,29 +185,43 @@ defmodule EnablePluginsCommandTest do
     # Clears enabled plugins file and stop all plugins
     set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
 
-    assert {:stream, test_stream0} =
-      @command.run(["rabbitmq_stomp"], context[:opts])
-    assert [[:rabbitmq_stomp],
-            %{mode: :online,
-              started: [:rabbitmq_stomp], stopped: [],
-              enabled: [:rabbitmq_stomp],
-              set: [:rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream0)
+    assert {:stream, test_stream0} = @command.run(["rabbitmq_stomp"], context[:opts])
+
+    assert [
+             [:rabbitmq_stomp],
+             %{
+               mode: :online,
+               started: [:rabbitmq_stomp],
+               stopped: [],
+               enabled: [:rabbitmq_stomp],
+               set: [:rabbitmq_stomp]
+             }
+           ] ==
+             Enum.to_list(test_stream0)
 
     check_plugins_enabled([:rabbitmq_stomp], context)
     assert_equal_sets([:amqp_client, :rabbitmq_stomp], currently_active_plugins(context))
 
-    {:stream, test_stream1} =
-      @command.run(["rabbitmq_federation"], context[:opts])
-    assert [[:rabbitmq_federation, :rabbitmq_stomp],
-            %{mode: :online,
-              started: [:rabbitmq_federation], stopped: [],
-              enabled: [:rabbitmq_federation],
-              set: [:rabbitmq_federation, :rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream1)
+    {:stream, test_stream1} = @command.run(["rabbitmq_federation"], context[:opts])
+
+    assert [
+             [:rabbitmq_federation, :rabbitmq_stomp],
+             %{
+               mode: :online,
+               started: [:rabbitmq_federation],
+               stopped: [],
+               enabled: [:rabbitmq_federation],
+               set: [:rabbitmq_federation, :rabbitmq_stomp]
+             }
+           ] ==
+             Enum.to_list(test_stream1)
 
     check_plugins_enabled([:rabbitmq_stomp, :rabbitmq_federation], context)
-    assert_equal_sets([:amqp_client, :rabbitmq_federation, :rabbitmq_stomp], currently_active_plugins(context))
+
+    assert_equal_sets(
+      [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp],
+      currently_active_plugins(context)
+    )
   end
 
   test "can enable multiple plugins at once", context do
@@ -163,33 +229,43 @@ defmodule EnablePluginsCommandTest do
     set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
 
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_stomp", "rabbitmq_federation"], context[:opts])
-    assert [[:rabbitmq_federation, :rabbitmq_stomp],
-            %{mode: :online,
-              started: [:rabbitmq_federation, :rabbitmq_stomp], stopped: [],
-              enabled: [:rabbitmq_federation, :rabbitmq_stomp],
-              set: [:rabbitmq_federation, :rabbitmq_stomp]}] ==
-      Enum.to_list(test_stream)
+             @command.run(["rabbitmq_stomp", "rabbitmq_federation"], context[:opts])
+
+    assert [
+             [:rabbitmq_federation, :rabbitmq_stomp],
+             %{
+               mode: :online,
+               started: [:rabbitmq_federation, :rabbitmq_stomp],
+               stopped: [],
+               enabled: [:rabbitmq_federation, :rabbitmq_stomp],
+               set: [:rabbitmq_federation, :rabbitmq_stomp]
+             }
+           ] ==
+             Enum.to_list(test_stream)
+
     check_plugins_enabled([:rabbitmq_stomp, :rabbitmq_federation], context)
 
-    assert_equal_sets([:amqp_client, :rabbitmq_federation, :rabbitmq_stomp], currently_active_plugins(context))
+    assert_equal_sets(
+      [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp],
+      currently_active_plugins(context)
+    )
   end
 
   test "does not enable an already implicitly enabled plugin", context do
     # Clears enabled plugins file and stop all plugins
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
-    assert {:stream, test_stream} =
-      @command.run(["amqp_client"], context[:opts])
-    assert [[:rabbitmq_federation],
-            %{mode: :online,
-              started: [], stopped: [],
-              enabled: [],
-              set: [:rabbitmq_federation]}] ==
-      Enum.to_list(test_stream)
-    check_plugins_enabled([:rabbitmq_federation], context)
-    assert [:amqp_client, :rabbitmq_federation] ==
-           currently_active_plugins(context)
+    assert {:stream, test_stream} = @command.run(["amqp_client"], context[:opts])
 
+    assert [
+             [:rabbitmq_federation],
+             %{mode: :online, started: [], stopped: [], enabled: [], set: [:rabbitmq_federation]}
+           ] ==
+             Enum.to_list(test_stream)
+
+    check_plugins_enabled([:rabbitmq_federation], context)
+
+    assert [:amqp_client, :rabbitmq_federation] ==
+             currently_active_plugins(context)
   end
 
   test "run: does not enable plugins with unmet version requirements", context do
@@ -199,17 +275,16 @@ defmodule EnablePluginsCommandTest do
     opts = get_opts_with_plugins_directories(context, [plugins_directory])
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
 
-    {:stream, _} =
-      @command.run(["mock_rabbitmq_plugin_for_3_9"], opts)
+    {:stream, _} = @command.run(["mock_rabbitmq_plugin_for_3_9"], opts)
     check_plugins_enabled([:mock_rabbitmq_plugin_for_3_9], context)
 
     # Not changed
     {:error, _version_error} = @command.run(["mock_rabbitmq_plugin_for_3_7"], opts)
     check_plugins_enabled([:mock_rabbitmq_plugin_for_3_9], context)
-
   end
 
-  test "run: does not enable plugins with unmet version requirements even when enabling all plugins", context do
+  test "run: does not enable plugins with unmet version requirements even when enabling all plugins",
+       context do
     set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
 
     plugins_directory = fixture_plugins_path("plugins_with_version_requirements")
@@ -224,20 +299,23 @@ defmodule EnablePluginsCommandTest do
 
   test "formats enabled plugins mismatch errors", context do
     err = {:enabled_plugins_mismatch, '/tmp/a/cli/path', '/tmp/a/server/path'}
+
     assert {:error, ExitCodes.exit_dataerr(),
-            "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"}
-      == @command.output({:error, err}, context[:opts])
+            "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"} ==
+             @command.output({:error, err}, context[:opts])
   end
 
   test "formats enabled plugins write errors", context do
     err1 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :eacces}
+
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist or permission was denied (EACCES)"} ==
-      @command.output({:error, err1}, context[:opts])
+             @command.output({:error, err1}, context[:opts])
 
     err2 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :enoent}
+
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist (ENOENT)"} ==
-      @command.output({:error, err2}, context[:opts])
+             @command.output({:error, err2}, context[:opts])
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/is_enabled_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/is_enabled_command_test.exs
@@ -14,25 +14,27 @@ defmodule PluginIsEnabledCommandTest do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
 
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
 
-    opts = %{enabled_plugins_file: plugins_file,
-             plugins_dir: plugins_dir,
-             rabbitmq_home: rabbitmq_home,
-             online: false, offline: false}
+    opts = %{
+      enabled_plugins_file: plugins_file,
+      plugins_dir: plugins_dir,
+      rabbitmq_home: rabbitmq_home,
+      online: false,
+      offline: false
+    }
 
     on_exit(fn ->
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
-
 
     {:ok, opts: opts}
   end
@@ -40,20 +42,22 @@ defmodule PluginIsEnabledCommandTest do
   setup context do
     {
       :ok,
-      opts: Map.merge(context[:opts], %{
-              node: get_rabbit_hostname(),
-              timeout: 1000
-            })
+      opts:
+        Map.merge(context[:opts], %{
+          node: get_rabbit_hostname(),
+          timeout: 1000
+        })
     }
   end
 
-
-
   test "validate: specifying both --online and --offline is reported as invalid", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["rabbitmq_stomp"], Map.merge(context[:opts], %{online: true, offline: true}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{online: true, offline: true})
+             )
+           )
   end
 
   test "validate: not specifying any plugins to check is reported as invalid", context do
@@ -61,43 +65,60 @@ defmodule PluginIsEnabledCommandTest do
     assert match?({:validation_failure, :not_enough_args}, @command.validate([], opts))
   end
 
-  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate_execution_environment(["rabbitmq_stomp"],
-      Map.merge(context[:opts], %{online: false,
-                                  offline: true,
-                                  enabled_plugins_file: "none"})) == :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine",
+       context do
+    assert @command.validate_execution_environment(
+             ["rabbitmq_stomp"],
+             Map.merge(context[:opts], %{
+               online: false,
+               offline: true,
+               enabled_plugins_file: "none"
+             })
+           ) == :ok
   end
 
-  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
-    opts = context[:opts] |> Map.merge(%{online: false,
-                                         offline: true,
-                                         plugins_dir: "none"})
+  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error",
+       context do
+    opts = context[:opts] |> Map.merge(%{online: false, offline: true, plugins_dir: "none"})
 
     assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+             {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "run: when given a single enabled plugin, reports it as such", context do
     opts = context[:opts] |> Map.merge(%{online: true, offline: false})
-    assert match?({:ok, _},
-      assert @command.run(["rabbitmq_stomp"], opts))
+
+    assert match?(
+             {:ok, _},
+             assert(@command.run(["rabbitmq_stomp"], opts))
+           )
   end
 
   test "run: when given a list of actually enabled plugins, reports them as such", context do
     opts = context[:opts] |> Map.merge(%{online: true, offline: false})
-    assert match?({:ok, _},
-      assert @command.run(["rabbitmq_stomp", "rabbitmq_federation"], opts))
+
+    assert match?(
+             {:ok, _},
+             assert(@command.run(["rabbitmq_stomp", "rabbitmq_federation"], opts))
+           )
   end
 
   test "run: when given a list of non-existent plugins, reports them as not enabled", context do
     opts = context[:opts] |> Map.merge(%{online: true, offline: false})
-    assert match?({:error, _},
-      assert @command.run(["rabbitmq_xyz", "abc_xyz"], opts))
+
+    assert match?(
+             {:error, _},
+             assert(@command.run(["rabbitmq_xyz", "abc_xyz"], opts))
+           )
   end
 
-  test "run: when given a list with one non-existent plugin, reports the group as not [all] enabled", context do
+  test "run: when given a list with one non-existent plugin, reports the group as not [all] enabled",
+       context do
     opts = context[:opts] |> Map.merge(%{online: true, offline: false})
-    assert match?({:error, _},
-      assert @command.run(["rabbitmq_stomp", "abc_xyz"], opts))
+
+    assert match?(
+             {:error, _},
+             assert(@command.run(["rabbitmq_stomp", "abc_xyz"], opts))
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -11,37 +11,49 @@ defmodule ListPluginsCommandTest do
   @command RabbitMQ.CLI.Plugins.Commands.ListCommand
 
   def reset_enabled_plugins_to_preconfigured_defaults(context) do
-    set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
+    set_enabled_plugins(
+      [:rabbitmq_stomp, :rabbitmq_federation],
       :online,
-      get_rabbit_hostname(), context[:opts])
+      get_rabbit_hostname(),
+      context[:opts]
+    )
   end
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
 
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
-    IO.puts("plugins list tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}")
+
+    IO.puts(
+      "plugins list tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}"
+    )
 
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
-    IO.puts("plugins list tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to")
 
-    opts = %{enabled_plugins_file: plugins_file,
-             plugins_dir: plugins_dir,
-             rabbitmq_home: rabbitmq_home,
-             minimal: false, verbose: false,
-             enabled: false, implicitly_enabled: false}
+    IO.puts(
+      "plugins list tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
+    )
+
+    opts = %{
+      enabled_plugins_file: plugins_file,
+      plugins_dir: plugins_dir,
+      rabbitmq_home: rabbitmq_home,
+      minimal: false,
+      verbose: false,
+      enabled: false,
+      implicitly_enabled: false
+    }
 
     on_exit(fn ->
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
-
 
     {:ok, opts: opts}
   end
@@ -51,137 +63,205 @@ defmodule ListPluginsCommandTest do
 
     {
       :ok,
-      opts: Map.merge(context[:opts], %{
-              node: get_rabbit_hostname(),
-              timeout: 1000
-            })
+      opts:
+        Map.merge(context[:opts], %{
+          node: get_rabbit_hostname(),
+          timeout: 1000
+        })
     }
   end
 
   test "validate: specifying both --minimal and --verbose is reported as invalid", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate([], Map.merge(context[:opts], %{minimal: true, verbose: true}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([], Map.merge(context[:opts], %{minimal: true, verbose: true}))
+           )
   end
 
   test "validate: specifying multiple patterns is reported as an error", context do
     assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
-  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine",
+       context do
+    assert @command.validate_execution_environment(
+             ["a"],
+             Map.merge(context[:opts], %{enabled_plugins_file: "none"})
+           ) == :ok
   end
 
-  test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+  test "validate_execution_environment: specifying non existent plugins_dir is reported as an error",
+       context do
+    assert @command.validate_execution_environment(
+             ["a"],
+             Map.merge(context[:opts], %{plugins_dir: "none"})
+           ) ==
+             {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "will report list of plugins from file for stopped node", context do
     node = context[:opts][:node]
     :ok = :rabbit_misc.rpc_call(node, :application, :stop, [:rabbitmq_stomp])
+
     on_exit(fn ->
       :rabbit_misc.rpc_call(node, :application, :start, [:rabbitmq_stomp])
     end)
-    assert %{status: :node_down,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: false},
-                       %{name: :rabbitmq_stomp, enabled: :enabled, running: false}]} =
-           @command.run([".*"], Map.merge(context[:opts], %{node: :nonode}))
+
+    assert %{
+             status: :node_down,
+             plugins: [
+               %{name: :rabbitmq_federation, enabled: :enabled, running: false},
+               %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
+             ]
+           } = @command.run([".*"], Map.merge(context[:opts], %{node: :nonode}))
   end
 
   test "will report list of started plugins for started node", context do
     node = context[:opts][:node]
     :ok = :rabbit_misc.rpc_call(node, :application, :stop, [:rabbitmq_stomp])
+
     on_exit(fn ->
       :rabbit_misc.rpc_call(node, :application, :start, [:rabbitmq_stomp])
     end)
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true},
-                       %{name: :rabbitmq_stomp, enabled: :enabled, running: false}]} =
-      @command.run([".*"], context[:opts])
+
+    assert %{
+             status: :running,
+             plugins: [
+               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+               %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
+             ]
+           } = @command.run([".*"], context[:opts])
   end
 
   test "will report description and dependencies for verbose mode", context do
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true, description: _, dependencies: [:amqp_client]},
-                       %{name: :rabbitmq_stomp, enabled: :enabled, running: true, description: _, dependencies: [:amqp_client]}]} =
-           @command.run([".*"], Map.merge(context[:opts], %{verbose: true}))
+    assert %{
+             status: :running,
+             plugins: [
+               %{
+                 name: :rabbitmq_federation,
+                 enabled: :enabled,
+                 running: true,
+                 description: _,
+                 dependencies: [:amqp_client]
+               },
+               %{
+                 name: :rabbitmq_stomp,
+                 enabled: :enabled,
+                 running: true,
+                 description: _,
+                 dependencies: [:amqp_client]
+               }
+             ]
+           } = @command.run([".*"], Map.merge(context[:opts], %{verbose: true}))
   end
 
   test "will report plugin names in minimal mode", context do
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
-           @command.run([".*"], Map.merge(context[:opts], %{minimal: true}))
+    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
+             @command.run([".*"], Map.merge(context[:opts], %{minimal: true}))
   end
 
   test "by default lists all plugins", context do
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+
     on_exit(fn ->
-      set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
     end)
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true},
-                       %{name: :rabbitmq_stomp, enabled: :not_enabled, running: false}]} =
-           @command.run([".*"], context[:opts])
+
+    assert %{
+             status: :running,
+             plugins: [
+               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+               %{name: :rabbitmq_stomp, enabled: :not_enabled, running: false}
+             ]
+           } = @command.run([".*"], context[:opts])
   end
 
   test "with enabled flag lists only explicitly enabled plugins", context do
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+
     on_exit(fn ->
-      set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
     end)
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]} =
-           @command.run([".*"], Map.merge(context[:opts], %{enabled: true}))
+
+    assert %{
+             status: :running,
+             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]
+           } = @command.run([".*"], Map.merge(context[:opts], %{enabled: true}))
   end
 
   test "with implicitly_enabled flag lists explicitly and implicitly enabled plugins", context do
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+
     on_exit(fn ->
-      set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
     end)
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]} =
-           @command.run([".*"], Map.merge(context[:opts], %{implicitly_enabled: true}))
+
+    assert %{
+             status: :running,
+             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]
+           } = @command.run([".*"], Map.merge(context[:opts], %{implicitly_enabled: true}))
   end
 
   test "will filter plugins by name with pattern provided", context do
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+
     on_exit(fn ->
-      set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
     end)
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_federation}]} =
-           @command.run(["fede"], Map.merge(context[:opts], %{minimal: true}))
-    assert %{status: :running,
-             plugins: [%{name: :rabbitmq_stomp}]} =
-           @command.run(["stomp$"], Map.merge(context[:opts], %{minimal: true}))
+
+    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}]} =
+             @command.run(["fede"], Map.merge(context[:opts], %{minimal: true}))
+
+    assert %{status: :running, plugins: [%{name: :rabbitmq_stomp}]} =
+             @command.run(["stomp$"], Map.merge(context[:opts], %{minimal: true}))
   end
 
-  test "validate: validation is OK when we use multiple plugins directories, one of them does not exist", context do
+  test "validate: validation is OK when we use multiple plugins directories, one of them does not exist",
+       context do
     opts = get_opts_with_non_existing_plugins_directory(context)
     assert @command.validate([], opts) == :ok
   end
 
-  test "validate: validation is OK when we use multiple plugins directories, directories do exist", context do
+  test "validate: validation is OK when we use multiple plugins directories, directories do exist",
+       context do
     opts = get_opts_with_existing_plugins_directory(context)
     assert @command.validate([], opts) == :ok
   end
 
-  test "should succeed when using multiple plugins directories, one of them does not exist", context do
+  test "should succeed when using multiple plugins directories, one of them does not exist",
+       context do
     opts = get_opts_with_non_existing_plugins_directory(context)
-    assert %{status: :running,
-               plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
+
+    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
              @command.run([".*"], Map.merge(opts, %{minimal: true}))
   end
 
-
-  test "should succeed when using multiple plugins directories, directories do exist and do contain plugins", context do
+  test "should succeed when using multiple plugins directories, directories do exist and do contain plugins",
+       context do
     opts = get_opts_with_existing_plugins_directory(context)
-    assert %{status: :running,
-               plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
+
+    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
              @command.run([".*"], Map.merge(opts, %{minimal: true}))
   end
 
@@ -190,24 +270,47 @@ defmodule ListPluginsCommandTest do
     opts = get_opts_with_plugins_directories(context, [plugins_directory])
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
     reset_enabled_plugins_to_preconfigured_defaults(context)
-    assert %{status: :running,
-                 plugins: [%{name: :mock_rabbitmq_plugins_01}, %{name: :mock_rabbitmq_plugins_02},
-                           %{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
-               @command.run([".*"], Map.merge(opts, %{minimal: true}))
+
+    assert %{
+             status: :running,
+             plugins: [
+               %{name: :mock_rabbitmq_plugins_01},
+               %{name: :mock_rabbitmq_plugins_02},
+               %{name: :rabbitmq_federation},
+               %{name: :rabbitmq_stomp}
+             ]
+           } = @command.run([".*"], Map.merge(opts, %{minimal: true}))
   end
 
   test "will report list of plugins with latest version picked", context do
     plugins_directory_01 = fixture_plugins_path("plugins-subdirectory-01")
     plugins_directory_02 = fixture_plugins_path("plugins-subdirectory-02")
-    opts = get_opts_with_plugins_directories(context, [plugins_directory_01, plugins_directory_02])
+
+    opts =
+      get_opts_with_plugins_directories(context, [plugins_directory_01, plugins_directory_02])
+
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
     reset_enabled_plugins_to_preconfigured_defaults(context)
-    assert %{status: :running,
-             plugins: [%{name: :mock_rabbitmq_plugins_01, enabled: :not_enabled, running: false, version: '0.2.0'},
-                       %{name: :mock_rabbitmq_plugins_02, enabled: :not_enabled, running: false, version: '0.2.0'},
-                       %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-                       %{name: :rabbitmq_stomp, enabled: :enabled, running: true}]} =
-      @command.run([".*"], opts)
+
+    assert %{
+             status: :running,
+             plugins: [
+               %{
+                 name: :mock_rabbitmq_plugins_01,
+                 enabled: :not_enabled,
+                 running: false,
+                 version: '0.2.0'
+               },
+               %{
+                 name: :mock_rabbitmq_plugins_02,
+                 enabled: :not_enabled,
+                 running: false,
+                 version: '0.2.0'
+               },
+               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+               %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
+             ]
+           } = @command.run([".*"], opts)
   end
 
   test "will report both running and pending upgrade versions", context do
@@ -215,21 +318,59 @@ defmodule ListPluginsCommandTest do
     plugins_directory_02 = fixture_plugins_path("plugins-subdirectory-02")
     opts = get_opts_with_plugins_directories(context, [plugins_directory_01])
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
-    set_enabled_plugins([:mock_rabbitmq_plugins_02, :rabbitmq_federation, :rabbitmq_stomp],
-                        :online, get_rabbit_hostname(), opts)
-    assert %{status: :running,
-             plugins: [%{name: :mock_rabbitmq_plugins_01, enabled: :not_enabled, running: false, version: '0.2.0'},
-                       %{name: :mock_rabbitmq_plugins_02, enabled: :enabled, running: true, version: '0.1.0', running_version: '0.1.0'},
-                       %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-                       %{name: :rabbitmq_stomp, enabled: :enabled, running: true}]} =
-      @command.run([".*"], opts)
-    opts = get_opts_with_plugins_directories(context, [plugins_directory_01, plugins_directory_02])
+
+    set_enabled_plugins(
+      [:mock_rabbitmq_plugins_02, :rabbitmq_federation, :rabbitmq_stomp],
+      :online,
+      get_rabbit_hostname(),
+      opts
+    )
+
+    assert %{
+             status: :running,
+             plugins: [
+               %{
+                 name: :mock_rabbitmq_plugins_01,
+                 enabled: :not_enabled,
+                 running: false,
+                 version: '0.2.0'
+               },
+               %{
+                 name: :mock_rabbitmq_plugins_02,
+                 enabled: :enabled,
+                 running: true,
+                 version: '0.1.0',
+                 running_version: '0.1.0'
+               },
+               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+               %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
+             ]
+           } = @command.run([".*"], opts)
+
+    opts =
+      get_opts_with_plugins_directories(context, [plugins_directory_01, plugins_directory_02])
+
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
-    assert %{status: :running,
-             plugins: [%{name: :mock_rabbitmq_plugins_01, enabled: :not_enabled, running: false, version: '0.2.0'},
-                       %{name: :mock_rabbitmq_plugins_02, enabled: :enabled, running: true, version: '0.2.0', running_version: '0.1.0'},
-                       %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-                       %{name: :rabbitmq_stomp, enabled: :enabled, running: true}]} =
-      @command.run([".*"], opts)
+
+    assert %{
+             status: :running,
+             plugins: [
+               %{
+                 name: :mock_rabbitmq_plugins_01,
+                 enabled: :not_enabled,
+                 running: false,
+                 version: '0.2.0'
+               },
+               %{
+                 name: :mock_rabbitmq_plugins_02,
+                 enabled: :enabled,
+                 running: true,
+                 version: '0.2.0',
+                 running_version: '0.1.0'
+               },
+               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+               %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
+             ]
+           } = @command.run([".*"], opts)
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
@@ -4,42 +4,123 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule PluginsFormatterTest do
   use ExUnit.Case, async: false
 
   @formatter RabbitMQ.CLI.Formatters.Plugins
 
   test "format_output with --silent and --minimal" do
-    result = @formatter.format_output(
-        %{status: :running,
-          plugins: [%{name: :amqp_client, enabled: :implicit, running: true, version: '3.7.0', running_version: nil},
-                    %{name: :mock_rabbitmq_plugins_01, enabled: :not_enabled, running: false, version: '0.2.0', running_version: nil},
-                    %{name: :mock_rabbitmq_plugins_02, enabled: :enabled, running: true, version: '0.2.0', running_version: '0.1.0'},
-                    %{name: :rabbitmq_federation, enabled: :enabled, running: true, version: '3.7.0', running_version: nil},
-                    %{name: :rabbitmq_stomp, enabled: :enabled, running: true, version: '3.7.0', running_version: nil}],
-          format: :minimal}, %{node: "rabbit@localhost", silent: true})
-    assert result == ["amqp_client",
-                      "mock_rabbitmq_plugins_01",
-                      "mock_rabbitmq_plugins_02",
-                      "rabbitmq_federation",
-                      "rabbitmq_stomp"]
+    result =
+      @formatter.format_output(
+        %{
+          status: :running,
+          plugins: [
+            %{
+              name: :amqp_client,
+              enabled: :implicit,
+              running: true,
+              version: '3.7.0',
+              running_version: nil
+            },
+            %{
+              name: :mock_rabbitmq_plugins_01,
+              enabled: :not_enabled,
+              running: false,
+              version: '0.2.0',
+              running_version: nil
+            },
+            %{
+              name: :mock_rabbitmq_plugins_02,
+              enabled: :enabled,
+              running: true,
+              version: '0.2.0',
+              running_version: '0.1.0'
+            },
+            %{
+              name: :rabbitmq_federation,
+              enabled: :enabled,
+              running: true,
+              version: '3.7.0',
+              running_version: nil
+            },
+            %{
+              name: :rabbitmq_stomp,
+              enabled: :enabled,
+              running: true,
+              version: '3.7.0',
+              running_version: nil
+            }
+          ],
+          format: :minimal
+        },
+        %{node: "rabbit@localhost", silent: true}
+      )
+
+    assert result == [
+             "amqp_client",
+             "mock_rabbitmq_plugins_01",
+             "mock_rabbitmq_plugins_02",
+             "rabbitmq_federation",
+             "rabbitmq_stomp"
+           ]
   end
 
   test "format_output pending upgrade version message" do
-    result = @formatter.format_output(
-        %{status: :running,
-          plugins: [%{name: :amqp_client, enabled: :implicit, running: true, version: '3.7.0', running_version: nil},
-                    %{name: :mock_rabbitmq_plugins_01, enabled: :not_enabled, running: false, version: '0.2.0', running_version: nil},
-                    %{name: :mock_rabbitmq_plugins_02, enabled: :enabled, running: true, version: '0.2.0', running_version: '0.1.0'},
-                    %{name: :rabbitmq_federation, enabled: :enabled, running: true, version: '3.7.0', running_version: nil},
-                    %{name: :rabbitmq_stomp, enabled: :enabled, running: true, version: '3.7.0', running_version: nil}],
-          format: :normal}, %{node: "rabbit@localhost"})
-    assert result == [" Configured: E = explicitly enabled; e = implicitly enabled",
-                     " | Status: * = running on rabbit@localhost", " |/",
-                     "[e*] amqp_client              3.7.0", "[  ] mock_rabbitmq_plugins_01 0.2.0",
-                     "[E*] mock_rabbitmq_plugins_02 0.1.0 (pending upgrade to 0.2.0)",
-                     "[E*] rabbitmq_federation      3.7.0", "[E*] rabbitmq_stomp           3.7.0"]
-  end
+    result =
+      @formatter.format_output(
+        %{
+          status: :running,
+          plugins: [
+            %{
+              name: :amqp_client,
+              enabled: :implicit,
+              running: true,
+              version: '3.7.0',
+              running_version: nil
+            },
+            %{
+              name: :mock_rabbitmq_plugins_01,
+              enabled: :not_enabled,
+              running: false,
+              version: '0.2.0',
+              running_version: nil
+            },
+            %{
+              name: :mock_rabbitmq_plugins_02,
+              enabled: :enabled,
+              running: true,
+              version: '0.2.0',
+              running_version: '0.1.0'
+            },
+            %{
+              name: :rabbitmq_federation,
+              enabled: :enabled,
+              running: true,
+              version: '3.7.0',
+              running_version: nil
+            },
+            %{
+              name: :rabbitmq_stomp,
+              enabled: :enabled,
+              running: true,
+              version: '3.7.0',
+              running_version: nil
+            }
+          ],
+          format: :normal
+        },
+        %{node: "rabbit@localhost"}
+      )
 
+    assert result == [
+             " Configured: E = explicitly enabled; e = implicitly enabled",
+             " | Status: * = running on rabbit@localhost",
+             " |/",
+             "[e*] amqp_client              3.7.0",
+             "[  ] mock_rabbitmq_plugins_01 0.2.0",
+             "[E*] mock_rabbitmq_plugins_02 0.1.0 (pending upgrade to 0.2.0)",
+             "[E*] rabbitmq_federation      3.7.0",
+             "[E*] rabbitmq_stomp           3.7.0"
+           ]
+  end
 end

--- a/deps/rabbitmq_cli/test/plugins/set_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/set_plugins_command_test.exs
@@ -10,134 +10,184 @@ defmodule SetPluginsCommandTest do
 
   @command RabbitMQ.CLI.Plugins.Commands.SetCommand
 
-
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
 
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
 
-    opts = %{enabled_plugins_file: plugins_file,
-             plugins_dir: plugins_dir,
-             rabbitmq_home: rabbitmq_home,
-             online: false, offline: false}
+    opts = %{
+      enabled_plugins_file: plugins_file,
+      plugins_dir: plugins_dir,
+      rabbitmq_home: rabbitmq_home,
+      online: false,
+      offline: false
+    }
 
     on_exit(fn ->
-      set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(),opts)
+      set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
 
     {:ok, opts: opts}
   end
 
   setup context do
-
-    set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
-                        :online,
-                        get_rabbit_hostname(),
-                        context[:opts])
+    set_enabled_plugins(
+      [:rabbitmq_stomp, :rabbitmq_federation],
+      :online,
+      get_rabbit_hostname(),
+      context[:opts]
+    )
 
     {
       :ok,
-      opts: Map.merge(context[:opts], %{
-              node: get_rabbit_hostname(),
-              timeout: 1000
-            })
+      opts:
+        Map.merge(context[:opts], %{
+          node: get_rabbit_hostname(),
+          timeout: 1000
+        })
     }
   end
 
   test "validate: specifying both --online and --offline is reported as invalid", context do
     assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate([], Map.merge(context[:opts], %{online: true, offline: true}))
-    )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([], Map.merge(context[:opts], %{online: true, offline: true}))
+           )
   end
 
-  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate_execution_environment([], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) ==
-      :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine",
+       context do
+    assert @command.validate_execution_environment(
+             [],
+             Map.merge(context[:opts], %{enabled_plugins_file: "none"})
+           ) ==
+             :ok
   end
 
-  test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment([], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+  test "validate_execution_environment: specifying non existent plugins_dir is reported as an error",
+       context do
+    assert @command.validate_execution_environment(
+             [],
+             Map.merge(context[:opts], %{plugins_dir: "none"})
+           ) ==
+             {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "will write enabled plugins file if node is inaccessible and report implicitly enabled list", context do
+  test "will write enabled plugins file if node is inaccessible and report implicitly enabled list",
+       context do
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
-    assert [[:rabbitmq_stomp],
-            %{mode: :offline, set: [:rabbitmq_stomp]}] =
-      Enum.to_list(test_stream)
+             @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{node: :nonode}))
+
+    assert [[:rabbitmq_stomp], %{mode: :offline, set: [:rabbitmq_stomp]}] =
+             Enum.to_list(test_stream)
+
     assert {:ok, [[:rabbitmq_stomp]]} = :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp] =
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
   test "will write enabled plugins in offline mode and report implicitly enabled list", context do
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_stomp"], Map.merge(context[:opts], %{offline: true, online: false}))
-    assert [[:rabbitmq_stomp],
-            %{mode: :offline, set: [:rabbitmq_stomp]}] =
-      Enum.to_list(test_stream)
+             @command.run(
+               ["rabbitmq_stomp"],
+               Map.merge(context[:opts], %{offline: true, online: false})
+             )
+
+    assert [[:rabbitmq_stomp], %{mode: :offline, set: [:rabbitmq_stomp]}] =
+             Enum.to_list(test_stream)
+
     assert {:ok, [[:rabbitmq_stomp]]} = :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp] =
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
   test "will update list of plugins and start/stop enabled/disabled plugins", context do
     assert {:stream, test_stream0} = @command.run(["rabbitmq_stomp"], context[:opts])
-    assert [[:rabbitmq_stomp],
-            %{mode: :online,
-              started: [], stopped: [:rabbitmq_federation],
-              set: [:rabbitmq_stomp]}] =
-      Enum.to_list(test_stream0)
+
+    assert [
+             [:rabbitmq_stomp],
+             %{
+               mode: :online,
+               started: [],
+               stopped: [:rabbitmq_federation],
+               set: [:rabbitmq_stomp]
+             }
+           ] = Enum.to_list(test_stream0)
+
     assert {:ok, [[:rabbitmq_stomp]]} = :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_stomp] =
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+
     assert {:stream, test_stream1} = @command.run(["rabbitmq_federation"], context[:opts])
-    assert [[:rabbitmq_federation],
-            %{mode: :online,
-              started: [:rabbitmq_federation], stopped: [:rabbitmq_stomp],
-              set: [:rabbitmq_federation]}] =
-      Enum.to_list(test_stream1)
+
+    assert [
+             [:rabbitmq_federation],
+             %{
+               mode: :online,
+               started: [:rabbitmq_federation],
+               stopped: [:rabbitmq_stomp],
+               set: [:rabbitmq_federation]
+             }
+           ] = Enum.to_list(test_stream1)
+
     assert {:ok, [[:rabbitmq_federation]]} = :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_federation] =
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
   test "can disable all plugins", context do
     assert {:stream, test_stream} = @command.run([], context[:opts])
-    assert [[],
-            %{mode: :online,
-              started: [], stopped: [:rabbitmq_federation, :rabbitmq_stomp],
-              set: []}] =
-      Enum.to_list(test_stream)
+
+    assert [
+             [],
+             %{
+               mode: :online,
+               started: [],
+               stopped: [:rabbitmq_federation, :rabbitmq_stomp],
+               set: []
+             }
+           ] = Enum.to_list(test_stream)
+
     assert {:ok, [[]]} = :file.consult(context[:opts][:enabled_plugins_file])
-    assert [] = Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+
+    assert [] =
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
   test "can set multiple plugins", context do
     set_enabled_plugins([], :online, get_rabbit_hostname(), context[:opts])
+
     assert {:stream, test_stream} =
-      @command.run(["rabbitmq_federation", "rabbitmq_stomp"], context[:opts])
-    assert [[:rabbitmq_federation, :rabbitmq_stomp],
-            %{mode: :online,
-              started: [:rabbitmq_federation, :rabbitmq_stomp],
-              stopped: [],
-              set: [:rabbitmq_federation, :rabbitmq_stomp]}] =
-      Enum.to_list(test_stream)
+             @command.run(["rabbitmq_federation", "rabbitmq_stomp"], context[:opts])
+
+    assert [
+             [:rabbitmq_federation, :rabbitmq_stomp],
+             %{
+               mode: :online,
+               started: [:rabbitmq_federation, :rabbitmq_stomp],
+               stopped: [],
+               set: [:rabbitmq_federation, :rabbitmq_stomp]
+             }
+           ] = Enum.to_list(test_stream)
+
     assert {:ok, [[:rabbitmq_federation, :rabbitmq_stomp]]} =
-           :file.consult(context[:opts][:enabled_plugins_file])
+             :file.consult(context[:opts][:enabled_plugins_file])
+
     assert [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp] =
-           Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
+             Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
   test "run: does not enable plugins with unmet version requirements", context do
@@ -146,7 +196,6 @@ defmodule SetPluginsCommandTest do
     plugins_directory = fixture_plugins_path("plugins_with_version_requirements")
     opts = get_opts_with_plugins_directories(context, [plugins_directory])
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
-
 
     {:stream, _} = @command.run(["mock_rabbitmq_plugin_for_3_9"], opts)
     check_plugins_enabled([:mock_rabbitmq_plugin_for_3_9], context)

--- a/deps/rabbitmq_cli/test/queues/add_member_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/add_member_command_test.exs
@@ -17,12 +17,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: when no arguments are provided, returns a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -33,8 +33,13 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommandTest do
   end
 
   test "validate: when three or more arguments are provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(
+             ["quorum-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"],
+             %{}
+           ) == {:validation_failure, :too_many_args}
   end
 
   test "validate: treats two positional arguments and default switches as a success" do
@@ -43,7 +48,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a", "rabbit@new-node"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a", "rabbit@new-node"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/check_if_node_is_mirror_sync_critical_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/check_if_node_is_mirror_sync_critical_command_test.exs
@@ -17,10 +17,11 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsMirrorSyncCriticalCommandTes
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "validate: accepts no positional arguments" do
@@ -29,8 +30,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsMirrorSyncCriticalCommandTes
 
   test "validate: any positional arguments fail validation" do
     assert @command.validate(["quorum-queue-a"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "two"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "two", "three"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "two"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "two", "three"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000

--- a/deps/rabbitmq_cli/test/queues/check_if_node_is_quorum_critical_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/check_if_node_is_quorum_critical_command_test.exs
@@ -17,10 +17,11 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
 
   test "validate: accepts no positional arguments" do
@@ -29,8 +30,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommandTest do
 
   test "validate: any positional arguments fail validation" do
     assert @command.validate(["quorum-queue-a"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "two"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "two", "three"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "two"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "two", "three"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000

--- a/deps/rabbitmq_cli/test/queues/delete_member_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/delete_member_command_test.exs
@@ -17,12 +17,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.DeleteMemberCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: when no arguments are provided, returns a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -33,8 +33,13 @@ defmodule RabbitMQ.CLI.Queues.Commands.DeleteMemberCommandTest do
   end
 
   test "validate: when three or more arguments are provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(
+             ["quorum-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"],
+             %{}
+           ) == {:validation_failure, :too_many_args}
   end
 
   test "validate: treats two positional arguments and default switches as a success" do
@@ -43,7 +48,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.DeleteMemberCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a", "rabbit@new-node"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a", "rabbit@new-node"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/grow_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/grow_command_test.exs
@@ -17,20 +17,19 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-      node: get_rabbit_hostname(),
-      timeout: context[:test_timeout] || 30000,
-      vhost_pattern: ".*",
-      queue_pattern: ".*",
-      errors_only: false
-    }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       vhost_pattern: ".*",
+       queue_pattern: ".*",
+       errors_only: false
+     }}
   end
 
   test "merge_defaults: defaults to reporting complete results" do
     assert @command.merge_defaults([], %{}) ==
-      {[], %{vhost_pattern: ".*",
-             queue_pattern: ".*",
-             errors_only: false}}
+             {[], %{vhost_pattern: ".*", queue_pattern: ".*", errors_only: false}}
   end
 
   test "validate: when no arguments are provided, returns a failure" do
@@ -51,17 +50,22 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommandTest do
 
   test "validate: when a node and something else is provided, returns a failure" do
     assert @command.validate(["quorum-queue-a", "banana"], %{}) ==
-      {:validation_failure, "strategy 'banana' is not recognised."}
+             {:validation_failure, "strategy 'banana' is not recognised."}
   end
 
   test "validate: when three arguments are provided, returns a failure" do
     assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a", "all"],
-                                             Map.merge(context[:opts], %{node: :jake@thedog, timeout: 200})))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a", "all"],
+               Map.merge(context[:opts], %{node: :jake@thedog, timeout: 200})
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/peek_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/peek_command_test.exs
@@ -18,12 +18,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: treats no arguments as a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -35,6 +35,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommandTest do
 
   test "validate: when two or more arguments are provided, returns a failure" do
     assert @command.validate(["quorum-queue-a", "1"], %{}) == :ok
+
     assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
              {:validation_failure, :too_many_args}
   end
@@ -53,7 +54,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.PeekCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a", "1"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a", "1"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/quorum_status_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/quorum_status_command_test.exs
@@ -17,12 +17,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.QuorumStatusCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: treats no arguments as a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -33,13 +33,21 @@ defmodule RabbitMQ.CLI.Queues.Commands.QuorumStatusCommandTest do
   end
 
   test "validate: when two or more arguments are provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["quorum-queue-a", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/reclaim_quorum_memory_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/reclaim_quorum_memory_command_test.exs
@@ -17,12 +17,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.ReclaimQuorumMemoryCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: treats no arguments as a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -33,13 +33,21 @@ defmodule RabbitMQ.CLI.Queues.Commands.ReclaimQuorumMemoryCommandTest do
   end
 
   test "validate: when two or more arguments are provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["quorum-queue-a", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/shrink_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/shrink_command_test.exs
@@ -17,11 +17,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        errors_only: false
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       errors_only: false
+     }}
   end
 
   test "merge_defaults: defaults to reporting complete results" do
@@ -38,9 +39,10 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommandTest do
 
   test "validate: when three or more arguments are provided, returns a failure" do
     assert @command.validate(["quorum-queue-a", "one-extra-arg"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
+
     assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
-      {:validation_failure, :too_many_args}
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: treats one positional arguments and default switches as a success" do
@@ -49,7 +51,12 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run(["quorum-queue-a"],
-                                Map.merge(context[:opts], %{node: :jake@thedog, vhost: "/", timeout: 200})))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["quorum-queue-a"],
+               Map.merge(context[:opts], %{node: :jake@thedog, vhost: "/", timeout: 200})
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/queues/stream_status_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/stream_status_command_test.exs
@@ -17,12 +17,12 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: treats no arguments as a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -33,13 +33,21 @@ defmodule RabbitMQ.CLI.Streams.Commands.StreamStatusCommandTest do
   end
 
   test "validate: when two or more arguments are provided, returns a failure" do
-    assert @command.validate(["stream-queue-a", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["stream-queue-a", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["stream-queue-a", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["stream-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["stream-queue-a"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200, tracking: false}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["stream-queue-a"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200, tracking: false}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/rabbitmqctl_test.exs
+++ b/deps/rabbitmq_cli/test/rabbitmqctl_test.exs
@@ -4,13 +4,11 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule RabbitMQCtlTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureIO
   import RabbitMQ.CLI.Core.ExitCodes
   import TestHelper
-
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -26,30 +24,34 @@ defmodule RabbitMQCtlTest do
 
   test "--help option prints help for the command and exits with an OK" do
     command = ["status", "--help"]
+
     assert capture_io(fn ->
-      error_check(command, exit_ok())
-    end) =~ ~r/Usage/
+             error_check(command, exit_ok())
+           end) =~ ~r/Usage/
   end
 
   test "bare --help prints general help and exits with an OK" do
     command = ["--help"]
+
     assert capture_io(fn ->
-      error_check(command, exit_ok())
-    end) =~ ~r/Usage/
+             error_check(command, exit_ok())
+           end) =~ ~r/Usage/
   end
 
   test "help [command] prints help for the command and exits with an OK" do
     command = ["help", "status"]
+
     assert capture_io(fn ->
-      error_check(command, exit_ok())
-    end) =~ ~r/Usage/
+             error_check(command, exit_ok())
+           end) =~ ~r/Usage/
   end
 
   test "bare help command prints general help and exits with an OK" do
     command = ["help"]
+
     assert capture_io(fn ->
-      error_check(command, exit_ok())
-    end) =~ ~r/Usage/
+             error_check(command, exit_ok())
+           end) =~ ~r/Usage/
   end
 
   #
@@ -58,53 +60,63 @@ defmodule RabbitMQCtlTest do
 
   test "print error message on a bad connection" do
     command = ["status", "-n", "sandwich@pastrami"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command, exit_unavailable())
-    end) =~ ~r/unable to perform an operation on node 'sandwich@pastrami'/
+             error_check(command, exit_unavailable())
+           end) =~ ~r/unable to perform an operation on node 'sandwich@pastrami'/
   end
 
   test "when an RPC call times out, prints a timeout message" do
     command = ["list_users", "-t", "0"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command, exit_tempfail())
-    end) =~ ~r/Error: operation list_users on node #{get_rabbit_hostname()} timed out. Timeout value used: 0/
+             error_check(command, exit_tempfail())
+           end) =~
+             ~r/Error: operation list_users on node #{get_rabbit_hostname()} timed out. Timeout value used: 0/
   end
 
   test "when authentication fails, prints an authentication error message" do
-    add_user "kirk", "khaaaaaan"
+    add_user("kirk", "khaaaaaan")
     command = ["authenticate_user", "kirk", "makeitso"]
-    assert capture_io(:stderr,
-      fn -> error_check(command, exit_dataerr())
-    end) =~ ~r/Error: failed to authenticate user \"kirk\"/
-    delete_user "kirk"
+
+    assert capture_io(
+             :stderr,
+             fn -> error_check(command, exit_dataerr()) end
+           ) =~ ~r/Error: failed to authenticate user \"kirk\"/
+
+    delete_user("kirk")
   end
 
   test "when invoked without arguments, displays a generic usage message and exits with a non-zero code" do
     command = []
+
     assert capture_io(:stderr, fn ->
-      error_check(command, exit_usage())
-    end) =~ ~r/usage/i
+             error_check(command, exit_usage())
+           end) =~ ~r/usage/i
   end
 
   test "when invoked with only a --help, shows a generic usage message and exits with a success" do
     command = ["--help"]
+
     assert capture_io(:stdio, fn ->
-      error_check(command, exit_ok())
-    end) =~ ~r/usage/i
+             error_check(command, exit_ok())
+           end) =~ ~r/usage/i
   end
 
   test "when invoked with --help [command], shows a generic usage message and exits with a success" do
     command = ["--help", "status"]
+
     assert capture_io(:stdio, fn ->
-      error_check(command, exit_ok())
-    end) =~ ~r/usage/i
+             error_check(command, exit_ok())
+           end) =~ ~r/usage/i
   end
 
   test "when no command name is provided, displays usage" do
     command = ["-n", "sandwich@pastrami"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command, exit_usage())
-    end) =~ ~r/usage/i
+             error_check(command, exit_usage())
+           end) =~ ~r/usage/i
   end
 
   test "short node name without the host part connects properly" do
@@ -114,16 +126,20 @@ defmodule RabbitMQCtlTest do
 
   test "a non-existent command results in help message displayed" do
     command = ["not_real"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command, exit_usage())
-    end) =~ ~r/Usage/
+             error_check(command, exit_usage())
+           end) =~ ~r/Usage/
   end
 
   test "a command that's been provided extra arguments exits with a reasonable error code" do
     command = ["status", "extra"]
-    output = capture_io(:stderr, fn ->
-      error_check(command, exit_usage())
-    end)
+
+    output =
+      capture_io(:stderr, fn ->
+        error_check(command, exit_usage())
+      end)
+
     assert output =~ ~r/too many arguments/
     assert output =~ ~r/Usage/
     assert output =~ ~r/status/
@@ -131,9 +147,12 @@ defmodule RabbitMQCtlTest do
 
   test "a command that's been provided insufficient arguments exits with a reasonable error code" do
     command = ["list_user_permissions"]
-    output = capture_io(:stderr, fn ->
-      error_check(command, exit_usage())
-    end)
+
+    output =
+      capture_io(:stderr, fn ->
+        error_check(command, exit_usage())
+      end)
+
     assert output =~ ~r/not enough arguments/
     assert output =~ ~r/Usage/
     assert output =~ ~r/list_user_permissions/
@@ -151,31 +170,34 @@ defmodule RabbitMQCtlTest do
 
   test "a mcommand with an unsupported option as the first command-line arg fails gracefully" do
     command1 = ["--invalid=true", "list_permissions", "-p", "/"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command1, exit_usage())
-    end) =~ ~r/Invalid options for this command/
+             error_check(command1, exit_usage())
+           end) =~ ~r/Invalid options for this command/
 
     command2 = ["--node", "rabbit", "status", "quack"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command2, exit_usage())
-    end) =~ ~r/too many arguments./
+             error_check(command2, exit_usage())
+           end) =~ ~r/too many arguments./
 
     command3 = ["--node", "rabbit", "add_user"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command3, exit_usage())
-    end) =~ ~r/not enough arguments./
+             error_check(command3, exit_usage())
+           end) =~ ~r/not enough arguments./
   end
 
-## ------------------------- Default Flags ------------------------------------
+  ## ------------------------- Default Flags ------------------------------------
 
   test "an empty node option is filled with the default rabbit node" do
     assert RabbitMQCtl.merge_all_defaults(%{})[:node] ==
-      TestHelper.get_rabbit_hostname()
+             TestHelper.get_rabbit_hostname()
   end
 
   test "a non-empty node option is not overwritten" do
     assert RabbitMQCtl.merge_all_defaults(%{node: :jake@thedog})[:node] ==
-      :jake@thedog
+             :jake@thedog
   end
 
   test "an empty timeout option is set to infinity" do
@@ -192,14 +214,16 @@ defmodule RabbitMQCtlTest do
 
   test "any flags that aren't global or command-specific cause a bad option" do
     command1 = ["status", "--nod=rabbit"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command1, exit_usage())
-    end) =~ ~r/Invalid options for this command/
+             error_check(command1, exit_usage())
+           end) =~ ~r/Invalid options for this command/
 
     command2 = ["list_permissions", "-o", "/"]
+
     assert capture_io(:stderr, fn ->
-      error_check(command2, exit_usage())
-    end) =~ ~r/Invalid options for this command/
+             error_check(command2, exit_usage())
+           end) =~ ~r/Invalid options for this command/
   end
 
   #
@@ -210,8 +234,17 @@ defmodule RabbitMQCtlTest do
     # Note: these are not script name (scope) aware without --script-name
     # but the actual command invoked in a shell will be
     check_output(["--auto-complete", "list_q"], "list_queues\n")
-    check_output(["--auto-complete", "list_con", "--script-name", "rabbitmq-diagnostics"], "list_connections\nlist_consumers\n")
-    check_output(["--auto-complete", "--script-name", "rabbitmq-diagnostics", "mem"], "memory_breakdown\n")
+
+    check_output(
+      ["--auto-complete", "list_con", "--script-name", "rabbitmq-diagnostics"],
+      "list_connections\nlist_consumers\n"
+    )
+
+    check_output(
+      ["--auto-complete", "--script-name", "rabbitmq-diagnostics", "mem"],
+      "memory_breakdown\n"
+    )
+
     check_output(["--auto-complete", "--script-name", "rabbitmq-queues", "add_m"], "add_member\n")
   end
 
@@ -219,39 +252,54 @@ defmodule RabbitMQCtlTest do
     # Note: these are not script name (scope) aware without --script-name
     # but the actual command invoked in a shell will be
     check_output(["autocomplete", "list_q"], "list_queues\n")
-    check_output(["autocomplete", "list_con", "--script-name", "rabbitmq-diagnostics"], "list_connections\nlist_consumers\n")
-    check_output(["autocomplete", "--script-name", "rabbitmq-diagnostics", "mem"], "memory_breakdown\n")
+
+    check_output(
+      ["autocomplete", "list_con", "--script-name", "rabbitmq-diagnostics"],
+      "list_connections\nlist_consumers\n"
+    )
+
+    check_output(
+      ["autocomplete", "--script-name", "rabbitmq-diagnostics", "mem"],
+      "memory_breakdown\n"
+    )
+
     check_output(["autocomplete", "--script-name", "rabbitmq-queues", "add_m"], "add_member\n")
   end
 
   defp check_output(cmd, out) do
     assert capture_io(fn ->
-      error_check(cmd, exit_ok())
-    end) == out
+             error_check(cmd, exit_ok())
+           end) == out
   end
 
-
-## ------------------------- Error formatting ---------------------------------
+  ## ------------------------- Error formatting ---------------------------------
 
   test "badrpc nodedown error" do
     exit_code = exit_unavailable()
     node = :example@node
+
     {:error, ^exit_code, message} =
-        RabbitMQCtl.handle_command_output(
-          {:error, {:badrpc, :nodedown}},
-          :no_command, %{node: node},
-          fn(output, _, _) -> output end)
+      RabbitMQCtl.handle_command_output(
+        {:error, {:badrpc, :nodedown}},
+        :no_command,
+        %{node: node},
+        fn output, _, _ -> output end
+      )
 
     assert message =~ ~r/Error: unable to perform an operation on node/
     assert message =~ ~r/DIAGNOSTICS/
     assert message =~ ~r/attempted to contact/
 
     localnode = :non_existent_node@localhost
+
     {:error, ^exit_code, message} =
-        RabbitMQCtl.handle_command_output(
-          {:error, {:badrpc, :nodedown}},
-          :no_command, %{node: localnode},
-          fn(output, _, _) -> output end)
+      RabbitMQCtl.handle_command_output(
+        {:error, {:badrpc, :nodedown}},
+        :no_command,
+        %{node: localnode},
+        fn output, _, _ -> output end
+      )
+
     assert message =~ ~r/DIAGNOSTICS/
     assert message =~ ~r/attempted to contact/
     assert message =~ ~r/suggestion: start the node/
@@ -261,41 +309,54 @@ defmodule RabbitMQCtlTest do
     exit_code = exit_tempfail()
     timeout = 1000
     nodename = :node@host
-    err_msg = "Error: operation example on node node@host timed out. Timeout value used: #{timeout}"
+
+    err_msg =
+      "Error: operation example on node node@host timed out. Timeout value used: #{timeout}"
+
     {:error, ^exit_code, ^err_msg} =
       RabbitMQCtl.handle_command_output(
-          {:error, {:badrpc, :timeout}},
-          ExampleCommand, %{timeout: timeout, node: nodename},
-          fn(output, _, _) -> output end)
+        {:error, {:badrpc, :timeout}},
+        ExampleCommand,
+        %{timeout: timeout, node: nodename},
+        fn output, _, _ -> output end
+      )
   end
 
   test "generic error" do
     exit_code = exit_unavailable()
+
     {:error, ^exit_code, "Error:\nerror message"} =
       RabbitMQCtl.handle_command_output(
         {:error, "error message"},
-        :no_command, %{},
-        fn(output, _, _) -> output end)
+        :no_command,
+        %{},
+        fn output, _, _ -> output end
+      )
   end
 
   test "inspect arbitrary error" do
     exit_code = exit_unavailable()
     error = %{i: [am: "arbitrary", error: 1]}
     inspected = inspect(error)
+
     {:error, ^exit_code, "Error:\n" <> ^inspected} =
       RabbitMQCtl.handle_command_output(
         {:error, error},
-        :no_command, %{},
-        fn(output, _, _) -> output end)
+        :no_command,
+        %{},
+        fn output, _, _ -> output end
+      )
   end
 
   test "atom error" do
     exit_code = exit_unavailable()
+
     {:error, ^exit_code, "Error:\nerror_message"} =
       RabbitMQCtl.handle_command_output(
         {:error, :error_message},
-        :no_command, %{},
-        fn(output, _, _) -> output end)
+        :no_command,
+        %{},
+        fn output, _, _ -> output end
+      )
   end
-
 end

--- a/deps/rabbitmq_cli/test/streams/add_replica_command_test.exs
+++ b/deps/rabbitmq_cli/test/streams/add_replica_command_test.exs
@@ -18,12 +18,12 @@ defmodule RabbitMQ.CLI.Streams.Commands.AddReplicaCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: when no arguments are provided, returns a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -34,8 +34,13 @@ defmodule RabbitMQ.CLI.Streams.Commands.AddReplicaCommandTest do
   end
 
   test "validate: when three or more arguments are provided, returns a failure" do
-    assert @command.validate(["stream-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["stream-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["stream-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(
+             ["stream-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"],
+             %{}
+           ) == {:validation_failure, :too_many_args}
   end
 
   test "validate: treats two positional arguments and default switches as a success" do
@@ -44,7 +49,12 @@ defmodule RabbitMQ.CLI.Streams.Commands.AddReplicaCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["stream-queue-a", "rabbit@new-node"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["stream-queue-a", "rabbit@new-node"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/streams/delete_replica_command_test.exs
+++ b/deps/rabbitmq_cli/test/streams/delete_replica_command_test.exs
@@ -18,13 +18,13 @@ defmodule RabbitMQ.CLI.Streams.Commands.DeleteReplicaCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        vhost: "/"
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       vhost: "/"
+     }}
   end
-
 
   test "validate: when no arguments are provided, returns a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -35,23 +35,35 @@ defmodule RabbitMQ.CLI.Streams.Commands.DeleteReplicaCommandTest do
   end
 
   test "validate: when three or more arguments are provided, returns a failure" do
-    assert @command.validate(["stream-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["stream-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["stream-queue-a", "rabbit@new-node", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(
+             ["stream-queue-a", "rabbit@new-node", "extra-arg", "another-extra-arg"],
+             %{}
+           ) == {:validation_failure, :too_many_args}
   end
 
   test "validate: treats two positional arguments and default switches as a success" do
     assert @command.validate(["stream-queue-a", "rabbit@new-node"], %{}) == :ok
   end
 
-  test "run: trying to delete the last member of a stream should fail and return a meaningful message", context do
+  test "run: trying to delete the last member of a stream should fail and return a meaningful message",
+       context do
     declare_stream("test_stream_1", "/")
+
     assert @command.run(["test_stream_1", get_rabbit_hostname()], context[:opts]) ==
              {:error, "Cannot delete the last member of a stream"}
   end
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["stream-queue-a", "rabbit@new-node"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["stream-queue-a", "rabbit@new-node"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/streams/set_stream_retention_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/streams/set_stream_retention_policy_command_test.exs
@@ -18,12 +18,12 @@ defmodule RabbitMQ.CLI.Streams.Commands.SetStreamRetentionPolicyCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
   end
-
 
   test "validate: when no arguments are provided, returns a failure" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
@@ -34,8 +34,11 @@ defmodule RabbitMQ.CLI.Streams.Commands.SetStreamRetentionPolicyCommandTest do
   end
 
   test "validate: when three or more arguments are provided, returns a failure" do
-    assert @command.validate(["stream-queue-a", "1D", "one-extra-arg"], %{}) == {:validation_failure, :too_many_args}
-    assert @command.validate(["stream-queue-a", "1D", "extra-arg", "another-extra-arg"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["stream-queue-a", "1D", "one-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["stream-queue-a", "1D", "extra-arg", "another-extra-arg"], %{}) ==
+             {:validation_failure, :too_many_args}
   end
 
   test "validate: treats two positional arguments and default switches as a success" do
@@ -44,12 +47,22 @@ defmodule RabbitMQ.CLI.Streams.Commands.SetStreamRetentionPolicyCommandTest do
 
   @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc" do
-    assert match?({:badrpc, _}, @command.run(["stream-queue-a", "1Y"],
-                                             %{node: :jake@thedog, vhost: "/", timeout: 200}))
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               ["stream-queue-a", "1Y"],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
   end
 
   test "run: targeting an unknown queue returns an error", context do
-    assert match?({:error, _}, @command.run(["stream-queue-a", "1Y"],
-                                            Map.merge(context[:opts], %{vhost: "/"})))
+    assert match?(
+             {:error, _},
+             @command.run(
+               ["stream-queue-a", "1Y"],
+               Map.merge(context[:opts], %{vhost: "/"})
+             )
+           )
   end
 end

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -5,10 +5,12 @@
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
 four_hours = 240 * 60 * 1000
+
 ExUnit.configure(
   exclude: [disabled: true],
   module_load_timeout: four_hours,
-  timeout: four_hours)
+  timeout: four_hours
+)
 
 ExUnit.start()
 
@@ -64,13 +66,18 @@ defmodule TestHelper do
   end
 
   def add_user(name, password) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :add_user,
-      [name, password, "acting-user"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :add_user, [
+      name,
+      password,
+      "acting-user"
+    ])
   end
 
   def delete_user(name) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :delete_user,
-      [name, "acting-user"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :delete_user, [
+      name,
+      "acting-user"
+    ])
   end
 
   def list_users() do
@@ -86,7 +93,11 @@ defmodule TestHelper do
   end
 
   def set_user_tags(name, tags) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :set_tags, [name, tags, "acting-user"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :set_tags, [
+      name,
+      tags,
+      "acting-user"
+    ])
   end
 
   def set_vhost_tags(name, tags) do
@@ -94,15 +105,30 @@ defmodule TestHelper do
   end
 
   def authenticate_user(name, password) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_access_control,:check_user_pass_login, [name, password])
+    :rpc.call(get_rabbit_hostname(), :rabbit_access_control, :check_user_pass_login, [
+      name,
+      password
+    ])
   end
 
   def set_parameter(vhost, component_name, key, value) do
-    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :parse_set, [vhost, component_name, key, value, :nouser])
+    :ok =
+      :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :parse_set, [
+        vhost,
+        component_name,
+        key,
+        value,
+        :nouser
+      ])
   end
 
   def clear_parameter(vhost, component_name, key) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :clear, [vhost, component_name, key, <<"acting-user">>])
+    :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :clear, [
+      vhost,
+      component_name,
+      key,
+      <<"acting-user">>
+    ])
   end
 
   def list_parameters(vhost) do
@@ -110,13 +136,19 @@ defmodule TestHelper do
   end
 
   def set_global_parameter(key, value) do
-    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :parse_set_global,
-      [key, value, "acting-user"])
+    :ok =
+      :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :parse_set_global, [
+        key,
+        value,
+        "acting-user"
+      ])
   end
 
   def clear_global_parameter(key) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :clear_global,
-      [key, "acting-user"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_runtime_parameters, :clear_global, [
+      key,
+      "acting-user"
+    ])
   end
 
   def list_global_parameters() do
@@ -124,7 +156,14 @@ defmodule TestHelper do
   end
 
   def set_permissions(user, vhost, [conf, write, read]) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :set_permissions, [user, vhost, conf, write, read, "acting-user"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :set_permissions, [
+      user,
+      vhost,
+      conf,
+      write,
+      read,
+      "acting-user"
+    ])
   end
 
   def list_policies(vhost) do
@@ -134,7 +173,17 @@ defmodule TestHelper do
   def set_policy(vhost, name, pattern, value) do
     {:ok, decoded} = :rabbit_json.try_decode(value)
     parsed = :maps.to_list(decoded)
-    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_policy, :set, [vhost, name, pattern, parsed, 0, "all", "acting-user"])
+
+    :ok =
+      :rpc.call(get_rabbit_hostname(), :rabbit_policy, :set, [
+        vhost,
+        name,
+        pattern,
+        parsed,
+        0,
+        "all",
+        "acting-user"
+      ])
   end
 
   def clear_policy(vhost, key) do
@@ -148,18 +197,41 @@ defmodule TestHelper do
   def set_operator_policy(vhost, name, pattern, value) do
     {:ok, decoded} = :rabbit_json.try_decode(value)
     parsed = :maps.to_list(decoded)
-    :ok = :rpc.call(get_rabbit_hostname(), :rabbit_policy, :set_op, [vhost, name, pattern, parsed, 0, "all", "acting-user"])
+
+    :ok =
+      :rpc.call(get_rabbit_hostname(), :rabbit_policy, :set_op, [
+        vhost,
+        name,
+        pattern,
+        parsed,
+        0,
+        "all",
+        "acting-user"
+      ])
   end
 
   def clear_operator_policy(vhost, key) do
     :rpc.call(get_rabbit_hostname(), :rabbit_policy, :delete_op, [vhost, key, "acting-user"])
   end
 
-  def declare_queue(name, vhost, durable \\ false, auto_delete \\ false, args \\ [], owner \\ :none) do
+  def declare_queue(
+        name,
+        vhost,
+        durable \\ false,
+        auto_delete \\ false,
+        args \\ [],
+        owner \\ :none
+      ) do
     queue_name = :rabbit_misc.r(vhost, :queue, name)
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_amqqueue, :declare,
-              [queue_name, durable, auto_delete, args, owner, "acting-user"])
+
+    :rpc.call(get_rabbit_hostname(), :rabbit_amqqueue, :declare, [
+      queue_name,
+      durable,
+      auto_delete,
+      args,
+      owner,
+      "acting-user"
+    ])
   end
 
   def declare_stream(name, vhost) do
@@ -168,23 +240,40 @@ defmodule TestHelper do
 
   def delete_queue(name, vhost) do
     queue_name = :rabbit_misc.r(vhost, :queue, name)
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_amqqueue, :delete,
-              [queue_name, false, false, "acting-user"])
+
+    :rpc.call(get_rabbit_hostname(), :rabbit_amqqueue, :delete, [
+      queue_name,
+      false,
+      false,
+      "acting-user"
+    ])
   end
 
   def lookup_queue(name, vhost) do
     queue_name = :rabbit_misc.r(vhost, :queue, name)
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_amqqueue, :lookup,
-              [queue_name])
+    :rpc.call(get_rabbit_hostname(), :rabbit_amqqueue, :lookup, [queue_name])
   end
 
-  def declare_exchange(name, vhost, type \\ :direct, durable \\ false, auto_delete \\ false, internal \\ false, args \\ []) do
+  def declare_exchange(
+        name,
+        vhost,
+        type \\ :direct,
+        durable \\ false,
+        auto_delete \\ false,
+        internal \\ false,
+        args \\ []
+      ) do
     exchange_name = :rabbit_misc.r(vhost, :exchange, name)
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_exchange, :declare,
-              [exchange_name, type, durable, auto_delete, internal, args, "acting-user"])
+
+    :rpc.call(get_rabbit_hostname(), :rabbit_exchange, :declare, [
+      exchange_name,
+      type,
+      durable,
+      auto_delete,
+      internal,
+      args,
+      "acting-user"
+    ])
   end
 
   def list_permissions(vhost) do
@@ -199,11 +288,11 @@ defmodule TestHelper do
 
   def set_topic_permissions(user, vhost, exchange, writePerm, readPerm) do
     :rpc.call(
-        get_rabbit_hostname(),
-        :rabbit_auth_backend_internal,
-        :set_topic_permissions,
-        [user, vhost, exchange, writePerm, readPerm, "acting-user"],
-        :infinity
+      get_rabbit_hostname(),
+      :rabbit_auth_backend_internal,
+      :set_topic_permissions,
+      [user, vhost, exchange, writePerm, readPerm, "acting-user"],
+      :infinity
     )
   end
 
@@ -218,14 +307,14 @@ defmodule TestHelper do
   end
 
   def clear_topic_permissions(user, vhost) do
-      :rpc.call(
-        get_rabbit_hostname(),
-        :rabbit_auth_backend_internal,
-        :clear_topic_permissions,
-        [user, vhost, "acting-user"],
-        :infinity
-      )
-    end
+    :rpc.call(
+      get_rabbit_hostname(),
+      :rabbit_auth_backend_internal,
+      :clear_topic_permissions,
+      [user, vhost, "acting-user"],
+      :infinity
+    )
+  end
 
   def set_vm_memory_high_watermark(limit) do
     :rpc.call(get_rabbit_hostname(), :vm_memory_monitor, :set_vm_memory_high_watermark, [limit])
@@ -234,7 +323,6 @@ defmodule TestHelper do
   def set_disk_free_limit(limit) do
     :rpc.call(get_rabbit_hostname(), :rabbit_disk_monitor, :set_disk_free_limit, [limit])
   end
-
 
   #
   # App lifecycle
@@ -245,15 +333,20 @@ defmodule TestHelper do
   end
 
   def await_rabbitmq_startup_with_retries(0) do
-    throw({:error, "Failed to call rabbit.await_startup/0 with retries: node #{get_rabbit_hostname()} was down"})
+    throw(
+      {:error,
+       "Failed to call rabbit.await_startup/0 with retries: node #{get_rabbit_hostname()} was down"}
+    )
   end
+
   def await_rabbitmq_startup_with_retries(retries_left) do
     case :rabbit_misc.rpc_call(get_rabbit_hostname(), :rabbit, :await_startup, []) do
       :ok ->
-          :ok
+        :ok
+
       {:badrpc, :nodedown} ->
-          :timer.sleep(50)
-          await_rabbitmq_startup_with_retries(retries_left - 1)
+        :timer.sleep(50)
+        await_rabbitmq_startup_with_retries(retries_left - 1)
     end
   end
 
@@ -265,12 +358,15 @@ defmodule TestHelper do
   def await_condition_with_retries(_fun, 0) do
     throw({:error, "Condition did not materialize"})
   end
+
   def await_condition_with_retries(fun, retries_left) do
     case fun.() do
-      true -> :ok
-      _    ->
-          :timer.sleep(50)
-          await_condition_with_retries(fun, retries_left - 1)
+      true ->
+        :ok
+
+      _ ->
+        :timer.sleep(50)
+        await_condition_with_retries(fun, retries_left - 1)
     end
   end
 
@@ -311,17 +407,20 @@ defmodule TestHelper do
   end
 
   def with_channel(vhost, fun) do
-    with_connection(vhost,
-      fn(conn) ->
+    with_connection(
+      vhost,
+      fn conn ->
         {:ok, chan} = AMQP.Channel.open(conn)
         AMQP.Confirm.select(chan)
         fun.(chan)
-      end)
+      end
+    )
   end
 
   def with_connection(vhost, fun) do
     Application.ensure_all_started(:amqp)
     {:ok, conn} = AMQP.Connection.open(virtual_host: vhost)
+
     ExUnit.Callbacks.on_exit(fn ->
       try do
         :amqp_connection.close(conn, 1000)
@@ -329,15 +428,19 @@ defmodule TestHelper do
         :exit, _ -> :ok
       end
     end)
+
     fun.(conn)
   end
 
   def with_connections(vhosts, fun) do
     Application.ensure_all_started(:amqp)
-    conns = for v <- vhosts do
-      {:ok, conn} = AMQP.Connection.open(virtual_host: v)
-      conn
-    end
+
+    conns =
+      for v <- vhosts do
+        {:ok, conn} = AMQP.Connection.open(virtual_host: v)
+        conn
+      end
+
     ExUnit.Callbacks.on_exit(fn ->
       try do
         for c <- conns, do: :amqp_connection.close(c, 1000)
@@ -345,23 +448,25 @@ defmodule TestHelper do
         :exit, _ -> :ok
       end
     end)
+
     fun.(conns)
   end
 
   def message_count(vhost, queue_name) do
-    with_channel(vhost, fn(channel) ->
+    with_channel(vhost, fn channel ->
       {:ok, %{message_count: mc}} = AMQP.Queue.declare(channel, queue_name)
       mc
     end)
   end
 
   def publish_messages(vhost, queue_name, count) do
-    with_channel(vhost, fn(channel) ->
+    with_channel(vhost, fn channel ->
       AMQP.Queue.purge(channel, queue_name)
+
       for i <- 1..count do
-        AMQP.Basic.publish(channel, "", queue_name,
-                           "test_message" <> Integer.to_string(i))
+        AMQP.Basic.publish(channel, "", queue_name, "test_message" <> Integer.to_string(i))
       end
+
       AMQP.Confirm.wait_for_confirms(channel, 30)
     end)
   end
@@ -372,11 +477,14 @@ defmodule TestHelper do
   end
 
   def await_no_client_connections_with_iterations(_node, n) when n <= 0 do
-    flunk "Ran out of retries, still have active client connections"
+    flunk("Ran out of retries, still have active client connections")
   end
+
   def await_no_client_connections_with_iterations(node, n) when n > 0 do
     case :rpc.call(node, :rabbit_networking, :connections_local, []) do
-      [] -> :ok
+      [] ->
+        :ok
+
       _xs ->
         :timer.sleep(10)
         await_no_client_connections_with_iterations(node, n - 1)
@@ -401,12 +509,14 @@ defmodule TestHelper do
     for pid <- :rpc.call(node, :rabbit_networking, :connections_local, []) do
       :rpc.call(node, :rabbit_networking, :close_connection, [pid, :force_closed])
     end
+
     await_no_client_connections(node, 5000)
   end
 
   def expect_client_connection_failure() do
     expect_client_connection_failure("/")
   end
+
   def expect_client_connection_failure(vhost) do
     Application.ensure_all_started(:amqp)
     assert {:error, :econnrefused} == AMQP.Connection.open(virtual_host: vhost)
@@ -459,12 +569,14 @@ defmodule TestHelper do
   end
 
   def emit_list_multiple_sources(list1, list2, ref, pid) do
-    pids = for list <- [list1, list2], do: Kernel.spawn_link(TestHelper, :emit_list, [list, ref, pid])
+    pids =
+      for list <- [list1, list2], do: Kernel.spawn_link(TestHelper, :emit_list, [list, ref, pid])
+
     :rabbit_control_misc.await_emitters_termination(pids)
   end
 
   def emit_list(list, ref, pid) do
-    emit_list_map(list, &(&1), ref, pid)
+    emit_list_map(list, & &1, ref, pid)
   end
 
   def emit_list_map(list, fun, ref, pid) do
@@ -473,14 +585,15 @@ defmodule TestHelper do
 
   def run_command_to_list(command, args) do
     res = Kernel.apply(command, :run, args)
+
     case Enumerable.impl_for(res) do
-      nil -> res;
-      _   -> Enum.to_list(res)
+      nil -> res
+      _ -> Enum.to_list(res)
     end
   end
 
   def vhost_exists?(vhost) do
-    Enum.any?(list_vhosts(), fn(v) -> v[:name] == vhost end)
+    Enum.any?(list_vhosts(), fn v -> v[:name] == vhost end)
   end
 
   def set_enabled_plugins(plugins, mode, node, opts) do
@@ -495,35 +608,51 @@ defmodule TestHelper do
 
   def enable_federation_plugin() do
     node = get_rabbit_hostname()
-    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
-                                                :application, :get_env,
-                                                [:rabbit, :enabled_plugins_file])
-    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
-                                               :application, :get_env,
-                                               [:rabbit, :plugins_dir])
+
+    {:ok, plugins_file} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :enabled_plugins_file])
+
+    {:ok, plugins_dir} =
+      :rabbit_misc.rpc_call(node, :application, :get_env, [:rabbit, :plugins_dir])
+
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
     {:ok, [_enabled_plugins]} = :file.consult(plugins_file)
 
-    opts = %{enabled_plugins_file: plugins_file,
-             plugins_dir: plugins_dir,
-             rabbitmq_home: rabbitmq_home,
-             online: true, offline: false}
+    opts = %{
+      enabled_plugins_file: plugins_file,
+      plugins_dir: plugins_dir,
+      rabbitmq_home: rabbitmq_home,
+      online: true,
+      offline: false
+    }
 
     plugins = currently_active_plugins(%{opts: %{node: node}})
+
     case Enum.member?(plugins, :rabbitmq_federation) do
-      true  -> :ok
+      true ->
+        :ok
+
       false ->
-        set_enabled_plugins(plugins ++ [:rabbitmq_federation], :online, get_rabbit_hostname(), opts)
+        set_enabled_plugins(
+          plugins ++ [:rabbitmq_federation],
+          :online,
+          get_rabbit_hostname(),
+          opts
+        )
     end
   end
 
   def set_vhost_limits(vhost, limits) do
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_vhost_limit, :parse_set, [vhost, limits, <<"acting-user">>])
+    :rpc.call(get_rabbit_hostname(), :rabbit_vhost_limit, :parse_set, [
+      vhost,
+      limits,
+      <<"acting-user">>
+    ])
   end
+
   def get_vhost_limits(vhost) do
     :rpc.call(get_rabbit_hostname(), :rabbit_vhost_limit, :list, [vhost])
-    |> Map.new
+    |> Map.new()
   end
 
   def clear_vhost_limits(vhost) do
@@ -539,23 +668,29 @@ defmodule TestHelper do
   end
 
   def set_user_limits(user, limits) do
-    :rpc.call(get_rabbit_hostname(),
-              :rabbit_auth_backend_internal, :set_user_limits, [user, limits, <<"acting-user">>])
+    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :set_user_limits, [
+      user,
+      limits,
+      <<"acting-user">>
+    ])
   end
 
   def get_user_limits(user) do
     :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :get_user_limits, [user])
-    |> Map.new
+    |> Map.new()
   end
 
   def clear_user_limits(user) do
-    clear_user_limits user, "max-connections"
-    clear_user_limits user, "max-channels"
+    clear_user_limits(user, "max-connections")
+    clear_user_limits(user, "max-channels")
   end
 
   def clear_user_limits(user, limittype) do
-    :rpc.call(get_rabbit_hostname(),
-        :rabbit_auth_backend_internal, :clear_user_limits, [user, limittype, <<"acting-user">>])
+    :rpc.call(get_rabbit_hostname(), :rabbit_auth_backend_internal, :clear_user_limits, [
+      user,
+      limittype,
+      <<"acting-user">>
+    ])
   end
 
   def set_scope(scope) do
@@ -566,11 +701,18 @@ defmodule TestHelper do
   end
 
   def switch_plugins_directories(old_value, new_value) do
-    :rabbit_misc.rpc_call(get_rabbit_hostname(), :application, :set_env,
-            [:rabbit, :plugins_dir, new_value])
+    :rabbit_misc.rpc_call(get_rabbit_hostname(), :application, :set_env, [
+      :rabbit,
+      :plugins_dir,
+      new_value
+    ])
+
     ExUnit.Callbacks.on_exit(fn ->
-        :rabbit_misc.rpc_call(get_rabbit_hostname(), :application, :set_env,
-                [:rabbit, :plugins_dir, old_value])
+      :rabbit_misc.rpc_call(get_rabbit_hostname(), :application, :set_env, [
+        :rabbit,
+        :plugins_dir,
+        old_value
+      ])
     end)
   end
 
@@ -588,9 +730,11 @@ defmodule TestHelper do
   def get_opts_with_existing_plugins_directory(context) do
     extra_plugin_directory = System.tmp_dir!() |> Path.join("existing_rabbitmq_dummy_plugins")
     File.mkdir!(extra_plugin_directory)
+
     ExUnit.Callbacks.on_exit(fn ->
       File.rm_rf(extra_plugin_directory)
     end)
+
     get_opts_with_plugins_directories(context, [extra_plugin_directory])
   end
 
@@ -606,30 +750,40 @@ defmodule TestHelper do
   end
 
   def assert_stream_without_errors(stream) do
-    true = Enum.all?(stream, fn({:error, _}) -> false;
-                               ({:error, _, _}) -> false;
-                               (_) -> true end)
+    true =
+      Enum.all?(stream, fn
+        {:error, _} -> false
+        {:error, _, _} -> false
+        _ -> true
+      end)
   end
 
   def wait_for_log_message(message, file \\ nil, attempts \\ 100) do
     ## Assume default log is the first one
-    log_file = case file do
-      nil ->
-        [default_log | _] = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
-        default_log
-      _ -> file
-    end
+    log_file =
+      case file do
+        nil ->
+          [default_log | _] = :rpc.call(get_rabbit_hostname(), :rabbit, :log_locations, [])
+          default_log
+
+        _ ->
+          file
+      end
+
     case File.read(log_file) do
       {:ok, data} ->
         case String.match?(data, Regex.compile!(message)) do
-          true -> :ok
+          true ->
+            :ok
+
           false ->
             :timer.sleep(100)
             wait_for_log_message(message, log_file, attempts - 1)
         end
+
       _ ->
         :timer.sleep(100)
-            wait_for_log_message(message, log_file, attempts - 1)
+        wait_for_log_message(message, log_file, attempts - 1)
     end
   end
 end

--- a/deps/rabbitmq_cli/test/upgrade/await_online_quorum_plus_one_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/await_online_quorum_plus_one_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AwaitOnlineQuorumPlusOneCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,10 +17,11 @@ defmodule AwaitOnlineQuorumPlusOneCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 5000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 5000
+     }}
   end
 
   test "merge_defaults: overrides a timeout" do
@@ -41,5 +41,4 @@ defmodule AwaitOnlineQuorumPlusOneCommandTest do
     opts = %{node: :jake@thedog, timeout: 200}
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], opts)))
   end
-
 end

--- a/deps/rabbitmq_cli/test/upgrade/await_online_synchronized_mirror_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/await_online_synchronized_mirror_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule AwaitOnlineSynchronizedMirrorsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,10 +17,11 @@ defmodule AwaitOnlineSynchronizedMirrorsCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 5000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 5000
+     }}
   end
 
   test "merge_defaults: overrides a timeout" do
@@ -41,5 +41,4 @@ defmodule AwaitOnlineSynchronizedMirrorsCommandTest do
     opts = %{node: :jake@thedog, timeout: 200}
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], opts)))
   end
-
 end

--- a/deps/rabbitmq_cli/test/upgrade/drain_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/drain_command_test.exs
@@ -23,10 +23,11 @@ defmodule DrainCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 5000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 5000
+     }}
   end
 
   test "merge_defaults: nothing to do" do

--- a/deps/rabbitmq_cli/test/upgrade/post_upgrade_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/post_upgrade_command_test.exs
@@ -4,7 +4,6 @@
 ##
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-
 defmodule PostUpgradeCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
@@ -18,10 +17,11 @@ defmodule PostUpgradeCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 5000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 5000
+     }}
   end
 
   test "merge_defaults: nothing to do" do
@@ -45,5 +45,4 @@ defmodule PostUpgradeCommandTest do
   test "run: returns an OK", context do
     assert match?({:ok, _}, @command.run([], context[:opts]))
   end
-
 end

--- a/deps/rabbitmq_cli/test/upgrade/revive_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/revive_command_test.exs
@@ -23,10 +23,11 @@ defmodule ReviveCommandTest do
   end
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 5000
-      }}
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 5000
+     }}
   end
 
   test "merge_defaults: nothing to do" do


### PR DESCRIPTION
## Proposed Changes

Elixir formatter was introduced in version [1.6.0](https://github.com/elixir-lang/elixir/releases/tag/v1.6.0). This change ensures
RabbitMQ CLI formatting conforms to Elixir's standard formatting.
Format checking is added to build steps, which means new code
changes will need to run the formatter to ensure successful CLI build.

mix format is also executed for the CLI and contribution notes updated.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
