### PR TITLE
Fix keys for route and partitions responses

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -207,8 +207,7 @@ emit_publisher_info_local(VHost, Items, Ref, AggregatorPid) ->
 
 list(VHost) ->
     [Client
-     || {_, ListSup, _, _}
-            <- supervisor:which_children(rabbit_stream_sup),
+     || {_, ListSup, _, _} <- supervisor:which_children(rabbit_stream_sup),
         {_, RanchEmbeddedSup, supervisor, _}
             <- supervisor:which_children(ListSup),
         {{ranch_listener_sup, _}, RanchListSup, _, _}

--- a/deps/rabbitmq_stream/src/rabbit_stream_connection_sup.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_connection_sup.erl
@@ -21,40 +21,34 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
--export([
-    start_link/3,
-    start_keepalive_link/0
-]).
+-export([start_link/3,
+         start_keepalive_link/0]).
 -export([init/1]).
 
 start_link(Ref, Transport, Opts) ->
     {ok, SupPid} = supervisor:start_link(?MODULE, []),
     {ok, KeepaliveSup} =
-        supervisor:start_child(
-            SupPid,
-            #{
-                id => rabbit_stream_keepalive_sup,
-                start => {rabbit_stream_connection_sup, start_keepalive_link, []},
-                restart => transient,
-                significant => true,
-                shutdown => infinity,
-                type => supervisor,
-                modules => [rabbit_keepalive_sup]
-            }
-        ),
+        supervisor:start_child(SupPid,
+                               #{id => rabbit_stream_keepalive_sup,
+                                 start =>
+                                     {rabbit_stream_connection_sup,
+                                      start_keepalive_link, []},
+                                 restart => transient,
+                                 significant => true,
+                                 shutdown => infinity,
+                                 type => supervisor,
+                                 modules => [rabbit_keepalive_sup]}),
     {ok, ReaderPid} =
-        supervisor:start_child(
-            SupPid,
-            #{
-                id => rabbit_stream_reader,
-                start => {rabbit_stream_reader, start_link, [KeepaliveSup, Transport, Ref, Opts]},
-                restart => transient,
-                significant => true,
-                shutdown => ?WORKER_WAIT,
-                type => worker,
-                modules => [rabbit_stream_reader]
-            }
-        ),
+        supervisor:start_child(SupPid,
+                               #{id => rabbit_stream_reader,
+                                 start =>
+                                     {rabbit_stream_reader, start_link,
+                                      [KeepaliveSup, Transport, Ref, Opts]},
+                                 restart => transient,
+                                 significant => true,
+                                 shutdown => ?WORKER_WAIT,
+                                 type => worker,
+                                 modules => [rabbit_stream_reader]}),
     {ok, SupPid, ReaderPid}.
 
 start_keepalive_link() ->
@@ -64,12 +58,8 @@ start_keepalive_link() ->
 
 init([]) ->
     {ok,
-        {
-            #{
-                strategy => one_for_all,
-                intensity => 0,
-                period => 1,
-                auto_shutdown => any_significant
-            },
-            []
-        }}.
+     {#{strategy => one_for_all,
+        intensity => 0,
+        period => 1,
+        auto_shutdown => any_significant},
+      []}}.

--- a/deps/rabbitmq_stream_common/test/rabbit_stream_core_SUITE.erl
+++ b/deps/rabbitmq_stream_common/test/rabbit_stream_core_SUITE.erl
@@ -135,7 +135,8 @@ roundtrip(_Config) ->
     test_roundtrip({response, 0, {tune, 10000, 12345}}),
     %  %% NB: does not write correlation id
     test_roundtrip({response, 0, {credit, 98, 200}}),
-    test_roundtrip({response, 99, {route, 1, <<"stream_name">>}}),
+    test_roundtrip({response, 99,
+                    {route, 1, [<<"stream1">>, <<"stream2">>]}}),
     test_roundtrip({response, 99,
                     {partitions, 1, [<<"stream1">>, <<"stream2">>]}}),
     test_roundtrip({response, 99, {consumer_update, 1, none}}),


### PR DESCRIPTION
These 2 responses were not using the `rabbit_stream_core` utilities so they were not using the "prefix" for responses.

Fixes #5956
