### PR TITLE
Add otp 25.1 to //packaging/docker-image:rabbitmq

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,10 +77,17 @@ http_file(
 )
 
 http_file(
-    name = "otp_src_25",
+    name = "otp_src_25_0",
     downloaded_file_path = "OTP-25.0.4.tar.gz",
     sha256 = "05878cb51a64b33c86836b12a21903075c300409b609ad5e941ddb0feb8c2120",
     urls = ["https://github.com/erlang/otp/archive/OTP-25.0.4.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_25_1",
+    downloaded_file_path = "OTP-25.1.tar.gz",
+    sha256 = "e00b2e02350688ee4ac83c41ec25c210774fe73b7f806860c46b185457ae135e",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.1.tar.gz"],
 )
 
 http_archive(

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -129,10 +129,18 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
-    name = "erlang_25_internal",
+    name = "erlang_25_0_internal",
     match_all = [
         "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_25",
+        "@erlang_config//:erlang_25_0",
+    ],
+)
+
+selects.config_setting_group(
+    name = "erlang_25_1_internal",
+    match_all = [
+        "@erlang_config//:erlang_internal",
+        "@erlang_config//:erlang_25_1",
     ],
 )
 
@@ -150,8 +158,9 @@ container_image(
     tars = select({
         ":erlang_23_internal": ["@otp_src_23//file"],
         ":erlang_24_internal": ["@otp_src_24//file"],
-        ":erlang_25_internal": ["@otp_src_25//file"],
-        "//conditions:default": ["@otp_src_25//file"],
+        ":erlang_25_0_internal": ["@otp_src_25_0//file"],
+        ":erlang_25_1_internal": ["@otp_src_25_1//file"],
+        "//conditions:default": ["@otp_src_25_1//file"],
     }),
 )
 

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -1,8 +1,4 @@
 load(
-    "@bazel_skylib//lib:selects.bzl",
-    "selects",
-)
-load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
     "container_layer",
@@ -112,38 +108,6 @@ container_run_and_commit_layer(
     tags = ["manual"],
 )
 
-selects.config_setting_group(
-    name = "erlang_23_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_23",
-    ],
-)
-
-selects.config_setting_group(
-    name = "erlang_24_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_24",
-    ],
-)
-
-selects.config_setting_group(
-    name = "erlang_25_0_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_25_0",
-    ],
-)
-
-selects.config_setting_group(
-    name = "erlang_25_1_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_25_1",
-    ],
-)
-
 container_image(
     name = "otp_source",
     base = ":otp_pkgs_image",
@@ -156,11 +120,10 @@ container_image(
     ],
     tags = ["manual"],
     tars = select({
-        ":erlang_23_internal": ["@otp_src_23//file"],
-        ":erlang_24_internal": ["@otp_src_24//file"],
-        ":erlang_25_0_internal": ["@otp_src_25_0//file"],
-        ":erlang_25_1_internal": ["@otp_src_25_1//file"],
-        "//conditions:default": ["@otp_src_25_1//file"],
+        "@erlang_config//:erlang_23": ["@otp_src_23//file"],
+        "@erlang_config//:erlang_24": ["@otp_src_24//file"],
+        "@erlang_config//:erlang_25_0": ["@otp_src_25_0//file"],
+        "@erlang_config//:erlang_25_1": ["@otp_src_25_1//file"],
     }),
 )
 

--- a/packaging/docker-image/test_configs/otp_ubuntu.yaml
+++ b/packaging/docker-image/test_configs/otp_ubuntu.yaml
@@ -7,4 +7,4 @@ commandTests:
     - -noshell
     - -eval
     - '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().'
-    expectedOutput: ["2\\d\\.\\d+\\.\\d+"]
+    expectedOutput: ["2\\d\\.\\d+"]


### PR DESCRIPTION
Adds more fine grained selection of the otp version when building dev oci images

This should also fix breakage in `.github/workflows/update-otp-patches.yaml` resulting from the lack of symmetry in `WORKSPACE` prior to this change