### PR TITLE
Use otp 25.1 for CI instead of 25.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,7 +42,7 @@ build:rbe-24 --config=rbe
 build:rbe-24 --platforms=//bazel/platforms:erlang_linux_24_platform
 
 build:rbe-25 --config=rbe
-build:rbe-25 --platforms=//bazel/platforms:erlang_linux_25_platform
+build:rbe-25 --platforms=//bazel/platforms:erlang_linux_25_1_platform
 
 # no-op config so that --config=local does not error
 build:local --color=auto

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,9 +46,15 @@ erlang_config.internal_erlang_from_github_release(
 )
 
 erlang_config.internal_erlang_from_github_release(
-    name = "25",
+    name = "25_0",
     sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
     version = "25.0.4",
+)
+
+erlang_config.internal_erlang_from_github_release(
+    name = "25_1",
+    sha256 = "a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31",
+    version = "25.1",
 )
 
 erlang_config.internal_erlang_from_http_archive(
@@ -98,7 +104,8 @@ register_toolchains(
     "@erlang_config//external:toolchain",
     "@erlang_config//23:toolchain",
     "@erlang_config//24:toolchain",
-    "@erlang_config//25:toolchain",
+    "@erlang_config//25_0:toolchain",
+    "@erlang_config//25_1:toolchain",
     "@erlang_config//git_master:toolchain",
     "@elixir_config//external:toolchain",
     "@elixir_config//1_10:toolchain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,10 +77,17 @@ http_file(
 )
 
 http_file(
-    name = "otp_src_25",
+    name = "otp_src_25_0",
     downloaded_file_path = "OTP-25.0.4.tar.gz",
     sha256 = "05878cb51a64b33c86836b12a21903075c300409b609ad5e941ddb0feb8c2120",
     urls = ["https://github.com/erlang/otp/archive/OTP-25.0.4.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_25_1",
+    downloaded_file_path = "OTP-25.1.tar.gz",
+    sha256 = "e00b2e02350688ee4ac83c41ec25c210774fe73b7f806860c46b185457ae135e",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.1.tar.gz"],
 )
 
 http_archive(
@@ -136,9 +143,14 @@ erlang_config(
             version = "24.3.4.5",
         ),
         internal_erlang_from_github_release(
-            name = "25",
+            name = "25_0",
             sha256 = "8fc707f92a124b2aeb0f65dcf9ac8e27b2a305e7bcc4cc1b2fdf770eec0165bf",
             version = "25.0.4",
+        ),
+        internal_erlang_from_github_release(
+            name = "25_1",
+            sha256 = "a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31",
+            version = "25.1",
         ),
         internal_erlang_from_http_archive(
             name = "git_master",

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -32,10 +32,18 @@ platform(
 )
 
 platform(
-    name = "erlang_linux_25_platform",
+    name = "erlang_linux_25_0_platform",
     constraint_values = [
-        "@erlang_config//:erlang_25",
-        "@erlang_config//:erlang_25_any_minor",
+        "@erlang_config//:erlang_25_0",
+        "@elixir_config//:elixir_1_14",
+    ],
+    parents = ["@rbe//config:platform"],
+)
+
+platform(
+    name = "erlang_linux_25_1_platform",
+    constraint_values = [
+        "@erlang_config//:erlang_25_1",
         "@elixir_config//:elixir_1_14",
     ],
     parents = ["@rbe//config:platform"],

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -1,8 +1,4 @@
 load(
-    "@bazel_skylib//lib:selects.bzl",
-    "selects",
-)
-load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_image",
     "container_layer",
@@ -112,30 +108,6 @@ container_run_and_commit_layer(
     tags = ["manual"],
 )
 
-selects.config_setting_group(
-    name = "erlang_23_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_23",
-    ],
-)
-
-selects.config_setting_group(
-    name = "erlang_24_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_24",
-    ],
-)
-
-selects.config_setting_group(
-    name = "erlang_25_internal",
-    match_all = [
-        "@erlang_config//:erlang_internal",
-        "@erlang_config//:erlang_25",
-    ],
-)
-
 container_image(
     name = "otp_source",
     base = ":otp_pkgs_image",
@@ -148,10 +120,10 @@ container_image(
     ],
     tags = ["manual"],
     tars = select({
-        ":erlang_23_internal": ["@otp_src_23//file"],
-        ":erlang_24_internal": ["@otp_src_24//file"],
-        ":erlang_25_internal": ["@otp_src_25//file"],
-        "//conditions:default": ["@otp_src_25//file"],
+        "@erlang_config//:erlang_23": ["@otp_src_23//file"],
+        "@erlang_config//:erlang_24": ["@otp_src_24//file"],
+        "@erlang_config//:erlang_25_0": ["@otp_src_25_0//file"],
+        "@erlang_config//:erlang_25_1": ["@otp_src_25_1//file"],
     }),
 )
 

--- a/packaging/docker-image/test_configs/otp_ubuntu.yaml
+++ b/packaging/docker-image/test_configs/otp_ubuntu.yaml
@@ -7,4 +7,4 @@ commandTests:
     - -noshell
     - -eval
     - '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().'
-    expectedOutput: ["2\\d\\.\\d+\\.\\d+"]
+    expectedOutput: ["2\\d\\.\\d+"]


### PR DESCRIPTION
Also adjust MODULE.bazel/WORKSPACE for easier backporting of otp patch version update PRs