### PR TITLE
Use rules_erlang 3.7.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.7.1",
+    version = "3.7.2",
 )
 
 erlang_config = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,7 +119,7 @@ git_repository(
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.7.1",
+    tag = "3.7.2",
 )
 
 load(


### PR DESCRIPTION
Update to the latest rules_erlang

This version of rules_erlang includes and adjustment that should improve the experience of switching between Make and Bazel, possibly eliminating the need to clean the deps dir before running bazel.