### PR TITLE
Support management path prefix when using OAuth2

### DIFF
--- a/deps/rabbitmq_management/.gitignore
+++ b/deps/rabbitmq_management/.gitignore
@@ -31,4 +31,5 @@ selenium/node_modules
 selenium/package-lock.json
 selenium/screens/*/*
 selenium/logs
-
+selenium/suites/logs/*
+selenium/suites/screens/*

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -4,8 +4,9 @@ var _management_logger;
 
 function oauth_initialize_if_required() {
     rabbit_port = window.location.port ? ":" +  window.location.port : ""
+    rabbit_path_prefix = window.location.pathname.replace(/(\/js\/oidc-oauth\/.*$|\/+$)/, "")
     rabbit_base_uri = window.location.protocol + "//" + window.location.hostname
-      + rabbit_port + rabbit_path_prefix()
+      + rabbit_port + rabbit_path_prefix
 
     var request = new XMLHttpRequest();
     request.open("GET", rabbit_base_uri + "/api/auth", false);
@@ -17,10 +18,7 @@ function oauth_initialize_if_required() {
     }
 
 }
-function rabbit_path_prefix() {
-  paths = window.location.pathname.split("/")
-  return paths[1] === "js" || paths[1] === "" ? "" : "/" + paths[1]
-}
+
 
 function auth_settings_apply_defaults(authSettings) {
   if (authSettings.enable_uaa == "true") {
@@ -144,13 +142,13 @@ function oauth_initiateLogin() {
 
 function oauth_redirectToHome(oauth) {
   set_auth_pref(oauth.user_name + ":" + oauth.access_token);
-  location.href = "/"
+  location.href = rabbit_path_prefix + "/"
 }
 function oauth_redirectToLogin(error) {
   _management_logger.debug("oauth_redirectToLogin called");
-  if (!error) location.href = "/"
+  if (!error) location.href = rabbit_path_prefix + "/"
   else {
-    location.href = "/?error=" + error
+    location.href = rabbit_path_prefix + "/?error=" + error
   }
 }
 function oauth_completeLogin() {

--- a/deps/rabbitmq_management/selenium/README.md
+++ b/deps/rabbitmq_management/selenium/README.md
@@ -49,6 +49,24 @@ And this is how we run all suites:
 run-suites.sh
 ```
 
+If you want to test your local changes, you can still build an image with these 2 commands from the
+root folder of the `rabbitmq-server` repo:
+```
+cd ../../../../
+make package-generic-unix
+make docker-image
+```
+
+The last command prints something like this:
+```
+ => => naming to docker.io/pivotalrabbitmq/rabbitmq:3.11.0-rc.2.51.g4f3e539.dirty                                                                            0.0s
+```
+
+To run a suite with a particular docker image we do it like this:
+```
+cd deps/rabbitmq_management/selenium/suites
+RABBITMQ_DOCKER_IMAGE=pivotalrabbitmq/rabbitmq:3.11.0-rc.2.51.g4f3e539.dirty ./oauth-with-uaa-with-mgt-prefix.sh
+```
 
 ## Run tests interactively using your local chrome browser
 

--- a/deps/rabbitmq_management/selenium/README.md
+++ b/deps/rabbitmq_management/selenium/README.md
@@ -6,20 +6,18 @@ And Mocha as the testing framework for Javascript.
 To run the tests we need:
 - make
 - docker
-- Ruby (needed to install `uaac` via `gem`)
 
 # How tests are organized
 
-All test cases are under the `test` folder and grouped into subfolders based on the area of functionality
-they are testing. For instance, under `oauth` folder, we have test cases about OAuth 2.0.
+All test cases and their configuration files are under the `test` folder and grouped into subfolders based on the area of functionality they are testing. For instance, under `oauth` folder, we have test cases about OAuth 2.0.
 Furthermore, within an area of functionality like OAuth 2.0 we want to test under different configuration.
 For instance under `test/oauth/with-uaa` we group all test cases which run against UAA. Whereas
 under `test/oauth/with-uaa-down` we group all test cases which run against a UAA which is down.
 
-Under the `test` folder we have test cases and some configuration files. And under `suites` folder we have
-the test suites where we literally script the following:
+And under `suites` folder we have the test suites where we literally script the following:
   - the suite's **setup**, e.g. start RabbitMQ and UAA with a specific configuration
-  - the test cases, e.g. run all tests under `test/oauth/with-uaa`
+  - the path to the test cases
+  - the path to the test case configuration
   - the suite's **teardown**, e.g. stop RabbitMQ and UAA
   - and save all logs and screen captures if any
 
@@ -41,14 +39,12 @@ name, e.g. `rabbitmq` or `uaa`. Whereas in interactive mode, we run most of the 
 
 ## Run tests in headless-mode
 
-In this mode, we are run suite of tests, not individual tests.
-
-If we want to run just one particular suite, run it directly:
+In this mode, we run suite of tests. This is how to run one suite:
 ```
 suites/oauth-with-uaa.sh
 ```
 
-Or we can run all suites:
+And this is how we run all suites:
 ```
 run-suites.sh
 ```

--- a/deps/rabbitmq_management/selenium/suites/oauth-with-uaa-with-mgt-prefix.sh
+++ b/deps/rabbitmq_management/selenium/suites/oauth-with-uaa-with-mgt-prefix.sh
@@ -7,12 +7,14 @@ SUITE=$( basename "${BASH_SOURCE[0]}" .sh)
 
 # Path to the test cases this suite should run. It is relative to the selenium/test folder
 TEST_CASES_PATH=/oauth/with-uaa
-# Path to the folder where all configuration file reside. It is relative to the selenim/test folder 
+# Path to the folder where all configuration file reside. It is relative to the selenim/test folder
 TEST_CONFIG_PATH=/oauth
 # Path to the uaa configuration. It is relative to the TEST_CONFIG_PATH
 UAA_CONFIG_PATH=/uaa-with-mgt-prefix
 # Name of the rabbitmq config file. It is relative to the TEST_CONFIG_PATH
 RABBITMQ_CONFIG_FILENAME=rabbitmq-with-mgt-prefix.config
+
+RABBITMQ_URL=http://rabbitmq:15672/my-prefix/another-prefix/
 
 source $SCRIPT/suite_template
 

--- a/deps/rabbitmq_management/selenium/suites/oauth-with-uaa-with-mgt-prefix.sh
+++ b/deps/rabbitmq_management/selenium/suites/oauth-with-uaa-with-mgt-prefix.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Name of the suite used to generate log and screen folders
+SUITE=$( basename "${BASH_SOURCE[0]}" .sh)
+
+# Path to the test cases this suite should run. It is relative to the selenium/test folder
+TEST_CASES_PATH=/oauth/with-uaa
+# Path to the folder where all configuration file reside. It is relative to the selenim/test folder 
+TEST_CONFIG_PATH=/oauth
+# Path to the uaa configuration. It is relative to the TEST_CONFIG_PATH
+UAA_CONFIG_PATH=/uaa-with-mgt-prefix
+# Name of the rabbitmq config file. It is relative to the TEST_CONFIG_PATH
+RABBITMQ_CONFIG_FILENAME=rabbitmq-with-mgt-prefix.config
+
+source $SCRIPT/suite_template
+
+_setup () {
+  start_rabbitmq
+  start_uaa
+}
+_save_logs() {
+  save_container_logs rabbitmq
+  save_container_logs uaa
+}
+_teardown() {
+  kill_container_if_exist rabbitmq
+  kill_container_if_exist uaa
+}
+run

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.config
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.config
@@ -3,10 +3,10 @@
     {auth_backends, [rabbit_auth_backend_oauth2]}
   ]},
    {rabbitmq_management, [
-      {login_session_timeout, 1},   %% in minutes
+      {login_session_timeout, 150},   %% in minutes
       {enable_uaa, true},
       {oauth_enabled, true},
-    %%  {path_prefix, "/my-prefix"},
+      {path_prefix, "/my-prefix/another-prefix"},
       {oauth_client_id, "rabbit_client_code"},
       {oauth_client_secret, "rabbit_client_code"},
       {oauth_provider_url, "http://localhost:8080"}

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.config
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.config
@@ -6,7 +6,7 @@
       {login_session_timeout, 1},   %% in minutes
       {enable_uaa, true},
       {oauth_enabled, true},
-      {path_prefix, "/my-prefix"},
+    %%  {path_prefix, "/my-prefix"},
       {oauth_client_id, "rabbit_client_code"},
       {oauth_client_secret, "rabbit_client_code"},
       {oauth_provider_url, "http://localhost:8080"}

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-with-mgt-prefix.config
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-with-mgt-prefix.config
@@ -6,7 +6,7 @@
       {login_session_timeout, 1},   %% in minutes
       {enable_uaa, true},
       {oauth_enabled, true},
-      {path_prefix, "/my-prefix"},
+      {path_prefix, "/my-prefix/another-prefix"},
       {oauth_client_id, "rabbit_client_code"},
       {oauth_client_secret, "rabbit_client_code"},
       {oauth_provider_url, "http://uaa:8080"}

--- a/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/uaa.yml
+++ b/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/uaa.yml
@@ -132,6 +132,7 @@ oauth:
       scope: rabbitmq.*,openid,profile
       authorities: uaa.resource,rabbitmq
       redirect-uri: http://localhost:15672
+      # redirect-uri: http://localhost:15672/my-prefix/
       autoapprove: true
 
     mgt_api_client_2:

--- a/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/uaa.yml
+++ b/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/uaa.yml
@@ -62,7 +62,7 @@ jwt:
   token:
     policy:
       # Will override global validity policies for the default zone only.
-      accessTokenValiditySeconds: 15
+      accessTokenValiditySeconds: 1500
       keys:
         legacy-token-key:
           signingKey: |
@@ -131,8 +131,8 @@ oauth:
       authorized-grant-types: authorization_code
       scope: rabbitmq.*,openid,profile
       authorities: uaa.resource,rabbitmq
-      redirect-uri: http://localhost:15672
-      # redirect-uri: http://localhost:15672/my-prefix/
+      #redirect-uri: http://localhost:15672
+      redirect-uri: http://localhost:15672/my-prefix/another-prefix/
       autoapprove: true
 
     mgt_api_client_2:

--- a/deps/rabbitmq_management/selenium/test/oauth/uaa-with-mgt-prefix/uaa.yml
+++ b/deps/rabbitmq_management/selenium/test/oauth/uaa-with-mgt-prefix/uaa.yml
@@ -131,7 +131,7 @@ oauth:
       authorized-grant-types: authorization_code
       scope: rabbitmq.*,openid,profile
       authorities: uaa.resource,rabbitmq
-      redirect-uri: http://rabbitmq:15672/my-prefix/
+      redirect-uri: http://rabbitmq:15672/my-prefix/another-prefix/
       autoapprove: true
 
     mgt_api_client_2:


### PR DESCRIPTION
## Proposed Changes

Support management plugin's [path prefix](https://www.rabbitmq.com/management.html#path-prefix) when OAuth 2.0 authentication is enabled.  

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

