### PR TITLE
Adopt otp 25.1.1

### DIFF
--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -83,12 +83,13 @@ jobs:
         let source = await readFile(s, 'utf-8');
         let pattern = await readFile(p, 'utf-8');
         let replacement = await readFile(r, 'utf-8');
+        if (!source.includes(pattern)) process.exit(1);
         let updated = source.replace(pattern, replacement);
         await writeFile(s, updated);
         EOF
 
         cat << EOF > old.txt
-                internal_erlang_from_http_archive(
+                internal_erlang_from_github_release(
                     name = "${{ matrix.name }}",
                     sha256 = "${OLD_SHA}",
                     version = "${OLD_VERSION}",
@@ -96,7 +97,7 @@ jobs:
         EOF
 
         cat << EOF > new.txt
-                internal_erlang_from_http_archive(
+                internal_erlang_from_github_release(
                     name = "${{ matrix.name }}",
                     sha256 = "${{ steps.fetch-version.outputs.SHA }}",
                     version = "${{ steps.fetch-version.outputs.VERSION }}",
@@ -104,6 +105,7 @@ jobs:
         EOF
 
         node replacer.mjs WORKSPACE old.txt new.txt
+        rm replacer.mjs old.txt new.txt
 
         set -x
         git diff

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,8 +53,8 @@ erlang_config.internal_erlang_from_github_release(
 
 erlang_config.internal_erlang_from_github_release(
     name = "25_1",
-    sha256 = "a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31",
-    version = "25.1",
+    sha256 = "42840c32e13a27bdb2c376d69aa22466513d441bfe5eb882de23baf8218308d3",
+    version = "25.1.1",
 )
 
 erlang_config.internal_erlang_from_http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,9 +85,9 @@ http_file(
 
 http_file(
     name = "otp_src_25_1",
-    downloaded_file_path = "OTP-25.1.tar.gz",
-    sha256 = "e00b2e02350688ee4ac83c41ec25c210774fe73b7f806860c46b185457ae135e",
-    urls = ["https://github.com/erlang/otp/archive/OTP-25.1.tar.gz"],
+    downloaded_file_path = "OTP-25.1.1.tar.gz",
+    sha256 = "3348616450868fa8b39bddf0b528030e4525afef5b30e3a4b54c375add7d3f4f",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.1.1.tar.gz"],
 )
 
 http_archive(
@@ -149,8 +149,8 @@ erlang_config(
         ),
         internal_erlang_from_github_release(
             name = "25_1",
-            sha256 = "a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31",
-            version = "25.1",
+            sha256 = "42840c32e13a27bdb2c376d69aa22466513d441bfe5eb882de23baf8218308d3",
+            version = "25.1.1",
         ),
         internal_erlang_from_http_archive(
             name = "git_master",


### PR DESCRIPTION
Automated changes created by https://github.com/rabbitmq/rabbitmq-server/actions/runs/3180613102 using the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action in the Update OTP Patch Versions for Bazel Based Workflows workflow.