### PR TITLE
Use Elixir 1.13.x with otp 24.x in bazel build

### DIFF
--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -24,7 +24,7 @@ platform(
     name = "erlang_linux_24_platform",
     constraint_values = [
         "@erlang_config//:erlang_24",
-        "@elixir_config//:elixir_1_12",
+        "@elixir_config//:elixir_1_13",
     ],
     parents = ["@rbe//config:platform"],
 )


### PR DESCRIPTION
CI does not actually test otp 24 on the main or v3.11.x, so we can make the change on main for consistency, and backport