### PR TITLE
Add 'mix format --check-formatted' to the rabbitmqctl_tests in bazel

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -52,6 +52,7 @@ rabbitmqctl_test(
     srcs = [
         "mix.exs",
         "config/config.exs",
+        ".formatter.exs",
     ] + glob([
         "lib/**/*.ex",
         "test/**/*.exs",

--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -76,8 +76,8 @@ export LC_ALL="en_US.UTF-8"
 
 MIX_INVOCATION_DIR="{mix_invocation_dir}"
 
-cp -R {package_dir}/config ${{MIX_INVOCATION_DIR}}/config
-cp -R {package_dir}/lib ${{MIX_INVOCATION_DIR}}/lib
+cp -r {package_dir}/config ${{MIX_INVOCATION_DIR}}/config
+cp -r {package_dir}/lib ${{MIX_INVOCATION_DIR}}/lib
 cp    {package_dir}/mix.exs ${{MIX_INVOCATION_DIR}}/mix.exs
 
 cd ${{MIX_INVOCATION_DIR}}

--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -56,6 +56,7 @@ ln -s ${{PWD}}/{package_dir}/config ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 ln -s ${{PWD}}/{package_dir}/lib ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 ln -s ${{PWD}}/{package_dir}/test ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 ln -s ${{PWD}}/{package_dir}/mix.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+ln -s ${{PWD}}/{package_dir}/.formatter.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 
 INITIAL_DIR=${{PWD}}
 cd ${{TEST_UNDECLARED_OUTPUTS_DIR}}
@@ -73,6 +74,7 @@ if [ ! -d _build/${{MIX_ENV}}/lib/rabbit_common ]; then
     cp -r ${{DEPS_DIR}}/* _build/${{MIX_ENV}}/lib
 fi
 "${{ABS_ELIXIR_HOME}}"/bin/mix deps.compile
+"${{ABS_ELIXIR_HOME}}"/bin/mix format --check-formatted
 "${{ABS_ELIXIR_HOME}}"/bin/mix compile
 
 # due to https://github.com/elixir-lang/elixir/issues/7699 we


### PR DESCRIPTION
to match the check on the Makefile side that was recently introduced in #5958 