### PR TITLE
Load plugins in dependency order

### DIFF
--- a/deps/rabbit/test/unit_plugin_versioning_SUITE.erl
+++ b/deps/rabbit/test/unit_plugin_versioning_SUITE.erl
@@ -149,10 +149,10 @@ plugin_validation(_Config) ->
             {Valid, Invalid} = rabbit_plugins:validate_plugins(Plugins,
                                                                RabbitVersion),
             Errors = lists:reverse(Invalid),
-            ExpectedValid = lists:reverse(lists:map(fun(#plugin{name = Name}) ->
-                                                        Name
-                                                    end,
-                                                    Valid))
+            ExpectedValid = lists:map(fun(#plugin{name = Name}) ->
+                                              Name
+                                      end,
+                                      Valid)
         end,
         Examples),
     ok.


### PR DESCRIPTION
## Proposed Changes

When enabling a plugin on the fly, the dir of the plugin and its dependencies are added to the load path (and their modules are loaded). There are some libraries which require their dependencies to be loaded before they are (e.g lz4 requires host_triple to load the NIF module).

During `rabbit_plugins:prepare_plugins/1`, `dependencies/3` gathers the wanted apps in the right order (every app comes after its deps) however `validate_plugins/1` used to reverse their order, so later code loading in `prepare_plugin/2` happened in the wrong order.

This is now fixed, so `validate_plugins/1` preserves the order of apps.

(only ran `unit_plugin_versioning_SUITE`)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
