### PR TITLE
Fix docs for rabbitmqctl restart_vhost

### DIFF
--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -1760,10 +1760,10 @@ Suppresses the
 parameter.
 .El
 .\" ------------------------------------------------------------------
-.It Cm restart_vhost Ar vhost
+.It Cm restart_vhost Oo Fl p Ar vhost Oc
 .Bl -tag -width Ds
 .It Ar vhost
-The name of the virtual host entry to restart.
+The name of the virtual host entry to restart, defaulting to "/".
 .El
 .Pp
 Restarts a failed vhost data stores and queues.


### PR DESCRIPTION
## Proposed Changes

This is a tiny edit to `rabbitmqctl` man page, `restart_vhost` incorrectly asked for argument instead of the flag.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it