### PR TITLE
Try out mirroring hex packages into our BCR fork

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 build --experimental_enable_bzlmod
 build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/dev/
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/erlang-packages/
 
 build --incompatible_strict_action_env
 build --local_test_jobs=1

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -57,7 +57,6 @@ jobs:
       run: |
         bazelisk test //... ^
           --config=buildbuddy ^
-          --noexperimental_enable_bzlmod ^
           --test_tag_filters=-aws,-docker,-bats,-starts-background-broker ^
           --build_tests_only ^
           --verbose_failures

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,6 +44,19 @@ bazel_dep(
     version = "0.5.8",
 )
 
+bazel_dep(
+    name = "ra",
+    version = "2.3.0",
+)
+
+git_override(
+    module_name = "ra",
+    remote = "https://github.com/rabbitmq/ra.git",
+    commit = "d18de709e5b1fa9418b3119211fd6becd4de7b85",
+    # Note: we will need bazel 6 where patch_cmds are supported, to inject the ra
+    #       version just like we do with the module extension
+)
+
 erlang_config = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",
     "erlang_config",
@@ -283,15 +296,15 @@ erlang_package.hex_package(
     version = "0.2.1",
 )
 
-erlang_package.git_package(
-    branch = "main",
-    patch_cmds = ["""
-VERSION=$(git rev-parse HEAD)
-echo "Injecting ${VERSION} into ra.app.src..."
-sed -i"_orig" "/vsn,/ s/2\\.[0-9]\\.[0-9]/${VERSION}/" src/ra.app.src
-"""],
-    repository = "rabbitmq/ra",
-)
+# erlang_package.git_package(
+#     branch = "main",
+#     patch_cmds = ["""
+# VERSION=$(git rev-parse HEAD)
+# echo "Injecting ${VERSION} into ra.app.src..."
+# sed -i"_orig" "/vsn,/ s/2\\.[0-9]\\.[0-9]/${VERSION}/" src/ra.app.src
+# """],
+#     repository = "rabbitmq/ra",
+# )
 
 erlang_package.hex_package(
     name = "ranch",
@@ -372,7 +385,7 @@ use_repo(
     "osiris",
     "prometheus",
     "proper",
-    "ra",
+    # "ra",
     "ranch",
     "recon",
     "redbug",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,17 @@ bazel_dep(
     version = "3.8.3",
 )
 
+git_override(
+    module_name = "rules_erlang",
+    remote = "https://github.com/rabbitmq/rules_erlang.git",
+    commit = "57ca51e73ba36fd35b5814d8628137920e9f9e58",
+)
+
+bazel_dep(
+    name = "accept",
+    version = "0.3.5",
+)
+
 erlang_config = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",
     "erlang_config",
@@ -102,12 +113,6 @@ register_toolchains(
 erlang_package = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",
     "erlang_package",
-)
-
-erlang_package.hex_package(
-    name = "accept",
-    sha256 = "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8",
-    version = "0.3.5",
 )
 
 erlang_package.hex_package(
@@ -351,7 +356,6 @@ erlang_app(
 
 use_repo(
     erlang_package,
-    "accept",
     "aten",
     "base64url",
     "cowboy",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,12 +28,6 @@ bazel_dep(
     version = "3.8.3",
 )
 
-git_override(
-    module_name = "rules_erlang",
-    remote = "https://github.com/rabbitmq/rules_erlang.git",
-    commit = "57ca51e73ba36fd35b5814d8628137920e9f9e58",
-)
-
 bazel_dep(
     name = "accept",
     version = "0.3.5",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,6 +39,11 @@ bazel_dep(
     version = "0.3.5",
 )
 
+bazel_dep(
+    name = "aten",
+    version = "0.5.8",
+)
+
 erlang_config = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",
     "erlang_config",
@@ -113,12 +118,6 @@ register_toolchains(
 erlang_package = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",
     "erlang_package",
-)
-
-erlang_package.hex_package(
-    name = "aten",
-    sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
-    version = "0.5.8",
 )
 
 erlang_package.hex_package(
@@ -356,7 +355,6 @@ erlang_app(
 
 use_repo(
     erlang_package,
-    "aten",
     "base64url",
     "cowboy",
     "cowlib",

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -6,12 +6,6 @@ load("@rules_erlang//:hex_pm.bzl", "hex_pm_erlang_app")
 
 def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
     hex_pm_erlang_app(
-        name = "accept",
-        version = "0.3.5",
-        sha256 = "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8",
-    )
-
-    hex_pm_erlang_app(
         name = "aten",
         sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
         version = "0.5.8",

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -6,12 +6,6 @@ load("@rules_erlang//:hex_pm.bzl", "hex_pm_erlang_app")
 
 def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
     hex_pm_erlang_app(
-        name = "aten",
-        sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
-        version = "0.5.8",
-    )
-
-    hex_pm_erlang_app(
         name = "base64url",
         version = "1.0.1",
         sha256 = "f9b3add4731a02a9b0410398b475b33e7566a695365237a6bdee1bb447719f5c",


### PR DESCRIPTION
`rules_erlang` `3.8` includes a new `untar` rule, which allows adding packages from hex.pm directly into our fork of the bazel-central-repository. For now this branch is a test of that approach with rabbitmq-server.