### PR TITLE
Remove erlang 23 from bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,9 +35,6 @@ build:rbe --host_platform=//bazel/platforms:erlang_internal_platform
 build:rbe --host_cpu=k8
 build:rbe --cpu=k8
 
-build:rbe-23 --config=rbe
-build:rbe-23 --platforms=//bazel/platforms:erlang_linux_23_platform
-
 build:rbe-24 --config=rbe
 build:rbe-24 --platforms=//bazel/platforms:erlang_linux_24_platform
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,12 +34,6 @@ erlang_config = use_extension(
 )
 
 erlang_config.internal_erlang_from_github_release(
-    name = "23",
-    sha256 = "e3ecb3ac2cc549ab90cd9f8921eaebc8613f4d5c89972a3987e5a762d5a2df08",
-    version = "23.3.4.16",
-)
-
-erlang_config.internal_erlang_from_github_release(
     name = "24",
     sha256 = "8444ff9abe23aea268adbb95463561fc222c965052d35d7c950b17be01c3ad82",
     version = "24.3.4.6",
@@ -75,12 +69,6 @@ elixir_config = use_extension(
 )
 
 elixir_config.internal_elixir_from_github_release(
-    name = "1_10",
-    sha256 = "8518c78f43fe36315dbe0d623823c2c1b7a025c114f3f4adbb48e04ef63f1d9f",
-    version = "1.10.4",
-)
-
-elixir_config.internal_elixir_from_github_release(
     name = "1_12",
     sha256 = "c5affa97defafa1fd89c81656464d61da8f76ccfec2ea80c8a528decd5cb04ad",
     version = "1.12.3",
@@ -105,13 +93,11 @@ use_repo(
 
 register_toolchains(
     "@erlang_config//external:toolchain",
-    "@erlang_config//23:toolchain",
     "@erlang_config//24:toolchain",
     "@erlang_config//25_0:toolchain",
     "@erlang_config//25_1:toolchain",
     "@erlang_config//git_master:toolchain",
     "@elixir_config//external:toolchain",
-    "@elixir_config//1_10:toolchain",
     "@elixir_config//1_12:toolchain",
     "@elixir_config//1_13:toolchain",
     "@elixir_config//1_14:toolchain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,13 +63,6 @@ http_file(
 )
 
 http_file(
-    name = "otp_src_23",
-    downloaded_file_path = "OTP-23.3.4.16.tar.gz",
-    sha256 = "ff091e8a2b3e6350b890d37123444474cf49754f6add0ccee17582858ee464e7",
-    urls = ["https://github.com/erlang/otp/archive/OTP-23.3.4.16.tar.gz"],
-)
-
-http_file(
     name = "otp_src_24",
     downloaded_file_path = "OTP-24.3.4.6.tar.gz",
     sha256 = "dc3d2c54eeb093e0dc9a0fe493bc69d6dfac0affbe77c9e3c935aa86c0f63cd5",
@@ -133,11 +126,6 @@ load(
 erlang_config(
     internal_erlang_configs = [
         internal_erlang_from_github_release(
-            name = "23",
-            sha256 = "e3ecb3ac2cc549ab90cd9f8921eaebc8613f4d5c89972a3987e5a762d5a2df08",
-            version = "23.3.4.16",
-        ),
-        internal_erlang_from_github_release(
             name = "24",
             sha256 = "8444ff9abe23aea268adbb95463561fc222c965052d35d7c950b17be01c3ad82",
             version = "24.3.4.6",
@@ -175,11 +163,6 @@ load(
 
 elixir_config(
     internal_elixir_configs = [
-        internal_elixir_from_github_release(
-            name = "1_10",
-            sha256 = "8518c78f43fe36315dbe0d623823c2c1b7a025c114f3f4adbb48e04ef63f1d9f",
-            version = "1.10.4",
-        ),
         internal_elixir_from_github_release(
             name = "1_12",
             sha256 = "c5affa97defafa1fd89c81656464d61da8f76ccfec2ea80c8a528decd5cb04ad",

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -12,15 +12,6 @@ platform(
 )
 
 platform(
-    name = "erlang_linux_23_platform",
-    constraint_values = [
-        "@erlang_config//:erlang_23",
-        "@elixir_config//:elixir_1_10",
-    ],
-    parents = ["@rbe//config:platform"],
-)
-
-platform(
     name = "erlang_linux_24_platform",
     constraint_values = [
         "@erlang_config//:erlang_24",

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -120,7 +120,6 @@ container_image(
     ],
     tags = ["manual"],
     tars = select({
-        "@erlang_config//:erlang_23": ["@otp_src_23//file"],
         "@erlang_config//:erlang_24": ["@otp_src_24//file"],
         "@erlang_config//:erlang_25_0": ["@otp_src_25_0//file"],
         "@erlang_config//:erlang_25_1": ["@otp_src_25_1//file"],


### PR DESCRIPTION
as it is no longer used on any current release branch