### PR TITLE
Close local MQTT connections when draining node

### DIFF
--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -95,11 +95,11 @@ drain() ->
     suspend_all_client_listeners(),
     rabbit_log:warning("Suspended all listeners and will no longer accept client connections"),
     {ok, NConnections} = close_all_client_connections(),
+    rabbit_log:warning("Closed ~b local client connections", [NConnections]),
     %% allow plugins to react e.g. by closing their protocol connections
     rabbit_event:notify(maintenance_connections_closed, #{
         reason => <<"node is being put into maintenance">>
     }),
-    rabbit_log:warning("Closed ~b local client connections", [NConnections]),
 
     TransferCandidates = primary_replica_transfer_candidate_nodes(),
     %% Note: only QQ leadership is transferred because it is a reasonably quick thing to do a lot of queues

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
@@ -9,10 +9,8 @@
 
 -behaviour(application).
 -export([start/2, stop/1]).
--export([connection_info_local/1,
-         emit_connection_info_local/3,
-         emit_connection_info_all/4,
-         close_all_client_connections/1]).
+-export([emit_connection_info_all/4,
+         close_local_client_connections/1]).
 
 start(normal, []) ->
     {ok, Listeners} = application:get_env(tcp_listeners),
@@ -20,8 +18,8 @@ start(normal, []) ->
     ok = mqtt_node:start(),
     Result = rabbit_mqtt_sup:start_link({Listeners, SslListeners}, []),
     EMPid = case rabbit_event:start_link() of
-              {ok, Pid}                       -> Pid;
-              {error, {already_started, Pid}} -> Pid
+                {ok, Pid}                       -> Pid;
+                {error, {already_started, Pid}} -> Pid
             end,
     gen_event:add_handler(EMPid, rabbit_mqtt_internal_event_handler, []),
     Result.
@@ -29,27 +27,19 @@ start(normal, []) ->
 stop(_) ->
     rabbit_mqtt_sup:stop_listeners().
 
--spec close_all_client_connections(string() | binary()) -> {'ok', non_neg_integer()}.
-close_all_client_connections(Reason) ->
-     Connections = rabbit_mqtt_collector:list(),
-    [rabbit_mqtt_reader:close_connection(Pid, Reason) || {_, Pid} <- Connections],
-    {ok, length(Connections)}.
-
-emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
-    Pids = [spawn_link(Node, rabbit_mqtt, emit_connection_info_local,
-                       [Items, Ref, AggregatorPid])
-            || Node <- Nodes],
-    rabbit_control_misc:await_emitters_termination(Pids),
-    ok.
-
-emit_connection_info_local(Items, Ref, AggregatorPid) ->
+emit_connection_info_all(_Nodes, Items, Ref, AggregatorPid) ->
     rabbit_control_misc:emitting_map_with_exit_handler(
-        AggregatorPid, Ref, fun({_, Pid}) ->
-            rabbit_mqtt_reader:info(Pid, Items)
-        end,
-        rabbit_mqtt_collector:list()).
+      AggregatorPid,
+      Ref,
+      fun(Pid) ->
+              rabbit_mqtt_reader:info(Pid, Items)
+      end,
+      rabbit_mqtt_collector:list_pids()
+     ).
 
-connection_info_local(Items) ->
-    Connections = rabbit_mqtt_collector:list(),
-    [rabbit_mqtt_reader:info(Pid, Items)
-     || {_, Pid} <- Connections].
+-spec close_local_client_connections(string() | binary()) -> {'ok', non_neg_integer()}.
+close_local_client_connections(Reason) ->
+    AllPids = rabbit_mqtt_collector:list_pids(),
+    LocalPids = lists:filter(fun(Pid) -> node(Pid) =:= node() end, AllPids),
+    [rabbit_mqtt_reader:close_connection(Pid, Reason) || Pid <- LocalPids],
+    {ok, length(LocalPids)}.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl
@@ -9,7 +9,8 @@
 
 -include("mqtt_machine.hrl").
 
--export([register/2, register/3, unregister/2, list/0, leave/1]).
+-export([register/2, register/3, unregister/2,
+         list/0, list_pids/0, leave/1]).
 
 %%----------------------------------------------------------------------------
 -spec register(term(), pid()) -> {ok, reference()} | {error, term()}.
@@ -44,26 +45,32 @@ unregister(ClientId, Pid) ->
             send_ra_command(Leader, {unregister, ClientId, Pid}, no_correlation)
     end.
 
+-spec list_pids() -> [pid()].
+list_pids() ->
+    list(fun(#machine_state{pids = Pids}) -> maps:keys(Pids) end).
+
 list() ->
+    list(fun(#machine_state{client_ids = Ids}) -> maps:to_list(Ids) end).
+
+list(QF) ->
     {ClusterName, _} = mqtt_node:server_id(),
-     QF = fun (#machine_state{client_ids = Ids}) -> maps:to_list(Ids) end,
     case ra_leaderboard:lookup_leader(ClusterName) of
         undefined ->
             NodeIds = mqtt_node:all_node_ids(),
             case ra:leader_query(NodeIds, QF) of
-                {ok, {_, Ids}, _} -> Ids;
+                {ok, {_, Result}, _} -> Result;
                 {timeout, _}      ->
-                    rabbit_log:debug("~ts:list/0 leader query timed out",
+                    rabbit_log:debug("~ts:list/1 leader query timed out",
                                      [?MODULE]),
                     []
             end;
         Leader ->
             case ra:leader_query(Leader, QF) of
-                {ok, {_, Ids}, _} -> Ids;
+                {ok, {_, Result}, _} -> Result;
                 {error, _} ->
                     [];
                 {timeout, _}      ->
-                    rabbit_log:debug("~ts:list/0 leader query timed out",
+                    rabbit_log:debug("~ts:list/1 leader query timed out",
                                      [?MODULE]),
                     []
             end

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_internal_event_handler.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_internal_event_handler.erl
@@ -25,10 +25,10 @@ handle_event({event, vhost_deleted, Info, _, _}, State) ->
   rabbit_mqtt_retainer_sup:delete_child(Name),
   {ok, State};
 handle_event({event, maintenance_connections_closed, _Info, _, _}, State) ->
-  %% we should close our connections
-  {ok, NConnections} = rabbit_mqtt:close_all_client_connections("node is being put into maintenance mode"),
-  rabbit_log:alert("Closed ~b local MQTT client connections", [NConnections]),
-  {ok, State};
+    %% we should close our connections
+    {ok, NConnections} = rabbit_mqtt:close_local_client_connections("node is being put into maintenance mode"),
+    rabbit_log:warning("Closed ~b local MQTT client connections", [NConnections]),
+    {ok, State};
 handle_event(_Event, State) ->
   {ok, State}.
 

--- a/deps/rabbitmq_mqtt/test/cluster_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/cluster_SUITE.erl
@@ -5,23 +5,37 @@
 %% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 -module(cluster_SUITE).
--compile([export_all]).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-import(rabbit_ct_broker_helpers,
+        [setup_steps/0,
+         teardown_steps/0,
+         get_node_config/3,
+         rabbitmqctl/3,
+         rpc/5,
+         stop_node/2,
+         drain_node/2,
+         revive_node/2]).
+
 all() ->
     [
-      {group, non_parallel_tests}
+     {group, cluster_size_3},
+     {group, cluster_size_5}
     ].
 
 groups() ->
     [
-      {non_parallel_tests, [], [
-                                connection_id_tracking,
-                                connection_id_tracking_on_nodedown,
-                                connection_id_tracking_with_decommissioned_node
-                               ]}
+     {cluster_size_3, [], [
+                           maintenance
+                          ]},
+     {cluster_size_5, [], [
+                           connection_id_tracking,
+                           connection_id_tracking_on_nodedown,
+                           connection_id_tracking_with_decommissioned_node
+                          ]}
     ].
 
 suite() ->
@@ -45,8 +59,20 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
-init_per_group(_, Config) ->
-    Config.
+init_per_group(cluster_size_3, Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "maintenance mode wrongly closes cluster-wide MQTT connections "
+             " in RMQ < 3.11.2 and < 3.10.10"};
+        false ->
+            set_cluster_size(3, Config)
+    end;
+init_per_group(cluster_size_5, Config) ->
+    set_cluster_size(5, Config).
+
+set_cluster_size(NodesCount, Config) ->
+    rabbit_ct_helpers:set_config(
+      Config, [{rmq_nodes_count, NodesCount}]).
 
 end_per_group(_, Config) ->
     Config.
@@ -58,23 +84,42 @@ init_per_testcase(Testcase, Config) ->
         {rmq_nodename_suffix, Testcase},
         {rmq_extra_tcp_ports, [tcp_port_mqtt_extra,
                                tcp_port_mqtt_tls_extra]},
-        {rmq_nodes_clustered, true},
-        {rmq_nodes_count, 5}
+        {rmq_nodes_clustered, true}
       ]),
     rabbit_ct_helpers:run_setup_steps(Config1,
       [ fun merge_app_env/1 ] ++
-      rabbit_ct_broker_helpers:setup_steps() ++
+      setup_steps() ++
       rabbit_ct_client_helpers:setup_steps()).
 
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,
       rabbit_ct_client_helpers:teardown_steps() ++
-      rabbit_ct_broker_helpers:teardown_steps()),
+      teardown_steps()),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% -------------------------------------------------------------------
 %% Test cases
 %% -------------------------------------------------------------------
+
+maintenance(Config) ->
+    {ok, MRef0, C0} = connect_to_node(Config, 0, <<"client-0">>),
+    {ok, MRef1a, C1a} = connect_to_node(Config, 1, <<"client-1a">>),
+    {ok, MRef1b, C1b} = connect_to_node(Config, 1, <<"client-1b">>),
+    timer:sleep(500),
+
+    ok = drain_node(Config, 2),
+    ok = revive_node(Config, 2),
+    timer:sleep(500),
+    [?assert(erlang:is_process_alive(C)) || C <- [C0, C1a, C1b]],
+
+    ok = drain_node(Config, 1),
+    [await_disconnection(Ref) || Ref <- [MRef1a, MRef1b]],
+    ok = revive_node(Config, 1),
+    ?assert(erlang:is_process_alive(C0)),
+
+    ok = drain_node(Config, 0),
+    await_disconnection(MRef0),
+    ok = revive_node(Config, 0).
 
 %% Note about running this testsuite in a mixed-versions cluster:
 %% All even-numbered nodes will use the same code base when using a
@@ -114,26 +159,26 @@ connection_id_tracking(Config) ->
     ok = emqtt:disconnect(C3).
 
 connection_id_tracking_on_nodedown(Config) ->
-    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Server = get_node_config(Config, 0, nodename),
     {ok, MRef, C} = connect_to_node(Config, 0, <<"simpleClient">>),
     {ok, _, _} = emqtt:subscribe(C, <<"TopicA">>, qos0),
     ok = emqtt:publish(C, <<"TopicA">>, <<"Payload">>),
     expect_publishes(<<"TopicA">>, [<<"Payload">>]),
     assert_connection_count(Config, 10, 2, 1),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, Server),
+    ok = stop_node(Config, Server),
     await_disconnection(MRef),
     assert_connection_count(Config, 10, 2, 0),
     ok.
 
 connection_id_tracking_with_decommissioned_node(Config) ->
-    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Server = get_node_config(Config, 0, nodename),
     {ok, MRef, C} = connect_to_node(Config, 0, <<"simpleClient">>),
     {ok, _, _} = emqtt:subscribe(C, <<"TopicA">>, qos0),
     ok = emqtt:publish(C, <<"TopicA">>, <<"Payload">>),
     expect_publishes(<<"TopicA">>, [<<"Payload">>]),
 
     assert_connection_count(Config, 10, 2, 1),
-    {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["decommission_mqtt_node", Server]),
+    {ok, _} = rabbitmqctl(Config, 0, ["decommission_mqtt_node", Server]),
     await_disconnection(MRef),
     assert_connection_count(Config, 10, 2, 0),
     ok.
@@ -145,7 +190,7 @@ connection_id_tracking_with_decommissioned_node(Config) ->
 assert_connection_count(_Config, 0,  _, _) ->
     ct:fail("failed to complete rabbit_mqtt_collector:list/0");
 assert_connection_count(Config, Retries, NodeId, NumElements) ->
-    List = rabbit_ct_broker_helpers:rpc(Config, NodeId, rabbit_mqtt_collector, list, []),
+    List = rpc(Config, NodeId, rabbit_mqtt_collector, list, []),
     case length(List) == NumElements of
         true ->
             ok;
@@ -157,7 +202,7 @@ assert_connection_count(Config, Retries, NodeId, NumElements) ->
 
 
 connect_to_node(Config, Node, ClientID) ->
-  Port = rabbit_ct_broker_helpers:get_node_config(Config, Node, tcp_port_mqtt),
+  Port = get_node_config(Config, Node, tcp_port_mqtt),
   {ok, C} = connect(Port, ClientID),
   MRef = erlang:monitor(process, C),
   {ok, MRef, C}.
@@ -177,7 +222,7 @@ await_disconnection(Ref) ->
     receive
         {'DOWN', Ref, _, _, _} -> ok
     after
-        30000 -> exit(missing_down_message)
+        20_000 -> exit(missing_down_message)
     end.
 
 expect_publishes(_Topic, []) -> ok;


### PR DESCRIPTION
When a node gets drained (i.e. goes into maintenance mode), only **local** connections should be terminated.

However, prior to this commit, MQTT connections got terminated **cluster-wide** when a single node was drained.
