### PR TITLE
Add ability to set default vhost limits by pattern

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -632,6 +632,7 @@ end}.
 %% {default_user,        <<"guest">>},
 %% {default_pass,        <<"guest">>},
 %% {default_permissions, [<<".*">>, <<".*">>, <<".*">>]},
+%% {default_limits,      [{vhost, []}]
 
 {mapping, "default_vhost", "rabbit.default_vhost", [
     {datatype, string}
@@ -679,6 +680,70 @@ fun(Conf) ->
     Read      = proplists:get_value(["default_permissions", "read"], Settings),
     Write     = proplists:get_value(["default_permissions", "write"], Settings),
     [list_to_binary(Configure), list_to_binary(Read), list_to_binary(Write)]
+end}.
+
+{mapping, "default_limits.vhost.$id.pattern", "rabbit.default_limits.vhost", [
+    {include_default, 1},
+    {comment, ".*"},
+    {validators, ["valid_regex"]},
+    {datatype, string}
+]}.
+
+{mapping, "default_limits.vhost.$id.max_connections", "rabbit.default_limits.vhost", [
+    {include_default, 1},
+    {comment, 1000},
+    {validators, [ "non_zero_positive_integer"]},
+    {datatype, integer}
+]}.
+
+{mapping, "default_limits.vhost.$id.max_queues", "rabbit.default_limits.vhost", [
+    {include_default, 1},
+    {comment, 100},
+    {validators, [ "non_zero_positive_integer"]},
+    {datatype, integer}
+]}.
+
+{translation, "rabbit.default_limits.vhost",
+fun(Conf) ->
+    Prefix = ["default_limits", "vhost"],
+    GetAll = fun(Spec) ->
+                     FullSpec = Prefix ++ Spec,
+                     lists:filtermap(
+                       fun({K, V}) ->
+                               case cuttlefish_variable:is_fuzzy_match(K, FullSpec) of
+                                   true -> [_, _, ID, _] = K,
+                                           {true, {ID, V}};
+                                   _    -> false
+                               end
+                       end,
+                       Conf)
+             end,
+    Get = fun(Spec) -> cuttlefish:conf_get(Prefix ++ Spec, Conf, undefined) end,
+
+    %% Warn about incomplete config
+    SettingIDs = lists:uniq(
+                   [ ID || {ID, _} <- GetAll(["$id", "max_connections"]) ] ++
+                   [ ID || {ID, _} <- GetAll(["$id", "max_queues"]) ]
+                  ),
+    [ cuttlefish:invalid(
+        io_lib:format(
+           "default_limits.vhost.~ts.pattern required",
+           [ID]))
+     || ID <- SettingIDs, Get([ID, "pattern"]) =:= undefined ],
+
+    %% Transform
+    Settings = [ {P, [{<<"max-connections">>, Get([ID, "max_connections"])},
+                      {<<"max-queues">>,      Get([ID, "max_queues"])}]} ||
+                 {ID, P} <- GetAll(["$id", "pattern"]) ],
+    Settings1 = lists:map(fun({P, L}) -> {
+                                    list_to_binary(P),
+                                    lists:filter(fun({_, V}) -> V =/= undefined end, L)
+                                   }
+                          end, Settings),
+    case Settings1 of
+        [] -> cuttlefish:unset();
+        _ -> Settings1
+    end
 end}.
 
 %% Tags for default user
@@ -2320,3 +2385,9 @@ end}.
 fun(Int) when is_integer(Int) ->
     Int >= 1
 end}.
+
+{validator, "valid_regex", "string must be a valid regular expression",
+ fun("")     -> false;
+    (String) -> {Res, _ } = re:compile(String),
+                Res =:= ok
+ end}.

--- a/deps/rabbit/src/rabbit_vhost_limit.erl
+++ b/deps/rabbit/src/rabbit_vhost_limit.erl
@@ -152,6 +152,8 @@ parse_set(VHost, Defn, ActingUser) ->
                 rabbit_misc:format("Could not parse JSON document: ~tp", [Reason])}
     end.
 
+-spec set(rabbit_types:name(), {binary(), binary()}, rabbit_types:user() | rabbit_types:username()) ->
+    rabbit_runtime_parameters:ok_or_error_string().
 set(VHost, Defn, ActingUser) ->
     rabbit_runtime_parameters:set_any(VHost, <<"vhost-limits">>,
                                       <<"limits">>, Defn, ActingUser).

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -100,6 +100,27 @@ ssl_options.fail_if_no_peer_cert = true",
  {socket_writer_gc_threshold_off,
   "socket_writer.gc_threshold = off", [{rabbit, [{writer_gc_threshold, undefined}]}],[]},
 
+ {default_limits_vhost,
+ "
+  default_limits.vhost.a.pattern = .*
+  default_limits.vhost.a.max_queues = 10
+  default_limits.vhost.a.max_connections = 100
+ ",
+  [{rabbit, [{default_limits, [{vhost, [
+      {<<".*">>, [{<<"max-connections">>, 100}, {<<"max-queues">>, 10}]}
+                                       ]}]}]}],
+  []},
+
+ {default_limits_vhost_no_undefined,
+ "
+  default_limits.vhost.a.pattern = .*
+  default_limits.vhost.a.max_queues = 10
+ ",
+  [{rabbit, [{default_limits, [{vhost, [
+      {<<".*">>, [{<<"max-queues">>, 10}]}
+                                       ]}]}]}],
+  []},
+
  {default_user_settings,
   "default_user = guest
 default_pass = guest


### PR DESCRIPTION
## Proposed Changes

A fairly straightforward implementation of #4999. Per ticket, vhost limit defaults can be set up with regex patterns in config, and the first matching is applied during vhost creation. Defaults come from a file and are not synced between cluster members.

Unlike the ticket, I do not allow negative limits in favor of omission.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This change _is not_ documented, nor added to release-notes. LMK if this needs to be addressed.

Before I'm happy with it, several concerns and questions:

- I'll admit I'm confused about the two places to store VHost limits: the record and the runtime params. Is one deprecated?
- In my manual tests validators didn't error nor log anything on bad config inputs. Any advice?