### PR TITLE
Make main branch use 3.11.2 as mixed version tests

### DIFF
--- a/.github/workflows/secondary-umbrella.yaml
+++ b/.github/workflows/secondary-umbrella.yaml
@@ -97,6 +97,22 @@ jobs:
             +    "+nowarn_export_all",
                  "-DINSTR_MOD=gm",
              ]
+        - erlang_major: "25"
+          tag: v3.11.2
+          patch: |
+            diff --git a/rabbitmq.bzl b/rabbitmq.bzl
+            index d9e815c72b..f5c10a2ce5 100644
+            --- a/rabbitmq.bzl
+            +++ b/rabbitmq.bzl
+            @@ -28,6 +28,8 @@ STARTS_BACKGROUND_BROKER_TAG = "starts-background-broker"
+             MIXED_VERSION_CLUSTER_TAG = "mixed-version-cluster"
+ 
+             RABBITMQ_ERLC_OPTS = DEFAULT_ERLC_OPTS + [
+            +    "-DTEST=1",
+            +    "+nowarn_export_all",
+                 "-DINSTR_MOD=gm",
+             ]
+
     timeout-minutes: 20
     steps:
     - name: Checkout Repository (Secondary Umbrella tag)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -407,5 +407,5 @@ secondary_umbrella = use_extension(
 
 use_repo(
     secondary_umbrella,
-    "rabbitmq-server-generic-unix-3.10",
+    "rabbitmq-server-generic-unix-3.11",
 )

--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -25,13 +25,13 @@ EOF
 
 def secondary_umbrella():
     http_archive(
-        name = "rabbitmq-server-generic-unix-3.10",
+        name = "rabbitmq-server-generic-unix-3.11",
         build_file = "@//:BUILD.package_generic_unix",
         patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-        strip_prefix = "rabbitmq_server-3.10.7",
+        strip_prefix = "rabbitmq_server-3.11.2",
         # This file if produced by the .github/workflows/secondary-umbrella.yaml
         # GitHub Actions workflow.
         urls = [
-            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/package-generic-unix-for-mixed-version-testing-v3.10.7.tar.xz",
+            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/package-generic-unix-for-mixed-version-testing-v3.11.2.tar.xz",
         ],
     )

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -274,12 +274,12 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/.secondary_umbrella.rabbitmq-server-generic-unix-3.10/rabbitmq-run",
+            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/.secondary_umbrella.rabbitmq-server-generic-unix-3.11/rabbitmq-run",
             "LANG": "C.UTF-8",
         }.items() + test_env.items()),
         tools = [
             ":rabbitmq-for-tests-run",
-            "@rabbitmq-server-generic-unix-3.10//:rabbitmq-run",
+            "@rabbitmq-server-generic-unix-3.11//:rabbitmq-run",
         ] + tools,
         runtime_deps = [
             "//bazel/elixir:erlang_app",


### PR DESCRIPTION
The 3.11.2 artifact already got uploaded to AWS via https://github.com/rabbitmq/rabbitmq-server/pull/6178