### PR TITLE
Add noopener, noreferrer to hrefs in rabbitmq_management

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
@@ -41,14 +41,14 @@
 <div id="main"></div>
 <div id="footer">
   <ul>
-    <li><a href="api/" target="_blank">HTTP API</a></li>
-    <li><a href="https://www.rabbitmq.com/admin-guide.html" target="_blank">Server Docs</a></li>
-    <li><a href="https://www.rabbitmq.com/getstarted.html" target="_blank">Tutorials</a></li>
-    <li><a href="https://groups.google.com/forum/#!forum/rabbitmq-users" target="_blank">Community Support</a></li>
-    <li><a href="https://rabbitmq-slack.herokuapp.com/" target="_blank">Community Slack</a></li>
-    <li><a href="https://www.rabbitmq.com/services.html" target="_blank">Commercial Support</a></li>
-    <li><a href="https://www.rabbitmq.com/plugins.html" target="_blank">Plugins</a></li>
-    <li><a href="https://www.rabbitmq.com/github.html" target="_blank">GitHub</a></li>
-    <li><a href="https://www.rabbitmq.com/changelog.html" target="_blank">Changelog</a></li>
+    <li><a rel="noopener noreferrer" href="api/" target="_blank">HTTP API</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/admin-guide.html" target="_blank">Server Docs</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/getstarted.html" target="_blank">Tutorials</a></li>
+    <li><a rel="noopener noreferrer" href="https://groups.google.com/forum/#!forum/rabbitmq-users" target="_blank">Community Support</a></li>
+    <li><a rel="noopener noreferrer" href="https://rabbitmq-slack.herokuapp.com/" target="_blank">Community Slack</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/services.html" target="_blank">Commercial Support</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/plugins.html" target="_blank">Plugins</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/github.html" target="_blank">GitHub</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/changelog.html" target="_blank">Changelog</a></li>
   </ul>
 </div>


### PR DESCRIPTION
## Proposed Changes

Our security flagged several vulnerable links. All modern browsers automatically add "noopener" to the '_blank' links, but old browser may still be duped.

See [OWASP](https://owasp.org/www-community/attacks/Reverse_Tabnabbing) for description and [this](https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing) for remediation.

By my estimate none of these links require referrer, so added that too. LMK if you want to scale it back.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
  
 - [x] I have read the `CONTRIBUTING.md` document
 - [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] All tests pass locally with my changes
 - [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
 - [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
