### PR TITLE
Stream Coordinator: fail active mnesia update actions on leader change

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1753,8 +1753,8 @@ fail_active_actions(Streams, Exclude) ->
                            end, Members),
               case Mnesia of
                   {updating, E} ->
-                      rabbit_log:debug("~ts: failing active action for ~ts node
-                                       ~w Action ~w",
+                      rabbit_log:debug("~ts: schema database action failed, will have to retry. "
+                                       "Stream ID: ~ts, node: ~w, action: ~w",
                                        [?MODULE, Id, node(), updating_mnesia]),
                       send_self_command({action_failed, Id,
                                          #{action => updating_mnesia,
@@ -1774,8 +1774,9 @@ fail_action(_StreamId, #member{current = undefined}) ->
 fail_action(StreamId, #member{role = {_, E},
                               current = {Action, Idx},
                               node = Node}) ->
-    rabbit_log:debug("~ts: failing active action for ~ts node ~w Action ~w",
-                     [?MODULE, StreamId, Node, Action]),
+    rabbit_log:debug("~ts: schema database action failed, will have to retry. "
+                     "Stream ID: ~ts, node: ~w, action: ~w",
+                     [?MODULE, StreamId, node(), updating_mnesia]),
     %% if we have an action send failure message
     send_self_command({action_failed, StreamId,
                        #{action => Action,

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1135,7 +1135,6 @@ receive_basic_cancel_on_queue_deletion(Config) ->
 recover_after_leader_and_coordinator_kill(Config) ->
     [Server1 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
-    % Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
                  declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
@@ -1145,7 +1144,6 @@ recover_after_leader_and_coordinator_kill(Config) ->
     QName = rabbit_misc:r(<<"/">>, queue, Q),
     [begin
          Sleep = rand:uniform(10),
-         ct:pal("Attempt ~b Sleep ~b", [Num, Sleep]),
          {ok, {_LeaderNode, LeaderPid}} = leader_info(Config),
          {_, CoordNode} = get_stream_coordinator_leader(Config),
          kill_stream_leader_then_coordinator_leader(Config, CoordNode,
@@ -1158,7 +1156,7 @@ recover_after_leader_and_coordinator_kill(Config) ->
                    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE,
                                                 validate_writer_pid, [QName])
            end)
-     end || Num <- lists:seq(1, 10)],
+     end || _Num <- lists:seq(1, 10)],
 
     {_, Node} = get_stream_coordinator_leader(Config),
 


### PR DESCRIPTION
Else it is possible that any mnesia update actions that are in progress when a stream coordinator leader change occurs get stuck and never restart.

Fixes #6179
