### PR TITLE
Shovel: handle `connection.(un)blocked` messages

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_worker.erl
@@ -13,7 +13,8 @@
          code_change/3]).
 
 %% for testing purposes
--export([get_connection_name/1]).
+-export([get_connection_name/1,
+         get_internal_config/1]).
 
 -include("rabbit_shovel.hrl").
 
@@ -244,3 +245,6 @@ get_connection_name(_) ->
 close_connections(#state{config = Conf}) ->
     ok = rabbit_shovel_behaviour:close_source(Conf),
     ok = rabbit_shovel_behaviour:close_dest(Conf).
+
+get_internal_config(#state{config = Conf}) ->
+    Conf.


### PR DESCRIPTION
## Proposed Changes

This is a follow-up of https://github.com/rabbitmq/rabbitmq-server/pull/5715 to allow a shovel to be blocked not just by credit-flow but also by an explicit `connection.blocked` message. This is in hope so that less messages would be in flight in buffers (which can be lost if a connection is closed) when the destination cluster has resource alarms. This mostly targets on-publish mode, but works for the other ack-modes as well.

(EDIT: the below part has been moved out of the scope of this PR

> Also now that shovels can be blocked for different reasons this is also reflected on the UI shovel status page.
> 
> Currently there is a known limitation that if the shovel is idle after
> it was unblocked by credit flow, then the status won't get updated until
> the next message. I would appreciate some advice if this needs to be fixed and how.
> 
> Historically why does [`credit_flow:state/0`](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit_common/src/credit_flow.erl#L167) have a state-change-interval delay? Is it because of performance optimisation or is it for UX so that even a very short period of `flow` state won't get unnoticed on the mgmt UI?
> 
> As a solution I can imagine
> - starting a timer every time a shovel transitions from flow to running and reporting the status after 1 second (I'm concerned about the performance impact of starting and canceling a lot of timers)
> - don't use `credit_flow:state/0` but store `credit_blocked_at` in the shovel status table, and replicate the logic at lookup time (this sounds more efficient but duplicates code)
> - do nothing, keep the limitation)
 

TODO make sure docs are up-to-date

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
