### PR TITLE
Persist static configuration

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -1253,7 +1253,7 @@ segment_entry_count() ->
     %% A value lower than the max write_buffer size results in nothing needing
     %% to be written to disk as long as the consumer consumes as fast as the
     %% producer produces.
-    application:get_env(rabbit, classic_queue_index_v2_segment_entry_count, 4096).
+    persistent_term:get({rabbit, classic_queue_index_v2_segment_entry_count}, 4096).
 
 %% Note that store files will also be removed if there are any in this directory.
 %% Currently the v2 per-queue store expects this function to remove its own files.

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -559,13 +559,13 @@ delete_segments(Segments, State0 = #qs{ write_buffer = WriteBuffer0,
 
 segment_entry_count() ->
     %% We use the same value as the index.
-    application:get_env(rabbit, classic_queue_index_v2_segment_entry_count, 4096).
+    persistent_term:get({rabbit, classic_queue_index_v2_segment_entry_count}, 4096).
 
 max_cache_size() ->
-    application:get_env(rabbit, classic_queue_store_v2_max_cache_size, 512000).
+    persistent_term:get({rabbit, classic_queue_store_v2_max_cache_size}, 512000).
 
 check_crc32() ->
-    application:get_env(rabbit, classic_queue_store_v2_check_crc32, true).
+    persistent_term:get({rabbit, classic_queue_store_v2_check_crc32}, true).
 
 %% Same implementation as rabbit_classic_queue_index_v2:segment_file/2,
 %% but with a different state record.


### PR DESCRIPTION
Put configuration that does not change during runtime, but is read often into persistent_term. This requires less CPU and memory as the flame graphs show.

Tested on https://github.com/rabbitmq/rabbitmq-server/tree/mqtt of 24 October 2022.

Start broker
```
 make run-broker TEST_TMPDIR="$HOME/scratch/rabbit/test" PLUGINS="rabbitmq_mqtt" RABBITMQ_CONFIG_FILE="$HOME/scratch/rabbit/rabbitmq.conf" RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+JPperf true +S 2 -mnesia dump_log_write_threshold=50000" RABBITMQ_MAX_NUMBER_OF_PROCESSES=134217727
```
where `rabbitmq.conf` defines
```
classic_queue.default_version = 2
mqtt.tcp_listen_options.sndbuf  = 2048
mqtt.tcp_listen_options.recbuf  = 2048
```
Run, then stop
```
./emqtt_bench sub -V 4 -c 25000 -t a/b -i 2 --prefix my_client_prefix --clean false --qos 1
```
This created 25k classic queues v2 bound to the topic exchange.

Next, while sending with large fan out as follows
```
./emqtt_bench pub -V 4 -c 1 -t a/b -I 10 --qos 0 --size 12
```
capture the different kind of flame graphs as follows:
```
sudo perf record --pid $(cat "test/rabbit@$(hostname --short)/rabbit@$(hostname --short).pid") --freq 9999 -g -- sleep 10
sudo perf record --pid $(cat "test/rabbit@$(hostname --short)/rabbit@$(hostname --short).pid") --event page-faults -g -- sleep 20
sudo perf record --pid $(cat "test/rabbit@$(hostname --short)/rabbit@$(hostname --short).pid") --event syscalls:sys_enter_mmap -g -- sleep 40
```

Before this PR, function `application:get_env/3` (called by rabbit_classic_queue_store_v2 and rabbit_classic_queue_index_v2)  causes:
* 7% of all CPU time
* 5.6% of all page faults
* 13% of all mmap system calls

CPU (zoomed):
<img width="1502" alt="Screenshot 2022-10-24 at 11 29 18" src="https://user-images.githubusercontent.com/12648310/197495069-5efb6df6-bdf3-4f13-b2a4-df0f65affff7.png">

Page faults (zoomed):
<img width="1496" alt="Screenshot 2022-10-24 at 11 29 33" src="https://user-images.githubusercontent.com/12648310/197495137-195098a1-0566-4b77-b086-a640d358c59f.png">

Memory maps:
<img width="1498" alt="Screenshot 2022-10-24 at 11 29 45" src="https://user-images.githubusercontent.com/12648310/197495173-e737e01e-126e-4316-8b30-b1ca93bb0112.png">

After this PR:
Page faults and memory maps for `application:get_env` and `persistent_term` is obviously 0.
CPU time for `persistent_term` is 0.6%.

I suggest we write static configuration that is never changed directly early in `rabbit.erl`. We can add there more stuff in the future if we discover that `application:get_env` is slow elsewhere.
Also we can't write that config in the queue supervisors because they in turn have vhost supervisors and we don't want to `persistent_term:put` when a new vhost is added.