### PR TITLE
Correctly decrease global counters in rabbit_channel:terminate/2

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -877,6 +877,7 @@ handle_post_hibernate(State0) ->
 
 terminate(_Reason,
           State = #ch{cfg = #conf{user = #user{username = Username}},
+                      consumer_mapping = CM,
                       queue_states = QueueCtxs}) ->
     _ = rabbit_queue_type:close(QueueCtxs),
     {_Res, _State1} = notify_queues(State),
@@ -885,6 +886,10 @@ terminate(_Reason,
                             fun() -> emit_stats(State) end),
     [delete_stats(Tag) || {Tag, _} <- get()],
     maybe_decrease_global_publishers(State),
+    _ = maps:map(
+          fun (_, _) ->
+                  rabbit_global_counters:consumer_deleted(amqp091)
+          end, CM),
     rabbit_core_metrics:channel_closed(self()),
     rabbit_event:notify(channel_closed, [{pid, self()},
                                          {user_who_performed_action, Username}]).
@@ -2905,7 +2910,7 @@ maybe_increase_global_publishers(State0) ->
     rabbit_global_counters:publisher_created(amqp091),
     State0#ch{publishing_mode = true}.
 
-maybe_decrease_global_publishers(#ch{publishing_mode = true}) ->
-    ok;
 maybe_decrease_global_publishers(#ch{publishing_mode = false}) ->
+    ok;
+maybe_decrease_global_publishers(#ch{publishing_mode = true}) ->
     rabbit_global_counters:publisher_deleted(amqp091).

--- a/deps/rabbit/test/queue_type_SUITE.erl
+++ b/deps/rabbit/test/queue_type_SUITE.erl
@@ -187,6 +187,15 @@ smoke(Config) ->
                    messages_get_empty_total => 2,
                    messages_redelivered_total => 1
                   }, ProtocolQueueTypeCounters),
+
+
+    ok = rabbit_ct_client_helpers:close_channel(Ch),
+
+    ?assertMatch(
+       #{consumers := 0,
+         publishers := 0},
+       maps:get([{protocol, amqp091}], get_global_counters(Config))),
+
     ok.
 
 ack_after_queue_delete(Config) ->


### PR DESCRIPTION
Previously publisher counts would be decremented only if "publishing_mode" was set to false resulting in ever decreasing global counters.

No consumer counts were decremented in terminate previously resulting in ever growing consumer counts.

Fixes #5462 

