### PR TITLE
Update lqueue based on OTP-25.1.2

### DIFF
--- a/deps/rabbit/src/lqueue.erl
+++ b/deps/rabbit/src/lqueue.erl
@@ -388,13 +388,13 @@ fold(Fun, Acc0, Q) ->
 %% Move half of elements from R to F, if there are at least three
 r2f(0, []) ->
     {0, [], []};
-r2f(1, [_] = R) ->
-    {1, [], R};
-r2f(2, [X, Y]) ->
-    {2, [X], [Y]};
+r2f(1, [_] = FF) ->
+    {1, [], FF};
+r2f(2, [Y, X]) ->
+    {2, [Y], [X]};
 r2f(Len, List) ->
-    {FF, RR} = lists:split(Len div 2 + 1, List),
-    {Len, FF, lists:reverse(RR, [])}.
+    {RR, FF} = lists:split(Len div 2, List),
+    {Len, RR, lists:reverse(FF, [])}.
 
 %% Move half of elements from F to R, if there are enough
 f2r(0, []) ->
@@ -404,5 +404,5 @@ f2r(1, [_] = F) ->
 f2r(2, [X, Y]) ->
     {2, [Y], [X]};
 f2r(Len, List) ->
-    {FF, RR} = lists:split(Len div 2 + 1, List),
+    {FF, RR} = lists:split(Len div 2, List),
     {Len, lists:reverse(RR, []), FF}.


### PR DESCRIPTION
This adds the following commits which remove a small unnecessary operation:

* https://github.com/erlang/otp/commit/1315cfb7ade016be50f9525921b9c85559312160
* https://github.com/erlang/otp/commit/765a74154219a89f3f5eb0e7dd10fdfa313f61df

We should be up to date considering the history https://github.com/erlang/otp/commits/master/lib/stdlib/src/queue.erl
