### PR TITLE
Mark @rbe as non-dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -386,7 +386,6 @@ use_repo(
 rbe = use_extension(
     "//bazel/bzlmod:extensions.bzl",
     "rbe",
-    dev_dependency = True,
 )
 
 rbe.git_repository(


### PR DESCRIPTION
If it's a dev dependency, projects that depend on rabbitmq-server as a bzlmod module cannot borrow rabbitmq-server's platform definitions, as the rbe repo won't be visible to rabbitmq-server in such a scenario