### PR TITLE
Make package_generic_unix & source_archive macros from dist.bzl useful outside of this repo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,13 +20,6 @@ exports_files([
     "release-notes",
 ])
 
-config_setting(
-    name = "debug_build",
-    values = {
-        "compilation_mode": "dbg",
-    },
-)
-
 bool_flag(
     name = "enable_test_build",
     build_setting_default = False,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -151,9 +151,15 @@ pkg_tar(
     visibility = ["//visibility:public"],
 )
 
-package_generic_unix(plugins = PLUGINS)
+package_generic_unix(
+    plugins = PLUGINS,
+    rabbitmq_workspace = "@",
+)
 
-source_archive(plugins = PLUGINS)
+source_archive(
+    plugins = PLUGINS,
+    rabbitmq_workspace = "@",
+)
 
 genrule(
     name = "test-logs",

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -133,10 +133,10 @@ def rabbitmq_app(
         extra_srcs = extra_srcs,
         extra_priv = extra_priv,
         erlc_opts = select({
-            "//:debug_build": without("+deterministic", RABBITMQ_ERLC_OPTS),
+            "@rules_erlang//:debug_build": without("+deterministic", RABBITMQ_ERLC_OPTS),
             "//conditions:default": RABBITMQ_ERLC_OPTS,
         }) + select({
-            "//:test_build": ["-DTEST=1", "+nowarn_export_all"],
+            Label("//:test_build"): ["-DTEST=1", "+nowarn_export_all"],
             "//conditions:default": [],
         }),
         build_deps = build_deps,
@@ -157,7 +157,7 @@ def rabbitmq_app(
         extra_srcs = extra_srcs,
         extra_priv = extra_priv,
         erlc_opts = select({
-            "//:debug_build": without("+deterministic", RABBITMQ_TEST_ERLC_OPTS),
+            "@rules_erlang//:debug_build": without("+deterministic", RABBITMQ_TEST_ERLC_OPTS),
             "//conditions:default": RABBITMQ_TEST_ERLC_OPTS,
         }),
         build_deps = with_test_versions(build_deps),
@@ -227,7 +227,7 @@ def rabbitmq_integration_suite(
         suite_name = name,
         tags = tags + [STARTS_BACKGROUND_BROKER_TAG],
         erlc_opts = select({
-            "//:debug_build": without("+deterministic", RABBITMQ_TEST_ERLC_OPTS + erlc_opts),
+            "@rules_erlang//:debug_build": without("+deterministic", RABBITMQ_TEST_ERLC_OPTS + erlc_opts),
             "//conditions:default": RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
         }),
         additional_hdrs = additional_hdrs,

--- a/rabbitmq_home.bzl
+++ b/rabbitmq_home.bzl
@@ -20,7 +20,7 @@ def _copy_script(ctx, script):
 
 def link_escript(ctx, escript):
     e = ctx.attr._rabbitmqctl_escript.files_to_run.executable
-    s = ctx.actions.declare_file(path_join(ctx.label.name, "escript", escript))
+    s = ctx.actions.declare_file(path_join(ctx.label.name, "escript", escript.basename))
     ctx.actions.symlink(
         output = s,
         target_file = e,
@@ -80,16 +80,7 @@ def _impl(ctx):
         source_scripts = ctx.files._scripts_windows
     scripts = [_copy_script(ctx, script) for script in source_scripts]
 
-    rabbitmq_ctl_copies = [
-        "rabbitmq-diagnostics",
-        "rabbitmq-plugins",
-        "rabbitmq-queues",
-        "rabbitmq-streams",
-        "rabbitmq-tanzu",
-        "rabbitmq-upgrade",
-        "rabbitmqctl",
-    ]
-    escripts = [link_escript(ctx, escript) for escript in rabbitmq_ctl_copies]
+    escripts = [link_escript(ctx, escript) for escript in ctx.files._scripts]
 
     plugins = flatten([_plugins_dir_links(ctx, plugin) for plugin in plugins])
 


### PR DESCRIPTION
Updates the macros so that something that depends on this repo (such as a plugin) can use these macros to generate the package-generic-unix archive with that plugin included.