### PR TITLE
Avoid crashing shovel plugin when another node goes down

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_status.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_status.erl
@@ -89,7 +89,12 @@ handle_cast({remove, Name}, State) ->
     {noreply, State}.
 
 handle_info(check, State) ->
-    rabbit_shovel_dyn_worker_sup_sup:cleanup_specs(),
+    try
+        rabbit_shovel_dyn_worker_sup_sup:cleanup_specs()
+    catch
+        C:E ->
+            rabbit_log_shovel:warning("Recurring shovel spec clean up failed with ~p:~p", [C, E])
+    end,
     {noreply, ensure_timer(State)};
 handle_info(_Info, State) ->
     {noreply, State}.


### PR DESCRIPTION
## Proposed Changes

When `rabbit_shovel_dyn_worker_sup_sup:cleanup_specs()` is called while another node is just going down the caller can exit which crashes rabbit_shovel_status gen_server with the below crash. If there are no static shovels configured `rabbit_shovel_sup` will have a restart strategy intensity of zero, hence termination of `rabbit_shovel_status` will also shut down the supervision tree and the app of rabbitmq_shovel plugin.

This change tries to avoid such dramatic consequences of a temporary issue.

```
** Generic server rabbit_shovel_status terminating
** Last message in was check
** When Server state == {state,{erlang,#Ref<0.2444609781.3637248001.190587>}}
** Reason for termination ==
** {{{nodedown,'rabbit@...'},
     {gen_server,call,[<16931.927.0>,which_children,infinity]}},
    [{gen_server,call,3,[{file,"gen_server.erl"},{line,382}]},
     {mirrored_supervisor,child,2,
         [{file,"mirrored_supervisor.erl"},{line,252}]},
     {mirrored_supervisor,'-fold/3-lc$^0/1-0-',2,
         [{file,"mirrored_supervisor.erl"},{line,249}]},
     {mirrored_supervisor,fold,3,
         [{file,"mirrored_supervisor.erl"},{line,248}]},
     {rabbit_shovel_dyn_worker_sup_sup,cleanup_specs,0,
         [{file,"rabbit_shovel_dyn_worker_sup_sup.erl"},{line,86}]},
     {rabbit_shovel_status,handle_info,2,
         [{file,"rabbit_shovel_status.erl"},{line,92}]},
     {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1120}]},
     {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1197}]}]}
...
    supervisor: {local,rabbit_shovel_sup}
    errorContext: child_terminated
    reason: {{nodedown,'rabbit@...'},
...
    supervisor: {local,rabbit_shovel_sup}
    errorContext: shutdown
    reason: reached_max_restart_intensity
...
Application rabbitmq_shovel exited with reason: shutdown

```


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
