### PR TITLE
See Issue 6020. Take plugin dependency into account

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -35,6 +35,7 @@ rabbitmq_home(
         "//deps/rabbit:erlang_app",
         "//deps/rabbitmq_federation:erlang_app",
         "//deps/rabbitmq_stomp:erlang_app",
+        "//deps/rabbitmq_stream_management:erlang_app",
         "//deps/amqp_client:erlang_app",
     ],
 )

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -318,4 +318,16 @@ defmodule EnablePluginsCommandTest do
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist (ENOENT)"} ==
              @command.output({:error, err2}, context[:opts])
   end
+
+  test "enable command will also load its dependent plugins", context do
+    # Clears enabled plugins file and stop all plugins
+    set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
+
+    # Enable rabbitmq_stream_management
+    @command.run(["rabbitmq_stream_management"], context[:opts])
+
+    # Check command add_super_stream is available due to dependency plugin rabbitmq_stream
+    assert RabbitMQ.CLI.Core.CommandModules.load_commands(:all, %{})["add_super_stream"] ==
+             RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand
+  end
 end


### PR DESCRIPTION
## Proposed Changes

Addresses #6020.

Comments to this issue suggested querying the node of its active plugins, which would require an RPC call. I took an approach where I include a plugins dependencies instead, and thus avoiding the need to do an RPC call. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #6020)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

