### PR TITLE
Fail fast in the rabbitmq_cli tests if test_helper.exs is missing

### DIFF
--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -55,7 +55,7 @@ export LC_ALL="en_US.UTF-8"
 INITIAL_DIR="$(pwd)"
 
 if [ ! -f ${{INITIAL_DIR}}/{package_dir}/test/test_helper.exs ]; then
-    echo "test_helper.exs cannot be found"
+    echo "test_helper.exs cannot be found. 'bazel clean' might fix this."
     exit 1
 fi
 

--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -52,13 +52,19 @@ export PATH="$ABS_ELIXIR_HOME"/bin:"{erlang_home}"/bin:${{PATH}}
 export LANG="en_US.UTF-8"
 export LC_ALL="en_US.UTF-8"
 
-ln -s ${{PWD}}/{package_dir}/config ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{PWD}}/{package_dir}/lib ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{PWD}}/{package_dir}/test ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{PWD}}/{package_dir}/mix.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{PWD}}/{package_dir}/.formatter.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+INITIAL_DIR="$(pwd)"
 
-INITIAL_DIR=${{PWD}}
+if [ ! -f ${{INITIAL_DIR}}/{package_dir}/test/test_helper.exs ]; then
+    echo "test_helper.exs cannot be found"
+    exit 1
+fi
+
+ln -s ${{INITIAL_DIR}}/{package_dir}/config ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+ln -s ${{INITIAL_DIR}}/{package_dir}/lib ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+ln -s ${{INITIAL_DIR}}/{package_dir}/test ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+ln -s ${{INITIAL_DIR}}/{package_dir}/mix.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+ln -s ${{INITIAL_DIR}}/{package_dir}/.formatter.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+
 cd ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 
 export IS_BAZEL=true


### PR DESCRIPTION
For reasons which are not yet fully understood, this file can go missing and require a `bazel clean` to get the suite working again. Having this check in place should make future flakes easier to diagnose, and help determine if subsequent symlinking in the underlying bazel rule should be replaced with copying, or if something else altogether is happening.