### PR TITLE
Copy rather than symlink files in rabbitmqctl_test.bzl

### DIFF
--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -59,11 +59,11 @@ if [ ! -f ${{INITIAL_DIR}}/{package_dir}/test/test_helper.exs ]; then
     exit 1
 fi
 
-ln -s ${{INITIAL_DIR}}/{package_dir}/config ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{INITIAL_DIR}}/{package_dir}/lib ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{INITIAL_DIR}}/{package_dir}/test ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{INITIAL_DIR}}/{package_dir}/mix.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-ln -s ${{INITIAL_DIR}}/{package_dir}/.formatter.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp -r ${{INITIAL_DIR}}/{package_dir}/config ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp -r ${{INITIAL_DIR}}/{package_dir}/lib ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp -r ${{INITIAL_DIR}}/{package_dir}/test ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp    ${{INITIAL_DIR}}/{package_dir}/mix.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp    ${{INITIAL_DIR}}/{package_dir}/.formatter.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 
 cd ${{TEST_UNDECLARED_OUTPUTS_DIR}}
 


### PR DESCRIPTION
Bazel seems to be cleaning up files after following directory symlinks after the test. Not what I would have expected, and maybe a consequence of lighter sandboxing used on macos with rabbitmq. In any case copying seems to be a reasonable workaround.