### PR TITLE
Split rabbitmq_cli format check into a separate test target in bazel

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -59,11 +59,6 @@ rabbitmqctl_check_formatted_test(
         "test/**/*.exs",
     ]),
     data = glob(["test/fixtures/**/*"]),
-    deps = [
-        "//deps/amqp_client:erlang_app",
-        "//deps/rabbit:erlang_app",
-        "//deps/rabbit_common:erlang_app",
-    ],
 )
 
 alias(

--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -59,6 +59,10 @@ rabbitmqctl_check_formatted_test(
         "test/**/*.exs",
     ]),
     data = glob(["test/fixtures/**/*"]),
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//os:macos"],
+        "//conditions:default": ["@platforms//os:linux"],
+    }),
 )
 
 alias(

--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load(":rabbitmqctl.bzl", "rabbitmqctl")
+load(":rabbitmqctl_check_formatted.bzl", "rabbitmqctl_check_formatted_test")
 load(":rabbitmqctl_test.bzl", "rabbitmqctl_test")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
@@ -46,8 +47,32 @@ rabbitmq_run(
     visibility = ["//visibility:public"],
 )
 
+rabbitmqctl_check_formatted_test(
+    name = "check_formatted",
+    size = "small",
+    srcs = [
+        "mix.exs",
+        "config/config.exs",
+        ".formatter.exs",
+    ] + glob([
+        "lib/**/*.ex",
+        "test/**/*.exs",
+    ]),
+    data = glob(["test/fixtures/**/*"]),
+    deps = [
+        "//deps/amqp_client:erlang_app",
+        "//deps/rabbit:erlang_app",
+        "//deps/rabbit_common:erlang_app",
+    ],
+)
+
+alias(
+    name = "rabbitmqctl_check_formatted",
+    actual = ":check_formatted",
+)
+
 rabbitmqctl_test(
-    name = "rabbitmqctl_tests",
+    name = "tests",
     size = "large",
     srcs = [
         "mix.exs",
@@ -66,4 +91,9 @@ rabbitmqctl_test(
         "//deps/rabbit:erlang_app",
         "//deps/rabbit_common:erlang_app",
     ],
+)
+
+alias(
+    name = "rabbitmqctl_tests",
+    actual = ":tests",
 )

--- a/deps/rabbitmq_cli/rabbitmqctl_check_formatted.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_check_formatted.bzl
@@ -80,40 +80,13 @@ if [ ! -d _build/${{MIX_ENV}}/lib/rabbit_common ]; then
     cp -r ${{DEPS_DIR}}/* _build/${{MIX_ENV}}/lib
 fi
 "${{ABS_ELIXIR_HOME}}"/bin/mix deps.compile
-"${{ABS_ELIXIR_HOME}}"/bin/mix compile
-
-# due to https://github.com/elixir-lang/elixir/issues/7699 we
-# "run" the tests, but skip them all, in order to trigger
-# compilation of all *_test.exs files before we actually run them
-"${{ABS_ELIXIR_HOME}}"/bin/mix test --exclude test
-
-export TEST_TMPDIR=${{TEST_UNDECLARED_OUTPUTS_DIR}}
-
-# we need a running broker with certain plugins for this to pass 
-trap 'catch $?' EXIT
-catch() {{
-    pid=$(cat ${{TEST_TMPDIR}}/*/*.pid)
-    kill -TERM "${{pid}}"
-}}
-cd ${{INITIAL_DIR}}
-./{rabbitmq_run_cmd} start-background-broker
-cd ${{TEST_UNDECLARED_OUTPUTS_DIR}}
-
-# The test cases will need to be able to load code from the deps
-# directly, so we set ERL_LIBS
-export ERL_LIBS=$DEPS_DIR
-
-# run the actual tests
-set +u
-set -x
-"${{ABS_ELIXIR_HOME}}"/bin/mix test --trace --max-failures 1 ${{TEST_FILE}}
+"${{ABS_ELIXIR_HOME}}"/bin/mix format --check-formatted
 """.format(
             maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
             erlang_home = erlang_home,
             elixir_home = elixir_home,
             package_dir = package_dir,
             deps_dir = deps_dir,
-            rabbitmq_run_cmd = ctx.attr.rabbitmq_run[DefaultInfo].files_to_run.executable.short_path,
         )
     else:
         output = ctx.actions.declare_file(ctx.label.name + ".bat")
@@ -144,14 +117,7 @@ echo y | "{elixir_home}\\bin\\mix" local.hex --force || goto :error
 echo y | "{elixir_home}\\bin\\mix" local.rebar --force || goto :error
 "{elixir_home}\\bin\\mix" deps.get || goto :error
 "{elixir_home}\\bin\\mix" deps.compile || goto :error
-"{elixir_home}\\bin\\mix" compile || goto :error
-
-REM need to start the background broker here
-set TEST_TEMPDIR=%OUTPUTS_DIR%
-
-set ERL_LIBS=%DEPS_DIR%
-
-"{elixir_home}\\bin\\mix" test --trace --max-failures 1 || goto :error
+"{elixir_home}\\bin\\mix" format --check-formatted || goto :error
 goto :EOF
 :error
 exit /b 1
@@ -160,7 +126,6 @@ exit /b 1
             elixir_home = windows_path(elixir_home),
             package_dir = windows_path(ctx.label.package),
             deps_dir = deps_dir,
-            rabbitmq_run_cmd = ctx.attr.rabbitmq_run[DefaultInfo].files_to_run.executable.short_path,
         )
 
     ctx.actions.write(
@@ -174,7 +139,6 @@ exit /b 1
     ).merge_all([
         erlang_runfiles,
         elixir_runfiles,
-        ctx.attr.rabbitmq_run[DefaultInfo].default_runfiles,
     ])
 
     return [DefaultInfo(
@@ -182,17 +146,13 @@ exit /b 1
         executable = output,
     )]
 
-rabbitmqctl_private_test = rule(
+rabbitmqctl_check_formatted_private_test = rule(
     implementation = _impl,
     attrs = {
         "is_windows": attr.bool(mandatory = True),
         "srcs": attr.label_list(allow_files = [".ex", ".exs"]),
         "data": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [ErlangAppInfo]),
-        "rabbitmq_run": attr.label(
-            executable = True,
-            cfg = "target",
-        ),
     },
     toolchains = [
         "//bazel/elixir:toolchain_type",
@@ -200,8 +160,8 @@ rabbitmqctl_private_test = rule(
     test = True,
 )
 
-def rabbitmqctl_test(**kwargs):
-    rabbitmqctl_private_test(
+def rabbitmqctl_check_formatted_test(**kwargs):
+    rabbitmqctl_check_formatted_private_test(
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,
             "//conditions:default": False,

--- a/deps/rabbitmq_cli/rabbitmqctl_check_formatted.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_check_formatted.bzl
@@ -1,8 +1,4 @@
 load(
-    "@rules_erlang//:erlang_app_info.bzl",
-    "ErlangAppInfo",
-)
-load(
     "@rules_erlang//:util.bzl",
     "path_join",
     "windows_path",
@@ -12,10 +8,6 @@ load(
     "elixir_dirs",
     "erlang_dirs",
     "maybe_install_erlang",
-)
-load(
-    ":rabbitmqctl.bzl",
-    "deps_dir_contents",
 )
 
 def _impl(ctx):
@@ -74,8 +66,6 @@ set -x
     else:
         output = ctx.actions.declare_file(ctx.label.name + ".bat")
         script = """@echo off
-echo Erlang Version: {erlang_version}
-
 :: set LANG="en_US.UTF-8"
 :: set LC_ALL="en_US.UTF-8"
 
@@ -89,6 +79,7 @@ robocopy {package_dir}\\config %OUTPUTS_DIR%\\config /E /NFL /NDL /NJH /NJS /nc 
 robocopy {package_dir}\\lib %OUTPUTS_DIR%\\lib /E /NFL /NDL /NJH /NJS /nc /ns /np
 robocopy {package_dir}\\test %OUTPUTS_DIR%\\test /E /NFL /NDL /NJH /NJS /nc /ns /np
 copy {package_dir}\\mix.exs %OUTPUTS_DIR%\\mix.exs || goto :error
+copy {package_dir}\\.formatter.exs %OUTPUTS_DIR%\\.formatter.exs || goto :error
 
 cd %OUTPUTS_DIR% || goto :error
 

--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -133,6 +133,7 @@ robocopy {package_dir}\\config %OUTPUTS_DIR%\\config /E /NFL /NDL /NJH /NJS /nc 
 robocopy {package_dir}\\lib %OUTPUTS_DIR%\\lib /E /NFL /NDL /NJH /NJS /nc /ns /np
 robocopy {package_dir}\\test %OUTPUTS_DIR%\\test /E /NFL /NDL /NJH /NJS /nc /ns /np
 copy {package_dir}\\mix.exs %OUTPUTS_DIR%\\mix.exs || goto :error
+copy {package_dir}\\.formatter.exs %OUTPUTS_DIR%\\.formatter.exs || goto :error
 
 cd %OUTPUTS_DIR% || goto :error
 


### PR DESCRIPTION
`bazel test //deps/rabbitmq_cli:all` runs tests and format check
`bazel test //deps/rabbitmq_cli:tests` runs just the tests 
`bazel test //deps/rabbitmq_cli:check_formatted` runs just the format check

Requires #6311