### PR TITLE
CLI tools: discover commands in plugins that are enabled indirectly as dependencies; rework plugin state assertions

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -35,6 +35,7 @@ rabbitmq_home(
         "//deps/rabbit:erlang_app",
         "//deps/rabbitmq_federation:erlang_app",
         "//deps/rabbitmq_stomp:erlang_app",
+        "//deps/rabbitmq_stream_management:erlang_app",
         "//deps/amqp_client:erlang_app",
     ],
 )

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/code_path.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/code_path.ex
@@ -8,11 +8,17 @@ defmodule RabbitMQ.CLI.Core.CodePath do
   alias RabbitMQ.CLI.Core.{Config, Paths, Platform}
 
   def add_plugins_to_load_path(opts) do
-    with {:ok, plugins_dir} <- Paths.plugins_dir(opts) do
-      String.split(to_string(plugins_dir), Platform.path_separator())
-      |> Enum.map(&add_directory_plugins_to_load_path/1)
+    case Paths.plugins_dir(opts) do
+      {:error, _} ->
+        :ok
 
-      :ok
+      val ->
+        with {:ok, plugins_dir} <- val do
+          String.split(to_string(plugins_dir), Platform.path_separator())
+          |> Enum.map(&add_directory_plugins_to_load_path/1)
+
+          :ok
+        end
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -41,9 +41,14 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   end
 
   def list(opts) do
-    {:ok, dir} = plugins_dir(opts)
-    add_all_to_path(dir)
-    :lists.usort(:rabbit_plugins.list(to_charlist(dir)))
+    case plugins_dir(opts) do
+      {:ok, dir} ->
+        add_all_to_path(dir)
+        :lists.usort(:rabbit_plugins.list(to_charlist(dir)))
+
+      {:error, _} ->
+        []
+    end
   end
 
   def list_names(opts) do

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -11,6 +11,7 @@ defmodule EnablePluginsCommandTest do
   alias RabbitMQ.CLI.Core.ExitCodes
 
   @command RabbitMQ.CLI.Plugins.Commands.EnableCommand
+  @disable_command RabbitMQ.CLI.Plugins.Commands.DisableCommand
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -348,6 +349,7 @@ defmodule EnablePluginsCommandTest do
     assert RabbitMQ.CLI.Core.CommandModules.load_commands(:all, %{})["add_super_stream"] ==
              RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand
 
+    @disable_command.run(["rabbitmq_stream_management"], context[:opts])
     reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -51,12 +51,7 @@ defmodule EnablePluginsCommandTest do
   end
 
   setup context do
-    set_enabled_plugins(
-      [:rabbitmq_stomp, :rabbitmq_federation],
-      :online,
-      get_rabbit_hostname(),
-      context[:opts]
-    )
+    reset_enabled_plugins_to_preconfigured_defaults(context)
 
     {
       :ok,
@@ -66,6 +61,15 @@ defmodule EnablePluginsCommandTest do
           timeout: 1000
         })
     }
+  end
+
+  def reset_enabled_plugins_to_preconfigured_defaults(context) do
+    set_enabled_plugins(
+      [:rabbitmq_stomp, :rabbitmq_federation],
+      :online,
+      get_rabbit_hostname(),
+      context[:opts]
+    )
   end
 
   test "validate: specifying both --online and --offline is reported as invalid", context do
@@ -99,7 +103,7 @@ defmodule EnablePluginsCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "if node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list",
+  test "run: if node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list",
        context do
     # Clears enabled plugins file
     set_enabled_plugins([], :offline, :nonode, context[:opts])
@@ -119,7 +123,7 @@ defmodule EnablePluginsCommandTest do
              currently_active_plugins(context)
   end
 
-  test "in offline mode, writes enabled plugins and reports implicitly enabled plugin list",
+  test "run: in offline mode, writes enabled plugins and reports implicitly enabled plugin list",
        context do
     # Clears enabled plugins file
     set_enabled_plugins([], :offline, :nonode, context[:opts])
@@ -144,7 +148,7 @@ defmodule EnablePluginsCommandTest do
     )
   end
 
-  test "adds additional plugins to those already enabled", context do
+  test "run: adds additional plugins to those already enabled", context do
     # Clears enabled plugins file
     set_enabled_plugins([], :offline, :nonode, context[:opts])
 
@@ -181,7 +185,7 @@ defmodule EnablePluginsCommandTest do
     check_plugins_enabled([:rabbitmq_stomp, :rabbitmq_federation], context)
   end
 
-  test "updates plugin list and starts newly enabled plugins", context do
+  test "run: updates plugin list and starts newly enabled plugins", context do
     # Clears enabled plugins file and stop all plugins
     set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
 
@@ -222,9 +226,11 @@ defmodule EnablePluginsCommandTest do
       [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp],
       currently_active_plugins(context)
     )
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
-  test "can enable multiple plugins at once", context do
+  test "run: can enable multiple plugins at once", context do
     # Clears plugins file and stop all plugins
     set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
 
@@ -249,9 +255,11 @@ defmodule EnablePluginsCommandTest do
       [:amqp_client, :rabbitmq_federation, :rabbitmq_stomp],
       currently_active_plugins(context)
     )
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
-  test "does not enable an already implicitly enabled plugin", context do
+  test "run: does not enable an already implicitly enabled plugin", context do
     # Clears enabled plugins file and stop all plugins
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
     assert {:stream, test_stream} = @command.run(["amqp_client"], context[:opts])
@@ -266,6 +274,8 @@ defmodule EnablePluginsCommandTest do
 
     assert [:amqp_client, :rabbitmq_federation] ==
              currently_active_plugins(context)
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
   test "run: does not enable plugins with unmet version requirements", context do
@@ -281,6 +291,8 @@ defmodule EnablePluginsCommandTest do
     # Not changed
     {:error, _version_error} = @command.run(["mock_rabbitmq_plugin_for_3_7"], opts)
     check_plugins_enabled([:mock_rabbitmq_plugin_for_3_9], context)
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
   test "run: does not enable plugins with unmet version requirements even when enabling all plugins",
@@ -295,17 +307,21 @@ defmodule EnablePluginsCommandTest do
     {:error, _version_error} = @command.run([], opts)
 
     check_plugins_enabled([], context)
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
-  test "formats enabled plugins mismatch errors", context do
+  test "output: formats enabled plugins mismatch errors", context do
     err = {:enabled_plugins_mismatch, '/tmp/a/cli/path', '/tmp/a/server/path'}
 
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"} ==
              @command.output({:error, err}, context[:opts])
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
-  test "formats enabled plugins write errors", context do
+  test "output: formats enabled plugins write errors", context do
     err1 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :eacces}
 
     assert {:error, ExitCodes.exit_dataerr(),
@@ -317,9 +333,11 @@ defmodule EnablePluginsCommandTest do
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist (ENOENT)"} ==
              @command.output({:error, err2}, context[:opts])
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 
-  test "enable command will also load its dependent plugins", context do
+  test "output: enable command will also load its dependent plugins", context do
     # Clears enabled plugins file and stop all plugins
     set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
 
@@ -329,5 +347,7 @@ defmodule EnablePluginsCommandTest do
     # Check command add_super_stream is available due to dependency plugin rabbitmq_stream
     assert RabbitMQ.CLI.Core.CommandModules.load_commands(:all, %{})["add_super_stream"] ==
              RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand
+
+    reset_enabled_plugins_to_preconfigured_defaults(context)
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -318,4 +318,16 @@ defmodule EnablePluginsCommandTest do
             "Could not update enabled plugins file at /tmp/a/path: the file does not exist (ENOENT)"} ==
              @command.output({:error, err2}, context[:opts])
   end
+
+  test "enable command will also load its dependent plugins", context do
+    # Clears enabled plugins file and stop all plugins
+    set_enabled_plugins([], :online, context[:opts][:node], context[:opts])
+
+    # Enable rabbitmq_stream_management
+    @command.run(["rabbitmq_stream_management"], context[:opts])
+
+    # Check command add_super_stream is available due to dependency plugin rabbitmq_stream
+    assert RabbitMQ.CLI.Core.CommandModules.load_commands(:all, %{})["add_super_stream"] ==
+             RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand
+  end
 end

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -83,6 +83,18 @@ defmodule ListPluginsCommandTest do
              {:validation_failure, :too_many_args}
   end
 
+  test "validate: succeeds when multiple plugins directories are used, and one of them does not exist",
+       context do
+    opts = get_opts_with_non_existing_plugins_directory(context)
+    assert @command.validate([], opts) == :ok
+  end
+
+  test "validate: succeeds when multiple plugins directories are used and all of them exist",
+       context do
+    opts = get_opts_with_existing_plugins_directory(context)
+    assert @command.validate([], opts) == :ok
+  end
+
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine",
        context do
     assert @command.validate_execution_environment(
@@ -100,7 +112,9 @@ defmodule ListPluginsCommandTest do
              {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "will report list of plugins from file for stopped node", context do
+  test "run: reports list of plugins from file for stopped node", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
     node = context[:opts][:node]
     :ok = :rabbit_misc.rpc_call(node, :application, :stop, [:rabbitmq_stomp])
 
@@ -108,16 +122,21 @@ defmodule ListPluginsCommandTest do
       :rabbit_misc.rpc_call(node, :application, :start, [:rabbitmq_stomp])
     end)
 
-    assert %{
-             status: :node_down,
-             plugins: [
-               %{name: :rabbitmq_federation, enabled: :enabled, running: false},
-               %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
-             ]
-           } = @command.run([".*"], Map.merge(context[:opts], %{node: :nonode}))
+    expected_plugins = [
+      %{name: :rabbitmq_federation, enabled: :enabled, running: false},
+      %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
+    ]
+
+    %{
+      plugins: actual_plugins
+    } = @command.run([".*"], Map.merge(context[:opts], %{node: :nonode}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "will report list of started plugins for started node", context do
+  test "run: reports list of started plugins for started node", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
     node = context[:opts][:node]
     :ok = :rabbit_misc.rpc_call(node, :application, :stop, [:rabbitmq_stomp])
 
@@ -125,43 +144,58 @@ defmodule ListPluginsCommandTest do
       :rabbit_misc.rpc_call(node, :application, :start, [:rabbitmq_stomp])
     end)
 
-    assert %{
-             status: :running,
-             plugins: [
-               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-               %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
-             ]
-           } = @command.run([".*"], context[:opts])
+    expected_plugins = [
+      %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+      %{name: :rabbitmq_stomp, enabled: :enabled, running: false}
+    ]
+
+    %{
+      status: :running,
+      plugins: actual_plugins
+    } = @command.run([".*"], context[:opts])
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "will report description and dependencies for verbose mode", context do
-    assert %{
-             status: :running,
-             plugins: [
-               %{
-                 name: :rabbitmq_federation,
-                 enabled: :enabled,
-                 running: true,
-                 description: _,
-                 dependencies: [:amqp_client]
-               },
-               %{
-                 name: :rabbitmq_stomp,
-                 enabled: :enabled,
-                 running: true,
-                 description: _,
-                 dependencies: [:amqp_client]
-               }
-             ]
-           } = @command.run([".*"], Map.merge(context[:opts], %{verbose: true}))
+  test "run: in verbose mode, reports plugin description and dependencies", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
+    expected_plugins = [
+      %{
+        name: :rabbitmq_federation,
+        enabled: :enabled,
+        running: true,
+        dependencies: [:amqp_client]
+      },
+      %{
+        name: :rabbitmq_stomp,
+        enabled: :enabled,
+        running: true,
+        dependencies: [:amqp_client]
+      }
+    ]
+
+    %{
+      plugins: actual_plugins
+    } = @command.run([".*"], Map.merge(context[:opts], %{verbose: true}))
+
+    assert_plugin_states(expected_plugins, actual_plugins)
+    assert Enum.all?(actual_plugins, fn p -> Keyword.fetch(p, :description) != :error end)
   end
 
-  test "will report plugin names in minimal mode", context do
-    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
-             @command.run([".*"], Map.merge(context[:opts], %{minimal: true}))
+  test "run: reports plugin names in minimal mode", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
+    expected_plugins = [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]
+
+    %{status: :running, plugins: actual_plugins} =
+      @command.run([".*"], Map.merge(context[:opts], %{minimal: true}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "by default lists all plugins", context do
+  test "run: by default lists all plugins", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
 
     on_exit(fn ->
@@ -173,16 +207,20 @@ defmodule ListPluginsCommandTest do
       )
     end)
 
-    assert %{
-             status: :running,
-             plugins: [
-               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-               %{name: :rabbitmq_stomp, enabled: :not_enabled, running: false}
-             ]
-           } = @command.run([".*"], context[:opts])
+    expected_plugins = [
+      %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+      %{name: :rabbitmq_stomp, enabled: :not_enabled, running: false}
+    ]
+
+    %{
+      plugins: actual_plugins
+    } = @command.run([".*"], context[:opts])
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "with enabled flag lists only explicitly enabled plugins", context do
+  test "run: with --enabled flag, lists only explicitly enabled plugins", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
     set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
 
     on_exit(fn ->
@@ -194,95 +232,117 @@ defmodule ListPluginsCommandTest do
       )
     end)
 
-    assert %{
-             status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]
-           } = @command.run([".*"], Map.merge(context[:opts], %{enabled: true}))
+    expected_plugins = [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]
+
+    %{
+      status: :running,
+      plugins: actual_plugins
+    } = @command.run([".*"], Map.merge(context[:opts], %{enabled: true}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "with implicitly_enabled flag lists explicitly and implicitly enabled plugins", context do
-    set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
-
-    on_exit(fn ->
-      set_enabled_plugins(
-        [:rabbitmq_stomp, :rabbitmq_federation],
-        :online,
-        context[:opts][:node],
-        context[:opts]
-      )
-    end)
-
-    assert %{
-             status: :running,
-             plugins: [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]
-           } = @command.run([".*"], Map.merge(context[:opts], %{implicitly_enabled: true}))
-  end
-
-  test "will filter plugins by name with pattern provided", context do
-    set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
-
-    on_exit(fn ->
-      set_enabled_plugins(
-        [:rabbitmq_stomp, :rabbitmq_federation],
-        :online,
-        context[:opts][:node],
-        context[:opts]
-      )
-    end)
-
-    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}]} =
-             @command.run(["fede"], Map.merge(context[:opts], %{minimal: true}))
-
-    assert %{status: :running, plugins: [%{name: :rabbitmq_stomp}]} =
-             @command.run(["stomp$"], Map.merge(context[:opts], %{minimal: true}))
-  end
-
-  test "validate: validation is OK when we use multiple plugins directories, one of them does not exist",
+  test "run: with --implicitly_enabled flag lists explicitly and implicitly enabled plugins",
        context do
-    opts = get_opts_with_non_existing_plugins_directory(context)
-    assert @command.validate([], opts) == :ok
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+    set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+
+    on_exit(fn ->
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
+    end)
+
+    expected_plugins = [%{name: :rabbitmq_federation, enabled: :enabled, running: true}]
+
+    %{
+      status: :running,
+      plugins: actual_plugins
+    } = @command.run([".*"], Map.merge(context[:opts], %{implicitly_enabled: true}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "validate: validation is OK when we use multiple plugins directories, directories do exist",
-       context do
-    opts = get_opts_with_existing_plugins_directory(context)
-    assert @command.validate([], opts) == :ok
+  test "run: filters plugins by name with pattern provided", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+    set_enabled_plugins([:rabbitmq_federation], :online, context[:opts][:node], context[:opts])
+
+    on_exit(fn ->
+      set_enabled_plugins(
+        [:rabbitmq_stomp, :rabbitmq_federation],
+        :online,
+        context[:opts][:node],
+        context[:opts]
+      )
+    end)
+
+    %{status: :running, plugins: actual_plugins} =
+      @command.run(["fede"], Map.merge(context[:opts], %{minimal: true}))
+
+    assert_plugin_states(actual_plugins, [%{name: :rabbitmq_federation}])
+
+    %{status: :running, plugins: actual_plugins2} =
+      @command.run(["stomp$"], Map.merge(context[:opts], %{minimal: true}))
+
+    assert_plugin_states(actual_plugins2, [%{name: :rabbitmq_stomp}])
   end
 
   test "should succeed when using multiple plugins directories, one of them does not exist",
        context do
     opts = get_opts_with_non_existing_plugins_directory(context)
 
-    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
-             @command.run([".*"], Map.merge(opts, %{minimal: true}))
+    expected_plugins = [
+      %{name: :rabbitmq_federation},
+      %{name: :rabbitmq_stomp}
+    ]
+
+    %{status: :running, plugins: actual_plugins} =
+      @command.run([".*"], Map.merge(opts, %{minimal: true}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "should succeed when using multiple plugins directories, directories do exist and do contain plugins",
+  test "run: succeeds when using multiple plugins directories, directories do exist and do contain plugins",
        context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
     opts = get_opts_with_existing_plugins_directory(context)
 
-    assert %{status: :running, plugins: [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]} =
-             @command.run([".*"], Map.merge(opts, %{minimal: true}))
+    expected_plugins = [%{name: :rabbitmq_federation}, %{name: :rabbitmq_stomp}]
+
+    %{status: :running, plugins: actual_plugins} =
+      @command.run([".*"], Map.merge(opts, %{minimal: true}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "should list plugins when using multiple plugins directories", context do
+  test "run: lists plugins when using multiple plugins directories", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
     plugins_directory = fixture_plugins_path("plugins-subdirectory-01")
     opts = get_opts_with_plugins_directories(context, [plugins_directory])
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
     reset_enabled_plugins_to_preconfigured_defaults(context)
 
-    assert %{
-             status: :running,
-             plugins: [
-               %{name: :mock_rabbitmq_plugins_01},
-               %{name: :mock_rabbitmq_plugins_02},
-               %{name: :rabbitmq_federation},
-               %{name: :rabbitmq_stomp}
-             ]
-           } = @command.run([".*"], Map.merge(opts, %{minimal: true}))
+    expected_plugins = [
+      %{name: :mock_rabbitmq_plugins_01},
+      %{name: :mock_rabbitmq_plugins_02},
+      %{name: :rabbitmq_federation},
+      %{name: :rabbitmq_stomp}
+    ]
+
+    %{
+      plugins: actual_plugins
+    } = @command.run([".*"], Map.merge(opts, %{minimal: true}))
+
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "will report list of plugins with latest version picked", context do
+  test "run: lists the most recent version of every plugin", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
     plugins_directory_01 = fixture_plugins_path("plugins-subdirectory-01")
     plugins_directory_02 = fixture_plugins_path("plugins-subdirectory-02")
 
@@ -292,28 +352,35 @@ defmodule ListPluginsCommandTest do
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
     reset_enabled_plugins_to_preconfigured_defaults(context)
 
-    assert %{
-             status: :running,
-             plugins: [
-               %{
-                 name: :mock_rabbitmq_plugins_01,
-                 enabled: :not_enabled,
-                 running: false,
-                 version: '0.2.0'
-               },
-               %{
-                 name: :mock_rabbitmq_plugins_02,
-                 enabled: :not_enabled,
-                 running: false,
-                 version: '0.2.0'
-               },
-               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-               %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
-             ]
-           } = @command.run([".*"], opts)
+    expected_plugins = [
+      %{
+        name: :mock_rabbitmq_plugins_01,
+        enabled: :not_enabled,
+        running: false,
+        version: '0.2.0'
+      },
+      %{
+        name: :mock_rabbitmq_plugins_02,
+        enabled: :not_enabled,
+        running: false,
+        version: '0.2.0'
+      },
+      %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+      %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
+    ]
+
+    %{
+      plugins: actual_plugins
+    } = @command.run([".*"], opts)
+
+    IO.inspect(actual_plugins)
+    IO.inspect(expected_plugins)
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
-  test "will report both running and pending upgrade versions", context do
+  test "run: reports both running and pending upgrade versions", context do
+    reset_enabled_plugins_to_preconfigured_defaults(context)
+
     plugins_directory_01 = fixture_plugins_path("plugins-subdirectory-01")
     plugins_directory_02 = fixture_plugins_path("plugins-subdirectory-02")
     opts = get_opts_with_plugins_directories(context, [plugins_directory_01])
@@ -326,51 +393,58 @@ defmodule ListPluginsCommandTest do
       opts
     )
 
-    assert %{
-             status: :running,
-             plugins: [
-               %{
-                 name: :mock_rabbitmq_plugins_01,
-                 enabled: :not_enabled,
-                 running: false,
-                 version: '0.2.0'
-               },
-               %{
-                 name: :mock_rabbitmq_plugins_02,
-                 enabled: :enabled,
-                 running: true,
-                 version: '0.1.0',
-                 running_version: '0.1.0'
-               },
-               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-               %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
-             ]
-           } = @command.run([".*"], opts)
+    expected_plugins = [
+      %{
+        name: :mock_rabbitmq_plugins_01,
+        enabled: :not_enabled,
+        running: false,
+        version: '0.2.0'
+      },
+      %{
+        name: :mock_rabbitmq_plugins_02,
+        enabled: :enabled,
+        running: true,
+        version: '0.1.0',
+        running_version: '0.1.0'
+      },
+      %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+      %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
+    ]
+
+    %{
+      status: :running,
+      plugins: actual_plugins
+    } = @command.run([".*"], opts)
+
+    assert_plugin_states(actual_plugins, expected_plugins)
 
     opts =
       get_opts_with_plugins_directories(context, [plugins_directory_01, plugins_directory_02])
 
     switch_plugins_directories(context[:opts][:plugins_dir], opts[:plugins_dir])
 
-    assert %{
-             status: :running,
-             plugins: [
-               %{
-                 name: :mock_rabbitmq_plugins_01,
-                 enabled: :not_enabled,
-                 running: false,
-                 version: '0.2.0'
-               },
-               %{
-                 name: :mock_rabbitmq_plugins_02,
-                 enabled: :enabled,
-                 running: true,
-                 version: '0.2.0',
-                 running_version: '0.1.0'
-               },
-               %{name: :rabbitmq_federation, enabled: :enabled, running: true},
-               %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
-             ]
-           } = @command.run([".*"], opts)
+    expected_plugins2 = [
+      %{
+        name: :mock_rabbitmq_plugins_01,
+        enabled: :not_enabled,
+        running: false,
+        version: '0.2.0'
+      },
+      %{
+        name: :mock_rabbitmq_plugins_02,
+        enabled: :enabled,
+        running: true,
+        version: '0.2.0',
+        running_version: '0.1.0'
+      },
+      %{name: :rabbitmq_federation, enabled: :enabled, running: true},
+      %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
+    ]
+
+    %{
+      plugins: actual_plugins2
+    } = @command.run([".*"], opts)
+
+    assert_plugin_states(actual_plugins2, expected_plugins2)
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -179,8 +179,7 @@ defmodule ListPluginsCommandTest do
       plugins: actual_plugins
     } = @command.run([".*"], Map.merge(context[:opts], %{verbose: true}))
 
-    assert_plugin_states(expected_plugins, actual_plugins)
-    assert Enum.all?(actual_plugins, fn p -> Keyword.fetch(p, :description) != :error end)
+    assert_plugin_states(actual_plugins, expected_plugins)
   end
 
   test "run: reports plugin names in minimal mode", context do
@@ -373,8 +372,6 @@ defmodule ListPluginsCommandTest do
       plugins: actual_plugins
     } = @command.run([".*"], opts)
 
-    IO.inspect(actual_plugins)
-    IO.inspect(expected_plugins)
     assert_plugin_states(actual_plugins, expected_plugins)
   end
 

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -606,6 +606,23 @@ defmodule TestHelper do
     Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, []))
   end
 
+  # Asserts that for every expected plugin, there is an actually
+  # present plugin on the node that has the same name, version,
+  # activation state and running/stopped state.
+  #
+  # If there are more activated plugins than expected,
+  # this is considered acceptable.
+  def assert_plugin_states(actual, expected) do
+    assert Enum.all?(expected, fn ep ->
+             Enum.find(actual, false, fn ap ->
+               ap.name == ep.name and
+                 ap.version == ep.version and
+                 ap.enabled == ep.enabled and
+                 ap.running == ep.running
+             end)
+           end)
+  end
+
   def enable_federation_plugin() do
     node = get_rabbit_hostname()
 

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -607,7 +607,20 @@ defmodule TestHelper do
   end
 
   # Asserts that for every expected plugin, there is an actually
-  # present plugin on the node that has the same name, version,
+  # present plugin on the node that has the same name.
+  #
+  # If there are more activated plugins than expected,
+  # this is considered acceptable.
+  def assert_plugin_presence(actual, expected) do
+    assert Enum.all?(expected, fn ep ->
+             Enum.find(actual, false, fn ap ->
+               ap[:name] == ep[:name]
+             end)
+           end)
+  end
+
+  # Asserts that for every expected plugin, there is an actually
+  # present plugin on the node that has the same name,
   # activation state and running/stopped state.
   #
   # If there are more activated plugins than expected,
@@ -615,10 +628,41 @@ defmodule TestHelper do
   def assert_plugin_states(actual, expected) do
     assert Enum.all?(expected, fn ep ->
              Enum.find(actual, false, fn ap ->
-               ap.name == ep.name and
-                 ap.version == ep.version and
-                 ap.enabled == ep.enabled and
-                 ap.running == ep.running
+               ap[:name] == ep[:name] and
+                 ap[:enabled] == ep[:enabled] and
+                 ap[:running] == ep[:running]
+             end)
+           end)
+  end
+
+  # Asserts that for every expected plugin, there is an actually
+  # present plugin on the node that has the same name, version,
+  # activation state.
+  #
+  # If there are more activated plugins than expected,
+  # this is considered acceptable.
+  def assert_plugin_states_and_versions(actual, expected) do
+    assert Enum.all?(expected, fn ep ->
+             Enum.find(actual, false, fn ap ->
+               ap[:name] == ep[:name] and
+                 ap[:version] == ep[:version] and
+                 ap[:enabled] == ep[:enabled]
+             end)
+           end)
+  end
+
+  # Asserts that for every expected plugin, there is an actually
+  # present plugin on the node that has the same name, dependencies,
+  # activation state.
+  #
+  # If there are more activated plugins than expected,
+  # this is considered acceptable.
+  def assert_plugin_states_and_dependencies(actual, expected) do
+    assert Enum.all?(expected, fn ep ->
+             Enum.find(actual, false, fn ap ->
+               ap[:name] == ep[:name] and
+                 Enum.sort(ap[:dependencies]) == Enum.sort(ep[:dependencies]) and
+                 ap[:enabled] == ep[:enabled]
              end)
            end)
   end

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -239,6 +239,7 @@ def rabbitmq_integration_suite(
             "RABBITMQ_RUN": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/rabbitmq-for-tests-run".format(package),
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
+            "RABBITMQ_PLUGINS_DIR": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
             "LANG": "C.UTF-8",
         }.items() + test_env.items()),

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -239,7 +239,6 @@ def rabbitmq_integration_suite(
             "RABBITMQ_RUN": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/rabbitmq-for-tests-run".format(package),
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
-            "RABBITMQ_PLUGINS_DIR": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
             "LANG": "C.UTF-8",
         }.items() + test_env.items()),

--- a/scripts/bazel/rabbitmq-run.bat
+++ b/scripts/bazel/rabbitmq-run.bat
@@ -99,6 +99,7 @@ if not exist "%TEST_TMPDIR%" mkdir %TEST_TMPDIR%
 
 if not exist "%RABBITMQ_LOG_BASE%" mkdir %RABBITMQ_LOG_BASE%
 if not exist "%RABBITMQ_MNESIA_BASE%" mkdir %RABBITMQ_MNESIA_BASE%
+if not exist "%RABBITMQ_PLUGINS_DIR%" mkdir %RABBITMQ_PLUGINS_DIR%
 if not exist "%RABBITMQ_PLUGINS_EXPAND_DIR%" mkdir %RABBITMQ_PLUGINS_EXPAND_DIR%
 
 if "%CMD%" == "run-broker" (

--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -79,6 +79,7 @@ setup_node_env() {
     mkdir -p "$TEST_TMPDIR"
     mkdir -p "$RABBITMQ_LOG_BASE"
     mkdir -p "$RABBITMQ_MNESIA_BASE"
+    mkdir -p "$RABBITMQ_PLUGINS_DIR"
     mkdir -p "$RABBITMQ_PLUGINS_EXPAND_DIR"
 }
 


### PR DESCRIPTION
This is #6289 by @SimonUnge (AWS) with some test suite improvements from me.