### PR TITLE
Remove trust_store_http from MODULE.bazel since it's an internal dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -380,7 +380,6 @@ use_repo(
     "sysmon_handler",
     "systemd",
     "thoas",
-    "trust_store_http",
 )
 
 rbe = use_extension(


### PR DESCRIPTION
Seems to have been an accidental result of conflict resolution in fe13f693381011b1fad1cf8d83d8f9c2e758febf