### PR TITLE
Fix seshat counter leaks

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -235,7 +235,8 @@ erlang_package.hex_package(
 )
 
 erlang_package.git_package(
-    branch = "main",
+    repository = "rabbitmq/osiris",
+    tag = "v1.3.2",
     patch_cmds = [
         """VERSION=$(git rev-parse HEAD)
 echo "Injecting ${VERSION} into Makefile..."
@@ -246,7 +247,6 @@ sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.baze
         """sed -i"_orig2" -E 's/ct_sharded\\.bzl/ct.bzl/' BUILD.bazel
 """,
     ],
-    repository = "rabbitmq/osiris",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris main
+dep_osiris = git https://github.com/rabbitmq/osiris v1.3.2
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.3.2
 

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -297,7 +297,7 @@ begin_stream(#stream_client{name = QName, readers = Readers0} = State0,
         undefined ->
             {error, no_local_stream_replica_available};
         _ ->
-            CounterSpec = {{?MODULE, QName, self()}, []},
+            CounterSpec = {{?MODULE, QName, Tag, self()}, []},
             {ok, Seg0} = osiris:init_reader(LocalPid, Offset, CounterSpec),
             NextOffset = osiris_log:next_offset(Seg0) - 1,
             osiris:register_offset_listener(LocalPid, NextOffset),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -3061,8 +3061,10 @@ remove_subscription(SubscriptionId,
                         Connection,
                     #stream_connection_state{consumers = Consumers} = State) ->
     #{SubscriptionId := Consumer} = Consumers,
-    Stream =
-        Consumer#consumer.configuration#consumer_configuration.stream,
+    #consumer{log = Log,
+              configuration = #consumer_configuration{stream = Stream}} =
+        Consumer,
+    close_log(Log),
     #{Stream := SubscriptionsForThisStream} = StreamSubscriptions,
     SubscriptionsForThisStream1 =
         lists:delete(SubscriptionId, SubscriptionsForThisStream),
@@ -3621,3 +3623,7 @@ ssl_info(F,
 get_chunk_selector(Properties) ->
     binary_to_atom(maps:get(<<"chunk_selector">>, Properties,
                             <<"user_data">>)).
+
+close_log(undefined) -> ok;
+close_log(Log) ->
+    osiris_log:close(Log).

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -144,7 +144,8 @@ end_per_testcase(_Test, _Config) ->
     ok.
 
 test_global_counters(Config) ->
-    test_server(gen_tcp, Config),
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    test_server(gen_tcp, Stream, Config),
     ?assertEqual(#{publishers => 0,
                    consumers => 0,
                    messages_confirmed_total => 2,
@@ -174,11 +175,13 @@ test_global_counters(Config) ->
     ok.
 
 test_stream(Config) ->
-    test_server(gen_tcp, Config),
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    test_server(gen_tcp, Stream, Config),
     ok.
 
 test_stream_tls(Config) ->
-    test_server(ssl, Config),
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    test_server(ssl, Stream, Config),
     ok.
 
 test_gc_consumers(Config) ->
@@ -294,7 +297,7 @@ sac_ff(Config) ->
     C = rabbit_stream_core:init(0),
     test_peer_properties(gen_tcp, S, C),
     test_authenticate(gen_tcp, S, C),
-    Stream = <<"stream1">>,
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
     test_create_stream(gen_tcp, S, Stream, C),
     test_declare_publisher(gen_tcp, S, 1, Stream, C),
     ?awaitMatch(#{publishers := 1}, get_global_counters(Config), ?WAIT),
@@ -401,7 +404,8 @@ get_node_name(Config) ->
 get_node_name(Config, Node) ->
     rabbit_ct_broker_helpers:get_node_config(Config, Node, nodename).
 
-test_server(Transport, Config) ->
+test_server(Transport, Stream, Config) ->
+    QName = rabbit_misc:r(<<"/">>, queue, Stream),
     Port =
         case Transport of
             gen_tcp ->
@@ -416,7 +420,6 @@ test_server(Transport, Config) ->
     C0 = rabbit_stream_core:init(0),
     C1 = test_peer_properties(Transport, S, C0),
     C2 = test_authenticate(Transport, S, C1),
-    Stream = <<"stream1">>,
     C3 = test_create_stream(Transport, S, Stream, C2),
     PublisherId = 42,
     ?assertMatch(#{publishers := 0}, get_global_counters(Config)),
@@ -429,9 +432,21 @@ test_server(Transport, Config) ->
     ?assertMatch(#{consumers := 0}, get_global_counters(Config)),
     C7 = test_subscribe(Transport, S, SubscriptionId, Stream, C6),
     ?awaitMatch(#{consumers := 1}, get_global_counters(Config), ?WAIT),
+    CounterKeys = maps:keys(get_osiris_counters(Config)),
+    %% find the counter key for the subscriber
+    {value, SubKey} = lists:search(fun ({rabbit_stream_reader, Q, Id, _}) ->
+                                           Q == QName andalso
+                                           Id == SubscriptionId;
+                                       (_) ->
+                                           false
+                                   end, CounterKeys),
     C8 = test_deliver(Transport, S, SubscriptionId, 0, Body, C7),
-    C9 = test_deliver(Transport, S, SubscriptionId, 1, Body, C8),
+    C8b = test_deliver(Transport, S, SubscriptionId, 1, Body, C8),
 
+    C9 = test_unsubscribe(Transport, S, SubscriptionId, C8b),
+
+    %% assert the counter key got removed after unsubscribe
+    ?assertNot(maps:is_key(SubKey, get_osiris_counters(Config))),
     %% exchange capabilities, which says we support deliver v2
     %% the connection should adapt its deliver frame accordingly
     C10 = test_exchange_command_versions(Transport, S, C9),
@@ -565,6 +580,18 @@ test_subscribe(Transport,
     ?assertMatch({response, 1, {subscribe, ?RESPONSE_CODE_OK}}, Cmd),
     C.
 
+test_unsubscribe(Transport,
+                 Socket,
+                 SubscriptionId, C0) ->
+    UnsubCmd = {request, 1,
+                {unsubscribe, SubscriptionId}},
+    UnsubscribeFrame = rabbit_stream_core:frame(UnsubCmd),
+    ok = Transport:send(Socket, UnsubscribeFrame ),
+    {Cmd, C} = receive_commands(Transport, Socket, C0),
+    ?assertMatch({response, 1, {unsubscribe, ?RESPONSE_CODE_OK}}, Cmd),
+    C.
+
+
 test_deliver(Transport, S, SubscriptionId, COffset, Body, C0) ->
     ct:pal("test_deliver ", []),
     {{deliver, SubscriptionId, Chunk}, C} =
@@ -675,6 +702,12 @@ receive_commands(Transport, S, C0) ->
             Res
     end.
 
+get_osiris_counters(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config,
+                                 0,
+                                 osiris_counters,
+                                 overview,
+                                 []).
 get_global_counters(Config) ->
     maps:get([{protocol, stream}],
              rabbit_ct_broker_helpers:rpc(Config,

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -135,7 +135,7 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
 
     git_repository(
         name = "osiris",
-        branch = "main",
+        tag = "v1.3.2",
         remote = "https://github.com/rabbitmq/osiris.git",
         patch_cmds = [
             """VERSION=$(git rev-parse HEAD)


### PR DESCRIPTION
rabbitmq_streams: close osiris log when unsubscribing. 

Update to osiris v1.3.2 which contains a fix that ensures counter records are removed when closing the osiris log.

Make rabbit_stream_queue counter key more unique.

This PR also pins the osiris dependency to a tag rather than using main. This should make backporting easier to reason about as in this case the test will fail if used with a lower osiris version.

Fixes #6317 