### PR TITLE
Remove duplicate dep_thoas declaration

### DIFF
--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -113,7 +113,6 @@ dep_toke                              = git_rmq           toke $(current_rmq_ref
 dep_accept = hex 0.3.5
 dep_cowboy = hex 2.8.0
 dep_cowlib = hex 2.9.1
-dep_thoas = hex 0.3.0
 dep_looking_glass = git https://github.com/rabbitmq/looking_glass.git master
 dep_prometheus = hex 4.9.1
 dep_ra = git https://github.com/rabbitmq/ra.git main


### PR DESCRIPTION
## Proposed Changes

I assume the later appearance of dep_thoas already overrode the now deleted line, so this is just to avoid confusion.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
