### PR TITLE
Adjust generated .app file for ra to include seshat as a dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -282,32 +282,6 @@ erlang_package.hex_package(
 erlang_package.git_package(
     repository = "rabbitmq/ra",
     tag = "v2.4.1",
-    patch_cmds = ["""sed -i"_orig" -E 's/erlc/erlang_bytecode/g' ra.bzl
-"""],
-    build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
-
-NAME = "ra"
-
-EXTRA_APPS = [
-    "sasl",
-    "crypto",
-]
-
-DEPS = [
-    "@gen_batch_server//:erlang_app",
-]
-
-RUNTIME_DEPS = [
-    "@aten//:erlang_app",
-]
-
-erlang_app(
-    app_name = NAME,
-    extra_apps = EXTRA_APPS,
-    runtime_deps = RUNTIME_DEPS,
-    deps = DEPS,
-)
-"""
 )
 
 erlang_package.hex_package(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -235,16 +235,6 @@ erlang_package.hex_package(
 )
 
 erlang_package.git_package(
-    patch_cmds = [
-        """VERSION=$(git rev-parse HEAD)
-echo "Injecting ${VERSION} into Makefile..."
-sed -i"_orig" -E '/PROJECT_VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' Makefile
-echo "Injecting ${VERSION} into BUILD.bazel..."
-sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.bazel
-""",
-        """sed -i"_orig2" -E 's/ct_sharded\\.bzl/ct.bzl/' BUILD.bazel
-""",
-    ],
     repository = "rabbitmq/osiris",
     tag = "v1.3.3",
 )

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -137,16 +137,6 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
         name = "osiris",
         tag = "v1.3.3",
         remote = "https://github.com/rabbitmq/osiris.git",
-        patch_cmds = [
-            """VERSION=$(git rev-parse HEAD)
-echo "Injecting ${VERSION} into Makefile..."
-sed -i"_orig" -E '/PROJECT_VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' Makefile
-echo "Injecting ${VERSION} into BUILD.bazel..."
-sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.bazel
-""",
-            """sed -i"_orig2" -E 's/ct_sharded\\.bzl/ct.bzl/' BUILD.bazel
-""",
-        ],
     )
 
     hex_pm_erlang_app(

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -176,12 +176,31 @@ sed -i"_orig" -E '/VERSION/ s/[0-9]+\\.[0-9]+\\.[0-9]+/'${VERSION}'/' BUILD.baze
         name = "ra",
         version = "2.4.1",
         sha256 = "b4e7ff475d63d27bb1e544bd43200ce110079c078f8e7d0ac87565262482be52",
-        deps = [
-            "@gen_batch_server//:erlang_app",
-        ],
-        runtime_deps = [
-            "@aten//:erlang_app",
-        ]
+        build_file_content = """load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+
+NAME = "ra"
+
+EXTRA_APPS = [
+    "sasl",
+    "crypto",
+]
+
+DEPS = [
+    "@gen_batch_server//:erlang_app",
+]
+
+RUNTIME_DEPS = [
+    "@aten//:erlang_app",
+    "@seshat//:erlang_app",
+]
+
+erlang_app(
+    app_name = NAME,
+    extra_apps = EXTRA_APPS,
+    runtime_deps = RUNTIME_DEPS,
+    deps = DEPS,
+)
+""",
     )
 
     hex_archive(


### PR DESCRIPTION
The quality of auto-detection of properities of a hex dependency was improved with bzlmod, thus in the MODULE.bazel file, ra is handled correctly with no hints. In WORKSPACE.bazel/workspace_helpers.bzl, this not the case, so a full build_file_content is needed.

Bazel 6, due this month, takes bzlmod out of experimental status, so I don't expect to close up the difference between the systems.

The easier solution is to publish ra to hex.pm with the BUILD.bazel file included, as it exists in the ra source, and is correct, eliminating the need for any auto-generation of it when imported/referenced by rabbitmq-server.