### PR TITLE
Aggregate memory usage on ra_server_sup_sup level

### DIFF
--- a/deps/rabbit/src/rabbit_vm.erl
+++ b/deps/rabbit/src/rabbit_vm.erl
@@ -183,16 +183,7 @@ interesting_sups() ->
 queue_sups() ->
     all_vhosts_children(rabbit_amqqueue_sup_sup).
 
-quorum_sups() ->
-    %% TODO: in the future not all ra servers may be queues and we needs
-    %% some way to filter this
-    case whereis(ra_server_sup_sup) of
-        undefined ->
-            [];
-        _ ->
-            [Pid || {_, Pid, _, _} <-
-                    supervisor:which_children(ra_server_sup_sup)]
-    end.
+quorum_sups() -> [ra_server_sup_sup].
 
 dlx_sups() -> [rabbit_fifo_dlx_sup].
 stream_server_sups() -> [osiris_server_sup].


### PR DESCRIPTION
With this change, `rabbitmq-diagnostics memory_breakdown` executes much faster with many QQs. Even with 100k QQs, it's under 5 seconds (previously over 20 minutes).

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/6388