### PR TITLE
Support code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@
 /plugins.lock
 /sbin/
 /sbin.lock
+ct.cover.spec
 erl_crash.dump
 rebar3.crashdump
 .envrc

--- a/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
+++ b/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
@@ -321,8 +321,7 @@ recover_bindings(Config) ->
     assert_index_table_empty(Config),
     rabbit_ct_broker_helpers:rabbitmqctl(Config, Server, ["import_definitions", Path], 10_000),
     ?assertEqual(?NUM_BINDINGS_TO_DIRECT_ECHANGE, table_size(Config, ?INDEX_TABLE_NAME)),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 0),
-    ok = rabbit_ct_broker_helpers:start_node(Config, 0),
+    ok = rabbit_ct_broker_helpers:restart_node(Config, 0),
     ?assertEqual(?NUM_BINDINGS_TO_DIRECT_ECHANGE_DURABLE, table_size(Config, ?INDEX_TABLE_NAME)),
 
     %% cleanup

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -1628,7 +1628,7 @@ stop_node_after(Config, Node, Sleep) ->
 
 kill_node(Config, Node) ->
     Pid = rpc(Config, Node, os, getpid, []),
-    cover_remove_node(Node),
+    cover_remove_node(Config, Node),
     Cmd = case os:type() of
               {win32, _} ->
                   case os:find_executable("taskkill.exe") of
@@ -1920,17 +1920,24 @@ user(Username) ->
           tags           = [administrator],
           authz_backends = [{rabbit_auth_backend_internal, none}]}.
 
-cover_add_node(Node) ->
+cover_add_node(Node)
+  when is_atom(Node) andalso Node =/= undefined ->
     if_cover(
       fun() ->
               {ok, [Node]} = ct_cover:add_nodes([Node])
       end).
 
-cover_remove_node(Node) ->
+cover_remove_node(Node)
+  when is_atom(Node) andalso Node =/= undefined ->
     if_cover(
       fun() ->
               ok = ct_cover:remove_nodes([Node])
       end).
+
+cover_remove_node(Config, Node) ->
+    NodeConfig = get_node_config(Config, Node),
+    Nodename = ?config(nodename, NodeConfig),
+    cover_remove_node(Nodename).
 
 if_cover(F) ->
     case os:getenv("COVER") of

--- a/deps/rabbitmq_mqtt/.gitignore
+++ b/deps/rabbitmq_mqtt/.gitignore
@@ -1,6 +1,7 @@
 .sw?
 .*.sw?
 *.beam
+*.coverdata
 .idea/*
 /.erlang.mk/
 /cover/
@@ -15,6 +16,7 @@
 /plugins.lock
 /sbin/
 /sbin.lock
+/test/ct.cover.spec
 /xrefr
 debug/*
 *.plt

--- a/erlang.mk
+++ b/erlang.mk
@@ -17,7 +17,7 @@
 ERLANG_MK_FILENAME := $(realpath $(lastword $(MAKEFILE_LIST)))
 export ERLANG_MK_FILENAME
 
-ERLANG_MK_VERSION = bf7a194
+ERLANG_MK_VERSION = 6423c1c
 ERLANG_MK_WITHOUT = 
 
 # Make 3.81 and 3.82 are deprecated.
@@ -6285,9 +6285,9 @@ ifeq ($(PLATFORM),msys2)
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 else ifeq ($(PLATFORM),darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(PLATFORM),freebsd)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
@@ -6707,9 +6707,9 @@ endif
 endif
 
 define ct_suite_target
-ct-$(1): test-build
-	$(verbose) mkdir -p $(CT_LOGS_DIR)
-	$(gen_verbose_esc) $(CT_RUN) -sname ct_$(PROJECT) -suite $(addsuffix _SUITE,$(1)) $(CT_EXTRA) $(CT_OPTS)
+ct-$1: test-build
+	$$(verbose) mkdir -p $$(CT_LOGS_DIR)
+	$$(gen_verbose_esc) $$(CT_RUN) -sname ct_$$(PROJECT) -suite $$(addsuffix _SUITE,$1) $$(CT_EXTRA) $$(CT_OPTS)
 endef
 
 $(foreach test,$(CT_SUITES),$(eval $(call ct_suite_target,$(test))))


### PR DESCRIPTION
Previously it was not possible to see code coverage for the majority of test cases: integration tests that create RabbitMQ nodes. It was only possible to see code coverage for unit tests. This commit allows to see code coverage for tests that create RabbitMQ nodes.

The only thing you need to do is setting the `COVER` variable, for example
```
make -C deps/rabbitmq_mqtt ct COVER=1
```
will show you coverage across all tests in the MQTT plugin.

This commit fixes the erlang.mk file that did not append the `-cover <sepc_path>` flag to the `ct_run` command.

Whenever a RabbitMQ node is started `ct_cover:add_nodes/1` is called. Contrary to the documentation which states

> To have effect, this function is to be called from init_per_suite/1 (see common_test) before any tests are performed.

I found that it also works in `init_per_group/1` or even within the test cases themselves.

Whenever a RabbitMQ node is stopped or killed `ct_cover:remove_nodes/1` is called to transfer results from the RabbitMQ node to the CT node.

Since the erlang.mk file writes a file called `test/ct.cover.spec` including the line:
```
{export,".../rabbitmq-server/deps/rabbitmq_mqtt/cover/ct.coverdata"}.
```
results across all test suites will be accumulated in that file.

The accumulated result can be seen through the link `Coverage log` on the test suite result pages.