### PR TITLE
#4842: obfuscate a sensitive field in authenticated user state

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -111,7 +111,7 @@ internal_check_user_login(Username, Fun) ->
             case Fun(User) of
                 true -> {ok, #auth_user{username = Username,
                                         tags     = Tags,
-                                        impl     = none}};
+                                        impl     = fun() -> none end}};
                 _    -> Refused
             end;
         {error, not_found} ->

--- a/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_cache/test/rabbit_auth_backend_cache_SUITE.erl
@@ -64,6 +64,7 @@ authentication_response(Config) ->
 authorization_response(Config) ->
     AuthProps = [{password, <<"guest">>}],
     {ok, #auth_user{impl = Impl, tags = Tags}} = rpc(Config,rabbit_auth_backend_internal, user_login_authentication, [<<"guest">>, AuthProps]),
+    true = is_function(Impl),
     {ok, Impl, Tags} = rpc(Config,rabbit_auth_backend_internal, user_login_authorization, [<<"guest">>, AuthProps]),
     {ok, Impl, Tags} = rpc(Config,rabbit_auth_backend_cache, user_login_authorization, [<<"guest">>, AuthProps]),
     {refused, FailErr, FailArgs} = rpc(Config,rabbit_auth_backend_internal, user_login_authorization, [<<"nonguest">>, AuthProps]),
@@ -163,7 +164,3 @@ cache_expiration_topic(Config) ->
 
 rpc(Config, M, F, A) ->
     rabbit_ct_broker_helpers:rpc(Config, 0, M, F, A).
-
-
-
-

--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -40,7 +40,7 @@ user_login_authentication(Username, AuthProps) ->
                                       T <- string:tokens(Rest, " ")],
                            {ok, #auth_user{username = Username,
                                            tags     = Tags,
-                                           impl     = none}};
+                                           impl     = fun() -> none end}};
         Other           -> {error, {bad_response, Other}}
     end.
 

--- a/deps/rabbitmq_auth_backend_http/test/auth_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_http/test/auth_SUITE.erl
@@ -38,8 +38,9 @@ end_per_suite(_Config) ->
 
 grants_access_to_user(Config) ->
     #{username := U, password := P, tags := T} = ?config(allowed_user, Config),
-    ?assertMatch({ok, #auth_user{username = U, tags = T}},
-		         rabbit_auth_backend_http:user_login_authentication(U, [{password, P}])).
+    {ok, User} = rabbit_auth_backend_http:user_login_authentication(U, [{password, P}]),
+    ?assertMatch({U, T, none},
+                 {User#auth_user.username, User#auth_user.tags, (User#auth_user.impl)()}).
 
 denies_access_to_user(Config) ->
     #{username := U, password := P} = ?config(denied_user, Config),

--- a/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
@@ -457,10 +457,10 @@ topic_authorisation_consumption(Config) ->
 topic_authorisation_consumption1(Config) ->
     %% we can't use the LDAP backend record here, falling back to simple tuples
     Alice = {auth_user,<<"Alice">>, [monitor],
-             {impl,"cn=Alice,ou=People,dc=rabbitmq,dc=com",<<"password">>}
+             fun() -> {impl,"cn=Alice,ou=People,dc=rabbitmq,dc=com",<<"password">>} end,
     },
     Bob = {auth_user,<<"Bob">>, [monitor],
-           {impl,"cn=Bob,ou=People,dc=rabbitmq,dc=com",<<"password">>}
+           fun() -> {impl,"cn=Bob,ou=People,dc=rabbitmq,dc=com",<<"password">>} end,
     },
     Resource = #resource{virtual_host = <<"/">>, name = <<"amq.topic">>, kind = topic},
     Context = #{routing_key  => <<"a.b">>,
@@ -946,4 +946,3 @@ expand_options(As, Bs) ->
                             false -> [A | R]
                         end
                 end, Bs, As).
-

--- a/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
@@ -457,10 +457,10 @@ topic_authorisation_consumption(Config) ->
 topic_authorisation_consumption1(Config) ->
     %% we can't use the LDAP backend record here, falling back to simple tuples
     Alice = {auth_user,<<"Alice">>, [monitor],
-             fun() -> {impl,"cn=Alice,ou=People,dc=rabbitmq,dc=com",<<"password">>} end,
+             fun() -> {impl,"cn=Alice,ou=People,dc=rabbitmq,dc=com",<<"password">>} end
     },
     Bob = {auth_user,<<"Bob">>, [monitor],
-           fun() -> {impl,"cn=Bob,ou=People,dc=rabbitmq,dc=com",<<"password">>} end,
+           fun() -> {impl,"cn=Bob,ou=People,dc=rabbitmq,dc=com",<<"password">>} end
     },
     Resource = #resource{virtual_host = <<"/">>, name = <<"amq.topic">>, kind = topic},
     Context = #{routing_key  => <<"a.b">>,


### PR DESCRIPTION
## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

If English isn't your first language, don't worry about it and try to communicate the problem you are trying to solve to the best of your abilities.
As long as we can understand the intent, it's all good.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #4842)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I obfuscate impl in all modules implementing the rabbit_authn_backend behaviour for consistency, even-though its just 'none' atoms in a few of them.

Note on testing - ldap suite seems not to work for osx with openldap setup etc.

