### PR TITLE
load_definitions should fail on invalid JSON

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -90,9 +90,12 @@ boot() ->
 
 maybe_load_definitions() ->
     %% Classic source: local file or data directory
-    maybe_load_definitions_from_local_filesystem(rabbit, load_definitions),
-    %% Extensible sources
-    maybe_load_definitions_from_pluggable_source(rabbit, definitions).
+    case maybe_load_definitions_from_local_filesystem(rabbit, load_definitions) of
+        ok ->
+            % Extensible sources
+            maybe_load_definitions_from_pluggable_source(rabbit, definitions);
+        {error, E} -> {error, E}
+    end.
 
 -spec import_raw(Body :: binary() | iolist()) -> ok | {error, term()}.
 import_raw(Body) ->


### PR DESCRIPTION
Prior to this change, a completely invalid JSON file would be silently ignored on boot - the node would start, but the definitions wouldn't be imported obviously. This makes the problem explicit with:

```
BOOT FAILED
===========
Error during startup: {error,not_json}
````

Fixes #2610
