### PR TITLE
Support x-max-age argument in stomp

### DIFF
--- a/deps/rabbitmq_stomp/examples/python/stream-receiver.py
+++ b/deps/rabbitmq_stomp/examples/python/stream-receiver.py
@@ -1,0 +1,40 @@
+import time
+import sys
+
+import stomp
+import random
+import requests
+
+class MyListener(stomp.ConnectionListener):
+  def on_error(self, frame):
+    print('received an error "%s"' % frame.body)
+  def on_message(self, frame):
+    print('received a message "%s"' % frame.body)
+
+# Define a STOMP connection and port
+conn = stomp.Connection([("localhost", 61613)])
+conn.set_listener('', MyListener())
+conn.connect('guest', 'guest', wait=True) # define the username/password
+
+# Setup a subscription
+conn.subscribe(destination='/exchange/stomp1', id=1234, ack='client', headers={
+    'x-queue-name': 'my-stomp-stream',
+    'x-queue-type': 'stream',
+    'x-max-age' : '10h',
+    'durable': True,
+    'auto-delete': False,
+    'id': 1234,
+    'prefetch-count': 10
+})
+
+response = requests.get("http://localhost:15672/api/queues/%2F/my-stomp-stream", auth=("guest", "guest"))
+stream = response.json()
+print("Stream arguments:")
+print("  x-queue-type:" + stream["arguments"]["x-queue-type"])
+print("  x-max-age:" + stream["arguments"]["x-max-age"])
+
+while True:
+  time.sleep(15) # send a random message every 15 seconds
+  conn.send( destination='/exchange/stomp1', body=str(random.randint(1,11)))
+
+conn.disconnect()

--- a/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
+++ b/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
@@ -43,6 +43,7 @@
 -define(HEADER_X_DEAD_LETTER_ROUTING_KEY, "x-dead-letter-routing-key").
 -define(HEADER_X_EXPIRES, "x-expires").
 -define(HEADER_X_MAX_LENGTH, "x-max-length").
+-define(HEADER_X_MAX_AGE, "x-max-age").
 -define(HEADER_X_MAX_LENGTH_BYTES, "x-max-length-bytes").
 -define(HEADER_X_MAX_PRIORITY, "x-max-priority").
 -define(HEADER_X_MESSAGE_TTL, "x-message-ttl").
@@ -60,6 +61,7 @@
                            ?HEADER_X_DEAD_LETTER_ROUTING_KEY,
                            ?HEADER_X_EXPIRES,
                            ?HEADER_X_MAX_LENGTH,
+                           ?HEADER_X_MAX_AGE,
                            ?HEADER_X_MAX_LENGTH_BYTES,
                            ?HEADER_X_MAX_PRIORITY,
                            ?HEADER_X_MESSAGE_TTL,

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_util.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_util.erl
@@ -289,6 +289,9 @@ build_argument(?HEADER_X_MAX_PRIORITY, Val) ->
 build_argument(?HEADER_X_MESSAGE_TTL, Val) ->
     {list_to_binary(?HEADER_X_MESSAGE_TTL), long,
      list_to_integer(string:strip(Val))};
+build_argument(?HEADER_X_MAX_AGE, Val) ->
+    {list_to_binary(?HEADER_X_MAX_AGE), longstr,
+     list_to_binary(string:strip(Val))};
 build_argument(?HEADER_X_QUEUE_TYPE, Val) ->
   {list_to_binary(?HEADER_X_QUEUE_TYPE), longstr,
     list_to_binary(string:strip(Val))}.

--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_stream.py
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_stream.py
@@ -10,7 +10,7 @@ import base
 import time
 import os
 import re
-
+import urllib.request, json
 
 class TestUserGeneratedQueueName(base.BaseTest):
 
@@ -25,6 +25,7 @@ class TestUserGeneratedQueueName(base.BaseTest):
                 headers={
                     'x-queue-name': queueName,
                     'x-queue-type': 'stream',
+                    'x-max-age' : '10h',
                     'durable': True,
                     'auto-delete': False,
                     'id': 1234,


### PR DESCRIPTION
Closes https://github.com/rabbitmq/rabbitmq-server/issues/5003.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Comments 

There are no tests that verify other `x-` arguments like `x-max-length`. I have added an example python application which is a stream subscriber program which subscribes to a stream passing `x-max-age` argument to the subscription request. 
The program queries the stream's details via the management rest api and prints out the type of queue and the `x-max-age` argument, 