### PR TITLE
Move Mnesia-specific code to `rabbit_db*` modules

### DIFF
--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -1,0 +1,33 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_db).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([run/1]).
+
+%% -------------------------------------------------------------------
+%% run().
+%% -------------------------------------------------------------------
+
+-spec run(Funs) -> Ret when
+      Funs :: #{mnesia := Fun},
+      Fun :: fun(() -> Ret),
+      Ret :: any().
+%% @doc Runs the function corresponding to the used database engine.
+%%
+%% @returns the return value of `Fun'.
+
+run(Funs)
+  when is_map(Funs) andalso is_map_key(mnesia, Funs) ->
+    #{mnesia := MnesiaFun} = Funs,
+    run_with_mnesia(MnesiaFun).
+
+run_with_mnesia(Fun) ->
+    Fun().

--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -1,0 +1,249 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_db_rtparams).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([set/2, set/4,
+         get/1,
+         get_or_set/2,
+         get_all/0, get_all/2,
+         delete/1, delete/3]).
+
+-define(MNESIA_TABLE, rabbit_runtime_parameters).
+
+%% -------------------------------------------------------------------
+%% set().
+%% -------------------------------------------------------------------
+
+-spec set(Key, Term) -> Ret when
+      Key :: atom(),
+      Term :: any(),
+      Ret :: new | {old, Term}.
+%% @doc Sets the new value of the global runtime parameter named `Key'.
+%%
+%% @returns `new' if the runtime parameter was not set before, or `{old,
+%% OldTerm}' with the old value.
+%%
+%% @private
+
+set(Key, Term) when is_atom(Key) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> set_in_mnesia(Key, Term) end}).
+
+set_in_mnesia(Key, Term) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> set_in_mnesia_tx(Key, Term) end).
+
+-spec set(VHostName, Comp, Name, Term) -> Ret when
+      VHostName :: vhost:name(),
+      Comp :: binary(),
+      Name :: binary() | atom(),
+      Term :: any(),
+      Ret :: new | {old, Term}.
+%% @doc Checks the existence of `VHostName' and sets the new value of the
+%% non-global runtime parameter named `Key'.
+%%
+%% @returns `new' if the runtime parameter was not set before, or `{old,
+%% OldTerm}' with the old value.
+%%
+%% @private
+
+set(VHostName, Comp, Name, Term)
+  when is_binary(VHostName) andalso
+       is_binary(Comp) andalso
+       (is_binary(Name) orelse is_atom(Name)) ->
+    Key = {VHostName, Comp, Name},
+    rabbit_db:run(
+      #{mnesia => fun() -> set_in_mnesia(VHostName, Key, Term) end}).
+
+set_in_mnesia(VHostName, Key, Term) ->
+    rabbit_misc:execute_mnesia_transaction(
+      rabbit_db_vhost:with_fun_in_mnesia_tx(
+        VHostName,
+        fun() -> set_in_mnesia_tx(Key, Term) end)).
+
+set_in_mnesia_tx(Key, Term) ->
+    Res = case mnesia:read(?MNESIA_TABLE, Key, read) of
+              [Params] -> {old, Params#runtime_parameters.value};
+              []       -> new
+          end,
+    Record = #runtime_parameters{key   = Key,
+                                 value = Term},
+    mnesia:write(?MNESIA_TABLE, Record, write),
+    Res.
+
+%% -------------------------------------------------------------------
+%% get().
+%% -------------------------------------------------------------------
+
+-spec get(Key) -> Ret when
+      Key :: atom() | {vhost:name(), binary(), binary()},
+      Ret :: #runtime_parameters{} | undefined.
+%% @doc Returns a runtime parameter.
+%%
+%% @returns the value of the runtime parameter if it exists, or `undefined'
+%% otherwise.
+%%
+%% @private
+
+get({VHostName, Comp, Name} = Key)
+  when is_binary(VHostName) andalso
+       is_binary(Comp) andalso
+       (is_binary(Name) orelse is_atom(Name)) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_in_mnesia(Key) end});
+get(Key) when is_atom(Key) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_in_mnesia(Key) end}).
+
+get_in_mnesia(Key) ->
+    case mnesia:dirty_read(?MNESIA_TABLE, Key) of
+        []       -> undefined;
+        [Record] -> Record
+    end.
+
+%% -------------------------------------------------------------------
+%% get_or_set().
+%% -------------------------------------------------------------------
+
+-spec get_or_set(Key, Default) -> Ret when
+      Key :: atom() | {vhost:name(), binary(), binary()},
+      Default :: any(),
+      Ret :: #runtime_parameters{}.
+%% @doc Returns a runtime parameter or sets its value if it does not exist.
+%%
+%% @private
+
+get_or_set({VHostName, Comp, Name} = Key, Default)
+  when is_binary(VHostName) andalso
+       is_binary(Comp) andalso
+       (is_binary(Name) orelse is_atom(Name)) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_or_set_in_mnesia(Key, Default) end});
+get_or_set(Key, Default) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_or_set_in_mnesia(Key, Default) end}).
+
+get_or_set_in_mnesia(Key, Default) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> get_or_set_in_mnesia_tx(Key, Default) end).
+
+get_or_set_in_mnesia_tx(Key, Default) ->
+    case mnesia:read(?MNESIA_TABLE, Key, read) of
+        [Record] ->
+            Record;
+        [] ->
+            Record = #runtime_parameters{key   = Key,
+                                         value = Default},
+            mnesia:write(?MNESIA_TABLE, Record, write),
+            Record
+    end.
+
+%% -------------------------------------------------------------------
+%% get_all().
+%% -------------------------------------------------------------------
+
+-spec get_all() -> Ret when
+      Ret :: [#runtime_parameters{}].
+%% @doc Gets all runtime parameters.
+%%
+%% @returns a list of runtime parameters records.
+%%
+%% @private
+
+get_all() ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_all_in_mnesia() end}).
+
+get_all_in_mnesia() ->
+    rabbit_misc:dirty_read_all(?MNESIA_TABLE).
+
+-spec get_all(VHostName, Comp) -> Ret when
+      VHostName :: vhost:name() | '_',
+      Comp :: binary() | '_',
+      Ret :: [#runtime_parameters{}].
+%% @doc Gets all non-global runtime parameters matching the given virtual host
+%% and component.
+%%
+%% @returns a list of runtime parameters records.
+%%
+%% @private
+
+get_all(VHostName, Comp)
+  when (is_binary(VHostName) orelse VHostName =:= '_') andalso
+       (is_binary(Comp) orelse Comp =:= '_') ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_all_in_mnesia(VHostName, Comp) end}).
+
+get_all_in_mnesia(VHostName, Comp) ->
+    mnesia:async_dirty(
+      fun () ->
+              case VHostName of
+                  '_' -> ok;
+                  _   -> rabbit_vhost:assert(VHostName)
+              end,
+              Match = #runtime_parameters{key = {VHostName, Comp, '_'},
+                                          _   = '_'},
+              mnesia:match_object(?MNESIA_TABLE, Match, read)
+      end).
+
+%% -------------------------------------------------------------------
+%% delete().
+%% -------------------------------------------------------------------
+
+-spec delete(Key) -> ok when
+      Key :: atom().
+%% @doc Deletes the global runtime parameter named `Key'.
+%%
+%% @private
+
+delete(Key) when is_atom(Key) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> delete_in_mnesia(Key) end}).
+
+-spec delete(VHostName, Comp, Name) -> ok when
+      VHostName :: vhost:name() | '_',
+      Comp :: binary() | '_',
+      Name :: binary() | atom() | '_'.
+%% @doc Deletes the non-global runtime parameter named `Name' for the given
+%% virtual host and component.
+%%
+%% @private
+
+delete(VHostName, Comp, Name)
+  when is_binary(VHostName) andalso
+       is_binary(Comp) andalso
+       (is_binary(Name) orelse (is_atom(Name) andalso Name =/= '_')) ->
+    Key = {VHostName, Comp, Name},
+    rabbit_db:run(
+      #{mnesia => fun() -> delete_in_mnesia(Key) end});
+delete(VHostName, Comp, Name)
+  when VHostName =:= '_' orelse Comp =:= '_' orelse Name =:= '_' ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() -> delete_matching_in_mnesia(VHostName, Comp, Name) end}).
+
+delete_in_mnesia(Key) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> delete_in_mnesia_tx(Key) end).
+
+delete_in_mnesia_tx(Key) ->
+    mnesia:delete(?MNESIA_TABLE, Key, write).
+
+delete_matching_in_mnesia(VHostName, Comp, Name) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> delete_matching_in_mnesia_tx(VHostName, Comp, Name) end).
+
+delete_matching_in_mnesia_tx(VHostName, Comp, Name) ->
+    Match = #runtime_parameters{key = {VHostName, Comp, Name},
+                                _   = '_'},
+    _ = [ok = mnesia:delete(?MNESIA_TABLE, Key, write)
+         || #runtime_parameters{key = Key} <-
+            mnesia:match_object(?MNESIA_TABLE, Match, write)],
+    ok.

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -1,0 +1,620 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_db_user).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([create/1,
+         update/2,
+         get_all/0,
+         with_fun_in_mnesia_tx/2,
+         get_user_permissions/2,
+         check_and_match_user_permissions/2,
+         set_user_permissions/1,
+         clear_user_permissions/2,
+         clear_matching_user_permissions/2,
+         get_topic_permissions/3,
+         check_and_match_topic_permissions/3,
+         set_topic_permissions/1,
+         clear_topic_permissions/3,
+         clear_matching_topic_permissions/3,
+         delete/1]).
+
+-define(MNESIA_TABLE, rabbit_user).
+-define(PERM_MNESIA_TABLE, rabbit_user_permission).
+-define(TOPIC_PERM_MNESIA_TABLE, rabbit_topic_permission).
+
+%% -------------------------------------------------------------------
+%% create().
+%% -------------------------------------------------------------------
+
+-spec create(User) -> ok when
+      User :: internal_user:internal_user().
+%% @doc Creates and writes an internal user record.
+%%
+%% @returns `ok' if the record was written to the database. It throws an
+%% exception if the user already exists or the transaction fails.
+%%
+%% @private
+
+create(User) ->
+    Username = internal_user:get_username(User),
+    rabbit_db:run(
+      #{mnesia => fun() -> create_in_mnesia(Username, User) end}).
+
+create_in_mnesia(Username, User) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> create_in_mnesia_tx(Username, User) end).
+
+create_in_mnesia_tx(Username, User) ->
+    case mnesia:wread({?MNESIA_TABLE, Username}) of
+        [] -> ok = mnesia:write(?MNESIA_TABLE, User, write);
+        _  -> mnesia:abort({user_already_exists, Username})
+    end.
+
+%% -------------------------------------------------------------------
+%% update().
+%% -------------------------------------------------------------------
+
+-spec update(Username, UpdateFun) -> ok when
+      Username :: internal_user:username(),
+      User :: internal_user:internal_user(),
+      UpdateFun :: fun((User) -> User).
+%% @doc Updates an existing internal user record using `UpdateFun'.
+%%
+%% @private
+
+update(Username, UpdateFun)
+  when is_binary(Username) andalso is_function(UpdateFun, 1) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> update_in_mnesia(Username, UpdateFun) end}).
+
+update_in_mnesia(Username, UpdateFun) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> update_in_mnesia_tx(Username, UpdateFun) end).
+
+update_in_mnesia_tx(Username, UpdateFun) ->
+    case mnesia:wread({?MNESIA_TABLE, Username}) of
+        [User0] ->
+            User1 = UpdateFun(User0),
+            ok = mnesia:write(?MNESIA_TABLE, User1, write);
+        [] ->
+            mnesia:abort({no_such_user, Username})
+    end.
+
+%% -------------------------------------------------------------------
+%% get_all().
+%% -------------------------------------------------------------------
+
+-spec get_all() -> [User] when
+      User :: internal_user:internal_user().
+%% @doc Returns all user records.
+%%
+%% @returns the list of internal user records.
+%%
+%% @private
+
+get_all() ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_all_in_mnesia() end}).
+
+get_all_in_mnesia() ->
+    mnesia:dirty_match_object(
+      ?MNESIA_TABLE,
+      internal_user:pattern_match_all()).
+
+%% -------------------------------------------------------------------
+%% with_fun_in_*().
+%% -------------------------------------------------------------------
+
+-spec with_fun_in_mnesia_tx(Username, TxFun) -> Fun when
+      Username :: internal_user:username(),
+      TxFun :: fun(() -> Ret),
+      Fun :: fun(() -> Ret),
+      Ret :: any().
+%% @doc Returns a function, calling `TxFun' only if the user named `Username'
+%% exists.
+%%
+%% The returned function must be used inside a Mnesia transaction.
+%%
+%% @returns a function calling `TxFun' only if the user exists.
+%%
+%% @private
+
+with_fun_in_mnesia_tx(Username, TxFun)
+  when is_binary(Username) andalso is_function(TxFun, 0) ->
+    fun() ->
+            ?assert(mnesia:is_transaction()),
+            case mnesia:read({?MNESIA_TABLE, Username}) of
+                [_User] -> TxFun();
+                []      -> mnesia:abort({no_such_user, Username})
+            end
+    end.
+
+%% -------------------------------------------------------------------
+%% get_user_permissions().
+%% -------------------------------------------------------------------
+
+-spec get_user_permissions(Username, VHostName) -> Ret when
+      Username :: internal_user:username(),
+      VHostName :: vhost:name(),
+      Ret :: UserPermission | undefined,
+      UserPermission :: #user_permission{}.
+%% @doc Returns the user permissions for the given user in the given virtual
+%% host.
+%%
+%% @returns the user permissions record if any, or `undefined'.
+%%
+%% @private
+
+get_user_permissions(Username, VHostName)
+  when is_binary(Username) andalso is_binary(VHostName) ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() -> get_user_permissions_in_mnesia(Username, VHostName) end}).
+
+get_user_permissions_in_mnesia(Username, VHostName) ->
+    Key = #user_vhost{username     = Username,
+                      virtual_host = VHostName},
+    case mnesia:dirty_read({?PERM_MNESIA_TABLE, Key}) of
+        [UserPermission] -> UserPermission;
+        []               -> undefined
+    end.
+
+%% -------------------------------------------------------------------
+%% check_and_match_user_permissions().
+%% -------------------------------------------------------------------
+
+-spec check_and_match_user_permissions(Username, VHostName) -> Ret when
+      Username :: internal_user:username() | '_',
+      VHostName :: vhost:name() | '_',
+      Ret :: [UserPermission],
+      UserPermission :: #user_permission{}.
+%% @doc Returns the user permissions matching the given user in the given virtual
+%% host.
+%%
+%% @returns a list of user permission records.
+%%
+%% @private
+
+check_and_match_user_permissions(Username, VHostName)
+  when (is_binary(Username) orelse Username =:= '_') andalso
+       (is_binary(VHostName) orelse VHostName =:= '_') ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() -> match_user_permissions_in_mnesia(Username, VHostName) end}).
+
+match_user_permissions_in_mnesia('_' = Username, '_' = VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() ->
+              match_user_permissions_in_mnesia_tx(Username, VHostName)
+      end);
+match_user_permissions_in_mnesia('_' = Username, VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+        rabbit_db_vhost:with_fun_in_mnesia_tx(
+          VHostName,
+          fun() ->
+                  match_user_permissions_in_mnesia_tx(Username, VHostName)
+          end));
+match_user_permissions_in_mnesia(Username, '_' = VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+        with_fun_in_mnesia_tx(
+          Username,
+          fun() ->
+                  match_user_permissions_in_mnesia_tx(Username, VHostName)
+          end));
+match_user_permissions_in_mnesia(Username, VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+        with_fun_in_mnesia_tx(
+          Username,
+          rabbit_db_vhost:with_fun_in_mnesia_tx(
+            VHostName,
+            fun() ->
+                    match_user_permissions_in_mnesia_tx(Username, VHostName)
+            end))).
+
+match_user_permissions_in_mnesia_tx(Username, VHostName) ->
+    mnesia:match_object(
+      ?PERM_MNESIA_TABLE,
+      #user_permission{user_vhost = #user_vhost{
+                                       username     = Username,
+                                       virtual_host = VHostName},
+                       permission = '_'},
+      read).
+
+%% -------------------------------------------------------------------
+%% set_user_permissions().
+%% -------------------------------------------------------------------
+
+-spec set_user_permissions(UserPermission) -> ok when
+      UserPermission :: #user_permission{}.
+%% @doc Sets the user permissions for the user and virtual host set in the
+%% `UserPermission' record.
+%%
+%% @private
+
+set_user_permissions(
+  #user_permission{user_vhost = #user_vhost{username = Username,
+                                            virtual_host = VHostName}}
+  = UserPermission) ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                set_user_permissions_in_mnesia(
+                  Username, VHostName, UserPermission)
+        end}).
+
+set_user_permissions_in_mnesia(Username, VHostName, UserPermission) ->
+    rabbit_misc:execute_mnesia_transaction(
+      with_fun_in_mnesia_tx(
+        Username,
+        rabbit_db_vhost:with_fun_in_mnesia_tx(
+          VHostName,
+          fun() -> set_user_permissions_in_mnesia_tx(UserPermission) end))).
+
+set_user_permissions_in_mnesia_tx(UserPermission) ->
+    mnesia:write(?PERM_MNESIA_TABLE, UserPermission, write).
+
+%% -------------------------------------------------------------------
+%% clear_user_permissions().
+%% -------------------------------------------------------------------
+
+-spec clear_user_permissions(Username, VHostName) -> ok when
+      Username :: internal_user:username(),
+      VHostName :: vhost:name().
+%% @doc Clears the user permissions of the given user in the given virtual
+%% host.
+%%
+%% @private
+
+clear_user_permissions(Username, VHostName)
+  when is_binary(Username) andalso is_binary(VHostName) ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() -> clear_user_permissions_in_mnesia(Username, VHostName) end}).
+
+clear_user_permissions_in_mnesia(Username, VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> clear_user_permissions_in_mnesia_tx(Username, VHostName) end).
+
+clear_user_permissions_in_mnesia_tx(Username, VHostName) ->
+    mnesia:delete({?PERM_MNESIA_TABLE,
+                   #user_vhost{username     = Username,
+                               virtual_host = VHostName}}).
+
+%% -------------------------------------------------------------------
+%% clear_matching_user_permissions().
+%% -------------------------------------------------------------------
+
+-spec clear_matching_user_permissions(Username, VHostName) -> Ret when
+      Username :: internal_user:username() | '_',
+      VHostName :: vhost:name() | '_',
+      Ret :: [#user_permission{}].
+%% @doc Clears all user permissions matching arguments.
+%%
+%% @returns a list of matching user permissions.
+%%
+%% @private
+
+clear_matching_user_permissions(Username, VHostName)
+  when (is_binary(Username) orelse Username =:= '_') andalso
+       (is_binary(VHostName) orelse VHostName =:= '_') ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                clear_matching_user_permissions_in_mnesia(Username, VHostName)
+        end
+       }).
+
+clear_matching_user_permissions_in_mnesia(Username, VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() ->
+              clear_matching_user_permissions_in_mnesia_tx( Username, VHostName)
+      end).
+
+clear_matching_user_permissions_in_mnesia_tx(Username, VHostName) ->
+    [begin
+         mnesia:delete(?PERM_MNESIA_TABLE, Key, write),
+         Record
+     end
+     || #user_permission{user_vhost = Key} = Record
+        <- match_user_permissions_in_mnesia_tx(Username, VHostName)].
+
+%% -------------------------------------------------------------------
+%% get_topic_permissions().
+%% -------------------------------------------------------------------
+
+-spec get_topic_permissions(Username, VHostName, ExchangeName) -> Ret when
+      Username :: internal_topic:topicname(),
+      VHostName :: vhost:name(),
+      ExchangeName :: binary(),
+      Ret :: TopicPermission | undefined,
+      TopicPermission :: #topic_permission{}.
+%% @doc Returns the topic permissions for the given user and exchange in the
+%% given virtual host.
+%%
+%% @returns the topic permissions record if any, or `undefined'.
+%%
+%% @private
+
+get_topic_permissions(Username, VHostName, ExchangeName)
+  when is_binary(Username) andalso
+       is_binary(VHostName) andalso
+       is_binary(ExchangeName) ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                get_topic_permissions_in_mnesia(
+                  Username, VHostName, ExchangeName)
+        end}).
+
+get_topic_permissions_in_mnesia(Username, VHostName, ExchangeName) ->
+    Key = #topic_permission_key{
+             user_vhost = #user_vhost{username     = Username,
+                                      virtual_host = VHostName},
+             exchange = ExchangeName},
+    case mnesia:dirty_read({?TOPIC_PERM_MNESIA_TABLE, Key}) of
+        [TopicPermission] -> TopicPermission;
+        []                -> undefined
+    end.
+
+%% -------------------------------------------------------------------
+%% check_and_match_topic_permissions().
+%% -------------------------------------------------------------------
+
+-spec check_and_match_topic_permissions(
+        Username, VHostName, ExchangeName) -> Ret when
+      Username :: internal_user:username() | '_',
+      VHostName :: vhost:name() | '_',
+      ExchangeName :: binary() | '_',
+      Ret :: [TopicPermission],
+      TopicPermission :: #topic_permission{}.
+%% @doc Returns the topic permissions matching the given user and exchange in
+%% the given virtual host.
+%%
+%% @returns a list of topic permissions records.
+%%
+%% @private
+
+check_and_match_topic_permissions(Username, VHostName, ExchangeName)
+  when (is_binary(Username) orelse Username =:= '_') andalso
+       (is_binary(VHostName) orelse VHostName =:= '_') andalso
+       (is_binary(ExchangeName) orelse ExchangeName =:= '_') ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                match_topic_permissions_in_mnesia(
+                  Username, VHostName, ExchangeName)
+        end}).
+
+match_topic_permissions_in_mnesia(
+  '_' = Username, '_' = VHostName, ExchangeName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() ->
+              match_topic_permissions_in_mnesia_tx(
+                Username, VHostName, ExchangeName)
+      end);
+match_topic_permissions_in_mnesia(
+  '_' = Username, VHostName, ExchangeName) ->
+    rabbit_misc:execute_mnesia_transaction(
+        rabbit_db_vhost:with_fun_in_mnesia_tx(
+          VHostName,
+          fun() ->
+                  match_topic_permissions_in_mnesia_tx(
+                    Username, VHostName, ExchangeName)
+          end));
+match_topic_permissions_in_mnesia(
+  Username, '_' = VHostName, ExchangeName) ->
+    rabbit_misc:execute_mnesia_transaction(
+        with_fun_in_mnesia_tx(
+          Username,
+          fun() ->
+                  match_topic_permissions_in_mnesia_tx(
+                    Username, VHostName, ExchangeName)
+          end));
+match_topic_permissions_in_mnesia(
+  Username, VHostName, ExchangeName) ->
+    rabbit_misc:execute_mnesia_transaction(
+        with_fun_in_mnesia_tx(
+          Username,
+          rabbit_db_vhost:with_fun_in_mnesia_tx(
+            VHostName,
+            fun() ->
+                    match_topic_permissions_in_mnesia_tx(
+                      Username, VHostName, ExchangeName)
+            end))).
+
+match_topic_permissions_in_mnesia_tx(Username, VHostName, ExchangeName) ->
+    mnesia:match_object(
+      ?TOPIC_PERM_MNESIA_TABLE,
+      #topic_permission{
+         topic_permission_key = #topic_permission_key{
+                                   user_vhost = #user_vhost{
+                                                   username     = Username,
+                                                   virtual_host = VHostName},
+                                   exchange = ExchangeName},
+         permission = '_'},
+      read).
+
+%% -------------------------------------------------------------------
+%% set_topic_permissions().
+%% -------------------------------------------------------------------
+
+-spec set_topic_permissions(TopicPermission) -> ok when
+      TopicPermission :: #topic_permission{}.
+%% @doc Sets the permissions for the user, virtual host and exchange set in
+%% the `TopicPermission' record.
+%%
+%% @private
+
+set_topic_permissions(
+  #topic_permission{
+     topic_permission_key =
+     #topic_permission_key{
+        user_vhost = #user_vhost{username = Username,
+                                 virtual_host = VHostName}}}
+  = TopicPermission) ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                set_topic_permissions_in_mnesia(
+                  Username, VHostName, TopicPermission)
+        end}).
+
+set_topic_permissions_in_mnesia(Username, VHostName, TopicPermission) ->
+    rabbit_misc:execute_mnesia_transaction(
+      with_fun_in_mnesia_tx(
+        Username,
+        rabbit_db_vhost:with_fun_in_mnesia_tx(
+          VHostName,
+          fun() ->
+                  set_topic_permissions_in_mnesia_tx(TopicPermission)
+          end))).
+
+set_topic_permissions_in_mnesia_tx(TopicPermission) ->
+    mnesia:write(?TOPIC_PERM_MNESIA_TABLE, TopicPermission, write).
+
+%% -------------------------------------------------------------------
+%% clear_topic_permissions().
+%% -------------------------------------------------------------------
+
+-spec clear_topic_permissions(Username, VHostName, ExchangeName) -> ok when
+      Username :: internal_user:username(),
+      VHostName :: vhost:name(),
+      ExchangeName :: binary() | '_'.
+%% @doc Clears the topic permissions of the given user and exchange in the
+%% given virtual host and exchange.
+%%
+%% @private
+
+clear_topic_permissions(Username, VHostName, ExchangeName)
+  when is_binary(Username) andalso is_binary(VHostName) andalso
+       (is_binary(ExchangeName) orelse ExchangeName =:= '_') ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                clear_topic_permissions_in_mnesia(
+                  Username, VHostName, ExchangeName)
+        end}).
+
+clear_topic_permissions_in_mnesia(Username, VHostName, ExchangeName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() ->
+              clear_topic_permissions_in_mnesia_tx(
+                Username, VHostName, ExchangeName)
+      end).
+
+clear_topic_permissions_in_mnesia_tx(Username, VHostName, ExchangeName) ->
+    delete_topic_permission_in_mnesia_tx(Username, VHostName, ExchangeName).
+
+%% -------------------------------------------------------------------
+%% clear_matching_topic_permissions().
+%% -------------------------------------------------------------------
+
+-spec clear_matching_topic_permissions(Username, VHostName, ExchangeName) ->
+    Ret when
+      Username :: internal_topic:topicname() | '_',
+      VHostName :: vhost:name() | '_',
+      ExchangeName :: binary() | '_',
+      Ret :: [#topic_permission{}].
+%% @doc Clears all topic permissions matching arguments.
+%%
+%% @returns a list of matching topic permissions.
+%%
+%% @private
+
+clear_matching_topic_permissions(Username, VHostName, ExchangeName)
+  when (is_binary(Username) orelse Username =:= '_') andalso
+       (is_binary(VHostName) orelse VHostName =:= '_') andalso
+       (is_binary(ExchangeName) orelse ExchangeName =:= '_') ->
+    rabbit_db:run(
+      #{mnesia =>
+        fun() ->
+                clear_matching_topic_permissions_in_mnesia(
+                  Username, VHostName, ExchangeName)
+        end}).
+
+clear_matching_topic_permissions_in_mnesia(
+  Username, VHostName, ExchangeName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() ->
+              clear_matching_topic_permissions_in_mnesia_tx(
+                Username, VHostName, ExchangeName)
+      end).
+
+clear_matching_topic_permissions_in_mnesia_tx(
+  Username, VHostName, ExchangeName) ->
+    [begin
+         mnesia:delete(?TOPIC_PERM_MNESIA_TABLE, Key, write),
+         Record
+     end
+     || #topic_permission{topic_permission_key = Key} = Record
+        <- match_topic_permissions_in_mnesia_tx(
+             Username, VHostName, ExchangeName)].
+
+%% -------------------------------------------------------------------
+%% delete().
+%% -------------------------------------------------------------------
+
+-spec delete(Username) -> Existed when
+      Username :: internal_user:username(),
+      Existed :: boolean().
+%% @doc Deletes a user and its permissions from the database.
+%%
+%% @returns a boolean indicating if the user existed. It throws an exception
+%% if the transaction fails.
+%%
+%% @private
+
+delete(Username) when is_binary(Username) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> delete_in_mnesia(Username) end}).
+
+delete_in_mnesia(Username) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> delete_in_mnesia_tx(Username) end).
+
+delete_in_mnesia_tx(Username) ->
+    Existed = mnesia:wread({?MNESIA_TABLE, Username}) =/= [],
+    delete_user_in_mnesia_tx(Username),
+    delete_user_permission_in_mnesia_tx(Username, '_'),
+    delete_topic_permission_in_mnesia_tx(Username, '_', '_'),
+    Existed.
+
+delete_user_in_mnesia_tx(Username) ->
+    mnesia:delete({?MNESIA_TABLE, Username}).
+
+delete_user_permission_in_mnesia_tx(Username, VHostName) ->
+    Pattern = user_permission_pattern(Username, VHostName),
+    _ = [mnesia:delete_object(?PERM_MNESIA_TABLE, R, write) ||
+         R <- mnesia:match_object(?PERM_MNESIA_TABLE, Pattern, write)],
+    ok.
+
+delete_topic_permission_in_mnesia_tx(Username, VHostName, ExchangeName) ->
+    Pattern = topic_permission_pattern(Username, VHostName, ExchangeName),
+    _ = [mnesia:delete_object(?TOPIC_PERM_MNESIA_TABLE, R, write) ||
+         R <- mnesia:match_object(?TOPIC_PERM_MNESIA_TABLE, Pattern, write)],
+    ok.
+
+user_permission_pattern(Username, VHostName) ->
+    #user_permission{user_vhost = #user_vhost{
+                                     username = Username,
+                                     virtual_host = VHostName},
+                     permission = '_'}.
+
+topic_permission_pattern(Username, VHostName, ExchangeName) ->
+    #topic_permission{
+             topic_permission_key =
+             #topic_permission_key{
+                user_vhost = #user_vhost{
+                                username     = Username,
+                                virtual_host = VHostName},
+                exchange = ExchangeName},
+             permission = '_'}.

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -1,0 +1,319 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_db_vhost).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("rabbit_common/include/logging.hrl").
+
+-include("vhost.hrl").
+
+-export([create_or_get/3,
+         merge_metadata/2,
+         set_tags/2,
+         exists/1,
+         get/1,
+         get_all/0,
+         list/0,
+         update/2,
+         with_fun_in_mnesia_tx/2,
+         delete/1]).
+
+-define(MNESIA_TABLE, rabbit_vhost).
+
+%% -------------------------------------------------------------------
+%% create_or_get().
+%% -------------------------------------------------------------------
+
+-spec create_or_get(VHostName, Limits, Metadata) -> Ret when
+      VHostName :: vhost:name(),
+      Limits :: vhost:limits(),
+      Metadata :: vhost:metadata(),
+      Ret :: {existing | new, VHost},
+      VHost :: vhost:vhost().
+%% @doc Writes a virtual host record if it doesn't exist already or returns
+%% the existing one.
+%%
+%% @returns the existing record if there is one in the database already, or
+%% the newly created record. It throws an exception if the transaction fails.
+%%
+%% @private
+
+create_or_get(VHostName, Limits, Metadata)
+  when is_binary(VHostName) andalso
+       is_list(Limits) andalso
+       is_map(Metadata) ->
+    VHost = vhost:new(VHostName, Limits, Metadata),
+    rabbit_db:run(
+      #{mnesia => fun() -> create_or_get_in_mnesia(VHostName, VHost) end}).
+
+create_or_get_in_mnesia(VHostName, VHost) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> create_or_get_in_mnesia_tx(VHostName, VHost) end).
+
+create_or_get_in_mnesia_tx(VHostName, VHost) ->
+    case mnesia:wread({?MNESIA_TABLE, VHostName}) of
+        [] ->
+            mnesia:write(?MNESIA_TABLE, VHost, write),
+            {new, VHost};
+
+        %% the vhost already exists
+        [ExistingVHost] ->
+            {existing, ExistingVHost}
+    end.
+
+%% -------------------------------------------------------------------
+%% merge_metadata().
+%% -------------------------------------------------------------------
+
+-spec merge_metadata(VHostName, Metadata) -> Ret when
+      VHostName :: vhost:name(),
+      Metadata :: vhost:metadata(),
+      Ret :: {ok, VHost} | {error, {no_such_vhost, VHostName}},
+      VHost :: vhost:vhost().
+%% @doc Updates the metadata of an existing virtual host record.
+%%
+%% @returns `{ok, VHost}' with the updated record if the record existed and
+%% the update succeeded or an error tuple if the record didn't exist. It
+%% throws an exception if the transaction fails.
+%%
+%% @private
+
+merge_metadata(VHostName, Metadata)
+  when is_binary(VHostName) andalso is_map(Metadata) ->
+    case do_merge_metadata(VHostName, Metadata) of
+        {ok, VHost} when ?is_vhost(VHost) ->
+            rabbit_log:debug("Updated a virtual host record ~tp", [VHost]),
+            {ok, VHost};
+        {error, _} = Error ->
+            Error
+    end.
+
+do_merge_metadata(VHostName, Metadata) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> merge_metadata_in_mnesia(VHostName, Metadata) end}).
+
+merge_metadata_in_mnesia(VHostName, Metadata) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> merge_metadata_in_mnesia_tx(VHostName, Metadata) end).
+
+merge_metadata_in_mnesia_tx(VHostName, Metadata) ->
+    case mnesia:wread({?MNESIA_TABLE, VHostName}) of
+        [] ->
+            {error, {no_such_vhost, VHostName}};
+        [VHost0] when ?is_vhost(VHost0) ->
+            VHost1 = vhost:merge_metadata(VHost0, Metadata),
+            ?assert(?is_vhost(VHost1)),
+            mnesia:write(?MNESIA_TABLE, VHost1, write),
+            {ok, VHost1}
+    end.
+
+%% -------------------------------------------------------------------
+%% set_tags().
+%% -------------------------------------------------------------------
+
+-spec set_tags(VHostName, Tags) -> VHost when
+      VHostName :: vhost:name(),
+      Tags :: [vhost:tags() | binary() | string()],
+      VHost :: vhost:vhost().
+%% @doc Sets the tags of an existing virtual host record.
+%%
+%% @returns the updated virtual host record if the record existed and the
+%% update succeeded. It throws an exception if the transaction fails.
+%%
+%% @private
+
+set_tags(VHostName, Tags)
+  when is_binary(VHostName) andalso is_list(Tags) ->
+    ConvertedTags = [rabbit_data_coercion:to_atom(Tag) || Tag <- Tags],
+    rabbit_db:run(
+      #{mnesia => fun() -> set_tags_in_mnesia(VHostName, ConvertedTags) end}).
+
+set_tags_in_mnesia(VHostName, Tags) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> set_tags_in_mnesia_tx(VHostName, Tags) end).
+
+set_tags_in_mnesia_tx(VHostName, Tags) ->
+    UpdateFun = fun(VHost) -> do_set_tags(VHost, Tags) end,
+    update_in_mnesia_tx(VHostName, UpdateFun).
+
+do_set_tags(VHost, Tags) when ?is_vhost(VHost) andalso is_list(Tags) ->
+    Metadata0 = vhost:get_metadata(VHost),
+    Metadata1 = Metadata0#{tags => Tags},
+    vhost:set_metadata(VHost, Metadata1).
+
+%% -------------------------------------------------------------------
+%% exists().
+%% -------------------------------------------------------------------
+
+-spec exists(VHostName) -> Exists when
+      VHostName :: vhost:name(),
+      Exists :: boolean().
+%% @doc Indicates if the virtual host named `VHostName' exists.
+%%
+%% @returns true if the virtual host exists, false otherwise.
+%%
+%% @private
+
+exists(VHostName) when is_binary(VHostName) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> exists_in_mnesia(VHostName) end}).
+
+exists_in_mnesia(VHostName) ->
+    mnesia:dirty_read({?MNESIA_TABLE, VHostName}) /= [].
+
+%% -------------------------------------------------------------------
+%% get().
+%% -------------------------------------------------------------------
+
+-spec get(VHostName) -> VHost | undefined when
+      VHostName :: vhost:name(),
+      VHost :: vhost:vhost().
+%% @doc Returns the record of the virtual host named `VHostName'.
+%%
+%% @returns the virtual host record or `undefined' if no virtual host is named
+%% `VHostName'.
+%%
+%% @private
+
+get(VHostName) when is_binary(VHostName) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_in_mnesia(VHostName) end}).
+
+get_in_mnesia(VHostName) ->
+    case mnesia:dirty_read({?MNESIA_TABLE, VHostName}) of
+        [VHost] when ?is_vhost(VHost) -> VHost;
+        []                            -> undefined
+    end.
+
+%% -------------------------------------------------------------------
+%% get_all().
+%% -------------------------------------------------------------------
+
+-spec get_all() -> [VHost] when
+      VHost :: vhost:vhost().
+%% @doc Returns all virtual host records.
+%%
+%% @returns the list of all virtual host records.
+%%
+%% @private
+
+get_all() ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_all_in_mnesia() end}).
+
+get_all_in_mnesia() ->
+    mnesia:dirty_match_object(?MNESIA_TABLE, vhost:pattern_match_all()).
+
+%% -------------------------------------------------------------------
+%% list().
+%% -------------------------------------------------------------------
+
+-spec list() -> [VHostName] when
+      VHostName :: vhost:name().
+%% @doc Lists the names of all virtual hosts.
+%%
+%% @returns a list of virtual host names.
+%%
+%% @private
+
+list() ->
+    rabbit_db:run(
+      #{mnesia => fun() -> list_in_mnesia() end}).
+
+list_in_mnesia() ->
+    mnesia:dirty_all_keys(?MNESIA_TABLE).
+
+%% -------------------------------------------------------------------
+%% update_in_*tx().
+%% -------------------------------------------------------------------
+
+-spec update(VHostName, UpdateFun) -> VHost when
+      VHostName :: vhost:name(),
+      UpdateFun :: fun((VHost) -> VHost),
+      VHost :: vhost:vhost().
+%% @doc Updates an existing virtual host record using the result of
+%% `UpdateFun'.
+%%
+%% @returns the updated virtual host record if the record existed and the
+%% update succeeded. It throws an exception if the transaction fails.
+%%
+%% @private
+
+update(VHostName, UpdateFun)
+  when is_binary(VHostName) andalso is_function(UpdateFun, 1) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> update_in_mnesia(VHostName, UpdateFun) end}).
+
+update_in_mnesia(VHostName, UpdateFun) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> update_in_mnesia_tx(VHostName, UpdateFun) end).
+
+update_in_mnesia_tx(VHostName, UpdateFun)
+  when is_binary(VHostName) andalso is_function(UpdateFun, 1) ->
+    case mnesia:wread({?MNESIA_TABLE, VHostName}) of
+        [VHost0] when ?is_vhost(VHost0) ->
+            VHost1 = UpdateFun(VHost0),
+            mnesia:write(?MNESIA_TABLE, VHost1, write),
+            VHost1;
+        [] ->
+            mnesia:abort({no_such_vhost, VHostName})
+    end.
+
+%% -------------------------------------------------------------------
+%% with_fun_in_*_tx().
+%% -------------------------------------------------------------------
+
+-spec with_fun_in_mnesia_tx(VHostName, TxFun) -> Fun when
+      VHostName :: vhost:name(),
+      TxFun :: fun(() -> Ret),
+      Fun :: fun(() -> Ret),
+      Ret :: any().
+%% @doc Returns a function, calling `TxFun' only if the virtual host named
+%% `VHostName' exists.
+%%
+%% The returned function must be used inside a Mnesia transaction.
+%%
+%% @returns a function calling `TxFun' only if the virtual host exists.
+%%
+%% @private
+
+with_fun_in_mnesia_tx(VHostName, TxFun)
+  when is_binary(VHostName) andalso is_function(TxFun, 0) ->
+    fun() ->
+            ?assert(mnesia:is_transaction()),
+            case mnesia:read({?MNESIA_TABLE, VHostName}) of
+                [_VHost] -> TxFun();
+                []       -> mnesia:abort({no_such_vhost, VHostName})
+            end
+    end.
+
+%% -------------------------------------------------------------------
+%% delete().
+%% -------------------------------------------------------------------
+
+-spec delete(VHostName) -> ok when
+      VHostName :: vhost:name().
+%% @doc Deletes a virtual host record.
+%%
+%% @returns `ok', even if the record didn't exist before. It throws an
+%% exception if the transaction fails.
+%%
+%% @private
+
+delete(VHostName) when is_binary(VHostName) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> delete_in_mnesia(VHostName) end}).
+
+delete_in_mnesia(VHostName) ->
+    rabbit_misc:execute_mnesia_transaction(
+      fun() -> delete_in_mnesia_tx(VHostName) end).
+
+delete_in_mnesia_tx(VHostName) ->
+    mnesia:delete({?MNESIA_TABLE, VHostName}),
+    ok.

--- a/deps/rabbit/src/rabbit_vhost_limit.erl
+++ b/deps/rabbit/src/rabbit_vhost_limit.erl
@@ -183,13 +183,9 @@ vhost_limit_validation() ->
      {<<"max-queues">>,      fun rabbit_parameter_validation:integer/2, optional}].
 
 update_vhost(VHostName, Limits) ->
-    rabbit_misc:execute_mnesia_transaction(
-      fun() ->
-              rabbit_vhost:update(VHostName,
-                                  fun(VHost) ->
-                                          rabbit_vhost:set_limits(VHost, Limits)
-                                  end)
-      end),
+    _ = rabbit_db_vhost:update(
+          VHostName,
+          fun(VHost) -> rabbit_vhost:set_limits(VHost, Limits) end),
     ok.
 
 get_limit(VirtualHost, Limit) ->

--- a/deps/rabbit/src/rabbit_vhost_limit.erl
+++ b/deps/rabbit/src/rabbit_vhost_limit.erl
@@ -152,7 +152,7 @@ parse_set(VHost, Defn, ActingUser) ->
                 rabbit_misc:format("Could not parse JSON document: ~tp", [Reason])}
     end.
 
--spec set(rabbit_types:name(), {binary(), binary()}, rabbit_types:user() | rabbit_types:username()) ->
+-spec set(vhost:name(), [{binary(), binary()}], rabbit_types:user() | rabbit_types:username()) ->
     rabbit_runtime_parameters:ok_or_error_string().
 set(VHost, Defn, ActingUser) ->
     rabbit_runtime_parameters:set_any(VHost, <<"vhost-limits">>,

--- a/deps/rabbit/src/rabbit_vhost_process.erl
+++ b/deps/rabbit/src/rabbit_vhost_process.erl
@@ -15,8 +15,8 @@
 
 %% On termination, the ptocess will notify of vhost going down.
 
-%% The process will also check periodically if the vhost still
-%% present in mnesia DB and stop the vhost supervision tree when it
+%% The process will also check periodically if the vhost is still
+%% present in the database and stop the vhost supervision tree when it
 %% disappears.
 
 -module(rabbit_vhost_process).

--- a/deps/rabbit/src/vhost.erl
+++ b/deps/rabbit/src/vhost.erl
@@ -36,11 +36,16 @@
 
 -type(name() :: binary()).
 
+-type(limits() :: list()).
+
 -type(metadata_key() :: atom()).
 
--type(metadata() :: #{description => binary(),
-                      tags => [atom()],
+-type(metadata() :: #{description => description(),
+                      tags => [tag()],
                       metadata_key() => any()} | undefined).
+
+-type(description() :: binary()).
+-type(tag() :: atom()).
 
 -type vhost() :: vhost_v2().
 
@@ -48,13 +53,13 @@
     %% name as a binary
     virtual_host :: name() | '_',
     %% proplist of limits configured, if any
-    limits :: list() | '_',
+    limits :: limits() | '_',
     metadata :: metadata() | '_'
 }).
 
 -type vhost_v2() :: #vhost{
                           virtual_host :: name(),
-                          limits :: list(),
+                          limits :: limits(),
                           metadata :: metadata()
                          }.
 
@@ -66,18 +71,21 @@
                                  }.
 
 -export_type([name/0,
+              limits/0,
               metadata_key/0,
               metadata/0,
+              description/0,
+              tag/0,
               vhost/0,
               vhost_v2/0,
               vhost_pattern/0,
               vhost_v2_pattern/0]).
 
--spec new(name(), list()) -> vhost().
+-spec new(name(), limits()) -> vhost().
 new(Name, Limits) ->
     #vhost{virtual_host = Name, limits = Limits}.
 
--spec new(name(), list(), map()) -> vhost().
+-spec new(name(), limits(), metadata()) -> vhost().
 new(Name, Limits, Metadata) ->
     #vhost{virtual_host = Name, limits = Limits, metadata = Metadata}.
 
@@ -119,7 +127,7 @@ pattern_match_all() ->
 -spec get_name(vhost()) -> name().
 get_name(#vhost{virtual_host = Value}) -> Value.
 
--spec get_limits(vhost()) -> list().
+-spec get_limits(vhost()) -> limits().
 get_limits(#vhost{limits = Value}) -> Value.
 
 -spec get_metadata(vhost()) -> metadata().
@@ -129,7 +137,7 @@ get_metadata(#vhost{metadata = Value}) -> Value.
 get_description(#vhost{} = VHost) ->
     maps:get(description, get_metadata(VHost), undefined).
 
--spec get_tags(vhost()) -> [atom()].
+-spec get_tags(vhost()) -> [tag()].
 get_tags(#vhost{} = VHost) ->
     maps:get(tags, get_metadata(VHost), undefined).
 
@@ -152,6 +160,6 @@ merge_metadata(VHost, Value) ->
     NewMeta = maps:merge(Meta0, Value),
     VHost#vhost{metadata = NewMeta}.
 
--spec is_tagged_with(vhost:vhost(), atom()) -> boolean().
+-spec is_tagged_with(vhost:vhost(), tag()) -> boolean().
 is_tagged_with(VHost, Tag) ->
     lists:member(Tag, get_tags(VHost)).

--- a/deps/rabbit/test/topic_permission_SUITE.erl
+++ b/deps/rabbit/test/topic_permission_SUITE.erl
@@ -127,11 +127,11 @@ topic_permission_database_access1(_Config) ->
     )),
 
     {error, {no_such_user, _}} = (catch rabbit_auth_backend_internal:list_user_topic_permissions(
-        "non-existing-user"
+        <<"non-existing-user">>
     )),
 
     {error, {no_such_vhost, _}} = (catch rabbit_auth_backend_internal:list_vhost_topic_permissions(
-        "non-existing-vhost"
+        <<"non-existing-vhost">>
     )),
 
     {error, {invalid_regexp, _, _}} = (catch rabbit_auth_backend_internal:set_topic_permissions(

--- a/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
@@ -63,6 +63,7 @@ defmodule AddVhostCommandTest do
     assert match?({:badrpc, _}, @command.run(["na"], opts))
   end
 
+  @tag vhost: @vhost
   test "run: adding the same host twice is idempotent", context do
     add_vhost(context[:vhost])
 

--- a/deps/rabbitmq_cli/test/ctl/clear_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_permissions_command_test.exs
@@ -55,10 +55,9 @@ defmodule ClearPermissionsTest do
     assert @command.validate(["too", "many"], %{}) == {:validation_failure, :too_many_args}
   end
 
-  @tag user: "fake_user"
-  test "run: can't clear permissions for non-existing user", context do
-    assert @command.run([context[:user]], context[:opts]) ==
-             {:error, {:no_such_user, context[:user]}}
+  @tag user: "fake_user", vhost: @default_vhost
+  test "run: clearing permissions for non-existing user still succeeds", context do
+    assert @command.run([context[:user]], context[:opts]) == :ok
   end
 
   @tag user: @user, vhost: @default_vhost
@@ -85,9 +84,8 @@ defmodule ClearPermissionsTest do
   end
 
   @tag user: @user, vhost: "bad_vhost"
-  test "run: on an invalid vhost, return no_such_vhost error", context do
-    assert @command.run([context[:user]], context[:opts]) ==
-             {:error, {:no_such_vhost, context[:vhost]}}
+  test "run: clearing permissions on a non-existent vhost still succeeds", context do
+    assert @command.run([context[:user]], context[:opts]) == :ok
   end
 
   @tag user: @user, vhost: @specific_vhost

--- a/deps/rabbitmq_cli/test/ctl/clear_topic_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_topic_permissions_command_test.exs
@@ -58,16 +58,14 @@ defmodule ClearTopicPermissionsTest do
              {:validation_failure, :too_many_args}
   end
 
-  @tag user: "fake_user"
-  test "run: can't clear topic permissions for non-existing user", context do
-    assert @command.run([context[:user]], context[:opts]) ==
-             {:error, {:no_such_user, context[:user]}}
+  @tag user: "fake_user", vhost: @specific_vhost
+  test "run: clearing topic permissions for non-existing user still succeeds", context do
+    assert @command.run([context[:user]], context[:opts]) == :ok
   end
 
   @tag user: @user, vhost: "bad_vhost"
-  test "run: on an invalid vhost, return no_such_vhost error", context do
-    assert @command.run([context[:user]], context[:opts]) ==
-             {:error, {:no_such_vhost, context[:vhost]}}
+  test "run: clearing topic permissions on an invalid vhost still succeeds", context do
+    assert @command.run([context[:user]], context[:opts]) == :ok
   end
 
   @tag user: @user, vhost: @specific_vhost

--- a/deps/rabbitmq_cli/test/ctl/delete_user_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/delete_user_command_test.exs
@@ -45,8 +45,8 @@ defmodule DeleteUserCommandTest do
   end
 
   @tag user: @user
-  test "run: An invalid username returns an error", context do
-    assert @command.run(["no_one"], context[:opts]) == {:error, {:no_such_user, "no_one"}}
+  test "run: deleting a non-existing user still succeeds", context do
+    assert @command.run(["no_one"], context[:opts]) == :ok
   end
 
   @tag user: @user

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_tags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_tags_command_test.exs
@@ -48,10 +48,10 @@ defmodule SetVhostTagsCommandTest do
     result =
       Enum.find(
         list_vhosts(),
-        fn record -> record[:vhost] == context[:vhost] end
+        fn record -> record[:name] == context[:vhost] end
       )
 
-    assert result[:tags] == context[:tags]
+    assert result[:tags] == [:qa]
   end
 
   @tag vhost: "non/ex1st3nT"
@@ -64,7 +64,7 @@ defmodule SetVhostTagsCommandTest do
            ) == {:error, {:no_such_vhost, context[:vhost]}}
   end
 
-  @tag user: @vhost, tags: [:qa, :limited]
+  @tag vhost: @vhost, tags: [:qa, :limited]
   test "run: with multiple optional arguments, adds multiple tags", context do
     @command.run(
       [context[:vhost] | context[:tags]],
@@ -74,13 +74,13 @@ defmodule SetVhostTagsCommandTest do
     result =
       Enum.find(
         list_vhosts(),
-        fn record -> record[:vhost] == context[:vhost] end
+        fn record -> record[:name] == context[:vhost] end
       )
 
     assert result[:tags] == context[:tags]
   end
 
-  @tag user: @vhost, tags: [:qa]
+  @tag vhost: @vhost, tags: [:qa]
   test "run: with no optional arguments, clears virtual host tags", context do
     set_vhost_tags(context[:vhost], context[:tags])
 
@@ -89,13 +89,13 @@ defmodule SetVhostTagsCommandTest do
     result =
       Enum.find(
         list_vhosts(),
-        fn record -> record[:vhost] == context[:vhost] end
+        fn record -> record[:name] == context[:vhost] end
       )
 
     assert result[:tags] == []
   end
 
-  @tag user: @vhost, tags: [:qa]
+  @tag vhost: @vhost, tags: [:qa]
   test "run: identical calls are idempotent", context do
     set_vhost_tags(context[:vhost], context[:tags])
 
@@ -107,13 +107,13 @@ defmodule SetVhostTagsCommandTest do
     result =
       Enum.find(
         list_vhosts(),
-        fn record -> record[:vhost] == context[:vhost] end
+        fn record -> record[:name] == context[:vhost] end
       )
 
     assert result[:tags] == context[:tags]
   end
 
-  @tag user: @vhost, old_tags: [:qa], new_tags: [:limited]
+  @tag vhost: @vhost, old_tags: [:qa], new_tags: [:limited]
   test "run: overwrites existing tags them", context do
     set_vhost_tags(context[:vhost], context[:old_tags])
 
@@ -125,13 +125,13 @@ defmodule SetVhostTagsCommandTest do
     result =
       Enum.find(
         list_vhosts(),
-        fn record -> record[:vhost] == context[:vhost] end
+        fn record -> record[:name] == context[:vhost] end
       )
 
     assert result[:tags] == context[:new_tags]
   end
 
-  @tag user: @vhost, tags: ["abc"]
+  @tag vhost: @vhost, tags: ["abc"]
   test "banner", context do
     assert @command.banner(
              [context[:vhost] | context[:tags]],

--- a/deps/rabbitmq_cli/test/rabbitmqctl_test.exs
+++ b/deps/rabbitmq_cli/test/rabbitmqctl_test.exs
@@ -164,8 +164,8 @@ defmodule RabbitMQCtlTest do
   end
 
   test "a command that fails with an error exits with a reasonable error code" do
-    command = ["delete_user", "voldemort"]
-    capture_io(:stderr, fn -> error_check(command, exit_nouser()) end)
+    command = ["set_vhost_tags", "voldemort", "mytag"]
+    capture_io(:stderr, fn -> error_check(command, exit_dataerr()) end)
   end
 
   test "a mcommand with an unsupported option as the first command-line arg fails gracefully" do

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_parameter.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_parameter.erl
@@ -71,8 +71,18 @@ accept_content(ReqData0, Context = #context{user = User}) ->
     end.
 
 delete_resource(ReqData, Context = #context{user = #user{username = Username}}) ->
-    ok = rabbit_runtime_parameters:clear(
-           rabbit_mgmt_util:vhost(ReqData), component(ReqData), name(ReqData), Username),
+    VHostName = rabbit_mgmt_util:vhost(ReqData),
+    Comp = component(ReqData),
+    Name = name(ReqData),
+    if
+        VHostName =/= not_found andalso
+        Comp =/= none andalso
+        Name =/= none ->
+            ok = rabbit_runtime_parameters:clear(
+                   VHostName, Comp, Name, Username);
+        true ->
+            ok
+    end,
     {true, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->
@@ -81,8 +91,17 @@ is_authorized(ReqData, Context) ->
 %%--------------------------------------------------------------------
 
 parameter(ReqData) ->
-    rabbit_runtime_parameters:lookup(
-      rabbit_mgmt_util:vhost(ReqData), component(ReqData), name(ReqData)).
+    VHostName = rabbit_mgmt_util:vhost(ReqData),
+    Comp = component(ReqData),
+    Name = name(ReqData),
+    if
+        VHostName =/= not_found andalso
+        Comp =/= none andalso
+        Name =/= none ->
+            rabbit_runtime_parameters:lookup(VHostName, Comp, Name);
+        true ->
+            not_found
+    end.
 
 component(ReqData) -> rabbit_mgmt_util:id(component, ReqData).
 name(ReqData)      -> rabbit_mgmt_util:id(name, ReqData).


### PR DESCRIPTION
The idea is to isolate in those modules the code to handle the records in the database. For now, we only support Mnesia, but there is work in progress to move to another database engine. Doing this reorganization of the code will also isolate the changes of this upcoming database engine switch, making them easier to rebase and review.

In the end, the `rabbit_db*` modules should export functions for each operations we want to perform. Things like "add this record", "list records matching that", "update a record using an anonymous function inside a transaction", etc.

Only the following subsystems are impacted in this commit:
* virtual vhosts
* internal users
* runtime parameters

They were modified together because they depend on each other.