### PR TITLE
Filter out global runtime parameters not meant to be exposed

### DIFF
--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -60,6 +60,9 @@
 -import(rabbit_misc, [pget/2]).
 
 -define(TABLE, rabbit_runtime_parameters).
+-define(INTERNAL_RUNTIME_PARAMETER_NAMES, [
+    imported_definition_hash_value
+]).
 
 %%---------------------------------------------------------------------------
 
@@ -293,12 +296,18 @@ list(VHost, Component) ->
 
 list_global() ->
     %% list only atom keys
-    mnesia:async_dirty(
+    All = mnesia:async_dirty(
         fun () ->
             Match = #runtime_parameters{key = '_', _ = '_'},
             [p(P) || P <- mnesia:match_object(?TABLE, Match, read),
                 is_atom(P#runtime_parameters.key)]
-        end).
+        end),
+    %% filter out global parameters that are not meant to be exposed
+    %% publicly
+    lists:filter(fun(PL) ->
+                    Name = proplists:get_value(name, PL),
+                    not lists:member(Name, ?INTERNAL_RUNTIME_PARAMETER_NAMES)
+                 end, All).
 
 -spec list_formatted(rabbit_types:vhost()) -> [rabbit_types:infos()].
 


### PR DESCRIPTION
The parameter used by the definitions.skip_if_unchanged was never meant to be publicly exposed.

It's too late to conceal internal cluster ID and it hasn't introduced any issues, so let's keep out of the list of internal parameters.

Backporting as far as #4062 was: so, `v3.10.x`.

Closes #6424.

