### PR TITLE
Streams rebalancing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -236,7 +236,7 @@ erlang_package.hex_package(
 
 erlang_package.git_package(
     repository = "rabbitmq/osiris",
-    tag = "v1.4.1",
+    tag = "v1.4.2",
 )
 
 erlang_package.hex_package(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -236,7 +236,7 @@ erlang_package.hex_package(
 
 erlang_package.git_package(
     repository = "rabbitmq/osiris",
-    tag = "v1.4.0",
+    tag = "v1.4.1",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.4.0
+dep_osiris = git https://github.com/rabbitmq/osiris v1.4.1
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.4.0
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.4.1
+dep_osiris = git https://github.com/rabbitmq/osiris v1.4.2
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.4.0
 

--- a/deps/rabbit/include/amqqueue.hrl
+++ b/deps/rabbit/include/amqqueue.hrl
@@ -33,16 +33,17 @@
 -define(amqqueue_v1_type, rabbit_classic_queue).
 
 -define(amqqueue_is_classic(Q),
-        (?is_amqqueue_v2(Q) andalso
-         ?amqqueue_v2_field_type(Q) =:= rabbit_classic_queue)).
+        ?amqqueue_type_is(Q, rabbit_classic_queue)).
 
 -define(amqqueue_is_quorum(Q),
-        (?is_amqqueue_v2(Q) andalso
-         ?amqqueue_v2_field_type(Q) =:= rabbit_quorum_queue)).
+        ?amqqueue_type_is(Q, rabbit_quorum_queue)).
 
 -define(amqqueue_is_stream(Q),
+        ?amqqueue_type_is(Q, rabbit_stream_queue)).
+
+-define(amqqueue_type_is(Q, Type),
         (?is_amqqueue_v2(Q) andalso
-         ?amqqueue_v2_field_type(Q) =:= rabbit_stream_queue)).
+         ?amqqueue_v2_field_type(Q) =:= Type)).
 
 -define(amqqueue_has_valid_pid(Q),
         (?is_amqqueue_v2(Q) andalso

--- a/deps/rabbit/src/amqqueue.erl
+++ b/deps/rabbit/src/amqqueue.erl
@@ -606,6 +606,8 @@ qnode(Queue) when ?is_amqqueue(Queue) ->
     qnode(QPid);
 qnode(QPid) when is_pid(QPid) ->
     node(QPid);
+qnode(none) ->
+    undefined;
 qnode({_, Node}) ->
     Node.
 

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -13,7 +13,7 @@
          delete_immediately/1, delete_exclusive/2, delete/4, purge/1,
          forget_all_durable/1]).
 -export([pseudo_queue/2, pseudo_queue/3, immutable/1]).
--export([exists/1, lookup/1, lookup_many/1,
+-export([exists/1, lookup/1, lookup/2, lookup_many/1,
          not_found_or_absent/1, not_found_or_absent_dirty/1,
          with/2, with/3, with_or_die/2,
          assert_equivalence/5,
@@ -383,6 +383,15 @@ lookup(Name) ->
 
 lookup_many(Names) when is_list(Names) ->
     lookup(Names).
+
+-spec lookup(binary(), binary()) ->
+    rabbit_types:ok(amqqueue:amqqueue()) |
+    rabbit_types:error('not_found').
+lookup(Name, VHost)
+  when is_binary(Name) andalso
+       is_binary(VHost) ->
+    QName = rabbit_misc:r(VHost, queue, Name),
+    lookup(QName).
 
 -spec exists(name()) -> boolean().
 exists(Name) ->

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -111,6 +111,14 @@
       depends_on    => [stream_queue]
      }}).
 
+-rabbit_feature_flag(
+   {restart_streams,
+    #{desc          => "Support for restarting streams with optional preferred next leader argument. "
+                       "Used to implement stream leader rebalancing",
+      stability     => stable,
+      depends_on    => [stream_queue]
+     }}).
+
 %% -------------------------------------------------------------------
 %% Direct exchange routing v2.
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1233,6 +1233,7 @@ grow(Node, VhostSpec, QueueSpec, Strategy) ->
         is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
         is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec) ].
 
+-spec transfer_leadership(amqqueue:amqqueue(), node()) -> {migrated, node()} | {not_migrated, atom()}.
 transfer_leadership(Q, Destination) ->
     {RaName, _} = Pid = amqqueue:get_pid(Q),
     case ra:transfer_leadership(Pid, {RaName, Destination}) of

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -159,7 +159,7 @@ restart_stream(Q, Options)
     case rabbit_feature_flags:is_enabled(restart_streams) of
         true ->
             rabbit_log:info("restarting stream ~s in vhost ~s with options ~p",
-                            [amqqueue:get_name(Q), amqqueue:get_vhost(Q), Options]),
+                            [maps:get(name, amqqueue:get_type_state(Q)), amqqueue:get_vhost(Q), Options]),
             #{name := StreamId} = amqqueue:get_type_state(Q),
             case process_command({restart_stream, StreamId, Options}) of
                 {ok, {ok, LeaderPid}, _} ->

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1163,7 +1163,6 @@ update_stream0(#{system_time := _} = Meta,
                                         N -> {writer, E};
                                         _ -> {replica, E}
                                     end,
-                             node = N,
                              state = {ready, E},
                              %% no members are running actions
                              current = undefined}
@@ -1177,8 +1176,7 @@ update_stream0(#{system_time := _} = Meta,
             reply_to = maps:get(from, Meta, undefined)};
 update_stream0(#{machine_version := MacVer} = Meta,
                {restart_stream, _StreamId, #{}},
-               #stream{members = Members0,
-                       target = _} = Stream0)
+               #stream{members = Members0} = Stream0)
   when MacVer >= 4 ->
     Members = maps:map(fun (_, M) ->
                                M#member{target = stopped}
@@ -1209,7 +1207,6 @@ update_stream0(#{system_time := _Ts} = _Meta,
             Stream0;
         false ->
             Members1 = Members0#{Node => #member{role = {replica, Epoch},
-                                                 node = Node,
                                                  target = stopped}},
             Members = set_running_to_stopped(Members1),
             Stream0#stream{members = Members,
@@ -1290,13 +1287,15 @@ update_stream0(Meta,
                        nodes = Nodes,
                        members = Members0} = Stream0) ->
     IsLeaderInCurrent = case find_leader(Members0) of
-                            {#member{role = {writer, Epoch},
-                                     target = running,
-                                     state = {ready, Epoch}}, _} ->
+                            {{_Node, #member{role = {writer, Epoch},
+                                             target = running,
+                                             state = {ready, Epoch}}},
+                             _Replicas} ->
                                 true;
-                            {#member{role = {writer, Epoch},
-                                     target = running,
-                                     state = {running, Epoch, _}}, _} ->
+                            {{_Node, #member{role = {writer, Epoch},
+                                             target = running,
+                                             state = {running, Epoch, _}}},
+                             _Replicas} ->
                                 true;
                             _ ->
                                 false
@@ -1330,9 +1329,9 @@ update_stream0(Meta,
             Members1 = Members0#{Node => Member},
 
             EpochOffsets = [{N, T}
-                            || #member{state = {stopped, E, T},
-                                       target = running,
-                                       node = N} <- maps:values(Members1),
+                            || {N, #member{state = {stopped, E, T},
+                                           target = running}}
+                               <- maps:to_list(Members1),
                                E == Epoch],
             case is_quorum(length(Nodes), length(EpochOffsets)) of
                 true ->
@@ -1453,8 +1452,7 @@ update_stream0(#{system_time := _Ts} = _Meta,
                {nodeup, Node},
                #stream{members = Members0} = Stream0) ->
     Members = maps:map(
-                fun (_, #member{node = N,
-                                current = {sleeping, nodeup}} = M)
+                fun (N, #member{current = {sleeping, nodeup}} = M)
                       when N == Node ->
                         M#member{current = undefined};
                     (_, M) ->
@@ -1513,7 +1511,8 @@ eval_listeners(MachineVersion, #stream{listeners = Listeners0,
                _OldStream, Effects0)
   when MachineVersion =< 1 ->
     case find_leader(Members) of
-        {#member{state = {running, _, LeaderPid}}, _} ->
+        {{_LeaderNode, #member{state = {running, _, LeaderPid}}},
+         _Replicas} ->
             %% a leader is running, check all listeners to see if any of them
             %% has not been notified of the current leader pid
             {Listeners, Effects} =
@@ -1628,47 +1627,47 @@ evaluate_stream(#{index := Idx} = Meta,
                         epoch = Epoch,
                         mnesia = {MnesiaTag, MnesiaEpoch},
                         members = Members0} = Stream0, Effs0) ->
-     case find_leader(Members0) of
-         {#member{state = LState,
-                  node = LeaderNode,
-                  target = deleted,
-                  current = undefined} = Writer0, Replicas}
+    case find_leader(Members0) of
+        {{LeaderNode, #member{state = LState,
+                              target = deleted,
+                              current = undefined} = Writer0},
+         Replicas}
            when LState =/= deleted ->
              Action = {aux, {delete_member, StreamId, LeaderNode,
-                             make_writer_conf(Writer0, Stream0)}},
+                             make_writer_conf(LeaderNode, Stream0)}},
              Writer = Writer0#member{current = {deleting, Idx}},
              Effs = [Action | Effs0],
              Stream = Stream0#stream{reply_to = undefined},
-             eval_replicas(Meta, Writer, Replicas, Stream, Effs);
-         {#member{state = {down, Epoch},
-                  target = stopped,
-                  node = LeaderNode,
-                  current = undefined} = Writer0, Replicas} ->
+             eval_replicas(Meta, {LeaderNode, Writer}, Replicas, Stream, Effs);
+        {{LeaderNode, #member{state = {down, Epoch},
+                              target = stopped,
+                              current = undefined} = Writer0},
+         Replicas} ->
              %% leader is down - all replicas need to be stopped
              %% and tail infos retrieved
              %% some replicas may already be in stopping or ready state
              Args = Meta#{epoch => Epoch,
                           node => LeaderNode},
-             Conf = make_writer_conf(Writer0, Stream0),
+             Conf = make_writer_conf(LeaderNode, Stream0),
              Action = {aux, {stop, StreamId, Args, Conf}},
              Writer = Writer0#member{current = {stopping, Idx}},
-             eval_replicas(Meta, Writer, Replicas, Stream0, [Action | Effs0]);
-         {#member{state = {ready, Epoch}, %% writer ready in current epoch
-                  target = running,
-                  node = LeaderNode,
-                  current = undefined} = Writer0, _Replicas} ->
+             eval_replicas(Meta, {LeaderNode, Writer}, Replicas, Stream0, [Action | Effs0]);
+        {{LeaderNode, #member{state = {ready, Epoch}, %% writer ready in current epoch
+                              target = running,
+                              current = undefined} = Writer0},
+         _Replicas} ->
              %% ready check has been completed and a new leader has been chosen
              %% time to start writer,
              %% if leader start fails, revert back to down state for all and re-run
-             WConf = make_writer_conf(Writer0, Stream0),
+             WConf = make_writer_conf(LeaderNode, Stream0),
              Members = Members0#{LeaderNode =>
                                  Writer0#member{current = {starting, Idx},
                                                 conf = WConf}},
              Args = Meta#{node => LeaderNode, epoch => Epoch},
              Actions = [{aux, {start_writer, StreamId, Args, WConf}} | Effs0],
              {Stream0#stream{members = Members}, Actions};
-         {#member{state = {running, Epoch, LeaderPid},
-                  target = running} = Writer, Replicas} ->
+        {{_WriterNode, #member{state = {running, Epoch, LeaderPid},
+                               target = running}} = Writer, Replicas} ->
              Effs1 = case From of
                          undefined ->
                              Effs0;
@@ -1688,43 +1687,42 @@ evaluate_stream(#{index := Idx} = Meta,
                  false ->
                      eval_replicas(Meta, Writer, Replicas, Stream1, Effs1)
              end;
-         {#member{state = S,
-                  target = stopped,
-                  node = LeaderNode,
-                  current = undefined} = Writer0, Replicas}
+        {{LeaderNode, #member{state = S,
+                              target = stopped,
+                              current = undefined} = Writer0}, Replicas}
            when element(1, S) =/= stopped ->
              %% leader should be stopped
              Args = Meta#{node => LeaderNode, epoch => Epoch},
              Action = {aux, {stop, StreamId, Args,
-                             make_writer_conf(Writer0, Stream0)}},
+                             make_writer_conf(LeaderNode, Stream0)}},
              Writer = Writer0#member{current = {stopping, Idx}},
-             eval_replicas(Meta, Writer, Replicas, Stream0, [Action | Effs0]);
+             eval_replicas(Meta, {LeaderNode, Writer}, Replicas, Stream0,
+                           [Action | Effs0]);
          {Writer, Replicas} ->
              eval_replicas(Meta, Writer, Replicas, Stream0, Effs0)
      end.
 
 eval_replicas(Meta, undefined, Replicas, Stream, Actions0) ->
-    {Members, Actions} = lists:foldl(
-                           fun (R, Acc) ->
-                                   eval_replica(Meta, R, deleted, Stream, Acc)
+    {Members, Actions} = maps:fold(
+                           fun (Node, R, Acc) ->
+                                   eval_replica(Meta, Node, R, deleted, Stream, Acc)
                            end, {#{}, Actions0},
                            Replicas),
     {Stream#stream{members = Members}, Actions};
-eval_replicas(Meta, #member{state = LeaderState,
-                            node = WriterNode} = Writer, Replicas,
+eval_replicas(Meta, {WriterNode, #member{state = LeaderState} = Writer}, Replicas,
               Stream, Actions0) ->
-    {Members, Actions} = lists:foldl(
-                           fun (R, Acc) ->
-                                   eval_replica(Meta, R, LeaderState,
+    {Members, Actions} = maps:fold(
+                           fun (Node, R, Acc) ->
+                                   eval_replica(Meta, Node, R, LeaderState,
                                                 Stream, Acc)
                            end, {#{WriterNode => Writer}, Actions0},
                            Replicas),
     {Stream#stream{members = Members}, Actions}.
 
 eval_replica(#{index := Idx} = Meta,
+             Node,
              #member{state = _State,
                      target = stopped,
-                     node = Node,
                      current = undefined} = Replica,
              _LeaderState,
              #stream{id = StreamId,
@@ -1738,10 +1736,10 @@ eval_replica(#{index := Idx} = Meta,
     Conf = Conf0#{epoch => Epoch},
     {Replicas#{Node => Replica#member{current = {stopping, Idx}}},
      [{aux, {stop, StreamId, Args, Conf}} | Actions]};
-eval_replica(#{index := Idx} = Meta, #member{state = _,
-                                             node = Node,
-                                             current = Current,
-                                             target = deleted} = Replica,
+eval_replica(#{index := Idx} = Meta,
+             Node,
+             #member{current = Current,
+                     target = deleted} = Replica,
              _LeaderState, #stream{id = StreamId,
                                    epoch = Epoch,
                                    conf = Conf}, {Replicas, Actions0}) ->
@@ -1756,10 +1754,10 @@ eval_replica(#{index := Idx} = Meta, #member{state = _,
         _ ->
             {Replicas#{Node => Replica}, Actions0}
     end;
-eval_replica(#{index := Idx} = Meta, #member{state = {State, Epoch},
-                                             node = Node,
-                                             target = running,
-                                             current = undefined} = Replica,
+eval_replica(#{index := Idx} = Meta, Node,
+             #member{state = {State, Epoch},
+                     target = running,
+                     current = undefined} = Replica,
              {running, Epoch, Pid},
              #stream{id = StreamId,
                      epoch = Epoch} = Stream,
@@ -1772,28 +1770,25 @@ eval_replica(#{index := Idx} = Meta, #member{state = {State, Epoch},
     {Replicas#{Node => Replica#member{current = {starting, Idx},
                                       conf = Conf}},
      [{aux, {start_replica, StreamId, Args, Conf}} | Actions]};
-eval_replica(_Meta, #member{state = {running, Epoch, _},
-                            target = running,
-                            node = Node} = Replica,
+eval_replica(_Meta, Node, #member{state = {running, Epoch, _},
+                                  target = running} = Replica,
              {running, Epoch, _}, _Stream, {Replicas, Actions}) ->
     {Replicas#{Node => Replica}, Actions};
-eval_replica(_Meta, #member{state = {stopped, _E, _},
-                            node = Node,
-                            current = undefined} = Replica,
+eval_replica(_Meta, Node, #member{state = {stopped, _E, _},
+                                  current = undefined} = Replica,
              _LeaderState, _Stream,
              {Replicas, Actions}) ->
     %%  if stopped we should just wait for a quorum to reach stopped and
     %%  update_stream will move to ready state
     {Replicas#{Node => Replica}, Actions};
-eval_replica(_Meta, #member{state = {ready, E},
-                            target = running,
-                            node = Node,
-                            current = undefined} = Replica,
+eval_replica(_Meta, Node, #member{state = {ready, E},
+                                  target = running,
+                                  current = undefined} = Replica,
              {ready, E}, _Stream,
              {Replicas, Actions}) ->
     %% if we're ready and so is the leader we just wait a swell
     {Replicas#{Node => Replica}, Actions};
-eval_replica(_Meta, #member{node = Node} = Replica, _LeaderState, _Stream,
+eval_replica(_Meta, Node, #member{} = Replica, _LeaderState, _Stream,
              {Replicas, Actions}) ->
     {Replicas#{Node => Replica}, Actions}.
 
@@ -1803,8 +1798,8 @@ fail_active_actions(Streams, Exclude) ->
                        members = Members,
                        mnesia = Mnesia})
             when not is_map_key(Id, Exclude)  ->
-              _ = maps:map(fun(_, M) ->
-                                   fail_action(Id, M)
+              _ = maps:map(fun(N, M) ->
+                                   fail_action(Id, N, M)
                            end, Members),
               case Mnesia of
                   {updating, E} ->
@@ -1824,11 +1819,10 @@ fail_active_actions(Streams, Exclude) ->
 
     ok.
 
-fail_action(_StreamId, #member{current = undefined}) ->
+fail_action(_StreamId, _, #member{current = undefined}) ->
     ok;
-fail_action(StreamId, #member{role = {_, E},
-                              current = {Action, Idx},
-                              node = Node}) ->
+fail_action(StreamId, Node, #member{role = {_, E},
+                                    current = {Action, Idx}}) ->
     rabbit_log:debug("~ts: failing stale action to trigger retry. "
                      "Stream ID: ~ts, node: ~w, action: ~w",
                      [?MODULE, StreamId, node(), Action]),
@@ -1864,9 +1858,9 @@ make_replica_conf(LeaderPid,
           replica_nodes => lists:delete(LeaderNode, Nodes),
           epoch => Epoch}.
 
-make_writer_conf(#member{node = Node}, #stream{epoch = Epoch,
-                                               nodes = Nodes,
-                                               conf = Conf}) ->
+make_writer_conf(Node, #stream{epoch = Epoch,
+                               nodes = Nodes,
+                               conf = Conf}) ->
     Conf#{leader_node => Node,
           nodes => Nodes,
           replica_nodes => lists:delete(Node, Nodes),
@@ -1875,15 +1869,15 @@ make_writer_conf(#member{node = Node}, #stream{epoch = Epoch,
 
 find_leader(Members) ->
     case lists:partition(
-           fun (#member{target = deleted}) ->
+           fun ({_, #member{target = deleted}}) ->
                    false;
-               (#member{role = {Role, _}}) ->
+               ({_, #member{role = {Role, _}}}) ->
                    Role == writer
-           end, maps:values(Members)) of
+           end, maps:to_list(Members)) of
         {[Writer], Replicas} ->
-            {Writer, Replicas};
+            {Writer, maps:from_list(Replicas)};
         {[], Replicas} ->
-            {undefined, Replicas}
+            {undefined, maps:from_list(Replicas)}
     end.
 
 select_leader(#{machine_version := 0}, EpochOffsets) ->

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -2052,7 +2052,9 @@ machine_version(2, 3, State) ->
     {State#?MODULE{single_active_consumer = rabbit_stream_sac_coordinator:init_state()},
      []};
 machine_version(3, 4, #?MODULE{streams = Streams0} = State) ->
-    %% unset the node field in the members record as no longer used
+    rabbit_log:info("Stream coordinator machine version changes from 3 to 4, updating state."),
+    %% the "preferred" field takes the place of the "node" field in this version
+    %% initializing the "preferred" field to false
     Streams = maps:map(
                 fun (_, #stream{members = Members} = S) ->
                         S#stream{members = maps:map(

--- a/deps/rabbit/src/rabbit_stream_coordinator.hrl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.hrl
@@ -51,7 +51,7 @@
                  listeners = #{} :: #{pid() | %% v0 & v1
                                       {pid(), leader | member} %% v2
                                       := LeaderPid :: pid()} |
-                 {node(), LocalPid :: pid()},
+                                     {node(), LocalPid :: pid()},
                  reply_to :: undefined | from(),
                  mnesia = {updated, 0} :: {updated | updating, osiris:epoch()},
                  target = running :: running | deleted

--- a/deps/rabbit/src/rabbit_stream_coordinator.hrl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.hrl
@@ -21,7 +21,7 @@
                               | {running | disconnected, osiris:epoch(), pid()}
                               | deleted,
          role :: {writer | replica, osiris:epoch()},
-         node :: node(),
+         reserved :: term(),
          %% the currently running action, if any
          current :: undefined |
                     {updating |
@@ -33,12 +33,12 @@
          conf :: undefined | osiris:config(),
          target = running :: running | stopped | deleted}).
 
-%% member lifecycle
-%% down -> stopped(tail) -> running | disconnected -> deleted
-%%
-%% split the handling of incoming events (down, success | fail of operations)
-%% and the actioning of current state (i.e. member A is down but the cluster target
-%% is `up` - start a current action to turn member A -> running
+%% member lifecycle:
+%% down(epoch) ->
+%% stopped(epoch, tail) ->
+%% ready(epoch+1) ->
+%% running(epoch+1) | disconnected(epoch+1) ->
+%% deleted
 
 -type from() :: {pid(), reference()}.
 
@@ -66,6 +66,7 @@
          %% not used as of v2
          listeners = #{} :: undefined | #{stream_id() =>
                                           #{pid() := queue_ref()}},
-         single_active_consumer = undefined :: undefined | rabbit_stream_sac_coordinator:state(),
+         single_active_consumer = undefined :: undefined |
+                                               rabbit_stream_sac_coordinator:state(),
          %% future extensibility
          reserved_2}).

--- a/deps/rabbit/src/rabbit_stream_coordinator.hrl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.hrl
@@ -21,7 +21,7 @@
                               | {running | disconnected, osiris:epoch(), pid()}
                               | deleted,
          role :: {writer | replica, osiris:epoch()},
-         reserved :: term(),
+         preferred = false :: term(),
          %% the currently running action, if any
          current :: undefined |
                     {updating |

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -36,7 +36,7 @@
 -export([list_with_minimum_quorum/0]).
 
 -export([set_retention_policy/3]).
--export([restart_stream/2,
+-export([restart_stream/3,
          add_replica/3,
          delete_replica/3]).
 -export([format_osiris_event/2]).
@@ -795,7 +795,8 @@ set_retention_policy(Name, VHost, Policy) ->
             end
     end.
 
-restart_stream(VHost, Name) ->
+restart_stream(VHost, Name, Options) ->
+    rabbit_log:info("restarting stream ~s with options ~p", [Name, Options]),
     QName = rabbit_misc:r(VHost, queue, Name),
     case rabbit_amqqueue:lookup(QName) of
         {ok, Q} when ?amqqueue_is_classic(Q) ->
@@ -803,7 +804,7 @@ restart_stream(VHost, Name) ->
         {ok, Q} when ?amqqueue_is_quorum(Q) ->
             {error, quorum_queue_not_supported};
         {ok, Q} when ?amqqueue_is_stream(Q) ->
-            rabbit_stream_coordinator:restart_stream(Q);
+            rabbit_stream_coordinator:restart_stream(Q, Options);
         E ->
             E
     end.

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -25,6 +25,9 @@
          credit/4,
          dequeue/4,
          info/2,
+         queue_length/1,
+         get_replicas/1,
+         transfer_leadership/2,
          init/1,
          close/1,
          update/2,
@@ -628,6 +631,20 @@ i(type, _) ->
     stream;
 i(_, _) ->
     ''.
+
+queue_length(Q) ->
+    i(messages, Q).
+
+get_replicas(Q) ->
+    i(members, Q).
+
+-spec transfer_leadership(amqqueue:amqqueue(), node()) -> {migrated, node()} | {not_migrated, atom()}.
+transfer_leadership(Q, Destination) ->
+    case rabbit_stream_coordinator:restart_stream(Q, #{preferred_leader_node => Destination}) of
+        {ok, NewNode} -> {migrated, NewNode};
+        {error, Reason} -> {not_migrated, Reason};
+        {timeout, _} -> {not_migrated, timeout}
+    end.
 
 -spec status(rabbit_types:vhost(), Name :: rabbit_misc:resource_name()) ->
     [[{binary(), term()}]] | {error, term()}.

--- a/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
@@ -105,16 +105,12 @@ listeners(_) ->
       ),
 
     LeaderPid0 = spawn(fun() -> ok end),
-    Leader0 = #member{
-                role = {writer, 1},
-                state = {running, 1, LeaderPid0},
-                node = N1
-               },
-    State1 = State0#?STATE{
-                       streams = #{S => #stream{
-                                           listeners = #{},
-                                           members = #{N1 => Leader0},
-                                           queue_ref = Q}
+    Leader0 = #member{role = {writer, 1},
+                      state = {running, 1, LeaderPid0}},
+    State1 = State0#?STATE{streams = #{S => #stream{id = S,
+                                                listeners = #{},
+                                                members = #{N1 => Leader0},
+                                                queue_ref = Q}
                       }},
 
     {State2, ok, Effs2} = register_listener(#{pid => ListPid,
@@ -1408,13 +1404,11 @@ started_stream(StreamId, LeaderPid, ReplicaPids) ->
                       name = list_to_binary(StreamId),
                       virtual_host = VHost},
     Members0 = #{node(LeaderPid) => #member{role = {writer, E},
-                                            node = node(LeaderPid),
                                             state = {running, E, LeaderPid},
                                             current = undefined}},
     Members = lists:foldl(fun (R, Acc) ->
                                   N = node(R),
                                   Acc#{N => #member{role = {replica, E},
-                                                    node = N,
                                                     state = {running, E, R},
                                                     current = undefined}}
                           end, Members0, ReplicaPids),

--- a/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
@@ -422,8 +422,8 @@ leader_down(_) ->
                                                    state = {stopped, E, N2Tail}}}},
                  S3),
     {S3, []} = evaluate_stream(meta(?LINE), S3, []),
-    N3Tail = {E, 102},
-    #{index := Idx4} = Meta4 = meta(?LINE),
+    N3Tail = {E, 101},
+    #{index := Idx4} = Meta4 = meta(?LINE + 1),
     S4 = update_stream(Meta4, {member_stopped, StreamId,
                                #{node => N3,
                                  index => Idx2,
@@ -1328,9 +1328,9 @@ overview(_Config) ->
     Cmd = {new_stream, StreamId, #{leader_node => node(),
                                    retention => [],
                                    queue => Q}},
-    {S1, _, _} = apply_cmd(#{index => 1,
-                             machine_version => 3,
-                             system_time => 203984982374}, Cmd, S0),
+    {S1, _, _} = apply_cmd(meta(#{index => 1,
+                                  machine_version => 3,
+                                  system_time => 203984982374}), Cmd, S0),
 
     ?assertMatch(#{num_monitors := 0,
                    num_streams := 1,
@@ -1342,9 +1342,11 @@ overview(_Config) ->
     ok.
 
 meta(N) when is_integer(N) ->
-    #{index => N,
-      machine_version => 1,
-      system_time => N + 1000}.
+    meta(#{index => N});
+meta(#{index := N} = M) when is_map(M) ->
+    maps:merge(#{term => 1,
+                 machine_version => rabbit_stream_coordinator:version(),
+                 system_time => N * 2}, M).
 
 started_stream(StreamId, LeaderPid, ReplicaPids) ->
     E = 1,

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1370,7 +1370,7 @@ restart_stream(Config) ->
                       kind = queue,
                       name = Q},
     %% restart the stream
-    ?assertMatch({ok, {ok, _}, _},
+    ?assertMatch({ok, _},
                  rabbit_ct_broker_helpers:rpc(Config, Server,
                                               rabbit_stream_coordinator,
                                               ?FUNCTION_NAME, [QName])),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2515,11 +2515,13 @@ ensure_retention_applied(Config, Server) ->
     rabbit_ct_broker_helpers:rpc(Config, Server, gen_server, call, [osiris_retention, test]).
 
 rebalance(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "rebalance test isn't mixed version compatible"};
-        false ->
-            rebalance0(Config)
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, restart_stream) of
+        ok ->
+            rebalance0(Config);
+        _ ->
+            ct:pal("skipping test ~s as feature flag `restart_stream` not supported",
+                   [?FUNCTION_NAME]),
+            ok
     end.
 
 rebalance0(Config) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/rebalance_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/rebalance_command.ex
@@ -58,7 +58,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
 
   def usage,
     do:
-      "rebalance < all | classic | quorum | steram > [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
+      "rebalance < all | classic | quorum | stream > [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
 
   def usage_additional do
     [

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/rebalance_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/rebalance_command.ex
@@ -13,7 +13,8 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
   @known_types [
     "all",
     "classic",
-    "quorum"
+    "quorum",
+    "stream"
   ]
 
   defp default_opts, do: %{vhost_pattern: ".*", queue_pattern: ".*"}
@@ -44,7 +45,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
         :ok
 
       false ->
-        {:error, "type #{type} is not supported. Try one of all, classic, quorum."}
+        {:error, "type #{type} is not supported. Try one of all, classic, quorum, stream."}
     end
   end
 
@@ -57,11 +58,11 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
 
   def usage,
     do:
-      "rebalance < all | classic | quorum > [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
+      "rebalance < all | classic | quorum | steram > [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
 
   def usage_additional do
     [
-      ["<type>", "queue type, must be one of: all, classic, quorum"],
+      ["<type>", "queue type, must be one of: all, classic, quorum, stream"],
       ["--queue-pattern <pattern>", "regular expression to match queue names"],
       ["--vhost-pattern <pattern>", "regular expression to match virtual host names"]
     ]
@@ -88,6 +89,10 @@ defmodule RabbitMQ.CLI.Queues.Commands.RebalanceCommand do
 
   def banner([:quorum], _) do
     "Re-balancing leaders of quorum queues..."
+  end
+
+  def banner([:stream], _) do
+    "Re-balancing leaders of streams..."
   end
 
   def banner([type], _) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/restart_stream_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/restart_stream_command.ex
@@ -1,0 +1,65 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Streams.Commands.RestartStreamCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+  import RabbitMQ.CLI.Core.DataCoercion
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{vhost: "/"}, opts)}
+  end
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([name] = _args, %{vhost: vhost, node: node_name}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_stream_queue, :restart_stream, [
+           vhost,
+           name
+         ]) do
+      {:error, :classic_queue_not_supported} ->
+        {:error, "Cannot restart a classic queue"}
+
+      {:error, :quorum_queue_not_supported} ->
+        {:error, "Cannot restart to a quorum queue"}
+
+      {:ok, LeaderNode} ->
+        LeaderNode
+
+      other ->
+        other
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "restart_stream [--vhost <vhost>] <stream>"
+
+  def usage_additional do
+    [
+      ["<stream>", "stream name"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.streams()
+    ]
+  end
+
+  def help_section, do: :replication
+
+  def description, do: "Restarts a stream."
+
+  def banner([name], _) do
+    [
+      "Restarting stream #{name}..."
+    ]
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/restart_stream_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/restart_stream_command.ex
@@ -47,12 +47,12 @@ defmodule RabbitMQ.CLI.Streams.Commands.RestartStreamCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
-  def usage, do: "restart_stream [--vhost <vhost>] <stream> [--preferred_leader_node <node>]"
+  def usage, do: "restart_stream [--vhost <vhost>] <stream> [--preferred-leader-node <node>]"
 
   def usage_additional do
     [
       ["<stream>", "stream name"],
-      ["--preferred_leader_node", "preferred leader node"]
+      ["--preferred-leader-node", "preferred leader node"]
     ]
   end
 

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -135,7 +135,7 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
 
     git_repository(
         name = "osiris",
-        tag = "v1.4.1",
+        tag = "v1.4.2",
         remote = "https://github.com/rabbitmq/osiris.git",
     )
 

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -135,7 +135,7 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
 
     git_repository(
         name = "osiris",
-        tag = "v1.4.0",
+        tag = "v1.4.1",
         remote = "https://github.com/rabbitmq/osiris.git",
     )
 


### PR DESCRIPTION
Implement "tie-break" selection when more than one replica has the potential to become the next writer. 
If the `preferred_leader_node` option is set it will favour this node for selection assuming its log is at least as up to date as any other member in the first quorum of members to respond. If not set or if not in the first quorum a simple modulo based selection is made to better distribute leader over the cluster.

This may improve writer distribution in cases where a rabbit node goes down and there are many streams.

Adding `restart_stream` command to `rabbitmq-streams` cli tool.

This leaders selection code as been included in the existing drain / rebalance features so that streams will