### PR TITLE
Consider streams when quorum critical check

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -49,7 +49,6 @@
          file_handle_other_reservation/0]).
 -export([file_handle_release_reservation/0]).
 -export([list_with_minimum_quorum/0,
-         list_with_minimum_quorum_for_cli/0,
          filter_quorum_critical/1,
          filter_quorum_critical/2,
          all_replica_states/0]).
@@ -353,19 +352,6 @@ all_replica_states() ->
 list_with_minimum_quorum() ->
     filter_quorum_critical(
       rabbit_amqqueue:list_local_quorum_queues()).
-
--spec list_with_minimum_quorum_for_cli() -> [#{binary() => term()}].
-list_with_minimum_quorum_for_cli() ->
-    QQs = list_with_minimum_quorum(),
-    [begin
-         #resource{name = Name} = amqqueue:get_name(Q),
-         #{
-             <<"readable_name">> => rabbit_data_coercion:to_binary(rabbit_misc:rs(amqqueue:get_name(Q))),
-             <<"name">> => Name,
-             <<"virtual_host">> => amqqueue:get_vhost(Q),
-             <<"type">> => <<"quorum">>
-         }
-     end || Q <- QQs].
 
 -spec filter_quorum_critical([amqqueue:amqqueue()]) -> [amqqueue:amqqueue()].
 filter_quorum_critical(Queues) ->

--- a/deps/rabbit/src/rabbit_upgrade_preparation.erl
+++ b/deps/rabbit/src/rabbit_upgrade_preparation.erl
@@ -62,9 +62,9 @@ list_with_minimum_quorum_for_cli() ->
                          rabbit_quorum_queue:list_with_minimum_quorum(),
                          rabbit_stream_queue:list_with_minimum_quorum()),
     [begin
-         #resource{name = Name} = amqqueue:get_name(Q),
+         #resource{name = Name} = QName = amqqueue:get_name(Q),
          #{
-           <<"readable_name">> => rabbit_data_coercion:to_binary(rabbit_misc:rs(amqqueue:get_name(Q))),
+           <<"readable_name">> => rabbit_data_coercion:to_binary(rabbit_misc:rs(QName)),
            <<"name">> => Name,
            <<"virtual_host">> => amqqueue:get_vhost(Q),
            <<"type">> => amqqueue:get_type(Q)

--- a/deps/rabbit/src/rabbit_upgrade_preparation.erl
+++ b/deps/rabbit/src/rabbit_upgrade_preparation.erl
@@ -7,8 +7,11 @@
 
 -module(rabbit_upgrade_preparation).
 
--export([await_online_quorum_plus_one/1, await_online_synchronised_mirrors/1]).
+-export([await_online_quorum_plus_one/1,
+         await_online_synchronised_mirrors/1,
+         list_with_minimum_quorum_for_cli/0]).
 
+-include_lib("rabbit_common/include/rabbit.hrl").
 %%
 %% API
 %%
@@ -32,7 +35,10 @@ await_online_synchronised_mirrors(Timeout) ->
 do_await_safe_online_quorum(0) ->
     false;
 do_await_safe_online_quorum(IterationsLeft) ->
-    case rabbit_quorum_queue:list_with_minimum_quorum() of
+    EndangeredQueues = lists:append(
+                         rabbit_quorum_queue:list_with_minimum_quorum(),
+                         rabbit_stream_queue:list_with_minimum_quorum()),
+    case EndangeredQueues of
         []  -> true;
         List when is_list(List) ->
             timer:sleep(?SAMPLING_INTERVAL),
@@ -49,3 +55,18 @@ do_await_online_synchronised_mirrors(IterationsLeft) ->
             timer:sleep(?SAMPLING_INTERVAL),
             do_await_online_synchronised_mirrors(IterationsLeft - 1)
     end.
+
+-spec list_with_minimum_quorum_for_cli() -> [#{binary() => term()}].
+list_with_minimum_quorum_for_cli() ->
+    EndangeredQueues = lists:append(
+                         rabbit_quorum_queue:list_with_minimum_quorum(),
+                         rabbit_stream_queue:list_with_minimum_quorum()),
+    [begin
+         #resource{name = Name} = amqqueue:get_name(Q),
+         #{
+           <<"readable_name">> => rabbit_data_coercion:to_binary(rabbit_misc:rs(amqqueue:get_name(Q))),
+           <<"name">> => Name,
+           <<"virtual_host">> => amqqueue:get_vhost(Q),
+           <<"type">> => amqqueue:get_type(Q)
+          }
+     end || Q <- EndangeredQueues].

--- a/deps/rabbit/test/upgrade_preparation_SUITE.erl
+++ b/deps/rabbit/test/upgrade_preparation_SUITE.erl
@@ -15,13 +15,17 @@
 
 all() ->
     [
-      {group, clustered}
+      {group, quorum_queue},
+      {group, stream}
     ].
 
 groups() ->
     [
-     {clustered, [], [
-         await_quorum_plus_one
+     {quorum_queue, [], [
+         await_quorum_plus_one_qq
+     ]},
+     {stream, [], [
+         await_quorum_plus_one_stream
      ]}
     ].
 
@@ -75,11 +79,25 @@ end_per_testcase(TestCase, Config) ->
 
 -define(WAITING_INTERVAL, 10000).
 
-await_quorum_plus_one(Config) ->
+await_quorum_plus_one_qq(Config) ->
     catch delete_queues(),
     [A, B, _C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, A),
     declare(Ch, <<"qq.1">>, [{<<"x-queue-type">>, longstr, <<"quorum">>}]),
+    timer:sleep(100),
+    ?assert(await_quorum_plus_one(Config, 0)),
+
+    ok = rabbit_ct_broker_helpers:stop_node(Config, B),
+    ?assertNot(await_quorum_plus_one(Config, 0)),
+
+    ok = rabbit_ct_broker_helpers:start_node(Config, B),
+    ?assert(await_quorum_plus_one(Config, 0)).
+
+await_quorum_plus_one_stream(Config) ->
+    catch delete_queues(),
+    [A, B, _C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, A),
+    declare(Ch, <<"st.1">>, [{<<"x-queue-type">>, longstr, <<"stream">>}]),
     timer:sleep(100),
     ?assert(await_quorum_plus_one(Config, 0)),
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/check_if_node_is_quorum_critical_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/check_if_node_is_quorum_critical_command.ex
@@ -6,7 +6,7 @@
 
 defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand do
   @moduledoc """
-  Exits with a non-zero code if there are quorum queues that would lose their quorum
+  Exits with a non-zero code if there are quorum queues or streams that would lose their quorum
   if the target node is shut down.
 
   This command is meant to be used as a pre-upgrade (pre-shutdown) check.
@@ -42,7 +42,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand do
           false ->
             case :rabbit_misc.rpc_call(
                    node_name,
-                   :rabbit_quorum_queue,
+                   :rabbit_upgrade_preparation,
                    :list_with_minimum_quorum_for_cli,
                    [],
                    timeout
@@ -101,7 +101,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand do
   end
 
   def output({:ok, []}, %{node: node_name}) do
-    {:ok, "Node #{node_name} reported no quorum queues with minimum quorum"}
+    {:ok, "Node #{node_name} reported no queues/streams with minimum quorum"}
   end
 
   def output({:ok, qs}, %{node: node_name, formatter: "json"}) when is_list(qs) do
@@ -128,14 +128,14 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand do
   def help_section(), do: :observability_and_health_checks
 
   def description() do
-    "Health check that exits with a non-zero code if there are queues " <>
-      "with minimum online quorum (queues that would lose their quorum if the target node is shut down)"
+    "Health check that exits with a non-zero code if there are queues/streams " <>
+      "with minimum online quorum (queues/streams that will lose their quorum if the target node shuts down)"
   end
 
   def usage, do: "check_if_node_is_quorum_critical"
 
   def banner([], %{node: node_name}) do
-    "Checking if node #{node_name} is critical for quorum of any quorum queues ..."
+    "Checking if node #{node_name} is critical for quorum of any queues/streams ..."
   end
 
   #
@@ -143,6 +143,6 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand do
   #
 
   def queue_lines(qs, node_name) do
-    for q <- qs, do: "#{q["readable_name"]} would lose quorum if node #{node_name} is stopped"
+    for q <- qs, do: "#{q["readable_name"]} will become unavailable if node #{node_name} stops"
   end
 end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_node_is_quorum_critical.erl
@@ -34,7 +34,7 @@ to_json(ReqData, Context) ->
             rabbit_mgmt_util:reply([{status, ok},
                                     {reason, <<"single node cluster">>}], ReqData, Context);
         false ->
-            case rabbit_quorum_queue:list_with_minimum_quorum_for_cli() of
+            case rabbit_upgrade_preparation:list_with_minimum_quorum_for_cli() of
                 [] ->
                     rabbit_mgmt_util:reply([{status, ok}], ReqData, Context);
                 Qs when length(Qs) > 0 ->


### PR DESCRIPTION
Extended the quorum critical check to also consider streams and their potential unavailability if the node is stopped.

Affects the following commands:
`rabbitmq-diagnostics check_if_node_is_quorum_critical`
`rabbitmq-upgrade await_online_quorum_plus_one`