### PR TITLE
Classic Queue Mirroring: reduce memory usage during dead-lettering of many messages

### DIFF
--- a/deps/rabbit/src/rabbit_dead_letter.erl
+++ b/deps/rabbit/src/rabbit_dead_letter.erl
@@ -104,7 +104,7 @@ group_by_queue_and_reason(Tables) ->
                            ensure_xdeath_event_count(Augmented, N),
                            Key, SeenKeys, Acc),
                   {sets:add_element(Key, SeenKeys), Acc1}
-          end, {sets:new(), []}, Tables),
+          end, {sets:new([{version, 2}]), []}, Tables),
     Grouped.
 
 update_x_death_header(Info, undefined) ->

--- a/deps/rabbit/src/rabbit_mirror_queue_master.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_master.erl
@@ -122,7 +122,7 @@ init_with_existing_bq(Q0, BQ, BQS) when ?is_amqqueue(Q0) ->
                backing_queue_state = BQS,
                seen_status         = #{},
                confirmed           = [],
-               known_senders       = sets:new(),
+               known_senders       = sets:new([{version, 2}]),
                wait_timeout        = rabbit_misc:get_env(rabbit, slave_wait_timeout, 15000)};
     {error, Reason} ->
         %% The GM can shutdown before the coordinator has started up

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -878,7 +878,7 @@ maybe_enqueue_message(
 
 get_sender_queue(ChPid, SQ) ->
     case maps:find(ChPid, SQ) of
-        error     -> {queue:new(), sets:new(), running};
+        error     -> {queue:new(), sets:new([{version, 2}]), running};
         {ok, Val} -> Val
     end.
 

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -18,8 +18,7 @@
 -export([set_maximum_since_use/2, info/1, go/2]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-         code_change/3, handle_pre_hibernate/1, prioritise_call/4,
-         prioritise_cast/3, prioritise_info/3, format_message_queue/2]).
+         code_change/3, handle_pre_hibernate/1, format_message_queue/2]).
 
 -export([joined/2, members_changed/3, handle_msg/3, handle_terminate/2]).
 
@@ -445,29 +444,6 @@ handle_pre_hibernate(State = #state { backing_queue       = BQ,
     BQS2 = BQ:set_ram_duration_target(DesiredDuration, BQS1),
     BQS3 = BQ:handle_pre_hibernate(BQS2),
     {hibernate, stop_rate_timer(State #state { backing_queue_state = BQS3 })}.
-
-prioritise_call(Msg, _From, _Len, _State) ->
-    case Msg of
-        info                                 -> 9;
-        {gm_deaths, _Dead}                   -> 5;
-        _                                    -> 0
-    end.
-
-prioritise_cast(Msg, _Len, _State) ->
-    case Msg of
-        {set_ram_duration_target, _Duration} -> 8;
-        {set_maximum_since_use, _Age}        -> 8;
-        {run_backing_queue, _Mod, _Fun}      -> 6;
-        {gm, _Msg}                           -> 5;
-        _                                    -> 0
-    end.
-
-prioritise_info(Msg, _Len, _State) ->
-    case Msg of
-        update_ram_duration                  -> 8;
-        sync_timeout                         -> 6;
-        _                                    -> 0
-    end.
 
 format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -20,7 +20,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3, handle_pre_hibernate/1, format_message_queue/2]).
 
--export([joined/2, members_changed/3, handle_msg/3, handle_terminate/2]).
+-export([joined/2, members_changed/3, handle_msg/3, handle_terminate/2,
+        prioritise_cast/3, prioritise_info/3]).
 
 -behaviour(gen_server2).
 -behaviour(gm).
@@ -64,6 +65,19 @@
 
 set_maximum_since_use(QPid, Age) ->
     gen_server2:cast(QPid, {set_maximum_since_use, Age}).
+
+
+prioritise_cast(Msg, _Len, _State) ->
+    case Msg of
+        {run_backing_queue, _Mod, _Fun}      -> 6;
+        _                                    -> 0
+    end.
+
+prioritise_info(Msg, _Len, _State) ->
+    case Msg of
+        sync_timeout                         -> 6;
+        _                                    -> 0
+    end.
 
 info(QPid) -> gen_server2:call(QPid, info, infinity).
 

--- a/deps/rabbit_common/src/gen_server2.erl
+++ b/deps/rabbit_common/src/gen_server2.erl
@@ -1326,10 +1326,8 @@ find_prioritisers(GS2State = #gs2_state { mod = Mod }) ->
 function_exported_or_default(Mod, Fun, Arity, Default) ->
     case erlang:function_exported(Mod, Fun, Arity) of
         true -> case Arity of
-                    3 -> fun (Msg, GS2State = #gs2_state { queue = Queue,
-                                                           state = State }) ->
-                                 Length = priority_queue:len(Queue),
-                                 case catch Mod:Fun(Msg, Length, State) of
+                    3 -> fun (Msg, GS2State = #gs2_state { state = State }) ->
+                                 case catch Mod:Fun(Msg, 0, State) of
                                      drop ->
                                          drop;
                                      Res when is_integer(Res) ->
@@ -1338,10 +1336,8 @@ function_exported_or_default(Mod, Fun, Arity, Default) ->
                                          handle_common_termination(Err, Msg, GS2State)
                                  end
                          end;
-                    4 -> fun (Msg, From, GS2State = #gs2_state { queue = Queue,
-                                                                 state = State }) ->
-                                 Length = priority_queue:len(Queue),
-                                 case catch Mod:Fun(Msg, From, Length, State) of
+                    4 -> fun (Msg, From, GS2State = #gs2_state { state = State }) ->
+                                 case catch Mod:Fun(Msg, From, 0, State) of
                                      Res when is_integer(Res) ->
                                          Res;
                                      Err ->


### PR DESCRIPTION
These changes fix issue #5312 (memory spike during dead-lettering of many messages). The nature of the changes is that they impact all mirroring operations and could therefore lead to some regressions in completely different scenarios. We've run extensive tests and didn't see any obvious regressions, but we need to be prepared that something might come up.

The reduced memory usage is clear for the scenario described in #5312 :
![Screenshot 2022-11-24 at 15 32 40](https://user-images.githubusercontent.com/9566114/203840014-af0d6198-f791-4592-870d-8dfb1474f2b8.png)


It's worth pointing out that the goal of the change was to reduce memory usage. However, as a side effect, it also led to some performance improvements, when consuming a long queue, so that it actually uses more memory (but consumes much faster). Here's the biggest difference (CQv2, 100B messages, consumption of a queue with 5 million messages; the sudden cliff was simply when the queue became empty - there were no publishers during this test):
![Screenshot 2022-11-24 at 18 30 31](https://user-images.githubusercontent.com/9566114/203840570-bd3b3e7b-75bd-432e-ac0b-4a8dfeefd86f.png)

Here's a link to additional results with different queue types (CQv1, CQv1 lazy, CQv2) and different message sizes (hover over the bottom of an annotation on the graph to see full perf-test invocation):
https://snapshots.raintank.io/dashboard/snapshot/ct7cS0pp3wyp5r1ne3UUWfv2zhdY5eIT

Fixes #5312 