### PR TITLE
Fix case_clause crash when stream queue provided for quorum queue commands

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1040,6 +1040,8 @@ status(Vhost, QueueName) ->
                          ]
                  end
              end || N <- Nodes];
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
             E
     end.
@@ -1075,6 +1077,8 @@ add_member(VHost, Name, Node, Timeout) ->
                             add_member(Q, Node, Timeout)
                     end
             end;
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
                     E
     end.
@@ -1130,6 +1134,8 @@ delete_member(VHost, Name, Node) ->
                 true ->
                     delete_member(Q, Node)
             end;
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
                     E
     end.
@@ -1287,6 +1293,8 @@ reclaim_memory(Vhost, QueueName) ->
         {ok, Q} when ?amqqueue_is_quorum(Q) ->
             ok = ra:pipeline_command(amqqueue:get_pid(Q),
                                      rabbit_fifo:make_garbage_collection());
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
             E
     end.
@@ -1550,7 +1558,9 @@ peek(Pos, Q) when ?is_amqqueue(Q) andalso ?amqqueue_is_quorum(Q) ->
             Err
     end;
 peek(_Pos, Q) when ?is_amqqueue(Q) andalso ?amqqueue_is_classic(Q) ->
-    {error, classic_queue_not_supported}.
+    {error, classic_queue_not_supported};
+peek(_Pos, Q) when ?is_amqqueue(Q) ->
+    {error, not_quorum_queue}.
 
 online(Q) when ?is_amqqueue(Q) ->
     Nodes = get_connected_nodes(Q),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -43,10 +43,12 @@ groups() ->
      {clustered, [], [
                       {cluster_size_2, [], [add_member_not_running,
                                             add_member_classic,
+                                            add_member_wrong_type,
                                             add_member_already_a_member,
                                             add_member_not_found,
                                             delete_member_not_running,
                                             delete_member_classic,
+                                            delete_member_wrong_type,
                                             delete_member_queue_not_found,
                                             delete_member,
                                             delete_member_not_a_member,
@@ -144,6 +146,7 @@ all_tests() ->
      delete_if_unused,
      queue_ttl,
      peek,
+     peek_wrong_type,
      message_ttl,
      per_message_ttl,
      per_message_ttl_mixed_expiry,
@@ -155,7 +158,9 @@ all_tests() ->
 
 memory_tests() ->
     [
-     memory_alarm_rolls_wal
+     memory_alarm_rolls_wal,
+     %%reclaim_memory,
+     reclaim_memory_wrong_type
     ].
 
 -define(SUPNAME, ra_server_sup_sup).
@@ -1674,6 +1679,16 @@ add_member_classic(Config) ->
                  rpc:call(Server, rabbit_quorum_queue, add_member,
                           [<<"/">>, CQ, Server, 5000])).
 
+add_member_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    SQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    ?assertEqual({error, not_quorum_queue},
+                 rpc:call(Server, rabbit_quorum_queue, add_member,
+                          [<<"/">>, SQ, Server, 5000])).
+
 add_member_already_a_member(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
@@ -1732,6 +1747,16 @@ delete_member_classic(Config) ->
     ?assertEqual({error, classic_queue_not_supported},
                  rpc:call(Server, rabbit_quorum_queue, delete_member,
                           [<<"/">>, CQ, Server])).
+
+delete_member_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    SQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    ?assertEqual({error, not_quorum_queue},
+                 rpc:call(Server, rabbit_quorum_queue, delete_member,
+                          [<<"/">>, SQ, Server])).
 
 delete_member_queue_not_found(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
@@ -2415,6 +2440,26 @@ memory_alarm_rolls_wal(Config) ->
     ?awaitMatch([], rabbit_ct_broker_helpers:get_alarms(Config, Server), ?DEFAULT_AWAIT),
     ok.
 
+reclaim_memory_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0}, declare(Ch, CQ, [])),
+    %% legacy, special case for classic queues
+    ?assertMatch({error, classic_queue_not_supported},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              reclaim_memory, [<<"/">>, CQ])),
+    SQ = ?config(alt_queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    %% all other (future) queue types get the same error
+    ?assertMatch({error, not_quorum_queue},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              reclaim_memory, [<<"/">>, SQ])),
+    ok.
+
 queue_length_limit_drop_head(Config) ->
     [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
@@ -2521,6 +2566,30 @@ peek(Config) ->
                                               peek, [3, QName])),
 
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
+    ok.
+
+peek_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0}, declare(Ch, CQ, [])),
+
+    CQName = rabbit_misc:r(<<"/">>, queue, CQ),
+    %% legacy, special case for classic queues
+    ?assertMatch({error, classic_queue_not_supported},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              peek, [1, CQName])),
+    SQ = ?config(alt_queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+
+    SQName = rabbit_misc:r(<<"/">>, queue, SQ),
+    %% all other (future) queue types get the same error
+    ?assertMatch({error, not_quorum_queue},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              peek, [1, SQName])),
     ok.
 
 message_ttl(Config) ->


### PR DESCRIPTION
## Proposed Changes

This prevents the below ugly printout when wrong queue name provided accidentally on the command line
```
$ rabbitmq-queues quorum_status sq1
Status of quorum queue sq1 on node rabbit@localhost ...
Error:
{{:case_clause, {:ok, {:amqqueue, {:resource, "/", :queue, "sq1"}, true, false, :none, [{"x-queue-type", :longstr, "stream"}], #PID<12159.7298.0>, [], [], [], :undefined, :undefined, [], [], :live, 0, [], "/", %{user: "guest"}, :rabbit_stream_queue, %{epoch: 1, event_formatter: {:rabbit_stream_queue, :format_osiris_event, [{:resource, "/", :queue, "sq1"}]}, leader_node: :"rabbit@localhost", leader_pid: #PID<12159.7298.0>, name: '__sq1_1669413361680170372', nodes: [:"rabbit@localhost", :"r3@localhost", :"r2@localhost"], reference: {:resource, "/", :queue, "sq1"}, replica_nodes: [:"r3@localhost", :"r2@localhost"], retention: []}}}}, [{:rabbit_quorum_queue, :status, 2, [file: 'rabbit_quorum_queue.erl', line: 1022]}]}
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
