### PR TITLE
Updated django url to re_path

### DIFF
--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_django/rabbitmq_auth_backend_django/urls.py
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_django/rabbitmq_auth_backend_django/urls.py
@@ -13,14 +13,14 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 import rabbitmq_auth_backend_django.auth.views as views
 
 urlpatterns = [
-    url(r'^auth/user',     views.user),
-    url(r'^auth/vhost',    views.vhost),
-    url(r'^auth/resource', views.resource),
-    url(r'^auth/topic',    views.topic),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^auth/user',     views.user),
+    re_path(r'^auth/vhost',    views.vhost),
+    re_path(r'^auth/resource', views.resource),
+    re_path(r'^auth/topic',    views.topic),
+    re_path(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
## Proposed Changes

While following the HTTP backend example for Django, it errors out and doesnt work.
Latest django  doesn't have 'django.conf.urls' anymore, this causes the demo to not work. I made changes that would fix that.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This is a very simple change needed to follow the tutorial. 