### PR TITLE
Fix case_clause crash when stream queue provided for quorum queue commands

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1040,6 +1040,8 @@ status(Vhost, QueueName) ->
                          ]
                  end
              end || N <- Nodes];
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
             E
     end.
@@ -1075,6 +1077,8 @@ add_member(VHost, Name, Node, Timeout) ->
                             add_member(Q, Node, Timeout)
                     end
             end;
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
                     E
     end.
@@ -1130,6 +1134,8 @@ delete_member(VHost, Name, Node) ->
                 true ->
                     delete_member(Q, Node)
             end;
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
                     E
     end.
@@ -1287,6 +1293,8 @@ reclaim_memory(Vhost, QueueName) ->
         {ok, Q} when ?amqqueue_is_quorum(Q) ->
             ok = ra:pipeline_command(amqqueue:get_pid(Q),
                                      rabbit_fifo:make_garbage_collection());
+        {ok, _Q} ->
+            {error, not_quorum_queue};
         {error, not_found} = E ->
             E
     end.
@@ -1550,7 +1558,9 @@ peek(Pos, Q) when ?is_amqqueue(Q) andalso ?amqqueue_is_quorum(Q) ->
             Err
     end;
 peek(_Pos, Q) when ?is_amqqueue(Q) andalso ?amqqueue_is_classic(Q) ->
-    {error, classic_queue_not_supported}.
+    {error, classic_queue_not_supported};
+peek(_Pos, Q) when ?is_amqqueue(Q) ->
+    {error, not_quorum_queue}.
 
 online(Q) when ?is_amqqueue(Q) ->
     Nodes = get_connected_nodes(Q),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -159,8 +159,7 @@ all_tests() ->
 memory_tests() ->
     [
      memory_alarm_rolls_wal,
-     %%reclaim_memory,
-     reclaim_memory_wrong_type
+     reclaim_memory_with_wrong_queue_type
     ].
 
 -define(SUPNAME, ra_server_sup_sup).
@@ -285,6 +284,8 @@ init_per_testcase(Testcase, Config) ->
         leader_locator_balanced_random_maintenance when IsMixed ->
             {skip, "leader_locator_balanced_random_maintenance isn't mixed versions compatible because "
              "delete_declare isn't mixed versions reliable"};
+        reclaim_memory_with_wrong_queue_type when IsMixed ->
+            {skip, "reclaim_memory_with_wrong_queue_type isn't mixed versions compatible"};
         _ ->
             Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
             rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
@@ -2440,7 +2441,7 @@ memory_alarm_rolls_wal(Config) ->
     ?awaitMatch([], rabbit_ct_broker_helpers:get_alarms(Config, Server), ?DEFAULT_AWAIT),
     ok.
 
-reclaim_memory_wrong_type(Config) ->
+reclaim_memory_with_wrong_queue_type(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -146,7 +146,7 @@ all_tests() ->
      delete_if_unused,
      queue_ttl,
      peek,
-     peek_wrong_type,
+     peek_with_wrong_queue_type,
      message_ttl,
      per_message_ttl,
      per_message_ttl_mixed_expiry,
@@ -286,6 +286,8 @@ init_per_testcase(Testcase, Config) ->
              "delete_declare isn't mixed versions reliable"};
         reclaim_memory_with_wrong_queue_type when IsMixed ->
             {skip, "reclaim_memory_with_wrong_queue_type isn't mixed versions compatible"};
+        peek_with_wrong_queue_type when IsMixed ->
+            {skip, "peek_with_wrong_queue_type isn't mixed versions compatible"};
         _ ->
             Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
             rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, []),
@@ -2569,7 +2571,7 @@ peek(Config) ->
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
     ok.
 
-peek_wrong_type(Config) ->
+peek_with_wrong_queue_type(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -43,10 +43,12 @@ groups() ->
      {clustered, [], [
                       {cluster_size_2, [], [add_member_not_running,
                                             add_member_classic,
+                                            add_member_wrong_type,
                                             add_member_already_a_member,
                                             add_member_not_found,
                                             delete_member_not_running,
                                             delete_member_classic,
+                                            delete_member_wrong_type,
                                             delete_member_queue_not_found,
                                             delete_member,
                                             delete_member_not_a_member,
@@ -144,6 +146,7 @@ all_tests() ->
      delete_if_unused,
      queue_ttl,
      peek,
+     peek_wrong_type,
      message_ttl,
      per_message_ttl,
      per_message_ttl_mixed_expiry,
@@ -155,7 +158,9 @@ all_tests() ->
 
 memory_tests() ->
     [
-     memory_alarm_rolls_wal
+     memory_alarm_rolls_wal,
+     %%reclaim_memory,
+     reclaim_memory_wrong_type
     ].
 
 -define(SUPNAME, ra_server_sup_sup).
@@ -1674,6 +1679,16 @@ add_member_classic(Config) ->
                  rpc:call(Server, rabbit_quorum_queue, add_member,
                           [<<"/">>, CQ, Server, 5000])).
 
+add_member_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    SQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    ?assertEqual({error, not_quorum_queue},
+                 rpc:call(Server, rabbit_quorum_queue, add_member,
+                          [<<"/">>, SQ, Server, 5000])).
+
 add_member_already_a_member(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
@@ -1732,6 +1747,16 @@ delete_member_classic(Config) ->
     ?assertEqual({error, classic_queue_not_supported},
                  rpc:call(Server, rabbit_quorum_queue, delete_member,
                           [<<"/">>, CQ, Server])).
+
+delete_member_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    SQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    ?assertEqual({error, not_quorum_queue},
+                 rpc:call(Server, rabbit_quorum_queue, delete_member,
+                          [<<"/">>, SQ, Server])).
 
 delete_member_queue_not_found(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
@@ -2415,6 +2440,26 @@ memory_alarm_rolls_wal(Config) ->
     ?awaitMatch([], rabbit_ct_broker_helpers:get_alarms(Config, Server), ?DEFAULT_AWAIT),
     ok.
 
+reclaim_memory_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0}, declare(Ch, CQ, [])),
+    %% legacy, special case for classic queues
+    ?assertMatch({error, classic_queue_not_supported},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              reclaim_memory, [<<"/">>, CQ])),
+    SQ = ?config(alt_queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    %% all other (future) queue types get the same error
+    ?assertMatch({error, not_quorum_queue},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              reclaim_memory, [<<"/">>, SQ])),
+    ok.
+
 queue_length_limit_drop_head(Config) ->
     [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
@@ -2521,6 +2566,30 @@ peek(Config) ->
                                               peek, [3, QName])),
 
     wait_for_messages(Config, [[QQ, <<"2">>, <<"2">>, <<"0">>]]),
+    ok.
+
+peek_wrong_type(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+
+    CQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0}, declare(Ch, CQ, [])),
+
+    CQName = rabbit_misc:r(<<"/">>, queue, CQ),
+    %% legacy, special case for classic queues
+    ?assertMatch({error, classic_queue_not_supported},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              peek, [1, CQName])),
+    SQ = ?config(alt_queue_name, Config),
+    ?assertEqual({'queue.declare_ok', SQ, 0, 0},
+                 declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+
+    SQName = rabbit_misc:r(<<"/">>, queue, SQ),
+    %% all other (future) queue types get the same error
+    ?assertMatch({error, not_quorum_queue},
+                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                              peek, [1, SQName])),
     ok.
 
 message_ttl(Config) ->


### PR DESCRIPTION
This is #6480 by @gomoripeti with a test exclusion for mixed version runs.