### PR TITLE
Fix feature-flags-related Dialyzer warnings

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1034,7 +1034,8 @@ assert_feature_flag_is_valid(FeatureName, FeatureProps) ->
                 throw(
                   {required_feature_flag_with_migration_fun, FeatureName});
             #{migration_fun := MigrationFunMF} ->
-                ?assertMatch({_, _}, MigrationFunMF),
+                ?assert(is_tuple(MigrationFunMF)),
+                ?assertEqual(2, size(MigrationFunMF)),
                 {MigrationMod, MigrationFun} = MigrationFunMF,
                 ?assert(is_atom(MigrationMod)),
                 ?assert(is_atom(MigrationFun)),

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -1061,7 +1061,7 @@ enable_dependencies1(
       Nodes :: [node()],
       FeatureName :: rabbit_feature_flags:feature_name(),
       Command :: rabbit_feature_flags:callback_name(),
-      Extra :: rabbit_feature_flags:callbacks_args(),
+      Extra :: map(),
       Timeout :: timeout(),
       Rets :: #{node() => term()}.
 


### PR DESCRIPTION
Most of the Dialyzer who appeared recently are due to advances in Dialyzer. We used some tricks to convince Dialyzer about return values of the `rabbit_ff_registry` module generated at runtime, but they didn't work anymore. This patch primarily reworks these tricks.