### PR TITLE
rabbit_runtime_parameters: Fix event when clearing a global runtime parameter

### DIFF
--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -193,7 +193,7 @@ clear(VHost, Component, Name, ActingUser) ->
 clear_global(Key, ActingUser) ->
     KeyAsAtom = rabbit_data_coercion:to_atom(Key),
     Notify = fun() ->
-                    event_notify(parameter_set, none, global,
+                    event_notify(parameter_cleared, none, global,
                                  [{name,  KeyAsAtom},
                                   {user_who_performed_action, ActingUser}]),
                     ok


### PR DESCRIPTION
The event was named `parameter_set` instead of `parameter_cleared`. The latter is the name already used when clearing a non-global runtime parameter.