### PR TITLE
Expose effective policy definition via CLI

### DIFF
--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -1321,7 +1321,11 @@ Whether the queue will be deleted automatically when no longer used.
 .It Cm arguments
 Queue arguments.
 .It Cm policy
-Effective policy name for the queue.
+Name of the user policy that is applied to the queue.
+.It Cm operator_policy
+Name of the operator policy that is applied to the queue.
+.It Cm effective_policy_definition
+Effective policy definition for the queue - merged values from the user and operator policies.
 .It Cm pid
 Erlang process identifier of the queue.
 .It Cm owner_pid

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -1325,7 +1325,7 @@ Name of the user policy that is applied to the queue.
 .It Cm operator_policy
 Name of the operator policy that is applied to the queue.
 .It Cm effective_policy_definition
-Effective policy definition for the queue - merged values from the user and operator policies.
+Effective policy definition for the queue: both user and operator policy definitions merged.
 .It Cm pid
 Erlang process identifier of the queue.
 .It Cm owner_pid

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -15,7 +15,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   @default_timeout 60_000
   @info_keys ~w(name durable auto_delete
-            arguments policy pid owner_pid exclusive exclusive_consumer_pid
+            arguments policy operator_policy effective_policy_definition
+            pid owner_pid exclusive exclusive_consumer_pid
             exclusive_consumer_tag messages_ready messages_unacknowledged messages
             messages_ready_ram messages_unacknowledged_ram messages_ram
             messages_persistent message_bytes message_bytes_ready


### PR DESCRIPTION
## Proposed Changes

Now it's only visible in the management UI.

One can craft a series of calls to `rabbitmqctl list_queues` and `rabbitmqctl list_policies` to achieve similiar result. But it's more difficult, and also doesn't take operator policy (if any) into account.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
