### PR TITLE
Modify rabbit_sharding_exchange_decorator boot requirements

### DIFF
--- a/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
+++ b/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
@@ -13,8 +13,7 @@
                            [exchange_decorator, <<"sharding">>, ?MODULE]}},
                     {cleanup, {rabbit_registry, unregister,
                                [exchange_decorator, <<"sharding">>]}},
-                    {requires, rabbit_registry},
-                    {enables, recovery}]}).
+                    {requires, [rabbit_registry, recovery]}]}).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 


### PR DESCRIPTION
Fixes #6582

Reported in the following discussions:

* https://github.com/rabbitmq/rabbitmq-server/discussions/3415
* https://github.com/rabbitmq/rabbitmq-server/discussions/6429

By following the reproduction steps given
[here](https://github.com/reichowc/rabbitmq-sharding-plugin) (thank you @reichowc), I am able to reproduce this issue using Docker and `make start-cluster`. Note that is important to enable another plugin that uses exchange decorators, like `rabbitmq_event_exchange`

Here is the sequence of events that causes [the error](https://github.com/rabbitmq/rabbitmq-server/discussions/3415#discussioncomment-1436194) ([link](https://github.com/rabbitmq/rabbitmq-server/discussions/3415#discussioncomment-1436194)):

* Cluster node boots and reaches the `rabbit_sharding_exchange_decorator` boot step, which only requires the `rabbit_registry` step to have completed.
* This boot step causes `rabbit_registry:register/3` to be called.
* The above function eventually leads to [this line](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit_common/src/rabbit_registry.erl#L78) being called, which in this case is `rabbit_exchange_decorator:added_to_rabbit_registry/2`.
* In the above module, `maybe_recover/1` is called, which leads to `rabbit_sharding_exchange_decorator:create/2` being called.
* In the above module, `create/2` eventually leads to `rabbit_sharding_shard:ensure_sharded_queues/1` being called, which tries to created the sharded queues. **NOTE**: at this time the vhost may not yet be running, and the error is triggered.

The `rabbit_sharding_exchange_decorator` boot step enables the `recovery` boot step, which is where vhosts are recovered. It seems as though this boot step should require the `recovery` step to have completed, and it shouldn't enable anything.