### PR TITLE
Copy rather than symlink rabbitmqctl in bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -100,6 +100,11 @@ rabbitmqctl(
     home = ":broker-home",
 )
 
+rabbitmqctl(
+    name = "rabbitmq-streams",
+    home = ":broker-home",
+)
+
 shell(
     name = "repl",
     deps = PLUGINS,

--- a/dist.bzl
+++ b/dist.bzl
@@ -11,9 +11,8 @@ load("@rules_erlang//:source_tree.bzl", "source_tree")
 load(
     ":rabbitmq_home.bzl",
     "RABBITMQ_HOME_ATTRS",
-    "RabbitmqHomeInfo",
+    "copy_escript",
     "flatten",
-    "link_escript",
 )
 load(
     ":rabbitmq.bzl",
@@ -77,7 +76,7 @@ def _sbin_dir_private_impl(ctx):
     ]
 
 def _escript_dir_private_impl(ctx):
-    escripts = [link_escript(ctx, escript) for escript in ctx.files._scripts]
+    escripts = [copy_escript(ctx, escript) for escript in ctx.files._scripts]
 
     return [
         DefaultInfo(


### PR DESCRIPTION
when creating rabbitmq home folders

This may help with some strange behavior in the cli when the default node is not reachable