### PR TITLE
Update other exchange decorators

### DIFF
--- a/deps/rabbitmq_event_exchange/src/rabbit_event_exchange_decorator.erl
+++ b/deps/rabbitmq_event_exchange/src/rabbit_event_exchange_decorator.erl
@@ -14,10 +14,9 @@
                    [{description, "event exchange decorator"},
                     {mfa, {rabbit_registry, register,
                            [exchange_decorator, <<"event">>, ?MODULE]}},
-                    {requires, rabbit_registry},
                     {cleanup, {rabbit_registry, unregister,
                                [exchange_decorator, <<"event">>]}},
-                    {enables, recovery}]}).
+                    {requires, [rabbit_registry, recovery]}]}).
 
 -behaviour(rabbit_exchange_decorator).
 

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange.erl
@@ -8,16 +8,15 @@
 %% TODO rename this
 -module(rabbit_federation_exchange).
 
+-include_lib("amqp_client/include/amqp_client.hrl").
+
 -rabbit_boot_step({?MODULE,
                    [{description, "federation exchange decorator"},
                     {mfa, {rabbit_registry, register,
                            [exchange_decorator, <<"federation">>, ?MODULE]}},
-                    {requires, rabbit_registry},
                     {cleanup, {rabbit_registry, unregister,
                                [exchange_decorator, <<"federation">>]}},
-                    {enables, recovery}]}).
-
--include_lib("amqp_client/include/amqp_client.hrl").
+                    {requires, [rabbit_registry, recovery]}]}).
 
 -behaviour(rabbit_exchange_decorator).
 

--- a/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
+++ b/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
@@ -7,6 +7,8 @@
 
 -module(rabbit_sharding_exchange_decorator).
 
+-include_lib("rabbit_common/include/rabbit.hrl").
+
 -rabbit_boot_step({?MODULE,
                    [{description, "sharding exchange decorator"},
                     {mfa, {rabbit_registry, register,
@@ -14,8 +16,6 @@
                     {cleanup, {rabbit_registry, unregister,
                                [exchange_decorator, <<"sharding">>]}},
                     {requires, [rabbit_registry, recovery]}]}).
-
--include_lib("rabbit_common/include/rabbit.hrl").
 
 -behaviour(rabbit_exchange_decorator).
 


### PR DESCRIPTION
Follow-up to #6582

Exchange decorators do not enable anything, but they all do depend on the `rabbit_registry` and `recovery` boot steps.