### PR TITLE
Make rabbitmqctl with no command (implicit "help") behave more like with "help"

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Core.CommandModules do
-  alias RabbitMQ.CLI.Core.{Config, DataCoercion}
+  alias RabbitMQ.CLI.Core.{Config, DataCoercion, Helpers}
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginsHelpers
   alias RabbitMQ.CLI.CommandBehaviour
 
@@ -45,7 +45,11 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
   end
 
   def load_commands(scope, opts) do
-    make_module_map(plugin_modules(opts) ++ ctl_modules(), scope)
+    nopts = case Helpers.normalise_node_option(opts) do
+      {:error, _} -> opts
+      {:ok, options} -> options
+    end
+    make_module_map(plugin_modules(nopts) ++ ctl_modules(), scope)
   end
 
   def ctl_modules() do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
@@ -45,10 +45,12 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
   end
 
   def load_commands(scope, opts) do
-    nopts = case Helpers.normalise_node_option(opts) do
-      {:error, _} -> opts
-      {:ok, options} -> options
-    end
+    nopts =
+      case Helpers.normalise_node_option(opts) do
+        {:error, _} -> opts
+        {:ok, options} -> options
+      end
+
     make_module_map(plugin_modules(nopts) ++ ctl_modules(), scope)
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -58,7 +58,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
     case opts[:list_commands] do
       true ->
-        {:ok, commands_description()}
+        {:ok, commands_description(opts)}
 
       _ ->
         {:ok, all_usage(opts)}
@@ -98,7 +98,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
     tool_usage(tool_name) ++
       ["\n\nAvailable commands:\n"] ++
-      commands_description() ++
+      commands_description(opts) ++
       help_footer(tool_name)
   end
 
@@ -228,8 +228,8 @@ short            | long          | description
     nil != CommandBehaviour.switches(command)[:timeout]
   end
 
-  defp commands_description() do
-    module_map = CommandModules.module_map()
+  defp commands_description(opts) do
+    module_map = CommandModules.module_map(opts)
 
     pad_commands_to =
       Enum.reduce(module_map, 0, fn {name, _}, longest ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -30,7 +30,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
   def run([command_name | _], opts) do
     CommandModules.load(opts)
 
-    module_map = CommandModules.module_map()
+    module_map = CommandModules.module_map(opts)
 
     case module_map[command_name] do
       nil ->


### PR DESCRIPTION
For instance, if '-n ...' has been used to specify a node, it will be used to discover plugins and print additional commands made available by plugins, as the "help" command does