### PR TITLE
Consistently expose default queue functionality in management UI

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -120,7 +120,8 @@ var ALL_COLUMNS =
                   ['connected_at', 'Connected at', false]]},
 
      'vhosts':
-     {'Overview': [['cluster-state',   'Cluster state',  false],
+     {'Overview': [['default-queue-type', 'Default queue type', false],
+                   ['cluster-state',   'Cluster state',  false],
                    ['description',   'Description',  false],
                    ['tags',   'Tags',  false]],
       'Messages': [['msgs-ready',      'Ready',          true],
@@ -685,7 +686,7 @@ function setup_global_vars() {
     }
     vhosts_interesting = JSON.parse(sync_get('/vhosts')).length > 1;
 
-    queue_type = "classic";
+    queue_type = "default";
     current_vhost = get_pref('vhost');
     exchange_types = overview.exchange_types;
 

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1467,7 +1467,9 @@ function collapse_multifields(params0) {
     }
     if (params.hasOwnProperty('queuetype')) {
         delete params['queuetype'];
-        params['arguments']['x-queue-type'] = queue_type;
+        if (queue_type != 'default') {
+            params['arguments']['x-queue-type'] = queue_type;
+        }
         if (queue_type == 'quorum' ||
             queue_type == 'stream') {
             params['durable'] = true;

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -249,7 +249,12 @@
           <th><label>Type:</label></th>
           <td>
             <select name="queuetype" onchange="select_queue_type(queuetype)">
-              <option value="classic">Classic</option>
+              <option value="default">Default for virtual host</option>
+              <% if (queue_type == "classic") { %>
+               <option value="classic" selected>Classic</option>
+              <% } else { %>
+               <option value="classic">Classic</option>
+              <% } %>
               <% if (queue_type == "quorum") { %>
                <option value="quorum" selected>Quorum</option>
               <% } else { %>
@@ -267,7 +272,7 @@
           <th><label>Name:</label></th>
           <td><input type="text" name="name"/><span class="mand">*</span></td>
         </tr>
-<% if (queue_type == "classic") { %>
+<% if (queue_type == "classic" || queue_type == "default") { %>
         <tr>
           <th><label>Durability:</label></th>
           <td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/vhost.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/vhost.ejs
@@ -21,6 +21,11 @@
       <tr>
         <th>Tracing enabled:</th>
         <td><%= fmt_boolean(vhost.tracing) %></td>
+      </tr>
+      <tr>
+        <th>Default queue type:</th>
+        <td><%= vhost.default_queue_type == "undefined" ? "&lt;not set&gt;" :vhost.default_queue_type %></td>
+      </tr>
       <tr>
         <th>State:</th>
         <td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/vhosts.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/vhosts.ejs
@@ -23,6 +23,9 @@
       <th><%= fmt_sort('Name', 'name') %></th>
       <th>Users <span class="help" id="internal-users-only"></span></th>
       <th>State</th>
+<% if (show_column('vhosts',           'default-queue-type')) { %>
+      <th>Default queue type</th>
+<% } %>
 <% if (show_column('vhosts',           'cluster-state')) { %>
       <th>Cluster state</th>
 <% } %>
@@ -69,6 +72,11 @@
          <td class="c"><%= fmt_permissions(vhost, permissions, 'vhost', 'user',
                            '<p class="warning">No users</p>') %></td>
          <td><%= fmt_vhost_state(vhost) %></td>
+<% if (show_column('vhosts', 'default-queue-type')) { %>
+   <td>
+     <%= vhost.default_queue_type == "undefined" ? "&lt;not set&gt;" :vhost.default_queue_type %>
+   </td>
+<% } %>
 <% if (show_column('vhosts', 'cluster-state')) { %>
          <td>
              <table>


### PR DESCRIPTION
## Proposed Changes

1. Allow to create queues in UI without `x-queue-type` argument, which should give default queue type logic a chance to run. What's more, those queues definitions will be exported without `x-queue-type`, so they can be loaded into another vhost and default queue logic will be applied again.

2. Show default queue type on the vhost page and the vhosts list pages

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it