### PR TITLE
Fix error filtering and printing in queue grow/shrink commands

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/grow_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/grow_command.ex
@@ -65,7 +65,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
         error
 
       results when errors_only ->
-        for {{:resource, vhost, _kind, name}, {:errors, _, _} = res} <- results,
+        for {{:resource, vhost, _kind, name}, {:error, _, _} = res} <- results,
             do: [
               {:vhost, vhost},
               {:name, name},
@@ -146,6 +146,6 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
   end
 
   defp format_result({:error, _size, err}) do
-    :io.format("error: ~W", [err, 10])
+    to_string(:io_lib.format("error: ~W", [err, 10]))
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/shrink_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/shrink_command.ex
@@ -107,6 +107,6 @@ defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommand do
   end
 
   defp format_result({:error, _size, err}) do
-    :io.format("error: ~W", [err, 10])
+    to_string(:io_lib.format("error: ~W", [err, 10]))
   end
 end


### PR DESCRIPTION
## Proposed Changes

Cosmetic micro changes only.

- Because of the `:errors` no output was shown for `rabbitmq-queues grow` with `--errors-only` option (even when there were errors)

- Using `:io.format` resulted in the `result` always having an `ok` value

```
% ./sbin/rabbitmq-queues grow r3@localhost all
Growing all quorum queues on r3@localhost...
error: {no_more_servers_to_try,[{error,noproc}, ...
vhost	name	size	result
/	qq5	2	ok
```
instead of:
```
% ./sbin/rabbitmq-queues grow r3@localhost all
Growing all quorum queues on r3@localhost...
vhost	name	size	result
/	qq5	2	error: {no_more_servers_to_try,[{error,noproc}, ...
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
