### PR TITLE
Make CT helpers available for erlang_ls

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,7 +5,10 @@ erlang_ls_tree(
     name = "erlang_ls_files",
     apps = all_plugins(
         rabbitmq_workspace = "",
-    ),
+    ) + [
+        "//deps/rabbitmq_ct_helpers:erlang_app",
+        "//deps/rabbitmq_ct_client_helpers:erlang_app",
+    ],
 )
 
 erlang_ls_config(


### PR DESCRIPTION
## Proposed Changes

Include common test helpers in bazel-generated erlang_ls-friendly directory tree. So that errors go away while editing tests.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist


- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
