### PR TITLE
Expose aten poll interval in rabbitmq.conf

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2312,6 +2312,20 @@ end}.
     end
 }.
 
+{mapping, "raft.adaptive_failure_detector.poll_interval", "aten.poll_interval", [
+{datatype, integer},
+{validators, ["non_zero_positive_integer"]}
+]}.
+
+{translation, "aten.poll_interval",
+  fun(Conf) ->
+      case cuttlefish:conf_get("raft.adaptive_failure_detector.poll_interval", Conf, undefined) of
+          undefined -> cuttlefish:unset();
+          Val       -> Val
+      end
+  end
+}.
+
 %%
 %% Backing queue version
 %%

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2313,8 +2313,8 @@ end}.
 }.
 
 {mapping, "raft.adaptive_failure_detector.poll_interval", "aten.poll_interval", [
-{datatype, integer},
-{validators, ["non_zero_positive_integer"]}
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
 ]}.
 
 {translation, "aten.poll_interval",

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -844,6 +844,13 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
+   {raft_adaptive_failure_detector_poll_interval,
+   "raft.adaptive_failure_detector.poll_interval = 10000",
+   [{aten, [
+      {poll_interval, 10000}
+     ]}],
+   []},
+
   %%
   %% Backing queue version
   %%


### PR DESCRIPTION
## Proposed Changes

as `raft.adaptive_failure_detector.poll_interval`.

On systems under peak load, inter-node communication link congestion can result in false positives and trigger QQ leader re-elections that are unnecessary and could make the situation worse.

Using a higher poll interval would at least reduce the probability of false positives.

Per discussion with @kjnilsson @mkuratczyk.

## Types of Changes


- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

The doc part of this change is TBD.