### PR TITLE
Use ubuntu-20.04 in actions as the base OS

### DIFF
--- a/.github/workflows/oci-base.yaml
+++ b/.github/workflows/oci-base.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   build-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -28,7 +28,7 @@ jobs:
   # * main-otp-max (image OTP 26)
 
   build-publish-dev-bazel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-a:
     name: Run A
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         erlang_version:
@@ -44,7 +44,7 @@ jobs:
   run-b:
     name: Run B
     needs: run-a
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         erlang_version:
@@ -79,7 +79,7 @@ jobs:
   parse-logs:
     name: Parse Logs
     needs: [run-a, run-b]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: CHECKOUT BAZEL
       uses: actions/checkout@v3

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -4,7 +4,7 @@ on:
 jobs:
   peer-discovery-aws-integration-test:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/secondary-umbrella.yaml
+++ b/.github/workflows/secondary-umbrella.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   package-generic-unix:
     name: package-generic-unix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-erlang-git:
     name: Test (Erlang Git Master)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   ensure-mixed-version-archive:
     name: Prepare Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       # otp-min
       otp_version_id: 25_0
@@ -120,7 +120,7 @@ jobs:
 
   test-mixed-versions:
     name: Test (Mixed Version Cluster)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: ensure-mixed-version-archive
     strategy:
       fail-fast: false
@@ -163,7 +163,7 @@ jobs:
           --verbose_failures
   test-exclusive-mixed-versions:
     name: Test (Exclusive Tests with Mixed Version Cluster)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: ensure-mixed-version-archive
     strategy:
       matrix:

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   selenimum:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +74,7 @@ jobs:
           --verbose_failures
   test-exclusive:
     name: Test (Exclusive Tests)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-elixir-patches.yaml
+++ b/.github/workflows/update-elixir-patches.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-toolchains:
     name: Update Elixir Versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-toolchains:
     name: Update OTP Versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       fail-fast: false


### PR DESCRIPTION
The ubuntu-latest tag is being switched to 22.04, and seems to be causing some issues