### PR TITLE
Remove unused rabbit_definitions:apply_defs/5

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -43,7 +43,7 @@
 %% import
 -export([import_raw/1, import_raw/2, import_parsed/1, import_parsed/2,
          import_parsed_with_hashing/1, import_parsed_with_hashing/2,
-         apply_defs/2, apply_defs/3, apply_defs/4, apply_defs/5,
+         apply_defs/2, apply_defs/3,
          should_skip_if_unchanged/0]).
 
 -export([all_definitions/0]).
@@ -461,44 +461,6 @@ apply_defs(Map, ActingUser, SuccessFun, VHost) when is_function(SuccessFun); is_
         SuccessFun()
     catch {error, E} -> {error, format(E)};
           exit:E     -> {error, format(E)}
-    after
-        rabbit_runtime:gc_all_processes()
-    end.
-
--spec apply_defs(Map :: #{atom() => any()},
-                ActingUser :: rabbit_types:username(),
-                SuccessFun :: fun(() -> 'ok'),
-                ErrorFun :: fun((any()) -> 'ok'),
-                VHost :: vhost:name()) -> 'ok' | {error, term()}.
-
-apply_defs(Map, ActingUser, SuccessFun, ErrorFun, VHost) ->
-    rabbit_log:info("Asked to import definitions for a virtual host. Virtual host: ~tp, acting user: ~tp",
-                    [VHost, ActingUser]),
-    try
-        validate_limits(Map, VHost),
-
-        concurrent_for_all(bindings,   ActingUser, Map, VHost, fun add_binding/3),
-        sequential_for_all(parameters, ActingUser, Map, VHost, fun add_parameter/3),
-        %% importing policies concurrently can be unsafe as queues will be getting
-        %% potentially out of order notifications of applicable policy changes
-        sequential_for_all(policies,   ActingUser, Map, VHost, fun add_policy/3),
-
-        rabbit_nodes:if_reached_target_cluster_size(
-            fun() ->
-                concurrent_for_all(queues,     ActingUser, Map, VHost, fun add_queue/3),
-                concurrent_for_all(bindings,   ActingUser, Map, VHost, fun add_binding/3)
-            end,
-
-            fun() ->
-                rabbit_log:info("There are fewer than target cluster size (~b) nodes online,"
-                                " skipping queue and binding import from definitions",
-                                [rabbit_nodes:target_cluster_size_hint()])
-            end
-        ),
-
-        SuccessFun()
-    catch {error, E} -> ErrorFun(format(E));
-          exit:E     -> ErrorFun(format(E))
     after
         rabbit_runtime:gc_all_processes()
     end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -12,8 +12,6 @@
 -export([accept_multipart/2]).
 -export([variances/2]).
 
--export([apply_defs/3, apply_defs/5]).
-
 -import(rabbit_misc, [pget/2]).
 
 -include("rabbit_mgmt.hrl").
@@ -209,15 +207,6 @@ apply_defs(Body, ActingUser) ->
 
 apply_defs(Body, ActingUser, VHost) ->
     rabbit_definitions:apply_defs(Body, ActingUser, VHost).
-
--spec apply_defs(Map :: #{atom() => any()},
-                ActingUser :: rabbit_types:username(),
-                SuccessFun :: fun(() -> 'ok'),
-                ErrorFun :: fun((any()) -> 'ok'),
-                VHost :: vhost:name()) -> 'ok' | {error, term()}.
-
-apply_defs(Body, ActingUser, SuccessFun, ErrorFun, VHost) ->
-    rabbit_definitions:apply_defs(Body, ActingUser, SuccessFun, ErrorFun, VHost).
 
 get_all_parts(Req) ->
     get_all_parts(Req, []).


### PR DESCRIPTION
## Proposed Changes

Turns out `rabbit_definitions:apply_defs/5` is not being used anywhere - it's a copy of `apply_defs/4`, but with custom error handling. And it contains a bug where it was trying to import bindings too early: https://github.com/rabbitmq/rabbitmq-server/blob/aec3dcbf37ac9f6cecf9f4c6bde7a49c4f045857/deps/rabbit/src/rabbit_definitions.erl#L480
 `apply_defs/4` imports exchanges at exactly the same place.

This PR removes this unused function, and a bunch of related exports that are not being used outside of their own module.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
