### PR TITLE
Update mix_task_archve_deps to 1.0.0

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-dist.mk
+++ b/deps/rabbit_common/mk/rabbitmq-dist.mk
@@ -19,7 +19,8 @@ dist_verbose = $(dist_verbose_$(V))
 
 MIX_ARCHIVES ?= $(HOME)/.mix/archives
 
-MIX_TASK_ARCHIVE_DEPS_VERSION = 0.5.0
+MIX_TASK_ARCHIVE_DEPS_VERSION = 1.0.0
+MIX_TASK_ARCHIVE_DEPS_SHA512 = 6947124c0848d0584416251fc31335d8c17ecd3dbcf8c4013a9c1f0df7a31d16b790dfc1cb45721624fb77610e31975b6804771fe5268797740002bf54c789b8
 mix_task_archive_deps = $(MIX_ARCHIVES)/mix_task_archive_deps-$(MIX_TASK_ARCHIVE_DEPS_VERSION)
 
 # We take the version of an Erlang application from the .app file. This
@@ -209,7 +210,7 @@ $(MIX_DIST_EZS): $(mix_task_archive_deps)
 MIX_TASK_ARCHIVE_DEPS_URL = https://github.com/rabbitmq/mix_task_archive_deps/releases/download/$(MIX_TASK_ARCHIVE_DEPS_VERSION)/mix_task_archive_deps-$(MIX_TASK_ARCHIVE_DEPS_VERSION).ez
 
 $(mix_task_archive_deps):
-	$(gen_verbose) mix archive.install --force $(MIX_TASK_ARCHIVE_DEPS_URL)
+	$(gen_verbose) mix archive.install --force --sha512 $(MIX_TASK_ARCHIVE_DEPS_SHA512) $(MIX_TASK_ARCHIVE_DEPS_URL)
 
 # We need to recurse because the top-level make instance is evaluated
 # before dependencies are downloaded.


### PR DESCRIPTION
Also update with SHA512 so that the download and install via `mix archive.install` works.

Related to: https://groups.google.com/g/rabbitmq-users/c/mSJMjyE20Nk

https://github.com/rabbitmq/mix_task_archive_deps/releases/tag/1.0.0

To test:

```
mix archive.install --force --sha512 6947124c0848d0584416251fc31335d8c17ecd3dbcf8c4013a9c1f0df7a31d16b790dfc1cb45721624fb77610e31975b6804771fe5268797740002bf54c789b8 https://github.com/rabbitmq/mix_task_archive_deps/releases/download/1.0.0/mix_task_archive_deps-1.0.0.ez
```