### PR TITLE
Use direct exchange routing v1 for custom exchange types

### DIFF
--- a/deps/rabbit/src/rabbit_exchange_type_direct.erl
+++ b/deps/rabbit/src/rabbit_exchange_type_direct.erl
@@ -31,10 +31,10 @@ description() ->
 
 serialise_events() -> false.
 
-route(#exchange{name = Name},
+route(#exchange{name = Name, type = Type},
       #delivery{message = #basic_message{routing_keys = Routes}}) ->
-    case rabbit_feature_flags:is_enabled(direct_exchange_routing_v2, non_blocking) of
-        true ->
+    case {Type, rabbit_feature_flags:is_enabled(direct_exchange_routing_v2, non_blocking)} of
+        {direct, true} ->
             route_v2(Name, Routes);
         _ ->
             rabbit_router:match_routing_key(Name, Routes)


### PR DESCRIPTION
Custom exchange types can use the direct exchange as a proxy for routing. However, custom exchange types should continue to use "direct exchange routing v1" because their bindings are not inserted into the new routing table `rabbit_index_route`.

This commits avoids changing the custom exchange types to call `rabbit_router:match_routing_key/2` directly as done in https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/pull/200 and
https://github.com/rabbitmq/rabbitmq-lvc-exchange/pull/32 because other exchange types are out there (as we learnt in https://github.com/rabbitmq/rabbitmq-server/pull/4606#issuecomment-1347617366) which also need to continue to use v1.

So, the cleaner approach is to only use direct exchange routing v2 if
1. the feature flag 'direct_exchange_routing_v2' is enabled, and
2. the source exchange is of type 'direct'