### PR TITLE
Backport #5726 (disk monitor resiliency improvements) to v3.8.x

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -386,6 +386,11 @@ suites = [
     ),
     rabbitmq_integration_suite(
         PACKAGE,
+        name = "disk_monitor_SUITE",
+        size = "medium",
+    ),
+    rabbitmq_integration_suite(
+        PACKAGE,
         name = "dynamic_ha_SUITE",
         size = "large",
         flaky = True,
@@ -823,11 +828,6 @@ suites = [
     rabbitmq_integration_suite(
         PACKAGE,
         name = "unit_credit_flow_SUITE",
-        size = "small",
-    ),
-    rabbitmq_integration_suite(
-        PACKAGE,
-        name = "unit_disk_monitor_mocks_SUITE",
         size = "small",
     ),
     rabbitmq_integration_suite(

--- a/deps/rabbit/src/rabbit_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_disk_monitor.erl
@@ -342,7 +342,7 @@ win32_get_disk_free_pwsh(DriveLetter) when
       (DriveLetter >= $A andalso DriveLetter =< $Z) ->
     % DriveLetter $c
     PoshCmd = "powershell.exe -NoLogo -NoProfile -NonInteractive -Command (Get-PSDrive " ++ [DriveLetter] ++ ").Free",
-    case run_cmd(PoshCmd) of
+    case run_os_cmd(PoshCmd) of
         {error, timeout} ->
             error;
         PoshResult ->

--- a/deps/rabbit/test/unit_disk_monitor_SUITE.erl
+++ b/deps/rabbit/test/unit_disk_monitor_SUITE.erl
@@ -69,7 +69,7 @@ set_disk_free_limit_command(Config) ->
 set_disk_free_limit_command1(_Config) ->
     F = fun () ->
         DiskFree = rabbit_disk_monitor:get_disk_free(),
-        DiskFree =/= unknown
+        DiskFree =/= 'NaN'
     end,
     rabbit_ct_helpers:await_condition(F),
 


### PR DESCRIPTION
## Proposed Changes

Merging pull request https://github.com/rabbitmq/rabbitmq-server/pull/5726 to 3.8.x branch

We are seeing this issue in Ubuntu installations with rabbitmq 3.8 under long time support (Focal). The `unknown` free disk space result breaks `rabbitmqctl status` command.