### PR TITLE
Use more modern method to download definitions

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -657,21 +657,47 @@ function postprocess() {
         });
 
     $('#download-definitions').on('click', function() {
-            var idx = $("select[name='vhost-download'] option:selected").index();
-            var vhost = ((idx <=0 ) ? "" : "/" + esc($("select[name='vhost-download'] option:selected").val()));
-        if (oauth.enabled) {
-            var path = 'api/definitions' + vhost + '?download=' +
-                esc($('#download-filename').val()) +
-                '&token=' + oauth.access_token;
+        // https://stackoverflow.com/questions/16086162/handle-file-download-from-ajax-post/23797348
+        // https://gist.github.com/zynick/12bae6dbc76f6aacedf0/
+        var idx = $("select[name='vhost-download'] option:selected").index();
+        var vhost = ((idx <=0 ) ? "" : "/" + esc($("select[name='vhost-download'] option:selected").val()));
+        var download_filename = esc($('#download-filename').val());
+        var path = 'api/definitions' + vhost + '?download=' + download_filename;
+        var req = xmlHttpRequest();
+        req.open('GET', path, true);
+        req.setRequestHeader('authorization', auth_header());
+        req.responseType = 'blob';
+        req.onload = function (_event) {
+            if (this.status >= 200 && this.status <= 299) {
+                var type = req.getResponseHeader('Content-Type');
+                var blob = new Blob([this.response], { type: type });
+                if (typeof window.navigator.msSaveBlob !== 'undefined') {
+                    window.navigator.msSaveBlob(blob, download_filename);
+                } else {
+                    var URL = window.URL || window.webkitURL;
+                    var downloadUrl = URL.createObjectURL(blob);
+                    var a = document.createElement("a");
+                    if (typeof a.download === 'undefined') {
+                        window.location = downloadUrl;
+                    } else {
+                        a.href = downloadUrl;
+                        a.download = download_filename;
+                        document.body.appendChild(a);
+                        a.click();
+                    }
+                    var cleanup = function () {
+                        URL.revokeObjectURL(downloadUrl);
+                        document.body.removeChild(a);
+                    };
+                    setTimeout(cleanup, 1000);
+                }
             } else {
-                var path = 'api/definitions' + vhost + '?download=' +
-                    esc($('#download-filename').val()) +
-                    '&auth=' + get_cookie_value('auth');
-            };
-            window.location = path;
-            setTimeout('app.run()');
-            return false;
-        });
+                // Unsuccessful status
+                show_popup('warn', 'Error downloading definitions');
+            }
+        };
+        req.send();
+    });
 
     $('.update-manual').on('click', function() {
             update_manual($(this).attr('for'), $(this).attr('query'));
@@ -1295,8 +1321,6 @@ function sync_req(type, params0, path_template, options) {
             });
         }
     }
-
-
 
     try {
         if (type == 'GET')


### PR DESCRIPTION
Does not require sending auth as a query parameter

Ref: https://vmware.slack.com/archives/C0RDGG81Z/p1669827808015729