### PR TITLE
rabbit_vhost: Emit `vhost_deleted` only if the vhost was actually deleted

### DIFF
--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -297,11 +297,12 @@ with_fun_in_mnesia_tx(VHostName, TxFun)
 %% delete().
 %% -------------------------------------------------------------------
 
--spec delete(VHostName) -> ok when
-      VHostName :: vhost:name().
-%% @doc Deletes a virtual host record.
+-spec delete(VHostName) -> Existed when
+      VHostName :: vhost:name(),
+      Existed :: boolean().
+%% @doc Deletes a virtual host record from the database.
 %%
-%% @returns `ok', even if the record didn't exist before. It throws an
+%% @returns a boolean indicating if the vhost existed or not. It throws an
 %% exception if the transaction fails.
 %%
 %% @private
@@ -315,5 +316,6 @@ delete_in_mnesia(VHostName) ->
       fun() -> delete_in_mnesia_tx(VHostName) end).
 
 delete_in_mnesia_tx(VHostName) ->
+    Existed = mnesia:wread({?MNESIA_TABLE, VHostName}) =/= [],
     mnesia:delete({?MNESIA_TABLE, VHostName}),
-    ok.
+    Existed.


### PR DESCRIPTION
This was the case before the reorganize of the code made in #6430 and therefore a regression in the mentionned pull request. This patch restores the behavior.

Note that this is already like that for internal users. Thus, the behavior and `rabbit_db_*` are consistent.