### PR TITLE
Feature flags: Add virgin node init support to v2 code path

### DIFF
--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -44,7 +44,9 @@
          start_link/0,
          rpc_call/5,
          all_nodes/0,
-         running_nodes/0]).
+         running_nodes/0,
+         collect_inventory_on_nodes/1, collect_inventory_on_nodes/2,
+         mark_as_enabled_on_nodes/4]).
 
 %% gen_statem callbacks.
 -export([callback_mode/0,


### PR DESCRIPTION
So far, when a new node is started, the feature flags v1 code is used to enable all stable feature flags (the default behavior). In the list, there would be `feature_flags_v2`, so this one would be enabled first and all others would be using the v2 code path.

If we mark `feature_flags_v2` as required, the v2 code path didn't handle this so far. This patch adds this missing code. Now, a virgin node's feature flags can be enabled fully using the v2 code path.

As part of that, the `get_forced_feature_flag_names()` function is moved from `rabbit_feature_flags` to `rabbit_ff_controller`.

It depends on #6791.

**Update**: The patch was split into two parts, this one (which was the initial scope) and #6810.