### PR TITLE
Parse and apply default_policies.operator

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -141,6 +141,7 @@ _APP_ENV = """[
 DEPS = [
     "//deps/amqp10_common:erlang_app",
     "//deps/rabbit_common:erlang_app",
+    "@cuttlefish//:erlang_app",
     "@ra//:erlang_app",
     "@ranch//:erlang_app",
     "@stdout_formatter//:erlang_app",
@@ -149,7 +150,6 @@ DEPS = [
 
 RUNTIME_DEPS = [
     "//deps/rabbit/apps/rabbitmq_prelaunch:erlang_app",
-    "@cuttlefish//:erlang_app",
     "@observer_cli//:erlang_app",
     "@osiris//:erlang_app",
     "@recon//:erlang_app",
@@ -1036,6 +1036,13 @@ suites = [
         size = "small",
         deps = [
             "//deps/rabbit_common:erlang_app",
+        ],
+    ),
+    rabbitmq_suite(
+        name = "rabbit_cuttlefish_SUITE",
+        size = "small",
+        deps = [
+            "@cuttlefish//:erlang_app",
         ],
     ),
     rabbitmq_integration_suite(

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -632,7 +632,6 @@ end}.
 %% {default_user,        <<"guest">>},
 %% {default_pass,        <<"guest">>},
 %% {default_permissions, [<<".*">>, <<".*">>, <<".*">>]},
-%% {default_limits,      [{vhosts, []}]
 
 {mapping, "default_vhost", "rabbit.default_vhost", [
     {datatype, string}
@@ -682,68 +681,119 @@ fun(Conf) ->
     [list_to_binary(Configure), list_to_binary(Read), list_to_binary(Write)]
 end}.
 
+{mapping, "default_policies.operator.$id.vhost_pattern", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, ".*"},
+    {validators, ["valid_regex"]},
+    {datatype, string}
+]}.
+
+{mapping, "default_policies.operator.$id.queue_pattern", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, ".*"},
+    {validators, ["valid_regex"]},
+    {datatype, string}
+]}.
+
+{mapping, "default_policies.operator.$id.expires", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, "1s"},
+    {datatype, {duration, ms}}
+]}.
+
+{mapping, "default_policies.operator.$id.message_ttl", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, "1s"},
+    {datatype, {duration, ms}}
+]}.
+
+{mapping, "default_policies.operator.$id.max_length", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, 100},
+    {validators, ["non_zero_positive_integer"]},
+    {datatype, integer}
+]}.
+
+{mapping, "default_policies.operator.$id.max_length_bytes", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, "1GB"},
+    {validators, ["non_zero_positive_integer"]},
+    {datatype, bytesize}
+]}.
+
+{mapping, "default_policies.operator.$id.max_in_memory_bytes", "rabbit.default_policies.operator", [
+        {include_default, 1},
+        {commented, "1GB"},
+        {validators, ["non_zero_positive_integer"]},
+        {datatype, bytesize}
+    ]}.
+
+{mapping, "default_policies.operator.$id.max_in_memory_length", "rabbit.default_policies.operator",
+    [
+        {include_default, 1},
+        {commented, 1000},
+        {validators, ["non_zero_positive_integer"]},
+        {datatype, integer}
+    ]}.
+
+{mapping, "default_policies.operator.$id.delivery_limit", "rabbit.default_policies.operator", [
+    {include_default, 1},
+    {commented, 1},
+    {validators, ["non_zero_positive_integer"]},
+    {datatype, integer}
+]}.
+
+{translation, "rabbit.default_policies.operator", fun(Conf) ->
+    Props = rabbit_cuttlefish:aggregate_props(Conf, ["default_policies", "operator"]),
+    Props1 = lists:map(
+                fun({K, Ss}) ->
+                    {K,
+                     lists:map(fun({N, V}) ->
+                        {binary:replace(N, <<"_">>, <<"-">>, [global]), V}
+                     end, Ss)}
+                end, Props),
+    case Props1 of
+        [] -> cuttlefish:unset();
+        _ -> Props1
+    end,
+    Props1
+end}.
+
 {mapping, "default_limits.vhosts.$id.pattern", "rabbit.default_limits.vhosts", [
     {include_default, 1},
-    {comment, ".*"},
+    {commented, ".*"},
     {validators, ["valid_regex"]},
     {datatype, string}
 ]}.
 
 {mapping, "default_limits.vhosts.$id.max_connections", "rabbit.default_limits.vhosts", [
     {include_default, 1},
-    {comment, 1000},
+    {commented, 1000},
     {validators, [ "non_zero_positive_integer"]},
     {datatype, integer}
 ]}.
 
 {mapping, "default_limits.vhosts.$id.max_queues", "rabbit.default_limits.vhosts", [
     {include_default, 1},
-    {comment, 100},
+    {commented, 100},
     {validators, [ "non_zero_positive_integer"]},
     {datatype, integer}
 ]}.
 
-{translation, "rabbit.default_limits.vhosts",
-fun(Conf) ->
-    Prefix = ["default_limits", "vhosts"],
-    GetAll = fun(Spec) ->
-                     FullSpec = Prefix ++ Spec,
-                     lists:filtermap(
-                       fun({K, V}) ->
-                               case cuttlefish_variable:is_fuzzy_match(K, FullSpec) of
-                                   true -> [_, _, ID, _] = K,
-                                           {true, {ID, V}};
-                                   _    -> false
-                               end
-                       end,
-                       Conf)
-             end,
-    Get = fun(Spec) -> cuttlefish:conf_get(Prefix ++ Spec, Conf, undefined) end,
-
-    %% Warn about incomplete config
-    SettingIDs = lists:uniq(
-                   [ ID || {ID, _} <- GetAll(["$id", "max_connections"]) ] ++
-                   [ ID || {ID, _} <- GetAll(["$id", "max_queues"]) ]
-                  ),
-    [ cuttlefish:invalid(
-        io_lib:format(
-           "default_limits.vhosts.~ts.pattern required",
-           [ID]))
-     || ID <- SettingIDs, Get([ID, "pattern"]) =:= undefined ],
-
-    %% Transform
-    Settings = [ {P, [{<<"max-connections">>, Get([ID, "max_connections"])},
-                      {<<"max-queues">>,      Get([ID, "max_queues"])}]} ||
-                 {ID, P} <- GetAll(["$id", "pattern"]) ],
-    Settings1 = lists:map(fun({P, L}) -> {
-                                    list_to_binary(P),
-                                    lists:filter(fun({_, V}) -> V =/= undefined end, L)
-                                   }
-                          end, Settings),
-    case Settings1 of
+{translation, "rabbit.default_limits.vhosts", fun(Conf) ->
+    Props = rabbit_cuttlefish:aggregate_props(Conf, ["default_limits", "vhosts"]),
+    Props1 = lists:map(
+                fun({K, Ss}) ->
+                    {K,
+                     lists:map(fun({N, V}) ->
+                        {binary:replace(N, <<"_">>, <<"-">>, [global]), V}
+                     end, Ss)}
+                end, Props),
+    case Props1 of
         [] -> cuttlefish:unset();
-        _ -> Settings1
-    end
+        _ -> Props1
+    end,
+    Props1
 end}.
 
 %% Tags for default user

--- a/deps/rabbit/src/rabbit_cuttlefish.erl
+++ b/deps/rabbit/src/rabbit_cuttlefish.erl
@@ -1,0 +1,36 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2022-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_cuttlefish).
+
+-export([
+    aggregate_props/2
+]).
+
+-type keyed_props() :: [{binary(), [{binary(), any()}]}].
+
+-spec aggregate_props([{string(), any()}], [string()]) ->
+    keyed_props().
+aggregate_props(Conf, Prefix) ->
+    Pattern = Prefix ++ ["$id", "$_"],
+    PrefixLen = length(Prefix),
+    FlatList = lists:filtermap(
+        fun({K, V}) ->
+            case cuttlefish_variable:is_fuzzy_match(K, Pattern) of
+                true -> {true, {lists:nthtail(PrefixLen, K), V}};
+                _ -> false
+            end
+        end,
+        Conf
+    ),
+    proplists:from_map(
+        maps:groups_from_list(
+            fun({[ID | _], _}) -> list_to_binary(ID) end,
+            fun({[_ | [Setting | _]], Value}) -> {list_to_binary(Setting), Value} end,
+            FlatList
+        )
+    ).

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -145,12 +145,34 @@ parse_tags(Val) when is_list(Val) ->
 default_limits(Name) ->
     AllLimits = application:get_env(rabbit, default_limits, []),
     VHostLimits = proplists:get_value(vhosts, AllLimits, []),
-    Match = lists:search(fun({RE, _}) ->
+    Match = lists:search(fun({_, Ss}) ->
+                                 RE = proplists:get_value(<<"pattern">>, Ss, ".*"),
                                  re:run(Name, RE, [{capture, none}]) =:= match
                          end, VHostLimits),
     case Match of
-        {value, {_, Limits}} -> Limits;
-        _                    -> []
+        {value, {_, Ss}} ->
+            proplists:delete(<<"pattern">>, Ss);
+        _ ->
+            []
+    end.
+
+-spec default_operator_policies(vhost:name()) ->
+    {binary(), binary(), proplists:proplist()} | not_found.
+default_operator_policies(Name) ->
+    AllPolicies = application:get_env(rabbit, default_policies, []),
+    OpPolicies = proplists:get_value(operator, AllPolicies, []),
+    Match = lists:search(fun({_, Ss}) ->
+                                 RE = proplists:get_value(<<"vhost-pattern">>, Ss, ".*"),
+                                 re:run(Name, RE, [{capture, none}]) =:= match
+                         end, OpPolicies),
+    case Match of
+        {value, {PolicyName, Ss}} ->
+            QPattern = proplists:get_value(<<"queue-pattern">>, Ss, ".*"),
+            Ss1 = proplists:delete(<<"queue-pattern">>, Ss),
+            Ss2 = proplists:delete(<<"vhost-pattern">>, Ss1),
+            {PolicyName, list_to_binary(QPattern), Ss2};
+        _ ->
+            not_found
     end.
 
 -spec add(vhost:name(), rabbit_types:username()) ->
@@ -213,10 +235,22 @@ do_add(Name, Metadata, ActingUser) ->
         existing ->
             ok
     end,
-    rabbit_log:info("Applying default limits to vhost '~tp': ~tp", [Name, DefaultLimits]),
     case DefaultLimits of
-        [] -> ok;
-        _  -> ok = rabbit_vhost_limit:set(Name, DefaultLimits, ActingUser)
+        [] ->
+            ok;
+        _  ->
+            ok = rabbit_vhost_limit:set(Name, DefaultLimits, ActingUser),
+            rabbit_log:info("Applied default limits to vhost '~tp': ~tp",
+                            [Name, DefaultLimits])
+    end,
+    case default_operator_policies(Name) of
+        not_found ->
+            ok;
+        {PolicyName, QPattern, Definition} = Policy ->
+            ok = rabbit_policy:set_op(Name, PolicyName, QPattern, Definition,
+                                undefined, undefined, ActingUser),
+            rabbit_log:info("Applied default operator policy to vhost '~tp': ~tp",
+                            [Name, Policy])
     end,
     [begin
          Resource = rabbit_misc:r(Name, exchange, ExchangeName),

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -118,26 +118,26 @@ ssl_options.fail_if_no_peer_cert = true",
   "disk_free_limit.absolute = 50000",
    [{rabbit, [{disk_free_limit, 50000}]}],[]},
 
-
- {default_vhost_limits_with_two_limits,
+ {default_policies_operator,
  "
-  default_limits.vhosts.a.pattern = .*
-  default_limits.vhosts.a.max_queues = 10
-  default_limits.vhosts.a.max_connections = 100
+  default_policies.operator.a.expires = 1h
+  default_policies.operator.a.queue_pattern = apple
+  default_policies.operator.a.vhost_pattern = banana
  ",
-  [{rabbit, [{default_limits, [{vhosts, [
-      {<<".*">>, [{<<"max-connections">>, 100}, {<<"max-queues">>, 10}]}
-                                       ]}]}]}],
+  [{rabbit, [{default_policies, [{operator, [
+      {<<"a">>, [{<<"expires">>, 3600000},
+                 {<<"queue-pattern">>, "apple"},
+                 {<<"vhost-pattern">>, "banana"}]}]}]}]}],
   []},
 
- {default_vhost_limits_with_one_limit,
+ {default_vhost_limits,
  "
-  default_limits.vhosts.a.pattern = .*
+  default_limits.vhosts.a.pattern = banana
   default_limits.vhosts.a.max_queues = 10
  ",
   [{rabbit, [{default_limits, [{vhosts, [
-      {<<".*">>, [{<<"max-queues">>, 10}]}
-                                       ]}]}]}],
+      {<<"a">>, [{<<"pattern">>, "banana"},
+                 {<<"max-queues">>, 10}]}]}]}]}],
   []},
 
  {default_user_settings,

--- a/deps/rabbit/test/rabbit_cuttlefish_SUITE.erl
+++ b/deps/rabbit/test/rabbit_cuttlefish_SUITE.erl
@@ -1,0 +1,55 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2022-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_cuttlefish_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+        aggregate_props_empty,
+        aggregate_props_one_group,
+        aggregate_props_two_groups,
+        aggregate_props_with_prefix
+    ].
+
+groups() ->
+    [
+        {parallel_tests, [parallel], all()}
+    ].
+
+aggregate_props_empty(_) ->
+    ?assertEqual(rabbit_cuttlefish:aggregate_props([], []), []).
+
+
+aggregate_props_one_group(_) ->
+    Have = rabbit_cuttlefish:aggregate_props([
+         {["1", "banana"], "apple"},
+         {["1", "orange"], "carrot"}
+        ], []),
+    ?assertEqual(Have,
+                 [{<<"1">>, [{<<"banana">>, "apple"},
+                             {<<"orange">>, "carrot"}]}]).
+
+aggregate_props_two_groups(_) ->
+    Have = rabbit_cuttlefish:aggregate_props([
+         {["1", "banana"], "apple"},
+         {["2", "orange"], "carrot"}
+        ], []),
+    ?assertEqual(Have,
+                 [{<<"1">>, [{<<"banana">>, "apple"}]},
+                  {<<"2">>, [{<<"orange">>, "carrot"}]}]).
+
+
+aggregate_props_with_prefix(_) ->
+    Have = rabbit_cuttlefish:aggregate_props([
+            {["pre", "fix", "1", "banana"], "apple"},
+            {["other"], "settings"}
+        ], ["pre", "fix"]),
+    ?assertEqual(Have, [{<<"1">>, [{<<"banana">>, "apple"}]}]).


### PR DESCRIPTION
## Proposed Changes

Implements #6380, and reworks `default_limits.vhosts` to use the same aggregation function. This in turn changed the internal data representation, but it is non-breaking for the end user.

Example:

  default_policies.operator.policy-name.vhost_pattern = ^device
  default_policies.operator.policy-name.queue_pattern = .*
  default_policies.operator.policy-name.max_length_bytes = 1GB
  default_policies.operator.policy-name.max_length = 1000000

Perhaps most importantly, both do not require vhost pattern anymore. Patterns (vhost and queue) quietly default to `".*"`.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Not sure if plural (default_policies.operators) looks better, but open to suggestions. Prefix `default_policies` was chosen to keep the door open for other types of policies in the future.

Fixed "comment" -> "commented" in cuttlefish spec.

Closes #6380.