### PR TITLE
Remove redundant binary_to_list/1 call

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -924,8 +924,7 @@ policy_precedence(PolVal, _ArgVal) ->
 
 stream_name(#resource{virtual_host = VHost, name = Name}) ->
     Timestamp = erlang:integer_to_binary(erlang:system_time()),
-    osiris_util:to_base64uri(erlang:binary_to_list(<<VHost/binary, "_", Name/binary, "_",
-                                                     Timestamp/binary>>)).
+    osiris_util:to_base64uri(<<VHost/binary, "_", Name/binary, "_", Timestamp/binary>>).
 
 recover(Q) ->
     {ok, Q}.


### PR DESCRIPTION
When creating the internal stream id. Modern versions of osiris can handle binary names just fine.
