### PR TITLE
Use rules_erlang 3.8.5

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,9 @@ build:buildbuddy --noslim_profile
 build:buildbuddy --experimental_profile_include_target_label
 build:buildbuddy --experimental_profile_include_primary_output
 
+# buildbuddy implies remote cache, so ct_logdir is restored to its default for reproducibility
+build:buildbuddy --@rules_erlang//:ct_logdir=
+
 build:rbe --config=buildbuddy
 
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ rebar3.crashdump
 *.plt
 *.lock
 
+/logs/
+
 /topic-branch-scratch/
 
 PACKAGES/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,156 +166,22 @@ source_archive(
     rabbitmq_workspace = "@",
 )
 
-genrule(
+alias(
     name = "test-logs",
-    outs = ["open-test-logs.sh"],
-    cmd = """set -euo pipefail
-cat << 'EOF' > $@
-#!/bin/bash
-set -euo pipefail
-if [ $$# -eq 0 ]; then
-    echo "Usage: bazel run test-logs TEST_LABEL [shard_index]"
-    exit 1
-fi
-
-RELATIVE=$${1#//}
-PACKAGE=$${RELATIVE%%:*}
-SUITE=$${RELATIVE##*:}
-OUTPUT_DIR=test.outputs
-
-if [ $$# -gt 1 ]; then
-    OUTPUT_DIR=shard_$$2_of_*/test.outputs
-fi
-
-if [ ! -d "bazel-testlogs/$$PACKAGE/$$SUITE/"$$OUTPUT_DIR ]; then
-    echo "Test output dir not found, perhaps shard_index needed?"
-    echo "Usage: bazel run test-logs TEST_LABEL [shard_index]"
-    exit 1
-fi
-
-cd "bazel-testlogs/$$PACKAGE/$$SUITE/"$$OUTPUT_DIR
-if [ -f outputs.zip ]; then
-    unzip -u outputs.zip
-fi
-set +e
-open index.html
-rc=$$?
-set -e
-if [[ $$rc -eq 3 ]]; then
-  # For xdg-open exit code 3 means "A required tool could not be found." That is, there is no browser.
-  echo "Open your browser at http://$$(hostname -s):8000/index.html"
-  python -m http.server 8000
-fi
-EOF
-""",
-    executable = True,
+    actual = "//bazel/util:test-logs",
 )
 
-genrule(
+alias(
     name = "remote-test-logs",
-    outs = ["open-remote-test-logs.sh"],
-    cmd = """set -euo pipefail
-cat << 'EOF' > $@
-#!/bin/bash
-set -euo pipefail
-if [ $$# -eq 0 ]; then
-    echo "Usage: bazel run remote-test-logs TEST_LABEL [shard_index]"
-    exit 1
-fi
-
-RELATIVE=$${1#//}
-PACKAGE=$${RELATIVE%%:*}
-SUITE=$${RELATIVE##*:}
-OUTPUT_DIR=test.outputs
-if [ $$# -gt 1 ]; then
-    OUTPUT_DIR=shard_$$2_of_*/test.outputs
-fi
-
-TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
-
-if [ ! -d "$$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR" ]; then
-    echo "Test output dir not found, perhaps shard_index needed?"
-    echo "Usage: bazel run remote-test-logs TEST_LABEL [shard_index]"
-    exit 1
-fi
-
-cd "$$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR" && unzip -u outputs.zip
-open index.html
-EOF
-""",
-    executable = True,
+    actual = "//bazel/util:remote-test-logs",
 )
 
-genrule(
+alias(
     name = "test-node-data",
-    outs = ["open-test-node-data.sh"],
-    cmd = """set -euo pipefail
-cat << 'EOF' > $@
-    set -euo pipefail
-    if [ $$# -eq 0 ]; then
-        echo "Usage: bazel run test-node-data TEST_LABEL [shard_index]"
-        exit 1
-    fi
-
-    RELATIVE=$${1#//}
-    PACKAGE=$${RELATIVE%%:*}
-    SUITE=$${RELATIVE##*:}
-    OUTPUT_DIR=test.outputs
-    if [ $$# -gt 1 ]; then
-        OUTPUT_DIR=shard_$$2_of_*/test.outputs
-    fi
-
-    if [ ! -d "bazel-testlogs/$$PACKAGE/$$SUITE/"$$OUTPUT_DIR ]; then
-        echo "Test output dir not found, perhaps shard_index needed?"
-        echo "Usage: bazel run test-node-data TEST_LABEL [shard_index]"
-        exit 1
-    fi
-
-    cd bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR
-    if [ -f outputs.zip ]; then
-        unzip -u outputs.zip
-    fi
-    open index.html
-    open ct_run.*/deps.*/run.*/log_private
-EOF
-""",
-    executable = True,
+    actual = "//bazel/util:test-node-data",
 )
 
-# NOTE: this rule may not work properly if --remote_download_minimal has been used,
-#       which is currently the default for remote runs
-genrule(
+alias(
     name = "remote-test-node-data",
-    outs = ["open-remote-test-node-data.sh"],
-    cmd = """set -euo pipefail
-cat << 'EOF' > $@
-    set -euo pipefail
-    if [ $$# -eq 0 ]; then
-        echo "Usage: bazel run remote-test-node-data TEST_LABEL [shard_index]"
-        exit 1
-    fi
-
-    RELATIVE=$${1#//}
-    PACKAGE=$${RELATIVE%%:*}
-    SUITE=$${RELATIVE##*:}
-    OUTPUT_DIR=test.outputs
-
-    if [ $$# -gt 1 ]; then
-        OUTPUT_DIR=shard_$$2_of_*/test.outputs
-    fi
-
-    TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
-
-    if [ ! -d $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR ]; then
-        echo "Test output dir not found, perhaps shard_index needed?"
-        echo "Usage: bazel run remote-test-node-data TEST_LABEL [shard_index]"
-        exit 1
-    fi
-
-    cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip -u outputs.zip
-    open index.html
-    open ct_run.*/deps.*/run.*/log_private
-EOF
-""",
-    executable = True,
+    actual = "//bazel/util:remote-test-node-data",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,25 +7,21 @@ bazel_dep(
     name = "rules_pkg",
     version = "0.5.1",
 )
-
 bazel_dep(
     name = "bazel_skylib",
     version = "1.2.0",
 )
-
 bazel_dep(
     name = "platforms",
     version = "0.0.5",
 )
-
 bazel_dep(
     name = "rules_cc",
     version = "0.0.2",
 )
-
 bazel_dep(
     name = "rules_erlang",
-    version = "3.8.4",
+    version = "3.8.5",
 )
 
 erlang_config = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,7 +119,7 @@ git_repository(
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.8.4",
+    tag = "3.8.5",
 )
 
 load(

--- a/bazel/util/BUILD.bazel
+++ b/bazel/util/BUILD.bazel
@@ -1,0 +1,177 @@
+load(":ct_logdir_vars.bzl", "ct_logdir_vars")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+ct_logdir_vars(
+    name = "ct_logdir_vars",
+)
+
+genrule(
+    name = "test-logs",
+    outs = ["open-test-logs.sh"],
+    cmd = """set -euo pipefail
+cat << 'EOF' > $@
+#!/bin/bash
+set -euo pipefail
+
+if [ -n "$(CT_LOGDIR)" ]; then
+    open "$(CT_LOGDIR)/index.html"
+    exit 0
+fi
+
+if [ $$# -eq 0 ]; then
+    echo "Usage: bazel run test-logs TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+RELATIVE=$${1#//}
+PACKAGE=$${RELATIVE%%:*}
+SUITE=$${RELATIVE##*:}
+OUTPUT_DIR=test.outputs
+
+if [ $$# -gt 1 ]; then
+    OUTPUT_DIR=shard_$$2_of_*/test.outputs
+fi
+
+if [ ! -d "bazel-testlogs/$$PACKAGE/$$SUITE/"$$OUTPUT_DIR ]; then
+    echo "Test output dir not found, perhaps shard_index needed?"
+    echo "Usage: bazel run test-logs TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+cd "bazel-testlogs/$$PACKAGE/$$SUITE/"$$OUTPUT_DIR
+if [ -f outputs.zip ]; then
+    unzip -u outputs.zip
+fi
+set +e
+open index.html
+rc=$$?
+set -e
+if [[ $$rc -eq 3 ]]; then
+  # For xdg-open exit code 3 means "A required tool could not be found." That is, there is no browser.
+  echo "Open your browser at http://$$(hostname -s):8000/index.html"
+  python -m http.server 8000
+fi
+EOF
+""",
+    executable = True,
+    toolchains = [":ct_logdir_vars"],
+)
+
+genrule(
+    name = "remote-test-logs",
+    outs = ["open-remote-test-logs.sh"],
+    cmd = """set -euo pipefail
+cat << 'EOF' > $@
+#!/bin/bash
+set -euo pipefail
+if [ $$# -eq 0 ]; then
+    echo "Usage: bazel run remote-test-logs TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+RELATIVE=$${1#//}
+PACKAGE=$${RELATIVE%%:*}
+SUITE=$${RELATIVE##*:}
+OUTPUT_DIR=test.outputs
+if [ $$# -gt 1 ]; then
+    OUTPUT_DIR=shard_$$2_of_*/test.outputs
+fi
+
+TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
+
+if [ ! -d "$$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR" ]; then
+    echo "Test output dir not found, perhaps shard_index needed?"
+    echo "Usage: bazel run remote-test-logs TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+cd "$$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR" && unzip -u outputs.zip
+open index.html
+EOF
+""",
+    executable = True,
+)
+
+genrule(
+    name = "test-node-data",
+    outs = ["open-test-node-data.sh"],
+    cmd = """set -euo pipefail
+cat << 'EOF' > $@
+set -euo pipefail
+
+if [ -n "$(CT_LOGDIR)" ]; then
+    open "$(CT_LOGDIR)/index.html"
+    exit 0
+fi
+
+if [ $$# -eq 0 ]; then
+    echo "Usage: bazel run test-node-data TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+RELATIVE=$${1#//}
+PACKAGE=$${RELATIVE%%:*}
+SUITE=$${RELATIVE##*:}
+OUTPUT_DIR=test.outputs
+if [ $$# -gt 1 ]; then
+    OUTPUT_DIR=shard_$$2_of_*/test.outputs
+fi
+
+if [ ! -d "bazel-testlogs/$$PACKAGE/$$SUITE/"$$OUTPUT_DIR ]; then
+    echo "Test output dir not found, perhaps shard_index needed?"
+    echo "Usage: bazel run test-node-data TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+cd bazel-testlogs/$$PACKAGE/$$SUITE/$$OUTPUT_DIR
+if [ -f outputs.zip ]; then
+    unzip -u outputs.zip
+fi
+open index.html
+open ct_run.*/deps.*/run.*/log_private
+EOF
+""",
+    executable = True,
+    toolchains = [":ct_logdir_vars"],
+)
+
+# NOTE: this rule may not work properly if --remote_download_minimal has been used,
+#       which is currently the default for remote runs
+genrule(
+    name = "remote-test-node-data",
+    outs = ["open-remote-test-node-data.sh"],
+    cmd = """set -euo pipefail
+cat << 'EOF' > $@
+set -euo pipefail
+if [ $$# -eq 0 ]; then
+    echo "Usage: bazel run remote-test-node-data TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+RELATIVE=$${1#//}
+PACKAGE=$${RELATIVE%%:*}
+SUITE=$${RELATIVE##*:}
+OUTPUT_DIR=test.outputs
+
+if [ $$# -gt 1 ]; then
+    OUTPUT_DIR=shard_$$2_of_*/test.outputs
+fi
+
+TESTLOGS=$$(echo $$(bazel info output_path)/k8-*/testlogs)
+
+if [ ! -d $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR ]; then
+    echo "Test output dir not found, perhaps shard_index needed?"
+    echo "Usage: bazel run remote-test-node-data TEST_LABEL [shard_index]"
+    exit 1
+fi
+
+cd $$TESTLOGS/$$PACKAGE/$$SUITE/$$OUTPUT_DIR && unzip -u outputs.zip
+open index.html
+open ct_run.*/deps.*/run.*/log_private
+EOF
+""",
+    executable = True,
+)

--- a/bazel/util/ct_logdir_vars.bzl
+++ b/bazel/util/ct_logdir_vars.bzl
@@ -1,0 +1,23 @@
+load(
+    "@bazel_skylib//rules:common_settings.bzl",
+    "BuildSettingInfo",
+)
+
+def _impl(ctx):
+    vars = {
+        "CT_LOGDIR": ctx.attr._ct_logdir[BuildSettingInfo].value,
+    }
+
+    return [platform_common.TemplateVariableInfo(vars)]
+
+ct_logdir_vars = rule(
+    implementation = _impl,
+    attrs = {
+        "_ct_logdir": attr.label(
+            default = Label("@rules_erlang//:ct_logdir"),
+        ),
+    },
+    provides = [
+        platform_common.TemplateVariableInfo,
+    ],
+)

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -11,4 +11,7 @@ build:buildbuddy --experimental_strict_action_env
 # don't re-run flakes automatically on the local machine
 build --flaky_test_attempts=1
 
+# write common test logs to logs/ dir
+build --@rules_erlang//:ct_logdir=/absolute/expanded/path/to/this/repo/logs
+
 build:buildbuddy --remote_header=x-buildbuddy-api-key=YOUR_API_KEY


### PR DESCRIPTION
rules_erlang 3.8.5 adds a new flag `--@rules_erlang//:ct_logdir=` that can be used (but not with remote execution) to accumulate common test logs into a separate directory, such as `logs`, like erlang.mk does by default. The `user-template.bazelrc` has been updated accordingly.

Note that the reason for setting this in `user.bazelrc` is that it should be an expanded path, as tests don't see all of the env vars, and for instance `$HOME` won't be expanded as expected. Therefore, my own `user.bazelrc` contains `build --@rules_erlang//:ct_logdir=/Users/kuryloskip/workspace/github.com/rabbitmq/rabbitmq-server/logs`. `.bazelrc` is already set to revert this flag when using buildbuddy in this repo.

This may mostly eliminate the need for `bazel run test-logs ...` for local tests, though it's still available if that is one's preference.

Also, this version of `rules_erlang` will use `make` from `$MAKE` when fetching and auto-patching erlang packages that use erlang.mk, instead of being hard coded to make, which can be useful on hosts where `make` is not GNU make.