### PR TITLE
Preserve heartbeat error reason

### DIFF
--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -519,10 +519,10 @@ mainloop(Deb, Buf, BufLen, State = #v1{sock = Sock,
             stop(tcp_healthcheck, State);
         closed ->
             stop(closed, State);
-        {other, {heartbeat_send_error, Reason}} ->
+        {other, {heartbeat_send_error, _}=ErrHeartbeat} ->
             %% The only portable way to detect disconnect on blocked
             %% connection is to wait for heartbeat send failure.
-            stop(Reason, State);
+            stop(ErrHeartbeat, State);
         {error, Reason} ->
             stop(Reason, State);
         {other, {system, From, Request}} ->


### PR DESCRIPTION
https://groups.google.com/g/rabbitmq-users/c/gRURlk9E6M0

In the above thread, the user experienced a heartbeat send timeout that was logged as `{inet_error, timeout}`. The only way to know this was related to heartbeats was to reproduce the issue and do a debug trace. After this change, the error message will be as follows:

```
2022-12-20 08:57:12.614470-08:00 [error] <0.959.0> closing AMQP connection <0.959.0> (127.0.0.1:52052 -> 127.0.0.1:5672):
2022-12-20 08:57:12.614470-08:00 [error] <0.959.0> {inet_error,{heartbeat_send_error,timeout}}
```

I grepped the code for cases where `inet_error` is caught. The one place where this happens is compatible with the change in this patch.