### PR TITLE
Check if stream coordinator is quorum critial

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -360,9 +360,9 @@ declare_queue(Config) ->
     %% Test declare an existing queue
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
-    
+
     ?assertMatch([_], find_queue_info(Config, [])),
-    
+
     %% Test declare an existing queue with different arguments
     ?assertExit(_, declare(Ch, Q, [])),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
@@ -1075,7 +1075,7 @@ consume_and_nack(Config) ->
                                                       multiple     = false,
                                                       requeue      = true}),
             %% Nack will throw a not implemented exception. As it is a cast operation,
-            %% we'll detect the conneciton/channel closure on the next call. 
+            %% we'll detect the conneciton/channel closure on the next call.
             %% Let's try to redeclare and see what happens
             ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
                         declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]))
@@ -1299,7 +1299,7 @@ consume_and_reject(Config) ->
             ok = amqp_channel:cast(Ch1, #'basic.reject'{delivery_tag = DeliveryTag,
                                                       requeue      = true}),
             %% Reject will throw a not implemented exception. As it is a cast operation,
-            %% we'll detect the conneciton/channel closure on the next call. 
+            %% we'll detect the conneciton/channel closure on the next call.
             %% Let's try to redeclare and see what happens
             ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
                         declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]))
@@ -1710,7 +1710,12 @@ max_length_bytes(Config) ->
 
     Payload = << <<"1">> || _ <- lists:seq(1, 100) >>,
 
-    publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 500)]), %% 100 bytes/msg * 500 = 50000 bytes
+    %% 100 bytes/msg * 500 = 50000 bytes
+    publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 100)]),
+    publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 100)]),
+    publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 100)]),
+    publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 100)]),
+    publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 100)]),
     ensure_retention_applied(Config, Server),
 
     %% We don't yet have reliable metrics, as the committed offset doesn't work

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/await_online_quorum_plus_one_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/await_online_quorum_plus_one_command.ex
@@ -57,7 +57,7 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineQuorumPlusOneCommand do
 
           false ->
             {:error,
-             "time is up, no quorum + 1 online replicas came online for at least some quorum queues"}
+             "time is up, no quorum + 1 online replicas came online for at least some quorum queues or streams"}
         end
 
       other ->
@@ -103,11 +103,11 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineQuorumPlusOneCommand do
   def help_section, do: :upgrade
 
   def description() do
-    "Waits for all quorum queues to have an above minimum online quorum. " <>
-      "This makes sure that no queues would lose their quorum if the target node is shut down"
+    "Waits for all quorum queues and streams to have an above minimum online quorum. " <>
+      "This makes sure that no queues/streams would lose their quorum if the target node is shut down"
   end
 
   def banner([], %{timeout: timeout}) do
-    "Will wait for a quorum + 1 of nodes to be online for all quorum queues for #{round(timeout / 1000)} seconds..."
+    "Will wait for a quorum + 1 of nodes to be online for all quorum queues and streams for #{round(timeout / 1000)} seconds..."
   end
 end


### PR DESCRIPTION
Since https://github.com/rabbitmq/rabbitmq-server/commit/d8ff9918, streams are considered when checking for a potential quorum loss. Now we also consider `rabbit_stream_coordinator`.

Fixes #4890