### PR TITLE
Fix Bazel 6 compatibility for tests

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -897,7 +897,9 @@ exec([Cmd | Args], Options) when is_list(Cmd) orelse is_binary(Cmd) ->
                | proplists:delete(env, PortOptions1)],
               Log ++ "~n~nEnvironment variables:~n" ++
               string:join(
-                [rabbit_misc:format("  ~ts=~ts", [K, V]) || {K, V} <- Env1],
+                [string:replace(
+                   rabbit_misc:format("  ~ts=~ts", [K, V]),
+                   "~", "~~", all) || {K, V} <- Env1],
                 "~n")
             }
     end,

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -277,7 +277,13 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$TEST_SRCDIR/.secondary_umbrella.rabbitmq-server-generic-unix-3.11/rabbitmq-run",
+
+            # The following variations were observed on different
+            # versions of bazel and in different environments:
+            # - _main~secondary_umbrella~rabbitmq-server-generic-unix-3.11
+            # -     @~secondary_umbrella~rabbitmq-server-generic-unix-3.11
+            # -      .secondary_umbrella.rabbitmq-server-generic-unix-3.11
+            "RABBITMQ_RUN_SECONDARY": "$(ls $TEST_SRCDIR/*secondary_umbrella*rabbitmq-server-generic-unix-3.11/rabbitmq-run)",
             "LANG": "C.UTF-8",
         }.items() + test_env.items()),
         tools = [


### PR DESCRIPTION
Directory name for tools in runfiles is a bit unpredictable. Maybe there is a better way, but at least this should cover all the cases that I've observed.

One unexpected consequence is that this directory name can contain `~`, and it's not being properly escaped in `ct:pal` calls (causing badarg's for `io:format/4`).