### PR TITLE
Fix error when free space can not be determined

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/information_unit.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/information_unit.ex
@@ -42,6 +42,10 @@ defmodule RabbitMQ.CLI.InformationUnit do
     :unknown
   end
 
+  def convert(:NaN, _) do
+    :NaN
+  end
+
   def known_unit?(val) do
     MapSet.member?(known_units(), String.downcase(val))
   end


### PR DESCRIPTION
When disk free space can not be determined for any reason the value is set to NaN and that was not considered when rabbitmqctl status command tried to show the free space returning this error instead:

`** (FunctionClauseError) no function clause matching in RabbitMQ.CLI.InformationUnit.convert/2`

The code has been changed to check for the :NaN value explicitly 
