### PR TITLE
Fix connection linger for WebSTOMP

### DIFF
--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -227,8 +227,13 @@ websocket_info({'EXIT', From, Reason},
     {stop, _Reason, ProcState} ->
         stop(State#state{ proc_state = ProcState });
     unknown_exit ->
-        stop(State)
+        %% Allow the server to send remaining error messages
+        self() ! close_websocket,
+        {ok, State}
   end;
+websocket_info(close_websocket, State) ->
+    stop(State);
+
 %%----------------------------------------------------------------------------
 
 websocket_info(emit_stats, State) ->
@@ -291,7 +296,9 @@ handle_data1(Bytes, State = #state{proc_state  = ProcState,
                                      proc_state  = ProcState1,
                                      connection  = ConnPid });
                 {stop, _Reason, ProcState1} ->
-                    stop(State#state{ proc_state = ProcState1 })
+                    %% do not exit here immediately, because we need to wait for messages eventually enqueued by process_request
+                    self() ! close_websocket,
+                    {ok, State#state{ proc_state = ProcState1 }}
             end;
         Other ->
             Other

--- a/deps/rabbitmq_web_stomp/test/cowboy_websocket_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/cowboy_websocket_SUITE.erl
@@ -189,9 +189,7 @@ sub_non_existent(Config) ->
 
     {<<"ERROR">>, [{<<"message">>,<<"not_found">>} | _Tail ], <<"NOT_FOUND - no exchange 'doesnotexist' in vhost '/'">>} = raw_recv(WS),
 
-    {close, {1000, <<"STOMP died">>}} = raw_recv(WS),
-
-    {close, _} = rfc6455_client:close(WS),
+    {close, _} = raw_recv(WS),
     ok.
 
 


### PR DESCRIPTION
## Proposed Changes

Resolve issue #6737 by delaying closing the websocket connection to happen after the ERROR frame is sent.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #6737)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Cause of the issue seems to be that `process_request` enqueues an ERROR frame, but `handle_data1` closes the connection immediately. By enqueuing a message `close_websocket` instead of closing the connection directly, we avoid this problem
