### PR TITLE
rabbit_db: Move missed vhost and user Mnesia-specific code

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -300,7 +300,10 @@ delete_user(Username, ActingUser) ->
             rabbit_types:error('not_found').
 
 lookup_user(Username) ->
-    rabbit_misc:dirty_read({rabbit_user, Username}).
+    case rabbit_db_user:get(Username) of
+        undefined -> {error, not_found};
+        User      -> {ok, User}
+    end.
 
 -spec exists(rabbit_types:username()) -> boolean().
 

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -13,6 +13,7 @@
 
 -export([create/1,
          update/2,
+         get/1,
          get_all/0,
          with_fun_in_mnesia_tx/2,
          get_user_permissions/2,
@@ -87,6 +88,30 @@ update_in_mnesia_tx(Username, UpdateFun) ->
             ok = mnesia:write(?MNESIA_TABLE, User1, write);
         [] ->
             mnesia:abort({no_such_user, Username})
+    end.
+
+%% -------------------------------------------------------------------
+%% get().
+%% -------------------------------------------------------------------
+
+-spec get(Username) -> User | undefined when
+      Username :: vhost:name(),
+      User :: vhost:vhost().
+%% @doc Returns the record of the internal user named `Username'.
+%%
+%% @returns the internal user record or `undefined' if no internal user is named
+%% `Username'.
+%%
+%% @private
+
+get(Username) when is_binary(Username) ->
+    rabbit_db:run(
+      #{mnesia => fun() -> get_in_mnesia(Username) end}).
+
+get_in_mnesia(Username) ->
+    case ets:lookup(?MNESIA_TABLE, Username) of
+        [User] -> User;
+        []     -> undefined
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -506,9 +506,9 @@ default_name() ->
 
 -spec lookup(vhost:name()) -> vhost:vhost() | rabbit_types:ok_or_error(any()).
 lookup(VHostName) ->
-    case rabbit_misc:dirty_read({rabbit_vhost, VHostName}) of
-        {error, not_found} -> {error, {no_such_vhost, VHostName}};
-        {ok, Record}       -> Record
+    case rabbit_db_vhost:get(VHostName) of
+        undefined -> {error, {no_such_vhost, VHostName}};
+        VHost     -> VHost
     end.
 
 -spec assert(vhost:name()) -> 'ok'.


### PR DESCRIPTION
This is a follow-up to #6430 (and should have been part of it).

It is a preparation step to be able to change the database layer.