### PR TITLE
erlang_ls workaround for bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,3 +3,4 @@
 .erlang.mk
 deps/osiris
 deps/ra
+extra_deps

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ callgrand*
 
 /user.bazelrc
 /bazel-*
+/extra_deps/
 
 .vscode
 .idea

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -109,6 +109,7 @@ rabbitmqctl(
     name = "rabbitmq-queues",
     home = ":broker-home",
 )
+
 shell(
     name = "repl",
     deps = PLUGINS,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,22 +7,18 @@ bazel_dep(
     name = "rules_pkg",
     version = "0.5.1",
 )
-
 bazel_dep(
     name = "bazel_skylib",
     version = "1.2.0",
 )
-
 bazel_dep(
     name = "platforms",
     version = "0.0.5",
 )
-
 bazel_dep(
     name = "rules_cc",
     version = "0.0.2",
 )
-
 bazel_dep(
     name = "rules_erlang",
     version = "3.8.5",

--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -4,6 +4,7 @@
 deps_dirs:
   - "deps/*"
   - "deps/*/apps/*"
+  - "extra_deps/*"
 diagnostics:
   disabled:
     - bound_var_in_pattern
@@ -16,6 +17,7 @@ diagnostics:
 include_dirs:
   - "deps"
   - "deps/*/include"
+  - "extra_deps/*/include"
 lenses:
   enabled:
     - ct-run-test

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,16 +1,18 @@
 load("//:rabbitmq.bzl", "all_plugins")
-load(":erlang_ls.bzl", "erlang_ls_config", "erlang_ls_tree")
+load(":erlang_ls.bzl", "deps_symlinks", "erlang_ls_config")
 
-erlang_ls_tree(
-    name = "erlang_ls_files",
+erlang_ls_config(
+    name = "erlang_ls.config",
+)
+
+deps_symlinks(
+    name = "symlink_deps_for_erlang_ls",
     apps = all_plugins(
         rabbitmq_workspace = "",
     ) + [
         "//deps/rabbitmq_ct_helpers:erlang_app",
         "//deps/rabbitmq_ct_client_helpers:erlang_app",
     ],
-)
-
-erlang_ls_config(
-    name = "erlang_ls.config",
+    dest = "extra_deps",  # must also be listed in .bazelignore
+    tags = ["local"],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,9 +1,5 @@
 load("//:rabbitmq.bzl", "all_plugins")
-load(":erlang_ls.bzl", "deps_symlinks", "erlang_ls_config")
-
-erlang_ls_config(
-    name = "erlang_ls.config",
-)
+load(":erlang_ls.bzl", "deps_symlinks")
 
 deps_symlinks(
     name = "symlink_deps_for_erlang_ls",

--- a/tools/erlang_ls.bzl
+++ b/tools/erlang_ls.bzl
@@ -7,41 +7,6 @@ load(
     "path_join",
 )
 
-def _erlang_ls_config(ctx):
-    runtime_prefix = path_join(
-        ctx.bin_dir.path,
-        ctx.label.package,
-        ctx.label.name + ".runfiles",
-        ctx.workspace_name,
-    )
-
-    ctx.actions.write(
-        output = ctx.outputs.executable,
-        content = """#!/usr/bin/env bash
-
-set -euo pipefail
-
-BAZEL_OUT_ABSOLUTE_PATH="${{PWD%/{}}}/bazel-out"
-
-cat << EOF
-apps_dirs:
-- ${{BAZEL_OUT_ABSOLUTE_PATH}}/*/bin/tools/erlang_ls_files/apps/*
-deps_dirs:
-- ${{BAZEL_OUT_ABSOLUTE_PATH}}/*/bin/tools/erlang_ls_files/deps/*
-include_dirs:
-- ${{BAZEL_OUT_ABSOLUTE_PATH}}/*/bin/tools/erlang_ls_files/apps
-- ${{BAZEL_OUT_ABSOLUTE_PATH}}/*/bin/tools/erlang_ls_files/apps/*/include
-- ${{BAZEL_OUT_ABSOLUTE_PATH}}/*/bin/tools/erlang_ls_files/deps
-- ${{BAZEL_OUT_ABSOLUTE_PATH}}/*/bin/tools/erlang_ls_files/deps/*/include
-EOF
-""".format(runtime_prefix),
-    )
-
-erlang_ls_config = rule(
-    implementation = _erlang_ls_config,
-    executable = True,
-)
-
 def _ln_command(target, source):
     return "ln -nsvwf \"{target}\" \"{source}\"".format(
         target = target,

--- a/tools/erlang_ls.bzl
+++ b/tools/erlang_ls.bzl
@@ -8,7 +8,7 @@ load(
 )
 
 def _ln_command(target, source):
-    return "ln -nsvwf \"{target}\" \"{source}\"".format(
+    return "ln -nsvf \"{target}\" \"{source}\"".format(
         target = target,
         source = source,
     )

--- a/tools/erlang_ls.bzl
+++ b/tools/erlang_ls.bzl
@@ -6,10 +6,6 @@ load(
     "@rules_erlang//:util.bzl",
     "path_join",
 )
-load(
-    "@rules_erlang//private:util.bzl",
-    "additional_file_dest_relative_path",
-)
 
 def _erlang_ls_config(ctx):
     runtime_prefix = path_join(
@@ -46,48 +42,54 @@ erlang_ls_config = rule(
     executable = True,
 )
 
-def _erlang_app_files(ctx, app, directory):
-    app_info = app[ErlangAppInfo]
-    app_path = path_join(directory, app_info.app_name)
-    files = []
-    for f in app_info.srcs + app_info.beam:
-        relative_path = additional_file_dest_relative_path(app.label, f)
-        dest = ctx.actions.declare_file(path_join(app_path, relative_path))
-        ctx.actions.symlink(output = dest, target_file = f)
-        files.append(dest)
-    return files
-
-def _erlang_ls_tree(ctx):
+def _deps_symlinks(ctx):
     apps = ctx.attr.apps
     deps = []
 
     for app in apps:
         app_info = app[ErlangAppInfo]
         for dep in app_info.deps:
-            # this puts non rabbitmq plugins, like amqp10_client into deps,
-            # but maybe those should be in apps? Does it matter?
-            if dep not in deps and dep not in apps:
+            if dep.label.workspace_name != "" and dep not in deps and dep not in apps:
                 deps.append(dep)
 
     files = []
-    for app in apps:
-        files.extend(
-            _erlang_app_files(ctx, app, path_join(ctx.label.name, "apps")),
-        )
-    for dep in deps:
-        files.extend(
-            _erlang_app_files(ctx, dep, path_join(ctx.label.name, "deps")),
-        )
+    output = ctx.actions.declare_file(ctx.label.name + ".sh")
 
-    return [
-        DefaultInfo(files = depset(files)),
+    commands = [
+        "set -euxo pipefail",
+        "",
+        "mkdir -p \"{}\"".format(path_join("$BUILD_WORKSPACE_DIRECTORY", ctx.attr.dest)),
+        "",
     ]
 
-erlang_ls_tree = rule(
-    implementation = _erlang_ls_tree,
+    for dep in deps:
+        app_info = dep[ErlangAppInfo]
+        files.extend(app_info.srcs)
+
+        commands.append("ln -s \"{target}\" \"{source}\"".format(
+            target = path_join("$PWD", "external", dep.label.workspace_name),
+            source = path_join("$BUILD_WORKSPACE_DIRECTORY", ctx.attr.dest, app_info.app_name),
+        ))
+
+    ctx.actions.write(
+        output = output,
+        content = "\n".join(commands),
+    )
+
+    return [DefaultInfo(
+        runfiles = ctx.runfiles(files = files),
+        executable = output,
+    )]
+
+deps_symlinks = rule(
+    implementation = _deps_symlinks,
     attrs = {
         "apps": attr.label_list(
             providers = [ErlangAppInfo],
         ),
+        "dest": attr.string(
+            mandatory = True,
+        ),
     },
+    executable = True,
 )


### PR DESCRIPTION
Adds a new bazel target, `bazel run //tools:symlink_deps_for_erlang_ls`, which will create an `extra_deps` folder with symlinks (to other symlinks) to 3rd party deps. It also created a few special case symlinks for generated headers and sources in `rabbit_common`. Unfortunately it might be necessary to clean the symlinks when switching back to make with `rm -df extra_deps; git clean -xffd deps/rabbit_common`.