### PR TITLE
Handle the body is undefined from AMQP 1.0 to AMQP 091

### DIFF
--- a/deps/rabbit/src/rabbit_msg_record.erl
+++ b/deps/rabbit/src/rabbit_msg_record.erl
@@ -221,7 +221,15 @@ map_add(KeyType, Key, Type, Value, Acc) ->
 to_amqp091(#?MODULE{msg = #msg{properties = P,
                                application_properties = APR,
                                message_annotations = MAR,
-                               data = #'v1_0.data'{content = Payload}}}) ->
+                               data = Data}}) ->
+
+  Payload =  case Data of
+               undefined ->
+                 <<>>;
+               #'v1_0.data'{content = C} ->
+                 C
+             end,
+
     #'v1_0.properties'{message_id = MsgId,
                        user_id = UserId,
                        reply_to = ReplyTo0,


### PR DESCRIPTION
Fixes part of https://github.com/rabbitmq/rabbitmq-server/issues/6837

If the body is undefined, the payload returns an empty binary.
Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>

This PR fixes a bug in case the native stream client sends a message without a body and an AMQP client reads the message.
example:
```java
 Producer producer = environment.producerBuilder()
                .stream(stream)
                .name("reference")//
                .build();
        for (int i = 0; i < 20; i++) {
            producer.send(
                    producer.messageBuilder().publishingId(i).properties().messageId(i).messageBuilder().build(),
```

then try to read in AMQP:
```python
channel.basic_qos(prefetch_count=100)  # mandatory
channel.basic_consume(
    queue=q_name,
    on_message_callback=callback,
    arguments={
        'x-stream-offset': 'first'
        #   'x-stream-offset': 15
        # with first start consuming always from the beginning
    },
    auto_ack=False)
channel.start_consuming()
```

The server raises:
```
2023-01-03 16:58:44.428652+00:00 [warning] <0.2303.0> Non-AMQP exit reason '{function_clause,
2023-01-03 16:58:44.428652+00:00 [warning] <0.2303.0>                        [{rabbit_msg_record,to_amqp091,
2023-01-03 16:58:44.428652+00:00 [warning] <0.2303.0>                          [{rabbit_msg_record,
2023-01-03 16:58:44.428652+00:00 [warning] <0.2303.0>                            {cfg},
2023-01-03 16:58:44.428652+00:00 [warning] <0.2303.0>                            {msg,undefined,
```

This because:
https://github.com/rabbitmq/rabbitmq-server/blob/aa02e3243c8fb8581af3a4616bba5fcbc51f5f41/deps/rabbit/src/rabbit_msg_record.erl#L221-L224

Does not consider the empty data


## Proposed Changes

With this fix, the function returns an empty binary `<<>>` When the body message is not defined.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

