### PR TITLE
Fix migration for direct_exchange_routing_v2

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -132,7 +132,7 @@
       Ret :: rabbit_feature_flags:enable_callback_ret().
 direct_exchange_routing_v2_enable(#{feature_name := FeatureName}) ->
     TableName = rabbit_index_route,
-    ok = rabbit_table:wait([rabbit_route], _Retry = true),
+    ok = rabbit_table:wait([rabbit_route, rabbit_exchange], _Retry = true),
     try
         ok = rabbit_table:create(
                TableName, rabbit_table:rabbit_index_route_definition()),


### PR DESCRIPTION
In two occasions (one being https://github.com/rabbitmq/rabbitmq-server/discussions/6755), we've seen that the migration function for feature flag
`direct_exchange_routing_v2` failed with the following error:

```
BOOT FAILED
===========
Error during startup: {error,
                       {incompatible_feature_flags,
                        {badarg,
                         [{ets,lookup,
                           [rabbit_exchange,
                            {resource,<<"/">>,exchange,<<"***_ex">>}],
                           [{error_info,
                             #{cause => id,module => erl_stdlib_errors}}]},
                          {rabbit_misc,dirty_read,1,
                           [{file,"rabbit_misc.erl"},{line,372}]},
                          {rabbit_binding,
                           '-populate_index_route_table/0-fun-0-',1,
                           [{file,"rabbit_binding.erl"},{line,756}]},
                          {lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},
                          {mnesia_tm,apply_fun,3,
                           [{file,"mnesia_tm.erl"},{line,842}]},
                          {mnesia_tm,execute_transaction,5,
                           [{file,"mnesia_tm.erl"},{line,818}]},
                          {rabbit_misc,
                           '-execute_mnesia_transaction/1-fun-0-',1,
                           [{file,"rabbit_misc.erl"},{line,566}]},
                          {worker_pool_worker,'-run/2-fun-0-',3,
                           [{file,"worker_pool_worker.erl"},{line,69}]}]}}}`
```

According to
https://github.com/erlang/otp/blob/0764c3073544b6ed96caaeac0be80e012cfccd73/lib/stdlib/src/erl_stdlib_errors.erl#L856-L857 with reason `the table identifier does not refer to an existing ETS table`

So, there is some race condition going on during startup / clustering.

Apparently, locking the Mnesia table `rabbit_exchange` in https://github.com/rabbitmq/rabbitmq-server/blob/c66a185d79df5cbb5572addd799c36e466ced8a2/deps/rabbit/src/rabbit_binding.erl#L751 still succeeds - otherwise I’d expect the transaction to abort with no_exists as in the following example:
```
(rabbit@host)14> mnesia:sync_transaction(fun() -> ok = mnesia:read_lock_table(rabbit_exchange) end).
{atomic,ok}
(rabbit@host)15> mnesia:sync_transaction(fun() -> ok = mnesia:read_lock_table(bla) end).
{aborted,{no_exists,bla}}
```
But then, a few lines later when doing a lookup on the ETS table `rabbit_exchange`, the lookup fails with the table identifier not being present.

I never ran into this race condition during my testing. So, it’s hard to validate this commit fixes above error, but I'd expect that waiting for the Mnesia table `rabbit_exchange` before reading from its ETS table will fix this race condition.