### PR TITLE
rabbit_feature_flags: Restore feature flag state if we fail to enable it

### DIFF
--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -744,7 +744,7 @@ mark_feature_flag_as_enabled_with_a_network_partition(Config) ->
     %% Mark the feature flag as enabled on all nodes from node B. This
     %% is expected to timeout.
     ?assertEqual(
-       {error, {badrpc, nodedown}},
+       {error, {erpc, noconnection}},
        rabbit_ct_broker_helpers:rpc(
          Config, B,
          rabbit_ff_controller, mark_as_enabled_on_nodes,

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -911,7 +911,7 @@ enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv2(Config) ->
                           FirstNode,
                           fun() ->
                                   ?assertEqual(
-                                     {error, {badrpc, nodedown}},
+                                     {error, {erpc, noconnection}},
                                      rabbit_feature_flags:enable(
                                        FeatureName)),
                                   ok
@@ -1318,14 +1318,13 @@ have_required_feature_flag_in_cluster_and_add_member_without_it(
            fun() ->
                    ?assertMatch(
                       {error,
-                       {badrpc,
-                        {'EXIT',
-                         {{assertNotEqual,
-                           [{module, rabbit_ff_registry_factory},
-                            {line, _},
-                            {expression, "State"},
-                            {value, state_changing}]},
-                          _}}}},
+                       {exception,
+                        {assertNotEqual,
+                         [{module, rabbit_ff_registry_factory},
+                          {line, _},
+                          {expression, "State"},
+                          {value, state_changing}]},
+                        _}},
                       rabbit_feature_flags:sync_feature_flags_with_cluster(
                         Nodes, false)),
                    ok
@@ -1411,7 +1410,7 @@ error_during_migration_after_initial_success(Config) ->
            NewNode,
            fun() ->
                    ?assertEqual(
-                      crash_on_joining_node,
+                      {error, crash_on_joining_node},
                       rabbit_feature_flags:sync_feature_flags_with_cluster(
                         Nodes, true)),
                    ok


### PR DESCRIPTION
When a node joins a cluster, it will synchronize its feature flags states with the cluster. As part of that, it will run the migration functions of the feature flags which must be enabled.

The migration function will be executed on the joining node only. It was already executed on each member and supposedly succeeded at the time the feature flag was enabled initially.

On the joining node, if the migration function fails, we used to mark the feature flag state as disabled. This is a bug because existing cluster members see the state going from enabled to disabled.

Instead of marking it as disabled everywhere, we should restore the state as it was before we tried to enable it on the joining node:
* enabled for the cluster members
* disabled for the joining node

This fixes a bug discovered as part of the investigation on an issue in the migration function of the `direct_exchange_routing_v2` feature flag (#6847).