### PR TITLE
Move nopush to reader to try to better make use of packets

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -244,7 +244,7 @@ erlang_package.hex_package(
 
 erlang_package.git_package(
     repository = "rabbitmq/osiris",
-    tag = "v1.4.2",
+    tag = "v1.4.3",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.4.2
+dep_osiris = git https://github.com/rabbitmq/osiris v1.4.3
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.4.0
 

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -44,6 +44,7 @@
 -record(consumer,
         {configuration :: #consumer_configuration{},
          credit :: non_neg_integer(),
+         send_limit :: non_neg_integer(),
          log :: undefined | osiris_log:state(),
          last_listener_offset = undefined :: undefined | osiris:offset()}).
 -record(stream_connection_state,
@@ -485,7 +486,7 @@ handle_info(Msg,
                                              Connection,
                                              State,
                                              Data),
-            Transport:setopts(S, [{active, once}]),
+            setopts(Transport, S, [{active, once}]),
             #stream_connection{connection_step = NewConnectionStep} =
                 Connection1,
             rabbit_log_connection:debug("Transitioned from ~ts to ~ts",
@@ -710,7 +711,7 @@ open(info, {resource_alarm, IsThereAlarm},
                                 [ConnectionName, Blocked, NewBlockedState]),
     case {Blocked, NewBlockedState} of
         {true, false} ->
-            Transport:setopts(S, [{active, once}]),
+            setopts(Transport, S, [{active, once}]),
             ok = rabbit_heartbeat:resume_monitor(Heartbeater),
             rabbit_log_connection:debug("Unblocking connection ~tp",
                                         [ConnectionName]);
@@ -748,7 +749,7 @@ open(info, {OK, S, Data},
             stop;
         close_sent ->
             rabbit_log_connection:debug("Transitioned to close_sent"),
-            Transport:setopts(S, [{active, once}]),
+            setopts(Transport, S, [{active, once}]),
             {next_state, close_sent,
              StatemData#statem_data{connection = Connection1,
                                     connection_state = State1}};
@@ -758,7 +759,7 @@ open(info, {OK, S, Data},
                     true ->
                         case should_unblock(Connection, Configuration) of
                             true ->
-                                Transport:setopts(S, [{active, once}]),
+                                setopts(Transport, S, [{active, once}]),
                                 ok =
                                     rabbit_heartbeat:resume_monitor(Heartbeater),
                                 State1#stream_connection_state{blocked = false};
@@ -768,7 +769,7 @@ open(info, {OK, S, Data},
                     false ->
                         case has_credits(Credits) of
                             true ->
-                                Transport:setopts(S, [{active, once}]),
+                                setopts(Transport, S, [{active, once}]),
                                 State1;
                             false ->
                                 ok =
@@ -989,7 +990,7 @@ open(cast,
             true ->
                 case should_unblock(Connection, Configuration) of
                     true ->
-                        Transport:setopts(S, [{active, once}]),
+                        setopts(Transport, S, [{active, once}]),
                         ok = rabbit_heartbeat:resume_monitor(Heartbeater),
                         State#stream_connection_state{blocked = false};
                     false ->
@@ -1036,7 +1037,7 @@ open(cast,
             true ->
                 case should_unblock(Connection, Configuration) of
                     true ->
-                        Transport:setopts(S, [{active, once}]),
+                        setopts(Transport, S, [{active, once}]),
                         ok = rabbit_heartbeat:resume_monitor(Heartbeater),
                         State#stream_connection_state{blocked = false};
                     false ->
@@ -1163,7 +1164,7 @@ close_sent(info, {tcp, S, Data},
         closing_done ->
             stop;
         _ ->
-            Transport:setopts(S, [{active, once}]),
+            setopts(Transport, S, [{active, once}]),
             {keep_state,
              StatemData#statem_data{connection = Connection1,
                                     connection_state = State1}}
@@ -1956,10 +1957,12 @@ handle_frame_post_auth(Transport,
                                                                     Properties,
                                                                 active =
                                                                     Active},
+                                    SendLimit = Credit div 2,
                                     ConsumerState =
                                         #consumer{configuration =
                                                       ConsumerConfiguration,
                                                   log = Log,
+                                                  send_limit = SendLimit,
                                                   credit = Credit},
 
                                     Connection1 =
@@ -3254,18 +3257,24 @@ send_chunks(DeliverVersion,
 
 send_chunks(_DeliverVersion,
             _Transport,
-            Consumer,
-            0,
+            #consumer{send_limit = SendLimit} = Consumer,
+            Credit,
             LastLstOffset,
-            _Counter) ->
+            _Counter) when Credit =< SendLimit ->
+    %% there are fewer credits than the credit limit so we won't enter
+    %% the send_chunks loop until we have more than the limit available.
+    %% Once we have that we are able to consume all credits all the way down
+    %% to zero
     {ok,
-     Consumer#consumer{credit = 0, last_listener_offset = LastLstOffset}};
+     Consumer#consumer{credit = Credit, last_listener_offset = LastLstOffset}};
 send_chunks(DeliverVersion,
             Transport,
-            #consumer{log = Log} = Consumer,
+            #consumer{configuration = #consumer_configuration{socket = Socket},
+                      log = Log} = Consumer,
             Credit,
             LastLstOffset,
             Counter) ->
+    setopts(Transport, Socket, [{nopush, true}]),
     send_chunks(DeliverVersion,
                 Transport,
                 Consumer,
@@ -3276,27 +3285,31 @@ send_chunks(DeliverVersion,
                 Counter).
 
 send_chunks(_DeliverVersion,
-            _Transport,
-            Consumer,
+            Transport,
+            #consumer{
+                      configuration = #consumer_configuration{socket = Socket}} =
+                Consumer,
             Log,
-            0 = _Credit,
+            0,
             LastLstOffset,
             _Retry,
             _Counter) ->
+    %% we have finished sending so need to uncork
+    setopts(Transport, Socket, [{nopush, false}]),
     {ok,
      Consumer#consumer{log = Log,
                        credit = 0,
                        last_listener_offset = LastLstOffset}};
 send_chunks(DeliverVersion,
             Transport,
-            #consumer{configuration = #consumer_configuration{socket = S}} =
+            #consumer{configuration = #consumer_configuration{socket = Socket}} =
                 Consumer,
             Log,
             Credit,
             LastLstOffset,
             Retry,
             Counter) ->
-    case osiris_log:send_file(S, Log,
+    case osiris_log:send_file(Socket, Log,
                               send_file_callback(DeliverVersion,
                                                  Transport,
                                                  Log,
@@ -3319,6 +3332,7 @@ send_chunks(DeliverVersion,
         {error, Reason} ->
             {error, Reason};
         {end_of_stream, Log1} ->
+            setopts(Transport, Socket, [{nopush, false}]),
             case Retry of
                 true ->
                     timer:sleep(1),
@@ -3639,3 +3653,7 @@ close_log(undefined) ->
     ok;
 close_log(Log) ->
     osiris_log:close(Log).
+
+setopts(Transport, Sock, Opts) ->
+    ok = Transport:setopts(Sock, Opts).
+

--- a/workspace_helpers.bzl
+++ b/workspace_helpers.bzl
@@ -135,7 +135,7 @@ def rabbitmq_external_deps(rabbitmq_workspace = "@rabbitmq-server"):
 
     git_repository(
         name = "osiris",
-        tag = "v1.4.2",
+        tag = "v1.4.3",
         remote = "https://github.com/rabbitmq/osiris.git",
     )
 


### PR DESCRIPTION
Also change credit to delay calling send_chunks until there is a "batch" of credit to consume. This is also to try to better utilise packets for cases where the stream contains many small chunks.

The goal is to improve throughput of stream protocol operations on a lot of very small (e.g. a few bytes) messages.