### PR TITLE
diagnostics check_port_connectivity: support --address

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
@@ -74,8 +74,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
       |> Enum.sort()
       |> Enum.join(", ")
 
-    {:ok, "Successfully connected to ports #{ports} on node #{node_name} (using node hostname resolution)"}
+    {:ok,
+     "Successfully connected to ports #{ports} on node #{node_name} (using node hostname resolution)"}
   end
+
   def output({true, listeners}, %{node: node_name, address: target_ip}) do
     ports =
       listeners
@@ -84,7 +86,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
       |> Enum.sort()
       |> Enum.join(", ")
 
-    {:ok, "Successfully connected to ports #{ports} on node #{node_name} (using #{target_ip} for target IP address)"}
+    {:ok,
+     "Successfully connected to ports #{ports} on node #{node_name} (using #{target_ip} for target IP address)"}
   end
 
   def output({false, failures}, %{formatter: "json", node: node_name}) do
@@ -110,6 +113,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
   def banner([], %{node: node_name, address: nil}) do
     "Testing TCP connections to all active listeners on node #{node_name} using hostname resolution ..."
   end
+
   def banner([], %{node: node_name, address: target_ip}) do
     "Testing TCP connections to all active listeners on node #{node_name} using #{target_ip} for node IP address ..."
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
@@ -14,7 +14,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
   """
 
   import RabbitMQ.CLI.Diagnostics.Helpers,
-    only: [check_listener_connectivity: 3]
+    only: [check_listener_connectivity: 4]
 
   import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
   import RabbitMQ.CLI.Core.Listeners
@@ -23,7 +23,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
 
   @default_timeout 30_000
 
-  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  def switches(), do: [timeout: :integer, address: :string]
+  def aliases(), do: [t: :timeout, a: :address]
 
   def merge_defaults(args, opts) do
     timeout =
@@ -33,13 +34,14 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
         other -> other
       end
 
-    {args, Map.merge(opts, %{timeout: timeout})}
+    opts1 = Map.merge(%{address: nil}, opts)
+    {args, Map.merge(opts1, %{timeout: timeout})}
   end
 
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([], %{node: node_name, timeout: timeout}) do
+  def run([], %{node: node_name, address: target_ip, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_networking, :active_listeners, [], timeout) do
       {:error, _} = err ->
         err
@@ -52,7 +54,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
 
         case locals do
           [] -> {true, locals}
-          _ -> check_connectivity_of(locals, node_name, timeout)
+          _ -> check_connectivity_of(locals, node_name, target_ip, timeout)
         end
 
       other ->
@@ -64,7 +66,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
     {:ok, %{"result" => "ok", "node" => node_name, "listeners" => listener_maps(listeners)}}
   end
 
-  def output({true, listeners}, %{node: node_name}) do
+  def output({true, listeners}, %{node: node_name, address: nil}) do
     ports =
       listeners
       |> listener_maps
@@ -72,7 +74,17 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
       |> Enum.sort()
       |> Enum.join(", ")
 
-    {:ok, "Successfully connected to ports #{ports} on node #{node_name}."}
+    {:ok, "Successfully connected to ports #{ports} on node #{node_name} (using node hostname resolution)"}
+  end
+  def output({true, listeners}, %{node: node_name, address: target_ip}) do
+    ports =
+      listeners
+      |> listener_maps
+      |> Enum.map(fn %{port: p} -> p end)
+      |> Enum.sort()
+      |> Enum.join(", ")
+
+    {:ok, "Successfully connected to ports #{ports} on node #{node_name} (using #{target_ip} for target IP address)"}
   end
 
   def output({false, failures}, %{formatter: "json", node: node_name}) do
@@ -93,24 +105,27 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def usage, do: "check_port_connectivity"
+  def usage, do: "check_port_connectivity [--address <target address>]"
 
-  def banner([], %{node: node_name}) do
-    "Testing TCP connections to all active listeners on node #{node_name} ..."
+  def banner([], %{node: node_name, address: nil}) do
+    "Testing TCP connections to all active listeners on node #{node_name} using hostname resolution ..."
+  end
+  def banner([], %{node: node_name, address: target_ip}) do
+    "Testing TCP connections to all active listeners on node #{node_name} using #{target_ip} for node IP address ..."
   end
 
   #
   # Implementation
   #
 
-  defp check_connectivity_of(listeners, node_name, timeout) do
+  defp check_connectivity_of(listeners, node_name, address, timeout) do
     # per listener timeout
     t = Kernel.trunc(timeout / (length(listeners) + 1))
 
     failures =
       Enum.reject(
         listeners,
-        fn l -> check_listener_connectivity(listener_map(l), node_name, t) end
+        fn l -> check_listener_connectivity(listener_map(l), node_name, address, t) end
       )
 
     case failures do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -5,20 +5,31 @@
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Diagnostics.Helpers do
-  def test_connection(hostname, port, timeout) do
-    case :gen_tcp.connect(hostname, port, [], timeout) do
-      {:error, _} -> :gen_tcp.connect(hostname, port, [:inet6], timeout)
+  def test_connection(hostname_or_ip, port, timeout) do
+    hostname_as_list = :rabbit_data_coercion.to_list(hostname_or_ip)
+    case :gen_tcp.connect(hostname_as_list, port, [], timeout) do
+      {:error, _} -> :gen_tcp.connect(hostname_as_list, port, [:inet6], timeout)
       r -> r
     end
   end
 
   def check_port_connectivity(port, node_name, timeout) do
+    check_port_connectivity(port, node_name, nil, timeout)
+  end
+
+
+  def check_port_connectivity(port, node_name, nil, timeout) do
     regex = Regex.recompile!(~r/^(.+)@/)
     hostname = Regex.replace(regex, to_string(node_name), "") |> to_charlist
 
+    check_port_connectivity(port, node_name, hostname, timeout)
+  end
+  def check_port_connectivity(port, node_name, hostname_or_ip, timeout) do
     try do
-      case test_connection(hostname, port, timeout) do
-        {:error, _} ->
+      IO.puts("Will connect to #{hostname_or_ip}:#{port}")
+      case test_connection(hostname_or_ip, port, timeout) do
+        {:error, err} ->
+          IO.puts("Error connecting to #{hostname_or_ip}:#{port}: #{err}")
           false
 
         {:ok, port} ->
@@ -33,7 +44,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
     end
   end
 
-  def check_listener_connectivity(%{port: port}, node_name, timeout) do
-    check_port_connectivity(port, node_name, timeout)
+  def check_listener_connectivity(%{port: port}, node_name, target_ip, timeout) do
+    check_port_connectivity(port, node_name, target_ip, timeout)
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -7,6 +7,7 @@
 defmodule RabbitMQ.CLI.Diagnostics.Helpers do
   def test_connection(hostname_or_ip, port, timeout) do
     hostname_as_list = :rabbit_data_coercion.to_list(hostname_or_ip)
+
     case :gen_tcp.connect(hostname_as_list, port, [], timeout) do
       {:error, _} -> :gen_tcp.connect(hostname_as_list, port, [:inet6], timeout)
       r -> r
@@ -17,16 +18,17 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
     check_port_connectivity(port, node_name, nil, timeout)
   end
 
-
   def check_port_connectivity(port, node_name, nil, timeout) do
     regex = Regex.recompile!(~r/^(.+)@/)
     hostname = Regex.replace(regex, to_string(node_name), "") |> to_charlist
 
     check_port_connectivity(port, node_name, hostname, timeout)
   end
+
   def check_port_connectivity(port, node_name, hostname_or_ip, timeout) do
     try do
       IO.puts("Will connect to #{hostname_or_ip}:#{port}")
+
       case test_connection(hostname_or_ip, port, timeout) do
         {:error, err} ->
           IO.puts("Error connecting to #{hostname_or_ip}:#{port}: #{err}")


### PR DESCRIPTION
For scenarios where node hostname resolution on the invoking host is not a suitable option and a particular address should be tried instead.

Closes #6853.
