### PR TITLE
CLI: Fix typo where we set `rabbit`'s `data_dir` environment variable

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/paths.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/paths.ex
@@ -37,7 +37,7 @@ defmodule RabbitMQ.CLI.Core.Paths do
                 {:error, :data_dir_not_found}
 
               val ->
-                Application.put_env(:rabbit_, :data_dir, to_charlist(val))
+                Application.put_env(:rabbit, :data_dir, to_charlist(val))
                 Application.put_env(:mnesia, :dir, to_charlist(val))
             end
 


### PR DESCRIPTION
The application name was incorrect, leading to errors when trying to use this data dir as part of the `forget_cluster_node` command.