### PR TITLE
Conform vhost tags to a list when set with the cli in all cases

### DIFF
--- a/deps/rabbit/src/vhost.erl
+++ b/deps/rabbit/src/vhost.erl
@@ -139,7 +139,7 @@ get_description(#vhost{} = VHost) ->
 
 -spec get_tags(vhost()) -> [tag()].
 get_tags(#vhost{} = VHost) ->
-    maps:get(tags, get_metadata(VHost), undefined).
+    maps:get(tags, get_metadata(VHost), []).
 
 -spec get_default_queue_type(vhost()) -> binary() | undefined.
 get_default_queue_type(#vhost{} = VHost) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -59,7 +59,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
       vhost,
       desc,
-      tags,
+      parse_tags(tags),
       Helpers.cli_acting_user()
     ])
   end

--- a/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
@@ -76,4 +76,12 @@ defmodule AddVhostCommandTest do
     assert @command.banner([context[:vhost]], context[:opts]) =~
              ~r/Adding vhost \"#{context[:vhost]}\" \.\.\./
   end
+
+  @tag vhost: @vhost
+  test "run: vhost tags are conformed to a list", context do
+    opts = Map.merge(context[:opts], %{description: "My vhost", tags: "my_tag"})
+    assert @command.run([context[:vhost]], opts) == :ok
+    record = list_vhosts() |> Enum.find(fn record -> record[:name] == context[:vhost] end)
+    assert record[:tags] == [:my_tag]
+  end
 end


### PR DESCRIPTION
`rabbitmqctl add_vhost myvhost --tags "my_tag"` would not previously conform "my_tag" to a list before setting vhost metadata, which could cause crashes when the list was read.