### PR TITLE
Fix all dialyzer warnings in `rabbitmq_stomp`

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/info_keys.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/info_keys.ex
@@ -17,7 +17,7 @@ defmodule RabbitMQ.CLI.Ctl.InfoKeys do
     validate_info_keys(args, valid_keys, [])
   end
 
-  @spec validate_info_keys([charlist], [charlist], aliases) ::
+  @spec validate_info_keys([charlist], [charlist | atom], aliases) ::
           {:ok, info_keys} | {:validation_failure, any}
   def validate_info_keys(args, valid_keys, aliases) do
     info_keys = prepare_info_keys(args, aliases)

--- a/deps/rabbitmq_stomp/BUILD.bazel
+++ b/deps/rabbitmq_stomp/BUILD.bazel
@@ -78,7 +78,6 @@ plt(
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
     plt = ":base_plt",
-    warnings_as_errors = False,
 )
 
 broker_for_integration_suites()

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_internal_event_handler.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_internal_event_handler.erl
@@ -25,7 +25,7 @@ handle_event(_Event, State) ->
   {ok, State}.
 
 handle_call(_Request, State) ->
-  {ok, State}.
+  {ok, ok, State}.
 
 handle_info(_Info, State) ->
   {ok, State}.

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
@@ -83,9 +83,6 @@ init([SupHelperPid, Ref, Configuration]) ->
                                 conserve_resources = false,
                                 recv_outstanding   = false})), #reader_state.stats_timer),
               {backoff, 1000, 1000, 10000});
-        {network_error, Reason} ->
-            rabbit_net:fast_close(RealSocket),
-            terminate({shutdown, Reason}, undefined);
         {error, enotconn} ->
             rabbit_net:fast_close(RealSocket),
             terminate(shutdown, undefined);
@@ -284,7 +281,7 @@ run_socket(State = #reader_state{state = blocked}) ->
 run_socket(State = #reader_state{recv_outstanding = true}) ->
     State;
 run_socket(State = #reader_state{socket = Sock}) ->
-    rabbit_net:setopts(Sock, [{active, once}]),
+    _ = rabbit_net:setopts(Sock, [{active, once}]),
     State#reader_state{recv_outstanding = true}.
 
 

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_sup.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_sup.erl
@@ -45,8 +45,8 @@ init([{Listeners, SslListeners0}, Configuration]) ->
                           SslListeners)}}.
 
 stop_listeners() ->
-    rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
-    rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
+    _ = rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
+    _ = rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
     ok.
 
 %%


### PR DESCRIPTION
To fix all warnings, some bazel stuff is still needed.
