### PR TITLE
Fix v3.10.x workflows

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -120,14 +120,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         erlang_major:
         - "24"
-        #! - "25"
-=======
-        otp_version_id:
-        - "25_2"
->>>>>>> cb8ee9c4bd (Adopt OTP 25.2)
+        - "25"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -169,15 +164,10 @@ jobs:
     strategy:
       matrix:
         include:
-<<<<<<< HEAD
         - erlang_version: "24"
           elixir_version: 1.13.4
-        #! - erlang_version: "25"
-        #!   elixir_version: 1.13.4
-=======
-        - erlang_version: "25.2"
-          elixir_version: 1.14.0
->>>>>>> cb8ee9c4bd (Adopt OTP 25.2)
+        - erlang_version: "25"
+          elixir_version: 1.13.4
     timeout-minutes: 60
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -122,7 +122,6 @@ jobs:
       matrix:
         erlang_major:
         - "24"
-        - "25"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -165,8 +164,6 @@ jobs:
       matrix:
         include:
         - erlang_version: "24"
-          elixir_version: 1.13.4
-        - erlang_version: "25"
           elixir_version: 1.13.4
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -14,15 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-<<<<<<< HEAD
         - erlang_version: "24"
           elixir_version: 1.13.4
-        #! - erlang_version: "25"
-        #!   elixir_version: 1.13.4
-=======
         - erlang_version: "25.2"
           elixir_version: 1.14.0
->>>>>>> cb8ee9c4bd (Adopt OTP 25.2)
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,15 +29,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-<<<<<<< HEAD
         erlang_major:
         - "24"
-        #! - "25"
-=======
-        otp_version_id:
-        - 25_0
-        - 25_2
->>>>>>> cb8ee9c4bd (Adopt OTP 25.2)
+        - "25"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -81,17 +75,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-<<<<<<< HEAD
         - erlang_version: "24"
           elixir_version: 1.13.4
-        #! - erlang_version: "25"
-        #!   elixir_version: 1.13.4
-=======
-        - erlang_version: "25.0"
-          elixir_version: 1.14.0
         - erlang_version: "25.2"
           elixir_version: 1.14.0
->>>>>>> cb8ee9c4bd (Adopt OTP 25.2)
     timeout-minutes: 60
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,6 @@ jobs:
       matrix:
         erlang_major:
         - "24"
-        - "25"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY


### PR DESCRIPTION
Accidentally committed conflict markers prevent some workflows, namely tests, from running.