### PR TITLE
Fix all dialyzer warnings in rabbitmq_stream

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -37,11 +37,12 @@
                          {'resources_missing',
                           [{'not_found', (rabbit_types:binding_source() |
                                           rabbit_types:binding_destination())} |
-                           {'absent', amqqueue:amqqueue()}]}).
+                           {'absent', amqqueue:amqqueue(), Reason :: term()}]}).
 
 -type bind_ok_or_error() :: 'ok' | bind_errors() |
-                            rabbit_types:error(
-                              {'binding_invalid', string(), [any()]}).
+                            rabbit_types:error({'binding_invalid', string(), [any()]}) |
+                            %% inner_fun() result
+                            rabbit_types:error(rabbit_types:amqp_error()).
 -type bind_res() :: bind_ok_or_error() | rabbit_misc:thunk(bind_ok_or_error()).
 -type inner_fun() ::
         fun((rabbit_types:exchange(),

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1936,11 +1936,6 @@ binding_action(Fun, SourceNameBin0, DestinationType, DestinationNameBin0,
             rabbit_amqqueue:not_found(Name);
         {error, {resources_missing, [{absent, Q, Reason} | _]}} ->
             rabbit_amqqueue:absent(Q, Reason);
-        {error, binding_not_found} ->
-            rabbit_misc:protocol_error(
-              not_found, "no binding ~ts between ~ts and ~ts",
-              [RoutingKey, rabbit_misc:rs(ExchangeName),
-               rabbit_misc:rs(DestinationName)]);
         {error, {binding_invalid, Fmt, Args}} ->
             rabbit_misc:protocol_error(precondition_failed, Fmt, Args);
         {error, #amqp_error{} = Error} ->

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -393,7 +393,11 @@ info_all(VHostPath, Items, Ref, AggregatorPid) ->
     rabbit_control_misc:emitting_map(
       AggregatorPid, Ref, fun(X) -> info(X, Items) end, list(VHostPath)).
 
--spec route(rabbit_types:exchange(), rabbit_types:delivery())
+%% rabbit_types:delivery() is more strict than #delivery{}, some
+%% fields can't be undefined. But there are places where
+%% rabbit_exchange:route/2 is called with the absolutely bare delivery
+%% like #delivery{message = #basic_message{routing_keys = [...]}}
+-spec route(rabbit_types:exchange(), #delivery{})
                  -> [rabbit_amqqueue:name()].
 
 route(#exchange{name = #resource{virtual_host = VHost, name = RName} = XName,

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -137,7 +137,8 @@
 -callback declare(amqqueue:amqqueue(), node()) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'absent', amqqueue:amqqueue(), absent_reason()} |
-    {'protocol_error', Type :: atom(), Reason :: string(), Args :: term()}.
+    {'protocol_error', Type :: atom(), Reason :: string(), Args :: term()} |
+    {'error', Err :: term() }.
 
 -callback delete(amqqueue:amqqueue(),
                  boolean(),
@@ -263,7 +264,8 @@ is_compatible(Type, Durable, Exclusive, AutoDelete) ->
 -spec declare(amqqueue:amqqueue(), node()) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'absent', amqqueue:amqqueue(), absent_reason()} |
-    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
+    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()} |
+    {'error', Err :: term() }.
 declare(Q0, Node) ->
     Q = rabbit_queue_decorator:set(rabbit_policy:set(Q0)),
     Mod = amqqueue:get_type(Q),

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/info_keys.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/info_keys.ex
@@ -66,7 +66,7 @@ defmodule RabbitMQ.CLI.Ctl.InfoKeys do
     with_valid_info_keys(args, valid_keys, [], fun)
   end
 
-  @spec with_valid_info_keys([charlist], [charlist], aliases, fun([atom])) :: any
+  @spec with_valid_info_keys([charlist], [charlist], aliases, ([atom] -> any)) :: any
   def with_valid_info_keys(args, valid_keys, aliases, fun) do
     case validate_info_keys(args, valid_keys, aliases) do
       {:ok, info_keys} -> fun.(:proplists.get_keys(info_keys))

--- a/deps/rabbitmq_stream/BUILD.bazel
+++ b/deps/rabbitmq_stream/BUILD.bazel
@@ -35,12 +35,13 @@ APP_ENV = """[
 BUILD_DEPS = [
     "//deps/rabbit_common:erlang_app",
     "//deps/rabbitmq_cli:rabbitmqctl",
-    "@ranch//:erlang_app",
 ]
 
 DEPS = [
     "//deps/rabbitmq_stream_common:erlang_app",
     "//deps/rabbit:erlang_app",
+    "@ranch//:erlang_app",
+    "@osiris//:erlang_app",
 ]
 
 rabbitmq_app(
@@ -64,12 +65,12 @@ plt(
         "//deps/rabbitmq_cli:rabbitmqctl",
         BUILD_DEPS + DEPS,
     ),
+    apps = ["erts", "kernel", "stdlib", "ssl"],
 )
 
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
-    warnings_as_errors = False,
 )
 
 broker_for_integration_suites()

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
@@ -215,6 +215,8 @@ run([SuperStream],
 stream_arguments(Opts) ->
     stream_arguments(#{}, Opts).
 
+%% Something strange, dialyzer infers that map_size/1 returns positive_integer()
+-dialyzer({no_match, stream_arguments/2}).
 stream_arguments(Acc, Arguments) when map_size(Arguments) =:= 0 ->
     Acc;
 stream_arguments(Acc, #{max_length_bytes := Value} = Arguments) ->

--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -53,8 +53,7 @@ start(_Type, _Args) ->
                                ++ "Enable stream_queue feature flag then disable "
                                   "and re-enable the rabbitmq_stream plugin. ",
                                "See https://www.rabbitmq.com/feature-flags.html "
-                               "to learn more",
-                               []),
+                               "to learn more"),
             {ok, self()}
     end.
 

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -267,11 +267,11 @@ handle_call({create_super_stream,
                                 ok ->
                                     {reply, ok, State};
                                 Error ->
-                                    [Fun() || Fun <- RollbackOps],
+                                    _ = [Fun() || Fun <- RollbackOps],
                                     {reply, Error, State}
                             end;
                         {{error, Reason}, RollbackOps} ->
-                            [Fun() || Fun <- RollbackOps],
+                            _ = [Fun() || Fun <- RollbackOps],
                             {reply, {error, Reason}, State}
                     end;
                 {error, Msg} ->
@@ -410,9 +410,7 @@ handle_call({topology, VirtualHost, Stream}, _From, State) ->
               {error, not_found} ->
                   {error, stream_not_found};
               {error, not_available} ->
-                  {error, stream_not_available};
-              R ->
-                  R
+                  {error, stream_not_available}
           end,
     {reply, Res, State};
 handle_call({route, RoutingKey, VirtualHost, SuperStream}, _From,
@@ -449,9 +447,9 @@ handle_call({partition_index, VirtualHost, SuperStream, Stream},
                      "super stream ~tp (virtual host ~tp)",
                      [Stream, SuperStream, VirtualHost]),
     Res = try
-              rabbit_exchange:lookup_or_die(ExchangeName),
+              _ = rabbit_exchange:lookup_or_die(ExchangeName),
               UnorderedBindings =
-                  [Binding
+                  _ = [Binding
                    || Binding = #binding{destination = #resource{name = Q} = D}
                           <- rabbit_binding:list_for_source(ExchangeName),
                       is_resource_stream_queue(D), Q == Stream],
@@ -620,7 +618,7 @@ delete_stream(VirtualHost, Reference, Username) ->
 super_stream_partitions(VirtualHost, SuperStream) ->
     ExchangeName = rabbit_misc:r(VirtualHost, exchange, SuperStream),
     try
-        rabbit_exchange:lookup_or_die(ExchangeName),
+        _ = rabbit_exchange:lookup_or_die(ExchangeName),
         UnorderedBindings =
             [Binding
              || Binding = #binding{destination = D}
@@ -818,12 +816,6 @@ add_super_stream_binding(VirtualHost,
             {error,
              {stream_not_found,
               rabbit_misc:format("stream ~ts does not exists (absent)", [Q])}};
-        {error, binding_not_found} ->
-            {error,
-             {not_found,
-              rabbit_misc:format("no binding ~ts between ~ts and ~ts",
-                                 [RoutingKey, rabbit_misc:rs(ExchangeName),
-                                  rabbit_misc:rs(QueueName)])}};
         {error, {binding_invalid, Fmt, Args}} ->
             {error, {binding_invalid, rabbit_misc:format(Fmt, Args)}};
         {error, #amqp_error{} = Error} ->

--- a/deps/rabbitmq_stream/src/rabbit_stream_metrics.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_metrics.erl
@@ -30,8 +30,8 @@
 -define(CTAG_PREFIX, <<"stream.subid-">>).
 
 init() ->
-    rabbit_core_metrics:create_table({?TABLE_CONSUMER, set}),
-    rabbit_core_metrics:create_table({?TABLE_PUBLISHER, set}),
+    _ = rabbit_core_metrics:create_table({?TABLE_CONSUMER, set}),
+    _ = rabbit_core_metrics:create_table({?TABLE_PUBLISHER, set}),
     ok.
 
 consumer_created(Connection,

--- a/deps/rabbitmq_stream/src/rabbit_stream_metrics_gc.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_metrics_gc.erl
@@ -54,7 +54,7 @@ handle_info(start_gc, State) ->
     {noreply, start_timer(State)}.
 
 terminate(_Reason, #state{timer = TRef}) ->
-    erlang:cancel_timer(TRef),
+    _ = erlang:cancel_timer(TRef),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/deps/rabbitmq_stream_common/src/rabbit_stream_core.erl
+++ b/deps/rabbitmq_stream_common/src/rabbit_stream_core.erl
@@ -30,7 +30,7 @@
 -define(STRING(Str), (byte_size(Str)):16, Str / binary).
 -define(DATASTR(Str), (byte_size(Str)):32, Str / binary).
 
--export_type([state/0]).
+-export_type([state/0, command_version/0]).
 
 -type command_version() :: 0..65535.
 -type correlation_id() :: non_neg_integer().

--- a/deps/rabbitmq_stream_management/BUILD.bazel
+++ b/deps/rabbitmq_stream_management/BUILD.bazel
@@ -46,7 +46,6 @@ plt(
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
     plt = ":base_plt",
-    warnings_as_errors = False,
 )
 
 rabbitmq_home(

--- a/deps/rabbitmq_stream_management/src/rabbit_stream_connections_mgmt.erl
+++ b/deps/rabbitmq_stream_management/src/rabbit_stream_connections_mgmt.erl
@@ -37,8 +37,7 @@ web_ui() ->
                                   "and re-enable the rabbitmq_stream_management "
                                   "plugin. ",
                                "See https://www.rabbitmq.com/feature-flags.html "
-                               "to learn more",
-                               []),
+                               "to learn more"),
             []
     end.
 


### PR DESCRIPTION
There are some elixir-related messages about undefined functions, but they don't produce warnings (yet).