### PR TITLE
Fix all dialyzer warnings in rabbitmq_federation

### DIFF
--- a/deps/rabbitmq_federation/BUILD.bazel
+++ b/deps/rabbitmq_federation/BUILD.bazel
@@ -55,7 +55,6 @@ plt(
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS + ["-Wno_undefined_callbacks"],
     plt = ":base_plt",
-    warnings_as_errors = False,
 )
 
 broker_for_integration_suites()

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange.erl
@@ -49,7 +49,7 @@ add_binding(transaction, _X, _B) ->
     ok;
 add_binding(Serial, X = #exchange{name = XName}, B) ->
     case federate(X) of
-        true  -> rabbit_federation_exchange_link:add_binding(Serial, XName, B),
+        true  -> _ = rabbit_federation_exchange_link:add_binding(Serial, XName, B),
                  ok;
         false -> ok
     end.
@@ -58,7 +58,7 @@ remove_bindings(transaction, _X, _Bs) ->
     ok;
 remove_bindings(Serial, X = #exchange{name = XName}, Bs) ->
     case federate(X) of
-        true  -> rabbit_federation_exchange_link:remove_bindings(Serial, XName, Bs),
+        true  -> _ = rabbit_federation_exchange_link:remove_bindings(Serial, XName, Bs),
                  ok;
         false -> ok
     end.

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
@@ -49,7 +49,7 @@
 %% and the Erlang client is not running. This then gets invoked when
 %% the federation app is started.
 go() ->
-    rabbit_federation_pg:start_scope(),
+    _ = rabbit_federation_pg:start_scope(),
     cast(go).
 
 add_binding(S, XN, B)      -> cast(XN, {enqueue, S, {add_binding, B}}).
@@ -198,7 +198,7 @@ terminate(Reason, #state{downstream_connection = DConn,
                          queue                 = Queue}) when Reason =:= shutdown;
                                                               Reason =:= {shutdown, restart};
                                                               Reason =:= gone ->
-    timer:cancel(TRef),
+    _ = timer:cancel(TRef),
     rabbit_federation_link_util:ensure_connection_closed(DConn),
 
     rabbit_log:debug("Exchange federation: link is shutting down, resource cleanup mode: ~tp", [Upstream#upstream.resource_cleanup_mode]),
@@ -222,7 +222,7 @@ terminate(Reason, #state{downstream_connection = DConn,
                          upstream_params       = UParams,
                          downstream_exchange   = XName,
                          internal_exchange_timer = TRef}) ->
-    timer:cancel(TRef),
+    _ = timer:cancel(TRef),
 
     rabbit_federation_link_util:ensure_connection_closed(DConn),
 
@@ -495,8 +495,8 @@ open_command_channel(Conn, Upstream = #upstream{name = UName}, UParams, DownXNam
             {ok, CCh};
         E ->
             rabbit_federation_link_util:ensure_connection_closed(Conn),
-            rabbit_federation_link_util:connection_error(command_channel, E,
-                                                         Upstream, UParams, DownXName, S0),
+            _ = rabbit_federation_link_util:connection_error(command_channel, E,
+                                                             Upstream, UParams, DownXName, S0),
             E
     end.
 

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -25,7 +25,7 @@ start_link() ->
     %% This scope is used by concurrently starting exchange and queue links,
     %% and other places, so we have to start it very early outside of the supervision tree.
     %% The scope is stopped in stop/1.
-    rabbit_federation_pg:start_scope(),
+    _ = rabbit_federation_pg:start_scope(),
     mirrored_supervisor:start_link({local, ?SUPERVISOR}, ?SUPERVISOR,
                                    fun rabbit_misc:execute_mnesia_transaction/1,
                                    ?MODULE, []).
@@ -49,13 +49,13 @@ start_child(X) ->
     end.
 
 adjust({clear_upstream, VHost, UpstreamName}) ->
-    [rabbit_federation_link_sup:adjust(Pid, X, {clear_upstream, UpstreamName}) ||
-        {#exchange{name = Name} = X, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
-        Name#resource.virtual_host == VHost],
+    _ = [rabbit_federation_link_sup:adjust(Pid, X, {clear_upstream, UpstreamName}) ||
+            {#exchange{name = Name} = X, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
+            Name#resource.virtual_host == VHost],
     ok;
 adjust(Reason) ->
-    [rabbit_federation_link_sup:adjust(Pid, X, Reason) ||
-        {X, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],
+    _ = [rabbit_federation_link_sup:adjust(Pid, X, Reason) ||
+            {X, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],
     ok.
 
 stop_child(X) ->

--- a/deps/rabbitmq_federation/src/rabbit_federation_link_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_link_sup.erl
@@ -22,7 +22,7 @@ start_link(XorQ) ->
     supervisor2:start_link(?MODULE, XorQ).
 
 adjust(Sup, XorQ, everything) ->
-    [stop(Sup, Upstream, XorQ) ||
+    _ = [stop(Sup, Upstream, XorQ) ||
         {Upstream, _, _, _} <- supervisor2:which_children(Sup)],
     [{ok, _Pid} = supervisor2:start_child(Sup, Spec) || Spec <- specs(XorQ)];
 
@@ -41,7 +41,7 @@ adjust(Sup, XorQ, {upstream, UpstreamName}) ->
                       false -> {OldUs, NewUs}
                   end
           end, {OldUpstreams0, NewUpstreams0}, OldUpstreams0),
-    [stop(Sup, OldUpstream, XorQ) || OldUpstream <- OldUpstreams],
+    _ = [stop(Sup, OldUpstream, XorQ) || OldUpstream <- OldUpstreams],
     [start(Sup, NewUpstream, XorQ) || NewUpstream <- NewUpstreams];
 
 adjust(Sup, XorQ, {clear_upstream, UpstreamName}) ->
@@ -50,7 +50,7 @@ adjust(Sup, XorQ, {clear_upstream, UpstreamName}) ->
     [stop(Sup, Upstream, XorQ) || Upstream <- children(Sup, UpstreamName)];
 
 adjust(Sup, X = #exchange{name = XName}, {upstream_set, _Set}) ->
-    adjust(Sup, X, everything),
+    _ = adjust(Sup, X, everything),
     case rabbit_federation_upstream:federate(X) of
         false -> ok;
         true  -> ok = rabbit_federation_db:prune_scratch(

--- a/deps/rabbitmq_federation/src/rabbit_federation_link_util.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_link_util.erl
@@ -82,16 +82,8 @@ start_conn_ch(Fun, OUpstream, OUParams,
     end.
 
 get_connection_name(#upstream{name = UpstreamName},
-    #upstream_params{x_or_q = Resource}) when is_record(Resource, exchange)->
-    Policy = Resource#exchange.policy,
-    PolicyName = proplists:get_value(name, Policy),
-    connection_name(UpstreamName, PolicyName);
-
-get_connection_name(#upstream{name = UpstreamName},
-    #upstream_params{x_or_q = Resource}) when ?is_amqqueue(Resource) ->
-    Policy = amqqueue:get_policy(Resource),
-    PolicyName = proplists:get_value(name, Policy),
-    connection_name(UpstreamName, PolicyName);
+    #upstream_params{x_or_q = Resource}) when is_record(Resource, exchange) orelse ?is_amqqueue(Resource) ->
+    connection_name(UpstreamName, rabbit_policy:name(Resource));
 
 get_connection_name(_, _) ->
     connection_name(undefined, undefined).

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue.erl
@@ -99,7 +99,7 @@ active_for(Q) ->
 
 consumer_state_changed(Q, MaxActivePriority, IsEmpty) ->
     QName = amqqueue:get_name(Q),
-    case IsEmpty andalso active_unfederated(MaxActivePriority) of
+    _ = case IsEmpty andalso active_unfederated(MaxActivePriority) of
         true  -> rabbit_federation_queue_link:run(QName);
         false -> rabbit_federation_queue_link:pause(QName)
     end,

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -31,7 +31,7 @@ start_link(Args) ->
 run(QName)   -> cast(QName, run).
 pause(QName) -> cast(QName, pause).
 go()         ->
-    rabbit_federation_pg:start_scope(),
+    _ = rabbit_federation_pg:start_scope(),
     cast(go).
 
 %%----------------------------------------------------------------------------
@@ -46,12 +46,7 @@ all() ->
     pg:get_members(?FEDERATION_PG_SCOPE, pgname(rabbit_federation_queues)).
 
 q(QName) ->
-    case pg:get_members(?FEDERATION_PG_SCOPE, pgname({rabbit_federation_queue, QName})) of
-        {error, {no_such_group, _}} ->
-            [];
-        Members ->
-            Members
-    end.
+    pg:get_members(?FEDERATION_PG_SCOPE, pgname({rabbit_federation_queue, QName})).
 
 %%----------------------------------------------------------------------------
 
@@ -77,7 +72,7 @@ init({Upstream, Queue}) when ?is_amqqueue(Queue) ->
     end.
 
 handle_call(Msg, _From, State) ->
-    {stop, {unexpected_call, Msg}, State}.
+    {stop, {unexpected_call, Msg}, {unexpected_call, Msg}, State}.
 
 handle_cast(maybe_go, State) ->
     go(State);

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link_sup_sup.erl
@@ -26,7 +26,7 @@ start_link() ->
     %% This scope is used by concurrently starting exchange and queue links,
     %% and other places, so we have to start it very early outside of the supervision tree.
     %% The scope is stopped in stop/1.
-    rabbit_federation_pg:start_scope(),
+    _ = rabbit_federation_pg:start_scope(),
     mirrored_supervisor:start_link({local, ?SUPERVISOR}, ?SUPERVISOR,
                                    fun rabbit_misc:execute_mnesia_transaction/1,
                                    ?MODULE, []).
@@ -51,13 +51,13 @@ start_child(Q) ->
 
 
 adjust({clear_upstream, VHost, UpstreamName}) ->
-    [rabbit_federation_link_sup:adjust(Pid, Q, {clear_upstream, UpstreamName}) ||
-        {Q, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
-        ?amqqueue_vhost_equals(Q, VHost)],
+    _ = [rabbit_federation_link_sup:adjust(Pid, Q, {clear_upstream, UpstreamName}) ||
+            {Q, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
+            ?amqqueue_vhost_equals(Q, VHost)],
     ok;
 adjust(Reason) ->
-    [rabbit_federation_link_sup:adjust(Pid, Q, Reason) ||
-        {Q, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],
+    _ = [rabbit_federation_link_sup:adjust(Pid, Q, Reason) ||
+            {Q, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],
     ok.
 
 stop_child(Q) ->


### PR DESCRIPTION
The only significant change is in `deps/rabbitmq_federation/src/rabbit_federation_link_util.erl`, where a function was rewritten to use `rabbit_policy:name/1` helper.