### PR TITLE
  Support OAuth 2.0 authentication in AMQP 1.0 plugin

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -92,7 +92,11 @@ user_login_authentication(Username, AuthProps) ->
                           false
                   end
               end);
-        false -> exit({unknown_auth_props, Username, AuthProps})
+        false ->
+            case proplists:get_value(rabbit_auth_backend_internal, AuthProps, undefined) of
+                undefined -> exit({unknown_auth_props, Username, AuthProps});
+                _ -> internal_check_user_login(Username, fun(_) -> true end)
+            end
     end.
 
 state_can_expire() -> false.

--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -129,7 +129,7 @@ extract_extra_auth_props(Creds, VHost, Pid, Infos) ->
 append_authz_backends(AuthProps, Infos) ->
     case proplists:get_value(authz_backends, Infos, undefined) of
         undefined -> AuthProps;
-        Authz_backends -> AuthProps ++ Authz_backends
+        AuthzBackends -> AuthProps ++ AuthzBackends
     end.
 
 extract_protocol(Infos) ->

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -710,6 +710,7 @@ send_to_new_1_0_session(Channel, Frame, State) ->
                                     user      = User},
         proxy_socket = ProxySocket} = State,
     %% Note: the equivalent, start_channel is in channel_sup_sup
+
     case rabbit_amqp1_0_session_sup_sup:start_session(
            %% NB subtract fixed frame header size
            ChanSupSup, {amqp10_framing, Sock, Channel,

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_sup.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_sup.erl
@@ -87,15 +87,15 @@ init([]) ->
     {ok, {SupFlags, []}}.
 
 
-%% For each AMQP 1.0 session opened, an internal AMQP connection is opened too.
-%% This AMQP connection will authenticate the user again. Again because at this point
+%% For each AMQP 1.0 session opened, an internal direct AMQP 0-9-1 connection is opened too.
+%% This direct connection will authenticate the user again. Again because at this point
 %% the SASL handshake has already taken place and this user has already been authenticated.
 %% However, we do not have the credentials the user presented. For that reason, the
-%% #amqp_adapter_info.additional_info carriess an extra property called authz_backends
+%% #amqp_adapter_info.additional_info carries an extra property called authz_backends
 %% which is initialized from the #user.authz_backends attribute. In other words, we
 %% propagate the outcome from the first authentication attempt to the subsequent attempts.
 
-%% Note: Check out rabbit_direct.erl to see how `authz_bakends` is propagated from
+%% See rabbit_direct.erl to see how `authz_bakends` is propagated from
 % amqp_adapter_info.additional_info to the rabbit_access_control module
 
 adapter_info(User, Sock) ->

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_sup.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_sup.erl
@@ -86,6 +86,18 @@ init([]) ->
                 auto_shutdown => any_significant},
     {ok, {SupFlags, []}}.
 
+
+%% For each AMQP 1.0 session opened, an internal AMQP connection is opened too.
+%% This AMQP connection will authenticate the user again. Again because at this point
+%% the SASL handshake has already taken place and this user has already been authenticated.
+%% However, we do not have the credentials the user presented. For that reason, the
+%% #amqp_adapter_info.additional_info carriess an extra property called authz_backends
+%% which is initialized from the #user.authz_backends attribute. In other words, we
+%% propagate the outcome from the first authentication attempt to the subsequent attempts.
+
+%% Note: Check out rabbit_direct.erl to see how `authz_bakends` is propagated from
+% amqp_adapter_info.additional_info to the rabbit_access_control module
+
 adapter_info(User, Sock) ->
     AdapterInfo = amqp_connection:socket_adapter_info(Sock, {'AMQP', "1.0"}),
     AdapterInfo#amqp_adapter_info{additional_info =

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -536,6 +536,13 @@ check_aud(Aud, ResourceServerId) ->
 
 get_scopes(#{?SCOPE_JWT_FIELD := Scope}) -> Scope.
 
+%% A token may be present in the password credential or in the rabbit_auth_backend_oauth2
+%% credential.  The former is the most common scenario for the first time authentication.
+%% However, there are scenarios where the same user (on the same connection) is authenticated
+%% more than once. When this scenario occurs, we extract the token from the credential
+%% called rabbit_auth_backend_oauth2 whose value is the Decoded token returned during the
+%% first authentication. 
+
 -spec token_from_context(map()) -> binary() | undefined.
 token_from_context(AuthProps) ->
     case maps:get(password, AuthProps, undefined) of


### PR DESCRIPTION
Protocol plugins such as mqtt, or stomp, they handle an incoming connection by opening an internal amqp connection and the credentials received over the initial connection are passed to the internal amqp connection. In other words, the authentication/authorization occurs at the internal amqp process.

With AMQP 1.0 plugin things are slightly different. When the plugin receives an amqp 1.0 connection, it reads the user credentials (carried on the sasl frame) and authenticates the user against the `rabbit_access_control` module. In other words, authentication happens on the plugin itself. If the authentication is successful, the username is kept on some state for future usage.
Later on another amqp 1.0 frame arrives which triggers opening an internal amqp connection with just the username as credentials, i..e no password.  However, that has not been a problem because the internal and some other auth-backend like LDAP, does support authenticating a user by its username only. 

However, OAuth 2 (and http backend too) requires the full credentials received during the initial connection phase, ie. the username and password. And this is exactly the [issue](https://github.com/rabbitmq/rabbitmq-server/issues/6909) because the internal amqp process tries to authenticate the user by passing a username and no password with the oauth2 backend which tries to parse a blank token and fails with the error "Invalid token". 

## Proposed Changes

Use the outcome from the first authentication as a valid credential for subsequent authentication attempts which occur when a session is opened.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Additional notes

Only the internal and ldap authentication backends support user authentication without password. This is the type of authentication used to create the internal amqp connection. 
The http authentication backend does not support authentication without password. In other words, it requires both,  username and password.


