### PR TITLE
Fix all dialyzer warnings in rabbitmq_management_agent

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
@@ -51,19 +51,14 @@ start_link() ->
 
 get_used_fd(State0) ->
     try
-        case get_used_fd(os:type(), State0) of
-            {State1, UsedFd} when is_number(UsedFd) ->
-                {State1, UsedFd};
-            {State1, _Other} ->
-                %% Defaults to 0 if data is not available
-                {State1, 0}
-        end
+        get_used_fd(os:type(), State0)
     catch
         _:Error ->
             State2 = log_fd_error("Could not infer the number of file handles used: ~tp", [Error], State0),
             {State2, 0}
     end.
 
+-spec get_used_fd({atom(), atom()}, #state{}) -> {#state{}, non_neg_integer()}.
 get_used_fd({unix, linux}, State0) ->
     case file:list_dir("/proc/" ++ os:getpid() ++ "/fd") of
         {ok, Files} ->

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_collector.erl
@@ -609,6 +609,7 @@ get_difference(Id, Stats, #state{old_aggr_stats = OldStats}) ->
             difference(OldStat, Stats)
     end.
 
+-dialyzer({no_match, sum_entry/2}).
 sum_entry({A0}, {B0}) ->
     {B0 + A0};
 sum_entry({A0, A1}, {B0, B1}) ->
@@ -626,6 +627,7 @@ sum_entry({A0, A1, A2, A3, A4, A5, A6}, {B0, B1, B2, B3, B4, B5, B6}) ->
 sum_entry({A0, A1, A2, A3, A4, A5, A6, A7}, {B0, B1, B2, B3, B4, B5, B6, B7}) ->
     {B0 + A0, B1 + A1, B2 + A2, B3 + A3, B4 + A4, B5 + A5, B6 + A6, B7 + A7}.
 
+-dialyzer({no_match, difference/2}).
 difference({A0}, {B0}) ->
     {B0 - A0};
 difference({A0, A1}, {B0, B1}) ->


### PR DESCRIPTION
Case is removed from `rabbit_mgmt_external_stats:get_used_fd/1`,
because `get_used_fd/2` always returns a number.
