### PR TITLE
Fix all dialyzer warnings in rabbitmq_sharding

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -214,7 +214,7 @@ declare(QueueName, Durable, AutoDelete, Args, Owner, ActingUser) ->
               rabbit_framing:amqp_table(),
               rabbit_types:maybe(pid()),
               rabbit_types:username(),
-              node()) ->
+              node() | {'ignore_location', node()}) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'absent', amqqueue:amqqueue(), absent_reason()} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.

--- a/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
+++ b/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
@@ -35,7 +35,7 @@ serialise_events(_X) -> false.
 create(transaction, _X) ->
     ok;
 create(none, X) ->
-    maybe_start_sharding(X),
+    _ = maybe_start_sharding(X),
     ok.
 
 add_binding(_Tx, _X, _B) -> ok.
@@ -52,13 +52,13 @@ active_for(X) ->
 %% we have to remove the policy from ?SHARDING_TABLE
 delete(transaction, _X, _Bs) -> ok;
 delete(none, X, _Bs) ->
-    maybe_stop_sharding(X),
+    _ = maybe_stop_sharding(X),
     ok.
 
 %% we have to remove the old policy from ?SHARDING_TABLE
 %% and then add the new one.
 policy_changed(OldX, NewX) ->
-    maybe_update_sharding(OldX, NewX),
+    _ = maybe_update_sharding(OldX, NewX),
     ok.
 
 %%----------------------------------------------------------------------------

--- a/deps/rabbitmq_sharding/src/rabbit_sharding_interceptor.erl
+++ b/deps/rabbitmq_sharding/src/rabbit_sharding_interceptor.erl
@@ -166,5 +166,6 @@ consumer_count(QName) ->
               rabbit_amqqueue:info(Q, [consumers])
       end).
 
-precondition_failed(Format, QName) ->
-    protocol_error(precondition_failed, Format, QName).
+-spec precondition_failed(io:format(), [any()]) -> no_return().
+precondition_failed(Format, Args) ->
+    protocol_error(precondition_failed, Format, Args).

--- a/deps/rabbitmq_sharding/src/rabbit_sharding_shard.erl
+++ b/deps/rabbitmq_sharding/src/rabbit_sharding_shard.erl
@@ -29,7 +29,7 @@
 %% We make sure the sharded queues are created when
 %% RabbitMQ starts.
 maybe_shard_exchanges() ->
-    [maybe_shard_exchanges(V) || V <- rabbit_vhost:list_names()],
+    _ = [maybe_shard_exchanges(V) || V <- rabbit_vhost:list_names()],
     ok.
 
 maybe_shard_exchanges(VHost) ->
@@ -38,12 +38,12 @@ maybe_shard_exchanges(VHost) ->
 
 %% queue needs to be declared on the respective node.
 ensure_sharded_queues(X) ->
-    add_queues(X),
+    _ = add_queues(X),
     bind_queues(X).
 
 maybe_update_shards(OldX, NewX) ->
-    maybe_unbind_queues(routing_key(OldX), routing_key(NewX), OldX),
-    add_queues(NewX),
+    _ = maybe_unbind_queues(routing_key(OldX), routing_key(NewX), OldX),
+    _ = add_queues(NewX),
     bind_queues(NewX).
 
 stop_sharding(OldX) ->


### PR DESCRIPTION
The only interesting bit is `{ignore_location, ...` - it's being
referenced in the classic queue code.
