### PR TITLE
Change `alias` to `test_suite` in deps/rabbitmq_cli/BUILD.bazel

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -66,9 +66,9 @@ rabbitmqctl_check_formatted_test(
     }),
 )
 
-alias(
+test_suite(
     name = "rabbitmqctl_check_formatted",
-    actual = ":check_formatted",
+    tests = ["check_formatted"],
 )
 
 rabbitmqctl_test(
@@ -93,7 +93,7 @@ rabbitmqctl_test(
     ],
 )
 
-alias(
+test_suite(
     name = "rabbitmqctl_tests",
-    actual = ":tests",
+    tests = ["tests"],
 )


### PR DESCRIPTION
bazel test won't work correctly on an alias, apparently: https://docs.bazel.build/versions/2.2.0/be/general.html#alias

the recommended workaround is to use a test_suite instead