### PR TITLE
Mark AMQP 1.0 properties chunk as binary

### DIFF
--- a/deps/rabbit/src/rabbit_msg_record.erl
+++ b/deps/rabbit/src/rabbit_msg_record.erl
@@ -190,7 +190,7 @@ from_amqp091(#'P_basic'{message_id = MsgId,
                            content_encoding = wrap(symbol, ContentEncoding),
                            creation_time = wrap(timestamp, ConvertedTs)},
 
-    APC0 = [{wrap(utf8, K), from_091(T, V)} || {K, T, V}
+    APC0 = [from_amqp091_header(Type, K, T, V) || {K, T, V}
                                                <- case Headers of
                                                       undefined -> [];
                                                       _ -> Headers
@@ -211,6 +211,11 @@ from_amqp091(#'P_basic'{message_id = MsgId,
                         application_properties = AP,
                         message_annotations = MA,
                         data = #'v1_0.data'{content = Data}}}.
+
+from_amqp091_header(<<"amqp-1.0">>, <<"x-amqp-1.0-properties">> = K, longstr, V) ->
+    {wrap(utf8, K), from_091(binary, V)};
+from_amqp091_header(_MessageType, K, T, V) ->
+    {wrap(utf8, K), from_091(T, V)}.
 
 map_add(_T, _Key, _Type, undefined, Acc) ->
     Acc;

--- a/deps/rabbit/src/rabbit_msg_record.erl
+++ b/deps/rabbit/src/rabbit_msg_record.erl
@@ -187,9 +187,9 @@ message_annotation(Key,
 %% this is the input function from storage and from, e.g. socket input
 -spec from_amqp091(#'P_basic'{}, iodata()) -> state().
 from_amqp091(PB, Data) ->
+    MA = from_amqp091_to_amqp10_message_annotations(PB),
     P = from_amqp091_to_amqp10_properties(PB),
     AP = from_amqp091_to_amqp10_app_properties(PB),
-    MA = from_amqp091_to_amqp10_message_annotations(PB),
 
     #?MODULE{cfg = #cfg{},
              msg = #msg{properties = P,

--- a/deps/rabbit/src/rabbit_msg_record.erl
+++ b/deps/rabbit/src/rabbit_msg_record.erl
@@ -12,8 +12,6 @@
          to_091/2
          ]).
 
--dialyzer({nowarn_function, add_message_annotations/2}).
-
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 
@@ -25,10 +23,10 @@
         {
          % header :: maybe(#'v1_0.header'{}),
          % delivery_annotations :: maybe(#'v1_0.delivery_annotations'{}),
-         message_annotations :: maybe(#'v1_0.message_annotations'{}) | iodata,
-         properties :: maybe(#'v1_0.properties'{}) | iodata,
-         application_properties :: maybe(#'v1_0.application_properties'{}) | iodata,
-         data :: maybe(amqp10_data()) | iodata
+         message_annotations :: maybe(#'v1_0.message_annotations'{}) | iodata(),
+         properties :: maybe(#'v1_0.properties'{}) | iodata(),
+         application_properties :: maybe(#'v1_0.application_properties'{}) | iodata(),
+         data :: maybe(amqp10_data()) | iodata()
          % footer :: maybe(#'v1_0.footer'{})
          }).
 

--- a/deps/rabbit/src/rabbit_msg_record.erl
+++ b/deps/rabbit/src/rabbit_msg_record.erl
@@ -12,6 +12,8 @@
          to_091/2
          ]).
 
+-dialyzer({nowarn_function, add_message_annotations/2}).
+
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 
@@ -64,7 +66,6 @@ init(Bin) when is_binary(Bin) ->
              _ ->
                  D0
          end,
-
 
     #?MODULE{cfg = #cfg{},
              msg = #msg{properties = P,

--- a/deps/rabbit/test/rabbit_msg_record_SUITE.erl
+++ b/deps/rabbit/test/rabbit_msg_record_SUITE.erl
@@ -23,6 +23,7 @@ all() ->
 all_tests() ->
     [
      ampq091_roundtrip,
+     amqp10_non_single_data_bodies,
      unsupported_091_header_is_dropped,
      message_id_ulong,
      message_id_uuid,
@@ -90,6 +91,43 @@ ampq091_roundtrip(_Config) ->
     Payload = [<<"data">>],
     test_amqp091_roundtrip(Props, Payload),
     test_amqp091_roundtrip(#'P_basic'{}, Payload),
+    ok.
+
+amqp10_non_single_data_bodies(_Config) ->
+    Props = #'P_basic'{type = <<"amqp-1.0">>},
+    Payloads = [
+                [#'v1_0.data'{content = <<"hello">>},
+                 #'v1_0.data'{content = <<"brave">>},
+                 #'v1_0.data'{content = <<"new">>},
+                 #'v1_0.data'{content = <<"world">>}
+                ],
+                #'v1_0.amqp_value'{content = {utf8, <<"hello world">>}},
+                [#'v1_0.amqp_sequence'{content = [{utf8, <<"one">>},
+                                                  {utf8, <<"blah">>}]},
+                 #'v1_0.amqp_sequence'{content = [{utf8, <<"two">>}]}
+                ]
+               ],
+
+    [begin
+         EncodedPayload = amqp10_encode_bin(Payload),
+
+         MsgRecord0 = rabbit_msg_record:from_amqp091(Props, EncodedPayload),
+         MsgRecord = rabbit_msg_record:init(
+                       iolist_to_binary(rabbit_msg_record:to_iodata(MsgRecord0))),
+         {PropsOut, PayloadEncodedOut} = rabbit_msg_record:to_amqp091(MsgRecord),
+         PayloadOut = case amqp10_framing:decode_bin(iolist_to_binary(PayloadEncodedOut)) of
+                          L when length(L) =:= 1 ->
+                              lists:nth(1, L);
+                          L ->
+                              L
+                      end,
+
+         ?assertEqual(Props, PropsOut),
+         ?assertEqual(iolist_to_binary(EncodedPayload),
+                      iolist_to_binary(PayloadEncodedOut)),
+         ?assertEqual(Payload, PayloadOut)
+
+     end || Payload <- Payloads],
     ok.
 
 unsupported_091_header_is_dropped(_Config) ->
@@ -227,19 +265,24 @@ reuse_amqp10_binary_chunks(_Config) ->
     Amqp091Headers = [{<<"x-amqp-1.0-message-annotations">>, longstr, Amqp10MsgAnnotationsBin},
                       {<<"x-amqp-1.0-properties">>, longstr, Amqp10PropsBin},
                       {<<"x-amqp-1.0-app-properties">>, longstr, Amqp10AppPropsBin}],
-    Amqp091Props = #'P_basic'{headers = Amqp091Headers},
-    R = rabbit_msg_record:from_amqp091(Amqp091Props, <<"payload-does-not-matter">>),
+    Amqp091Props = #'P_basic'{type= <<"amqp-1.0">>, headers = Amqp091Headers},
+    Body = #'v1_0.amqp_value'{content = {utf8, <<"hello world">>}},
+    EncodedBody = amqp10_encode_bin(Body),
+    R = rabbit_msg_record:from_amqp091(Amqp091Props, EncodedBody),
     RBin = rabbit_msg_record:to_iodata(R),
-    Amqp10DecodedMsg = amqp10_framing:decode_bin(list_to_binary(RBin)),
+    Amqp10DecodedMsg = amqp10_framing:decode_bin(iolist_to_binary(RBin)),
     [Amqp10DecodedMsgAnnotations, Amqp10DecodedProps,
-     Amqp10DecodedAppProps, _] = Amqp10DecodedMsg,
+     Amqp10DecodedAppProps, DecodedBody] = Amqp10DecodedMsg,
     ?assertEqual(Amqp10MsgAnnotations, Amqp10DecodedMsgAnnotations),
     ?assertEqual(Amqp10Props, Amqp10DecodedProps),
     ?assertEqual(Amqp10AppProps, Amqp10DecodedAppProps),
+    ?assertEqual(Body, DecodedBody),
     ok.
 
+amqp10_encode_bin(L) when is_list(L) ->
+    iolist_to_binary([amqp10_encode_bin(X) || X <- L]);
 amqp10_encode_bin(X) ->
-    list_to_binary(amqp10_framing:encode_bin(X)).
+    iolist_to_binary(amqp10_framing:encode_bin(X)).
 
 %% Utility
 

--- a/deps/rabbit/test/rabbit_msg_record_SUITE.erl
+++ b/deps/rabbit/test/rabbit_msg_record_SUITE.erl
@@ -227,7 +227,7 @@ reuse_amqp10_binary_chunks(_Config) ->
     Amqp091Headers = [{<<"x-amqp-1.0-message-annotations">>, longstr, Amqp10MsgAnnotationsBin},
                       {<<"x-amqp-1.0-properties">>, longstr, Amqp10PropsBin},
                       {<<"x-amqp-1.0-app-properties">>, longstr, Amqp10AppPropsBin}],
-    Amqp091Props = #'P_basic'{type = <<"amqp-1.0">>, headers = Amqp091Headers},
+    Amqp091Props = #'P_basic'{headers = Amqp091Headers},
     R = rabbit_msg_record:from_amqp091(Amqp091Props, <<"payload-does-not-matter">>),
     RBin = rabbit_msg_record:to_iodata(R),
     Amqp10DecodedMsg = amqp10_framing:decode_bin(list_to_binary(RBin)),

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_message.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_message.erl
@@ -25,6 +25,7 @@
 assemble(MsgBin) ->
     {RKey, Props, Content0} = assemble(header, {<<"">>, #'P_basic'{}, []},
                                       decode_section(MsgBin), MsgBin),
+
     Content1 = case Content0 of
                    Sections when is_list(Content0) ->
                        lists:reverse(Sections);

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_message.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_message.erl
@@ -23,9 +23,15 @@
 -include("rabbit_amqp1_0.hrl").
 
 assemble(MsgBin) ->
-    {RKey, Props, Content} = assemble(header, {<<"">>, #'P_basic'{}, []},
+    {RKey, Props, Content0} = assemble(header, {<<"">>, #'P_basic'{}, []},
                                       decode_section(MsgBin), MsgBin),
-    {RKey, #amqp_msg{props = Props, payload = Content}}.
+    Content1 = case Content0 of
+                   Sections when is_list(Content0) ->
+                       lists:reverse(Sections);
+                   _ ->
+                       Content0
+               end,
+    {RKey, #amqp_msg{props = Props, payload = Content1}}.
 
 assemble(header, {R, P, C}, {H = #'v1_0.header'{}, Rest}, _Uneaten) ->
     assemble(message_annotations, {R, translate_header(H, P), C},


### PR DESCRIPTION
This PR improves the support for AMQP 1.0 message format, especially in the context of streams:

* reuse AMQP 1.0 binary chunks if present before storing the message in the stream (when the original message is an AMQP 1.0 message)
* support the different types of bodies a message AMQP 1.0 can have (one AMQP value, several data or AMQP sequence sections)
* keep original order of sections