### PR TITLE
See #5957. HTTP api to generate hashed password from cleartext password

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -183,5 +183,6 @@ dispatcher() ->
      {"/auth/attempts/:node",                                  rabbit_mgmt_wm_auth_attempts, [all]},
      {"/auth/attempts/:node/source",                           rabbit_mgmt_wm_auth_attempts, [by_source]},
      {"/login",                                                rabbit_mgmt_wm_login, []},
-     {"/config/effective",                                     rabbit_mgmt_wm_environment, []}
+     {"/config/effective",                                     rabbit_mgmt_wm_environment, []},
+     {"/auth/hash_password/:password",                         rabbit_mgmt_wm_hash_password, []}
     ].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_hash_password.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_hash_password.erl
@@ -1,0 +1,36 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_hash_password).
+
+-export([init/2, to_json/2, content_types_provided/2, is_authorized/2]).
+-export([variances/2, allowed_methods/2]).
+
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+%%--------------------------------------------------------------------
+
+init(Req, _State) ->
+    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
+
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
+allowed_methods(ReqData, Context) ->
+    {[<<"GET">>, <<"OPTIONS">>], ReqData, Context}.
+
+content_types_provided(ReqData, Context) ->
+    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    Password = rabbit_mgmt_util:id(password, ReqData),
+    HashedPassword = rabbit_password:hash(Password),
+    rabbit_mgmt_util:reply([{ok, base64:encode(HashedPassword)}], ReqData, Context).
+
+is_authorized(ReqData, Context) ->
+    rabbit_mgmt_util:is_authorized_admin(ReqData, Context).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -65,6 +65,7 @@ all_tests() -> [
     users_legacy_administrator_test,
     adding_a_user_with_password_test,
     adding_a_user_with_password_hash_test,
+    adding_a_user_with_generated_password_hash_test,
     adding_a_user_with_permissions_in_single_operation_test,
     adding_a_user_without_tags_fails_test,
     adding_a_user_without_password_or_hash_test,
@@ -143,7 +144,7 @@ all_tests() -> [
     single_active_consumer_qq_test,
 %%    oauth_test,  %% disabled until we are able to enable oauth2 plugin
     disable_basic_auth_test,
-    login_test,  
+    login_test,
     csp_headers_test,
     auth_attempts_test,
     user_limits_list_test,
@@ -582,6 +583,17 @@ adding_a_user_with_password_hash_test(Config) ->
                                        {password_hash, <<"2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b">>}],
              [?CREATED, ?NO_CONTENT]),
     http_delete(Config, "/users/user11", ?NO_CONTENT).
+
+adding_a_user_with_generated_password_hash_test(Config) ->
+    #{ok := HashedPassword} = http_get(Config, "/auth/hash_password/some_password"),
+
+    http_put(Config, "/users/user12", [{tags, <<"administrator">>},
+                                       {password_hash, HashedPassword}],
+             [?CREATED, ?NO_CONTENT]),
+    % If the get succeeded, the hashed password generation is correct
+    User = http_get(Config, "/users/user12", "user12", "some_password", ?OK),
+    ?assertEqual(maps:get(password_hash, User), HashedPassword),
+    http_delete(Config, "/users/user12", ?NO_CONTENT).
 
 adding_a_user_with_permissions_in_single_operation_test(Config) ->
     QArgs = #{},


### PR DESCRIPTION
## Proposed Changes

HTTP api to generate hashed password. See #5957

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Current 'solution' generates the hashed password with a GET, with the password in the URI: /auth/hash_password/some_password

But, perhaps it would be better with a POST and a payload, i.e {password, <somepassword>}?

Easy to fix, this is mainly to get comments on what approach you prefer. And what URI to use as well!
@lukebakken 
