### PR TITLE
Bump node versions for selenium tests

### DIFF
--- a/deps/rabbitmq_management/selenium/Dockerfile
+++ b/deps/rabbitmq_management/selenium/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:14.15.4 as base
+FROM node:16.19.0 as base
 
 WORKDIR /code
 


### PR DESCRIPTION
Search for `Error: Cannot find module 'node:events'` in internet
suggests using at least node 16.6.
