### PR TITLE
Fixes a memory leak in AMQP 1.0 plugin

### DIFF
--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -31,7 +31,8 @@
 
 -record(v1, {parent, sock, connection, callback, recv_len, pending_recv,
              connection_state, queue_collector, heartbeater, helper_sup,
-             channel_sup_sup_pid, buf, buf_len, throttle, proxy_socket}).
+             channel_sup_sup_pid, buf, buf_len, throttle, proxy_socket,
+             tracked_channels}).
 
 -record(v1_connection, {user, timeout_sec, frame_max, auth_mechanism, auth_state,
                         hostname}).
@@ -66,7 +67,8 @@ unpack_from_0_9_1({Parent, Sock,RecvLen, PendingRecv,
                                     frame_max      = ?FRAME_MIN_SIZE,
                                     auth_mechanism = none,
                                     auth_state     = none},
-        proxy_socket = ProxySocket}.
+        proxy_socket        = ProxySocket,
+        tracked_channels    = maps:new()}.
 
 shutdown(Pid, Explanation) ->
     gen_server:call(Pid, {shutdown, Explanation}, infinity).
@@ -240,9 +242,9 @@ close_connection(State = #v1{connection = #v1_connection{
     State#v1{connection_state = closed}.
 
 handle_dependent_exit(ChPid, Reason, State) ->
+    credit_flow:peer_down(ChPid),
+
     case {ChPid, termination_kind(Reason)} of
-        {undefined, uncontrolled} ->
-            exit({abnormal_dependent_exit, ChPid, Reason});
         {_Channel, controlled} ->
             maybe_close(control_throttle(State));
         {Channel, uncontrolled} ->
@@ -435,13 +437,21 @@ handle_1_0_connection_frame(_Frame, State) ->
     maybe_close(State#v1{connection_state = closing}).
 
 handle_1_0_session_frame(Channel, Frame, State) ->
-    case get({channel, Channel}) of
-        {ch_fr_pid, SessionPid} ->
+    case find_session_pid_for_channel(Channel, State) of
+        undefined ->
+            case ?IS_RUNNING(State) of
+                true ->
+                    send_to_new_1_0_session(Channel, Frame, State);
+                false ->
+                    throw({channel_frame_while_starting,
+                           Channel, State#v1.connection_state,
+                           Frame})
+            end;
+        SessionPid ->
             ok = rabbit_amqp1_0_session:process_frame(SessionPid, Frame),
             case Frame of
                 #'v1_0.end'{} ->
-                    erase({channel, Channel}),
-                    State;
+                    untrack_channel(Channel, State);
                 #'v1_0.transfer'{} ->
                     case (State#v1.connection_state =:= blocking) of
                         true ->
@@ -453,24 +463,6 @@ handle_1_0_session_frame(Channel, Frame, State) ->
                     end;
                 _ ->
                     State
-            end;
-        closing ->
-            case Frame of
-                #'v1_0.end'{} ->
-                    erase({channel, Channel});
-                _Else ->
-                    ok
-            end,
-            State;
-        undefined ->
-            case ?IS_RUNNING(State) of
-                true ->
-                    ok = send_to_new_1_0_session(Channel, Frame, State),
-                    State;
-                false ->
-                    throw({channel_frame_while_starting,
-                           Channel, State#v1.connection_state,
-                           Frame})
             end
     end.
 
@@ -695,6 +687,18 @@ auth_phase_1_0(Response,
               handshake, 8)
     end.
 
+track_channel(Channel, ChFrPid, State) ->
+  rabbit_log:debug("AMQP 1.0 opened channel = ~tp " , [{Channel, ChFrPid}]),
+  State#v1{tracked_channels = maps:put(Channel, ChFrPid, State#v1.tracked_channels)}.
+untrack_channel(Channel, State) ->
+  case maps:take(Channel, State#v1.tracked_channels) of
+    {Value, NewMap} -> rabbit_log:debug("AMQP 1.0 closed channel = ~tp ", [{Channel, Value}]),
+                       State#v1{tracked_channels = NewMap};
+    error -> State
+  end.
+find_session_pid_for_channel(Channel, State) ->
+  maps:get(Channel, State#v1.tracked_channels, undefined).
+
 send_to_new_1_0_session(Channel, Frame, State) ->
     #v1{sock = Sock, queue_collector = Collector,
         channel_sup_sup_pid = ChanSupSup,
@@ -711,16 +715,15 @@ send_to_new_1_0_session(Channel, Frame, State) ->
                             _         -> FrameMax - 8
                         end,
                         self(), User, vhost(Hostname), Collector, ProxySocket}) of
-        {ok, ChSupPid, ChFrPid} ->
+        {ok, _ChSupPid, ChFrPid} ->
             erlang:monitor(process, ChFrPid),
-            put({channel, Channel}, {ch_fr_pid, ChFrPid}),
-            put({ch_sup_pid, ChSupPid}, {{channel, Channel}, {ch_fr_pid, ChFrPid}}),
-            put({ch_fr_pid, ChFrPid}, {channel, Channel}),
+            ModifiedState = track_channel(Channel, ChFrPid, State),
             rabbit_log_connection:info(
                         "AMQP 1.0 connection ~tp: "
                         "user '~ts' authenticated and granted access to vhost '~ts'",
                         [self(), User#user.username, vhost(Hostname)]),
-            ok = rabbit_amqp1_0_session:process_frame(ChFrPid, Frame);
+            ok = rabbit_amqp1_0_session:process_frame(ChFrPid, Frame),
+            ModifiedState;
         {error, {not_allowed, _}} ->
             rabbit_log:error("AMQP 1.0: user '~ts' is not allowed to access virtual host '~ts'",
                 [User#user.username, vhost(Hostname)]),


### PR DESCRIPTION
Fixes issue https://github.com/rabbitmq/rabbitmq-server/issues/6969

## Proposed Changes

Remove unnecessary entries from the process dictionary of the reader process. 
Clear `credit_from` entries from the reader's proc dict by calling `peer_down` when the channel process associated to a session is closed. 

Refactoring: Use  `v1` record to track the session's channel process rather than the reader's process dictionary. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI


