### PR TITLE
Ensure that a timeout closes exe port on win32

### DIFF
--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -1516,6 +1516,7 @@ win32_cmd_receive(Port, MonRef, Acc0) ->
             flush_exit(Port),
             {error, nodata}
     after 5000 ->
+              win32_cmd_receive_finish(Port, MonRef),
               {error, timeout}
     end.
 


### PR DESCRIPTION
Fixes #7038