### PR TITLE
Fix empty channel detail format in management api

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -540,9 +540,12 @@ clean_channel_details(Obj) ->
          undefined -> Obj0;
          Chd ->
              pset(channel_details,
-                  lists:keydelete(pid, 1, Chd),
+                  format_channel_details(lists:keydelete(pid, 1, Chd)),
                   Obj0)
      end.
+
+format_channel_details([]) -> #{};
+format_channel_details(Any) -> Any.
 
 -spec format_consumer_arguments(proplists:proplist()) -> proplists:proplist().
 format_consumer_arguments(Obj) ->


### PR DESCRIPTION
## Proposed Changes

This fixes the response body format  of management API `GET /api/queues/%2f/{queuename}`. While a channel is being deleted, the API returns an empty object as field `.consumer_details[].channel_details` so that SDK deserializers can handle this.

Close: #2684

```bash
# empty channel_detail is formatted as empty object
$ curl -s http://guest:guest@localhost:15672/api/queues/%2f/queue1 | jq .consumer_details[].channel_details
{
  "connection_name": "172.28.0.1:33550 -> 172.28.0.2:5672",
  "name": "172.28.0.1:33550 -> 172.28.0.2:5672 (1)",
  "node": "rabbit@d088896b1c04",
  "number": 1,
  "peer_host": "172.28.0.1",
  "peer_port": 33550,
  "user": "guest"
}
{}
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #2684)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

The response body above is checked by local Docker image `bazel/packaging/docker-image:rabbitmq`.
