### PR TITLE
Reference BUILD.lib_name files with full label in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -120,42 +120,42 @@ erlang_package = use_extension(
 
 erlang_package.hex_package(
     name = "accept",
-    build_file = "@//bazel:BUILD.accept",
+    build_file = "@rabbitmq-server//bazel:BUILD.accept",
     sha256 = "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8",
     version = "0.3.5",
 )
 
 erlang_package.hex_package(
     name = "aten",
-    build_file = "@//bazel:BUILD.aten",
+    build_file = "@rabbitmq-server//bazel:BUILD.aten",
     sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
     version = "0.5.8",
 )
 
 erlang_package.hex_package(
     name = "base64url",
-    build_file = "@//bazel:BUILD.base64url",
+    build_file = "@rabbitmq-server//bazel:BUILD.base64url",
     sha256 = "f9b3add4731a02a9b0410398b475b33e7566a695365237a6bdee1bb447719f5c",
     version = "1.0.1",
 )
 
 erlang_package.hex_package(
     name = "cowboy",
-    build_file = "@//bazel:BUILD.cowboy",
+    build_file = "@rabbitmq-server//bazel:BUILD.cowboy",
     sha256 = "4643e4fba74ac96d4d152c75803de6fad0b3fa5df354c71afdd6cbeeb15fac8a",
     version = "2.8.0",
 )
 
 erlang_package.hex_package(
     name = "cowlib",
-    build_file = "@//bazel:BUILD.cowlib",
+    build_file = "@rabbitmq-server//bazel:BUILD.cowlib",
     sha256 = "e4175dc240a70d996156160891e1c62238ede1729e45740bdd38064dad476170",
     version = "2.9.1",
 )
 
 erlang_package.hex_package(
     name = "credentials_obfuscation",
-    build_file = "@//bazel:BUILD.credentials_obfuscation",
+    build_file = "@rabbitmq-server//bazel:BUILD.credentials_obfuscation",
     sha256 = "fe8ece91a1ba6c8a08eb1063cfd5b063a723c5fe29a1fad6b7cbd76cb18d2eeb",
     version = "3.2.0",
 )
@@ -168,49 +168,49 @@ erlang_package.git_package(
 
 erlang_package.hex_package(
     name = "cuttlefish",
-    build_file = "@//bazel:BUILD.cuttlefish",
+    build_file = "@rabbitmq-server//bazel:BUILD.cuttlefish",
     sha256 = "d3ef90bd2f5923477ab772fbda5cd5ad088438e4fd56801b455b87ada9f46fa3",
     version = "3.1.0",
 )
 
 erlang_package.hex_package(
     name = "eetcd",
-    build_file = "@//bazel:BUILD.eetcd",
+    build_file = "@rabbitmq-server//bazel:BUILD.eetcd",
     sha256 = "66493bfd6698c1b6baa49679034c3def071ff329961ca1aa7b1dee061c2809af",
     version = "0.3.6",
 )
 
 erlang_package.git_package(
     name = "emqtt",
-    build_file = "@//bazel:BUILD.emqtt",
+    build_file = "@rabbitmq-server//bazel:BUILD.emqtt",
     repository = "emqx/emqtt",
     tag = "1.7.0-rc.2",
 )
 
 erlang_package.hex_package(
     name = "enough",
-    build_file = "@//bazel:BUILD.enough",
+    build_file = "@rabbitmq-server//bazel:BUILD.enough",
     sha256 = "0460c7abda5f5e0ea592b12bc6976b8a5c4b96e42f332059cd396525374bf9a1",
     version = "0.1.0",
 )
 
 erlang_package.hex_package(
     name = "gen_batch_server",
-    build_file = "@//bazel:BUILD.gen_batch_server",
+    build_file = "@rabbitmq-server//bazel:BUILD.gen_batch_server",
     sha256 = "94a49a528486298b009d2a1b452132c0a0d68b3e89d17d3764cb1ec879b7557a",
     version = "0.8.7",
 )
 
 erlang_package.hex_package(
     name = "getopt",
-    build_file = "@//bazel:BUILD.getopt",
+    build_file = "@rabbitmq-server//bazel:BUILD.getopt",
     sha256 = "a0029aea4322fb82a61f6876a6d9c66dc9878b6cb61faa13df3187384fd4ea26",
     version = "1.0.2",
 )
 
 erlang_package.hex_package(
     name = "gun",
-    build_file = "@//bazel:BUILD.gun",
+    build_file = "@rabbitmq-server//bazel:BUILD.gun",
     sha256 = "3106ce167f9c9723f849e4fb54ea4a4d814e3996ae243a1c828b256e749041e0",
     version = "1.3.3",
 )
@@ -223,27 +223,27 @@ erlang_package.git_package(
 
 erlang_package.git_package(
     name = "jose",
-    build_file = "@//bazel:BUILD.jose",
+    build_file = "@rabbitmq-server//bazel:BUILD.jose",
     commit = "d63c1c5c8f9c1a4f1438e234b886de8607a0034e",
     repository = "michaelklishin/erlang-jose",
 )
 
 erlang_package.hex_package(
     name = "thoas",
-    build_file = "@//bazel:BUILD.thoas",
+    build_file = "@rabbitmq-server//bazel:BUILD.thoas",
     sha256 = "4918d50026c073c4ab1388437132c77a6f6f7c8ac43c60c13758cc0adce2134e",
     version = "0.4.1",
 )
 
 erlang_package.git_package(
     branch = "master",
-    build_file = "@//bazel:BUILD.meck",
+    build_file = "@rabbitmq-server//bazel:BUILD.meck",
     repository = "eproxus/meck",
 )
 
 erlang_package.hex_package(
     name = "observer_cli",
-    build_file = "@//bazel:BUILD.observer_cli",
+    build_file = "@rabbitmq-server//bazel:BUILD.observer_cli",
     sha256 = "a41b6d3e11a3444e063e09cc225f7f3e631ce14019e5fbcaebfda89b1bd788ea",
     version = "1.7.3",
 )
@@ -255,62 +255,62 @@ erlang_package.git_package(
 
 erlang_package.hex_package(
     name = "prometheus",
-    build_file = "@//bazel:BUILD.prometheus",
+    build_file = "@rabbitmq-server//bazel:BUILD.prometheus",
     sha256 = "2a99bb6dce85e238c7236fde6b0064f9834dc420ddbd962aac4ea2a3c3d59384",
     version = "4.10.0",
 )
 
 erlang_package.git_package(
     branch = "master",
-    build_file = "@//bazel:BUILD.proper",
+    build_file = "@rabbitmq-server//bazel:BUILD.proper",
     repository = "manopapad/proper",
 )
 
 erlang_package.hex_package(
     name = "quantile_estimator",
-    build_file = "@//bazel:BUILD.quantile_estimator",
+    build_file = "@rabbitmq-server//bazel:BUILD.quantile_estimator",
     sha256 = "282a8a323ca2a845c9e6f787d166348f776c1d4a41ede63046d72d422e3da946",
     version = "0.2.1",
 )
 
 erlang_package.hex_package(
     name = "ra",
-    build_file = "@//bazel:BUILD.ra",
+    build_file = "@rabbitmq-server//bazel:BUILD.ra",
     sha256 = "7fae3112cea737bc64d5ff51c1b79a7f30f13ed3d11c565d2a6966ea5aa40473",
     version = "2.4.6",
 )
 
 erlang_package.hex_package(
     name = "ranch",
-    build_file = "@//bazel:BUILD.ranch",
+    build_file = "@rabbitmq-server//bazel:BUILD.ranch",
     sha256 = "244ee3fa2a6175270d8e1fc59024fd9dbc76294a321057de8f803b1479e76916",
     version = "2.1.0",
 )
 
 erlang_package.hex_package(
     name = "recon",
-    build_file = "@//bazel:BUILD.recon",
+    build_file = "@rabbitmq-server//bazel:BUILD.recon",
     sha256 = "6c6683f46fd4a1dfd98404b9f78dcabc7fcd8826613a89dcb984727a8c3099d7",
     version = "2.5.3",
 )
 
 erlang_package.hex_package(
     name = "redbug",
-    build_file = "@//bazel:BUILD.redbug",
+    build_file = "@rabbitmq-server//bazel:BUILD.redbug",
     sha256 = "3624feb7a4b78fd9ae0e66cc3158fe7422770ad6987a1ebf8df4d3303b1c4b0c",
     version = "2.0.7",
 )
 
 erlang_package.hex_package(
     name = "seshat",
-    build_file = "@//bazel:BUILD.seshat",
+    build_file = "@rabbitmq-server//bazel:BUILD.seshat",
     sha256 = "2c3deec7ff86e0d0c05edebd3455c8363123c227be292ffffc1a05eec08bff63",
     version = "0.4.0",
 )
 
 erlang_package.hex_package(
     name = "stdout_formatter",
-    build_file = "@//bazel:BUILD.stdout_formatter",
+    build_file = "@rabbitmq-server//bazel:BUILD.stdout_formatter",
     sha256 = "51f1df921b0477275ea712763042155dbc74acc75d9648dbd54985c45c913b29",
     version = "0.2.4",
 )
@@ -322,14 +322,14 @@ erlang_package.git_package(
 
 erlang_package.hex_package(
     name = "sysmon_handler",
-    build_file = "@//bazel:BUILD.sysmon_handler",
+    build_file = "@rabbitmq-server//bazel:BUILD.sysmon_handler",
     sha256 = "922cf0dd558b9fdb1326168373315b52ed6a790ba943f6dcbd9ee22a74cebdef",
     version = "1.3.0",
 )
 
 erlang_package.hex_package(
     name = "systemd",
-    build_file = "@//bazel:BUILD.systemd",
+    build_file = "@rabbitmq-server//bazel:BUILD.systemd",
     sha256 = "8ec5ed610a5507071cdb7423e663e2452a747a624bb8a58582acd9491ccad233",
     version = "0.6.1",
 )


### PR DESCRIPTION
This allows the files to be resolved, if another repo depends on this one