### PR TITLE
Set MQTT max packet size

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Revert "Format MQTT code with erlfmt"
+209f23fa2f58e0240116b3e8e5be9cd54d34b569
+# Format MQTT code with erlfmt
+1de9fcf582def91d1cee6bea457dd24e8a53a431

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -91,7 +91,7 @@ init(Ref) ->
                             connection_state = running,
                             received_connect_packet = false,
                             conserve = false,
-                            parse_state = rabbit_mqtt_packet:initial_state(),
+                            parse_state = rabbit_mqtt_packet:init_state(),
                             proc_state = ProcessorState},
             State1 = control_throttle(State0),
             State = rabbit_event:init_stats_timer(State1, #state.stats_timer),
@@ -336,7 +336,7 @@ process_received_bytes(Bytes,
                 {ok, ProcState1} ->
                     process_received_bytes(
                       Rest,
-                      State #state{parse_state = rabbit_mqtt_packet:initial_state(),
+                      State #state{parse_state = rabbit_mqtt_packet:reset_state(),
                                    proc_state = ProcState1});
                 %% PUBLISH and more
                 {error, unauthorized = Reason, ProcState1} ->

--- a/deps/rabbitmq_mqtt/test/util.erl
+++ b/deps/rabbitmq_mqtt/test/util.erl
@@ -14,6 +14,7 @@
          connect/2,
          connect/3,
          connect/4,
+         start_client/4,
          get_events/1,
          assert_event_type/2,
          assert_event_prop/2,
@@ -119,6 +120,11 @@ connect(ClientId, Config, AdditionalOpts) ->
     connect(ClientId, Config, 0, AdditionalOpts).
 
 connect(ClientId, Config, Node, AdditionalOpts) ->
+    {C, Connect} = start_client(ClientId, Config, Node, AdditionalOpts),
+    {ok, _Properties} = Connect(C),
+    C.
+
+start_client(ClientId, Config, Node, AdditionalOpts) ->
     {Port, WsOpts, Connect} =
     case rabbit_ct_helpers:get_config(Config, websocket, false) of
         false ->
@@ -136,5 +142,4 @@ connect(ClientId, Config, Node, AdditionalOpts) ->
                {clientid, rabbit_data_coercion:to_binary(ClientId)}
               ] ++ WsOpts ++ AdditionalOpts,
     {ok, C} = emqtt:start_link(Options),
-    {ok, _Properties} = Connect(C),
-    C.
+    {C, Connect}.

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -32,7 +32,7 @@
 
 -record(state, {
           socket :: {rabbit_proxy_socket, any(), any()} | rabbit_net:socket(),
-          parse_state = rabbit_mqtt_packet:initial_state() :: rabbit_mqtt_packet:state(),
+          parse_state = rabbit_mqtt_packet:init_state() :: rabbit_mqtt_packet:state(),
           proc_state :: undefined | rabbit_mqtt_processor:state(),
           connection_state = running :: running | blocked,
           conserve = false :: boolean(),
@@ -273,7 +273,7 @@ handle_data1(Data, State = #state{ parse_state = ParseState,
                 {ok, ProcState1} ->
                     handle_data1(
                       Rest,
-                      State#state{parse_state = rabbit_mqtt_packet:initial_state(),
+                      State#state{parse_state = rabbit_mqtt_packet:reset_state(),
                                   proc_state = ProcState1});
                 {error, Reason, _} ->
                     stop_mqtt_protocol_error(State, Reason, ConnName);
@@ -296,7 +296,7 @@ parse(Data, ParseState) ->
     end.
 
 stop_mqtt_protocol_error(State, Reason, ConnName) ->
-    ?LOG_INFO("MQTT protocol error ~tp for connection ~tp", [Reason, ConnName]),
+    ?LOG_WARNING("Web MQTT protocol error ~tp for connection ~tp", [Reason, ConnName]),
     stop(State, ?CLOSE_PROTOCOL_ERROR, Reason).
 
 stop(State) ->


### PR DESCRIPTION
Set default max size of 65,536 for CONNECT packet.

In MQTT 3.1.1, the CONNECT packet consists of
1. 10 bytes variable header
1. ClientId (up to 23 bytes must be supported)
1. Will Topic
1. Will Message (maximum length 2^16 bytes)
1. User Name
1. Password

 Restricting the CONNECT packet size to 2^16 = 65,536 bytes seems to be a reasonalbe default.

 The value is configurable via advanced.config.