### PR TITLE
Remove MQTT processor field peer_addr

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_util.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_util.erl
@@ -23,7 +23,8 @@
          init_sparkplug/0,
          mqtt_to_amqp/1,
          amqp_to_mqtt/1,
-         truncate_binary/2
+         truncate_binary/2,
+         ip_address_to_binary/1
         ]).
 
 -define(MAX_TOPIC_TRANSLATION_CACHE_SIZE, 12).
@@ -209,3 +210,7 @@ truncate_binary(Bin, Size)
 truncate_binary(Bin, Size)
   when is_binary(Bin) ->
     binary:part(Bin, 0, Size).
+
+-spec ip_address_to_binary(inet:ip_address()) -> binary().
+ip_address_to_binary(IpAddress) ->
+    list_to_binary(inet:ntoa(IpAddress)).


### PR DESCRIPTION
as it seems to always match peer_host.

Commit 7e09b85426959883c2cbe5f409aeaa299427fd8e adds peer address provided by WebMQTT plugin.

However, this seems unnecessary since function rabbit_net:peername/1 on the unwrapped socket provides the same address.

The peer address was the address of the proxy if the proxy protocol is enabled.

This commit simplifies code and reduces memory consumption.