### PR TITLE
Backport a CT broker helper fix from #5895 

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -1450,15 +1450,14 @@ clear_permissions(Config, Node, Username, VHost, ActingUser) ->
 
 set_vhost_limit(Config, Node, VHost, Limit0, Value) ->
     Limit = case Limit0 of
-      max_connections -> <<"max-connections">>;
-      max_queues      -> <<"max-queues">>;
-      Other -> rabbit_data_coercion:to_binary(Other)
+        max_connections -> <<"max-connections">>;
+        max_queues      -> <<"max-queues">>;
+        Other -> rabbit_data_coercion:to_binary(Other)
     end,
-    Definition = rabbit_json:encode(#{Limit => Value}),
+    Limits = [{Limit, Value}],
     rpc(Config, Node,
-        rabbit_vhost_limit,
-        set,
-        [VHost, Definition, <<"ct-tests">>]).
+        rabbit_vhost_limit, set,
+        [VHost, Limits, <<"ct-tests">>]).
 
 set_user_limits(Config, Username, Limits) ->
     set_user_limits(Config, 0, Username, Limits).


### PR DESCRIPTION
Previously the helper was not setting the virtual host limit
correctly.

