### PR TITLE
CQ: Fix performance regression after moving to v2 sets

### DIFF
--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -936,7 +936,7 @@ handle_cast({remove, CRef, MsgIds}, State) ->
                       ignore  -> {Removed, State2}
                   end
           end, {[], State}, MsgIds),
-    noreply(maybe_compact(client_confirm(CRef, sets:from_list(RemovedMsgIds),
+    noreply(maybe_compact(client_confirm(CRef, sets:from_list(RemovedMsgIds, [{version, 2}]),
                                          ignored, State1)));
 
 handle_cast({combine_files, Source, Destination, Reclaimed},

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -1608,7 +1608,7 @@ publish_and_confirm(Q, Payload, Count) ->
               {ok, Acc, _Actions} = rabbit_queue_type:deliver([Q], Delivery, Acc0),
               Acc
       end, QTState0, Seqs),
-    wait_for_confirms(sets:from_list(Seqs)),
+    wait_for_confirms(sets:from_list(Seqs, [{version, 2}])),
     QTState.
 
 wait_for_confirms(Unconfirmed) ->
@@ -1619,7 +1619,7 @@ wait_for_confirms(Unconfirmed) ->
                 {'$gen_cast', {queue_event, _QName, {confirm, Confirmed, _}}} ->
                     wait_for_confirms(
                       sets:subtract(
-                        Unconfirmed, sets:from_list(Confirmed)))
+                        Unconfirmed, sets:from_list(Confirmed, [{version, 2}])))
             after ?TIMEOUT ->
                       flush(),
                       exit(timeout_waiting_for_confirm)


### PR DESCRIPTION
sets:from_list also must be told to use v2 otherwise it will use v1.

cc @mkuratczyk 