### PR TITLE
Activate stream delivery v2 correctly

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2721,7 +2721,7 @@ process_client_command_versions(C, []) ->
 process_client_command_versions(C, [H | T]) ->
     process_client_command_versions(process_client_command_api(C, H), T).
 
-process_client_command_api(C, {deliver, ?VERSION_1, ?VERSION_2}) ->
+process_client_command_api(C, {deliver, _, ?VERSION_2}) ->
     C#stream_connection{deliver_version = ?VERSION_2};
 process_client_command_api(C, _) ->
     C.


### PR DESCRIPTION
As soon as v2 is supported, whatever the min supported version is.