### PR TITLE
Fix issue #7142

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/limits.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/limits.ejs
@@ -1,6 +1,6 @@
 <h1>Limits</h1>
 
-<div class="section">
+<div class="section" id="virtual-host-limits">
     <h2>Virtual host Limits</h2>
     <div class="hider">
         <div class="updatable">
@@ -49,7 +49,7 @@
     </div>
 </div>
 
-<div class="section administrator-only">
+<div class="section administrator-only" id="set-virtual-host-limits">
     <h2>Set / update a virtual host limit</h2>
     <div class="hider">
         <form action="#/limits" method="put">
@@ -88,7 +88,7 @@
     </div>
 </div>
 
-<div class="section">
+<div class="section" id="user-limits">
   <h2>User Limits</h2>
   <div class="hider">
       <div class="updatable">
@@ -137,7 +137,7 @@
   </div>
 </div>
 
-<div class="section administrator-only">
+<div class="section administrator-only" id="set-user-limits">
   <h2>Set / update a user limit</h2>
   <div class="hider">
       <form action="#/user-limits" method="put">
@@ -146,9 +146,9 @@
                 <th><label>User:</label></th>
                 <td>
                   <select name="user">
-                      <% for (var i = 0; i < users.items.length; i++) { %>
-                      <option value="<%= fmt_string(users.items[i].name) %>">
-                          <%= fmt_string(users.items[i].name) %>
+                      <% for (var i = 0; i < users.length; i++) { %>
+                      <option value="<%= fmt_string(users[i].name) %>">
+                          <%= fmt_string(users[i].name) %>
                       </option>
                       <% } %>
                   </select>

--- a/deps/rabbitmq_management/selenium/suites/limits.sh
+++ b/deps/rabbitmq_management/selenium/suites/limits.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Name of the suite used to generate log and screen folders
+SUITE=$( basename "${BASH_SOURCE[0]}" .sh)
+
+# Path to the test cases this suite should run. It is relative to the selenium/test folder
+TEST_CASES_PATH=/limits
+# Path to the folder where all configuration file reside. It is relative to the selenim/test folder
+TEST_CONFIG_PATH=/basic-auth
+
+source $SCRIPT/suite_template
+
+_setup () {
+  start_rabbitmq
+}
+_save_logs() {
+  save_container_logs rabbitmq
+}
+_teardown() {
+  kill_container_if_exist rabbitmq
+}
+run

--- a/deps/rabbitmq_management/selenium/test/definitions/Makefile
+++ b/deps/rabbitmq_management/selenium/test/definitions/Makefile
@@ -10,5 +10,11 @@ RABBITMQ_SERVER_ROOT = ../../../../../
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+start-rabbitmq: ## Start RabbitMQ
+	@(docker kill rabbitmq >/dev/null 2>&1  && docker rm rabbitmq)
+	@(gmake --directory=${RABBITMQ_SERVER_ROOT} run-broker \
+		RABBITMQ_ENABLED_PLUGINS="rabbitmq_management" \
+		RABBITMQ_CONFIG_FILE=deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.config)
+
 test: ## Run tests interactively e.g. make test [TEST=landing.js]
 	@(RABBITMQ_URL=http://localhost:15672 RUN_LOCAL=true SCREENSHOTS_DIR=${PWD}/../../screens npm test $(PWD)/$(TEST))

--- a/deps/rabbitmq_management/selenium/test/limits/Makefile
+++ b/deps/rabbitmq_management/selenium/test/limits/Makefile
@@ -1,0 +1,14 @@
+.ONESHELL:# single shell invocation for all lines in the recipe
+SHELL = bash# we depend on bash expansion for e.g. queue patterns
+
+.DEFAULT_GOAL = help
+RABBITMQ_SERVER_ROOT = ../../../../../
+
+
+### TARGETS ###
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run tests interactively e.g. make test [TEST=landing.js]
+	@(RABBITMQ_URL=http://localhost:15672 RUN_LOCAL=true SCREENSHOTS_DIR=${PWD}/../../screens npm test $(PWD)/$(TEST))

--- a/deps/rabbitmq_management/selenium/test/limits/Makefile
+++ b/deps/rabbitmq_management/selenium/test/limits/Makefile
@@ -10,5 +10,11 @@ RABBITMQ_SERVER_ROOT = ../../../../../
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+start-rabbitmq: ## Start RabbitMQ
+	@(docker kill rabbitmq >/dev/null 2>&1  && docker rm rabbitmq)
+	@(gmake --directory=${RABBITMQ_SERVER_ROOT} run-broker \
+		RABBITMQ_ENABLED_PLUGINS="rabbitmq_management" \
+		RABBITMQ_CONFIG_FILE=deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.config)
+
 test: ## Run tests interactively e.g. make test [TEST=landing.js]
 	@(RABBITMQ_URL=http://localhost:15672 RUN_LOCAL=true SCREENSHOTS_DIR=${PWD}/../../screens npm test $(PWD)/$(TEST))

--- a/deps/rabbitmq_management/selenium/test/limits/users.js
+++ b/deps/rabbitmq_management/selenium/test/limits/users.js
@@ -1,0 +1,44 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+require('chromedriver')
+const assert = require('assert')
+const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
+
+const LoginPage = require('../pageobjects/LoginPage')
+const OverviewPage = require('../pageobjects/OverviewPage')
+const AdminTab = require('../pageobjects/AdminTab')
+const LimitsAdminTab = require('../pageobjects/LimitsAdminTab')
+
+describe('List all user_limits', function () {
+  let login
+  let overview
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    login = new LoginPage(driver)
+    overview = new OverviewPage(driver)
+    adminTab = new AdminTab(driver)
+    limitsSection = new LimitsAdminTab(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+
+    await login.login('guest', 'guest')
+    if (!await overview.isLoaded()) {
+      throw new Error('Failed to login')
+    }
+
+  })
+
+  it('when there are no limits', async function () {
+    await overview.clickOnAdminTab()
+    await adminTab.clickOnLimits()
+
+    await limitsSection.list_user_limits()
+
+  })
+
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})

--- a/deps/rabbitmq_management/selenium/test/limits/users.js
+++ b/deps/rabbitmq_management/selenium/test/limits/users.js
@@ -8,7 +8,7 @@ const OverviewPage = require('../pageobjects/OverviewPage')
 const AdminTab = require('../pageobjects/AdminTab')
 const LimitsAdminTab = require('../pageobjects/LimitsAdminTab')
 
-describe('List all user_limits', function () {
+describe('user_limits', function () {
   let login
   let overview
   let captureScreen
@@ -32,9 +32,7 @@ describe('List all user_limits', function () {
   it('when there are no limits', async function () {
     await overview.clickOnAdminTab()
     await adminTab.clickOnLimits()
-
-    await limitsSection.list_user_limits()
-
+    assert.equal(0, (await limitsSection.list_user_limits()).length)
   })
 
 

--- a/deps/rabbitmq_management/selenium/test/limits/virtual-hosts.js
+++ b/deps/rabbitmq_management/selenium/test/limits/virtual-hosts.js
@@ -1,0 +1,44 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+require('chromedriver')
+const assert = require('assert')
+const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
+
+const LoginPage = require('../pageobjects/LoginPage')
+const OverviewPage = require('../pageobjects/OverviewPage')
+const AdminTab = require('../pageobjects/AdminTab')
+const LimitsAdminTab = require('../pageobjects/LimitsAdminTab')
+
+describe('List all virtual_host_limits', function () {
+  let login
+  let overview
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    login = new LoginPage(driver)
+    overview = new OverviewPage(driver)
+    adminTab = new AdminTab(driver)
+    limitsSection = new LimitsAdminTab(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+
+    await login.login('guest', 'guest')
+    if (!await overview.isLoaded()) {
+      throw new Error('Failed to login')
+    }
+
+  })
+
+  it('when there are no limits', async function () {
+    await overview.clickOnAdminTab()
+    await adminTab.clickOnLimits()
+
+    await limitsSection.list_virtual_host_limits()
+    
+  })
+
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})

--- a/deps/rabbitmq_management/selenium/test/limits/virtual-hosts.js
+++ b/deps/rabbitmq_management/selenium/test/limits/virtual-hosts.js
@@ -8,7 +8,7 @@ const OverviewPage = require('../pageobjects/OverviewPage')
 const AdminTab = require('../pageobjects/AdminTab')
 const LimitsAdminTab = require('../pageobjects/LimitsAdminTab')
 
-describe('List all virtual_host_limits', function () {
+describe('virtual_host_limits', function () {
   let login
   let overview
   let captureScreen
@@ -32,9 +32,8 @@ describe('List all virtual_host_limits', function () {
   it('when there are no limits', async function () {
     await overview.clickOnAdminTab()
     await adminTab.clickOnLimits()
+    assert.equal(0, (await limitsSection.list_virtual_host_limits()).length)
 
-    await limitsSection.list_virtual_host_limits()
-    
   })
 
 

--- a/deps/rabbitmq_management/selenium/test/pageobjects/AdminTab.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/AdminTab.js
@@ -2,15 +2,28 @@ const { By, Key, until, Builder } = require('selenium-webdriver')
 
 const OverviewPage = require('./OverviewPage')
 
+const SELECTED_ADMIN_TAB = By.css('div#menu ul#tabs li a.selected[href="#/users"]')
+
 const ALL_USERS_SECTION = By.css('div#users-section')
 const USER_LINK = By.css('div#menu ul#tabs li a[href="#/connections"]')
+
 const FILTER_USER = By.css('input#users-name')
 const CHECKBOX_REGEX = By.css('input#filter-regex-mode')
 const FILTERED_USER = By.css('span.filter-highlight')
 
+// RHM : RIGHT HAND MENU
+const USERS_ON_RHM = By.css('div#rhs ul li a[href="#/users"]')
+const LIMITS_ON_RHM = By.css('div#rhs ul li a[href="#/limits"]')
+
 module.exports = class AdminTab extends OverviewPage {
   async isLoaded () {
-    await this.waitForDisplayed(ADMIN_TAB)
+    await this.waitForDisplayed(SELECTED_ADMIN_TAB)
+  }
+  async clickOnUsers() {
+    await this.click(USERS_ON_RHM)
+  }
+  async clickOnLimits() {
+    await this.click(LIMITS_ON_RHM)
   }
 
   async searchForUser(user, regex = false) {

--- a/deps/rabbitmq_management/selenium/test/pageobjects/LimitsAdminTab.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/LimitsAdminTab.js
@@ -7,6 +7,9 @@ const SELECTED_LIMITS_ON_RHM = By.css('div#rhs ul li a[href="#/limits"]')
 const VIRTUAL_HOST_LIMITS_SECTION = By.css('div#main div#virtual-host-limits')
 const USER_LIMITS_SECTION = By.css('div#main div#user-limits')
 
+const VIRTUAL_HOST_LIMITS_TABLE_ROWS = By.css('div#main div#virtual-host-limits table.list tbody tr')
+const USER_LIMITS_TABLE_ROWS = By.css('div#main div#user-limits table.list tbody tr')
+
 module.exports = class LimitsAdminTab extends AdminTab {
   async isLoaded () {
     await this.waitForDisplayed(SELECTED_LIMITS_ON_RHM)
@@ -14,9 +17,23 @@ module.exports = class LimitsAdminTab extends AdminTab {
 
   async list_virtual_host_limits() {
     await this.click(VIRTUAL_HOST_LIMITS_SECTION)
+    try
+    {
+      rows = driver.findElements(VIRTUAL_HOST_LIMITS_TABLE_ROWS)
+      return rows
+    } catch (NoSuchElement) {
+      return Promise.resolve([])
+    }
   }
   async list_user_limits() {
     await this.click(USER_LIMITS_SECTION)
+    try
+    {
+      rows = driver.findElements(VIRTUAL_HOST_LIMITS_TABLE_ROWS)
+      return rows
+    } catch (NoSuchElement) {
+      return Promise.resolve([])
+    }
   }
 
 }

--- a/deps/rabbitmq_management/selenium/test/pageobjects/LimitsAdminTab.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/LimitsAdminTab.js
@@ -1,0 +1,22 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+
+const AdminTab = require('./AdminTab')
+
+const SELECTED_LIMITS_ON_RHM = By.css('div#rhs ul li a[href="#/limits"]')
+
+const VIRTUAL_HOST_LIMITS_SECTION = By.css('div#main div#virtual-host-limits')
+const USER_LIMITS_SECTION = By.css('div#main div#user-limits')
+
+module.exports = class LimitsAdminTab extends AdminTab {
+  async isLoaded () {
+    await this.waitForDisplayed(SELECTED_LIMITS_ON_RHM)
+  }
+
+  async list_virtual_host_limits() {
+    await this.click(VIRTUAL_HOST_LIMITS_SECTION)
+  }
+  async list_user_limits() {
+    await this.click(USER_LIMITS_SECTION)
+  }
+
+}


### PR DESCRIPTION
Fixes #7142 

The issue is that users retrieved with the intention to list in the limits view are not paged hence they are not wrapped
around a paging struct where users would be under items attribute. The limits template thinks that users are paged and when it executes `users.items.length` , it cannot find `items`.

Pending selenium tests

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
