### PR TITLE
Use maybe expression in MQTT plugin

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.9.2",
+    version = "3.9.3",
 )
 
 erlang_config = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_r
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.9.2",
+    tag = "3.9.3",
 )
 
 load("@rules_erlang//:internal_deps.bzl", "rules_erlang_internal_deps")

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -77,6 +77,7 @@ start_rabbitmq_server() {
         -syslog logger '[]' \
         -syslog syslog_error_logger false \
         -kernel prevent_overlapping_partitions false \
+        -enable-feature maybe_expr \
         "$@"
 }
 

--- a/deps/rabbit/scripts/rabbitmq-server.bat
+++ b/deps/rabbit/scripts/rabbitmq-server.bat
@@ -71,6 +71,7 @@ if "!RABBITMQ_ALLOW_INPUT!"=="" (
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
 -kernel prevent_overlapping_partitions false ^
+-enable-feature maybe_expr ^
 !STAR!
 
 if ERRORLEVEL 1 (

--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -201,6 +201,7 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
 -kernel prevent_overlapping_partitions false ^
+-enable-feature maybe_expr ^
 !STARVAR!
 
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:\=\\!

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -1401,18 +1401,10 @@ auth_phase(Response,
            State = #v1{connection = Connection =
                            #connection{protocol       = Protocol,
                                        auth_mechanism = {Name, AuthMechanism},
-                                       auth_state     = AuthState},
+                                       auth_state     = AuthState,
+                                       host           = RemoteAddress},
                        sock = Sock}) ->
-    rabbit_log:debug("Raw client connection hostname during authN phase: ~tp", [Connection#connection.host]),
-    RemoteAddress = case Connection#connection.host of
-        %% the hostname was already resolved, e.g. by reverse DNS lookups
-        Bin when is_binary(Bin) -> Bin;
-        %% the hostname is an IP address
-        Tuple when is_tuple(Tuple) ->
-            rabbit_data_coercion:to_binary(inet:ntoa(Connection#connection.host));
-        Other -> rabbit_data_coercion:to_binary(Other)
-    end,
-    rabbit_log:debug("Resolved client hostname during authN phase: ~ts", [RemoteAddress]),
+    rabbit_log:debug("Client address during authN phase: ~tp", [RemoteAddress]),
     case AuthMechanism:handle_response(Response, AuthState) of
         {refused, Username, Msg, Args} ->
             rabbit_core_metrics:auth_attempt_failed(RemoteAddress, Username, amqp091),

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -79,7 +79,6 @@
 -export([raw_read_file/1]).
 -export([find_child/2]).
 -export([is_regular_file/1]).
--export([pipeline/3]).
 
 %% Horrible macro to use in guards
 -define(IS_BENIGN_EXIT(R),
@@ -1442,45 +1441,3 @@ find_powershell() ->
         PwshExe ->
             PwshExe
     end.
-
-%% -------------------------------------------------------------------------
-%% Begin copy from
-%% https://github.com/emqx/emqx/blob/cffdcb42843d48bf99d8bd13695bc73149c98a23/apps/emqx/src/emqx_misc.erl#L141-L157
-
-%%--------------------------------------------------------------------
-%% Copyright (c) 2017-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
-%%
-%% Licensed under the Apache License, Version 2.0 (the "License");
-%% you may not use this file except in compliance with the License.
-%% You may obtain a copy of the License at
-%%
-%%     http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing, software
-%% distributed under the License is distributed on an "AS IS" BASIS,
-%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-%% See the License for the specific language governing permissions and
-%% limitations under the License.
-%%--------------------------------------------------------------------
-
-pipeline([], Input, State) ->
-    {ok, Input, State};
-pipeline([Fun | More], Input, State) ->
-    case apply_fun(Fun, Input, State) of
-        ok -> pipeline(More, Input, State);
-        {ok, NState} -> pipeline(More, Input, NState);
-        {ok, Output, NState} -> pipeline(More, Output, NState);
-        {error, Reason} -> {error, Reason, State};
-        {error, Reason, NState} -> {error, Reason, NState}
-    end.
-
--compile({inline, [apply_fun/3]}).
-apply_fun(Fun, Input, State) ->
-    case erlang:fun_info(Fun, arity) of
-        {arity, 1} -> Fun(Input);
-        {arity, 2} -> Fun(Input, State)
-    end.
-
-%% End copy from
-%% https://github.com/emqx/emqx/blob/cffdcb42843d48bf99d8bd13695bc73149c98a23/apps/emqx/src/emqx_misc.erl#L141-L157
-%% -------------------------------------------------------------------------

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -225,8 +225,8 @@ rabbitmq_integration_suite(
 
 rabbitmq_integration_suite(
    name = "shared_SUITE",
+   shard_count = 6,
    size = "large",
-   timeout = "eternal",
    runtime_deps = [
        "@emqtt//:erlang_app",
        "//deps/rabbitmq_management_agent:erlang_app",

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl
@@ -45,6 +45,8 @@
 %% The Client is not authorized to connect.
 -define(CONNACK_NOT_AUTHORIZED,         5).
 
+-type connack_return_code() :: ?CONNACK_ACCEPT..?CONNACK_NOT_AUTHORIZED.
+
 %% qos levels
 
 -define(QOS_0, 0).
@@ -70,20 +72,20 @@
 
 -type mqtt_packet() :: #mqtt_packet{}.
 
--record(mqtt_packet_connect,  {proto_ver,
-                               will_retain,
-                               will_qos,
-                               will_flag,
-                               clean_sess,
-                               keep_alive,
-                               client_id,
-                               will_topic,
-                               will_msg,
-                               username,
-                               password}).
+-record(mqtt_packet_connect,  {proto_ver :: 3 | 4,
+                               will_retain :: boolean(),
+                               will_qos :: 0..2,
+                               will_flag :: boolean(),
+                               clean_sess :: boolean(),
+                               keep_alive :: non_neg_integer(),
+                               client_id :: binary(),
+                               will_topic :: option(binary()),
+                               will_msg :: option(binary()),
+                               username :: option(binary()),
+                               password :: option(binary())}).
 
--record(mqtt_packet_connack,  {session_present,
-                               return_code}).
+-record(mqtt_packet_connack,  {session_present :: boolean(),
+                               return_code :: connack_return_code()}).
 
 -record(mqtt_packet_publish,  {topic_name :: undefined | binary(),
                                packet_id :: packet_id()}).

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl
@@ -59,10 +59,10 @@
 %% Packet identifier is a non zero two byte integer.
 -type packet_id() :: 1..16#ffff.
 
--record(mqtt_packet_fixed,    {type   = 0,
-                               dup    = 0,
-                               qos    = 0,
-                               retain = 0
+-record(mqtt_packet_fixed,    {type = 0 :: packet_type(),
+                               dup = false :: boolean(),
+                               qos = 0 :: qos(),
+                               retain = false :: boolean()
                               }).
 
 -record(mqtt_packet,          {fixed :: #mqtt_packet_fixed{},
@@ -74,7 +74,7 @@
 
 -record(mqtt_packet_connect,  {proto_ver :: 3 | 4,
                                will_retain :: boolean(),
-                               will_qos :: 0..2,
+                               will_qos :: qos(),
                                will_flag :: boolean(),
                                clean_sess :: boolean(),
                                keep_alive :: non_neg_integer(),
@@ -103,7 +103,7 @@
 -record(mqtt_msg,             {retain :: boolean(),
                                qos :: qos(),
                                topic :: binary(),
-                               dup :: option(boolean()),
+                               dup :: boolean(),
                                packet_id :: option(packet_id()),
                                payload :: binary()}).
 

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1599,8 +1599,7 @@ check_resource_access(User, Resource, Perm, Context) ->
 
 check_topic_access(
   TopicName, Access,
-  #state{auth_state = #auth_state{user = User = #user{username = Username},
-                                  authz_ctx = AuthzCtx},
+  #state{auth_state = #auth_state{user = User = #user{username = Username}},
          cfg = #cfg{client_id = ClientId,
                     vhost = VHost,
                     exchange = #resource{name = ExchangeBin}}}) ->
@@ -1618,7 +1617,9 @@ check_topic_access(
                                  name = ExchangeBin},
             RoutingKey = mqtt_to_amqp(TopicName),
             Context = #{routing_key  => RoutingKey,
-                        variable_map => AuthzCtx},
+                        variable_map => #{<<"username">> => Username,
+                                          <<"vhost">> => VHost,
+                                          <<"client_id">> => ClientId}},
             try rabbit_access_control:check_topic_access(User, Resource, Access, Context) of
                 ok ->
                     CacheTail = lists:sublist(Cache, ?MAX_PERMISSION_CACHE_SIZE - 1),

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -176,14 +176,17 @@ process_connect(
             ra_register_state = RaRegisterState}}
     end,
     Result = case Result0 of
-                 {ok, State0} -> process_connect(State0);
-                 Error -> Error
+                 {ok, State0 = #state{}} ->
+                     process_connect(State0);
+                 {error, _} = Err0 ->
+                     Err0
              end,
     case Result of
-        {ok, SessPresent, State} ->
+        {ok, SessPresent, State = #state{}} ->
             send_conn_ack(?CONNACK_ACCEPT, SessPresent, ProtoVerAtom, SendFun),
             {ok, State};
-        {error, ReturnErrCode} = Err ->
+        {error, ReturnErrCode} = Err
+          when is_number(ReturnErrCode) ->
             %% If a server sends a CONNACK packet containing a non-zero return
             %% code it MUST set Session Present to 0 [MQTT-3.2.2-4].
             SessPresent = false,
@@ -206,7 +209,7 @@ process_connect(State0) ->
         rabbit_networking:register_non_amqp_connection(self()),
         {ok, SessPresent, State}
     else
-        Error ->
+        {error, _} = Error ->
             unregister_client(State0),
             Error
     end.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -166,7 +166,7 @@ process_connect(
                        peer_port = PeerPort,
                        send_fun = SendFun,
                        exchange = rabbit_misc:r(VHost, exchange, rabbit_mqtt_util:env(exchange)),
-                       retainer_pid = rabbit_mqtt_retainer_sup:child_for_vhost(VHost),
+                       retainer_pid = rabbit_mqtt_retainer_sup:start_child_for_vhost(VHost),
                        vhost = VHost,
                        client_id = ClientId,
                        will_msg = make_will_msg(Packet)},

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -534,8 +534,8 @@ no_queue_bind_permission(Config) ->
     ["MQTT resource access refused: write access to queue "
      "'mqtt-subscription-mqtt-userqos0' in vhost 'mqtt-vhost' "
      "refused for user 'mqtt-user'",
-     "Failed to bind queue 'mqtt-subscription-mqtt-userqos0' "
-     "in vhost 'mqtt-vhost' with topic test/topic: access_refused"
+     "Failed to add binding between exchange 'amq.topic' in vhost 'mqtt-vhost' and queue "
+     "'mqtt-subscription-mqtt-userqos0' in vhost 'mqtt-vhost' for topic test/topic: access_refused"
     ],
     test_subscribe_permissions_combination(<<".*">>, <<"">>, <<".*">>, Config, ExpectedLogs).
 
@@ -570,8 +570,8 @@ no_queue_unbind_permission(Config) ->
     ok = assert_connection_closed(C2),
     ExpectedLogs =
     ["MQTT resource access refused: read access to exchange 'amq.topic' in vhost 'mqtt-vhost' refused for user 'mqtt-user'",
-     "Failed to unbind queue 'mqtt-subscription-mqtt-userqos1' in vhost 'mqtt-vhost' with topic 'my/topic': access_refused",
-     "MQTT protocol error on connection.*: subscribe_error"
+     "Failed to remove binding between exchange 'amq.topic' in vhost 'mqtt-vhost' and queue "
+     "'mqtt-subscription-mqtt-userqos1' in vhost 'mqtt-vhost' for topic my/topic: access_refused"
     ],
     wait_log(Config, [?FAIL_IF_CRASH_LOG, {ExpectedLogs, fun () -> stop end}]),
 
@@ -619,7 +619,7 @@ no_queue_delete_permission(Config) ->
        ,{[io_lib:format("MQTT resource access refused: configure access to queue "
                         "'mqtt-subscription-~sqos1' in vhost 'mqtt-vhost' refused for user 'mqtt-user'",
                         [ClientId]),
-          "MQTT connection .* is closing due to an authorization failure"],
+          "Rejected MQTT connection .* with CONNACK return code 5"],
          fun() -> stop end}
       ]),
     ok.
@@ -653,7 +653,7 @@ no_queue_consume_permission_on_connect(Config) ->
        ,{[io_lib:format("MQTT resource access refused: read access to queue "
                         "'mqtt-subscription-~sqos1' in vhost 'mqtt-vhost' refused for user 'mqtt-user'",
                         [ClientId]),
-          "MQTT connection .* is closing due to an authorization failure"],
+          "Rejected MQTT connection .* with CONNACK return code 5"],
          fun () -> stop end}
       ]),
     ok.
@@ -713,8 +713,8 @@ no_topic_read_permission(Config) ->
              [?FAIL_IF_CRASH_LOG,
               {["MQTT topic access refused: read access to topic 'test.topic' in exchange "
                 "'amq.topic' in vhost 'mqtt-vhost' refused for user 'mqtt-user'",
-                "Failed to bind queue 'mqtt-subscription-mqtt-userqos0' "
-                "in vhost 'mqtt-vhost' with topic test/topic: access_refused"
+                "Failed to add binding between exchange 'amq.topic' in vhost 'mqtt-vhost' and queue "
+                "'mqtt-subscription-mqtt-userqos0' in vhost 'mqtt-vhost' for topic test/topic: access_refused"
                ],
                fun () -> stop end}
              ]),
@@ -757,7 +757,7 @@ loopback_user_connects_from_remote_host(Config) ->
     wait_log(Config,
              [?FAIL_IF_CRASH_LOG,
               {["MQTT login failed: user 'mqtt-user' can only connect via localhost",
-                "MQTT connection .* is closing due to an authorization failure"],
+                "Rejected MQTT connection .* with CONNACK return code 5"],
                fun () -> stop end}
              ]),
 

--- a/deps/rabbitmq_mqtt/test/java_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/java_SUITE.erl
@@ -84,9 +84,9 @@ init_per_testcase(Testcase, Config) ->
     {ok, _} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0,
         ["set_topic_permissions",  "-p", "/", "guest", "amq.topic",
             % Write permission
-            "test-topic|test-retained-topic|{username}.{client_id}.a|^sp[AB]v\\d+___\\d+",
+            "test-topic|^test-retained-topic$|^{username}.{client_id}.a$|^sp[AB]v\\d+___\\d+",
             % Read permission
-            "test-topic|test-retained-topic|last-will|{username}.{client_id}.a|^sp[AB]v\\d+___\\d+"]),
+            "test-topic|^test-retained-topic$|^last-will$|^{username}.{client_id}.a$|^sp[AB]v\\d+___\\d+"]),
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->

--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
@@ -904,7 +904,7 @@ public class MqttTest implements MqttCallback {
     }
 
     @Test public void topicAuthorisationVariableExpansion(TestInfo info) throws Exception {
-        final String client_id = clientId(info);
+        final String client_id = "client-id-variable-expansion";
         MqttConnectOptions client_opts = new TestMqttConnectOptions();
         MqttClient client = newConnectedClient(client_id, client_opts);
         client.setCallback(this);

--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/rabbit-test.sh
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/rabbit-test.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-CTL=$1
-USER="O=client,CN=$(hostname)"
-
-# Test direct connections
-$CTL add_user "$USER" ''
-$CTL set_permissions -p / "$USER" ".*" ".*" ".*"
-$CTL set_topic_permissions -p / "$USER" "amq.topic" "test-topic|test-retained-topic|.*topic.*" "test-topic|test-retained-topic|.*topic.*|last-will"

--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/setup-rabbit-test.sh
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/setup-rabbit-test.sh
@@ -1,2 +1,0 @@
-#!/bin/sh -e
-sh -e `dirname $0`/rabbit-test.sh "$DEPS_DIR/rabbit/scripts/rabbitmqctl -n $RABBITMQ_NODENAME"

--- a/deps/rabbitmq_mqtt/test/rabbit_auth_backend_mqtt_mock.erl
+++ b/deps/rabbitmq_mqtt/test/rabbit_auth_backend_mqtt_mock.erl
@@ -27,7 +27,7 @@ setup(CallerPid) ->
     end.
 
 
-user_login_authentication(_, AuthProps) ->
+user_login_authentication(_Username, AuthProps) ->
     ets:insert(?MODULE, {authentication, AuthProps}),
     {ok, #auth_user{username = <<"dummy">>,
                     tags     = [],

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -250,7 +250,7 @@ event_authentication_failure(Config) ->
 
     ?assertMatch({error, _}, emqtt:connect(C)),
 
-    [E, _ConnectionClosedEvent] = util:get_events(Server),
+    [E] = util:get_events(Server),
     util:assert_event_type(user_authentication_failure, E),
     util:assert_event_prop([{name, <<"Trudy">>},
                             {connection_type, network}],

--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -1307,8 +1307,7 @@ trace(Config) ->
                    <<"channel">> := 0,
                    <<"user">> := <<"guest">>,
                    <<"properties">> := #{<<"delivery_mode">> := 2,
-                                         <<"headers">> := #{<<"x-mqtt-publish-qos">> := 1,
-                                                            <<"x-mqtt-dup">> := false}},
+                                         <<"headers">> := #{<<"x-mqtt-publish-qos">> := 1}},
                    <<"routed_queues">> := [<<"mqtt-subscription-trace_subscriberqos0">>]},
                  rabbit_misc:amqp_table(PublishHeaders)),
 
@@ -1324,8 +1323,7 @@ trace(Config) ->
                    <<"channel">> := 0,
                    <<"user">> := <<"guest">>,
                    <<"properties">> := #{<<"delivery_mode">> := 2,
-                                         <<"headers">> := #{<<"x-mqtt-publish-qos">> := 1,
-                                                            <<"x-mqtt-dup">> := false}},
+                                         <<"headers">> := #{<<"x-mqtt-publish-qos">> := 1}},
                    <<"redelivered">> := 0},
                  rabbit_misc:amqp_table(DeliverHeaders)),
 

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1322,14 +1322,13 @@ handle_frame_pre_auth(Transport,
                         AS ->
                             AS
                     end,
-                RemoteAddress = list_to_binary(inet:ntoa(Host)),
                 C1 = Connection0#stream_connection{auth_mechanism =
                                                        {Mechanism,
                                                         AuthMechanism}},
                 {C2, CmdBody} =
                     case AuthMechanism:handle_response(SaslBin, AuthState) of
                         {refused, Username, Msg, Args} ->
-                            rabbit_core_metrics:auth_attempt_failed(RemoteAddress,
+                            rabbit_core_metrics:auth_attempt_failed(Host,
                                                                     Username,
                                                                     stream),
                             auth_fail(Username, Msg, Args, C1, State),
@@ -1338,7 +1337,7 @@ handle_frame_pre_auth(Transport,
                              {sasl_authenticate,
                               ?RESPONSE_AUTHENTICATION_FAILURE, <<>>}};
                         {protocol_error, Msg, Args} ->
-                            rabbit_core_metrics:auth_attempt_failed(RemoteAddress,
+                            rabbit_core_metrics:auth_attempt_failed(Host,
                                                                     <<>>,
                                                                     stream),
                             notify_auth_result(none,
@@ -1352,7 +1351,7 @@ handle_frame_pre_auth(Transport,
                             {C1#stream_connection{connection_step = failure},
                              {sasl_authenticate, ?RESPONSE_SASL_ERROR, <<>>}};
                         {challenge, Challenge, AuthState1} ->
-                            rabbit_core_metrics:auth_attempt_succeeded(RemoteAddress,
+                            rabbit_core_metrics:auth_attempt_succeeded(Host,
                                                                        <<>>,
                                                                        stream),
                             {C1#stream_connection{authentication_state =
@@ -1367,7 +1366,7 @@ handle_frame_pre_auth(Transport,
                                                                           S)
                             of
                                 ok ->
-                                    rabbit_core_metrics:auth_attempt_succeeded(RemoteAddress,
+                                    rabbit_core_metrics:auth_attempt_succeeded(Host,
                                                                                Username,
                                                                                stream),
                                     notify_auth_result(Username,
@@ -1383,7 +1382,7 @@ handle_frame_pre_auth(Transport,
                                      {sasl_authenticate, ?RESPONSE_CODE_OK,
                                       <<>>}};
                                 not_allowed ->
-                                    rabbit_core_metrics:auth_attempt_failed(RemoteAddress,
+                                    rabbit_core_metrics:auth_attempt_failed(Host,
                                                                             Username,
                                                                             stream),
                                     rabbit_log_connection:warning("User '~ts' can only connect via localhost",

--- a/erlang.mk
+++ b/erlang.mk
@@ -6667,7 +6667,8 @@ CT_RUN = ct_run \
 	-noinput \
 	-pa $(CURDIR)/ebin $(TEST_DIR) \
 	-dir $(TEST_DIR) \
-	-logdir $(CT_LOGS_DIR)
+	-logdir $(CT_LOGS_DIR) \
+	-enable-feature maybe_expr
 
 ifeq ($(CT_SUITES),)
 ct: $(if $(IS_APP)$(ROOT_DIR),,apps-ct)

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -27,6 +27,8 @@ STARTS_BACKGROUND_BROKER_TAG = "starts-background-broker"
 
 MIXED_VERSION_CLUSTER_TAG = "mixed-version-cluster"
 
+ENABLE_FEATURE_MAYBE_EXPR = "-enable-feature maybe_expr"
+
 RABBITMQ_ERLC_OPTS = DEFAULT_ERLC_OPTS + [
     "-DINSTR_MOD=gm",
 ]
@@ -168,6 +170,7 @@ def rabbitmq_app(
 def rabbitmq_suite(erlc_opts = [], test_env = {}, **kwargs):
     ct_suite(
         erlc_opts = RABBITMQ_TEST_ERLC_OPTS + erlc_opts,
+        ct_run_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
         test_env = dict({
             "RABBITMQ_CT_SKIP_AS_ERROR": "true",
             "LANG": "C.UTF-8",
@@ -233,6 +236,7 @@ def rabbitmq_integration_suite(
         }),
         additional_hdrs = additional_hdrs,
         additional_srcs = additional_srcs,
+        ct_run_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
         data = data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",
@@ -259,6 +263,7 @@ def rabbitmq_integration_suite(
         name = name + "-mixed",
         suite_name = name,
         tags = tags + [STARTS_BACKGROUND_BROKER_TAG, MIXED_VERSION_CLUSTER_TAG],
+        ct_run_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
         data = data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",


### PR DESCRIPTION
This commit is pure refactoring making the code base more maintainable.

Replace rabbit_misc:pipeline/3 with the new OTP 25 experimental maybe expression because
"Frequent ways in which people work with sequences of failable operations include folds over lists of functions, and abusing list comprehensions. Both patterns have heavy weaknesses that makes them less than ideal."
https://www.erlang.org/eeps/eep-0049#obsoleting-messy-patterns

Additionally, this commit is more restrictive in the type spec of rabbit_mqtt_processor state fields.
Specifically, many fields were defined to be `undefined | T` where `undefined` was only temporarily until the first CONNECT packet was processed by the processor.
It's better to initialise the MQTT processor upon first CONNECT packet because there is no point in having a processor without having received any packet.
This allows many type specs in the processor to change from `undefined | T` to just `T`.
Additionally, memory is saved by removing the `received_connect_packet` field from the `rabbit_mqtt_reader` and `rabbit_web_mqtt_handler`.