### PR TITLE
Feature flags: Fix experimental feature flags inventory

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -682,7 +682,13 @@ get_state(FeatureName) when is_atom(FeatureName) ->
                  end
     end.
 
--spec get_stability(feature_name() | feature_props_extended()) -> stability().
+-spec get_stability
+(FeatureName) -> Stability | undefined when
+      FeatureName :: feature_name(),
+      Stability :: stability();
+(FeatureProps) -> Stability when
+      FeatureProps :: feature_props_extended(),
+      Stability :: stability().
 %% @doc
 %% Returns the stability of a feature flag.
 %%
@@ -696,12 +702,12 @@ get_state(FeatureName) when is_atom(FeatureName) ->
 %% <li>`experimental': the feature flag is experimental and may change in
 %%   the future (without a guaranteed upgrade path): enabling it in
 %%   production is not recommended.</li>
-%% <li>`unavailable': the feature flag is unsupported by at least one
-%%   node in the cluster and can not be enabled for now.</li>
 %% </ul>
 %%
 %% @param FeatureName The name of the feature flag to check.
-%% @returns `stable' or `experimental'.
+%% @param FeatureProps A feature flag properties map.
+%% @returns `required', `stable' or `experimental', or `undefined' if the
+%% given feature flag name doesn't correspond to a known feature flag.
 
 get_stability(FeatureName) when is_atom(FeatureName) ->
     case rabbit_ff_registry:get(FeatureName) of

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -396,7 +396,7 @@ do_initialize_registry(RegistryVsn,
            "Feature flags:   [~ts] ~ts~n",
            [case maps:get(FeatureName, FeatureStates, false) of
                 true           -> "x";
-                state_changing -> "~~";
+                state_changing -> "~";
                 false          -> " "
             end,
             FeatureName])


### PR DESCRIPTION
When we collect feature flag properties from all nodes, we start with an empty cluster inventory (a common Erlang recursion pattern). This means that all feature flags are unknown at first.

In `merge_feature_flags()`, we must compute a global stability level for each feature flag, in case all nodes are not on the same page (like one nodes considers a feature flag experimental, but another one marks it as stable). That's why we rank stability level: required > stable > experimental.

This ranking had one issue: `rabbit_feature_flags:get_stability/1` defaults to `stable` if a feature flag has not explicit stability set. Therefore, with our empty starting inventory, the starting stability would be `stable`. And it would superceed an experimental feature flag stability level, even though all nodes agree on that.

Now, if a feature flag is missing from our inventory being collected, we consider its stability level to be experimental. This is different from a known feature flag with no explicit stability level. This way, we are sure that feature flags marked as experimental everywhere will be considered experimental globally.

While here, fix two other small issues:
* a badly formatted list of feature flags when logged
* an incorrect spec and doc for `get_stability/1`