### PR TITLE
Fix pid tracking when decommissioning an MQTT node

### DIFF
--- a/deps/rabbitmq_mqtt/src/mqtt_machine.erl
+++ b/deps/rabbitmq_mqtt/src/mqtt_machine.erl
@@ -157,7 +157,7 @@ apply(Meta, {leave, Node}, #machine_state{client_ids = Ids,
                         end, [], Remove),
 
     State = State0#machine_state{client_ids = Keep,
-                                 pids = maps:without(maps:keys(Remove), Pids0)},
+                                 pids = maps:without(maps:values(Remove), Pids0)},
     {State, ok, Effects ++ snapshot_effects(Meta, State)};
 apply(_Meta, {machine_version, 0, 1}, {machine_state, Ids}) ->
     Pids = maps:fold(


### PR DESCRIPTION
Prior to this commit test `deps.rabbitmq_mqtt.cluster_SUITE` `connection_id_tracking_with_decommissioned_node` was flaky and sometimes failed with
```
{cluster_SUITE,connection_id_tracking_with_decommissioned_node,160}
{test_case_failed,failed to match connection count 0}
```
Example of such a flake is https://github.com/rabbitmq/rabbitmq-server/actions/runs/4077109124/jobs/7025722000#step:5:1188