### PR TITLE
Handle various credentials scenarios while authenticating in the internal backend

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -69,7 +69,7 @@ hashing_module_for_user(User) ->
 %% possible when the EXTERNAL authentication mechanism is used, see
 %% rabbit_auth_mechanism_plain:handle_response/2 and rabbit_reader:auth_phase/2.
 user_login_authentication(Username, []) ->
-    internal_check_user_login(Username, fun(_) -> true end);
+    user_login_authentication(Username, [{password, none}]);
 %% For cases when we do have a set of credentials. rabbit_auth_mechanism_plain:handle_response/2
 %% performs initial validation.
 user_login_authentication(Username, AuthProps) ->
@@ -80,6 +80,8 @@ user_login_authentication(Username, AuthProps) ->
         {password, ""} ->
             {refused, ?BLANK_PASSWORD_REJECTION_MESSAGE,
              [Username]};
+        {password, none} -> %% For cases when we do not have password, e.g. when using TLS.
+            internal_check_user_login(Username, fun(_) -> true end);
         {password, Cleartext} ->
             internal_check_user_login(
               Username,

--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -80,7 +80,7 @@ user_login_authentication(Username, AuthProps) ->
         {password, ""} ->
             {refused, ?BLANK_PASSWORD_REJECTION_MESSAGE,
              [Username]};
-        {password, none} -> %% For cases when we do not have password, e.g. when using TLS.
+        {password, none} -> %% For cases when authenticating using an x.509 certificate
             internal_check_user_login(Username, fun(_) -> true end);
         {password, Cleartext} ->
             internal_check_user_login(


### PR DESCRIPTION
The changes proposed by this plugin are really meant to address a back-port issue encountered while merging the PR [6931](https://github.com/rabbitmq/rabbitmq-server/pull/6931) into v3.11.x branch. 
The issue occurs when the user authenticates -against the internal backend- using X.509 certificate via the mqtt plugin in `3.11.x` branch. The user presents the credentials `[{password: none}]` which the internal backend does not handle it correctly and rejects the authentication.  This issue does not occur in the `main` branch because the mqtt plugin sends empty credentials, i.e. `[]`, which are handled correctly by the internal backend. 

After this PR is accepted, the internal auth backend handles the following 3 scenarios:
- TLS authentication where credentials proplist has just `[ { password: none }]` 
- TLS authentication where credentials proplist is just `[]`
- Second/nth authentication attempt  of the same user on the same connection (amqp 1.0) where the original credentials are no longer available. In this scenario, the credentials proplist has `[ {rabbit_auth_backend_internal, Impl } ]` where `Impl` is a function that returns the outcome from the first authentication attempt.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
