### PR TITLE
Add OAuth 2.0 MQTT system test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -184,7 +184,7 @@ erlang_package.git_package(
     name = "emqtt",
     build_file = "@rabbitmq-server//bazel:BUILD.emqtt",
     repository = "emqx/emqtt",
-    tag = "1.7.0-rc.2",
+    tag = "1.7.0-rc.3",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
@@ -64,7 +64,11 @@ dialyze(
     plt = ":base_plt",
 )
 
-broker_for_integration_suites()
+broker_for_integration_suites(
+    extra_plugins = [
+        "//deps/rabbitmq_mqtt:erlang_app",
+    ],
+)
 
 rabbitmq_test_helper(
     name = "rabbit_auth_backend_oauth2_test_util",
@@ -110,6 +114,9 @@ rabbitmq_integration_suite(
     size = "medium",
     additional_beam = [
         ":rabbit_auth_backend_oauth2_test_util",
+    ],
+    runtime_deps = [
+        "@emqtt//:erlang_app",
     ],
 )
 

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -1,15 +1,21 @@
 PROJECT = rabbitmq_auth_backend_oauth2
 PROJECT_DESCRIPTION = OAuth 2 and JWT-based AuthN and AuthZ backend
 
+# We do not need QUIC as dependency of emqtt.
+BUILD_WITHOUT_QUIC=1
+export BUILD_WITHOUT_QUIC
+
 BUILD_DEPS = rabbit_common
 DEPS = rabbit cowlib jose base64url
-TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
+TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client rabbitmq_mqtt emqtt
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
 dep_jose = git https://github.com/michaelklishin/erlang-jose mk-thoas-support
 dep_base64url = hex 1.0.1
+
+dep_emqtt = git https://github.com/emqx/emqtt.git 1.7.0-rc.3
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -35,7 +35,8 @@ groups() ->
                        test_successful_connection_with_a_full_permission_token_and_explicitly_configured_vhost,
                        test_successful_connection_with_simple_strings_for_aud_and_scope,
                        test_successful_token_refresh,
-                       test_successful_connection_without_verify_aud
+                       test_successful_connection_without_verify_aud,
+                       mqtt
                       ]},
      {basic_unhappy_path, [], [
                        test_failed_connection_with_expired_token,
@@ -135,7 +136,8 @@ init_per_testcase(Testcase, Config) when Testcase =:= test_successful_connection
 
 init_per_testcase(Testcase, Config) when Testcase =:= test_successful_connection_with_complex_claim_as_a_map orelse
                                          Testcase =:= test_successful_connection_with_complex_claim_as_a_list orelse
-                                         Testcase =:= test_successful_connection_with_complex_claim_as_a_binary ->
+                                         Testcase =:= test_successful_connection_with_complex_claim_as_a_binary orelse
+                                         Testcase =:= mqtt ->
   ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
         [rabbitmq_auth_backend_oauth2, extra_scopes_source, ?EXTRA_SCOPES_SOURCE]),
   rabbit_ct_helpers:testcase_started(Config, Testcase),
@@ -381,6 +383,33 @@ test_successful_connection_without_verify_aud(Config) ->
         amqp_channel:call(Ch, #'queue.declare'{exclusive = true}),
     close_connection_and_channel(Conn, Ch).
 
+mqtt(Config) ->
+    Topic = <<"test/topic">>,
+    Payload = <<"mqtt-test-message">>,
+    {_Algo, Token} = generate_valid_token_with_extra_fields(
+                       Config,
+                       #{<<"additional_rabbitmq_scopes">> =>
+                         <<"rabbitmq.configure:*/*/* rabbitmq.read:*/*/* rabbitmq.write:*/*/*">>}
+                      ),
+    Opts = [{port, rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt)},
+            {proto_ver, v4},
+            {username, <<"">>},
+            {password, Token}],
+    {ok, Sub} = emqtt:start_link([{clientid, <<"mqtt-subscriber">>} | Opts]),
+    {ok, _} = emqtt:connect(Sub),
+    {ok, _, [1]} = emqtt:subscribe(Sub, Topic, at_least_once),
+    {ok, Pub} = emqtt:start_link([{clientid, <<"mqtt-publisher">>} | Opts]),
+    {ok, _} = emqtt:connect(Pub),
+    {ok, _} = emqtt:publish(Pub, Topic, Payload, at_least_once),
+    receive
+        {publish, #{client_pid := Sub,
+                    topic := Topic,
+                    payload := Payload}} -> ok
+    after 1000 -> ct:fail("no publish received")
+    end,
+    ok = emqtt:disconnect(Sub),
+    ok = emqtt:disconnect(Pub).
+
 test_successful_connection_with_complex_claim_as_a_map(Config) ->
     {_Algo, Token} = generate_valid_token_with_extra_fields(
         Config,
@@ -406,7 +435,7 @@ test_successful_connection_with_complex_claim_as_a_list(Config) ->
 test_successful_connection_with_complex_claim_as_a_binary(Config) ->
     {_Algo, Token} = generate_valid_token_with_extra_fields(
         Config,
-        #{<<"additional_rabbitmq_scopes">> => <<"rabbitmq.configure:*/* rabbitmq.read:*/*" "rabbitmq.write:*/*">>}
+        #{<<"additional_rabbitmq_scopes">> => <<"rabbitmq.configure:*/* rabbitmq.read:*/* rabbitmq.write:*/*">>}
     ),
     Conn     = open_unmanaged_connection(Config, 0, <<"username">>, Token),
     {ok, Ch} = amqp_connection:open_channel(Conn),

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -43,7 +43,7 @@ DEPS = ranch rabbit_common rabbit amqp_client ra
 TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_web_mqtt
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_emqtt = git https://github.com/emqx/emqtt.git 1.7.0-rc.2
+dep_emqtt = git https://github.com/emqx/emqtt.git 1.7.0-rc.3
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/deps/rabbitmq_web_mqtt/Makefile
+++ b/deps/rabbitmq_web_mqtt/Makefile
@@ -24,7 +24,7 @@ TEST_DEPS = emqtt rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_manage
 # See rabbitmq-components.mk.
 BUILD_DEPS += ranch
 
-dep_emqtt = git https://github.com/emqx/emqtt.git 1.7.0-rc.2
+dep_emqtt = git https://github.com/emqx/emqtt.git 1.7.0-rc.3
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk


### PR DESCRIPTION
Add a test that rabbitmq_auth_backend_oauth2 works with MQTT.
See https://github.com/rabbitmq/rabbitmq-oauth2-tutorial#mqtt-protocol
We should add a similar test for AMQP 1.0 given https://github.com/rabbitmq/rabbitmq-server/pull/6931 is merged.