### PR TITLE
Add API functions to behaviour module

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_internal_event_handler.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_internal_event_handler.erl
@@ -20,11 +20,11 @@ init([]) ->
 
 handle_event({event, vhost_created, Info, _, _}, ?STATE) ->
     Name = pget(name, Info),
-    rabbit_mqtt_retainer_sup:child_for_vhost(Name),
+    rabbit_mqtt_retainer_sup:start_child_for_vhost(Name),
     {ok, ?STATE};
 handle_event({event, vhost_deleted, Info, _, _}, ?STATE) ->
     Name = pget(name, Info),
-    rabbit_mqtt_retainer_sup:delete_child(Name),
+    rabbit_mqtt_retainer_sup:delete_child_for_vhost(Name),
     {ok, ?STATE};
 handle_event({event, maintenance_connections_closed, _Info, _, _}, ?STATE) ->
     %% we should close our connections

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -438,7 +438,7 @@ register_client(Packet = #mqtt_packet_connect{proto_ver = ProtoVersion},
     NewProcState =
     fun(RegisterState) ->
             rabbit_mqtt_util:register_clientid(VHost, ClientId),
-            RetainerPid = rabbit_mqtt_retainer_sup:child_for_vhost(VHost),
+            RetainerPid = rabbit_mqtt_retainer_sup:start_child_for_vhost(VHost),
             ExchangeBin = rabbit_mqtt_util:env(exchange),
             ExchangeName = rabbit_misc:r(VHost, exchange, ExchangeBin),
             Cfg = Cfg0#cfg{exchange = ExchangeName,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store.erl
@@ -7,26 +7,6 @@
 
 -module(rabbit_mqtt_retained_msg_store).
 
--include("rabbit_mqtt_packet.hrl").
-
--callback new(Directory :: file:name_all(), rabbit_types:vhost()) ->
-    State :: any().
-
--callback recover(Directory :: file:name_all(), rabbit_types:vhost()) ->
-    {ok, State :: any()} | {error, Reason :: term()}.
-
--callback insert(Topic :: binary(), mqtt_msg(), State :: any()) ->
-    ok.
-
--callback lookup(Topic :: binary(), State :: any()) ->
-    retained_message() | not_found.
-
--callback delete(Topic :: binary(), State :: any()) ->
-    ok.
-
--callback terminate(State :: any()) ->
-    ok.
-
 %% TODO Support retained messages in RabbitMQ cluster, for
 %% 1. support PUBLISH with retain on a different node than SUBSCRIBE
 %% 2. replicate retained message for data safety
@@ -37,3 +17,73 @@
 %% Possible solutions for 2.
 %% * rabbitmq_mqtt_retained_msg_store_khepri
 %% * rabbitmq_mqtt_retained_msg_store_ra (implementing our own ra machine)
+
+-include("rabbit_mqtt.hrl").
+-include("rabbit_mqtt_packet.hrl").
+-include_lib("kernel/include/logger.hrl").
+-export([start/1, insert/3, lookup/2, delete/2, terminate/1]).
+-export_type([state/0]).
+
+-define(STATE, ?MODULE).
+-record(?STATE, {store_mod :: module(),
+                 store_state :: term()}).
+-opaque state() :: #?STATE{}.
+
+-callback new(Directory :: file:name_all(), rabbit_types:vhost()) ->
+    State :: any().
+
+-callback recover(Directory :: file:name_all(), rabbit_types:vhost()) ->
+    {ok, State :: any()} | {error, uninitialized}.
+
+-callback insert(Topic :: binary(), mqtt_msg(), State :: any()) ->
+    ok.
+
+-callback lookup(Topic :: binary(), State :: any()) ->
+    mqtt_msg() | undefined.
+
+-callback delete(Topic :: binary(), State :: any()) ->
+    ok.
+
+-callback terminate(State :: any()) ->
+    ok.
+
+-spec start(rabbit_types:vhost()) -> state().
+start(VHost) ->
+    {ok, Mod} = application:get_env(?APP_NAME, retained_message_store),
+    Dir = rabbit:data_dir(),
+    ?LOG_INFO("Starting MQTT retained message store ~s for vhost '~ts'",
+              [Mod, VHost]),
+    S = case Mod:recover(Dir, VHost) of
+            {ok, StoreState} ->
+                ?LOG_INFO("Recovered MQTT retained message store ~s for vhost '~ts'",
+                          [Mod, VHost]),
+                StoreState;
+            {error, uninitialized} ->
+                StoreState = Mod:new(Dir, VHost),
+                ?LOG_INFO("Initialized MQTT retained message store ~s for vhost '~ts'",
+                          [Mod, VHost]),
+                StoreState
+        end,
+    #?STATE{store_mod = Mod,
+            store_state = S}.
+
+-spec insert(Topic :: binary(), mqtt_msg(), state()) -> ok.
+insert(Topic, Msg, #?STATE{store_mod = Mod,
+                           store_state = StoreState}) ->
+    ok = Mod:insert(Topic, Msg, StoreState).
+
+-spec lookup(Topic :: binary(), state()) ->
+    mqtt_msg() | undefined.
+lookup(Topic, #?STATE{store_mod = Mod,
+                      store_state = StoreState}) ->
+    Mod:lookup(Topic, StoreState).
+
+-spec delete(Topic :: binary(), state()) -> ok.
+delete(Topic, #?STATE{store_mod = Mod,
+                      store_state = StoreState}) ->
+    ok = Mod:delete(Topic, StoreState).
+
+-spec terminate(state()) -> ok.
+terminate(#?STATE{store_mod = Mod,
+                  store_state = StoreState}) ->
+    ok = Mod:terminate(StoreState).

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_dets.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_dets.erl
@@ -12,10 +12,7 @@
 
 -export([new/2, recover/2, insert/3, lookup/2, delete/2, terminate/1]).
 
--record(store_state, {
-  %% DETS table name
-  table
-}).
+-record(store_state, {table :: dets:tab_name()}).
 
 -type store_state() :: #store_state{}.
 
@@ -36,11 +33,12 @@ recover(Dir, VHost) ->
 insert(Topic, Msg, #store_state{table = T}) ->
   ok = dets:insert(T, #retained_message{topic = Topic, mqtt_msg = Msg}).
 
--spec lookup(binary(), store_state()) -> retained_message() | not_found.
+-spec lookup(binary(), store_state()) ->
+    mqtt_msg() | undefined.
 lookup(Topic, #store_state{table = T}) ->
   case dets:lookup(T, Topic) of
-    []      -> not_found;
-    [Entry] -> Entry
+    []      -> undefined;
+    [#retained_message{mqtt_msg = Msg}] -> Msg
   end.
 
 -spec delete(binary(), store_state()) -> ok.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_ets.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_ets.erl
@@ -13,11 +13,9 @@
 -export([new/2, recover/2, insert/3, lookup/2, delete/2, terminate/1]).
 
 -record(store_state, {
-  %% ETS table ID
-  table,
-  %% where the table is stored on disk
-  filename
-}).
+          table :: ets:tid(),
+          filename :: file:filename_all()
+         }).
 
 -type store_state() :: #store_state{}.
 
@@ -44,11 +42,11 @@ insert(Topic, Msg, #store_state{table = T}) ->
   true = ets:insert(T, #retained_message{topic = Topic, mqtt_msg = Msg}),
   ok.
 
--spec lookup(binary(), store_state()) -> retained_message() | not_found.
+-spec lookup(binary(), store_state()) -> mqtt_msg() | undefined.
 lookup(Topic, #store_state{table = T}) ->
   case ets:lookup(T, Topic) of
-    []      -> not_found;
-    [Entry] -> Entry
+    []      -> undefined;
+    [#retained_message{mqtt_msg = Msg}] -> Msg
   end.
 
 -spec delete(binary(), store_state()) -> ok.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_noop.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retained_msg_store_noop.erl
@@ -21,7 +21,7 @@ insert(_Topic, _Msg, _State) ->
   ok.
 
 lookup(_Topic, _State) ->
-  not_found.
+  undefined.
 
 delete(_Topic, _State) ->
   ok.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_retainer_sup.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_retainer_sup.erl
@@ -6,68 +6,57 @@
 %%
 
 -module(rabbit_mqtt_retainer_sup).
+
 -behaviour(supervisor).
 
--export([start_link/1, init/1, start_child/2,start_child/1, child_for_vhost/1,
-         delete_child/1]).
+%% supervsior callback
+-export([init/1]).
 
--spec start_child(binary()) -> supervisor:startchild_ret().
--spec start_child(term(), binary()) -> supervisor:startchild_ret().
+%% API
+-export([start_link/0,
+         start_child_for_vhost/1,
+         delete_child_for_vhost/1]).
 
-start_link(SupName) ->
-    supervisor:start_link(SupName, ?MODULE, []).
+-spec start_link() -> supervisor:startlink_ret().
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
--spec child_for_vhost(rabbit_types:vhost()) -> pid().
-child_for_vhost(VHost) when is_binary(VHost) ->
-  case rabbit_mqtt_retainer_sup:start_child(VHost) of
-    {ok, Pid}                       -> Pid;
-    {error, {already_started, Pid}} -> Pid
-  end.
+-spec start_child_for_vhost(rabbit_types:vhost()) -> pid().
+start_child_for_vhost(VHost)
+  when is_binary(VHost) ->
+    case supervisor:start_child(?MODULE, child_spec(VHost)) of
+        {ok, Pid}                       -> Pid;
+        {error, {already_started, Pid}} -> Pid
+    end.
 
-start_child(VHost) when is_binary(VHost) ->
-  start_child(rabbit_mqtt_retainer:store_module(), VHost).
+-spec delete_child_for_vhost(rabbit_types:vhost()) -> ok.
+delete_child_for_vhost(VHost) ->
+    Id = vhost_to_atom(VHost),
+    ok = supervisor:terminate_child(?MODULE, Id),
+    ok = supervisor:delete_child(?MODULE, Id).
 
-start_child(RetainStoreMod, VHost) ->
-    supervisor:start_child(
-        ?MODULE,
-        #{
-            id => vhost_to_atom(VHost),
-            start => {rabbit_mqtt_retainer, start_link, [RetainStoreMod, VHost]},
-            restart => permanent,
-            shutdown => 60,
-            type => worker,
-            modules => [rabbit_mqtt_retainer]
-        }
-    ).
-
-delete_child(VHost) ->
-  Id = vhost_to_atom(VHost),
-  ok = supervisor:terminate_child(?MODULE, Id),
-  ok = supervisor:delete_child(?MODULE, Id).
-
+-spec init([]) ->
+    {ok, {supervisor:sup_flags(),
+          [supervisor:child_spec()]}}.
 init([]) ->
-  Mod = rabbit_mqtt_retainer:store_module(),
-  rabbit_log:info("MQTT retained message store: ~tp",
-    [Mod]),
-  {ok, {
-      #{strategy => one_for_one, intensity => 5, period => 5},
-      child_specs(Mod, rabbit_vhost:list_names())
-  }}.
+    {ok, {#{intensity => 5,
+            period => 5},
+          child_specs(rabbit_vhost:list_names())
+         }}.
 
-child_specs(Mod, VHosts) ->
-    %% see start_child/2
-    [
-        #{
-            id => vhost_to_atom(V),
-            start => {rabbit_mqtt_retainer, start_link, [Mod, V]},
-            restart => permanent,
-            shutdown => infinity,
-            type => worker,
-            modules => [rabbit_mqtt_retainer]
-        }
-     || V <- VHosts
-    ].
+-spec child_specs([rabbit_types:vhost()]) ->
+    [supervisor:child_spec()].
+child_specs(VHosts) ->
+    lists:map(fun child_spec/1, VHosts).
 
+-spec child_spec(rabbit_types:vhost()) ->
+    supervisor:child_spec().
+child_spec(VHost) ->
+    #{id => vhost_to_atom(VHost),
+      start => {rabbit_mqtt_retainer, start_link, [VHost]},
+      shutdown => 120_000}.
+
+-spec vhost_to_atom(rabbit_types:vhost()) -> atom().
 vhost_to_atom(VHost) ->
     %% we'd like to avoid any conversion here because
     %% this atom isn't meant to be human-readable, only

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
@@ -46,17 +46,14 @@ init([{Listeners, SslListeners0}]) ->
          start => {pg, start_link, [PgScope]},
          restart => transient,
          shutdown => ?WORKER_WAIT,
-         type => worker,
-         modules => [pg]
+         type => worker
         },
        #{
          id => rabbit_mqtt_retainer_sup,
-         start => {rabbit_mqtt_retainer_sup, start_link,
-                   [{local, rabbit_mqtt_retainer_sup}]},
+         start => {rabbit_mqtt_retainer_sup, start_link, []},
          restart => transient,
          shutdown => ?SUPERVISOR_WAIT,
-         type => supervisor,
-         modules => [rabbit_mqtt_retainer_sup]
+         type => supervisor
         }
        | listener_specs(
            fun tcp_listener_spec/1,


### PR DESCRIPTION
Include API functions to the `rabbit_mqtt_retained_msg_store` behaviour module.

> There is a best practice to have the behaviour module include the API also as it helps other parts of the code to be correct and a bit more dialyzable.

This PR also fixes a bug where the retainer process had only 60 milliseconds shutdown time before being unconditionally killed. 60 milliseconds might be too short to dump a large ETS table containing many retained messages to disk.