### PR TITLE
Fixing the rabbitmq_auth_backend_oauth2 schema

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -38,7 +38,7 @@
 
 %% Configure the plugin to also look in other fields using additional_scopes_key (maps to extra_scopes_source in the old format)
 %%
-%% {additional_rabbitmq_scopes, <<"my_custom_scope_key">>},
+%% {additional_scopes_key, <<"my_custom_scope_key">>},
 
 {mapping,
  "auth_oauth2.additional_scopes_key",
@@ -77,12 +77,6 @@
  fun(Conf) ->
     list_to_binary(cuttlefish:conf_get("auth_oauth2.preferred_username_claims", Conf))
  end}.
-
-{mapping,
- "auth_oauth2.additional_scopes_key",
- "rabbitmq_auth_backend_oauth2.extra_scopes_source",
- [{datatype, string}]}.
-
 
 %% ID of the default signing key
 %%


### PR DESCRIPTION
Fixing reference to the old key 'additional_rabbitmq_scopes'. Removing redundant mapping

## Proposed Changes

I am unable to make use of the key 'additional_scopes_key'; It seems to me that is a bug caused by the redundant mapping.  

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
