### PR TITLE
Cleanup dialyzer calls

### DIFF
--- a/deps/amqp10_client/BUILD.bazel
+++ b/deps/amqp10_client/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
+    "RABBITMQ_DIALYZER_OPTS",
     "assert_suites",
     "broker_for_integration_suites",
     "rabbitmq_app",
@@ -36,6 +37,7 @@ APP_EXTRA_KEYS = """%% Hex.pm package informations.
 """
 
 EXTRA_APPS = [
+    "public_key",
     "ssl",
     "inets",
     "crypto",
@@ -70,6 +72,7 @@ plt(
 
 dialyze(
     plt = ":base_plt",
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
 )
 
 broker_for_integration_suites(

--- a/deps/amqp10_common/BUILD.bazel
+++ b/deps/amqp10_common/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze")
 load(
     "//:rabbitmq.bzl",
+    "RABBITMQ_DIALYZER_OPTS",
     "assert_suites",
     "rabbitmq_app",
     "rabbitmq_suite",
@@ -73,6 +74,7 @@ xref()
 
 dialyze(
     plt = "//:base_plt",
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
 )
 
 rabbitmq_suite(

--- a/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
-load("//:rabbitmq.bzl", "APP_VERSION", "rabbitmq_app", "rabbitmq_suite")
+load(
+    "//:rabbitmq.bzl",
+    "RABBITMQ_DIALYZER_OPTS",
+    "APP_VERSION",
+    "rabbitmq_app",
+    "rabbitmq_suite",
+)
 
 APP_NAME = "rabbitmq_prelaunch"
 
@@ -45,6 +51,7 @@ plt(
 
 dialyze(
     plt = ":base_plt",
+    dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
 )
 
 suites = [

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -214,7 +214,7 @@ cancel(Q, ConsumerTag, OkMsg, ActingUser, State) ->
         Err -> Err
     end.
 
--spec settle(rabbit_amqqueue:name(), rarabbit_queue_type:settle_op(),
+-spec settle(rabbit_amqqueue:name(), rabbit_queue_type:settle_op(),
              rabbit_types:ctag(), [non_neg_integer()], state()) ->
     {state(), rabbit_queue_type:actions()}.
 settle(_QName, complete, _CTag, MsgIds, State) ->

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -214,7 +214,7 @@ tcp_listener_spec(NamePrefix, Address, SocketOpts,
 
 -spec tcp_listener_spec
         (name_prefix(), address(), [gen_tcp:listen_option()], module(), module(),
-         any(), protocol(), non_neg_integer(), non_neg_integer(), supervisor:worker(), label()) ->
+         any(), protocol(), non_neg_integer(), non_neg_integer(), 'supervisor' | 'worker', label()) ->
             supervisor:child_spec().
 
 tcp_listener_spec(NamePrefix, {IPAddress, Port, Family}, SocketOpts,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -147,7 +147,7 @@ update(Q, State) when ?amqqueue_is_quorum(Q) ->
     %% QQ state maintains it's own updates
     State.
 
--spec handle_event(rabbit_amqquue:name(),
+-spec handle_event(rabbit_amqqueue:name(),
                    {amqqueue:ra_server_id(), any()},
                    rabbit_fifo_client:state()) ->
     {ok, rabbit_fifo_client:state(), rabbit_queue_type:actions()} |

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -74,7 +74,11 @@ ensure_secondary_index(Table, Field) ->
     {aborted, {already_exists, Table, _}} -> ok
   end.
 
--spec ensure_table_copy(mnesia:table(), node(), mnesia:storage_type()) ->
+%% mnesia:table() and mnesia:storage_type() are not exported
+-type mnesia_table() :: atom().
+-type mnesia_storage_type() :: 'ram_copies' | 'disc_copies' | 'disc_only_copies'.
+
+-spec ensure_table_copy(mnesia_table(), node(), mnesia_storage_type()) ->
     ok | {error, any()}.
 ensure_table_copy(TableName, Node, StorageType) ->
     rabbit_log:debug("Will add a local schema database copy for table '~ts'", [TableName]),
@@ -239,7 +243,7 @@ create_local_copies(Type) ->
       end, definitions(Type)),
     ok.
 
--spec create_local_copy(mnesia:table(), mnesia:storage_type()) -> ok.
+-spec create_local_copy(mnesia_table(), mnesia_storage_type()) -> ok.
 create_local_copy(Tab, Type) ->
     StorageType = mnesia:table_info(Tab, storage_type),
     {atomic, ok} =

--- a/deps/rabbit/src/tcp_listener_sup.erl
+++ b/deps/rabbit/src/tcp_listener_sup.erl
@@ -23,7 +23,7 @@
 
 -spec start_link
         (inet:ip_address(), inet:port_number(), module(), [gen_tcp:listen_option()],
-         module(), any(), mfargs(), mfargs(), integer(), integer(), supervisor:worker(), string()) ->
+         module(), any(), mfargs(), mfargs(), integer(), integer(), 'worker' | 'supervisor', string()) ->
                            rabbit_types:ok_pid_or_error().
 
 start_link(IPAddress, Port, Transport, SocketOpts, ProtoSup, ProtoOpts, OnStartup, OnShutdown,

--- a/deps/rabbit_common/src/rabbit_pbe.erl
+++ b/deps/rabbit_common/src/rabbit_pbe.erl
@@ -41,12 +41,17 @@ decrypt_term(Cipher, Hash, Iterations, PassPhrase, {encrypted, _Base64Binary}=En
 
 -type encryption_result() :: {'encrypted', binary()} | {'plaintext', binary()}.
 
--spec encrypt(crypto:block_cipher(), crypto:hash_algorithms(),
+%% crypto:cipher() and crypto:hash_algorithm() are not public
+-type crypto_cipher() :: atom().
+-type crypto_hash_algorithm() :: atom().
+
+-spec encrypt(crypto_cipher(), crypto_hash_algorithm(),
     pos_integer(), iodata() | '$pending-secret', binary()) -> encryption_result().
 encrypt(Cipher, Hash, Iterations, PassPhrase, ClearText) ->
     credentials_obfuscation_pbe:encrypt(Cipher, Hash, Iterations, PassPhrase, ClearText).
 
--spec decrypt(crypto:block_cipher(), crypto:hash_algorithms(),
+
+-spec decrypt(crypto_cipher(), crypto_hash_algorithm(),
     pos_integer(), iodata(), encryption_result()) -> any().
 decrypt(_Cipher, _Hash, _Iterations, _PassPhrase, {plaintext, Term}) ->
     Term;

--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -52,10 +52,8 @@ xref(
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     apps = [
-        "erts",
-        "kernel",
-        "stdlib",
         "ssl",
     ],
     libs = ["//deps/rabbitmq_cli:elixir"],

--- a/deps/rabbitmq_auth_backend_cache/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_cache/BUILD.bazel
@@ -47,6 +47,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = DEPS,
 )
 

--- a/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
+++ b/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
@@ -42,6 +42,8 @@ xref(
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
+    apps = ["mnesia"],
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
 )

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange.erl
@@ -26,10 +26,10 @@ setup_schema() ->
        }).
 
 setup_schema_in_mnesia() ->
-    mnesia:create_table(?HASH_RING_STATE_TABLE, [{record_name, chx_hash_ring},
+    _ = mnesia:create_table(?HASH_RING_STATE_TABLE, [{record_name, chx_hash_ring},
                                                  {attributes, record_info(fields, chx_hash_ring)},
                                                  {type, ordered_set}]),
-    mnesia:add_table_copy(?HASH_RING_STATE_TABLE, node(), ram_copies),
+    _ = mnesia:add_table_copy(?HASH_RING_STATE_TABLE, node(), ram_copies),
     rabbit_table:wait([?HASH_RING_STATE_TABLE]).
 
 create(X) ->

--- a/deps/rabbitmq_event_exchange/BUILD.bazel
+++ b/deps/rabbitmq_event_exchange/BUILD.bazel
@@ -31,6 +31,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = DEPS,
 )
 

--- a/deps/rabbitmq_federation/BUILD.bazel
+++ b/deps/rabbitmq_federation/BUILD.bazel
@@ -49,6 +49,7 @@ xref(
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
 )

--- a/deps/rabbitmq_federation_management/BUILD.bazel
+++ b/deps/rabbitmq_federation_management/BUILD.bazel
@@ -45,6 +45,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
 )
 

--- a/deps/rabbitmq_management/BUILD.bazel
+++ b/deps/rabbitmq_management/BUILD.bazel
@@ -77,11 +77,8 @@ xref()
 
 plt(
     name = "base_plt",
-    apps = [
-        "erts",
-        "kernel",
-        "stdlib",
-    ] + EXTRA_APPS,
+    plt = "//:base_plt",
+    apps = EXTRA_APPS,
     deps = DEPS + RUNTIME_DEPS,
 )
 

--- a/deps/rabbitmq_management_agent/BUILD.bazel
+++ b/deps/rabbitmq_management_agent/BUILD.bazel
@@ -74,7 +74,6 @@ plt(
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
     plt = ":base_plt",
-    warnings_as_errors = False,
 )
 
 broker_for_integration_suites()

--- a/deps/rabbitmq_peer_discovery_consul/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_consul/BUILD.bazel
@@ -37,6 +37,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = DEPS,
 )
 

--- a/deps/rabbitmq_peer_discovery_k8s/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_k8s/BUILD.bazel
@@ -37,6 +37,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = DEPS,
 )
 

--- a/deps/rabbitmq_prometheus/BUILD.bazel
+++ b/deps/rabbitmq_prometheus/BUILD.bazel
@@ -46,6 +46,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS + RUNTIME_DEPS,
 )
 

--- a/deps/rabbitmq_random_exchange/BUILD.bazel
+++ b/deps/rabbitmq_random_exchange/BUILD.bazel
@@ -36,6 +36,7 @@ xref()
 plt(
     name = "base_plt",
     deps = BUILD_DEPS + DEPS,
+    plt = "//:base_plt",
 )
 
 dialyze(

--- a/deps/rabbitmq_sharding/BUILD.bazel
+++ b/deps/rabbitmq_sharding/BUILD.bazel
@@ -30,13 +30,13 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = DEPS,
 )
 
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
     plt = ":base_plt",
-    warnings_as_errors = False,
 )
 
 broker_for_integration_suites()

--- a/deps/rabbitmq_shovel/BUILD.bazel
+++ b/deps/rabbitmq_shovel/BUILD.bazel
@@ -65,6 +65,8 @@ xref(
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
+    apps = EXTRA_APPS,
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS + RUNTIME_DEPS,
 )

--- a/deps/rabbitmq_shovel_management/BUILD.bazel
+++ b/deps/rabbitmq_shovel_management/BUILD.bazel
@@ -44,6 +44,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
 )
 

--- a/deps/rabbitmq_stomp/BUILD.bazel
+++ b/deps/rabbitmq_stomp/BUILD.bazel
@@ -71,6 +71,7 @@ xref(
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS + RUNTIME_DEPS,
 )

--- a/deps/rabbitmq_stream/BUILD.bazel
+++ b/deps/rabbitmq_stream/BUILD.bazel
@@ -61,10 +61,8 @@ xref(
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     apps = [
-        "erts",
-        "kernel",
-        "stdlib",
         "ssl",
     ],
     libs = ["//deps/rabbitmq_cli:elixir"],

--- a/deps/rabbitmq_stream_management/BUILD.bazel
+++ b/deps/rabbitmq_stream_management/BUILD.bazel
@@ -40,6 +40,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
 )
 

--- a/deps/rabbitmq_top/BUILD.bazel
+++ b/deps/rabbitmq_top/BUILD.bazel
@@ -42,6 +42,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
 )
 

--- a/deps/rabbitmq_tracing/BUILD.bazel
+++ b/deps/rabbitmq_tracing/BUILD.bazel
@@ -51,6 +51,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
 )
 

--- a/deps/rabbitmq_trust_store/BUILD.bazel
+++ b/deps/rabbitmq_trust_store/BUILD.bazel
@@ -25,6 +25,7 @@ EXTRA_APPS = [
     "ssl",
     "crypto",
     "public_key",
+    "inets",
 ]
 
 DEPS = [
@@ -51,7 +52,7 @@ plt(
     name = "base_plt",
     apps = EXTRA_APPS,
     plt = "//:base_plt",
-    deps = DEPS,
+    deps = DEPS + RUNTIME_DEPS,
 )
 
 dialyze(

--- a/deps/rabbitmq_trust_store/src/rabbit_trust_store_http_provider.erl
+++ b/deps/rabbitmq_trust_store/src/rabbit_trust_store_http_provider.erl
@@ -18,11 +18,11 @@
 -record(http_state,{
     url :: string(),
     http_options :: list(),
-    headers :: httpc:headers()
+    headers :: [{[byte()], binary() | iolist()}]
 }).
 
 list_certs(Config) ->
-    init(Config),
+    _ = init(Config),
     State = init_state(Config),
     list_certs(Config, State).
 

--- a/deps/rabbitmq_web_mqtt_examples/BUILD.bazel
+++ b/deps/rabbitmq_web_mqtt_examples/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_erlang//:xref2.bzl", "xref")
-load("@rules_erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",
@@ -34,9 +34,15 @@ rabbitmq_app(
 
 xref()
 
+plt(
+    name = "base_plt",
+    plt = "//:base_plt",
+    deps = RUNTIME_DEPS,
+)
+
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
-    plt = "//:base_plt",
+    plt = ":base_plt",
 )
 
 alias(

--- a/deps/rabbitmq_web_stomp/BUILD.bazel
+++ b/deps/rabbitmq_web_stomp/BUILD.bazel
@@ -60,6 +60,7 @@ xref()
 
 plt(
     name = "base_plt",
+    plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
 )
 

--- a/deps/rabbitmq_web_stomp_examples/BUILD.bazel
+++ b/deps/rabbitmq_web_stomp_examples/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_erlang//:xref2.bzl", "xref")
-load("@rules_erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "RABBITMQ_DIALYZER_OPTS",
@@ -34,9 +34,15 @@ rabbitmq_app(
 
 xref()
 
+plt(
+    name = "base_plt",
+    plt = "//:base_plt",
+    deps = RUNTIME_DEPS,
+)
+
 dialyze(
     dialyzer_opts = RABBITMQ_DIALYZER_OPTS,
-    plt = "//:base_plt",
+    plt = ":base_plt",
 )
 
 alias(


### PR DESCRIPTION
- Use the same base .plt everywhere, so there is no need to list standard apps everywhere
- Fix typespecs: some typos and the use of not-exported types

There are still a few unsolved problems, but they are up to discussion.
