### PR TITLE
HTTP API: make it possible to restrict operator policy changes via API (with slightly different naming)

### DIFF
--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -54,6 +54,7 @@
 -export([ntoa/1, ntoab/1]).
 -export([is_process_alive/1]).
 -export([pget/2, pget/3, pupdate/3, pget_or_die/2, pmerge/3, pset/3, plmerge/2]).
+-export([deep_pget/2, deep_pget/3]).
 -export([format_message_queue/2]).
 -export([append_rpc_all_nodes/4, append_rpc_all_nodes/5]).
 -export([os_cmd/1, pwsh_cmd/1, win32_cmd/2]).
@@ -934,6 +935,21 @@ pupdate(K, UpdateFun, P) ->
             pset(K, UpdateFun(V), P);
         _ ->
             undefined
+    end.
+
+%% pget nested values
+-spec deep_pget(list(), list() | map()) -> term().
+deep_pget(K, P) ->
+    deep_pget(K, P, undefined).
+
+-spec deep_pget(list(), list() | map(), term()) -> term().
+deep_pget([], P, _) ->
+    P;
+
+deep_pget([K|Ks], P, D) ->
+    case rabbit_misc:pget(K, P, D) of
+        D -> D;
+        Pn -> deep_pget(Ks, Pn, D)
     end.
 
 %% property merge

--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -37,6 +37,7 @@ groups() ->
             data_coercion_atomize_keys_proplist,
             data_coercion_atomize_keys_map,
             pget,
+            deep_pget,
             encrypt_decrypt,
             encrypt_decrypt_term,
             version_equivalence,
@@ -327,6 +328,22 @@ pget(_Config) ->
 
     ?assertEqual(1, rabbit_misc:pget(a, #{a => 1})),
     ?assertEqual(undefined, rabbit_misc:pget(b, #{a => 1})).
+
+deep_pget(_Config) ->
+    ?assertEqual(1, rabbit_misc:deep_pget([p, p], [{p, [{p, 1}]}])),
+    ?assertEqual(1, rabbit_misc:deep_pget([m, p], #{m => [{p, 1}]})),
+    ?assertEqual(1, rabbit_misc:deep_pget([p, m], [{p, #{m => 1}}])),
+    ?assertEqual(1, rabbit_misc:deep_pget([m, m], #{m => #{m => 1}})),
+
+    ?assertEqual(undefined, rabbit_misc:deep_pget([p, x], [{p, [{p, 1}]}])),
+    ?assertEqual(undefined, rabbit_misc:deep_pget([m, x], #{m => [{p, 1}]})),
+    ?assertEqual(undefined, rabbit_misc:deep_pget([p, x], [{p, #{m => 1}}])),
+    ?assertEqual(undefined, rabbit_misc:deep_pget([m, x], #{m => #{m => 1}})),
+
+    ?assertEqual(undefined, rabbit_misc:deep_pget([x, p], [{p, [{p, 1}]}])),
+    ?assertEqual(undefined, rabbit_misc:deep_pget([x, p], #{m => [{p, 1}]})),
+    ?assertEqual(undefined, rabbit_misc:deep_pget([x, m], [{p, #{m => 1}}])),
+    ?assertEqual(undefined, rabbit_misc:deep_pget([x, m], #{m => #{m => 1}})).
 
 pid_decompose_compose(_Config) ->
     Pid = self(),

--- a/deps/rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl
+++ b/deps/rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl
@@ -6,6 +6,7 @@
 -define(SEE_OTHER, 303).
 -define(BAD_REQUEST, 400).
 -define(NOT_AUTHORISED, 401).
+-define(METHOD_NOT_ALLOWED, 405).
 %%-define(NOT_FOUND, 404). Defined for AMQP by amqp_client.hrl (as 404)
 %% httpc seems to get racy when using HTTP 1.1
 -define(HTTPC_OPTS, [{version, "HTTP/1.0"}, {autoredirect, false}]).

--- a/deps/rabbitmq_management/bin/rabbitmqadmin
+++ b/deps/rabbitmq_management/bin/rabbitmqadmin
@@ -632,6 +632,8 @@ class Management:
             die("Access refused: {0}".format(path))
         if resp.status == 404:
             die("Not found: {0}".format(path))
+        if resp.status == 405:
+            die("Method not allowed: {0}".format(json.loads(resp.read())['reason']))
         if resp.status == 301:
             url = urlparse.urlparse(resp.getheader('location'))
             [host, port] = url.netloc.split(':')

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -528,3 +528,10 @@ fun(File) ->
     ReadFile = file:list_dir(File),
     element(1, ReadFile) == ok
 end}.
+
+%% Disables setting operator policies over API.
+
+{mapping, "management.restrictions.operator_policy_changes.disabled", "rabbitmq_management.restrictions.operator_policy_changes.disabled", [
+    {datatype, {enum, [true, false]}},
+    {include_default, false}
+]}.

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -619,6 +619,7 @@ var is_user_policymaker;         // ...user is not a policymaker
 var user_monitor;                // ...user cannot monitor
 var nodes_interesting;           // ...we are not in a cluster
 var vhosts_interesting;          // ...there is only one vhost
+var edit_op_policy_enabled;      // ...editing operator policies is enabled
 var queue_type;
 var rabbit_versions_interesting; // ...all cluster nodes run the same version
 var disable_stats;               // ...disable all stats, management only mode
@@ -643,6 +644,7 @@ var user;
 function setup_global_vars() {
     var overview = JSON.parse(sync_get('/overview'));
     rates_mode = overview.rates_mode;
+    edit_op_policy_enabled = overview.edit_op_policy_enabled;
     user_tags = expand_user_tags(user.tags);
     user_administrator = jQuery.inArray("administrator", user_tags) != -1;
     is_user_policymaker = jQuery.inArray("policymaker", user_tags) != -1;

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -619,7 +619,7 @@ var is_user_policymaker;         // ...user is not a policymaker
 var user_monitor;                // ...user cannot monitor
 var nodes_interesting;           // ...we are not in a cluster
 var vhosts_interesting;          // ...there is only one vhost
-var edit_op_policy_enabled;      // ...editing operator policies is enabled
+var is_op_policy_updating_enabled;      // ...editing operator policies is enabled
 var queue_type;
 var rabbit_versions_interesting; // ...all cluster nodes run the same version
 var disable_stats;               // ...disable all stats, management only mode
@@ -644,7 +644,7 @@ var user;
 function setup_global_vars() {
     var overview = JSON.parse(sync_get('/overview'));
     rates_mode = overview.rates_mode;
-    edit_op_policy_enabled = overview.edit_op_policy_enabled;
+    is_op_policy_updating_enabled = overview.is_op_policy_updating_enabled;
     user_tags = expand_user_tags(user.tags);
     user_administrator = jQuery.inArray("administrator", user_tags) != -1;
     is_user_policymaker = jQuery.inArray("policymaker", user_tags) != -1;

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -186,7 +186,9 @@
     <th>Apply to</th>
     <th>Definition</th>
     <th>Priority</th>
+<% if (user_administrator && edit_op_policy_enabled) { %>
     <th class="administrator-only">Clear</th>
+<% } %>
   </tr>
  </thead>
  <tbody>
@@ -203,6 +205,7 @@
      <td><%= fmt_string(policy['apply-to']) %></td>
      <td><%= fmt_table_short(policy.definition) %></td>
      <td><%= fmt_string(policy.priority) %></td>
+<% if (user_administrator && edit_op_policy_enabled) { %>
      <td class="administrator-only">
         <form action="#/operator_policies" method="delete" class="confirm">
             <input type="hidden" name="name" value="<%= fmt_string(policy.name) %>"/>
@@ -210,6 +213,7 @@
             <input type="submit" value="Clear"/>
         </form>
       </td>
+<% } %>
    </tr>
 <% } %>
  </tbody>
@@ -221,7 +225,7 @@
   </div>
 </div>
 
-<% if (user_administrator && vhosts.length > 0) { %>
+<% if (user_administrator && vhosts.length > 0 && edit_op_policy_enabled) { %>
 
 <div class="section-hidden">
   <h2>Add / update an operator policy</h2>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -186,7 +186,7 @@
     <th>Apply to</th>
     <th>Definition</th>
     <th>Priority</th>
-<% if (user_administrator && edit_op_policy_enabled) { %>
+<% if (user_administrator && is_op_policy_updating_enabled) { %>
     <th class="administrator-only">Clear</th>
 <% } %>
   </tr>
@@ -205,7 +205,7 @@
      <td><%= fmt_string(policy['apply-to']) %></td>
      <td><%= fmt_table_short(policy.definition) %></td>
      <td><%= fmt_string(policy.priority) %></td>
-<% if (user_administrator && edit_op_policy_enabled) { %>
+<% if (user_administrator && is_op_policy_updating_enabled) { %>
      <td class="administrator-only">
         <form action="#/operator_policies" method="delete" class="confirm">
             <input type="hidden" name="name" value="<%= fmt_string(policy.name) %>"/>
@@ -225,7 +225,7 @@
   </div>
 </div>
 
-<% if (user_administrator && vhosts.length > 0 && edit_op_policy_enabled) { %>
+<% if (user_administrator && vhosts.length > 0 && is_op_policy_updating_enabled) { %>
 
 <div class="section-hidden">
   <h2>Add / update an operator policy</h2>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -1,0 +1,22 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2023-2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_mgmt_features).
+
+-export([is_edit_op_policy_disabled/0]).
+
+is_edit_op_policy_disabled() ->
+    case get_restriction([operator_policy_changes, disabled]) of
+        true -> true;
+        _ -> false
+    end.
+
+%% Private
+
+get_restriction(Path) ->
+    Restrictions = application:get_env(rabbitmq_management,  restrictions, []),
+    rabbit_misc:deep_pget(Path, Restrictions, false).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -7,9 +7,9 @@
 
 -module(rabbit_mgmt_features).
 
--export([is_edit_op_policy_disabled/0]).
+-export([is_op_policy_updating_disabled/0]).
 
-is_edit_op_policy_disabled() ->
+is_op_policy_updating_disabled() ->
     case get_restriction([operator_policy_changes, disabled]) of
         true -> true;
         _ -> false

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -46,6 +46,7 @@
 -export([qs_val/2]).
 -export([get_path_prefix/0]).
 -export([catch_no_such_user_or_vhost/2]).
+-export([method_not_allowed/3]).
 
 -export([disable_stats/1, enable_queue_totals/1]).
 
@@ -770,6 +771,9 @@ not_authorised(Reason, ReqData, Context) ->
 
 not_found(Reason, ReqData, Context) ->
     halt_response(404, not_found, Reason, ReqData, Context).
+
+method_not_allowed(Reason, ReqData, Context) ->
+    halt_response(405, method_not_allowed, Reason, ReqData, Context).
 
 internal_server_error(Error, Reason, ReqData, Context) ->
     rabbit_log:error("~ts~n~ts", [Error, Reason]),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_operator_policy.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_operator_policy.erl
@@ -72,7 +72,7 @@ delete_resource(ReqData, Context = #context{user = #user{username = Username}}) 
     {true, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->
-    case rabbit_mgmt_features:is_edit_op_policy_disabled() of
+    case rabbit_mgmt_features:is_op_policy_updating_disabled() of
         true ->
             rabbit_mgmt_util:method_not_allowed(<<"Broker settings disallow editing of operator policies.">>, ReqData, Context);
         false ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_operator_policy.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_operator_policy.erl
@@ -72,7 +72,12 @@ delete_resource(ReqData, Context = #context{user = #user{username = Username}}) 
     {true, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->
-    rabbit_mgmt_util:is_authorized_admin(ReqData, Context).
+    case rabbit_mgmt_features:is_edit_op_policy_disabled() of
+        true ->
+            rabbit_mgmt_util:method_not_allowed(<<"Broker settings disallow editing of operator policies.">>, ReqData, Context);
+        false ->
+            rabbit_mgmt_util:is_authorized_admin(ReqData, Context)
+    end.
 
 %%--------------------------------------------------------------------
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -51,6 +51,7 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {erlang_full_version,       erlang_full_version()},
                  {release_series_support_status, rabbit_release_series:readable_support_status()},
                  {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
+                 {edit_op_policy_enabled,        not rabbit_mgmt_features:is_edit_op_policy_disabled()},
                  {enable_queue_totals,           rabbit_mgmt_util:enable_queue_totals(ReqData)}],
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -51,7 +51,7 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {erlang_full_version,       erlang_full_version()},
                  {release_series_support_status, rabbit_release_series:readable_support_status()},
                  {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
-                 {is_is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},
+                 {is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},
                  {enable_queue_totals,           rabbit_mgmt_util:enable_queue_totals(ReqData)}],
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -51,7 +51,7 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {erlang_full_version,       erlang_full_version()},
                  {release_series_support_status, rabbit_release_series:readable_support_status()},
                  {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
-                 {edit_op_policy_enabled,        not rabbit_mgmt_features:is_edit_op_policy_disabled()},
+                 {is_is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},
                  {enable_queue_totals,           rabbit_mgmt_util:enable_queue_totals(ReqData)}],
     try
         case rabbit_mgmt_util:disable_stats(ReqData) of

--- a/deps/rabbitmq_management/test/rabbit_mgmt_runtime_parameters_util.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_runtime_parameters_util.erl
@@ -40,10 +40,14 @@ notify_clear(_, _, _, _) -> ok.
 %----------------------------------------------------------------------------
 
 register_policy_validator() ->
+    rabbit_registry:register(operator_policy_validator, <<"testeven">>, ?MODULE),
+    rabbit_registry:register(operator_policy_validator, <<"testpos">>,  ?MODULE),
     rabbit_registry:register(policy_validator, <<"testeven">>, ?MODULE),
     rabbit_registry:register(policy_validator, <<"testpos">>,  ?MODULE).
 
 unregister_policy_validator() ->
+    rabbit_registry:unregister(operator_policy_validator, <<"testeven">>),
+    rabbit_registry:unregister(operator_policy_validator, <<"testpos">>),
     rabbit_registry:unregister(policy_validator, <<"testeven">>),
     rabbit_registry:unregister(policy_validator, <<"testpos">>).
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
@@ -79,7 +79,7 @@ path_prefix_test(_Config) ->
     ?assertEqual(Pfx0, Got3).
 
 default_restrictions(_) ->
-    ?assertEqual(false, rabbit_mgmt_features:is_edit_op_policy_disabled()).
+    ?assertEqual(false, rabbit_mgmt_features:is_op_policy_updating_disabled()).
 
 %%--------------------------------------------------------------------
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_test_unit_SUITE.erl
@@ -22,6 +22,7 @@ groups() ->
      {parallel_tests, [parallel], [
                                    tokenise_test,
                                    pack_binding_test,
+                                   default_restrictions,
                                    path_prefix_test
                                   ]}
     ].
@@ -76,6 +77,9 @@ path_prefix_test(_Config) ->
     application:set_env(rabbitmq_management, path_prefix, Pfx2),
     Got3 = rabbit_mgmt_util:get_path_prefix(),
     ?assertEqual(Pfx0, Got3).
+
+default_restrictions(_) ->
+    ?assertEqual(false, rabbit_mgmt_features:is_edit_op_policy_disabled()).
 
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
This is #7165 by @illotum with some naming changes from me.