### PR TITLE
rabbit_feature_flags: Remove duplicated code

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1045,33 +1045,21 @@ mark_as_enabled_locally(FeatureName, IsEnabled) ->
 %% Coordination with remote nodes.
 %% -------------------------------------------------------------------
 
--ifndef(TEST).
 -spec remote_nodes() -> [node()].
 %% @private
 
 remote_nodes() ->
-    mnesia:system_info(db_nodes) -- [node()].
+    rabbit_ff_controller:all_nodes() -- [node()].
 
 -spec running_remote_nodes() -> [node()].
 %% @private
 
 running_remote_nodes() ->
-    mnesia:system_info(running_db_nodes) -- [node()].
--else.
+    rabbit_ff_controller:running_nodes() -- [node()].
+
+-ifdef(TEST).
 -define(PT_OVERRIDDEN_NODES, {?MODULE, overridden_nodes}).
 -define(PT_OVERRIDDEN_RUNNING_NODES, {?MODULE, overridden_running_nodes}).
-
-remote_nodes() ->
-    case get_overriden_nodes() of
-        undefined -> mnesia:system_info(db_nodes) -- [node()];
-        Nodes     -> Nodes -- [node()]
-    end.
-
-running_remote_nodes() ->
-    case get_overriden_running_nodes() of
-        undefined -> mnesia:system_info(running_db_nodes) -- [node()];
-        Nodes     -> Nodes -- [node()]
-    end.
 
 override_nodes(Nodes) ->
     persistent_term:put(?PT_OVERRIDDEN_NODES, Nodes).


### PR DESCRIPTION
... in the `rabbit_feature_flags` module.

`rabbit_ff_controller` already provides functions to list nodes.