### PR TITLE
Require all feature flags introduced before 3.11.1

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -7,20 +7,11 @@
 
 -module(rabbit_core_ff).
 
--include_lib("kernel/include/logger.hrl").
-
--include_lib("rabbit_common/include/logging.hrl").
-
--export([direct_exchange_routing_v2_enable/1,
-         listener_records_in_ets_enable/1,
-         listener_records_in_ets_post_enable/1,
-         tracking_records_in_ets_enable/1,
-         tracking_records_in_ets_post_enable/1]).
-
 -rabbit_feature_flag(
    {classic_mirrored_queue_version,
     #{desc          => "Support setting version for classic mirrored queues",
-      stability     => stable
+      %%TODO remove compatibility code
+      stability     => required
      }}).
 
 -rabbit_feature_flag(
@@ -68,7 +59,8 @@
    {stream_single_active_consumer,
     #{desc          => "Single active consumer for streams",
       doc_url       => "https://www.rabbitmq.com/stream.html",
-      stability     => stable,
+      %%TODO remove compatibility code
+      stability     => required,
       depends_on    => [stream_queue]
      }}).
 
@@ -81,31 +73,25 @@
 -rabbit_feature_flag(
    {direct_exchange_routing_v2,
     #{desc       => "v2 direct exchange routing implementation",
-      stability  => stable,
-      depends_on => [feature_flags_v2, implicit_default_bindings],
-      callbacks  => #{enable => {?MODULE, direct_exchange_routing_v2_enable}}
+      %%TODO remove compatibility code
+      stability  => required,
+      depends_on => [feature_flags_v2, implicit_default_bindings]
      }}).
 
 -rabbit_feature_flag(
    {listener_records_in_ets,
     #{desc       => "Store listener records in ETS instead of Mnesia",
-      stability  => stable,
-      depends_on => [feature_flags_v2],
-      callbacks  => #{enable =>
-                      {?MODULE, listener_records_in_ets_enable},
-                      post_enable =>
-                      {?MODULE, listener_records_in_ets_post_enable}}
+      %%TODO remove compatibility code
+      stability  => required,
+      depends_on => [feature_flags_v2]
      }}).
 
 -rabbit_feature_flag(
    {tracking_records_in_ets,
     #{desc          => "Store tracking records in ETS instead of Mnesia",
-      stability     => stable,
-      depends_on    => [feature_flags_v2],
-      callbacks     => #{enable =>
-                             {?MODULE, tracking_records_in_ets_enable},
-                         post_enable =>
-                             {?MODULE, tracking_records_in_ets_post_enable}}
+      %%TODO remove compatibility code
+      stability     => required,
+      depends_on    => [feature_flags_v2]
      }}).
 
 -rabbit_feature_flag(
@@ -124,129 +110,3 @@
       stability     => stable,
       depends_on    => [stream_queue]
      }}).
-
-%% -------------------------------------------------------------------
-%% Direct exchange routing v2.
-%% -------------------------------------------------------------------
-
--spec direct_exchange_routing_v2_enable(Args) -> Ret when
-      Args :: rabbit_feature_flags:enable_callback_args(),
-      Ret :: rabbit_feature_flags:enable_callback_ret().
-direct_exchange_routing_v2_enable(#{feature_name := FeatureName}) ->
-    TableName = rabbit_index_route,
-    ok = rabbit_table:wait([rabbit_route, rabbit_exchange], _Retry = true),
-    try
-        case rabbit_db_binding:create_index_route_table() of
-            ok ->
-                ok;
-            {error, Err} = Error ->
-                ?LOG_ERROR(
-                  "Feature flags: `~ts`: failed to add copy of table ~ts to "
-                  "node ~tp: ~tp",
-                   [FeatureName, TableName, node(), Err],
-                  #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-                Error
-        end
-    catch throw:{error, Reason} ->
-              ?LOG_ERROR(
-                "Feature flags: `~ts`: enable callback failure: ~tp",
-                [FeatureName, Reason],
-                #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-              {error, Reason}
-    end.
-
-%% -------------------------------------------------------------------
-%% Listener records moved from Mnesia to ETS.
-%% -------------------------------------------------------------------
-
-listener_records_in_ets_enable(#{feature_name := FeatureName}) ->
-    try
-        rabbit_mnesia:execute_mnesia_transaction(
-          fun () ->
-                  _ = mnesia:lock({table, rabbit_listener}, read),
-                  Listeners = mnesia:select(
-                                rabbit_listener, [{'$1',[],['$1']}]),
-                  lists:foreach(
-                    fun(Listener) ->
-                            ets:insert(rabbit_listener_ets, Listener)
-                    end, Listeners)
-          end)
-    catch
-        throw:{error, {no_exists, rabbit_listener}} ->
-            ok;
-        throw:{error, Reason} ->
-            ?LOG_ERROR(
-              "Feature flags: `~ts`: failed to migrate Mnesia table: ~tp",
-              [FeatureName, Reason],
-              #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-            {error, Reason}
-    end.
-
-listener_records_in_ets_post_enable(#{feature_name := FeatureName}) ->
-    try
-        case mnesia:delete_table(rabbit_listener) of
-            {atomic, ok} ->
-                ok;
-            {aborted, {no_exists, _}} ->
-                ok;
-            {aborted, Err} ->
-                ?LOG_ERROR(
-                  "Feature flags: `~ts`: failed to delete Mnesia table: ~tp",
-                  [FeatureName, Err],
-                  #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-                ok
-        end
-    catch
-        throw:{error, Reason} ->
-            ?LOG_ERROR(
-              "Feature flags: `~ts`: failed to delete Mnesia table: ~tp",
-              [FeatureName, Reason],
-              #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-            ok
-    end.
-
-tracking_records_in_ets_enable(#{feature_name := FeatureName}) ->
-    try
-        rabbit_connection_tracking:migrate_tracking_records(),
-        rabbit_channel_tracking:migrate_tracking_records()
-    catch
-        throw:{error, {no_exists, _}} ->
-            ok;
-        throw:{error, Reason} ->
-            ?LOG_ERROR(
-               "Enabling feature flag ~ts failed: ~tp",
-               [FeatureName, Reason],
-               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-            {error, Reason}
-    end.
-
-tracking_records_in_ets_post_enable(#{feature_name := FeatureName}) ->
-    try
-        [delete_table(FeatureName, Tab) ||
-            Tab <- rabbit_connection_tracking:get_all_tracked_connection_table_names_for_node(node())],
-        [delete_table(FeatureName, Tab) ||
-            Tab <- rabbit_channel_tracking:get_all_tracked_channel_table_names_for_node(node())]
-    catch
-        throw:{error, Reason} ->
-            ?LOG_ERROR(
-               "Enabling feature flag ~ts failed: ~tp",
-               [FeatureName, Reason],
-               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-            %% adheres to the callback interface
-            ok
-    end.
-
-delete_table(FeatureName, Tab) ->
-    case mnesia:delete_table(Tab) of
-        {atomic, ok} ->
-            ok;
-        {aborted, {no_exists, _}} ->
-            ok;
-        {aborted, Err} ->
-            ?LOG_ERROR(
-               "Enabling feature flag ~ts failed to delete mnesia table ~tp: ~tp",
-               [FeatureName, Tab, Err],
-               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
-            %% adheres to the callback interface
-            ok
-    end.

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -9,7 +9,7 @@
 
 -export([
     create/0, create/2, ensure_local_copies/1, ensure_table_copy/3,
-    create_local_copy/2, wait_for_replicated/1, wait/1, wait/2,
+    wait_for_replicated/1, wait/1, wait/2,
     force_load/0, is_present/0, is_empty/0, needs_default_data/0,
     check_schema_integrity/1, clear_ram_only_tables/0, retry_timeout/0,
     wait_for_replicated/0, exists/1]).

--- a/deps/rabbit/test/queue_type_SUITE.erl
+++ b/deps/rabbit/test/queue_type_SUITE.erl
@@ -1,9 +1,6 @@
 -module(queue_type_SUITE).
 
--compile(export_all).
-
--export([
-         ]).
+-compile([export_all, nowarn_export_all]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_ff.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_ff.erl
@@ -10,11 +10,13 @@
 -rabbit_feature_flag(
    {empty_basic_get_metric,
     #{desc          => "Count AMQP `basic.get` on empty queues in stats",
-      stability     => stable
+      %%TODO remove compatibility code
+      stability     => required
      }}).
 
 -rabbit_feature_flag(
   {drop_unroutable_metric,
    #{desc          => "Count unroutable publishes to be dropped in stats",
-     stability     => stable
+     %%TODO remove compatibility code
+     stability     => required
     }}).

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -267,22 +267,16 @@ def rabbitmq_integration_suite(
         data = data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",
-            # The feature flags listed below are required. This means they must
-            # be enabled in mixed-version testing before even starting cluster
-            # because newer node don't have the corresponding
-            # compatibility/migration code.
-            #
-            # Starting from 3.11.0:
-            #   quorum_queue
-            #   implicit_default_bindings
-            #   virtual_host_metadata
-            #   maintenance_mode_status
-            #   user_limits
-            # Starting from 3.12.0:
-            #   feature_flags_v2
-            #   stream_queue
-            #   classic_queue_type_delivery_support
-            "RABBITMQ_FEATURE_FLAGS": "quorum_queue,implicit_default_bindings,virtual_host_metadata,maintenance_mode_status,user_limits,feature_flags_v2,stream_queue,classic_queue_type_delivery_support",
+            # The feature flags listed below are required. This means they must be enabled in mixed-version testing
+            # before even starting the cluster because newer nodes don't have the corresponding compatibility/migration code.
+            "RABBITMQ_FEATURE_FLAGS":
+            # required starting from 3.11.0 in rabbit:
+            "quorum_queue,implicit_default_bindings,virtual_host_metadata,maintenance_mode_status,user_limits," +
+            # required starting from 3.12.0 in rabbit:
+            "feature_flags_v2,stream_queue,classic_queue_type_delivery_support,classic_mirrored_queue_version," +
+            "stream_single_active_consumer,direct_exchange_routing_v2,listener_records_in_ets,tracking_records_in_ets",
+            # required starting from 3.12.0 in rabbitmq_management_agent:
+            # empty_basic_get_metric, drop_unroutable_metric
             "RABBITMQ_RUN": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/rabbitmq-for-tests-run".format(package),
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),


### PR DESCRIPTION
RabbitMQ 3.12 requires feature flag `feature_flags_v2` which got introduced in 3.11.0 (see https://github.com/rabbitmq/rabbitmq-server/pull/6810).

Therefore, we can mark all feature flags that got introduced in 3.11.0
or before 3.11.0 as required because users will have to upgrade to
3.11.x first, before upgrading to 3.12.x

The advantage of marking these feature flags as required is that we can
start deleting any compatibliy code for these feature flags, similarly
as done in https://github.com/rabbitmq/rabbitmq-server/issues/5215

This list shows when a given feature flag was first introduced:

```
classic_mirrored_queue_version 3.11.0
stream_single_active_consumer 3.11.0
direct_exchange_routing_v2 3.11.0
listener_records_in_ets 3.11.0
tracking_records_in_ets 3.11.0

empty_basic_get_metric 3.8.10
drop_unroutable_metric 3.8.10
```

In this commit, we also force all required feature flags in Erlang
application `rabbit` to be enabled in mixed version cluster testing
and delete any tests that were about a feature flag starting as disabled.

Furthermore, this commit already deletes the callback (migration) functions
given they do not run anymore in 3.12.x.

All other clean up (i.e. branching depending on whether a feature flag
is enabled) will be done in separate commits.