### PR TITLE
Run MQTT maintenance test in mixed version cluster

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -167,14 +167,6 @@ end_per_group(_, Config) ->
       rabbit_ct_client_helpers:teardown_steps() ++
       rabbit_ct_broker_helpers:teardown_steps()).
 
-init_per_testcase(Testcase = maintenance, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "maintenance mode wrongly closes cluster-wide MQTT connections "
-             "in RMQ < 3.11.2 and < 3.10.10"};
-        false ->
-            init_per_testcase0(Testcase, Config)
-    end;
 init_per_testcase(T, Config)
   when T =:= management_plugin_connection;
        T =:= management_plugin_enable ->


### PR DESCRIPTION
Nowadays, the old RabbitMQ nodes in mixed version cluster tests on `main` branch run in version 3.11.7.

Since maintenance mode was wrongly closing cluster-wide MQTT connections only in RabbitMQ <3.11.2 (and <3.10.10), we can re-enable this mixed version test.