### PR TITLE
Ignore stream data folder in rabbit_mnesia:is_virgin_node/0

### DIFF
--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -929,7 +929,7 @@ create_schema() ->
     rabbit_misc:ensure_ok(mnesia:create_schema([node()]), cannot_create_schema),
     rabbit_log:debug("Bootstraped a schema database successfully"),
     start_mnesia(),
-    
+
     rabbit_log:debug("Will create schema database tables"),
     ok = rabbit_table:create(),
     rabbit_log:debug("Created schema database tables successfully"),
@@ -1100,6 +1100,7 @@ is_virgin_node() ->
             [rabbit_node_monitor:cluster_status_filename(),
              rabbit_node_monitor:running_nodes_filename(),
              rabbit_node_monitor:coordination_filename(),
+             rabbit_node_monitor:stream_filename(),
              rabbit_node_monitor:default_quorum_filename(),
              rabbit_node_monitor:quorum_filename(),
              rabbit_feature_flags:enabled_feature_flags_list_file()],

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -12,6 +12,7 @@
 -export([start_link/0]).
 -export([running_nodes_filename/0,
          cluster_status_filename/0, coordination_filename/0,
+         stream_filename/0,
          quorum_filename/0, default_quorum_filename/0,
          prepare_cluster_status_files/0,
          write_cluster_status/1, read_cluster_status/0,
@@ -71,6 +72,9 @@ cluster_status_filename() ->
 
 coordination_filename() ->
     filename:join(rabbit:data_dir(), "coordination").
+
+stream_filename() ->
+    filename:join(rabbit:data_dir(), "stream").
 
 quorum_filename() ->
     ra_env:data_dir().


### PR DESCRIPTION
A Node that hosted a stream replica, may start receiving data as soon as it starts, in some cases before `rabbit_mnesia:is_virgin_node/0` is called.

https://github.com/rabbitmq/rabbitmq-server/discussions/7139