### PR TITLE
Remove compatibility code for management agent feature flags

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_data_compat.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_data_compat.erl
@@ -8,10 +8,8 @@
 -module(rabbit_mgmt_data_compat).
 
 -export([fill_get_empty_queue_metric/1,
-         drop_get_empty_queue_metric/1,
          fill_consumer_active_fields/1,
-         fill_drop_unroutable_metric/1,
-         drop_drop_unroutable_metric/1]).
+         fill_drop_unroutable_metric/1]).
 
 fill_get_empty_queue_metric(Slide) ->
     exometer_slide:map(
@@ -26,21 +24,6 @@ fill_get_empty_queue_metric(Slide) ->
               Value
       end, Slide).
 
-drop_get_empty_queue_metric(Slide) ->
-    exometer_slide:map(
-      fun
-          (Value) when is_tuple(Value) andalso size(Value) =:= 8 ->
-              %% We want to remove the last element, which is
-              %% the count of basic.get on empty queues.
-              list_to_tuple(
-                lists:sublist(
-                  tuple_to_list(Value), size(Value) - 1));
-          (Value) when is_tuple(Value) andalso size(Value) =:= 7 ->
-              Value;
-          (Value) ->
-              Value
-      end, Slide).
-
 fill_drop_unroutable_metric(Slide) ->
     exometer_slide:map(
       fun
@@ -50,20 +33,6 @@ fill_drop_unroutable_metric(Slide) ->
               %% Inject a 0
               list_to_tuple(
                 tuple_to_list(Value) ++ [0]);
-          (Value) ->
-              Value
-      end, Slide).
-
-drop_drop_unroutable_metric(Slide) ->
-    exometer_slide:map(
-      fun
-          (Value) when is_tuple(Value) andalso size(Value) =:= 4 ->
-              %% Remove the last element.
-              list_to_tuple(
-                lists:sublist(
-                  tuple_to_list(Value), size(Value) - 1));
-          (Value) when is_tuple(Value) andalso size(Value) =:= 3 ->
-              Value;
           (Value) ->
               Value
       end, Slide).

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_ff.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_ff.erl
@@ -10,13 +10,11 @@
 -rabbit_feature_flag(
    {empty_basic_get_metric,
     #{desc          => "Count AMQP `basic.get` on empty queues in stats",
-      %%TODO remove compatibility code
       stability     => required
      }}).
 
 -rabbit_feature_flag(
   {drop_unroutable_metric,
    #{desc          => "Count unroutable publishes to be dropped in stats",
-     %%TODO remove compatibility code
      stability     => required
     }}).

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_ff.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_ff.erl
@@ -26,4 +26,4 @@
 
 -spec track_client_id_in_ra() -> boolean().
 track_client_id_in_ra() ->
-    not rabbit_feature_flags:is_enabled(delete_ra_cluster_mqtt_node).
+    rabbit_feature_flags:is_disabled(delete_ra_cluster_mqtt_node).


### PR DESCRIPTION
Remove compatibility code for feature flags
* drop_unroutable_metric
* empty_basic_get_metric

since they are required in 3.12.0.

Depends on https://github.com/rabbitmq/rabbitmq-server/pull/7219