### PR TITLE
Don't use `rabbit_ct_helpers:is_mixed_versions()` in tests

### DIFF
--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -139,23 +139,17 @@ start_with_invalid_schema_in_path(Config) ->
     end.
 
 persistent_cluster_id(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-      false ->
-        [Rabbit, Hare] = cluster_members(Config),
-        ClusterIDA1 = rpc:call(Rabbit, rabbit_nodes, persistent_cluster_id, []),
-        ClusterIDB1 = rpc:call(Hare, rabbit_nodes, persistent_cluster_id, []),
-        ?assertEqual(ClusterIDA1, ClusterIDB1),
+    [Rabbit, Hare] = cluster_members(Config),
+    ClusterIDA1 = rpc:call(Rabbit, rabbit_nodes, persistent_cluster_id, []),
+    ClusterIDB1 = rpc:call(Hare, rabbit_nodes, persistent_cluster_id, []),
+    ?assertEqual(ClusterIDA1, ClusterIDB1),
 
-        rabbit_ct_broker_helpers:restart_node(Config, Rabbit),
-        ClusterIDA2 = rpc:call(Rabbit, rabbit_nodes, persistent_cluster_id, []),
-        rabbit_ct_broker_helpers:restart_node(Config, Hare),
-        ClusterIDB2 = rpc:call(Hare, rabbit_nodes, persistent_cluster_id, []),
-        ?assertEqual(ClusterIDA1, ClusterIDA2),
-        ?assertEqual(ClusterIDA2, ClusterIDB2);
-      _ ->
-        %% skip the test in mixed version mode
-        {skip, "Should not run in mixed version environments"}
-    end.
+    rabbit_ct_broker_helpers:restart_node(Config, Rabbit),
+    ClusterIDA2 = rpc:call(Rabbit, rabbit_nodes, persistent_cluster_id, []),
+    rabbit_ct_broker_helpers:restart_node(Config, Hare),
+    ClusterIDB2 = rpc:call(Hare, rabbit_nodes, persistent_cluster_id, []),
+    ?assertEqual(ClusterIDA1, ClusterIDA2),
+    ?assertEqual(ClusterIDA2, ClusterIDB2).
 
 create_bad_schema(Rabbit, Hare, Config) ->
     {ok, RabbitMnesiaDir} = rpc:call(Rabbit, application, get_env, [mnesia, dir]),

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -286,36 +286,18 @@ import_case18(Config) ->
     ok.
 
 import_case19(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        false ->
-            import_invalid_file_case(Config, "failing_case19");
-        true ->
-            %% skip the test in mixed version mode
-            {skip, "Should not run in mixed version environments"}
-    end.
+    import_invalid_file_case(Config, "failing_case19").
 
 export_import_round_trip_case1(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-      false ->
-        %% case 6 has runtime parameters that do not depend on any plugins
-        import_file_case(Config, "case6"),
-        Defs = export(Config),
-        import_raw(Config, rabbit_json:encode(Defs));
-      _ ->
-        %% skip the test in mixed version mode
-        {skip, "Should not run in mixed version environments"}
-    end.
+    %% case 6 has runtime parameters that do not depend on any plugins
+    import_file_case(Config, "case6"),
+    Defs = export(Config),
+    import_raw(Config, rabbit_json:encode(Defs)).
 
 export_import_round_trip_case2(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-      false ->
-        import_file_case(Config, "case9", "case9a"),
-        Defs = export(Config),
-        import_parsed(Config, Defs);
-      _ ->
-        %% skip the test in mixed version mode
-        {skip, "Should not run in mixed version environments"}
-    end.
+    import_file_case(Config, "case9", "case9a"),
+    Defs = export(Config),
+    import_parsed(Config, Defs).
 
 import_on_a_booting_node_using_classic_local_source(Config) ->
     %% see case5.json

--- a/deps/rabbit/test/dynamic_qq_SUITE.erl
+++ b/deps/rabbit/test/dynamic_qq_SUITE.erl
@@ -57,27 +57,21 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(Testcase, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() andalso
-         Testcase == quorum_unaffected_after_vhost_failure of
-        true ->
-            {skip, "test case not mixed versions compatible"};
-        false ->
-            rabbit_ct_helpers:testcase_started(Config, Testcase),
-            ClusterSize = ?config(rmq_nodes_count, Config),
-            TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
-            Group = proplists:get_value(name, ?config(tc_group_properties, Config)),
-            Q = rabbit_data_coercion:to_binary(io_lib:format("~p_~tp", [Group, Testcase])),
-            Config1 = rabbit_ct_helpers:set_config(Config, [
-                                                            {rmq_nodename_suffix, Testcase},
-                                                            {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}},
-                                                            {queue_name, Q},
-                                                            {queue_args, [{<<"x-queue-type">>, longstr, <<"quorum">>}]}
-                                                           ]),
-            rabbit_ct_helpers:run_steps(
-              Config1,
-              rabbit_ct_broker_helpers:setup_steps() ++
-              rabbit_ct_client_helpers:setup_steps())
-    end.
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    ClusterSize = ?config(rmq_nodes_count, Config),
+    TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
+    Group = proplists:get_value(name, ?config(tc_group_properties, Config)),
+    Q = rabbit_data_coercion:to_binary(io_lib:format("~p_~tp", [Group, Testcase])),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+                                                    {rmq_nodename_suffix, Testcase},
+                                                    {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}},
+                                                    {queue_name, Q},
+                                                    {queue_args, [{<<"x-queue-type">>, longstr, <<"quorum">>}]}
+                                                   ]),
+    rabbit_ct_helpers:run_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
 
 end_per_testcase(Testcase, Config) ->
     Config1 = rabbit_ct_helpers:run_steps(Config,
@@ -196,50 +190,45 @@ quorum_unaffected_after_vhost_failure(Config) ->
     ?assertEqual(Servers, lists:sort(proplists:get_value(online, Info, []))).
 
 recover_follower_after_standalone_restart(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-      false ->
-            %% Tests that followers can be brought up standalone after forgetting the
-            %% rest of the cluster. Consensus won't be reached as there is only one node in the
-            %% new cluster.
-            Servers = [A, B, C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-            Ch = rabbit_ct_client_helpers:open_channel(Config, A),
+    %% Tests that followers can be brought up standalone after forgetting the
+    %% rest of the cluster. Consensus won't be reached as there is only one node in the
+    %% new cluster.
+    Servers = [A, B, C] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, A),
 
-            QName = ?config(queue_name, Config),
-            Args = ?config(queue_args, Config),
-            amqp_channel:call(Ch, #'queue.declare'{queue = QName,
-                                                   arguments = Args,
-                                                   durable = true
-                                                  }),
+    QName = ?config(queue_name, Config),
+    Args = ?config(queue_args, Config),
+    amqp_channel:call(Ch, #'queue.declare'{queue = QName,
+                                           arguments = Args,
+                                           durable = true
+                                          }),
 
-            rabbit_ct_client_helpers:publish(Ch, QName, 15),
-            rabbit_ct_client_helpers:close_channel(Ch),
+    rabbit_ct_client_helpers:publish(Ch, QName, 15),
+    rabbit_ct_client_helpers:close_channel(Ch),
 
-            Name = ra_name(QName),
-            wait_for_messages_ready(Servers, Name, 15),
+    Name = ra_name(QName),
+    wait_for_messages_ready(Servers, Name, 15),
 
-            rabbit_ct_broker_helpers:stop_node(Config, C),
-            rabbit_ct_broker_helpers:stop_node(Config, B),
-            rabbit_ct_broker_helpers:stop_node(Config, A),
+    rabbit_ct_broker_helpers:stop_node(Config, C),
+    rabbit_ct_broker_helpers:stop_node(Config, B),
+    rabbit_ct_broker_helpers:stop_node(Config, A),
 
-            %% Restart one follower
-            forget_cluster_node(Config, B, C),
-            forget_cluster_node(Config, B, A),
+    %% Restart one follower
+    forget_cluster_node(Config, B, C),
+    forget_cluster_node(Config, B, A),
 
-            ok = rabbit_ct_broker_helpers:start_node(Config, B),
-            wait_for_messages_ready([B], Name, 15),
-            ok = rabbit_ct_broker_helpers:stop_node(Config, B),
+    ok = rabbit_ct_broker_helpers:start_node(Config, B),
+    wait_for_messages_ready([B], Name, 15),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, B),
 
-            %% Restart the other
-            forget_cluster_node(Config, C, B),
-            forget_cluster_node(Config, C, A),
+    %% Restart the other
+    forget_cluster_node(Config, C, B),
+    forget_cluster_node(Config, C, A),
 
-            ok = rabbit_ct_broker_helpers:start_node(Config, C),
-            wait_for_messages_ready([C], Name, 15),
-            ok = rabbit_ct_broker_helpers:stop_node(Config, C),
-            ok;
-        _ ->
-            {skip, "cannot be run in mixed mode"}
-    end.
+    ok = rabbit_ct_broker_helpers:start_node(Config, C),
+    wait_for_messages_ready([C], Name, 15),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, C),
+    ok.
 
 %%----------------------------------------------------------------------------
 forget_cluster_node(Config, Node, NodeToRemove) ->

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -48,11 +48,11 @@ suite() ->
 
 all() ->
     [
-     {group, feature_flags_v2}
+     {group, cluster_size_1},
+     {group, cluster_size_3}
     ].
 
 groups() ->
-    Groups =
     [
      {cluster_size_1, [parallel],
       [
@@ -73,9 +73,6 @@ groups() ->
        have_required_feature_flag_in_cluster_and_add_member_without_it,
        error_during_migration_after_initial_success
       ]}
-    ],
-    [
-     {feature_flags_v2, [], Groups}
     ].
 
 %% -------------------------------------------------------------------
@@ -92,8 +89,6 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     Config.
 
-init_per_group(feature_flags_v2, Config) ->
-    rabbit_ct_helpers:set_config(Config, {enable_feature_flags_v2, true});
 init_per_group(cluster_size_1, Config) ->
     rabbit_ct_helpers:set_config(Config, {nodes_count, 1});
 init_per_group(cluster_size_3, Config) ->

--- a/deps/rabbit/test/quorum_queue_utils.erl
+++ b/deps/rabbit/test/quorum_queue_utils.erl
@@ -34,15 +34,7 @@ wait_for_messages(Servers, QName, Number, Fun, 0) ->
 wait_for_messages(Servers, QName, Number, Fun, N) ->
     Msgs = dirty_query(Servers, QName, Fun),
     ct:pal("Got messages ~tp ~tp", [QName, Msgs]),
-    %% hack to allow the check to succeed in mixed versions clusters if at
-    %% least one node matches the criteria rather than all nodes for
-    F = case rabbit_ct_helpers:is_mixed_versions() of
-            true ->
-                any;
-            false ->
-                all
-        end,
-    case lists:F(fun(C) when is_integer(C) ->
+    case lists:all(fun(C) when is_integer(C) ->
                          C == Number;
                     (_) ->
                          false

--- a/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_integration_SUITE.erl
@@ -111,28 +111,22 @@ merge_app_env(Config) ->
       {ra, [{min_wal_roll_over_interval, 30000}]}).
 
 init_per_testcase(Testcase, Config) ->
-    case {Testcase, rabbit_ct_helpers:is_mixed_versions()} of
-        {single_dlx_worker, true} ->
-            {skip, "single_dlx_worker is not mixed version compatible because process "
-             "rabbit_fifo_dlx_sup does not exist in 3.9"};
-        _ ->
-            Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
-            T = rabbit_data_coercion:to_binary(Testcase),
-            Counters = get_global_counters(Config1),
-            Config2 = rabbit_ct_helpers:set_config(Config1,
-                                                   [{source_queue, <<T/binary, "_source">>},
-                                                    {dead_letter_exchange, <<T/binary, "_dlx">>},
-                                                    {target_queue_1, <<T/binary, "_target_1">>},
-                                                    {target_queue_2, <<T/binary, "_target_2">>},
-                                                    {target_queue_3, <<T/binary, "_target_3">>},
-                                                    {target_queue_4, <<T/binary, "_target_4">>},
-                                                    {target_queue_5, <<T/binary, "_target_5">>},
-                                                    {target_queue_6, <<T/binary, "_target_6">>},
-                                                    {policy, <<T/binary, "_policy">>},
-                                                    {counters, Counters}
-                                                   ]),
-            rabbit_ct_helpers:run_steps(Config2, rabbit_ct_client_helpers:setup_steps())
-    end.
+    Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
+    T = rabbit_data_coercion:to_binary(Testcase),
+    Counters = get_global_counters(Config1),
+    Config2 = rabbit_ct_helpers:set_config(Config1,
+                                           [{source_queue, <<T/binary, "_source">>},
+                                            {dead_letter_exchange, <<T/binary, "_dlx">>},
+                                            {target_queue_1, <<T/binary, "_target_1">>},
+                                            {target_queue_2, <<T/binary, "_target_2">>},
+                                            {target_queue_3, <<T/binary, "_target_3">>},
+                                            {target_queue_4, <<T/binary, "_target_4">>},
+                                            {target_queue_5, <<T/binary, "_target_5">>},
+                                            {target_queue_6, <<T/binary, "_target_6">>},
+                                            {policy, <<T/binary, "_policy">>},
+                                            {counters, Counters}
+                                           ]),
+    rabbit_ct_helpers:run_steps(Config2, rabbit_ct_client_helpers:setup_steps()).
 
 end_per_testcase(Testcase, Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -141,13 +141,6 @@ init_per_suite(Config0) ->
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
-init_per_group(cluster_size_3_parallel = Group, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "not mixed versions compatible"};
-        _ ->
-            init_per_group1(Group, Config)
-    end;
 init_per_group(Group, Config) ->
     init_per_group1(Group, Config).
 

--- a/deps/rabbit/test/upgrade_preparation_SUITE.erl
+++ b/deps/rabbit/test/upgrade_preparation_SUITE.erl
@@ -45,21 +45,14 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_group(Group, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            %% in a 3.8/3.9 mixed cluster, ra will not cluster across versions,
-            %% so quorum plus one will not be achieved
-            {skip, "not mixed versions compatible"};
-        _ ->
-            Config1 = rabbit_ct_helpers:set_config(Config,
-                                                   [
-                                                    {rmq_nodes_count, 3},
-                                                    {rmq_nodename_suffix, Group}
-                                                   ]),
-            rabbit_ct_helpers:run_steps(Config1,
-                                        rabbit_ct_broker_helpers:setup_steps() ++
-                                            rabbit_ct_client_helpers:setup_steps())
-    end.
+    Config1 = rabbit_ct_helpers:set_config(Config,
+                                           [
+                                            {rmq_nodes_count, 3},
+                                            {rmq_nodename_suffix, Group}
+                                           ]),
+    rabbit_ct_helpers:run_steps(Config1,
+                                rabbit_ct_broker_helpers:setup_steps() ++
+                                    rabbit_ct_client_helpers:setup_steps()).
 
 end_per_group(_Group, Config) ->
     rabbit_ct_helpers:run_steps(Config,

--- a/deps/rabbitmq_amqp1_0/test/system_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/system_SUITE.erl
@@ -57,21 +57,16 @@ end_per_suite(Config) ->
     Config.
 
 init_per_group(streams, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        false ->
-            Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
-            Config1 = rabbit_ct_helpers:set_config(Config, [
-                {rmq_nodename_suffix, Suffix},
-                {amqp10_client_library, dotnet}
-              ]),
-            rabbit_ct_helpers:run_setup_steps(Config1, [
-                fun build_dotnet_test_project/1
-            ] ++
-            rabbit_ct_broker_helpers:setup_steps() ++
-            rabbit_ct_client_helpers:setup_steps());
-        _     ->
-            {skip, "stream tests are skipped in mixed mode"}
-    end;
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Suffix},
+        {amqp10_client_library, dotnet}
+      ]),
+    rabbit_ct_helpers:run_setup_steps(Config1, [
+        fun build_dotnet_test_project/1
+    ] ++
+    rabbit_ct_broker_helpers:setup_steps() ++
+    rabbit_ct_client_helpers:setup_steps());
 init_per_group(Group, Config) ->
     Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
     Config1 = rabbit_ct_helpers:set_config(Config, [

--- a/deps/rabbitmq_consistent_hash_exchange/test/rabbit_exchange_type_consistent_hash_SUITE.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/test/rabbit_exchange_type_consistent_hash_SUITE.erl
@@ -65,15 +65,7 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_group(clustered = Group, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        false ->
-            init_per_group(Group, Config, 3);
-        true ->
-            %% Consistent hash exchange plugin prior to
-            %% https://github.com/rabbitmq/rabbitmq-server/pull/5121
-            %% does not add bindings idempotently which makes test node_restart fail.
-            {skip, "not mixed versions compatible"}
-    end;
+    init_per_group(Group, Config, 3);
 init_per_group(Group, Config) ->
     init_per_group(Group, Config, 1).
 

--- a/deps/rabbitmq_federation/test/exchange_SUITE.erl
+++ b/deps/rabbitmq_federation/test/exchange_SUITE.erl
@@ -413,85 +413,79 @@ unbind_on_client_unbind(Config) ->
   clean_up_federation_related_bits(Config).
 
 max_hops(Config) ->
-  case rabbit_ct_helpers:is_mixed_versions() of
-    false ->
-      [NodeA, NodeB, NodeC] = rabbit_ct_broker_helpers:get_node_configs(
-        Config, nodename),
-      await_credentials_obfuscation_seeding_on_two_nodes(Config),
+  [NodeA, NodeB, NodeC] = rabbit_ct_broker_helpers:get_node_configs(
+    Config, nodename),
+  await_credentials_obfuscation_seeding_on_two_nodes(Config),
 
-      UpX = <<"ring">>,
+  UpX = <<"ring">>,
 
-      %% form of ring of upstreams,
-      %% A upstream points at B
-      rabbit_ct_broker_helpers:set_parameter(
-        Config, NodeA, <<"federation-upstream">>, <<"upstream">>,
-        [
-          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeB)},
-          {<<"exchange">>, UpX},
-          {<<"max-hops">>, 2}
-        ]),
-      %% B upstream points at C
-      rabbit_ct_broker_helpers:set_parameter(
-        Config, NodeB, <<"federation-upstream">>, <<"upstream">>,
-        [
-          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeC)},
-          {<<"exchange">>, UpX},
-          {<<"max-hops">>, 2}
-        ]),
-      %% C upstream points at A
-      rabbit_ct_broker_helpers:set_parameter(
-        Config, NodeC, <<"federation-upstream">>, <<"upstream">>,
-        [
-          {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeA)},
-          {<<"exchange">>, UpX},
-          {<<"max-hops">>, 2}
-        ]),
+  %% form of ring of upstreams,
+  %% A upstream points at B
+  rabbit_ct_broker_helpers:set_parameter(
+    Config, NodeA, <<"federation-upstream">>, <<"upstream">>,
+    [
+      {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeB)},
+      {<<"exchange">>, UpX},
+      {<<"max-hops">>, 2}
+    ]),
+  %% B upstream points at C
+  rabbit_ct_broker_helpers:set_parameter(
+    Config, NodeB, <<"federation-upstream">>, <<"upstream">>,
+    [
+      {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeC)},
+      {<<"exchange">>, UpX},
+      {<<"max-hops">>, 2}
+    ]),
+  %% C upstream points at A
+  rabbit_ct_broker_helpers:set_parameter(
+    Config, NodeC, <<"federation-upstream">>, <<"upstream">>,
+    [
+      {<<"uri">>,      rabbit_ct_broker_helpers:node_uri(Config, NodeA)},
+      {<<"exchange">>, UpX},
+      {<<"max-hops">>, 2}
+    ]),
 
-      %% policy on A
-      [begin
-        rabbit_ct_broker_helpers:set_policy(
-          Config, Node,
-          <<"fed.x">>, <<"^ring">>, <<"exchanges">>,
-          [
-            {<<"federation-upstream">>, <<"upstream">>}
-          ])
-       end || Node <- [NodeA, NodeB, NodeC]],
+  %% policy on A
+  [begin
+    rabbit_ct_broker_helpers:set_policy(
+      Config, Node,
+      <<"fed.x">>, <<"^ring">>, <<"exchanges">>,
+      [
+        {<<"federation-upstream">>, <<"upstream">>}
+      ])
+   end || Node <- [NodeA, NodeB, NodeC]],
 
-      NodeACh = rabbit_ct_client_helpers:open_channel(Config, NodeA),
-      NodeBCh = rabbit_ct_client_helpers:open_channel(Config, NodeB),
-      NodeCCh = rabbit_ct_client_helpers:open_channel(Config, NodeC),
+  NodeACh = rabbit_ct_client_helpers:open_channel(Config, NodeA),
+  NodeBCh = rabbit_ct_client_helpers:open_channel(Config, NodeB),
+  NodeCCh = rabbit_ct_client_helpers:open_channel(Config, NodeC),
 
-      FedX = <<"ring">>,
-      X = exchange_declare_method(FedX),
-      declare_exchange(NodeACh, X),
-      declare_exchange(NodeBCh, X),
-      declare_exchange(NodeCCh, X),
+  FedX = <<"ring">>,
+  X = exchange_declare_method(FedX),
+  declare_exchange(NodeACh, X),
+  declare_exchange(NodeBCh, X),
+  declare_exchange(NodeCCh, X),
 
-      Q1 = declare_and_bind_queue(NodeACh, <<"ring">>, <<"key">>),
-      Q2 = declare_and_bind_queue(NodeBCh, <<"ring">>, <<"key">>),
-      Q3 = declare_and_bind_queue(NodeCCh, <<"ring">>, <<"key">>),
+  Q1 = declare_and_bind_queue(NodeACh, <<"ring">>, <<"key">>),
+  Q2 = declare_and_bind_queue(NodeBCh, <<"ring">>, <<"key">>),
+  Q3 = declare_and_bind_queue(NodeCCh, <<"ring">>, <<"key">>),
 
-      await_binding(Config, NodeA, <<"ring">>, <<"key">>, 3),
-      await_binding(Config, NodeB, <<"ring">>, <<"key">>, 3),
-      await_binding(Config, NodeC, <<"ring">>, <<"key">>, 3),
+  await_binding(Config, NodeA, <<"ring">>, <<"key">>, 3),
+  await_binding(Config, NodeB, <<"ring">>, <<"key">>, 3),
+  await_binding(Config, NodeC, <<"ring">>, <<"key">>, 3),
 
-      publish(NodeACh, <<"ring">>, <<"key">>, <<"HELLO flopsy">>),
-      publish(NodeBCh, <<"ring">>, <<"key">>, <<"HELLO mopsy">>),
-      publish(NodeCCh, <<"ring">>, <<"key">>, <<"HELLO cottontail">>),
+  publish(NodeACh, <<"ring">>, <<"key">>, <<"HELLO flopsy">>),
+  publish(NodeBCh, <<"ring">>, <<"key">>, <<"HELLO mopsy">>),
+  publish(NodeCCh, <<"ring">>, <<"key">>, <<"HELLO cottontail">>),
 
-      Msgs = [<<"HELLO flopsy">>, <<"HELLO mopsy">>, <<"HELLO cottontail">>],
-      expect(NodeACh, Q1, Msgs),
-      expect(NodeBCh, Q2, Msgs),
-      expect(NodeCCh, Q3, Msgs),
-      expect_empty(NodeACh, Q1),
-      expect_empty(NodeBCh, Q2),
-      expect_empty(NodeCCh, Q3),
+  Msgs = [<<"HELLO flopsy">>, <<"HELLO mopsy">>, <<"HELLO cottontail">>],
+  expect(NodeACh, Q1, Msgs),
+  expect(NodeBCh, Q2, Msgs),
+  expect(NodeCCh, Q3, Msgs),
+  expect_empty(NodeACh, Q1),
+  expect_empty(NodeBCh, Q2),
+  expect_empty(NodeCCh, Q3),
 
-      clean_up_federation_related_bits(Config);
-    true ->
-      %% skip the test in mixed version mode
-      {skip, "Should not run in mixed version environments"}
-  end.
+  clean_up_federation_related_bits(Config).
 
 exchange_federation_link_status(Config) ->
   FedX = <<"single_upstream.federated">>,

--- a/deps/rabbitmq_federation/test/queue_SUITE.erl
+++ b/deps/rabbitmq_federation/test/queue_SUITE.erl
@@ -117,15 +117,10 @@ init_per_group(cluster_size_1 = Group, Config) ->
       ]),
     init_per_group1(Group, Config1);
 init_per_group(cluster_size_2 = Group, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "not mixed versions compatible"};
-        _ ->
-            Config1 = rabbit_ct_helpers:set_config(Config, [
-                {rmq_nodes_count, 2}
-            ]),
-            init_per_group1(Group, Config1)
-    end.
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodes_count, 2}
+    ]),
+    init_per_group1(Group, Config1).
 
 init_per_group1(Group, Config) ->
     SetupFederation = case Group of

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -205,12 +205,7 @@ init_per_testcase(Testcase = permissions_vhost_test, Config) ->
     rabbit_ct_broker_helpers:delete_vhost(Config, <<"myvhost2">>),
     rabbit_ct_helpers:testcase_started(Config, Testcase);
 init_per_testcase(Testcase = stream_queues_have_consumers_field, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "mixed version clusters are not supported"};
-        _ ->
-            rabbit_ct_helpers:testcase_started(Config, Testcase)
-    end;
+    rabbit_ct_helpers:testcase_started(Config, Testcase);
 init_per_testcase(Testcase = disabled_operator_policy_test, Config) ->
     Restrictions = [{operator_policy_changes, [{disabled, true}]}],
     rabbit_ct_broker_helpers:rpc_all(Config,

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -80,12 +80,7 @@ end_per_group(_, Config) ->
 init_per_testcase(Testcase, Config)
         when Testcase == is_quorum_critical_test
             orelse Testcase == is_mirror_sync_critical_test ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "not mixed versions compatible"};
-        _ ->
-            rabbit_ct_helpers:testcase_started(Config, Testcase)
-    end;
+    rabbit_ct_helpers:testcase_started(Config, Testcase);
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
@@ -229,32 +229,26 @@ vhosts_test(Config) ->
     ?assert(not maps:is_key(recv_oct, GetFirst)),
     ?assert(maps:is_key(cluster_state, GetFirst)),
 
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            %% these won't pass for older 3.8 nodes
-            ok;
-        false ->
-            %% PUT can update metadata (description, tags)
-            Desc0 = "desc 0",
-            Meta0 = [
-                {description, Desc0},
-                {tags,        "tag1,tag2"}
-            ],
-            http_put(Config, "/vhosts/myvhost", Meta0, {group, '2xx'}),
-            #{description := Desc1, tags := Tags1} = http_get(Config, "/vhosts/myvhost", ?OK),
-            ?assertEqual(Desc0, Desc1),
-            ?assertEqual([<<"tag1">>, <<"tag2">>], Tags1),
+    %% PUT can update metadata (description, tags)
+    Desc0 = "desc 0",
+    Meta0 = [
+        {description, Desc0},
+        {tags,        "tag1,tag2"}
+    ],
+    http_put(Config, "/vhosts/myvhost", Meta0, {group, '2xx'}),
+    #{description := Desc1, tags := Tags1} = http_get(Config, "/vhosts/myvhost", ?OK),
+    ?assertEqual(Desc0, Desc1),
+    ?assertEqual([<<"tag1">>, <<"tag2">>], Tags1),
 
-            Desc2 = "desc 2",
-            Meta2 = [
-                {description, Desc2},
-                {tags,        "tag3"}
-            ],
-            http_put(Config, "/vhosts/myvhost", Meta2, {group, '2xx'}),
-            #{description := Desc3, tags := Tags3} = http_get(Config, "/vhosts/myvhost", ?OK),
-            ?assertEqual(Desc2, Desc3),
-            ?assertEqual([<<"tag3">>], Tags3)
-    end,
+    Desc2 = "desc 2",
+    Meta2 = [
+        {description, Desc2},
+        {tags,        "tag3"}
+    ],
+    http_put(Config, "/vhosts/myvhost", Meta2, {group, '2xx'}),
+    #{description := Desc3, tags := Tags3} = http_get(Config, "/vhosts/myvhost", ?OK),
+    ?assertEqual(Desc2, Desc3),
+    ?assertEqual([<<"tag3">>], Tags3),
 
     %% Check individually
     Get = http_get(Config, "/vhosts/%2F", ?OK),

--- a/deps/rabbitmq_shovel/test/dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/dynamic_SUITE.erl
@@ -70,16 +70,6 @@ end_per_suite(Config) ->
       rabbit_ct_client_helpers:teardown_steps() ++
       rabbit_ct_broker_helpers:teardown_steps()).
 
-init_per_group(quorum_queue_tests, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        false -> Config;
-        _     -> {skip, "quorum queue tests are skipped in mixed mode"}
-    end;
-init_per_group(stream_queue_tests, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        false -> Config;
-        _     -> {skip, "stream queue tests are skipped in mixed mode"}
-    end;
 init_per_group(_, Config) ->
     Config.
 

--- a/deps/rabbitmq_stream/test/commands_SUITE.erl
+++ b/deps/rabbitmq_stream/test/commands_SUITE.erl
@@ -61,23 +61,16 @@ groups() ->
        add_delete_super_stream_run]}].
 
 init_per_suite(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip,
-             "mixed version clusters are not supported for "
-             "this suite"};
-        _ ->
-            Config1 =
-                rabbit_ct_helpers:set_config(Config,
-                                             [{rmq_nodename_suffix, ?MODULE}]),
-            Config2 =
-                rabbit_ct_helpers:set_config(Config1,
-                                             {rabbitmq_ct_tls_verify,
-                                              verify_none}),
-            rabbit_ct_helpers:log_environment(),
-            rabbit_ct_helpers:run_setup_steps(Config2,
-                                              rabbit_ct_broker_helpers:setup_steps())
-    end.
+    Config1 =
+        rabbit_ct_helpers:set_config(Config,
+                                     [{rmq_nodename_suffix, ?MODULE}]),
+    Config2 =
+        rabbit_ct_helpers:set_config(Config1,
+                                     {rabbitmq_ct_tls_verify,
+                                      verify_none}),
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config2,
+                                      rabbit_ct_broker_helpers:setup_steps()).
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -51,13 +51,8 @@ groups() ->
      {cluster, [], [test_stream, test_stream_tls, test_metadata, java]}].
 
 init_per_suite(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "mixed version clusters are not supported"};
-        _ ->
-            rabbit_ct_helpers:log_environment(),
-            Config
-    end.
+    rabbit_ct_helpers:log_environment(),
+    Config.
 
 end_per_suite(Config) ->
     Config.

--- a/deps/rabbitmq_stream/test/rabbit_stream_manager_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_manager_SUITE.erl
@@ -28,13 +28,8 @@ groups() ->
 %% -------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "mixed version clusters are not supported"};
-        _ ->
-            rabbit_ct_helpers:log_environment(),
-            Config
-    end.
+    rabbit_ct_helpers:log_environment(),
+    Config.
 
 end_per_suite(Config) ->
     Config.

--- a/deps/rabbitmq_stream_management/test/http_SUITE.erl
+++ b/deps/rabbitmq_stream_management/test/http_SUITE.erl
@@ -24,30 +24,25 @@ groups() ->
 %% -------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "suite is not mixed versions compatible"};
-        _ ->
-            rabbit_ct_helpers:log_environment(),
-            Config1 =
-                rabbit_ct_helpers:set_config(Config,
-                                             [{rmq_nodename_suffix, ?MODULE}]),
-            Config2 =
-                rabbit_ct_helpers:set_config(Config1,
-                                             {rabbitmq_ct_tls_verify,
-                                              verify_none}),
-            SetupStep =
-                fun(StepConfig) ->
-                   rabbit_ct_helpers:merge_app_env(StepConfig,
-                                                   {rabbit,
-                                                    [{collect_statistics_interval,
-                                                      500}]})
-                end,
-            rabbit_ct_helpers:run_setup_steps(Config2,
-                                              [SetupStep]
-                                              ++ rabbit_ct_broker_helpers:setup_steps()
-                                              ++ rabbit_ct_client_helpers:setup_steps())
-    end.
+    rabbit_ct_helpers:log_environment(),
+    Config1 =
+        rabbit_ct_helpers:set_config(Config,
+                                     [{rmq_nodename_suffix, ?MODULE}]),
+    Config2 =
+        rabbit_ct_helpers:set_config(Config1,
+                                     {rabbitmq_ct_tls_verify,
+                                      verify_none}),
+    SetupStep =
+        fun(StepConfig) ->
+           rabbit_ct_helpers:merge_app_env(StepConfig,
+                                           {rabbit,
+                                            [{collect_statistics_interval,
+                                              500}]})
+        end,
+    rabbit_ct_helpers:run_setup_steps(Config2,
+                                      [SetupStep]
+                                      ++ rabbit_ct_broker_helpers:setup_steps()
+                                      ++ rabbit_ct_client_helpers:setup_steps()).
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,


### PR DESCRIPTION
Skipping tests because they run in a mixed-version cluster defeats the purpose of feature flags, thus it's counter-productive to check this.

There are some exceptions where we explicitely provide no support for a feature in a mixed-version cluster. There will be an explanation near the call to `is_mixed_versions()`.

See #7228 for another set of patches related to this topic.