### PR TITLE
Remove mixed version check in MQTT tests

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -61,6 +61,7 @@
 
     is_feature_flag_supported/2,
     is_feature_flag_supported/3,
+    is_feature_flag_enabled/2,
     enable_feature_flag/2,
     enable_feature_flag/3,
 
@@ -1684,6 +1685,11 @@ forget_cluster_node(Config, Node, NodeToForget, Opts) ->
     NameToForget =
         rabbit_ct_broker_helpers:get_node_config(Config, NodeToForget, nodename),
     rabbit_control_helper:command(forget_cluster_node, Name, [NameToForget], Opts).
+
+is_feature_flag_enabled(Config, FeatureName) ->
+    Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    rabbit_ct_broker_helpers:rpc(
+      Config, Node, rabbit_feature_flags, is_enabled, [FeatureName]).
 
 is_feature_flag_supported(Config, FeatureName) ->
     Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -299,14 +299,13 @@ rabbit_mqtt_qos0_queue_overflow(Config) ->
     %% We expect that
     %% 1. all sent messages were either received or dropped
     ?assertEqual(NumMsgs, NumReceived + NumDropped),
-    case rabbit_ct_helpers:is_mixed_versions(Config) of
-        false ->
+    case rabbit_ct_broker_helpers:is_feature_flag_enabled(Config, rabbit_mqtt_qos0_queue) of
+        true ->
             %% 2. at least one message was dropped (otherwise our whole test case did not
             %%    test what it was supposed to test: that messages are dropped due to the
             %%    server being overflowed with messages while the client receives too slowly)
             ?assert(NumDropped >= 1);
-        true ->
-            %% Feature flag rabbit_mqtt_qos0_queue is disabled.
+        false ->
             ?assertEqual(0, NumDropped)
     end,
     %% 3. we received at least 1000 messages because everything below the default

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -261,6 +261,8 @@ event_authentication_failure(Config) ->
 %% Test that queue type rabbit_mqtt_qos0_queue drops QoS 0 messages when its
 %% max length is reached.
 rabbit_mqtt_qos0_queue_overflow(Config) ->
+    ok = rabbit_ct_broker_helpers:enable_feature_flag(Config, rabbit_mqtt_qos0_queue),
+
     Topic = atom_to_binary(?FUNCTION_NAME),
     Msg = binary:copy(<<"x">>, 1000),
     NumMsgs = 10_000,
@@ -299,15 +301,10 @@ rabbit_mqtt_qos0_queue_overflow(Config) ->
     %% We expect that
     %% 1. all sent messages were either received or dropped
     ?assertEqual(NumMsgs, NumReceived + NumDropped),
-    case rabbit_ct_broker_helpers:is_feature_flag_enabled(Config, rabbit_mqtt_qos0_queue) of
-        true ->
-            %% 2. at least one message was dropped (otherwise our whole test case did not
-            %%    test what it was supposed to test: that messages are dropped due to the
-            %%    server being overflowed with messages while the client receives too slowly)
-            ?assert(NumDropped >= 1);
-        false ->
-            ?assertEqual(0, NumDropped)
-    end,
+    %% 2. at least one message was dropped (otherwise our whole test case did not
+    %%    test what it was supposed to test: that messages are dropped due to the
+    %%    server being overflowed with messages while the client receives too slowly)
+    ?assert(NumDropped >= 1),
     %% 3. we received at least 1000 messages because everything below the default
     %% of mailbox_soft_limit=1000 should not be dropped
     ?assert(NumReceived >= 1000),


### PR DESCRIPTION
In the MQTT test assertions, instead of checking whether the test runs in mixed version mode where all non-required feature flags are disabled by default, check whether the given feature flag is enabled.

Prior to this commit, once feature flag `rabbit_mqtt_qos0_queue` becomes required, the test cases would have failed.