### PR TITLE
rabbit_feature_flags: Fix formatting of the logged list of feature flags

### DIFF
--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -390,9 +390,9 @@ do_initialize_registry(RegistryVsn,
                        WrittenToDisk) ->
     %% We log the state of those feature flags.
     ?LOG_DEBUG(
-      "Feature flags: list of feature flags found:~n" ++
+      "Feature flags: list of feature flags found:\n" ++
       lists:flatten(
-        [rabbit_misc:format(
+        [io_lib:format(
            "Feature flags:   [~ts] ~ts~n",
            [case maps:get(FeatureName, FeatureStates, false) of
                 true           -> "x";
@@ -401,7 +401,7 @@ do_initialize_registry(RegistryVsn,
             end,
             FeatureName])
          || FeatureName <- lists:sort(maps:keys(AllFeatureFlags))] ++
-        [rabbit_misc:format(
+        [io_lib:format(
            "Feature flags: scanned applications: ~tp~n"
            "Feature flags: feature flag states written to disk: ~ts",
            [ScannedApps,


### PR DESCRIPTION
If we don't pass arguments, `?LOG_*()` don't consider the passed string as a format string, but as the plain message. Therefore, `~n` was not interpreted.

While here, use `io_lib:format/2` instead of `rabbit_misc:format/2` as we do a `lists:flatten/1` in the end anyway.