### PR TITLE
Decrease default MQTT mailbox_soft_limit

### DIFF
--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -42,7 +42,7 @@ APP_ENV = """[
 	                         ]},
 	    {proxy_protocol, false},
 	    {sparkplug, false},
-	    {mailbox_soft_limit, 1000}
+	    {mailbox_soft_limit, 200}
 	  ]"""
 
 BUILD_DEPS = [

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -27,7 +27,7 @@ define PROJECT_ENV
 	                         ]},
 	    {proxy_protocol, false},
 	    {sparkplug, false},
-	    {mailbox_soft_limit, 1000}
+	    {mailbox_soft_limit, 200}
 	  ]
 endef
 

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -305,9 +305,9 @@ rabbit_mqtt_qos0_queue_overflow(Config) ->
     %%    test what it was supposed to test: that messages are dropped due to the
     %%    server being overflowed with messages while the client receives too slowly)
     ?assert(NumDropped >= 1),
-    %% 3. we received at least 1000 messages because everything below the default
-    %% of mailbox_soft_limit=1000 should not be dropped
-    ?assert(NumReceived >= 1000),
+    %% 3. we received at least 200 messages because everything below the default
+    %% of mailbox_soft_limit=200 should not be dropped
+    ?assert(NumReceived >= 200),
 
     ok = emqtt:disconnect(Sub),
     ok = emqtt:disconnect(Pub).


### PR DESCRIPTION
Let's decrease the mailbox_soft_limit from 1000 to 200.
Obviously, both values are a bit arbitrary.
However, MQTT workloads usually do not have high throughput patterns for
a single MQTT connection. The only valid scenario where an MQTT
connections' process mailbox could have many messages is in large fan-in
scenarios where many MQTT devices sending messages at once to a single MQTT
device - which is rather unusual.

It makes more sense to protect against cluster wide memory alarms by
decreasing the mailbox_soft_limit.