### PR TITLE
Correct a copy-and-paste artifact in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-RabbitMQ packaging source code is licensed under the MPL 2.0. For
+RabbitMQ server and its tier 1 (core) plugins source code is licensed under the MPL 2.0. For
 the MPL2, please see LICENSE-MPL-RabbitMQ.
 
 Some RabbitMQ server OCF files are licensed under the Apache Software License 2.0.


### PR DESCRIPTION
We originally copied the file from the packaging repository, it seems.