### PR TITLE
Remove compatibility for flag stream_single_active_consumer

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -59,7 +59,6 @@
    {stream_single_active_consumer,
     #{desc          => "Single active consumer for streams",
       doc_url       => "https://www.rabbitmq.com/stream.html",
-      %%TODO remove compatibility code
       stability     => required,
       depends_on    => [stream_queue]
      }}).

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1887,23 +1887,9 @@ handle_frame_post_auth(Transport,
                                               Properties]),
                             Sac = single_active_consumer(Properties),
                             ConsumerName = consumer_name(Properties),
-                            case {Sac, rabbit_stream_utils:is_sac_ff_enabled(),
-                                  ConsumerName}
+                            case {Sac, ConsumerName}
                             of
-                                {true, false, _} ->
-                                    rabbit_log:warning("Cannot create subcription ~tp, stream single "
-                                                       "active consumer feature flag is not enabled",
-                                                       [SubscriptionId]),
-                                    response(Transport,
-                                             Connection,
-                                             subscribe,
-                                             CorrelationId,
-                                             ?RESPONSE_CODE_PRECONDITION_FAILED),
-                                    rabbit_global_counters:increase_protocol_counter(stream,
-                                                                                     ?PRECONDITION_FAILED,
-                                                                                     1),
-                                    {Connection, State};
-                                {true, _, undefined} ->
+                                {true, undefined} ->
                                     rabbit_log:warning("Cannot create subcription ~tp, a single active "
                                                        "consumer must have a name",
                                                        [SubscriptionId]),

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -28,7 +28,6 @@
          extract_stream_list/2,
          sort_partitions/1,
          strip_cr_lf/1,
-         is_sac_ff_enabled/0,
          consumer_activity_status/2,
          command_versions/0]).
 
@@ -244,9 +243,6 @@ sort_partitions(Partitions) ->
 
 strip_cr_lf(NameBin) ->
     binary:replace(NameBin, [<<"\n">>, <<"\r">>], <<"">>, [global]).
-
-is_sac_ff_enabled() ->
-    rabbit_feature_flags:is_enabled(stream_single_active_consumer).
 
 consumer_activity_status(Active, Properties) ->
     case {rabbit_stream_reader:single_active_consumer(Properties), Active}


### PR DESCRIPTION
Remove compatibility code for feature flag `stream_single_active_consumer` because this feature flag is `required` in 3.12.

See https://github.com/rabbitmq/rabbitmq-server/pull/7219