### PR TITLE
Remove compatibility for flag direct_exchange_routing_v2

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -73,7 +73,6 @@
 -rabbit_feature_flag(
    {direct_exchange_routing_v2,
     #{desc       => "v2 direct exchange routing implementation",
-      %%TODO remove compatibility code
       stability  => required,
       depends_on => [feature_flags_v2, implicit_default_bindings]
      }}).

--- a/deps/rabbit/src/rabbit_exchange_type_direct.erl
+++ b/deps/rabbit/src/rabbit_exchange_type_direct.erl
@@ -33,11 +33,9 @@ serialise_events() -> false.
 
 route(#exchange{name = Name, type = Type},
       #delivery{message = #basic_message{routing_keys = Routes}}) ->
-    case {Type, rabbit_feature_flags:is_enabled(direct_exchange_routing_v2, non_blocking)} of
-        {direct, true} ->
-            route_v2(Name, Routes);
-        _ ->
-            rabbit_router:match_routing_key(Name, Routes)
+    case Type of
+        direct -> route_v2(Name, Routes);
+        _ -> rabbit_router:match_routing_key(Name, Routes)
     end.
 
 validate(_X) -> ok.


### PR DESCRIPTION
Remove compatibility code for feature flag `direct_exchange_routing_v2` because this feature flag is required in 3.12.

See #7219