### PR TITLE
Fix flaky MQTT test

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -579,15 +579,15 @@ global_counters(Config, ProtoVer) ->
     ?assertEqual(1, maps:get(consumers, get_global_counters(Config, ProtoVer))),
 
     ok = emqtt:disconnect(C),
-    ?assertEqual(#{publishers => 0,
-                   consumers => 0,
-                   messages_confirmed_total => 2,
-                   messages_received_confirm_total => 2,
-                   messages_received_total => 5,
-                   messages_routed_total => 3,
-                   messages_unroutable_dropped_total => 1,
-                   messages_unroutable_returned_total => 1},
-                 get_global_counters(Config, ProtoVer)).
+    eventually(?_assertEqual(#{publishers => 0,
+                               consumers => 0,
+                               messages_confirmed_total => 2,
+                               messages_received_confirm_total => 2,
+                               messages_received_total => 5,
+                               messages_routed_total => 3,
+                               messages_unroutable_dropped_total => 1,
+                               messages_unroutable_returned_total => 1},
+                             get_global_counters(Config, ProtoVer))).
 
 queue_down_qos1(Config) ->
     {Conn1, Ch1} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 1),


### PR DESCRIPTION
Very rarely, the assertion failed with
```
=== Ended at 2023-02-13 13:25:52
=== Location: [{shared_SUITE,global_counters,590},
              {test_server,ts_tc,1782},
              {test_server,run_test_case_eval1,1291},
              {test_server,run_test_case_eval,1223}]
=== === Reason: {assertEqual,
                     [{module,shared_SUITE},
                      {line,590},
                      {expression,"get_global_counters ( Config , ProtoVer )"},
                      {expected,
                          #{consumers => 0,messages_confirmed_total => 2,
                            messages_received_confirm_total => 2,
                            messages_received_total => 5,
                            messages_routed_total => 3,
                            messages_unroutable_dropped_total => 1,
                            messages_unroutable_returned_total => 1,
                            publishers => 0}},
                      {value,
                          #{consumers => 1,messages_confirmed_total => 2,
                            messages_received_confirm_total => 2,
                            messages_received_total => 5,
                            messages_routed_total => 3,
                            messages_unroutable_dropped_total => 1,
                            messages_unroutable_returned_total => 1,
                            publishers => 1}}]}
  in function  shared_SUITE:global_counters/2 (shared_SUITE.erl, line 590)
  in call from test_server:ts_tc/3 (test_server.erl, line 1782)
  in call from test_server:run_test_case_eval1/6 (test_server.erl, line 1291)
  in call from test_server:run_test_case_eval/9 (test_server.erl, line 1223)
```

The DISCONNECT packet is sent one-way from client to server.

An instance of such a failed test is https://github.com/rabbitmq/rabbitmq-server/actions/runs/4163879079/jobs/7204801766