### PR TITLE
Remove unused catch clauses

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -521,14 +521,6 @@ clear_permissions(Username, VirtualHost, ActingUser) ->
                                                  {user_who_performed_action, ActingUser}]),
         R
     catch
-        throw:{error, {no_such_vhost, _}} = Error ->
-            rabbit_log:warning("Failed to clear permissions for user '~ts': virtual host '~ts' does not exist",
-                               [Username, VirtualHost]),
-            throw(Error);
-        throw:{error, {no_such_user, _}} = Error ->
-            rabbit_log:warning("Failed to clear permissions for user '~ts': the user does not exist",
-                               [Username]),
-            throw(Error);
         Class:Error:Stacktrace ->
             rabbit_log:warning("Failed to clear permissions for user '~ts' in virtual host '~ts': ~tp",
                                [Username, VirtualHost, Error]),


### PR DESCRIPTION
Delete functions do not check vhost or user existence anymore, they just return ok if the entry is no longer on the metadata store.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

