### PR TITLE
Remove compatibility for flag tracking_records_in_ets

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -209,16 +209,6 @@
                    [{description, "message delivery logic ready"},
                     {requires,    [core_initialized, recovery]}]}).
 
--rabbit_boot_step({connection_tracking,
-                   [{description, "connection tracking infrastructure"},
-                    {mfa,         {rabbit_connection_tracking, boot, []}},
-                    {enables,     routing_ready}]}).
-
--rabbit_boot_step({channel_tracking,
-                   [{description, "channel tracking infrastructure"},
-                    {mfa,         {rabbit_channel_tracking, boot, []}},
-                    {enables,     routing_ready}]}).
-
 -rabbit_boot_step({background_gc,
                    [{description, "background garbage collection"},
                     {mfa,         {rabbit_sup, start_restartable_child,

--- a/deps/rabbit/src/rabbit_channel_tracking.erl
+++ b/deps/rabbit/src/rabbit_channel_tracking.erl
@@ -17,8 +17,7 @@
 %%  * rabbit_event
 -behaviour(rabbit_tracking).
 
--export([boot/0,
-         update_tracked/1,
+-export([update_tracked/1,
          handle_cast/1,
          register_tracked/1,
          unregister_tracked/1,
@@ -43,12 +42,6 @@
 %%
 %% API
 %%
-
-%% Sets up and resets channel tracking tables for this node.
--spec boot() -> ok.
-
-boot() ->
-    ok.
 
 -spec update_tracked(term()) -> ok.
 

--- a/deps/rabbit/src/rabbit_channel_tracking.erl
+++ b/deps/rabbit/src/rabbit_channel_tracking.erl
@@ -23,7 +23,6 @@
          register_tracked/1,
          unregister_tracked/1,
          count_tracked_items_in/1,
-         clear_tracking_tables/0,
          shutdown_tracked_items/2]).
 
 -export([list/0, list_of_user/1, list_on_node/1,
@@ -33,10 +32,6 @@
          delete_tracked_channel_user_entry/1]).
 
 -export([count_local_tracked_items_of_user/1]).
-
--ifdef(TEST).
--export([get_all_tracked_channel_table_names_for_node/1]).
--endif.
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -53,9 +48,6 @@
 -spec boot() -> ok.
 
 boot() ->
-    ensure_tracked_channels_table_for_this_node(),
-    ensure_per_user_tracked_channels_table_for_node(),
-    clear_tracking_tables(),
     ok.
 
 -spec update_tracked(term()) -> ok.
@@ -115,30 +107,13 @@ handle_cast({user_deleted, Details}) ->
     %% Schedule user entry deletion, allowing time for connections to close
     _ = timer:apply_after(?TRACKING_EXECUTION_TIMEOUT, ?MODULE,
             delete_tracked_channel_user_entry, [Username]),
-    ok;
-handle_cast({node_deleted, Details}) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            Node = pget(node, Details),
-            rabbit_log_channel:info(
-              "Node '~ts' was removed from the cluster, deleting"
-              " its channel tracking tables...", [Node]),
-            delete_tracked_channels_table_for_node(Node),
-            delete_per_user_tracked_channels_table_for_node(Node)
-    end.
+    ok.
 
 -spec register_tracked(rabbit_types:tracked_channel()) -> ok.
 -dialyzer([{nowarn_function, [register_tracked/1]}]).
 
-register_tracked(TrackedCh = #tracked_channel{node = Node}) when Node == node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> register_tracked_ets(TrackedCh);
-        false -> register_tracked_mnesia(TrackedCh)
-    end.
-
-register_tracked_ets(TrackedCh = #tracked_channel{pid = ChPid, username = Username}) ->
+register_tracked(TrackedCh = #tracked_channel{pid = ChPid, username = Username,
+                                              node = Node}) when Node == node() ->
     case ets:lookup(?TRACKED_CHANNEL_TABLE, ChPid) of
         []    ->
             ets:insert(?TRACKED_CHANNEL_TABLE, TrackedCh),
@@ -149,45 +124,13 @@ register_tracked_ets(TrackedCh = #tracked_channel{pid = ChPid, username = Userna
     end,
     ok.
 
-register_tracked_mnesia(TrackedCh =
-                            #tracked_channel{node = Node, name = Name, username = Username}) ->
-    ChId = rabbit_tracking:id(Node, Name),
-    TableName = tracked_channel_table_name_for(Node),
-    PerUserChTableName = tracked_channel_per_user_table_name_for(Node),
-    case mnesia:dirty_read(TableName, ChId) of
-      []    ->
-          mnesia:dirty_write(TableName, TrackedCh),
-          mnesia:dirty_update_counter(PerUserChTableName, Username, 1),
-            ok;
-      [#tracked_channel{}] ->
-          ok
-    end,
-    ok.
-
 -spec unregister_tracked_by_pid(pid()) -> any().
 unregister_tracked_by_pid(ChPid) when node(ChPid) == node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> unregister_tracked_by_pid_ets(ChPid);
-        false -> unregister_tracked_by_pid_mnesia(ChPid)
-    end.
-
-unregister_tracked_by_pid_ets(ChPid) ->
     case ets:lookup(?TRACKED_CHANNEL_TABLE, ChPid) of
         []     -> ok;
         [#tracked_channel{username = Username}] ->
             ets:update_counter(?TRACKED_CHANNEL_TABLE_PER_USER, Username, -1),
             ets:delete(?TRACKED_CHANNEL_TABLE, ChPid)
-    end.
-
-unregister_tracked_by_pid_mnesia(ChPid) ->
-    case get_tracked_channel_by_pid_mnesia(ChPid) of
-        []     -> ok;
-        [#tracked_channel{id = ChId, node = Node, username = Username}] ->
-            TableName = tracked_channel_table_name_for(Node),
-            PerUserChannelTableName = tracked_channel_per_user_table_name_for(Node),
-
-            mnesia:dirty_update_counter(PerUserChannelTableName, Username, -1),
-            mnesia:dirty_delete(TableName, ChId)
     end.
 
 %% @doc This function is exported and implements a rabbit_tracking
@@ -196,38 +139,16 @@ unregister_tracked_by_pid_mnesia(ChPid) ->
 %% on it.
 -spec unregister_tracked(rabbit_types:tracked_channel_id()) -> ok.
 unregister_tracked(ChId = {Node, _Name}) when Node == node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> unregister_tracked_ets(ChId);
-        false -> unregister_tracked_mnesia(ChId)
-    end.
-
-unregister_tracked_ets(ChId) ->
-    case get_tracked_channel_by_id_ets(ChId) of
+    case get_tracked_channel_by_id(ChId) of
         []     -> ok;
         [#tracked_channel{pid = ChPid, username = Username}] ->
             ets:update_counter(?TRACKED_CHANNEL_TABLE_PER_USER, Username, -1),
             ets:delete(?TRACKED_CHANNEL_TABLE, ChPid)
     end.
 
-unregister_tracked_mnesia(ChId = {Node, _Name}) when Node =:= node() ->
-    TableName = tracked_channel_table_name_for(Node),
-    PerUserChannelTableName = tracked_channel_per_user_table_name_for(Node),
-    case mnesia:dirty_read(TableName, ChId) of
-        []     -> ok;
-        [#tracked_channel{username = Username}] ->
-            mnesia:dirty_update_counter(PerUserChannelTableName, Username, -1),
-            mnesia:dirty_delete(TableName, ChId)
-    end.
-
 -spec count_tracked_items_in({atom(), rabbit_types:username()}) -> non_neg_integer().
 
-count_tracked_items_in(Type) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> count_tracked_items_in_ets(Type);
-        false -> count_tracked_items_in_mnesia(Type)
-    end.
-
-count_tracked_items_in_ets({user, Username}) ->
+count_tracked_items_in({user, Username}) ->
     rabbit_tracking:count_on_all_nodes(
       ?MODULE, count_local_tracked_items_of_user, [Username],
       ["channels of user ", Username]).
@@ -235,20 +156,6 @@ count_tracked_items_in_ets({user, Username}) ->
 -spec count_local_tracked_items_of_user(rabbit_types:username()) -> non_neg_integer().
 count_local_tracked_items_of_user(Username) ->
     rabbit_tracking:read_ets_counter(?TRACKED_CHANNEL_TABLE_PER_USER, Username).
-
-count_tracked_items_in_mnesia({user, Username}) ->
-    rabbit_tracking:count_tracked_items_mnesia(
-        fun tracked_channel_per_user_table_name_for/1,
-        #tracked_channel_per_user.channel_count, Username,
-        "channels of user").
-
--spec clear_tracking_tables() -> ok.
-
-clear_tracking_tables() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> ok;
-        false -> clear_tracked_channel_tables_for_this_node()
-    end.
 
 -spec shutdown_tracked_items(list(), term()) -> ok.
 
@@ -267,50 +174,18 @@ list() ->
 -spec list_of_user(rabbit_types:username()) -> [rabbit_types:tracked_channel()].
 
 list_of_user(Username) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> list_of_user_ets(Username);
-        false -> list_of_user_mnesia(Username)
-    end.
-
-list_of_user_ets(Username) ->
-    rabbit_tracking:match_tracked_items_ets(
+    rabbit_tracking:match_tracked_items(
       ?TRACKED_CHANNEL_TABLE,
       #tracked_channel{username = Username, _ = '_'}).
 
-list_of_user_mnesia(Username) ->
-    rabbit_tracking:match_tracked_items_mnesia(
-        fun tracked_channel_table_name_for/1,
-        #tracked_channel{username = Username, _ = '_'}).
-
 -spec list_on_node(node()) -> [rabbit_types:tracked_channel()].
+list_on_node(Node) when Node == node() ->
+    ets:tab2list(?TRACKED_CHANNEL_TABLE);
 list_on_node(Node) ->
-     case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true when Node == node() ->
-            list_on_node_ets();
-        true ->
-            case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node]) of
-                List when is_list(List) ->
-                    List;
-                _ ->
-                    []
-            end;
-        false ->
-            list_on_node_mnesia(Node)
-    end.
-
-list_on_node_ets() ->
-    ets:tab2list(?TRACKED_CHANNEL_TABLE).
-
-list_on_node_mnesia(Node) ->
-    try mnesia:dirty_match_object(
-          tracked_channel_table_name_for(Node),
-          #tracked_channel{_ = '_'})
-    catch exit:{aborted, {no_exists, _}} ->
-            %% The table might not exist yet (or is already gone)
-            %% between the time rabbit_nodes:list_running() runs and
-            %% returns a specific node, and
-            %% mnesia:dirty_match_object() is called for that node's
-            %% table.
+    case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node]) of
+        List when is_list(List) ->
+            List;
+        _ ->
             []
     end.
 
@@ -326,117 +201,31 @@ tracked_channel_per_user_table_name_for(Node) ->
         "tracked_channel_table_per_user_on_node_~ts", [Node])).
 
 ensure_tracked_tables_for_this_node() ->
-    _ = ensure_tracked_channels_table_for_this_node_ets(),
-    _ = ensure_per_user_tracked_channels_table_for_this_node_ets(),
+    _ = ensure_tracked_channels_table_for_this_node(),
+    _ = ensure_per_user_tracked_channels_table_for_this_node(),
     ok.
 
-%% internal
-ensure_tracked_channels_table_for_this_node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            ensure_tracked_channels_table_for_this_node_mnesia()
-    end.
-
-ensure_per_user_tracked_channels_table_for_node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            ensure_per_user_tracked_channels_table_for_this_node_mnesia()
-    end.
-
 %% Create tables
-ensure_tracked_channels_table_for_this_node_ets() ->
+ensure_tracked_channels_table_for_this_node() ->
     rabbit_log:info("Setting up a table for channel tracking on this node: ~tp",
                     [?TRACKED_CHANNEL_TABLE]),
     ets:new(?TRACKED_CHANNEL_TABLE, [named_table, public, {write_concurrency, true},
                                      {keypos, #tracked_channel.pid}]).
 
-ensure_tracked_channels_table_for_this_node_mnesia() ->
-    Node = node(),
-    TableName = tracked_channel_table_name_for(Node),
-    case mnesia:create_table(TableName, [{record_name, tracked_channel},
-                                         {attributes, record_info(fields, tracked_channel)}]) of
-        {atomic, ok}                   ->
-            rabbit_log:info("Setting up a table for channel tracking on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, {already_exists, _}} ->
-            rabbit_log:info("Setting up a table for channel tracking on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, Error}               ->
-            rabbit_log:error("Failed to create a tracked channel table for node ~tp: ~tp", [Node, Error]),
-            ok
-    end.
-
-ensure_per_user_tracked_channels_table_for_this_node_ets() ->
+ensure_per_user_tracked_channels_table_for_this_node() ->
     rabbit_log:info("Setting up a table for channel tracking on this node: ~tp",
                     [?TRACKED_CHANNEL_TABLE_PER_USER]),
     ets:new(?TRACKED_CHANNEL_TABLE_PER_USER, [named_table, public, {write_concurrency, true}]).
 
-ensure_per_user_tracked_channels_table_for_this_node_mnesia() ->
-    Node = node(),
-    TableName = tracked_channel_per_user_table_name_for(Node),
-    case mnesia:create_table(TableName, [{record_name, tracked_channel_per_user},
-                                         {attributes, record_info(fields, tracked_channel_per_user)}]) of
-        {atomic, ok}                   ->
-            rabbit_log:info("Setting up a table for channel tracking on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, {already_exists, _}} ->
-            rabbit_log:info("Setting up a table for channel tracking on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, Error}               ->
-            rabbit_log:error("Failed to create a per-user tracked channel table for node ~tp: ~tp", [Node, Error]),
-            ok
-    end.
-
-clear_tracked_channel_tables_for_this_node() ->
-    [rabbit_tracking:clear_tracking_table(T)
-        || T <- get_all_tracked_channel_table_names_for_node(node())].
-
-delete_tracked_channels_table_for_node(Node) ->
-    TableName = tracked_channel_table_name_for(Node),
-    rabbit_tracking:delete_tracking_table(TableName, Node, "tracked channel").
-
-delete_per_user_tracked_channels_table_for_node(Node) ->
-    TableName = tracked_channel_per_user_table_name_for(Node),
-    rabbit_tracking:delete_tracking_table(TableName, Node,
-        "per-user tracked channels").
-
-get_all_tracked_channel_table_names_for_node(Node) ->
-    [tracked_channel_table_name_for(Node),
-        tracked_channel_per_user_table_name_for(Node)].
-
 get_tracked_channels_by_connection_pid(ConnPid) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> get_tracked_channels_by_connection_pid_ets(ConnPid);
-        false -> get_tracked_channels_by_connection_pid_mnesia(ConnPid)
-    end.
-
-get_tracked_channels_by_connection_pid_ets(ConnPid) ->
     rabbit_tracking:match_tracked_items_local(
-        ?TRACKED_CHANNEL_TABLE,
-        #tracked_channel{connection = ConnPid, _ = '_'}).
+      ?TRACKED_CHANNEL_TABLE,
+      #tracked_channel{connection = ConnPid, _ = '_'}).
 
-get_tracked_channels_by_connection_pid_mnesia(ConnPid) ->
-    rabbit_tracking:match_tracked_items_mnesia(
-        fun tracked_channel_table_name_for/1,
-        #tracked_channel{connection = ConnPid, _ = '_'}).
-
-get_tracked_channel_by_id_ets(ChId) ->
-    rabbit_tracking:match_tracked_items_ets(
+get_tracked_channel_by_id(ChId) ->
+    rabbit_tracking:match_tracked_items(
         ?TRACKED_CHANNEL_TABLE,
         #tracked_channel{id = ChId, _ = '_'}).
-
-get_tracked_channel_by_pid_mnesia(ChPid) ->
-    rabbit_tracking:match_tracked_items_mnesia(
-        fun tracked_channel_table_name_for/1,
-        #tracked_channel{pid = ChPid, _ = '_'}).
 
 delete_tracked_channel_user_entry(Username) ->
     rabbit_tracking:delete_tracked_entry(

--- a/deps/rabbit/src/rabbit_channel_tracking_handler.erl
+++ b/deps/rabbit/src/rabbit_channel_tracking_handler.erl
@@ -29,7 +29,7 @@
                                    [rabbit_event, ?MODULE, []]}},
                     {cleanup,     {gen_event, delete_handler,
                                    [rabbit_event, ?MODULE, []]}},
-                    {requires,    [channel_tracking]},
+                    {requires,    [tracking_metadata_store]},
                     {enables,     recovery}]}).
 
 %%

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -23,13 +23,11 @@
          register_tracked/1,
          unregister_tracked/1,
          count_tracked_items_in/1,
-         clear_tracking_tables/0,
          shutdown_tracked_items/2]).
 
 -export([tracked_connection_table_name_for/1,
          tracked_connection_per_vhost_table_name_for/1,
          tracked_connection_per_user_table_name_for/1,
-         clear_tracked_connection_tables_for_this_node/0,
 
          ensure_tracked_tables_for_this_node/0,
 
@@ -42,10 +40,6 @@
 
 -export([count_local_tracked_items_in_vhost/1,
          count_local_tracked_items_of_user/1]).
-
--ifdef(TEST).
--export([get_all_tracked_connection_table_names_for_node/1]).
--endif.
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -68,10 +62,6 @@
 %% Sets up and resets connection tracking tables for this
 %% node.
 boot() ->
-    ensure_tracked_connections_table_for_this_node(),
-    ensure_per_vhost_tracked_connections_table_for_this_node(),
-    ensure_per_user_tracked_connections_table_for_this_node(),
-    clear_tracking_tables(),
     ok.
 
 -spec update_tracked(term()) -> ok.
@@ -148,32 +138,14 @@ handle_cast({user_deleted, Details}) ->
     rabbit_log_connection:info("Closing all connections from user '~ts' because it's being deleted", [Username]),
     shutdown_tracked_items(
         rabbit_connection_tracking:list_of_user(Username),
-        rabbit_misc:format("user '~ts' is deleted", [Username]));
-%% A node had been deleted from the cluster.
-handle_cast({node_deleted, Details}) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            Node = pget(node, Details),
-            rabbit_log_connection:info("Node '~ts' was removed from the cluster, deleting its connection tracking tables...", [Node]),
-            delete_tracked_connections_table_for_node(Node),
-            delete_per_vhost_tracked_connections_table_for_node(Node),
-            delete_per_user_tracked_connections_table_for_node(Node)
-    end.
+        rabbit_misc:format("user '~ts' is deleted", [Username])).
 
 -spec register_tracked(rabbit_types:tracked_connection()) -> ok.
 -dialyzer([{nowarn_function, [register_tracked/1]}]).
 
-register_tracked(#tracked_connection{node = Node} = Conn) when Node =:= node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> register_tracked_ets(Conn);
-        false -> register_tracked_mnesia(Conn)
-    end.
-
-register_tracked_ets(#tracked_connection{username = Username, vhost = VHost, id = ConnId} = Conn) ->
+register_tracked(#tracked_connection{username = Username, vhost = VHost, id = ConnId, node = Node} = Conn) when Node =:= node() ->
     _ = case ets:lookup(?TRACKED_CONNECTION_TABLE, ConnId) of
-        []    ->
+            []    ->
             ets:insert(?TRACKED_CONNECTION_TABLE, Conn),
             ets:update_counter(?TRACKED_CONNECTION_TABLE_PER_VHOST, VHost, 1, {VHost, 0}),
             ets:update_counter(?TRACKED_CONNECTION_TABLE_PER_USER, Username, 1, {Username, 0});
@@ -182,30 +154,8 @@ register_tracked_ets(#tracked_connection{username = Username, vhost = VHost, id 
     end,
     ok.
 
-register_tracked_mnesia(#tracked_connection{username = Username, vhost = VHost, id = ConnId, node = Node} = Conn) ->
-    TableName = tracked_connection_table_name_for(Node),
-    PerVhostTableName = tracked_connection_per_vhost_table_name_for(Node),
-    PerUserConnTableName = tracked_connection_per_user_table_name_for(Node),
-    %% upsert
-    case mnesia:dirty_read(TableName, ConnId) of
-        []    ->
-            mnesia:dirty_write(TableName, Conn),
-            mnesia:dirty_update_counter(PerVhostTableName, VHost, 1),
-            mnesia:dirty_update_counter(PerUserConnTableName, Username, 1),
-            ok;
-        [#tracked_connection{}] ->
-            ok
-    end,
-    ok.
-
 -spec unregister_tracked(rabbit_types:tracked_connection_id()) -> ok.
 unregister_tracked(ConnId = {Node, _Name}) when Node =:= node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> unregister_tracked_ets(ConnId);
-        false -> unregister_tracked_mnesia(ConnId)
-    end.
-
-unregister_tracked_ets(ConnId) ->
     case ets:lookup(?TRACKED_CONNECTION_TABLE, ConnId) of
         []     -> ok;
         [#tracked_connection{vhost = VHost, username = Username}] ->
@@ -214,30 +164,12 @@ unregister_tracked_ets(ConnId) ->
             ets:delete(?TRACKED_CONNECTION_TABLE, ConnId)
     end.
 
-unregister_tracked_mnesia(ConnId = {Node, _Name}) ->
-    TableName = tracked_connection_table_name_for(Node),
-    PerVhostTableName = tracked_connection_per_vhost_table_name_for(Node),
-    PerUserConnTableName = tracked_connection_per_user_table_name_for(Node),
-    case mnesia:dirty_read(TableName, ConnId) of
-        []     -> ok;
-        [#tracked_connection{vhost = VHost, username = Username}] ->
-            mnesia:dirty_update_counter(PerUserConnTableName, Username, -1),
-            mnesia:dirty_update_counter(PerVhostTableName, VHost, -1),
-            mnesia:dirty_delete(TableName, ConnId)
-    end.
-
 -spec count_tracked_items_in({atom(), rabbit_types:vhost()}) -> non_neg_integer().
-count_tracked_items_in(Type) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> count_tracked_items_in_ets(Type);
-        false -> count_tracked_items_in_mnesia(Type)
-    end.
-
-count_tracked_items_in_ets({vhost, VirtualHost}) ->
+count_tracked_items_in({vhost, VirtualHost}) ->
     rabbit_tracking:count_on_all_nodes(
       ?MODULE, count_local_tracked_items_in_vhost, [VirtualHost],
       ["connections in vhost ", VirtualHost]);
-count_tracked_items_in_ets({user, Username}) ->
+count_tracked_items_in({user, Username}) ->
     rabbit_tracking:count_on_all_nodes(
       ?MODULE, count_local_tracked_items_of_user, [Username],
       ["connections for user ", Username]).
@@ -250,25 +182,6 @@ count_local_tracked_items_in_vhost(VirtualHost) ->
 count_local_tracked_items_of_user(Username) ->
     rabbit_tracking:read_ets_counter(?TRACKED_CONNECTION_TABLE_PER_USER, Username).
 
-count_tracked_items_in_mnesia({vhost, VirtualHost}) ->
-    rabbit_tracking:count_tracked_items_mnesia(
-        fun tracked_connection_per_vhost_table_name_for/1,
-        #tracked_connection_per_vhost.connection_count, VirtualHost,
-        "connections in vhost");
-count_tracked_items_in_mnesia({user, Username}) ->
-    rabbit_tracking:count_tracked_items_mnesia(
-        fun tracked_connection_per_user_table_name_for/1,
-        #tracked_connection_per_user.connection_count, Username,
-        "connections for user").
-
--spec clear_tracking_tables() -> ok.
-
-clear_tracking_tables() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> ok;
-        false -> clear_tracked_connection_tables_for_this_node()
-    end.
-
 -spec shutdown_tracked_items(list(), term()) -> ok.
 
 shutdown_tracked_items(TrackedItems, Message) ->
@@ -277,135 +190,25 @@ shutdown_tracked_items(TrackedItems, Message) ->
 %% Extended API
 
 ensure_tracked_tables_for_this_node() ->
-    ensure_tracked_connections_table_for_this_node_ets(),
-    _ = ensure_per_vhost_tracked_connections_table_for_this_node_ets(),
-    ensure_per_user_tracked_connections_table_for_this_node_ets().
-
--spec ensure_tracked_connections_table_for_this_node() -> ok.
+    ensure_tracked_connections_table_for_this_node(),
+    _ = ensure_per_vhost_tracked_connections_table_for_this_node(),
+    ensure_per_user_tracked_connections_table_for_this_node().
 
 ensure_tracked_connections_table_for_this_node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            ensure_tracked_connections_table_for_this_node_mnesia()
-    end.
-
-ensure_tracked_connections_table_for_this_node_ets() ->
     _ = ets:new(?TRACKED_CONNECTION_TABLE, [named_table, public, {write_concurrency, true},
                                         {keypos, #tracked_connection.id}]),
     rabbit_log:info("Setting up a table for connection tracking on this node: ~tp",
                     [?TRACKED_CONNECTION_TABLE]).
 
-ensure_tracked_connections_table_for_this_node_mnesia() ->
-    Node = node(),
-    TableName = tracked_connection_table_name_for(Node),
-    case mnesia:create_table(TableName, [{record_name, tracked_connection},
-                                         {attributes, record_info(fields, tracked_connection)}]) of
-        {atomic, ok}                   ->
-            rabbit_log:info("Setting up a table for connection tracking on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, {already_exists, _}} ->
-            rabbit_log:info("Setting up a table for connection tracking on this node: ~tp",
-                            [TableName]);
-        {aborted, Error}               ->
-            rabbit_log:error("Failed to create a tracked connection table for node ~tp: ~tp", [Node, Error]),
-            ok
-    end.
-
--spec ensure_per_vhost_tracked_connections_table_for_this_node() -> ok.
-
 ensure_per_vhost_tracked_connections_table_for_this_node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            ensure_per_vhost_tracked_connections_table_for_this_node_mnesia()
-    end.
-
-ensure_per_vhost_tracked_connections_table_for_this_node_ets() ->
     rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~tp",
                     [?TRACKED_CONNECTION_TABLE_PER_VHOST]),
     ets:new(?TRACKED_CONNECTION_TABLE_PER_VHOST, [named_table, public, {write_concurrency, true}]).
 
-ensure_per_vhost_tracked_connections_table_for_this_node_mnesia() ->
-    Node = node(),
-    TableName = tracked_connection_per_vhost_table_name_for(Node),
-    case mnesia:create_table(TableName, [{record_name, tracked_connection_per_vhost},
-                                         {attributes, record_info(fields, tracked_connection_per_vhost)}]) of
-        {atomic, ok}                   ->
-            rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, {already_exists, _}} ->
-            rabbit_log:info("Setting up a table for per-vhost connection counting on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, Error}               ->
-            rabbit_log:error("Failed to create a per-vhost tracked connection table for node ~tp: ~tp", [Node, Error]),
-            ok
-    end.
-
--spec ensure_per_user_tracked_connections_table_for_this_node() -> ok.
-
 ensure_per_user_tracked_connections_table_for_this_node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            ok;
-        false ->
-            ensure_per_user_tracked_connections_table_for_this_node_mnesia()
-    end.
-
-ensure_per_user_tracked_connections_table_for_this_node_ets() ->
     _ = ets:new(?TRACKED_CONNECTION_TABLE_PER_USER, [named_table, public, {write_concurrency, true}]),
     rabbit_log:info("Setting up a table for per-user connection counting on this node: ~tp",
                     [?TRACKED_CONNECTION_TABLE_PER_USER]).
-
-ensure_per_user_tracked_connections_table_for_this_node_mnesia() ->
-    Node = node(),
-    TableName = tracked_connection_per_user_table_name_for(Node),
-    case mnesia:create_table(TableName, [{record_name, tracked_connection_per_user},
-                                         {attributes, record_info(fields, tracked_connection_per_user)}]) of
-        {atomic, ok}                   ->
-            rabbit_log:info("Setting up a table for per-user connection counting on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, {already_exists, _}} ->
-            rabbit_log:info("Setting up a table for per-user connection counting on this node: ~tp",
-                            [TableName]),
-            ok;
-        {aborted, Error}               ->
-            rabbit_log:error("Failed to create a per-user tracked connection table for node ~tp: ~tp", [Node, Error]),
-            ok
-    end.
-
--spec clear_tracked_connection_tables_for_this_node() -> ok.
-
-clear_tracked_connection_tables_for_this_node() ->
-    [rabbit_tracking:clear_tracking_table(T)
-        || T <- get_all_tracked_connection_table_names_for_node(node())],
-    ok.
-
--spec delete_tracked_connections_table_for_node(node()) -> ok.
-
-delete_tracked_connections_table_for_node(Node) ->
-    TableName = tracked_connection_table_name_for(Node),
-    rabbit_tracking:delete_tracking_table(TableName, Node, "tracked connection").
-
--spec delete_per_vhost_tracked_connections_table_for_node(node()) -> ok.
-
-delete_per_vhost_tracked_connections_table_for_node(Node) ->
-    TableName = tracked_connection_per_vhost_table_name_for(Node),
-    rabbit_tracking:delete_tracking_table(TableName, Node,
-        "per-vhost tracked connection").
-
--spec delete_per_user_tracked_connections_table_for_node(node()) -> ok.
-
-delete_per_user_tracked_connections_table_for_node(Node) ->
-    TableName = tracked_connection_per_user_table_name_for(Node),
-    rabbit_tracking:delete_tracking_table(TableName, Node,
-                                          "per-user tracked connection").
 
 -spec tracked_connection_table_name_for(node()) -> atom().
 
@@ -422,13 +225,6 @@ tracked_connection_per_vhost_table_name_for(Node) ->
 tracked_connection_per_user_table_name_for(Node) ->
     list_to_atom(rabbit_misc:format(
         "tracked_connection_table_per_user_on_node_~ts", [Node])).
-
--spec get_all_tracked_connection_table_names_for_node(node()) -> [atom()].
-
-get_all_tracked_connection_table_names_for_node(Node) ->
-    [tracked_connection_table_name_for(Node),
-        tracked_connection_per_vhost_table_name_for(Node),
-            tracked_connection_per_user_table_name_for(Node)].
 
 -spec lookup(rabbit_types:connection_name()) -> rabbit_types:tracked_connection() | 'not_found'.
 
@@ -450,17 +246,7 @@ lookup(Name, [Node | Nodes]) ->
     end.
 
 lookup_internal(Name, Node) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> lookup_ets(Name, Node);
-        false -> lookup_mnesia(Name, Node)
-    end.
-
-lookup_ets(Name, Node) ->
     ets:lookup(?TRACKED_CONNECTION_TABLE, {Node, Name}).
-
-lookup_mnesia(Name, Node) ->
-    TableName = tracked_connection_table_name_for(Node),
-    mnesia:dirty_read(TableName, {Node, Name}).
 
 -spec list() -> [rabbit_types:tracked_connection()].
 
@@ -478,129 +264,56 @@ count() ->
               count_on_node(Node) + Acc
       end, 0, rabbit_nodes:list_running()).
 
-count_on_node(Node) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true when Node == node() ->
-            count_on_node_ets();
-        true ->
-            case rabbit_misc:rpc_call(Node, ?MODULE, count_on_node, [Node]) of
-                Int when is_integer(Int) ->
-                    Int;
-                _ ->
-                    0
-            end;
-        false ->
-            count_on_node_mnesia(Node)
-    end.
-
-count_on_node_ets() ->
+count_on_node(Node) when Node == node() ->
     case ets:info(?TRACKED_CONNECTION_TABLE, size) of
         undefined -> 0;
         Size -> Size
+    end;
+count_on_node(Node) ->
+    case rabbit_misc:rpc_call(Node, ?MODULE, count_on_node, [Node]) of
+        Int when is_integer(Int) ->
+            Int;
+        _ ->
+            0
     end.
-
-count_on_node_mnesia(Node) ->
-    Tab = tracked_connection_table_name_for(Node),
-    %% mnesia:table_info() returns 0 if the table doesn't exist. We
-    %% don't need the same kind of protection as the list() function
-    %% above.
-    mnesia:table_info(Tab, size).
 
 -spec list(rabbit_types:vhost()) -> [rabbit_types:tracked_connection()].
 
 list(VHost) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> list_ets(VHost);
-        false -> list_mnesia(VHost)
-    end.
-
-list_ets(VHost) ->
-    rabbit_tracking:match_tracked_items_ets(
+    rabbit_tracking:match_tracked_items(
         ?TRACKED_CONNECTION_TABLE,
         #tracked_connection{vhost = VHost, _ = '_'}).
 
-list_mnesia(VHost) ->
-    rabbit_tracking:match_tracked_items_mnesia(
-        fun tracked_connection_table_name_for/1,
-        #tracked_connection{vhost = VHost, _ = '_'}).
-
 -spec list_on_node(node()) -> [rabbit_types:tracked_connection()].
+list_on_node(Node) when Node == node() ->
+    ets:tab2list(?TRACKED_CONNECTION_TABLE);
 list_on_node(Node) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true when Node == node() ->
-            list_on_node_ets();
-        true ->
-            case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node]) of
-                List when is_list(List) ->
-                    List;
-                _ ->
-                    []
-            end;
-        false ->
-            list_on_node_mnesia(Node)
-    end.
-
-list_on_node_ets() ->
-    ets:tab2list(?TRACKED_CONNECTION_TABLE).
-
-list_on_node_mnesia(Node) ->
-    try mnesia:dirty_match_object(
-          tracked_connection_table_name_for(Node),
-          #tracked_connection{_ = '_'})
-    catch exit:{aborted, {no_exists, _}} ->
-            %% The table might not exist yet (or is already gone)
-            %% between the time rabbit_nodes:list_running() runs and
-            %% returns a specific node, and
-            %% mnesia:dirty_match_object() is called for that node's
-            %% table.
+    case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node]) of
+        List when is_list(List) ->
+            List;
+        _ ->
             []
     end.
 
 -spec list_on_node(node(), rabbit_types:vhost()) -> [rabbit_types:tracked_connection()].
 
-list_on_node(Node, VHost) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true when Node == node() ->
-            list_on_node_ets(VHost);
-        true ->
-            case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node, VHost]) of
-                List when is_list(List) ->
-                    List;
-                _ ->
-                    []
-            end;
-        false ->
-            list_on_node_mnesia(Node, VHost)
-    end.
-
-list_on_node_ets(VHost) ->
+list_on_node(Node, VHost) when Node == node() ->
     ets:match_object(?TRACKED_CONNECTION_TABLE,
-                     #tracked_connection{vhost = VHost, _ = '_'}).
-
-list_on_node_mnesia(Node, VHost) ->
-    try mnesia:dirty_match_object(
-          tracked_connection_table_name_for(Node),
-          #tracked_connection{vhost = VHost, _ = '_'})
-    catch exit:{aborted, {no_exists, _}} -> []
+                     #tracked_connection{vhost = VHost, _ = '_'});
+list_on_node(Node, VHost) ->
+    case rabbit_misc:rpc_call(Node, ?MODULE, list_on_node, [Node, VHost]) of
+        List when is_list(List) ->
+            List;
+        _ ->
+            []
     end.
 
 -spec list_of_user(rabbit_types:username()) -> [rabbit_types:tracked_connection()].
 
 list_of_user(Username) ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true -> list_of_user_ets(Username);
-        false -> list_of_user_mnesia(Username)
-    end.
-
-list_of_user_ets(Username) ->
-    rabbit_tracking:match_tracked_items_ets(
+    rabbit_tracking:match_tracked_items(
       ?TRACKED_CONNECTION_TABLE,
       #tracked_connection{username = Username, _ = '_'}).
-
-list_of_user_mnesia(Username) ->
-    rabbit_tracking:match_tracked_items_mnesia(
-        fun tracked_connection_table_name_for/1,
-        #tracked_connection{username = Username, _ = '_'}).
 
 %% Internal, delete tracked entries
 

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -17,8 +17,7 @@
 %%  * rabbit_event
 -behaviour(rabbit_tracking).
 
--export([boot/0,
-         update_tracked/1,
+-export([update_tracked/1,
          handle_cast/1,
          register_tracked/1,
          unregister_tracked/1,
@@ -56,13 +55,6 @@
 %%
 
 %% Behaviour callbacks
-
--spec boot() -> ok.
-
-%% Sets up and resets connection tracking tables for this
-%% node.
-boot() ->
-    ok.
 
 -spec update_tracked(term()) -> ok.
 

--- a/deps/rabbit/src/rabbit_connection_tracking_handler.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking_handler.erl
@@ -29,7 +29,7 @@
                                    [rabbit_event, ?MODULE, []]}},
                     {cleanup,     {gen_event, delete_handler,
                                    [rabbit_event, ?MODULE, []]}},
-                    {requires,    [connection_tracking]},
+                    {requires,    [tracking_metadata_store]},
                     {enables,     recovery}]}).
 
 %%

--- a/deps/rabbit/src/rabbit_connection_tracking_handler.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking_handler.erl
@@ -57,10 +57,6 @@ handle_event(#event{type = vhost_down, props = Details}, State) ->
 handle_event(#event{type = user_deleted, props = Details}, State) ->
     ok = rabbit_connection_tracking:update_tracked({user_deleted, Details}),
     {ok, State};
-%% A node had been deleted from the cluster.
-handle_event(#event{type = node_deleted, props = Details}, State) ->
-    ok = rabbit_connection_tracking:update_tracked({node_deleted, Details}),
-    {ok, State};
 handle_event(_Event, State) ->
     {ok, State}.
 

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -86,7 +86,6 @@
 -rabbit_feature_flag(
    {tracking_records_in_ets,
     #{desc          => "Store tracking records in ETS instead of Mnesia",
-      %%TODO remove compatibility code
       stability     => required,
       depends_on    => [feature_flags_v2]
      }}).

--- a/deps/rabbit/src/rabbit_tracking.erl
+++ b/deps/rabbit/src/rabbit_tracking.erl
@@ -13,7 +13,6 @@
 %%  * rabbit_connection_tracking
 %%  * rabbit_channel_tracking
 
--callback boot() -> ok.
 -callback update_tracked(term()) -> ok.
 -callback handle_cast(term()) -> ok.
 -callback register_tracked(

--- a/deps/rabbit/src/rabbit_tracking.erl
+++ b/deps/rabbit/src/rabbit_tracking.erl
@@ -23,14 +23,11 @@
               rabbit_types:tracked_connection_id() |
                   rabbit_types:tracked_channel_id()) -> 'ok'.
 -callback count_tracked_items_in(term()) -> non_neg_integer().
--callback clear_tracking_tables() -> 'ok'.
 -callback shutdown_tracked_items(list(), term()) -> ok.
 
--export([id/2, delete_tracked_entry/4, delete_tracked_entry_internal/4,
-         clear_tracking_table/1, delete_tracking_table/3]).
--export([count_on_all_nodes/4, match_tracked_items_ets/2]).
+-export([id/2, delete_tracked_entry/4, delete_tracked_entry_internal/4]).
+-export([count_on_all_nodes/4, match_tracked_items/2]).
 -export([read_ets_counter/2, match_tracked_items_local/2]).
--export([count_tracked_items_mnesia/4, match_tracked_items_mnesia/2]).
 
 %%----------------------------------------------------------------------------
 
@@ -67,26 +64,8 @@ read_ets_counter(Tab, Key) ->
         [{_, Val}] -> Val
     end.
 
-count_tracked_items_mnesia(TableNameFun, CountRecPosition, Key, ContextMsg) ->
-    lists:foldl(fun (Node, Acc) ->
-                        Tab = TableNameFun(Node),
-                        try
-                            N = case mnesia:dirty_read(Tab, Key) of
-                                    []    -> 0;
-                                    [Val] ->
-                                        element(CountRecPosition, Val)
-                                end,
-                            Acc + N
-                        catch _:Err  ->
-                                rabbit_log:error(
-                                  "Failed to fetch number of ~tp ~tp on node ~tp:~n~tp",
-                                  [ContextMsg, Key, Node, Err]),
-                                Acc
-                        end
-                end, 0, rabbit_nodes:list_running()).
-
--spec match_tracked_items_ets(atom(), tuple()) -> term().
-match_tracked_items_ets(Tab, MatchSpec) ->
+-spec match_tracked_items(atom(), tuple()) -> term().
+match_tracked_items(Tab, MatchSpec) ->
     lists:foldl(
       fun (Node, Acc) when Node == node() ->
               Acc ++ match_tracked_items_local(Tab, MatchSpec);
@@ -103,34 +82,6 @@ match_tracked_items_ets(Tab, MatchSpec) ->
 match_tracked_items_local(Tab, MatchSpec) ->
     ets:match_object(Tab, MatchSpec).
 
-match_tracked_items_mnesia(TableNameFun, MatchSpec) ->
-    lists:foldl(
-        fun (Node, Acc) ->
-                Tab = TableNameFun(Node),
-                Acc ++ mnesia:dirty_match_object(
-                         Tab,
-                         MatchSpec)
-        end, [], rabbit_nodes:list_running()).
-
--spec clear_tracking_table(atom()) -> ok.
-clear_tracking_table(TableName) ->
-    case mnesia:clear_table(TableName) of
-        {atomic, ok} -> ok;
-        {aborted, _} -> ok
-    end.
-
--spec delete_tracking_table(atom(), node(), string()) -> ok.
-
-delete_tracking_table(TableName, Node, ContextMsg) ->
-    case mnesia:delete_table(TableName) of
-        {atomic, ok}              -> ok;
-        {aborted, {no_exists, _}} -> ok;
-        {aborted, Error} ->
-            rabbit_log:error("Failed to delete a ~tp table for node ~tp: ~tp",
-                [ContextMsg, Node, Error]),
-            ok
-    end.
-
 -spec delete_tracked_entry({atom(), atom(), list()}, atom(), function(), term()) -> ok.
 delete_tracked_entry(_ExistsCheckSpec = {M, F, A}, TableName, TableNameFun, Key) ->
     ClusterNodes = rabbit_nodes:list_running(),
@@ -144,15 +95,9 @@ delete_tracked_entry(_ExistsCheckSpec = {M, F, A}, TableName, TableNameFun, Key)
             ok
     end.
 
-delete_tracked_entry_internal(Node, Tab, TableNameFun, Key) when Node == node() ->
-    case rabbit_feature_flags:is_enabled(tracking_records_in_ets) of
-        true ->
-            true = ets:delete(Tab, Key),
-            ok;
-        false ->
-            mnesia:dirty_delete(TableNameFun(Node), Key),
-            ok
-    end;
+delete_tracked_entry_internal(Node, Tab, _TableNameFun, Key) when Node == node() ->
+    true = ets:delete(Tab, Key),
+    ok;
 delete_tracked_entry_internal(Node, Tab, TableNameFun, Key) ->
     case rabbit_misc:rpc_call(Node, ?MODULE, delete_tracked_entry_internal, [Node, Tab, TableNameFun, Key]) of
         ok ->

--- a/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_channel_limit_SUITE.erl
@@ -110,28 +110,10 @@ end_per_group(_Group, Config) ->
 
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
-    clear_all_connection_tracking_tables(Config),
-    clear_all_channel_tracking_tables(Config),
     Config.
 
 end_per_testcase(Testcase, Config) ->
-    clear_all_connection_tracking_tables(Config),
-    clear_all_channel_tracking_tables(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
-
-clear_all_connection_tracking_tables(Config) ->
-    [rabbit_ct_broker_helpers:rpc(Config,
-        N,
-        rabbit_connection_tracking,
-        clear_tracking_tables,
-        []) || N <- rabbit_ct_broker_helpers:get_node_configs(Config, nodename)].
-
-clear_all_channel_tracking_tables(Config) ->
-    [rabbit_ct_broker_helpers:rpc(Config,
-        N,
-        rabbit_channel_tracking,
-        clear_tracking_tables,
-        []) || N <- rabbit_ct_broker_helpers:get_node_configs(Config, nodename)].
 
 %% -------------------------------------------------------------------
 %% Test cases.

--- a/deps/rabbit/test/per_user_connection_tracking_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_tracking_SUITE.erl
@@ -83,19 +83,10 @@ end_per_group(_Group, Config) ->
 
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
-    clear_all_connection_tracking_tables(Config),
     Config.
 
 end_per_testcase(Testcase, Config) ->
-    clear_all_connection_tracking_tables(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
-
-clear_all_connection_tracking_tables(Config) ->
-    [rabbit_ct_broker_helpers:rpc(Config,
-        N,
-        rabbit_connection_tracking,
-        clear_tracked_connection_tables_for_this_node,
-        []) || N <- rabbit_ct_broker_helpers:get_node_configs(Config, nodename)].
 
 %% -------------------------------------------------------------------
 %% Test cases.

--- a/deps/rabbit/test/per_vhost_connection_limit_SUITE.erl
+++ b/deps/rabbit/test/per_vhost_connection_limit_SUITE.erl
@@ -123,7 +123,6 @@ init_per_testcase(vhost_limit_after_node_renamed = Testcase, Config) ->
       rabbit_ct_client_helpers:setup_steps());
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
-    clear_all_connection_tracking_tables(Config),
     Config.
 
 end_per_testcase(vhost_limit_after_node_renamed = Testcase, Config) ->
@@ -133,15 +132,7 @@ end_per_testcase(vhost_limit_after_node_renamed = Testcase, Config) ->
       rabbit_ct_broker_helpers:teardown_steps()),
     rabbit_ct_helpers:testcase_finished(Config1, Testcase);
 end_per_testcase(Testcase, Config) ->
-    clear_all_connection_tracking_tables(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
-
-clear_all_connection_tracking_tables(Config) ->
-    rabbit_ct_broker_helpers:rpc_all(
-      Config,
-      rabbit_connection_tracking,
-      clear_tracked_connection_tables_for_this_node,
-      []).
 
 %% -------------------------------------------------------------------
 %% Test cases.

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -96,7 +96,6 @@ end_per_group(_Group, Config) ->
 
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
-    clear_all_connection_tracking_tables(Config),
     Config.
 
 end_per_testcase(Testcase, Config) ->
@@ -109,7 +108,6 @@ end_per_testcase(Testcase, Config) ->
             delete_vhost(Config, VHost2)
     end,
     delete_vhost(Config, VHost1),
-    clear_all_connection_tracking_tables(Config),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 delete_vhost(Config, VHost) ->
@@ -117,13 +115,6 @@ delete_vhost(Config, VHost) ->
         ok                          -> ok;
         {error, {no_such_vhost, _}} -> ok
     end.
-
-clear_all_connection_tracking_tables(Config) ->
-    [rabbit_ct_broker_helpers:rpc(Config,
-        N,
-        rabbit_connection_tracking,
-        clear_tracked_connection_tables_for_this_node,
-        []) || N <- rabbit_ct_broker_helpers:get_node_configs(Config, nodename)].
 
 %% -------------------------------------------------------------------
 %% Test cases.


### PR DESCRIPTION
Remove compatibility code for feature flag `tracking_records_in_ets` because this feature flag is required in 3.12.

See https://github.com/rabbitmq/rabbitmq-server/pull/7219

