### PR TITLE
rabbit_vhost:set_tags/2 avoids notifying if tags are unchanged

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1043,6 +1043,9 @@ rabbitmq_integration_suite(
     name = "vhost_SUITE",
     size = "medium",
     flaky = True,
+    additional_srcs = [
+        "test/test_rabbit_event_handler.erl",
+    ],
 )
 
 rabbitmq_suite(

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -132,7 +132,7 @@ merge_metadata_in_mnesia_tx(VHostName, Metadata) ->
 
 set_tags(VHostName, Tags)
   when is_binary(VHostName) andalso is_list(Tags) ->
-    ConvertedTags = [rabbit_data_coercion:to_atom(Tag) || Tag <- Tags],
+    ConvertedTags = lists:usort([rabbit_data_coercion:to_atom(Tag) || Tag <- Tags]),
     rabbit_db:run(
       #{mnesia => fun() -> set_tags_in_mnesia(VHostName, ConvertedTags) end}).
 

--- a/deps/rabbit/test/test_rabbit_event_handler.erl
+++ b/deps/rabbit/test/test_rabbit_event_handler.erl
@@ -1,0 +1,33 @@
+-module(test_rabbit_event_handler).
+
+-behaviour(gen_event).
+
+-export([okay/0]).
+-export([init/1, handle_call/2, handle_event/2, handle_info/2,
+    terminate/2, code_change/3]).
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+% an exported callable func, used to allow rabbit_ct_broker_helpers
+% to load this code when rpc'd
+okay() -> ok.
+
+init([]) ->
+    {ok, #{events => []}}.
+
+handle_event(#event{} = Event, #{events := Events} = State) ->
+    {ok, State#{events => [Event | Events]}};
+handle_event(_, State) ->
+    {ok, State}.
+
+handle_call(events,  #{events := Events} = State) ->
+    {ok, Events, State}.
+
+handle_info(_Info, State) ->
+    {ok, State}.
+
+terminate(_Arg, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -28,6 +28,7 @@ groups() ->
         single_node_vhost_deletion_forces_connection_closure,
         vhost_failure_forces_connection_closure,
         vhost_creation_idempotency,
+        vhost_update_idempotency,
         parse_tags
     ],
     ClusterSize2Tests = [
@@ -318,6 +319,42 @@ vhost_creation_idempotency(Config) ->
         ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
         ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost))
     after
+        rabbit_ct_broker_helpers:delete_vhost(Config, VHost)
+    end.
+
+vhost_update_idempotency(Config) ->
+    VHost = <<"update-idempotency-test">>,
+    ActingUser = <<"acting-user">>,
+    try
+        % load the dummy event handler on the node
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, test_rabbit_event_handler, okay, []),
+
+        ok = rabbit_ct_broker_helpers:rpc(Config, 0, gen_event, add_handler,
+                                          [rabbit_event, test_rabbit_event_handler, []]),
+
+        ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+
+        ?assertMatch({vhost,VHost, [], #{tags := [private,replicate]}},
+                     rabbit_ct_broker_helpers:rpc(Config, 0,
+                                                  rabbit_vhost, update_tags,
+                                                  [VHost, [private, replicate], ActingUser])),
+        ?assertMatch({vhost,VHost, [], #{tags := [private,replicate]}},
+                     rabbit_ct_broker_helpers:rpc(Config, 0,
+                                                  rabbit_vhost, update_tags,
+                                                  [VHost, [replicate, private], ActingUser])),
+
+        Events = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                              gen_event, call,
+                                              [rabbit_event, test_rabbit_event_handler, events, 100]),
+        ct:pal(?LOW_IMPORTANCE, "Events: ~p", [lists:reverse(Events)]),
+        TagsSetEvents = lists:filter(fun
+                                         (#event{type = vhost_tags_set}) -> true;
+                                         (_) -> false
+                                     end, Events),
+        ?assertMatch([#event{}], TagsSetEvents)
+    after
+        rabbit_ct_broker_helpers:rpc(Config, 0,
+                                     gen_event, delete_handler, [rabbit_event, test_rabbit_event_handler, []]),
         rabbit_ct_broker_helpers:delete_vhost(Config, VHost)
     end.
 

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -334,11 +334,11 @@ vhost_update_idempotency(Config) ->
 
         ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
 
-        ?assertMatch({vhost,VHost, [], #{tags := [private,replicate]}},
+        ?assertMatch({vhost,VHost, _, #{tags := [private,replicate]}},
                      rabbit_ct_broker_helpers:rpc(Config, 0,
                                                   rabbit_vhost, update_tags,
                                                   [VHost, [private, replicate], ActingUser])),
-        ?assertMatch({vhost,VHost, [], #{tags := [private,replicate]}},
+        ?assertMatch({vhost,VHost, _, #{tags := [private,replicate]}},
                      rabbit_ct_broker_helpers:rpc(Config, 0,
                                                   rabbit_vhost, update_tags,
                                                   [VHost, [replicate, private], ActingUser])),

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -351,7 +351,11 @@ vhost_update_idempotency(Config) ->
                                          (#event{type = vhost_tags_set}) -> true;
                                          (_) -> false
                                      end, Events),
-        ?assertMatch([#event{}], TagsSetEvents)
+        ?assertMatch([#event{type = vhost_tags_set,
+                             props = [{name, VHost},
+                                      {tags, [private, replicate]},
+                                      {user_who_performed_action, ActingUser}]}],
+                     TagsSetEvents)
     after
         rabbit_ct_broker_helpers:rpc(Config, 0,
                                      gen_event, delete_handler, [rabbit_event, test_rabbit_event_handler, []]),

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_tags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_tags_command_test.exs
@@ -77,7 +77,7 @@ defmodule SetVhostTagsCommandTest do
         fn record -> record[:name] == context[:vhost] end
       )
 
-    assert result[:tags] == context[:tags]
+    assert Enum.sort(result[:tags]) == Enum.sort(context[:tags])
   end
 
   @tag vhost: @vhost, tags: [:qa]


### PR DESCRIPTION
Additionally, tags are now always sorted when set