### PR TITLE
Remove compatibility for flag listener_records_in_ets

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -78,7 +78,6 @@
 -rabbit_feature_flag(
    {listener_records_in_ets,
     #{desc       => "Store listener records in ETS instead of Mnesia",
-      %%TODO remove compatibility code
       stability  => required,
       depends_on => [feature_flags_v2]
      }}).

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -21,7 +21,7 @@
 
 -export([boot/0, start_tcp_listener/2, start_tcp_listener/3,
          start_ssl_listener/3, start_ssl_listener/4,
-         stop_tcp_listener/1, on_node_down/1, active_listeners/0,
+         stop_tcp_listener/1, active_listeners/0,
          node_listeners/1, node_client_listeners/1,
          register_connection/1, unregister_connection/1,
          register_non_amqp_connection/1, unregister_non_amqp_connection/1,
@@ -251,9 +251,6 @@ ranch_ref_of_protocol(Protocol) ->
 
 -spec listener_of_protocol(atom()) -> #listener{}.
 listener_of_protocol(Protocol) ->
-    listener_of_protocol_ets(Protocol).
-
-listener_of_protocol_ets(Protocol) ->
     MatchSpec = #listener{
                    protocol = Protocol,
                    _ = '_'
@@ -361,9 +358,6 @@ tcp_listener_started(Protocol, Opts, IPAddress, Port) ->
                   ip_address = IPAddress,
                   port = Port,
                   opts = Opts},
-    tcp_listener_started_ets(L).
-
-tcp_listener_started_ets(L) ->
     true = ets:insert(?ETS_TABLE, L),
     ok.
 
@@ -382,9 +376,6 @@ tcp_listener_stopped(Protocol, Opts, IPAddress, Port) ->
                   ip_address = IPAddress,
                   port = Port,
                   opts = Opts},
-    tcp_listener_stopped_ets(L).
-
-tcp_listener_stopped_ets(L) ->
     true = ets:delete_object(?ETS_TABLE, L),
     ok.
 
@@ -440,9 +431,6 @@ active_listeners() ->
 -spec node_listeners(node()) -> [rabbit_types:listener()].
 
 node_listeners(Node) ->
-    node_listeners_ets(Node).
-
-node_listeners_ets(Node) ->
     case rabbit_misc:rpc_call(Node, ets, tab2list, [?ETS_TABLE]) of
         {badrpc, _} ->
             %% Some of the reasons are the node being down or is
@@ -463,11 +451,6 @@ node_client_listeners(Node) ->
                              (_) -> true
                          end, Xs)
     end.
-
--spec on_node_down(node()) -> 'ok'.
-
-on_node_down(_Node) ->
-    ok.
 
 -spec register_connection(pid()) -> ok.
 

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -815,7 +815,6 @@ handle_dead_rabbit(Node, State = #state{partitions = Partitions,
     ok = rabbit_amqqueue:on_node_down(Node),
     ok = rabbit_alarm:on_node_down(Node),
     ok = rabbit_mnesia:on_node_down(Node),
-    ok = rabbit_networking:on_node_down(Node),
     %% If we have been partitioned, and we are now in the only remaining
     %% partition, we no longer care about partitions - forget them. Note
     %% that we do not attempt to deal with individual (other) partitions

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -296,7 +296,6 @@ definitions(ram) ->
         {Tab, TabDef} <- definitions()].
 
 definitions() ->
-    Definitions =
     [{rabbit_user,
       [{record_name, internal_user},
        {attributes, internal_user:fields()},
@@ -396,21 +395,7 @@ definitions() ->
        {match, amqqueue:pattern_match_on_name(queue_name_match())}]}
     ]
         ++ gm:table_definitions()
-        ++ mirrored_supervisor:table_definitions(),
-
-    MaybeListener = case rabbit_feature_flags:is_enabled(listener_records_in_ets) of
-                        false ->
-                            [{rabbit_listener, rabbit_listener_definition()}];
-                        true ->
-                            []
-                    end,
-    Definitions ++ MaybeListener.
-
-rabbit_listener_definition() ->
-    [{record_name, listener},
-     {attributes, record_info(fields, listener)},
-     {type, bag},
-     {match, #listener{_='_'}}].
+        ++ mirrored_supervisor:table_definitions().
 
 binding_match() ->
     #binding{source = exchange_name_match(),


### PR DESCRIPTION
Remove compatibility code for feature flag `listener_records_in_ets` because this feature flag is required in 3.12.

See https://github.com/rabbitmq/rabbitmq-server/pull/7219