### PR TITLE
Update the spec for rabbit_binding:new/4 to match rabbit_types

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -55,9 +55,9 @@
 
 %%----------------------------------------------------------------------------
 
--spec new(rabbit_types:exchange(),
+-spec new(rabbit_types:binding_source(),
           key(),
-          rabbit_types:exchange() | amqqueue:amqqueue(),
+          rabbit_types:binding_destination(),
           rabbit_framing:amqp_table()) ->
     rabbit_types:binding().
 


### PR DESCRIPTION
Since `new` is just a wrapper for record initialization, the spec was updated to match the type info for the record