### PR TITLE
Add rabbit_queue_type:is_enabled/1

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -217,16 +217,24 @@ declare(QueueName = #resource{virtual_host = VHost}, Durable, AutoDelete, Args,
         Owner, ActingUser, Node) ->
     ok = check_declare_arguments(QueueName, Args),
     Type = get_queue_type(Args),
-    Q = amqqueue:new(QueueName,
-                     none,
-                     Durable,
-                     AutoDelete,
-                     Owner,
-                     Args,
-                     VHost,
-                     #{user => ActingUser},
-                     Type),
-    rabbit_queue_type:declare(Q, Node).
+    case rabbit_queue_type:is_enabled(Type) of
+        true ->
+            Q = amqqueue:new(QueueName,
+                             none,
+                             Durable,
+                             AutoDelete,
+                             Owner,
+                             Args,
+                             VHost,
+                             #{user => ActingUser},
+                             Type),
+            rabbit_queue_type:declare(Q, Node);
+        false ->
+            {protocol_error, internal_error,
+             "Cannot declare a queue '~ts' of type '~ts' on node '~ts': "
+             "the corresponding feature flag is disabled",
+             [rabbit_misc:rs(QueueName), Type, Node]}
+    end.
 
 get_queue_type(Args) ->
     case rabbit_misc:table_lookup(Args, <<"x-queue-type">>) of

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -23,6 +23,7 @@
 -export_type([state/0]).
 
 -export([
+         is_enabled/0,
          is_compatible/3,
          declare/2,
          delete/4,
@@ -57,6 +58,9 @@
          deliver_to_consumer/5,
          send_drained/3,
          send_credit_reply/3]).
+
+-spec is_enabled() -> boolean().
+is_enabled() -> true.
 
 -spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
 is_compatible(_, _, _) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -15,6 +15,7 @@
          discover/1,
          feature_flag_name/1,
          default/0,
+         is_enabled/1,
          is_compatible/4,
          declare/2,
          delete/4,
@@ -114,6 +115,8 @@
               action/0,
               actions/0,
               settle_op/0]).
+
+-callback is_enabled() -> boolean().
 
 -callback is_compatible(Durable :: boolean(),
                         Exclusive :: boolean(),
@@ -233,6 +236,11 @@ feature_flag_name(_) ->
 
 default() ->
     rabbit_classic_queue.
+
+%% is a specific queue type implementation enabled
+-spec is_enabled(module()) -> boolean().
+is_enabled(Type) ->
+    Type:is_enabled().
 
 -spec is_compatible(module(), boolean(), boolean(), boolean()) ->
     boolean().

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -61,7 +61,8 @@
          notify_decorators/3,
          spawn_notify_decorators/3]).
 
--export([is_compatible/3,
+-export([is_enabled/0,
+         is_compatible/3,
          declare/2,
          is_stateful/0]).
 
@@ -111,6 +112,9 @@
 -define(SNAPSHOT_INTERVAL, 8192). %% the ra default is 4096
 
 %%----------- rabbit_queue_type ---------------------------------------------
+
+-spec is_enabled() -> boolean().
+is_enabled() -> true.
 
 -spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
 is_compatible(_Durable = true,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -9,7 +9,8 @@
 
 -behaviour(rabbit_queue_type).
 
--export([is_compatible/3,
+-export([is_enabled/0,
+         is_compatible/3,
          declare/2,
          delete/4,
          purge/1,
@@ -88,6 +89,9 @@
 -import(rabbit_queue_type_util, [args_policy_lookup/3]).
 
 -type client() :: #stream_client{}.
+
+-spec is_enabled() -> boolean().
+is_enabled() -> true.
 
 -spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
 is_compatible(_Durable = true,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -980,7 +980,7 @@ queue_args(_, _) ->
     [].
 
 queue_type(?QOS_0, true, QArgs) ->
-    case rabbit_feature_flags:is_enabled(?QUEUE_TYPE_QOS_0) of
+    case rabbit_queue_type:is_enabled(?QUEUE_TYPE_QOS_0) of
         true ->
             ?QUEUE_TYPE_QOS_0;
         false ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -28,6 +28,7 @@
          declare/2,
          delete/4,
          deliver/2,
+         is_enabled/0,
          is_compatible/3,
          is_recoverable/1,
          recover/2,
@@ -132,6 +133,9 @@ deliver(Qs, #delivery{message = BasicMessage,
     end,
     delegate:invoke_no_result(Pids, {gen_server, cast, [Msg]}),
     {[], Actions}.
+
+-spec is_enabled() -> boolean().
+is_enabled() -> rabbit_feature_flags:is_enabled(?MODULE).
 
 -spec is_compatible(boolean(), boolean(), boolean()) ->
     boolean().


### PR DESCRIPTION
This commits partially reverts 575f4e78bcc8faf820a40bbc8e8a2c6520989ba9

Function `rabbit_queue_type:is_enabled/1` seems to be useful for future queue types.

See https://github.com/rabbitmq/rabbitmq-server/pull/7269#issuecomment-1429838579
