### PR TITLE
erlang_ls: Look for lib includes in extra_deps

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -17,6 +17,7 @@ diagnostics:
 include_dirs:
   - "deps"
   - "deps/*/include"
+  - "extra_deps"
   - "extra_deps/*/include"
 lenses:
   enabled:


### PR DESCRIPTION
## Proposed Changes

This fixes ErlangLS include lookups for `include_lib` attributes like

```erl
-include_lib("khepri/lib/include.hrl").
```

when running erlang_ls and building with Bazel.

`khepri` ends up in the `extra_deps` directory as a symlink after running `bazel run //tools:symlink_deps_for_erlang_ls`, so this change picks up that `khepri` directory as a lib for `include_lib`s.

This fixes some spurious diagnostics from erlang_ls running on #7206.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
