### PR TITLE
CQ: Remove compat code for classic_mirrored_queue_version

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -10,7 +10,6 @@
 -rabbit_feature_flag(
    {classic_mirrored_queue_version,
     #{desc          => "Support setting version for classic mirrored queues",
-      %%TODO remove compatibility code
       stability     => required
      }}).
 

--- a/deps/rabbit/src/rabbit_mirror_queue_master.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_master.erl
@@ -494,14 +494,9 @@ set_queue_mode(Mode, State = #state { gm                  = GM,
 set_queue_version(Version, State = #state { gm                  = GM,
                                             backing_queue       = BQ,
                                             backing_queue_state = BQS }) ->
-    case rabbit_feature_flags:is_enabled(classic_mirrored_queue_version) of
-        true ->
-            ok = gm:broadcast(GM, {set_queue_version, Version}),
-            BQS1 = BQ:set_queue_version(Version, BQS),
-            State #state { backing_queue_state = BQS1 };
-        false ->
-            State
-    end.
+    ok = gm:broadcast(GM, {set_queue_version, Version}),
+    BQS1 = BQ:set_queue_version(Version, BQS),
+    State #state { backing_queue_state = BQS1 }.
 
 zip_msgs_and_acks(Msgs, AckTags, Accumulator,
                   #state { backing_queue = BQ,


### PR DESCRIPTION
Remove compat code that is no longer necessary in 3.12+.