### PR TITLE
Fix issue 7301 - broken vhost link

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/permissions.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/permissions.ejs
@@ -1,4 +1,4 @@
-<div class="section">
+<div class="section" id="permissions">
   <h2>Permissions</h2>
   <div class="hider">
     <h3>Current permissions</h3>
@@ -55,8 +55,8 @@ for (var i = 0; i < permissions.length; i++) {
           <td>
             <input type="hidden" name="vhost" value="<%= fmt_string(parent.name) %>"/>
             <select name="username">
-              <% for (var i = 0; i < users.items.length; i++) { %>
-              <option value="<%= fmt_string(users.items[i].name) %>"><%= fmt_string(users.items[i].name) %></option>
+              <% for (var i = 0; i < users.length; i++) { %>
+              <option value="<%= fmt_string(users[i].name) %>"><%= fmt_string(users[i].name) %></option>
               <% } %>
             </select>
           </td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/topic-permissions.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/topic-permissions.ejs
@@ -1,4 +1,4 @@
-<div class="section">
+<div class="section" id="topic-permissions">
   <h2>Topic permissions</h2>
   <div class="hider">
     <h3>Current topic permissions</h3>
@@ -56,8 +56,8 @@ for (var i = 0; i < topic_permissions.length; i++) {
           <td>
             <input type="hidden" name="vhost" value="<%= fmt_string(parent.name) %>"/>
             <select name="username">
-              <% for (var i = 0; i < users.items.length; i++) { %>
-              <option value="<%= fmt_string(users.items[i].name) %>"><%= fmt_string(users.items[i].name) %></option>
+              <% for (var i = 0; i < users.length; i++) { %>
+              <option value="<%= fmt_string(users[i].name) %>"><%= fmt_string(users[i].name) %></option>
               <% } %>
             </select>
           </td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/vhost.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/vhost.ejs
@@ -8,11 +8,11 @@
 <% } %>
 
 <% if (!disable_stats) { %>
-<div class="section">
+<div class="section" id="overview">
   <h2>Overview</h2>
   <div class="hider updatable">
     <%= queue_lengths('lengths-vhost', vhost) %>
-<% if (rates_mode != 'none') { %>
+<% if (rates_mode != 'none' && vhost.message_stats) { %>
     <%= message_rates('msg-rates-vhost', vhost.message_stats) %>
 <% } %>
     <%= data_rates('data-rates-vhost', vhost, 'Data rates') %>
@@ -44,6 +44,7 @@
             </td>
             </tr>
         <% } %>
+
         </table>
         </td>
       </tr>
@@ -56,7 +57,7 @@
 
 <%= format('topic-permissions', {'mode': 'vhost', 'topic_permissions': topic_permissions, 'users':users, 'parent': vhost, 'exchanges': exchanges}) %>
 
-<div class="section-hidden">
+<div class="section-hidden" id="delete-vhost">
 <h2>Delete this vhost</h2>
 <div class="hider">
 <form action="#/vhosts" method="delete" class="confirm">

--- a/deps/rabbitmq_management/selenium/README.md
+++ b/deps/rabbitmq_management/selenium/README.md
@@ -116,3 +116,23 @@ make RABBITMQ_CONFIG_FILE=rabbitmq-localhost-keycloak.config start-rabbitmq
 
 We do not have this issue when we run the headless suites because they use dedicated files
 for each suite. Doing the same when running locally, i.e using `localhost`, would be too tedious.
+
+## Chrome vs Chrome driver version mismatch
+
+If you find the following error when you first attempt to run one of the selenium tests
+```
+SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 108
+Current browser version is 110.0.5481.100 with binary path /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+```
+It is because your current Chrome version is newer than the `chromedriver` configured in package.json.
+```
+  ....
+  "dependencies": {
+    "chromedriver": "^110.0.0",
+  ...
+```
+To fix the problem, bump the version in your package.json to match your local chrome version and run again the
+following command:
+```
+  npm install
+```

--- a/deps/rabbitmq_management/selenium/package.json
+++ b/deps/rabbitmq_management/selenium/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chromedriver": "^108.0.0",
+    "chromedriver": "^110.0.0",
     "ejs": "^3.1.8",
     "express": "^4.18.2",
     "geckodriver": "^3.0.2",

--- a/deps/rabbitmq_management/selenium/suites/vhosts.sh
+++ b/deps/rabbitmq_management/selenium/suites/vhosts.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Name of the suite used to generate log and screen folders
+SUITE=$( basename "${BASH_SOURCE[0]}" .sh)
+
+# Path to the test cases this suite should run. It is relative to the selenium/test folder
+TEST_CASES_PATH=/vhosts
+# Path to the folder where all configuration file reside. It is relative to the selenim/test folder
+TEST_CONFIG_PATH=/basic-auth
+
+source $SCRIPT/suite_template
+
+_setup () {
+  start_rabbitmq
+}
+_save_logs() {
+  save_container_logs rabbitmq
+}
+_teardown() {
+  kill_container_if_exist rabbitmq
+}
+run

--- a/deps/rabbitmq_management/selenium/test/pageobjects/AdminTab.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/AdminTab.js
@@ -14,6 +14,7 @@ const FILTERED_USER = By.css('span.filter-highlight')
 // RHM : RIGHT HAND MENU
 const USERS_ON_RHM = By.css('div#rhs ul li a[href="#/users"]')
 const LIMITS_ON_RHM = By.css('div#rhs ul li a[href="#/limits"]')
+const VHOSTS_ON_RHM = By.css('div#rhs ul li a[href="#/vhosts"]')
 
 module.exports = class AdminTab extends OverviewPage {
   async isLoaded () {
@@ -24,6 +25,9 @@ module.exports = class AdminTab extends OverviewPage {
   }
   async clickOnLimits() {
     await this.click(LIMITS_ON_RHM)
+  }
+  async clickOnVhosts() {
+    await this.click(VHOSTS_ON_RHM)
   }
 
   async searchForUser(user, regex = false) {

--- a/deps/rabbitmq_management/selenium/test/pageobjects/VhostAdminTab.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/VhostAdminTab.js
@@ -1,0 +1,24 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+
+const AdminTab = require('./AdminTab')
+
+const VHOST_NAME = By.css('div#main h1 b')
+const OVERVIEW_SECTION = By.css('div#main div#overview')
+const PERMISSIONS_SECTION = By.css('div#main div#permissions')
+const TOPIC_PERMISSIONS_SECTION = By.css('div#main div#topic-permissions')
+
+
+module.exports = class VhostAdminTab extends AdminTab {
+  async isLoaded () {
+    await this.waitForDisplayed(VHOST_NAME)
+    await this.waitForDisplayed(OVERVIEW_SECTION)
+    await this.waitForDisplayed(PERMISSIONS_SECTION)
+    return await this.waitForDisplayed(TOPIC_PERMISSIONS_SECTION)
+  }
+
+  async getName() {
+    return await this.getText(VHOST_NAME)
+  }
+
+
+}

--- a/deps/rabbitmq_management/selenium/test/pageobjects/VhostsAdminTab.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/VhostsAdminTab.js
@@ -1,0 +1,37 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+
+const AdminTab = require('./AdminTab')
+
+const SELECTED_VHOSTS_ON_RHM = By.css('div#rhs ul li a[href="#/vhosts"]')
+const FILTER_VHOST = By.css('div#main div.filter input#filter')
+const CHECKBOX_REGEX = By.css('div#main div.filter input#filter-regex-mode')
+
+const VHOSTS_TABLE_ROWS = By.css('div#main table.list tbody tr')
+
+module.exports = class VhostsAdminTab extends AdminTab {
+  async isLoaded () {
+    await this.waitForDisplayed(SELECTED_VHOSTS_ON_RHM)
+  }
+  async searchForVhosts(vhost, regex = false) {
+    await this.sendKeys(FILTER_VHOST, vhost)
+    await this.sendKeys(FILTER_VHOST, Key.RETURN)
+    if (regex) {
+      await this.click(CHECKBOX_REGEX)
+    }
+    await this.driver.sleep(250)
+    await this.waitForDisplayed(VHOSTS_TABLE_ROWS)
+    return this.driver.findElement(VHOSTS_TABLE_ROWS)
+  }
+  async hasVhosts(vhost, regex = false) {
+    return await this.searchForVhosts(vhost, regex) != undefined
+  }
+  async clickOnVhost(vhost_rows, vhost) {
+     let links = await vhost_rows.findElements(By.css("td a"))
+     for (let link of links) {
+       let text = await link.getText()
+       if ( text === "/" ) return link.click()
+     }
+     throw "Vhost " + vhost + " not found"
+  }
+
+}

--- a/deps/rabbitmq_management/selenium/test/vhosts/Makefile
+++ b/deps/rabbitmq_management/selenium/test/vhosts/Makefile
@@ -1,0 +1,20 @@
+.ONESHELL:# single shell invocation for all lines in the recipe
+SHELL = bash# we depend on bash expansion for e.g. queue patterns
+
+.DEFAULT_GOAL = help
+RABBITMQ_SERVER_ROOT = ../../../../../
+
+
+### TARGETS ###
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+start-rabbitmq: ## Start RabbitMQ
+	@(docker kill rabbitmq >/dev/null 2>&1  && docker rm rabbitmq)
+	@(gmake --directory=${RABBITMQ_SERVER_ROOT} run-broker \
+		RABBITMQ_ENABLED_PLUGINS="rabbitmq_management" \
+		RABBITMQ_CONFIG_FILE=deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.config)
+
+test: ## Run tests interactively e.g. make test [TEST=landing.js]
+	@(RABBITMQ_URL=http://localhost:15672 RUN_LOCAL=true SCREENSHOTS_DIR=${PWD}/../../screens npm test $(PWD)/$(TEST))

--- a/deps/rabbitmq_management/selenium/test/vhosts/admin-vhosts.js
+++ b/deps/rabbitmq_management/selenium/test/vhosts/admin-vhosts.js
@@ -1,0 +1,53 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+require('chromedriver')
+const assert = require('assert')
+const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
+
+const LoginPage = require('../pageobjects/LoginPage')
+const OverviewPage = require('../pageobjects/OverviewPage')
+const AdminTab = require('../pageobjects/AdminTab')
+const VhostsAdminTab = require('../pageobjects/VhostsAdminTab')
+const VhostAdminTab = require('../pageobjects/VhostAdminTab')
+
+describe('Virtual Hosts in Admin tab', function () {
+  let login
+  let overview
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    login = new LoginPage(driver)
+    overview = new OverviewPage(driver)
+    adminTab = new AdminTab(driver)
+    vhostsTab = new VhostsAdminTab(driver)
+    vhostTab = new VhostAdminTab(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+
+    await login.login('guest', 'guest')
+    if (!await overview.isLoaded()) {
+      throw new Error('Failed to login')
+    }
+
+  })
+
+  it('find default vhost', async function () {
+    await overview.clickOnAdminTab()
+    await adminTab.clickOnVhosts()
+    assert.equal(true, await vhostsTab.hasVhosts("/"))
+  })
+  it('find default vhost and view it', async function () {
+    await overview.clickOnAdminTab()
+    await adminTab.clickOnVhosts()
+    await vhostsTab.clickOnVhost(await vhostsTab.searchForVhosts("/"), "/")
+    if (!await vhostTab.isLoaded()) {
+      throw new Error('Failed to load vhost')
+    }
+    assert.equal("/", await vhostTab.getName())
+  })
+
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})


### PR DESCRIPTION
The root cause is that the templates that renders permissions and topic permissions within the vhost page assumes that the `users` attribute has a paged list of users (i.e. wrapped around an `items` attribute) however the attribute is just a plain array.

## Proposed Changes

Modified the affected templates to list users assuming they are just a plain array rather than an array under `items`. 
Added selenium tests.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Fixes #7301.
