### PR TITLE
rabbit_feature_flags: Support required feature flags in plugins

### DIFF
--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -247,6 +247,8 @@ maybe_initialize_registry(NewSupportedFeatureFlags,
                       fun(FeatureName, FeatureProps) ->
                               Stability = maps:get(
                                             stability, FeatureProps, stable),
+                              ProvidedBy = maps:get(
+                                             provided_by, FeatureProps),
                               State = case FeatureStates0 of
                                           #{FeatureName := FeatureState} ->
                                               FeatureState;
@@ -262,6 +264,9 @@ maybe_initialize_registry(NewSupportedFeatureFlags,
                                       %% This is the very first time the node
                                       %% starts, we already mark the required
                                       %% feature flag as enabled.
+                                      ?assertNotEqual(state_changing, State),
+                                      true;
+                                  required when ProvidedBy =/= rabbit ->
                                       ?assertNotEqual(state_changing, State),
                                       true;
                                   required ->

--- a/deps/rabbit/test/feature_flags_SUITE_data/my_plugin/src/my_plugin.erl
+++ b/deps/rabbit/test/feature_flags_SUITE_data/my_plugin/src/my_plugin.erl
@@ -8,3 +8,6 @@
 -module(my_plugin).
 
 -rabbit_feature_flag({plugin_ff, #{desc => "Plugin's feature flag A"}}).
+
+-rabbit_feature_flag({required_plugin_ff, #{desc => "Plugin's feature flag B",
+                                            stability => required}}).

--- a/deps/rabbit/test/feature_flags_v2_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_v2_SUITE.erl
@@ -351,7 +351,7 @@ enable_supported_feature_flag_on_a_single_node(Config) ->
 
 enable_supported_feature_flag_on_a_single_node() ->
     FeatureName = ?FUNCTION_NAME,
-    FeatureFlags = #{FeatureName => #{provided_by => ?MODULE,
+    FeatureFlags = #{FeatureName => #{provided_by => rabbit,
                                       stability => stable}},
     ?assertEqual(
        ok, rabbit_feature_flags:inject_test_feature_flags(FeatureFlags)),
@@ -417,7 +417,7 @@ enable_supported_feature_flag_in_a_3node_cluster(Config) ->
     override_running_nodes(Nodes),
 
     FeatureName = ?FUNCTION_NAME,
-    FeatureFlags = #{FeatureName => #{provided_by => ?MODULE,
+    FeatureFlags = #{FeatureName => #{provided_by => rabbit,
                                       stability => stable}},
     inject_on_nodes(Nodes, FeatureFlags),
 
@@ -584,7 +584,7 @@ enable_feature_flag_in_cluster_and_add_member_after(Config) ->
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable,
                        callbacks => #{enable => {?MODULE, mf_count_runs}}}},
     inject_on_nodes(AllNodes, FeatureFlags),
@@ -686,7 +686,7 @@ enable_feature_flag_in_cluster_and_add_member_concurrently_mfv2(Config) ->
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable,
                        callbacks =>
                        #{enable =>
@@ -871,7 +871,7 @@ enable_feature_flag_in_cluster_and_remove_member_concurrently_mfv2(Config) ->
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable,
                        callbacks =>
                        #{enable =>
@@ -990,7 +990,7 @@ enable_feature_flag_with_post_enable(Config) ->
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable,
                        callbacks =>
                        #{post_enable =>
@@ -1175,10 +1175,10 @@ have_required_feature_flag_in_cluster_and_add_member_with_it_disabled(
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable}},
     RequiredFeatureFlags = #{FeatureName =>
-                             #{provided_by => ?MODULE,
+                             #{provided_by => rabbit,
                                stability => required}},
     inject_on_nodes([NewNode], FeatureFlags),
     inject_on_nodes(Nodes, RequiredFeatureFlags),
@@ -1258,10 +1258,10 @@ have_required_feature_flag_in_cluster_and_add_member_without_it(
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable}},
     RequiredFeatureFlags = #{FeatureName =>
-                             #{provided_by => ?MODULE,
+                             #{provided_by => rabbit,
                                stability => required}},
     inject_on_nodes([NewNode], FeatureFlags),
     inject_on_nodes(Nodes, RequiredFeatureFlags),
@@ -1355,7 +1355,7 @@ error_during_migration_after_initial_success(Config) ->
 
     FeatureName = ?FUNCTION_NAME,
     FeatureFlags = #{FeatureName =>
-                     #{provided_by => ?MODULE,
+                     #{provided_by => rabbit,
                        stability => stable,
                        callbacks =>
                        #{enable => {?MODULE, mf_crash_on_joining_node}}}},


### PR DESCRIPTION
### Why
If a plugin was already enabled when RabbitMQ starts, its required feature flags were correctly handled and thus enabled. However, this was not the case for a plugin enabled at runtime.

Here is an example with the `drop_unroutable_metric` from the rabbitmq_management_agent plugin:

    Feature flags: `drop_unroutable_metric`: required feature flag not
    enabled! It must be enabled before upgrading RabbitMQ.

Supporting required feature flags in plugin is trickier than in the core broker. Indeed, with the broker, we know when this is the first time the broker is started. Therefore we are sure that a required feature flag can be enabled directly, there is no existing data/context that could conflict with the code behind the required feature flag.

For plugins, this is different: a plugin can be enabled/disabled at runtime and between broker restarts (and thus upgrades). So, when a plugin is enabled and it has a required feature flag, we have no way to make sure that there is no existing and conflicting data/context.

### How
In this patch, if the required feature flag is provided by a plugin (i.e. not `rabbit`), we always mark it as enabled.

The plugin is responsible for handling any existing data/context and perform any cleanup/conversion.

Reported by: @ansd