### PR TITLE
Faster node startup with many classic queues

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -154,15 +154,14 @@ find_missing_queues(Q1s, Q2s) when length(Q1s) == length(Q2s)->
 find_missing_queues(Q1s, Q2s) ->
     find_missing_queues(lists:sort(Q1s), lists:sort(Q2s), []).
 
-find_missing_queues([], Q2s, Acc) ->
-    %% Q2s should always be empty here
-    Acc ++ Q2s;
+find_missing_queues([], [], Acc) ->
+    Acc;
 find_missing_queues([Q1|Rem1], [Q2|Rem2] = Q2s, Acc) ->
     case amqqueue:get_name(Q1) == amqqueue:get_name(Q2) of
         true ->
             find_missing_queues(Rem1, Rem2, Acc);
         false ->
-            find_missing_queues(Rem1, Q2s, Acc ++ Q1)
+            find_missing_queues(Rem1, Q2s, [Q1|Acc])
     end.
 
 -spec policy_changed(amqqueue:amqqueue()) -> ok.

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -142,13 +142,27 @@ recover(VHost, Queues) ->
         {ok, _}         ->
             RecoveredQs = recover_durable_queues(lists:zip(Queues,
                                                            OrderedRecoveryTerms)),
-            RecoveredNames = [amqqueue:get_name(Q) || Q <- RecoveredQs],
-            FailedQueues = [Q || Q <- Queues,
-                                 not lists:member(amqqueue:get_name(Q), RecoveredNames)],
-            {RecoveredQs, FailedQueues};
+            FailedQs = find_missing_queues(Queues,RecoveredQs),
+            {RecoveredQs, FailedQs};
         {error, Reason} ->
             rabbit_log:error("Failed to start queue supervisor for vhost '~ts': ~ts", [VHost, Reason]),
             throw({error, Reason})
+    end.
+
+find_missing_queues(Q1s, Q2s) when length(Q1s) == length(Q2s)->
+    [];
+find_missing_queues(Q1s, Q2s) ->
+    find_missing_queues(lists:sort(Q1s), lists:sort(Q2s), []).
+
+find_missing_queues([], Q2s, Acc) ->
+    %% Q2s should always be empty here
+    Acc ++ Q2s;
+find_missing_queues([Q1|Rem1], [Q2|Rem2] = Q2s, Acc) ->
+    case amqqueue:get_name(Q1) == amqqueue:get_name(Q2) of
+        true ->
+            find_missing_queues(Rem1, Rem2, Acc);
+        false ->
+            find_missing_queues(Rem1, Q2s, Acc ++ Q1)
     end.
 
 -spec policy_changed(amqqueue:amqqueue()) -> ok.

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -154,8 +154,10 @@ find_missing_queues(Q1s, Q2s) when length(Q1s) == length(Q2s)->
 find_missing_queues(Q1s, Q2s) ->
     find_missing_queues(lists:sort(Q1s), lists:sort(Q2s), []).
 
-find_missing_queues([], [], Acc) ->
+find_missing_queues([], _, Acc) ->
     Acc;
+find_missing_queues(Q1s, [], Acc) ->
+    Q1s ++ Acc;
 find_missing_queues([Q1|Rem1], [Q2|Rem2] = Q2s, Acc) ->
     case amqqueue:get_name(Q1) == amqqueue:get_name(Q2) of
         true ->


### PR DESCRIPTION
On my machines, in a test with 100k queues, node startup goes down from 4-5 minutes to roughly 1 minute. The difference will be even larger with more queues as `lists:member` gets very expensive with a long list.