### PR TITLE
Add timeout for test AMQP 0.9.1 connection to open

### DIFF
--- a/deps/rabbitmq_ct_client_helpers/src/rabbit_ct_client_helpers.erl
+++ b/deps/rabbitmq_ct_client_helpers/src/rabbit_ct_client_helpers.erl
@@ -147,6 +147,8 @@ open_connection(Config, Node) ->
     Pid ! {open_connection, self()},
     receive
         Conn when is_pid(Conn) -> Conn
+    after 60_000 ->
+        ct:fail("Timed out waiting for connection to open")
     end.
 
 open_unmanaged_connection(Config) ->

--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -1259,7 +1259,7 @@ clean_session_kill_node(Config) ->
     ?assertEqual(0, rpc(Config, ets, info, [rabbit_durable_queue, size])).
 
 rabbit_status_connection_count(Config) ->
-    _ = rabbit_ct_client_helpers:open_connection(Config, 0),
+    _Pid = rabbit_ct_client_helpers:open_connection(Config, 0),
     C = connect(?FUNCTION_NAME, Config),
 
     {ok, String} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["status"]),


### PR DESCRIPTION
We see sporadic test failures where a test case hangs in the receive until the Bazel suite timeout is reached.

There is no point in a test case to wait forever for an AMQP 0.9.1 connection to establish. Let's time out after 1 minute.

This will make the test case fail faster.

Example in https://app.buildbuddy.io/invocation/a71cb460-702a-4380-ba12-7b1f7dd2e8d2?target=%2F%2Fdeps%2Frabbitmq_mqtt%3Ashared_SUITE:
```
2023-02-16 16:34:36.348
Testcases still in progress:
 - mqtt/cluster_size_1/tests/rabbit_status_connection_count (0:00:35)
----------------------------------------------------
2023-02-16 16:35:36.348
Testcases still in progress:
 - mqtt/cluster_size_1/tests/rabbit_status_connection_count (0:01:35)
----------------------------------------------------

...

----------------------------------------------------
2023-02-16 16:42:36.348
Testcases still in progress:
 - mqtt/cluster_size_1/tests/rabbit_status_connection_count (0:08:35)
----------------------------------------------------
2023-02-16 16:43:36.348
Testcases still in progress:
 - mqtt/cluster_size_1/tests/rabbit_status_connection_count (0:09:35)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
rabbit_ct_client_helpers:open_connection failed on line 147
Reason: {timetrap_timeout,300000}
```