### PR TITLE
Fix flaky MQTT Java test

### DIFF
--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/src/test/java/com/rabbitmq/mqtt/test/MqttTest.java
@@ -532,6 +532,8 @@ public class MqttTest implements MqttCallback {
         failOnDelivery = false;
 
         client.setCallback(this);
+        // Wait for client to leave connection state 'DISCONNECTING'.
+        Thread.sleep(500);
         client.connect(client_opts);
 
         // Message has been redelivered after session resume


### PR DESCRIPTION
Every ~30 runs, test case `sessionRedelivery` was failing with error:
```
[ERROR] sessionRedelivery{TestInfo}  Time elapsed: 1.298 s  <<< ERROR!
org.eclipse.paho.client.mqttv3.MqttException: Client is currently disconnecting
	at com.rabbitmq.mqtt.test.MqttTest.sessionRedelivery(MqttTest.java:535)
```

The problem was that the Java client was still in connection state `DISCONNECTING` which throws a Java exception when `connect()`ing.

So, the problem was client side.

We already check for [isConnected()](https://www.eclipse.org/paho/files/javadoc/org/eclipse/paho/client/mqttv3/MqttClient.html#isConnected--) to be `false` which [internally checks](https://github.com/eclipse/paho.mqtt.java/blob/f4e0db802a4433645ef011e711646a09ec9fae89/org.eclipse.paho.client.mqttv3/src/main/java-templates/org/eclipse/paho/client/mqttv3/internal/ClientComms.java#L565) for
```
conState == CONNECTED
```
However, there is no public client API to check for other connection states. Therefore just waiting for a few milliseconds fixes the flake.