### PR TITLE
Reduce the default number of attempts to start the broker in tests

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -178,7 +178,7 @@
   ]).
 
 -define(DEFAULT_USER, "guest").
--define(NODE_START_ATTEMPTS, 10).
+-define(NODE_START_ATTEMPTS, 3).
 
 -define(TCP_PORTS_BASE, 21000).
 -define(TCP_PORTS_LIST, [


### PR DESCRIPTION
With the containerized CI environment, port conflicts are much less likely, so reducing the attempt count is reasonable. It also allows suites to fail faster for some scenarios, which lowers the chances the test will hit the timeout in bazel. This is desirable because in the event of a timeout in CI, logs are not captured.