### PR TITLE
Exclude bazel related files from `make source-dist`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,16 @@ RSYNC_FLAGS += -a $(RSYNC_V)		\
 	       --exclude '.hg*'				\
 	       --exclude '.travis.yml*'			\
 	       --exclude '.*.plt'			\
+	       --exclude '*.bzl'			\
+	       --exclude '*.bazel'			\
+	       --exclude '*.bazelrc'			\
+	       --exclude 'moduleindex.yaml'		\
+	       --exclude 'BUILD.*'			\
 	       --exclude '$(notdir $(ERLANG_MK_TMP))'	\
 	       --exclude '_build/'			\
 	       --exclude '__pycache__/'			\
+	       --exclude 'bazel*/'			\
+	       --exclude 'tools/'			\
 	       --exclude 'ci/'				\
 	       --exclude 'cover/'			\
 	       --exclude 'deps/'			\


### PR DESCRIPTION
rync exclustions are updated to include bazel related files since they are unused in the make based workflow