### PR TITLE
Add documentation for hashing passwords

### DIFF
--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -683,6 +683,14 @@ password for the user named
 This user now cannot log in with a password (but may be able to through
 e.g. SASL EXTERNAL if configured).
 .\" ------------------------------------------------------------------
+.It Cm hash_password Ar plaintext
+.Bl -tag -width Ds
+.It Ar plaintext
+The plaintext password to hash
+.El
+.Pp
+Hashes a plaintext password according to the currently configured password hashing algorithm
+.\" ------------------------------------------------------------------
 .It Cm delete_user Ar username
 .Bl -tag -width Ds
 .It Ar username
@@ -2221,15 +2229,6 @@ The name of the queue to purge.
 .El
 .Pp
 Purges a queue (removes all messages in it).
-.El
-.\" ------------------------------------------------------------------
-.It Cm hash_password Ar plaintext
-.Bl -tag -width Ds
-.It Ar plaintext
-The plaintext password to hash
-.El
-.Pp
-Hashes a plaintext password according to the currently configured password hashing algorithm
 .El
 .\" ------------------------------------------------------------------------------------------------
 .Sh PLUGIN COMMANDS

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -2222,6 +2222,15 @@ The name of the queue to purge.
 .Pp
 Purges a queue (removes all messages in it).
 .El
+.\" ------------------------------------------------------------------
+.It Cm hash_password Ar plaintext
+.Bl -tag -width Ds
+.It Ar plaintext
+The plaintext password to hash
+.El
+.Pp
+Hashes a plaintext password according to the currently configured password hashing algorithm
+.El
 .\" ------------------------------------------------------------------------------------------------
 .Sh PLUGIN COMMANDS
 .\" ------------------------------------------------------------------------------------------------

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/hash_password_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/hash_password_command.ex
@@ -9,7 +9,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HashPasswordCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.Core.MergesNoDefaults
-  use RabbitMQ.CLI.DefaultOutput
 
   def run([cleartextpassword], _opts) do
     hash_password(cleartextpassword)
@@ -46,6 +45,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HashPasswordCommand do
     :ok
   end
 
+  ## Use default output for all non-special case outputs
+  use RabbitMQ.CLI.DefaultOutput
+
   def usage, do: "hash_password <cleartext_password>"
 
   def banner([arg], _options),
@@ -53,4 +55,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HashPasswordCommand do
 
   def banner([], _options),
     do: "Will hash provided password"
+
+  def description(), do: "Hashes a plaintext password"
 end

--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1157,6 +1157,16 @@ or:
           A list of authentication attempts by remote address and username.
         </td>
       </tr>
+      <tr>
+        <td>X</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td class="path">/api/auth/hash_password/<i>plaintext-password</i></td>
+        <td>
+          Hashes <code>plaintext-password</code> according to the currently configured password hashing algorithm.
+        </td>
+      </tr>
     </table>
 
 


### PR DESCRIPTION
Fixes #7432

Adds HTTP API documentation as well as `rabbitmqctl hash_password` docs.

Add `rabbitmqctl` docs