### PR TITLE
Fix rabbitmq-diagnostics remote_shell for 26.0

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
@@ -6,19 +6,27 @@
 
 defmodule RabbitMQ.CLI.Diagnostics.Commands.RemoteShellCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+  @dialyzer :no_missing_calls
 
   use RabbitMQ.CLI.Core.MergesNoDefaults
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name}) do
-    _ = Supervisor.terminate_child(:kernel_sup, :user)
-    Process.flag(:trap_exit, true)
-    user_drv = :user_drv.start(['tty_sl -c -e', {node_name, :shell, :start, []}])
-    Process.link(user_drv)
+    _ = :c.l(:shell)
 
-    receive do
-      {'EXIT', _user_drv, _} ->
-        {:ok, "Disconnected from #{node_name}."}
+    if :erlang.function_exported(:shell, :start_interactive, 1) do
+      :shell.start_interactive({node_name, :shell, :start, []})
+      :timer.sleep(:infinity)
+    else
+      _ = Supervisor.terminate_child(:kernel_sup, :user)
+      Process.flag(:trap_exit, true)
+      user_drv = :user_drv.start(['tty_sl -c -e', {node_name, :shell, :start, []}])
+      Process.link(user_drv)
+
+      receive do
+        {'EXIT', _user_drv, _} ->
+          {:ok, "Disconnected from #{node_name}."}
+      end
     end
   end
 


### PR DESCRIPTION
I have removed the format commands because I have no idea why they make compilation fail with my changes and I don't know how to fix (no clear error message). If the format commands are important please someone who knows fix the PR or provide instructions.

This PR fixes remote_shell for 26.0 and future versions and simplifies the code by using the new function from 26 (or will once the <26 compat gets removed).

cc @mkuratczyk 