### PR TITLE
Fix remote_shell on win32

### DIFF
--- a/deps/rabbit/scripts/rabbitmq-diagnostics.bat
+++ b/deps/rabbit/scripts/rabbitmq-diagnostics.bat
@@ -36,7 +36,13 @@ if not defined ERL_CRASH_DUMP_SECONDS (
     set ERL_CRASH_DUMP_SECONDS=0
 )
 
-"!ERLANG_HOME!\bin\erl.exe" +B ^
+if "%1"=="remote_shell" (
+    set ERL_CMD=werl.exe
+) else (
+    set ERL_CMD=erl.exe
+)
+
+"!ERLANG_HOME!\bin\!ERL_CMD!" +B ^
 -boot !CLEAN_BOOT_FILE! ^
 -noinput -noshell -hidden -smp enable ^
 !RABBITMQ_CTL_ERL_ARGS! ^


### PR DESCRIPTION
This command requires werl.exe. In OTP 26, this will still work because werl.exe is the same as erl.exe