### PR TITLE
Fix 2549 - auth_oauth2.preferred_username_claims should accept multiple values

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -68,14 +68,15 @@
 %% {preferred_username_claims, [<<"username">>, <<"user_name">>, <<"email">> ]},
 
 {mapping,
- "auth_oauth2.preferred_username_claims",
+ "auth_oauth2.preferred_username_claims.$preferred_username_claims",
  "rabbitmq_auth_backend_oauth2.preferred_username_claims",
  [{datatype, string}]}.
 
 {translation,
  "rabbitmq_auth_backend_oauth2.preferred_username_claims",
  fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("auth_oauth2.preferred_username_claims", Conf))
+    Settings = cuttlefish_variable:filter_by_prefix("auth_oauth2.preferred_username_claims", Conf),
+    [list_to_binary(V) || {_, V} <- Settings]
  end}.
 
 %% ID of the default signing key

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -1,7 +1,12 @@
 [
   {oauth2_pem_config2,
        "auth_oauth2.resource_server_id = new_resource_server_id
+        auth_oauth2.resource_server_type = new_resource_server_type
         auth_oauth2.additional_scopes_key = my_custom_scope_key
+        auth_oauth2.preferred_username_claims.1 = user_name
+        auth_oauth2.preferred_username_claims.2 = username
+        auth_oauth2.preferred_username_claims.3 = email
+        auth_oauth2.verify_aud = true
         auth_oauth2.default_key = id1
         auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
         auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem
@@ -17,7 +22,10 @@
         [
         {rabbitmq_auth_backend_oauth2, [
             {resource_server_id,<<"new_resource_server_id">>},
+            {resource_server_type,<<"new_resource_server_type">>},
             {extra_scopes_source, <<"my_custom_scope_key">>},
+            {preferred_username_claims, [<<"user_name">>, <<"username">>, <<"email">>]},
+            {verify_aud, true},
             {key_config, [
             {default_key, <<"id1">>},
             {signing_keys,

--- a/deps/rabbitmq_management/selenium/suites/oauth-idp-initiated-with-uaa.sh
+++ b/deps/rabbitmq_management/selenium/suites/oauth-idp-initiated-with-uaa.sh
@@ -12,12 +12,12 @@ TEST_CONFIG_PATH=/oauth
 # Path to the uaa configuration. It is relative to the TEST_CONFIG_PATH
 UAA_CONFIG_PATH=/uaa
 # Name of the rabbitmq config file. It is relative to the TEST_CONFIG_PATH
-RABBITMQ_CONFIG_FILENAME=rabbitmq-idp-initiated.config
+RABBITMQ_CONFIG_FILENAME=rabbitmq-idp-initiated.conf
 
 source $SCRIPT/suite_template
 
 _setup () {
-  start_uaa  
+  start_uaa
   start_rabbitmq
   start_fakeportal
 }

--- a/deps/rabbitmq_management/selenium/suites/oauth-with-uaa.sh
+++ b/deps/rabbitmq_management/selenium/suites/oauth-with-uaa.sh
@@ -11,6 +11,7 @@ TEST_CASES_PATH=/oauth/with-uaa
 TEST_CONFIG_PATH=/oauth
 # Path to the uaa configuration. It is relative to the TEST_CONFIG_PATH
 UAA_CONFIG_PATH=/uaa
+RABBITMQ_CONFIG_FILENAME=rabbitmq.conf
 
 source $SCRIPT/suite_template
 

--- a/deps/rabbitmq_management/selenium/suites/suite_template
+++ b/deps/rabbitmq_management/selenium/suites/suite_template
@@ -290,6 +290,8 @@ run() {
   build_mocha_image
   start_selenium
 
+  trap _teardown EXIT
+  
   echo "Set up ..."
   [[ $(type -t _setup) == function ]] &&  _setup
 

--- a/deps/rabbitmq_management/selenium/suites/suite_template
+++ b/deps/rabbitmq_management/selenium/suites/suite_template
@@ -84,14 +84,21 @@ start_rabbitmq () {
   init_rabbitmq
   kill_container_if_exist rabbitmq
 
+  MOUNT_RABBITMQ_CONFIG="/etc/rabbitmq/rabbitmq.config"
+  if [[ "$RABBITMQ_CONFIG_FILE" == *.conf ]]
+  then
+    MOUNT_RABBITMQ_CONFIG="/etc/rabbitmq/rabbitmq.conf"
+  fi
+
   docker run \
     --detach \
     --name rabbitmq \
     --net ${DOCKER_NETWORK} \
     -p 15672:15672 -p 5672:5672 \
     -v ${RABBITMQ_CONFIG_DIR}/logging.conf:/etc/rabbitmq/conf.d/logging.conf:ro \
-    -v ${RABBITMQ_CONFIG_FILE}:/etc/rabbitmq/rabbitmq.config:ro \
+    -v ${RABBITMQ_CONFIG_FILE}:${MOUNT_RABBITMQ_CONFIG}:ro \
     -v ${RABBITMQ_CONFIG_DIR}/enabled_plugins:/etc/rabbitmq/enabled_plugins \
+    -v ${RABBITMQ_CONFIG_DIR}:/config \
     ${RABBITMQ_DOCKER_IMAGE}
 
   wait_for_message rabbitmq "Server startup complete"

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-idp-initiated.conf
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-idp-initiated.conf
@@ -1,0 +1,11 @@
+auth_backends.1 = rabbit_auth_backend_oauth2
+
+management.login_session_timeout = 1
+management.oauth_enabled = true
+management.oauth_initiated_logon_type = idp_initiated
+management.oauth_provider_url = http://fakeportal:3000
+
+auth_oauth2.resource_server_id = rabbitmq
+auth_oauth2.preferred_username_claims.1 = user_name
+auth_oauth2.default_key = legacy-token-key
+auth_oauth2.signing_keys.legacy-token-key = /config/uaa/signing-key.pem

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-idp-initiated.conf
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-idp-initiated.conf
@@ -3,6 +3,7 @@ auth_backends.1 = rabbit_auth_backend_oauth2
 management.login_session_timeout = 1
 management.oauth_enabled = true
 management.oauth_initiated_logon_type = idp_initiated
+management.oauth_scopes = openid profile rabbitmq.*
 management.oauth_provider_url = http://fakeportal:3000
 
 auth_oauth2.resource_server_id = rabbitmq

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.conf
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.conf
@@ -10,4 +10,4 @@ management.oauth_provider_url = http://localhost:8080
 auth_oauth2.resource_server_id = rabbitmq
 auth_oauth2.preferred_username_claims.1 = user_name
 auth_oauth2.default_key = legacy-token-key
-auth_oauth2.jwks_url = http://localhost:8080/token_keys
+auth_oauth2.signing_keys.legacy-token-key = deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/signing-key.pem

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.conf
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.conf
@@ -1,0 +1,13 @@
+auth_backends.1 = rabbit_auth_backend_oauth2
+
+management.login_session_timeout = 1
+management.enable_uaa = true
+management.oauth_enabled = true
+management.oauth_client_id = rabbit_client_code
+management.oauth_client_secret = rabbit_client_code
+management.oauth_provider_url = http://localhost:8080
+
+auth_oauth2.resource_server_id = rabbitmq
+auth_oauth2.preferred_username_claims.1 = user_name
+auth_oauth2.default_key = legacy-token-key
+auth_oauth2.jwks_url = http://localhost:8080/token_keys

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.config
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq-localhost.config
@@ -6,11 +6,8 @@
       {login_session_timeout, 1},   %% in minutes
       {enable_uaa, true},
       {oauth_enabled, true},
-      %{oauth_initiated_logon_type, idp_initiated},
       {oauth_client_id, "rabbit_client_code"},
-      %{oauth_client_id, "rabbit_idp_user"},
-      {oauth_client_secret, " "},
-      %{oauth_provider_url, "http://localhost:3000"}
+      {oauth_client_secret, "rabbit_client_code"},
       {oauth_provider_url, "http://localhost:8080"}
   ]},
   {rabbitmq_auth_backend_oauth2, [

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq.conf
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq.conf
@@ -1,0 +1,13 @@
+auth_backends.1 = rabbit_auth_backend_oauth2
+
+management.login_session_timeout = 1
+management.oauth_enabled = true
+management.oauth_client_id = rabbit_client_code
+management.oauth_client_secret = rabbit_client_code
+management.oauth_scopes = openid profile rabbitmq.*
+management.oauth_provider_url = http://uaa:8080
+
+auth_oauth2.resource_server_id = rabbitmq
+auth_oauth2.preferred_username_claims.1 = user_name
+auth_oauth2.default_key = legacy-token-key
+auth_oauth2.signing_keys.legacy-token-key = /config/uaa/signing-key.pem

--- a/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/signing-key.pem
+++ b/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/signing-key.pem
@@ -1,0 +1,9 @@
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+VwIDAQAB
+-----END PUBLIC KEY-----

--- a/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/uaa.yml
+++ b/deps/rabbitmq_management/selenium/test/oauth/uaa-localhost/uaa.yml
@@ -129,7 +129,7 @@ oauth:
       authorities: rabbitmq.tag:monitoring
     rabbit_client_code:
       id: rabbit_client_code
-      secret: " "
+      secret: rabbit_client_code
       authorized-grant-types: authorization_code,refresh_token
       scope: rabbitmq.*,openid,profile
       authorities: uaa.resource,rabbitmq.*

--- a/deps/rabbitmq_management/selenium/test/oauth/uaa/signing-key.pem
+++ b/deps/rabbitmq_management/selenium/test/oauth/uaa/signing-key.pem
@@ -1,0 +1,9 @@
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+VwIDAQAB
+-----END PUBLIC KEY-----

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -620,16 +620,16 @@
    management.oauth_provider_url = http://localhost:8080
    management.oauth_client_id = rabbitmq_client_code
    management.oauth_client_secret = rabbitmq_client_secret
-   management.oauth_scopes = openid profile
-   management.oauth_initiated_logon_type = sp_initiated",
+   management.oauth_scopes = openid profile rabbitmq.*
+   management.oauth_initiated_logon_type = idp_initiated",
   [
    {rabbitmq_management, [
                           {oauth_enabled, true},
                           {oauth_provider_url, "http://localhost:8080"},
                           {oauth_client_id, "rabbitmq_client_code"},
                           {oauth_client_secret, "rabbitmq_client_secret"},
-                          {oauth_scopes, "openid profile"},
-                          {oauth_initiated_logon_type, sp_initiated}
+                          {oauth_scopes, "openid profile rabbitmq.*"},
+                          {oauth_initiated_logon_type, idp_initiated}
                          ]}
   ], [rabbitmq_management]
  }

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -311,7 +311,7 @@
  %%
  %% Inter-node query result caching
  %%
- 
+
  {db_cache_multiplier,
   "management.db_cache_multiplier = 7",
   [
@@ -320,7 +320,7 @@
                          ]}
   ], [rabbitmq_management]
  },
- 
+
  %%
  %% CORS
  %%
@@ -611,6 +611,25 @@
   [
    {rabbitmq_management, [
                           {listener, [{cowboy_opts, [{max_keepalive, 120}]}]}
+                         ]}
+  ], [rabbitmq_management]
+ },
+
+ {oauth2,
+  "management.oauth_enabled = true
+   management.oauth_provider_url = http://localhost:8080
+   management.oauth_client_id = rabbitmq_client_code
+   management.oauth_client_secret = rabbitmq_client_secret
+   management.oauth_scopes = openid profile
+   management.oauth_initiated_logon_type = sp_initiated",
+  [
+   {rabbitmq_management, [
+                          {oauth_enabled, true},
+                          {oauth_provider_url, "http://localhost:8080"},
+                          {oauth_client_id, "rabbitmq_client_code"},
+                          {oauth_client_secret, "rabbitmq_client_secret"},
+                          {oauth_scopes, "openid profile"},
+                          {oauth_initiated_logon_type, sp_initiated}
                          ]}
   ], [rabbitmq_management]
  }


### PR DESCRIPTION
## Proposed changes

- auth_oauth2.preferred_username_claims should accept multiple values
- Use new config style on two selenium test suites
- Test oauth2 backend's config schema and oauth2 management config schema

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Notes for reviewer

This PR is accompanied by another docs's [PR](https://github.com/rabbitmq/rabbitmq-website/pull/1614). 
