### PR TITLE
`rabbit_db*`: Fix EDoc syntax errors

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -343,11 +343,13 @@ get_all_for_destination_in_mnesia(Dst) ->
 -spec fold(Fun, Acc) -> Acc when
       Fun :: fun((Binding :: rabbit_types:binding(), Acc) -> Acc),
       Acc :: any().
-%% @doc Folds over all the bindings, making it more efficient than `get_all()` and
-%% folding over the returned binding list.
-%% Just used by prometheus_rabbitmq_core_metrics_collector to iterate over the bindings.
+%% @doc Folds over all the bindings, making it more efficient than `get_all()'
+%% and folding over the returned binding list.
 %%
-%% @returns the fold accumulator
+%% Just used by prometheus_rabbitmq_core_metrics_collector to iterate over the
+%% bindings.
+%%
+%% @returns the fold accumulator.
 %%
 %% @private
 

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -196,7 +196,7 @@ count_in_mnesia() ->
 %% `UpdateFun'.
 %%
 %% @returns the updated exchange record if the record existed and the
-%% update succeeded. It returns `not_found` if the transaction fails.
+%% update succeeded. It returns `not_found' if the transaction fails.
 %%
 %% @private
 

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -489,7 +489,8 @@ exists_in_mnesia(QName) ->
       QName :: rabbit_amqqueue:name(),
       Exists :: boolean().
 %% @doc Indicates if queue named `QName' exists using a consistent read.
-%% Just used by `rabbit_classic_queue:is_recoverable` for transient queues.
+%%
+%% Just used by `rabbit_classic_queue:is_recoverable()' for transient queues.
 %%
 %% @returns true if the queue exists, false otherwise.
 %%


### PR DESCRIPTION
It's easy to mix `...` from Markdown and `...' from EDoc.

While here, wrap too long lines.