### PR TITLE
Pin rabbitmq_cli prod deps

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -20,6 +20,8 @@ rabbitmqctl(
     visibility = ["//visibility:public"],
     deps = [
         "//deps/rabbit_common:erlang_app",
+        "@observer_cli//:erlang_app",
+        "@stdout_formatter//:erlang_app",
     ],
 )
 
@@ -119,6 +121,8 @@ rabbitmqctl_test(
         "//deps/amqp_client:erlang_app",
         "//deps/rabbit:erlang_app",
         "//deps/rabbit_common:erlang_app",
+        "@observer_cli//:erlang_app",
+        "@stdout_formatter//:erlang_app",
     ],
 )
 

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -1,7 +1,7 @@
 PROJECT = rabbitmq_cli
 
 BUILD_DEPS = rabbit_common
-DEPS = observer_cli
+DEPS = observer_cli stdout_formatter
 TEST_DEPS = amqp_client rabbit
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk


### PR DESCRIPTION
Pin versions of non-test deps of rabbitmq_cli

All prod deps on the erlang side have been pinned for some time, so this makes things symmetric