### PR TITLE
Return "precondition failed" on exchange deletion if appropriate

### DIFF
--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -428,7 +428,13 @@ delete(XName, IfUnused, Username) ->
                                       ?EXCHANGE_DELETE_IN_PROGRESS_COMPONENT,
                                       XName#resource.name, true, Username),
         Deletions = process_deletions(rabbit_db_exchange:delete(XName, IfUnused)),
-        rabbit_binding:notify_deletions(Deletions, Username)
+        case Deletions of
+            {error, _} ->
+                Deletions;
+            _ ->
+                rabbit_binding:notify_deletions(Deletions, Username),
+                ok
+        end
     after
         rabbit_runtime_parameters:clear(XName#resource.virtual_host,
                                         ?EXCHANGE_DELETE_IN_PROGRESS_COMPONENT,


### PR DESCRIPTION
If unused flag is set. This keeps the original behavior.