### PR TITLE
Allow picking ports for `bazel run broker`

### DIFF
--- a/BAZEL.md
+++ b/BAZEL.md
@@ -33,6 +33,18 @@ Create a `user.bazelrc` by making a copy of `user-template.bazelrc` and updating
 
 `bazel run broker`
 
+You can set different environment variables to control some configuration aspects, like this:
+
+```
+    RABBITMQ_CONFIG_FILES=/path/to/conf.d \
+    RABBITMQ_NODENAME=<node>@localhost \
+    RABBITMQ_NODE_PORT=7000 \
+    bazel run broker
+```
+
+This will start RabbitMQ with configs being read from the provided directory. It also will start a node with a given node name, and with all listening ports calculated from the given one - this way you can start non-conflicting rabbits even from different checkouts on a single machine.
+
+
 ### Running tests
 
 Many rabbit tests spawn single or clustered rabbit nodes, and therefore it's best to run test suites sequentially on a single machine. Hence the `build --local_test_jobs=1` flag used in `.bazelrc`. Additionally, it may be reasonable to disable test sharding and stream test output when running tests locally with `--test_output=streamed` as an additional argument (to just disable sharding, but not stream output, use `--test_sharding_strategy=disabled`). Naturally that restriction does not hold if utilizing remote execution (as is the case for RabbitMQ's CI pipelines).

--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -17,18 +17,63 @@ rmq_realpath() {
 }
 
 write_config_file() {
+    local rabbit_fragment=
+    local rabbitmq_management_fragment=
+    local rabbitmq_mqtt_fragment=
+    local rabbitmq_web_mqtt_fragment=
+    local rabbitmq_web_mqtt_examples_fragment=
+    local rabbitmq_stomp_fragment=
+    local rabbitmq_web_stomp_fragment=
+    local rabbitmq_web_stomp_examples_fragment=
+    local rabbitmq_stream_fragment=
+    local rabbitmq_prometheus_fragment=
+
+    if [[ -n $RABBITMQ_NODE_PORT ]]; then
+        rabbit_fragment="{tcp_listeners, [$RABBITMQ_NODE_PORT]}"
+        rabbitmq_management_fragment="{listener, [{port, $(($RABBITMQ_NODE_PORT + 10000))}]}"
+        rabbitmq_mqtt_fragment="{tcp_listeners, [$((1883 + $RABBITMQ_NODE_PORT - 5672))]}"
+        rabbitmq_web_mqtt_fragment="{tcp_config, [{port, $((15675 + $RABBITMQ_NODE_PORT - 5672))}]}"
+        rabbitmq_web_mqtt_examples_fragment="{listener, [{port, $((15670 + $RABBITMQ_NODE_PORT - 5672))}]}"
+        rabbitmq_stomp_fragment="{tcp_listeners, [$((61613 + $RABBITMQ_NODE_PORT - 5672))]}"
+        rabbitmq_web_stomp_fragment="{tcp_config, [{port, $((15674 + $RABBITMQ_NODE_PORT - 5672))}]}"
+        rabbitmq_web_stomp_examples_fragment="{listener, [{port, $((15670 + $RABBITMQ_NODE_PORT - 5672))}]}"
+        rabbitmq_stream_fragment="{tcp_listeners, [$((5552 + $RABBITMQ_NODE_PORT - 5672))]}"
+        rabbitmq_prometheus_fragment="{tcp_config, [{port, $((15692 + $RABBITMQ_NODE_PORT - 5672))}]}"
+    fi
     cat << EOF > "$RABBITMQ_CONFIG_FILE"
 %% vim:ft=erlang:
 
 [
   {rabbit, [
+      ${rabbit_fragment}${rabbit_fragment+,}
       {loopback_users, []}
     ]},
   {rabbitmq_management, [
+      ${rabbitmq_management_fragment}
     ]},
   {rabbitmq_mqtt, [
+      ${rabbitmq_mqtt_fragment}
+    ]},
+  {rabbitmq_web_mqtt, [
+      ${rabbitmq_web_mqtt_fragment}
+    ]},
+  {rabbitmq_web_mqtt_examples, [
+      ${rabbitmq_web_mqtt_examples_fragment}
     ]},
   {rabbitmq_stomp, [
+      ${rabbitmq_stomp_fragment}
+    ]},
+  {rabbitmq_web_stomp, [
+      ${rabbitmq_web_stomp_fragment}
+    ]},
+  {rabbitmq_web_stomp_examples, [
+      ${rabbitmq_web_stomp_examples_fragment}
+    ]},
+  {rabbitmq_stream, [
+      ${rabbitmq_stream_fragment}
+    ]},
+  {rabbitmq_prometheus, [
+      ${rabbitmq_prometheus_fragment}
     ]},
   {ra, [
       {data_dir, "${RABBITMQ_QUORUM_DIR}"},


### PR DESCRIPTION
This way multiple brokers can be run at the same time. Before that the
only option was to use `bazel run start-cluster`, but it's not
granular enough to run rabbits from different checkouts or with
different configs.
