### PR TITLE
Fix CMQ crash when master goes down, queue length at x-max-length limit with consumers connected

### DIFF
--- a/deps/rabbit/src/rabbit_mirror_queue_master.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_master.erl
@@ -513,7 +513,8 @@ zip_msgs_and_acks(Msgs, AckTags, Accumulator,
             master_state().
 
 promote_backing_queue_state(QName, CPid, BQ, BQS, GM, AckTags, Seen, KS) ->
-    {_MsgIds, BQS1} = BQ:requeue(AckTags, BQS),
+    {MsgIds, BQS1} = BQ:requeue(AckTags, BQS),
+    ok = gm:broadcast(GM, {requeue, MsgIds}),
     Len   = BQ:len(BQS1),
     Depth = BQ:depth(BQS1),
     true = Len == Depth, %% ASSERTION: everything must have been requeued


### PR DESCRIPTION
Please check the commit comment for details.

This probably affects all released versions for the past 12 years. I have only tested that the issue exists in v3.9.x branch, v3.10.x, v3.11.x, v3.12.x and main branches. This should be backported at a minimum to v3.12.x so we can do further chaos testing. Whether this should be backported to v3.11.x or earlier is an open question.