### PR TITLE
etcd: do not filter out node TTL

### DIFF
--- a/deps/rabbitmq_peer_discovery_etcd/src/rabbitmq_peer_discovery_etcd_v3_client.erl
+++ b/deps/rabbitmq_peer_discovery_etcd/src/rabbitmq_peer_discovery_etcd_v3_client.erl
@@ -34,9 +34,9 @@
 
 -define(ETCD_CONN_NAME, ?MODULE).
 %% 60s by default matches the default heartbeat timeout.
-%% We add 1s for state machine bookkeeping and
+%% We add 1s for state machine bookkeeping and...
 -define(DEFAULT_NODE_KEY_LEASE_TTL, 61).
-%% don't allow node lease key TTL to be lower than this
+%% ...don't allow node lease key TTL to be lower than this
 %% as overly low values can cause annoying timeouts in etcd client operations
 -define(MINIMUM_NODE_KEY_LEASE_TTL, 15).
 %% default randomized delay range was 5s to 60s, so this value
@@ -426,7 +426,7 @@ normalize_settings(Map) when is_map(Map) ->
     end,
 
     AllEndpoints = Endpoints ++ LegacyEndpoints,
-    maps:merge(maps:without([etcd_prefix, etcd_node_ttl, lock_wait_time], Map),
+    maps:merge(maps:without([etcd_prefix, lock_wait_time], Map),
                #{endpoints => AllEndpoints}).
 
 pick_transport(#statem_data{tls_options = []}) ->


### PR DESCRIPTION
The easiest way to test this is by inspecting the logs.

Using the following `rabbitmq.conf`:

``` ini
cluster_formation.peer_discovery_backend = etcd

cluster_formation.etcd.host = localhost
cluster_formation.etcd.port = 2379

cluster_formation.etcd.endpoints.1 = localhost:2379
cluster_formation.etcd.endpoints.2 = localhost:2479

# cluster_formation.etcd.username = rabbitmq
# cluster_formation.etcd.password = rabbitmq

cluster_formation.etcd.key_prefix = example_prefix
cluster_formation.etcd.cluster_name = lolz_cluster

cluster_formation.etcd.node_ttl = 279
cluster_formation.etcd.lock_timeout = 15

log.file.level = debug
log.console.level = debug
```

and a local etcd node started with all defaults

``` shell
etcd
```

and a node with blank data directory started like this

``` shell
bazel run broker RABBITMQ_ENABLED_PLUGINS="rabbitmq_management,rabbitmq_peer_discovery_etcd" RABBITMQ_NODE_PORT=5672 RABBITMQ_CONFIG_FILE=/path/to/peer_discovery.etcd.7554.conf
```

you'll see this in the logs

```
[debug] <0.733.0> etcd peer discovery: acquired a lease 7587869165524620044 for node key /rabbitmq/discovery/rabbitmq/clusters/lolz_cluster/nodes/rabbit@{hostname} with TTL = 279
```

whereas previously the TTL value would be `61` (the default).

Closes #7554.