### PR TITLE
MQTT: Fix 3.12-beta.1 cluster creation

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -186,7 +186,7 @@ process_connect(
             send_conn_ack(?CONNACK_ACCEPT, SessPresent, ProtoVerAtom, SendFun),
             {ok, State};
         {error, ReturnErrCode} = Err
-          when is_number(ReturnErrCode) ->
+          when is_integer(ReturnErrCode) ->
             %% If a server sends a CONNACK packet containing a non-zero return
             %% code it MUST set Session Present to 0 [MQTT-3.2.2-4].
             SessPresent = false,
@@ -1637,7 +1637,7 @@ mailbox_soft_limit_exceeded() ->
 is_socket_busy(Socket) ->
     case rabbit_net:getstat(Socket, [send_pend]) of
         {ok, [{send_pend, NumBytes}]}
-          when is_number(NumBytes) andalso NumBytes > 0 ->
+          when is_integer(NumBytes) andalso NumBytes > 0 ->
             true;
         _ ->
             false


### PR DESCRIPTION
Deploying a 5 node RabbitMQ cluster with rabbitmq_mqtt plugin enabled using the cluster-operator with rabbitmq image
rabbitmq:3.12.0-beta.1-management often fails with the following error:
```
Feature flags: failed to enable `delete_ra_cluster_mqtt_node`:
{error,
    {no_more_servers_to_try,
        [{error,
            noproc},
        {error,
            noproc},
        {timeout,
            {mqtt_node,
                'rabbit@mqtt-rabbit-3-12-server-2.mqtt-rabbit-3-12-nodes.default'}}]}}
```

During rabbitmq_mqtt plugin start, the plugin decides whether it should create a Ra cluster:
If feature flag delete_ra_cluster_mqtt_node is enabled, no Ra cluster gets created.
If this feature flag is disabled, a Ra cluster is created.

Even though all feature flags are enabled by default for a fresh cluster, the feature flag subsystem cannot provide any promise when feature flag migration functions run during the boot process: The migration functions can run before plugins are started or many seconds after plugins are started.
There is also no API that tells when feature flag initialisation on the local node is completed.

Therefore, during a fresh 3.12 cluster start with rabbitmq_mqtt enabled, some nodes decide to start a Ra cluster (because not all feature flags are enabled yet when the rabbitmq_mqtt plugin is started). Prior to this commit, when the feature flag delete_ra_cluster_mqtt_node got enabled, Ra cluster deletion timed out because the Ra cluster never got initialised successfully: Members never proceeded past the pre-vote phase because their Ra peers already had feature flag delete_ra_cluster_mqtt_node enabled and therefore don't participate.

One possible fix is to remove the feature flag delete_ra_cluster_mqtt_node and have the newly upgraded 3.12 node delete its Ra membership during a rolling update. However, this approach is too risky because during a rolling update of a 3 node cluster A, B, and C the following issue arises:
1. C upgrades successfully and deletes its Ra membership
2. B shuts down. At this point A and B are members of the Ra cluster while only A is online (i.e. not a majority). MQTT clients which try to re-connect to A fail because A times out registering the client in https://github.com/rabbitmq/rabbitmq-server/blob/ad5cc7e2505cd3376e50bdb81910f9db3087675e/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl#L174-L179

Therefore this commit fixes 3.12 cluster creation as follows: The Ra cluster deletion timeout is reduced from 60 seconds to 15 seconds, and the Ra server is force deleted if Ra cluster deletion fails. Force deleting the server will wipe the Ra cluster data on disk.