### PR TITLE
Allow applying policies to specific queue types

### DIFF
--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -1724,7 +1724,13 @@ Which types of object this policy should apply to.
 Possible values are:
 .Bl -bullet -compact
 .It
-queues
+queues (all queue types, including streams)
+.It
+classic_queues (classic queues only)
+.It
+quorum_queues (quorum queues only)
+.It
+streams (streams only)
 .It
 exchanges
 .It

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -83,6 +83,9 @@
               <option value="all">Exchanges and queues</option>
               <option value="exchanges">Exchanges</option>
               <option value="queues">Queues</option>
+              <option value="classic_queues">Classic Queues</option>
+              <option value="quorum_queues">Quorum Queues</option>
+              <option value="streams">Streams</option>
             </select>
           </td>
         </tr>
@@ -259,6 +262,9 @@
           <td>
             <select name="apply-to">
               <option value="queues">Queues</option>
+              <option value="classic_queues">Classic Queues</option>
+              <option value="quorum_queues">Quorum Queues</option>
+              <option value="streams">Streams</option>
             </select>
           </td>
         </tr>

--- a/release-notes/3.12.0.md
+++ b/release-notes/3.12.0.md
@@ -141,6 +141,11 @@ in the `3.11.x` release series.
 
    GitHub issue: [#7208](https://github.com/rabbitmq/rabbitmq-server/issues/7208).
 
+ * Policies can now be defined to only apply to specific queue types. For example, you can have two policies that match all queue names ('.*')
+   but different queue types, so that different parameters are applied to all queues of a specific type. Example usage:
+   ```
+   rabbitmqctl set_policy at-least-once-dead-lettering ".*" '{"dead-letter-strategy": "at-least-once"}' --apply-to quorum_queues
+   ```
 
 ### CLI Tools
 


### PR DESCRIPTION
Rather than relying on queue name conventions, allow applying policies based on the queue type. For example, this allows multiple policies that apply to all queue names (".*") that specify different parameters for different queue types.

New `rabbitmqctl set_policy` options:
```
rabbitmqctl set_policy ttl10 ".*" '{"message-ttl": 10}' --apply-to classic_queues
rabbitmqctl set_policy ttl20 ".*" '{"message-ttl": 20}' --apply-to quorum_queues
rabbitmqctl set_policy age ".*" '{"max-age": "1h"}' --apply-to streams
```

New UI:
![Screenshot 2023-03-14 at 08 21 24](https://user-images.githubusercontent.com/9566114/224925070-28c1ba92-b160-4249-95bf-5bf83aefe6cb.png)

Docs PR:
https://github.com/rabbitmq/rabbitmq-website/pull/1624