### PR TITLE
Support x-stream-max-segment-size-bytes in STOMP plugin

### DIFF
--- a/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
+++ b/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
@@ -45,6 +45,7 @@
 -define(HEADER_X_MAX_LENGTH, "x-max-length").
 -define(HEADER_X_MAX_AGE, "x-max-age").
 -define(HEADER_X_MAX_LENGTH_BYTES, "x-max-length-bytes").
+-define(HEADER_X_STREAM_MAX_SEGMENT_SIZE_BYTES, "x-stream-max-segment-size-bytes").
 -define(HEADER_X_MAX_PRIORITY, "x-max-priority").
 -define(HEADER_X_MESSAGE_TTL, "x-message-ttl").
 -define(HEADER_X_QUEUE_NAME, "x-queue-name").
@@ -62,6 +63,7 @@
                            ?HEADER_X_EXPIRES,
                            ?HEADER_X_MAX_LENGTH,
                            ?HEADER_X_MAX_AGE,
+                           ?HEADER_X_STREAM_MAX_SEGMENT_SIZE_BYTES,
                            ?HEADER_X_MAX_LENGTH_BYTES,
                            ?HEADER_X_MAX_PRIORITY,
                            ?HEADER_X_MESSAGE_TTL,

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_util.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_util.erl
@@ -292,6 +292,9 @@ build_argument(?HEADER_X_MESSAGE_TTL, Val) ->
 build_argument(?HEADER_X_MAX_AGE, Val) ->
     {list_to_binary(?HEADER_X_MAX_AGE), longstr,
      list_to_binary(string:strip(Val))};
+build_argument(?HEADER_X_STREAM_MAX_SEGMENT_SIZE_BYTES, Val) ->
+    {list_to_binary(?HEADER_X_STREAM_MAX_SEGMENT_SIZE_BYTES), long,
+     list_to_integer(string:strip(Val))};
 build_argument(?HEADER_X_QUEUE_TYPE, Val) ->
   {list_to_binary(?HEADER_X_QUEUE_TYPE), longstr,
     list_to_binary(string:strip(Val))}.

--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_stream.py
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_stream.py
@@ -26,6 +26,7 @@ class TestUserGeneratedQueueName(base.BaseTest):
                     'x-queue-name': queueName,
                     'x-queue-type': 'stream',
                     'x-max-age' : '10h',
+                    'x-stream-max-segment-size-bytes' : 1048576,
                     'durable': True,
                     'auto-delete': False,
                     'id': 1234,


### PR DESCRIPTION
To be able to set the max segment size of the created stream when using a "/queue/<name>" destination.