### PR TITLE
Use pkg_files rules to avoid extra tars

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load(
     "bool_flag",
     "string_flag",
 )
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_erlang//:dialyze.bzl", "plt")
 load("@rules_erlang//:shell.bzl", "shell")
 load("@rules_erlang//:erl_eval.bzl", "erl_eval")
@@ -161,36 +161,36 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-pkg_tar(
-    name = "scripts-tar",
+pkg_files(
+    name = "scripts-files",
     srcs = [
         "scripts/bash_autocomplete.sh",
         "scripts/rabbitmq-script-wrapper",
         "scripts/rabbitmqctl-autocomplete.sh",
         "scripts/zsh_autocomplete.sh",
     ],
-    package_dir = "scripts",
+    prefix = "scripts",
     visibility = ["//visibility:public"],
 )
 
-pkg_tar(
-    name = "release-notes-tar",
+pkg_files(
+    name = "release-notes-files",
     srcs = glob([
         "release-notes/*.md",
         "release-notes/*.txt",
     ]),
-    package_dir = "release-notes",
+    prefix = "release-notes",
     visibility = ["//visibility:public"],
 )
 
 package_generic_unix(
+    name = "package-generic-unix",
     plugins = PLUGINS,
-    rabbitmq_workspace = "@",
 )
 
 source_archive(
+    name = "source_archive",
     plugins = PLUGINS,
-    rabbitmq_workspace = "@",
 )
 
 alias(

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ RSYNC_FLAGS += -a $(RSYNC_V)		\
 	       --exclude '*.bazelrc'			\
 	       --exclude 'moduleindex.yaml'		\
 	       --exclude 'BUILD.*'			\
+	       --exclude 'erlang_ls.config'		\
 	       --exclude '$(notdir $(ERLANG_MK_TMP))'	\
 	       --exclude '_build/'			\
 	       --exclude '__pycache__/'			\

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "rabbitmq-server")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 

--- a/dist.bzl
+++ b/dist.bzl
@@ -1,3 +1,4 @@
+load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_erlang//:erlang_app_info.bzl", "ErlangAppInfo", "flat_deps")
 load("@rules_erlang//:util.bzl", "path_join")
@@ -229,23 +230,23 @@ def versioned_plugins_dir(**kwargs):
     )
 
 def package_generic_unix(
+        name = "package-generic-unix",
         plugins = None,
-        rabbitmq_workspace = "@rabbitmq-server",
         extra_licenses = [],
         package_dir = "rabbitmq_server-{}".format(APP_VERSION)):
     collect_licenses(
         name = "licenses",
         srcs = [
-            Label(rabbitmq_workspace + "//:root-licenses"),
+            Label("@rabbitmq-server//:root-licenses"),
         ] + extra_licenses,
         deps = plugins,
     )
 
-    pkg_tar(
-        name = "license-files-tar",
+    pkg_files(
+        name = "license-files",
         srcs = [
             ":licenses",
-            Label(rabbitmq_workspace + "//deps/rabbit:INSTALL"),
+            Label("@rabbitmq-server//deps/rabbit:INSTALL"),
         ],
         visibility = ["//visibility:public"],
     )
@@ -254,24 +255,24 @@ def package_generic_unix(
         name = "sbin-dir",
     )
 
-    pkg_tar(
-        name = "sbin-tar",
+    pkg_files(
+        name = "sbin-files",
         srcs = [
             ":sbin-dir",
         ],
-        package_dir = "sbin",
+        prefix = "sbin",
     )
 
     escript_dir(
         name = "escript-dir",
     )
 
-    pkg_tar(
-        name = "escripts-tar",
+    pkg_files(
+        name = "escript-files",
         srcs = [
             ":escript-dir",
         ],
-        package_dir = "escript",
+        prefix = "escript",
     )
 
     versioned_plugins_dir(
@@ -279,65 +280,66 @@ def package_generic_unix(
         plugins = plugins,
     )
 
-    pkg_tar(
-        name = "plugins-tar",
+    pkg_files(
+        name = "plugins-files",
         srcs = [
             ":plugins-dir",
         ],
-        package_dir = "plugins",
     )
 
     pkg_tar(
-        name = "package-generic-unix",
+        name = name,
         extension = "tar.xz",
         package_dir = package_dir,
         visibility = ["//visibility:public"],
+        srcs = [
+            ":escript-files",
+            ":sbin-files",
+            ":plugins-files",
+            ":license-files",
+            Label("@rabbitmq-server//:release-notes-files"),
+            Label("@rabbitmq-server//:scripts-files"),
+        ],
         deps = [
-            ":escripts-tar",
-            ":sbin-tar",
-            ":plugins-tar",
-            ":license-files-tar",
-            Label(rabbitmq_workspace + "//:release-notes-tar"),
-            Label(rabbitmq_workspace + "//:scripts-tar"),
-            Label(rabbitmq_workspace + "//deps/rabbit:manpages-dir"),
+            Label("@rabbitmq-server//deps/rabbit:manpages-dir"),
         ],
     )
 
 def source_archive(
-        plugins = None,
-        rabbitmq_workspace = "@rabbitmq-server"):
+        name = "source_archive",
+        plugins = None):
     source_tree(
         name = "source-tree",
         deps = plugins + [
-            Label(rabbitmq_workspace + "//deps/rabbitmq_cli:erlang_app"),
+            Label("@rabbitmq-server//deps/rabbitmq_cli:erlang_app"),
         ],
     )
 
-    pkg_tar(
-        name = "deps-archive",
+    pkg_files(
+        name = "deps-files",
         srcs = [
             ":source-tree",
         ],
-        package_dir = "deps",
         strip_prefix = "source-tree",
+        prefix = "deps",
     )
 
     pkg_tar(
         name = "cli-deps-archive",
         deps = [
-            Label(rabbitmq_workspace + "//deps/rabbitmq_cli:fetched_srcs"),
+            Label("@rabbitmq-server//deps/rabbitmq_cli:fetched_srcs"),
         ],
         package_dir = "deps/rabbitmq_cli",
     )
 
     pkg_tar(
-        name = "source_archive",
+        name = name,
         extension = "tar.xz",
         srcs = [
-            Label(rabbitmq_workspace + "//:root-licenses"),
+            ":deps-files",
+            Label("@rabbitmq-server//:root-licenses"),
         ],
         deps = [
-            ":deps-archive",
             ":cli-deps-archive",
         ],
         visibility = ["//visibility:public"],


### PR DESCRIPTION
in package-generic-unix and source_archive macros