### PR TITLE
Avoid fetching test deps when building rabbitmqctl with bazel

### DIFF
--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -121,7 +121,7 @@ export MIX_ENV=prod
 export ERL_COMPILER_OPTIONS=deterministic
 "${{ABS_ELIXIR_HOME}}"/bin/mix local.hex --force
 "${{ABS_ELIXIR_HOME}}"/bin/mix local.rebar --force
-"${{ABS_ELIXIR_HOME}}"/bin/mix deps.get
+"${{ABS_ELIXIR_HOME}}"/bin/mix deps.get --only prod
 if [ ! -d _build/${{MIX_ENV}}/lib/rabbit_common ]; then
     cp -r ${{DEPS_DIR}}/* _build/${{MIX_ENV}}/lib
 fi


### PR DESCRIPTION
Also for bazel offline build readiness

Relates to #7609 