### PR TITLE
added :streams to the help command scopes

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -14,7 +14,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def scopes(), do: [:ctl, :diagnostics, :plugins, :queues, :vmware, :upgrade]
+  def scopes(), do: [:ctl, :diagnostics, :plugins, :queues, :streams, :vmware, :upgrade]
   def switches(), do: [list_commands: :boolean]
 
   def distribution(_), do: :none


### PR DESCRIPTION
## Proposed Changes

The rabbitmq-streams cli tool mentions: `Use 'rabbitmq-streams help <command>' to learn more about a specific command`. However, when using `rabbitmq-streams help stream_status` for example, we get `Command 'help' not found.`.
This PR adds streams to the scope of the help_command and ensures that the help pages are displayed when using the help function.


## Types of Changes



- [x ] Bug fix (non-breaking change which fixes issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I couldn't see an existing issue raised for this. Looks like an obvious fix but let me know if not and a CA is needed.
