### PR TITLE
Remove "dev_dependency = True" from erlang_dev_package in MODULE

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -359,7 +359,6 @@ use_repo(
 erlang_dev_package = use_extension(
     "@rules_erlang//bzlmod:extensions.bzl",
     "erlang_package",
-    dev_dependency = True,
 )
 
 erlang_dev_package.git_package(


### PR DESCRIPTION
deps/rabbitmq_ct_helpers depends on proper and meck, so unfortunately if proper and meck are marked as dev dependencies, bazel modules depending on rabbitmq-server cannot build it

Another way of putting it is that they are not actually "dev" dependencies of for all components that rabbitmq-server exposes

They are still marked as "testonly = True" so that they aren't accidentally included in release artifacts