### PR TITLE
Add "Summary" jobs to test workflows in actions

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -133,3 +133,12 @@ jobs:
 
           docker push pivotalrabbitmq/rabbitmq:${TAG_1}
           docker push pivotalrabbitmq/rabbitmq:${TAG_2}
+
+  summary:
+    needs:
+    - build-publish-dev-bazel
+    runs-on: ubuntu-latest
+    steps:
+    - name: SUMMARY
+      run: |
+        echo "SUCCESS"

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -215,3 +215,12 @@ jobs:
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
+  summary:
+    needs:
+    - test-mixed-versions
+    - test-exclusive-mixed-versions
+    runs-on: ubuntu-latest
+    steps:
+    - name: SUMMARY
+      run: |
+        echo "SUCCESS"

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -21,7 +21,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
-  selenimum:
+  selenium:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -101,3 +101,12 @@ jobs:
         path: |
           logs/*
           screens/*
+
+  summary:
+    needs:
+    - selenium
+    runs-on: ubuntu-latest
+    steps:
+    - name: SUMMARY
+      run: |
+        echo "SUCCESS"

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -63,3 +63,11 @@ jobs:
           --test_tag_filters=-aws,-docker,-bats,-starts-background-broker ^
           --build_tests_only ^
           --verbose_failures
+  summary:
+    needs:
+    - test
+    runs-on: ubuntu-latest
+    steps:
+    - name: SUMMARY
+      run: |
+        echo "SUCCESS"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,3 +127,12 @@ jobs:
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
+  summary:
+    needs:
+    - test
+    - test-exclusive
+    runs-on: ubuntu-latest
+    steps:
+    - name: SUMMARY
+      run: |
+        echo "SUCCESS"


### PR DESCRIPTION
These exist to make it easier to manage the branch protection rules, so that required checks don't change when OTP versions change in a branch