### PR TITLE
Give each of the summary jobs in actions different names

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -134,7 +134,7 @@ jobs:
           docker push pivotalrabbitmq/rabbitmq:${TAG_1}
           docker push pivotalrabbitmq/rabbitmq:${TAG_2}
 
-  summary:
+  summary-oci:
     needs:
     - build-publish-dev-bazel
     runs-on: ubuntu-latest

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -215,7 +215,7 @@ jobs:
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
-  summary:
+  summary-mixed-versions:
     needs:
     - test-mixed-versions
     - test-exclusive-mixed-versions

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -102,7 +102,7 @@ jobs:
           logs/*
           screens/*
 
-  summary:
+  summary-selenium:
     needs:
     - selenium
     runs-on: ubuntu-latest

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -63,7 +63,7 @@ jobs:
           --test_tag_filters=-aws,-docker,-bats,-starts-background-broker ^
           --build_tests_only ^
           --verbose_failures
-  summary:
+  summary-windows:
     needs:
     - test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,7 +127,7 @@ jobs:
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
-  summary:
+  summary-test:
     needs:
     - test
     - test-exclusive


### PR DESCRIPTION
Otherwise they do not appear to be selectable in the github branch protection rules UI