### PR TITLE
Fix rabbit_policy:match_all/2

### DIFF
--- a/deps/rabbit/src/rabbit_policy.erl
+++ b/deps/rabbit/src/rabbit_policy.erl
@@ -517,7 +517,9 @@ maybe_notify_of_policy_change({Q1, Q2}, PolicyDef, ActingUser) when ?is_amqqueue
     rabbit_amqqueue:policy_changed(Q1, Q2).
 
 matches_type(exchange, <<"exchanges">>) -> true;
+matches_type(queue,    <<"queues">>)    -> true;
 matches_type(exchange, <<"all">>)       -> true;
+matches_type(queue,    <<"all">>)       -> true;
 matches_type(_,        _)               -> false.
 
 matches_queue_type(queue, _, <<"all">>)    -> true;


### PR DESCRIPTION
when called with names instead of records, by falling back to the old behaviour prior to #7601 