### PR TITLE
Include the queue type in the queue_deleted rabbit_event

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -133,14 +133,6 @@ recover(VHost) ->
 filter_pid_per_type(QPids) ->
     lists:partition(fun(QPid) -> ?IS_CLASSIC(QPid) end, QPids).
 
-filter_resource_per_type(Resources) ->
-    Queues = [begin
-                  {ok, Q} = lookup(Resource),
-                  QPid = amqqueue:get_pid(Q),
-                  {Resource, QPid}
-              end || Resource <- Resources],
-    lists:partition(fun({_Resource, QPid}) -> ?IS_CLASSIC(QPid) end, Queues).
-
 -spec stop(rabbit_types:vhost()) -> 'ok'.
 stop(VHost) ->
     %% Classic queues
@@ -1506,11 +1498,17 @@ delete_immediately(QPids) ->
     end.
 
 delete_immediately_by_resource(Resources) ->
-    {Classic, Quorum} = filter_resource_per_type(Resources),
-    [gen_server2:cast(QPid, delete_immediately) || {_, QPid} <- Classic],
-    [rabbit_quorum_queue:delete_immediately(Resource, QPid)
-     || {Resource, QPid} <- Quorum],
-    ok.
+    lists:foreach(
+      fun(Resource) ->
+              {ok, Q} = lookup(Resource),
+              QPid = amqqueue:get_pid(Q),
+              case ?IS_CLASSIC(QPid) of
+                  true ->
+                      gen_server2:cast(QPid, delete_immediately);
+                  _ ->
+                      rabbit_quorum_queue:delete_immediately(Q)
+              end
+      end, Resources).
 
 -spec delete
         (amqqueue:amqqueue(), 'false', 'false', rabbit_types:username()) ->
@@ -1676,12 +1674,13 @@ notify_sent_queue_down(QPid) ->
 resume(QPid, ChPid) -> delegate:invoke_no_result(QPid, {gen_server2, cast,
                                                         [{resume, ChPid}]}).
 
--spec internal_delete(name(), rabbit_types:username()) -> 'ok'.
+-spec internal_delete(amqqueue:amqqueue(), rabbit_types:username()) -> 'ok'.
 
-internal_delete(QueueName, ActingUser) ->
-    internal_delete(QueueName, ActingUser, normal).
+internal_delete(Queue, ActingUser) ->
+    internal_delete(Queue, ActingUser, normal).
 
-internal_delete(QueueName, ActingUser, Reason) ->
+internal_delete(Queue, ActingUser, Reason) ->
+    QueueName = amqqueue:get_name(Queue),
     case rabbit_db_queue:delete(QueueName, Reason) of
         ok ->
             ok;
@@ -1691,6 +1690,7 @@ internal_delete(QueueName, ActingUser, Reason) ->
             rabbit_core_metrics:queue_deleted(QueueName),
             ok = rabbit_event:notify(queue_deleted,
                                      [{name, QueueName},
+                                      {type, amqqueue:get_type(Queue)},
                                       {user_who_performed_action, ActingUser}])
     end.
 

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1874,7 +1874,7 @@ on_node_down(Node) ->
             end,
             notify_queue_binding_deletions(Deletions),
             rabbit_core_metrics:queues_deleted(QueueNames),
-            notify_queues_deleted(QueueNames),
+            notify_transient_queues_deleted(QueueNames),
             ok
     end.
 
@@ -1897,11 +1897,12 @@ notify_queue_binding_deletions(QueueDeletions) ->
     Deletions = rabbit_binding:process_deletions(QueueDeletions),
     rabbit_binding:notify_deletions(Deletions, ?INTERNAL_USER).
 
-notify_queues_deleted(QueueDeletions) ->
+notify_transient_queues_deleted(QueueDeletions) ->
     lists:foreach(
       fun(Queue) ->
               ok = rabbit_event:notify(queue_deleted,
                                        [{name, Queue},
+                                        {kind, rabbit_classic_queue},
                                         {user, ?INTERNAL_USER}])
       end,
       QueueDeletions).

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -314,7 +314,6 @@ terminate_delete(EmitStats, Reason0,
                  State = #q{q = Q,
                             backing_queue = BQ,
                             status = Status}) ->
-    QName = amqqueue:get_name(Q),
     ActingUser = terminated_by(Status),
     fun (BQS) ->
         Reason = case Reason0 of
@@ -330,7 +329,7 @@ terminate_delete(EmitStats, Reason0,
         %% logged.
         try
             %% don't care if the internal delete doesn't return 'ok'.
-            rabbit_amqqueue:internal_delete(QName, ActingUser, Reason0)
+            rabbit_amqqueue:internal_delete(Q, ActingUser, Reason0)
         catch
             {error, ReasonE} -> error(ReasonE)
         end,

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -466,10 +466,9 @@ delete_crashed(Q, ActingUser) ->
                   [Q, ActingUser]).
 
 delete_crashed_internal(Q, ActingUser) ->
-    QName = amqqueue:get_name(Q),
     {ok, BQ} = application:get_env(rabbit, backing_queue_module),
     BQ:delete_crashed(Q),
-    ok = rabbit_amqqueue:internal_delete(QName, ActingUser).
+    ok = rabbit_amqqueue:internal_delete(Q, ActingUser).
 
 recover_durable_queues(QueuesAndRecoveryTerms) ->
     {Results, Failures} =

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -177,8 +177,7 @@ delete_stream(Q, ActingUser)
     #{name := StreamId} = amqqueue:get_type_state(Q),
     case process_command({delete_stream, StreamId, #{}}) of
         {ok, ok, _} ->
-            QName = amqqueue:get_name(Q),
-              _ = rabbit_amqqueue:internal_delete(QName, ActingUser),
+            _ = rabbit_amqqueue:internal_delete(Q, ActingUser),
             {ok, {ok, 0}};
         Err ->
             Err

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -160,8 +160,7 @@ create_stream(Q0) ->
                                           ActingUser}]),
                     {new, Q};
                 Error ->
-
-                    _ = rabbit_amqqueue:internal_delete(QName, ActingUser),
+                    _ = rabbit_amqqueue:internal_delete(Q, ActingUser),
                     {protocol_error, internal_error, "Cannot declare a queue '~ts' on node '~ts': ~255p",
                      [rabbit_misc:rs(QName), node(), Error]}
             end;

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -413,8 +413,7 @@ assert_benign({error, not_found}, _) -> ok;
 assert_benign({error, {absent, Q, _}}, ActingUser) ->
     %% Removing the database entries here is safe. If/when the down node
     %% restarts, it will clear out the on-disk storage of the queue.
-    QName = amqqueue:get_name(Q),
-    rabbit_amqqueue:internal_delete(QName, ActingUser).
+    rabbit_amqqueue:internal_delete(Q, ActingUser).
 
 -spec exists(vhost:name()) -> boolean().
 

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -911,7 +911,7 @@ bq_queue_recover1(Config) ->
                   rabbit_variable_queue:fetch(true, VQ1),
               CountMinusOne = rabbit_variable_queue:len(VQ2),
               _VQ3 = rabbit_variable_queue:delete_and_terminate(shutdown, VQ2),
-              ok = rabbit_amqqueue:internal_delete(QName, <<"acting-user">>)
+              ok = rabbit_amqqueue:internal_delete(Q1, <<"acting-user">>)
       end),
     passed.
 

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -97,7 +97,7 @@ declare(Q0, _Node) ->
 delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
     QName = amqqueue:get_name(Q),
     log_delete(QName, amqqueue:get_exclusive_owner(Q)),
-    ok = rabbit_amqqueue:internal_delete(QName, ActingUser),
+    ok = rabbit_amqqueue:internal_delete(Q, ActingUser),
     {ok, 0}.
 
 -spec deliver([{amqqueue:amqqueue(), stateless}], Delivery :: term()) ->
@@ -164,7 +164,7 @@ recover(_VHost, Queues) ->
               true = is_recoverable(Q),
               QName = amqqueue:get_name(Q),
               log_delete(QName, amqqueue:get_exclusive_owner(Q)),
-              rabbit_amqqueue:internal_delete(QName, ?INTERNAL_USER)
+              rabbit_amqqueue:internal_delete(Q, ?INTERNAL_USER)
       end, Queues),
     %% We mark the queue recovery as failed because these queues are not really
     %% recovered, but deleted.


### PR DESCRIPTION
This is useful for understanding if a deleted queue was matching any policies given the more selective policies introduced in #7601.