### PR TITLE
Classic queues: make CQv2 the new default

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -78,6 +78,8 @@ _APP_ENV = """[
 	                         ]},
 	    {halt_on_upgrade_failure, true},
 	    {ssl_apps, [asn1, crypto, public_key, ssl]},
+	    %% classic queue storage implementation version
+	    {classic_queue_default_version, 2},
 	    %% see rabbitmq-server#114
 	    {mirroring_flow_control, true},
 	    {mirroring_sync_batch_size, 4096},

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -65,6 +65,8 @@ define PROJECT_ENV
 	                         ]},
 	    {halt_on_upgrade_failure, true},
 	    {ssl_apps, [asn1, crypto, public_key, ssl]},
+	    %% classic queue storage implementation version
+        {classic_queue_default_version, 2},
 	    %% see rabbitmq-server#114
 	    {mirroring_flow_control, true},
 	    {mirroring_sync_batch_size, 4096},

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2408,7 +2408,7 @@ end}.
 
 {translation, "rabbit.classic_queue_default_version",
     fun(Conf) ->
-        case cuttlefish:conf_get("classic_queue.default_version", Conf, 1) of
+        case cuttlefish:conf_get("classic_queue.default_version", Conf, 2) of
             1 -> 1;
             2 -> 2;
             _ -> cuttlefish:unset()

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -470,12 +470,10 @@ init_queue_mode(Mode, State = #q {backing_queue = BQ,
 
 init_queue_version(Version0, State = #q {backing_queue = BQ,
                                          backing_queue_state = BQS}) ->
-    %% When the version is undefined we use the default version 1.
-    %% We want to BQ:set_queue_version in all cases because a v2
-    %% policy might have been deleted, for example, and we want
-    %% the queue to go back to v1.
+    %% When the version is undefined we use the default version 2 starting with
+    %% RabbitMQ 3.12.0.
     Version = case Version0 of
-        undefined -> rabbit_misc:get_env(rabbit, classic_queue_default_version, 1);
+        undefined -> rabbit_misc:get_env(rabbit, classic_queue_default_version, 2);
         _ -> Version0
     end,
     BQS1 = BQ:set_queue_version(Version, BQS),

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -492,8 +492,9 @@ process_recovery_terms(Terms) ->
 
 queue_version(Q) ->
     Resolve = fun(_, ArgVal) -> ArgVal end,
+    %% If queue-version is undefined, we assume v2 starting with RabbitMQ 3.12.0.
     case rabbit_queue_type_util:args_policy_lookup(<<"queue-version">>, Resolve, Q) of
-        undefined -> rabbit_misc:get_env(rabbit, classic_queue_default_version, 1);
+        undefined -> rabbit_misc:get_env(rabbit, classic_queue_default_version, 2);
         Vsn when is_integer(Vsn) -> Vsn;
         Vsn -> binary_to_integer(Vsn)
     end.

--- a/release-notes/3.12.0.md
+++ b/release-notes/3.12.0.md
@@ -109,8 +109,16 @@ in the `3.11.x` release series.
 
    GitHub issue: [#7553](https://github.com/rabbitmq/rabbitmq-server/pull/7553#issuecomment-1463660454)
 
- * Reduced memory footprint, improved memory use predictability and throughput of classic queues.
+ * Reduced memory footprint, improved memory use predictability and throughput of classic queues (version 2, or CQv2).
    This particularly benefits classic queues with longer backlogs.
+
+   Classic queue v2 (CQv2) storage implementation **is now the default**. It is possible to switch
+   the default back to CQv1 using `rabbitmq.conf`:
+
+   ``` ini
+   # uses CQv1 by default
+   classic_queue.default_version = 1
+   ```
 
    GitHub issues: [#4522](https://github.com/rabbitmq/rabbitmq-server/pull/4522), [#7516](https://github.com/rabbitmq/rabbitmq-server/pull/7516)
 


### PR DESCRIPTION
CQv2 is significantly more efficient (x2-4 on some workloads), has lower and more predictable memory footprint, and eliminates the need to make classic queues lazy to achieve that predictability.

Per several discussions with the team.
