### PR TITLE
rabbit_node_monitor: Use `rabbit_mnesia` in partition handling-specific code

### DIFF
--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -470,7 +470,7 @@ handle_cast({announce_guid, Node, GUID}, State = #state{node_guids = GUIDs}) ->
 handle_cast({check_partial_partition, Node, Rep, NodeGUID, MyGUID, RepGUID},
             State = #state{guid       = MyGUID,
                            node_guids = GUIDs}) ->
-    case lists:member(Node, rabbit_nodes:list_reachable()) andalso
+    case lists:member(Node, rabbit_mnesia:cluster_nodes(running)) andalso
         maps:find(Node, GUIDs) =:= {ok, NodeGUID} of
         true  -> spawn_link( %%[1]
                    fun () ->
@@ -623,7 +623,7 @@ handle_info({nodedown, Node, Info}, State = #state{guid       = MyGUID,
                              Node, node(), DownGUID, CheckGUID, MyGUID})
             end,
     _ = case maps:find(Node, GUIDs) of
-        {ok, DownGUID} -> Alive = rabbit_nodes:list_reachable()
+        {ok, DownGUID} -> Alive = rabbit_mnesia:cluster_nodes(running)
                               -- [node(), Node],
                           [case maps:find(N, GUIDs) of
                                {ok, CheckGUID} -> Check(N, CheckGUID, DownGUID);


### PR DESCRIPTION
### Why

The partition detection code defines a partitioned node as an Erlang node running RabbitMQ but which is not among the Mnesia running nodes.

Since  #7058, `rabbit_node_monitor` uses the list functions exported by `rabbit_nodes` for everything, except the partition detection code which is Mnesia-specific and relies on `rabbit_mnesia:cluster_nodes/1`.

Unfortunately, we saw regressions in the Jepsen testsuite during the 3.12.0 release cycle only because that testsuite is not executed on `main`.

It happens that the partition detection code is using `rabbit_nodes` list functions in two places where it should have continued to use `rabbit_mnesia`.

### How
The fix bug fix simply consists of reverting the two calls to `rabbit_nodes` back to calls to `rabbit_mnesia` as it used to do. This seems to improve the situation a lot in the manual testing.

This code will go away with our use of Mnesia in the future, so it's not a problem to call `rabbit_mnesia` here.