### PR TITLE
fix up bazel build of rabbitmq_cli when branch switching

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -25,7 +25,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
     check_port_connectivity(port, node_name, hostname, timeout)
   end
 
-  def check_port_connectivity(port, node_name, hostname_or_ip, timeout) do
+  def check_port_connectivity(port, _node_name, hostname_or_ip, timeout) do
     try do
       IO.puts("Will connect to #{hostname_or_ip}:#{port}")
 

--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -122,9 +122,11 @@ export ERL_COMPILER_OPTIONS=deterministic
 "${{ABS_ELIXIR_HOME}}"/bin/mix local.hex --force
 "${{ABS_ELIXIR_HOME}}"/bin/mix local.rebar --force
 "${{ABS_ELIXIR_HOME}}"/bin/mix deps.get --only prod
-if [ ! -d _build/${{MIX_ENV}}/lib/rabbit_common ]; then
-    cp -r ${{DEPS_DIR}}/* _build/${{MIX_ENV}}/lib
-fi
+for d in {precompiled_deps}; do
+    mkdir _build/${{MIX_ENV}}/lib/$d
+    ln -s ${{DEPS_DIR}}/$d/ebin _build/${{MIX_ENV}}/lib/$d
+    ln -s ${{DEPS_DIR}}/$d/include _build/${{MIX_ENV}}/lib/$d
+done
 "${{ABS_ELIXIR_HOME}}"/bin/mix deps.compile
 "${{ABS_ELIXIR_HOME}}"/bin/mix compile
 "${{ABS_ELIXIR_HOME}}"/bin/mix escript.build
@@ -151,6 +153,10 @@ find . -type l -delete
         ebin_dir = ebin.path,
         consolidated_dir = consolidated.path,
         fetched_srcs = fetched_srcs.path,
+        precompiled_deps = " ".join([
+            dep[ErlangAppInfo].app_name
+            for dep in ctx.attr.deps
+        ]),
     )
 
     inputs = depset(


### PR DESCRIPTION
It seems to be the case that sometime after switching branch there are errors when building the cli, that are fixed with a `bazel clean`, such as:

```
ERROR: /Users/mkuratczyk/rabbitmq/rabbitmq-server/deps/rabbitmq_cli/BUILD.bazel:11:12: MIX deps/rabbitmq_cli/escript/rabbitmqctl failed: (Exit 1): bash failed: error executing command (from target //deps/rabbitmq_cli:rabbitmqctl) /bin/bash -c ... (remaining 1 argument skipped)
cp: /Users/mkuratczyk/data/_bazel_mkuratczyk/c6c37788822ef0f8af3f5b88cfd34f26/execroot/_main/bazel-out/darwin_arm64-dbg/bin/deps/rabbitmq_cli/rabbitmqctl_deps/rabbit_common/src/rabbit_exchange_type.erl: No such file or directory
```

A bazel clean can be rather expensive, though, so it would be nice to avoid it.