### PR TITLE
Always import default data if rabbit_table:needs_default_data/0 is true

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1056,14 +1056,13 @@ recover() ->
 -spec maybe_insert_default_data() -> 'ok'.
 
 maybe_insert_default_data() ->
-    NoDefsToImport = not rabbit_definitions:has_configured_definitions_to_load(),
-    case rabbit_table:needs_default_data() andalso NoDefsToImport of
+    case rabbit_table:needs_default_data() of
         true  ->
             ?LOG_INFO("Will seed default virtual host and user...",
                       #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
             insert_default_data();
         false ->
-            ?LOG_INFO("Will not seed default virtual host and user: have definitions to load...",
+            ?LOG_INFO("Will NOT seed default virtual host and user...",
                       #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
             ok
     end.


### PR DESCRIPTION
Fixes #7678

References:
* #2384
* #2396

PR #2396 preserved the old behavior where definitions import took priority over the default data and environment data that may be present. This behavior continues to confuse users where they expect `RABBITMQ_DEFAULT_USER` / `RABBITMQ_DEFAULT_PASS` to be imported, especially if there is no `users` data in the definitions file.

This PR allows default data and the environment to be imported first, then possibly overwritten by the definitions file.