### PR TITLE
Recovery terms in per-queue files instead of DETS

### DIFF
--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -56,7 +56,7 @@ recover(VHost) ->
     rabbit_log:info("Making sure data directory '~ts' for vhost '~ts' exists",
                     [VHostDir, VHost]),
     VHostStubFile = filename:join(VHostDir, ".vhost"),
-    ok = rabbit_file:ensure_dir(VHostStubFile),
+    ok = filelib:ensure_dir(VHostStubFile),
     ok = file:write_file(VHostStubFile, VHost),
     ok = ensure_config_file(VHost),
     {Recovered, Failed} = rabbit_amqqueue:recover(VHost),

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -1589,7 +1589,7 @@ variable_queue_read_terms(QName) ->
                 virtual_host = VHost,
                 name = Name } = QName,
     <<Num:128>> = erlang:md5(<<"queue", VHost/binary, Name/binary>>),
-    DirName = rabbit_misc:format("~.36B", [Num]),
+    DirName = filename:join([rabbit_vhost:msg_store_dir_path(VHost), "queues", rabbit_misc:format("~.36B", [Num])]),
     {ok, Terms} = rabbit_recovery_terms:read(VHost, DirName),
     Terms.
 


### PR DESCRIPTION
Note: this PR maintains backwards compatibility; a separate PR will remove the old bits

Per-vhost DETS file with recovery terms for all queues is a bottleneck when stopping RabbitMQ - all queues try save their state, leading to a very long file server mailbox and very unpredictable time to stop RabbitMQ (on my machine it can vary from 20 seconds to 5 minutes with 100k classic queues).

In this PR we can still read the recovery terms from DETS but we only save them in per-queue files. This way each queue can quickly store its state. Under the same condition, my machine can consistently stop RabbitMQ in 15 seconds or so.

The tradeoff is a slower startup time: on my machine, it goes up from 29 seconds to 38 seconds, but that's still better than what we had until https://github.com/rabbitmq/rabbitmq-server/pull/7676 was merged a few days ago. More importantly, the total of stop+start is lower and more predictable.

This PR also improves shutdown with many classic queues v1. Startup time with 100k CQv1s is so long and unpredictable that it's hard to even tell if this PR affects it (it varies from 4 to 8 minutes for me).

Unfortunately this PR makes startup on MacOS slower (~55s instead of 30s for me), but we don't have to optimise for that. In most cases (with much fewer queues), it won't be noticeable anyway.