### PR TITLE
More cleanup for the old upgrade subsystem

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1049,7 +1049,6 @@ boot_delegate() ->
 -spec recover() -> 'ok'.
 
 recover() ->
-    ok = rabbit_policy:recover(),
     ok = rabbit_vhost:recover(),
     ok.
 

--- a/deps/rabbit/src/rabbit_policy.erl
+++ b/deps/rabbit/src/rabbit_policy.erl
@@ -33,7 +33,6 @@
 -import(rabbit_misc, [pget/2, pget/3]).
 
 -export([register/0]).
--export([invalidate/0, recover/0]).
 -export([name/1, name_op/1, effective_definition/1, merge_operator_definitions/2, get/2, get_arg/3, set/1]).
 -export([validate/5, notify/5, notify_clear/4]).
 -export([parse_set/7, set/7, delete/3, lookup/2, list/0, list/1,
@@ -244,50 +243,6 @@ get_arg(AName,   PName, X = #exchange{arguments = Args}) ->
         undefined    -> get(PName, X);
         {_Type, Arg} -> Arg
     end.
-
-%%----------------------------------------------------------------------------
-
-%% Gets called during upgrades - therefore must not assume anything about the
-%% state of Mnesia
-invalidate() ->
-    rabbit_file:write_file(invalid_file(), <<"">>).
-
-recover() ->
-    case rabbit_file:is_file(invalid_file()) of
-        true  -> recover0(),
-                 rabbit_file:delete(invalid_file());
-        false -> ok
-    end.
-
-%% To get here we have to have just completed an Mnesia upgrade - i.e. we are
-%% the first node starting. So we can rewrite the whole database.  Note that
-%% recovery has not yet happened; we must work with the rabbit_durable_<thing>
-%% variants.
-recover0() ->
-    Xs0 = rabbit_db_exchange:get_all_durable(),
-    Policies = list(),
-    OpPolicies = list_op(),
-    Xs = [rabbit_exchange_decorator:set(
-            X#exchange{policy = match(Name, Policies),
-                       operator_policy = match(Name, OpPolicies)})
-          || X = #exchange{name = Name} <- Xs0],
-    Qs = rabbit_amqqueue:list_durable(),
-    _ = rabbit_db_exchange:set(Xs),
-    Qs0 = [begin
-               QName = amqqueue:get_name(Q0),
-               Policy1 = match(QName, Policies),
-               Q1 = amqqueue:set_policy(Q0, Policy1),
-               OpPolicy1 = match(QName, OpPolicies),
-               Q2 = amqqueue:set_operator_policy(Q1, OpPolicy1),
-               rabbit_queue_decorator:set(Q2)
-           end || Q0 <- Qs],
-    %% This function is just used to recover policies, thus no transient entities
-    %% are considered for this process as there is none to recover on boot.
-    _ = rabbit_db_queue:set_many(Qs0),
-    ok.
-
-invalid_file() ->
-    filename:join(rabbit:data_dir(), "policies_are_invalid").
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
This was a part of a very old migration to add `apply-to` to policies: https://github.com/rabbitmq/rabbitmq-server/commit/6371de0dbef8c04b0cda394c8eecdb08bcdd9605

And the only way to trigger this code was removed in https://github.com/rabbitmq/rabbitmq-server/pull/5415
