### PR TITLE
QQ: do not add x-delivery-count header for the first delivery.

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -239,7 +239,8 @@ dequeue(QueueName, ConsumerTag, Settlement,
     end.
 
 add_delivery_count_header(#basic_message{} = Msg0, Count)
-  when is_integer(Count) ->
+  when is_integer(Count) andalso
+       Count > 0 ->
     rabbit_basic:add_header(<<"x-delivery-count">>, long, Count, Msg0);
 add_delivery_count_header(Msg, _Count) ->
     Msg.

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -2329,7 +2329,7 @@ consume_redelivery_count(Config) ->
      #amqp_msg{props = #'P_basic'{headers = H0}}} =
         amqp_channel:call(Ch, #'basic.get'{queue = QQ,
                                            no_ack = false}),
-    ?assertMatch({DCHeader, _, 0}, rabbit_basic:header(DCHeader, H0)),
+    ?assertMatch(undefined, rabbit_basic:header(DCHeader, H0)),
     amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = DeliveryTag,
                                         multiple     = false,
                                         requeue      = true}),

--- a/release-notes/3.12.0.md
+++ b/release-notes/3.12.0.md
@@ -211,6 +211,7 @@ in the `3.11.x` release series.
 
    GitHub issues: [#5895](https://github.com/rabbitmq/rabbitmq-server/pull/5895), [#7091](https://github.com/rabbitmq/rabbitmq-server/pull/7091), [#7234](https://github.com/rabbitmq/rabbitmq-server/pull/7234)
 
+ * The `x-mqtt-dup` header will no longer be present for consumer deliveries as it wasn't used correctly.
 
 ### Management Plugin
 

--- a/release-notes/3.12.0.md
+++ b/release-notes/3.12.0.md
@@ -170,6 +170,12 @@ in the `3.11.x` release series.
    rabbitmqctl set_policy at-least-once-dead-lettering ".*" '{"dead-letter-strategy": "at-least-once"}' --apply-to quorum_queues
    ```
 
+ * Quorum queues: The `x-delivery-count` header will no longer be added to messages the first time they are delivered (`x-delivery-count=0`)
+   as it has a potential performance impact on consumer deliveries. The documentation already states that the header is only present
+   for re-deliveries.
+
+   GitHub issue: [#7732](https://github.com/rabbitmq/rabbitmq-server/pull/7732)
+
 ### CLI Tools
 
 #### Features
@@ -195,7 +201,6 @@ in the `3.11.x` release series.
  * `rabbitmq-diagnostics cluster_status` now lists how many CPU cores are available to individual nodes, plus a total.
 
    GitHub issue: [#7135](https://github.com/rabbitmq/rabbitmq-server/pull/7135)
-
 
 ### MQTT Plugin
 


### PR DESCRIPTION
The x-delivery-count header only needs to be added when a message is redelivered. Adding it on the first delivery attempt is unnecessary, not recorded in the quorum queue documentation and causes additional work deserialising the binary basic properties data to add this header.

This could be notable for messages with substantial property data incl. heavy use of headers for example.

NB: there is a chance some client applications have a dependency on this header being there for the very first delivery.