### PR TITLE
Do not use DETS ram file for recovery terms

### DIFF
--- a/deps/rabbit/src/rabbit_recovery_terms.erl
+++ b/deps/rabbit/src/rabbit_recovery_terms.erl
@@ -121,7 +121,7 @@ open_table(VHost, RetriesLeft) ->
     VHostDir = rabbit_vhost:msg_store_dir_path(VHost),
     File = filename:join(VHostDir, "recovery.dets"),
     Opts = [{file,      File},
-            {ram_file,  true},
+            {ram_file,  false},
             {auto_save, infinity}],
     case dets:open_file(VHost, Opts) of
         {ok, _}        -> ok;


### PR DESCRIPTION
Using a ram file should be an optimisation but in my tests, it's much better not to use it. We've tested on different hardware and different operating systems and in all cases, not using a RAM file provided much shorter shutdown times and very similar startup times.

On most systems, a node with 100k empty classic queues (either v1 or v2) would need 40-180 seconds to stop (`rabbitmqctl stop_app`). With this change, most of these systems can do it in 7-15 seconds. Startup times are marginally affected for CQv2 in some cases, eg. 27 instead of 25 seconds. CQv1s start so slowly (many minutes), that this change is irrelevant to CQv1 startup time.

Previous attempt was https://github.com/rabbitmq/rabbitmq-server/pull/7726