### PR TITLE
HTTP API: rename default queue type key

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/vhosts.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/vhosts.ejs
@@ -168,7 +168,7 @@
           <th><label>Default Queue Type:</label></th>
           <td>
             <!-- <select name="queuetype" onchange="select_queue_type(queuetype)"> -->
-            <select name="defaultqueuetype">
+            <select name="default_queue_type">
                 <option value="classic">Classic</option>
                 <option value="quorum">Quorum</option>
                 <option value="stream">Stream</option>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
@@ -63,7 +63,10 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
         Trace = rabbit_mgmt_util:parse_bool(maps:get(tracing, BodyMap, undefined)),
         Description = maps:get(description, BodyMap, <<"">>),
         Tags = maps:get(tags, BodyMap, <<"">>),
-        DefaultQT = maps:get(defaultqueuetype, BodyMap, undefined),
+        %% defaultqueuetype was an unfortunate name picked originally for 3.11.0,
+        %% so fall back to it. See rabbitmq/rabbitmq-server#7734.
+        FallbackQT = maps:get(defaultqueuetype, BodyMap, undefined),
+        DefaultQT = maps:get(default_queue_type, BodyMap, FallbackQT),
         case put_vhost(Name, Description, Tags, DefaultQT, Trace, Username) of
             ok ->
                 {true, ReqData, Context};

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -1701,7 +1701,7 @@ defs_default_queue_type_vhost(Config, QueueType) ->
     register_parameters_and_policy_validator(Config),
 
     %% Create a test vhost
-    http_put(Config, "/vhosts/test-vhost", #{defaultqueuetype => QueueType}, {group, '2xx'}),
+    http_put(Config, "/vhosts/test-vhost", #{default_queue_type => QueueType}, {group, '2xx'}),
     PermArgs = [{configure, <<".*">>}, {write, <<".*">>}, {read, <<".*">>}],
     http_put(Config, "/permissions/test-vhost/guest", PermArgs, {group, '2xx'}),
 


### PR DESCRIPTION
from defaultqueuetype to default_queue_type.
defaultqueuetype is still used as a fallback for backwards compatibility.

Closes #7734, references #5305.
