### PR TITLE
Recovery terms: use ram_file on start, but not on shutdown

### DIFF
--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -536,7 +536,8 @@ bounds(State = #qistate { segments = Segments }) ->
 -spec start(rabbit_types:vhost(), [rabbit_amqqueue:name()]) -> {[[any()]], {walker(A), A}}.
 
 start(VHost, DurableQueueNames) ->
-    ok = rabbit_recovery_terms:start(VHost),
+    {ok, RecoveryTermsPid} = rabbit_recovery_terms:start(VHost),
+    rabbit_vhost_sup_sup:save_vhost_recovery_terms(VHost, RecoveryTermsPid),
     {DurableTerms, DurableDirectories} =
         lists:foldl(
           fun(QName, {RecoveryTerms, ValidDirectories}) ->


### PR DESCRIPTION
Using a ram file should be an optimisation but in my tests, it's much better not to use it while writing recovery terms on shutdown. We've tested on different hardware and different operating systems and in all cases, not using a RAM file provided much shorter shutdown times and very similar startup times.

On most systems, a node with 100k empty classic queues (either v1 or v2) would need 40-180 seconds to stop (rabbitmqctl stop_app). With this change, most of these systems can do it in 7-15 seconds.

Without a ram file at all, startup times are are affected for CQv2. In some cases marginally (eg. 27 instead of 25 seconds), but in some cases quite a bit (98s instead of 72s; in this environment the shutdown time was improved from 100s to 23s).

Based on these observations, this PR keeps the ram file enabled on startup but disables it as soon as all recovery terms are read. Therefore it should not affect startup times (everything works as before), while providing significantly better shutdown time.

This PR provides a pretty consistent ~2m30s restart time, while `main`/`v3.12.x` requires 1-2 minutes more.
![Screenshot 2023-03-27 at 13 41 12](https://user-images.githubusercontent.com/9566114/227931464-e257ec80-ffee-420e-8b6e-c8e52b60215b.png)


Previous attempts:
https://github.com/rabbitmq/rabbitmq-server/pull/7726
https://github.com/rabbitmq/rabbitmq-server/pull/7736