### PR TITLE
Closes #7750

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
-  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers}
+  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, FeatureFlags, Helpers}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 


### PR DESCRIPTION
Adds a missing Elixir import which was (likely unintentionally) removed in #7435 (#7429).

Closes #7750.