### PR TITLE
Fix AMQP 1.0 + OAuth authentication issue 

### DIFF
--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -53,7 +53,8 @@ auth_fun({none, _}, _VHost, _ExtraAuthProps) ->
     fun () -> {ok, rabbit_auth_backend_dummy:user()} end;
 
 auth_fun({Username, none}, _VHost, ExtraAuthProps) ->
-    fun () -> rabbit_access_control:check_user_login(Username, [{password, none}] ++ ExtraAuthProps) end;
+    fun () ->
+      rabbit_access_control:check_user_login(Username, [{password, none}] ++ ExtraAuthProps) end;
 
 auth_fun({Username, Password}, VHost, ExtraAuthProps) ->
     fun () ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -541,18 +541,22 @@ get_scopes(#{?SCOPE_JWT_FIELD := Scope}) -> Scope.
 %% However, there are scenarios where the same user (on the same connection) is authenticated
 %% more than once. When this scenario occurs, we extract the token from the credential
 %% called rabbit_auth_backend_oauth2 whose value is the Decoded token returned during the
-%% first authentication. 
+%% first authentication.
 
 -spec token_from_context(map()) -> binary() | undefined.
 token_from_context(AuthProps) ->
     case maps:get(password, AuthProps, undefined) of
-        undefined ->
-            case maps:get(rabbit_auth_backend_oauth2, AuthProps, undefined) of
-                undefined -> undefined;
-                Impl -> Impl()
-            end;
+        undefined -> token_from_rabbit_auth_backend_oauth2(AuthProps);
+        none -> token_from_rabbit_auth_backend_oauth2(AuthProps);
         Token -> Token
     end.
+
+-spec token_from_rabbit_auth_backend_oauth2(map()) -> binary() | undefined.
+token_from_rabbit_auth_backend_oauth2(AuthProps) ->
+  case maps:get(rabbit_auth_backend_oauth2, AuthProps, undefined) of
+      undefined -> undefined;
+      Impl -> Impl()
+  end.
 
 %% Decoded tokens look like this:
 %%


### PR DESCRIPTION
## Proposed Changes

Fix issue which occurs over AMQP 1.0 plugin passing an OAuth2 token thru the password field. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

Apply only to v3.11.x . For v3.10.x and v3.9.x backport, use this other PR: https://github.com/rabbitmq/rabbitmq-server/pull/7766