### PR TITLE
Fix AMQP 1.0 Authentication issue with OAuth tokens on v3.10

### DIFF
--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -52,8 +52,9 @@ list() ->
 auth_fun({none, _}, _VHost, _ExtraAuthProps) ->
     fun () -> {ok, rabbit_auth_backend_dummy:user()} end;
 
-auth_fun({Username, none}, _VHost, _ExtraAuthProps) ->
-    fun () -> rabbit_access_control:check_user_login(Username, []) end;
+auth_fun({Username, none}, _VHost, ExtraAuthProps) ->
+    fun () ->
+        rabbit_access_control:check_user_login(Username, [{password, none}] ++ ExtraAuthProps) end;
 
 auth_fun({Username, Password}, VHost, ExtraAuthProps) ->
     fun () ->
@@ -73,7 +74,7 @@ auth_fun({Username, Password}, VHost, ExtraAuthProps) ->
               {'auth_failure', string()} | 'access_refused').
 
 connect(Creds, VHost, Protocol, Pid, Infos) ->
-    ExtraAuthProps = extract_extra_auth_props(Creds, VHost, Pid, Infos),
+    ExtraAuthProps = append_authz_backends(extract_extra_auth_props(Creds, VHost, Pid, Infos), Infos),
     AuthFun = auth_fun(Creds, VHost, ExtraAuthProps),
     case rabbit_boot_state:has_reached_and_is_active(core_started) of
         true  ->
@@ -112,6 +113,12 @@ extract_extra_auth_props(Creds, VHost, Pid, Infos) ->
             [];
         Protocol ->
             maybe_call_connection_info_module(Protocol, Creds, VHost, Pid, Infos)
+    end.
+
+append_authz_backends(AuthProps, Infos) ->
+    case proplists:get_value(authz_backends, Infos, undefined) of
+        undefined -> AuthProps;
+        AuthzBackends -> AuthProps ++ AuthzBackends
     end.
 
 extract_protocol(Infos) ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -536,6 +536,13 @@ check_aud(Aud, ResourceServerId) ->
 
 get_scopes(#{?SCOPE_JWT_FIELD := Scope}) -> Scope.
 
+%% A token may be present in the password credential or in the rabbit_auth_backend_oauth2
+%% credential.  The former is the most common scenario for the first time authentication.
+%% However, there are scenarios where the same user (on the same connection) is authenticated
+%% more than once. When this scenario occurs, we extract the token from the credential
+%% called rabbit_auth_backend_oauth2 whose value is the Decoded token returned during the
+%% first authentication.
+
 -spec token_from_context(map()) -> binary() | undefined.
 token_from_context(AuthProps) ->
     case maps:get(password, AuthProps, undefined) of


### PR DESCRIPTION
## Proposed Changes

Authenticate an internal AMQP connection created from an AMQP 1.0 Session using an Oauth token previously obtained during the connection establishment phase.

This is a backport of this [PR](https://github.com/rabbitmq/rabbitmq-server/pull/7758) applied to v3.11.x branch. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
