### PR TITLE
Revert "Fix AMQP 1.0 + OAuth authentication issue "

### DIFF
--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -53,8 +53,7 @@ auth_fun({none, _}, _VHost, _ExtraAuthProps) ->
     fun () -> {ok, rabbit_auth_backend_dummy:user()} end;
 
 auth_fun({Username, none}, _VHost, ExtraAuthProps) ->
-    fun () ->
-      rabbit_access_control:check_user_login(Username, [{password, none}] ++ ExtraAuthProps) end;
+    fun () -> rabbit_access_control:check_user_login(Username, [{password, none}] ++ ExtraAuthProps) end;
 
 auth_fun({Username, Password}, VHost, ExtraAuthProps) ->
     fun () ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -541,22 +541,18 @@ get_scopes(#{?SCOPE_JWT_FIELD := Scope}) -> Scope.
 %% However, there are scenarios where the same user (on the same connection) is authenticated
 %% more than once. When this scenario occurs, we extract the token from the credential
 %% called rabbit_auth_backend_oauth2 whose value is the Decoded token returned during the
-%% first authentication.
+%% first authentication. 
 
 -spec token_from_context(map()) -> binary() | undefined.
 token_from_context(AuthProps) ->
     case maps:get(password, AuthProps, undefined) of
-        undefined -> token_from_rabbit_auth_backend_oauth2(AuthProps);
-        none -> token_from_rabbit_auth_backend_oauth2(AuthProps);
+        undefined ->
+            case maps:get(rabbit_auth_backend_oauth2, AuthProps, undefined) of
+                undefined -> undefined;
+                Impl -> Impl()
+            end;
         Token -> Token
     end.
-
--spec token_from_rabbit_auth_backend_oauth2(map()) -> binary() | undefined.
-token_from_rabbit_auth_backend_oauth2(AuthProps) ->
-  case maps:get(rabbit_auth_backend_oauth2, AuthProps, undefined) of
-      undefined -> undefined;
-      Impl -> Impl()
-  end.
 
 %% Decoded tokens look like this:
 %%


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-server#7758.

To see if an obscure failure in `//deps/rabbit:config_schema_SUITE` on BuildBuddy may go away.