### PR TITLE
bazel: Pin ct_helper

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -362,9 +362,9 @@ erlang_dev_package = use_extension(
 )
 
 erlang_dev_package.git_package(
-    branch = "master",
+    commit = "478aa272708ed4ad282ca02bed41a5320330e8af",
     build_file = "@//:bazel/BUILD.ct_helper",
-    repository = "extend/ct_helper",
+    repository = "ninenines/ct_helper",
 )
 
 erlang_dev_package.git_package(


### PR DESCRIPTION
This should resolve a build failure for the `//deps/rabbitmq_trust_store:config_schema_SUITE` rule. https://github.com/ninenines/ct_helper/commit/be0655ef7aeb4ef1d3c06b3eef6644d8e501c540 removed the `erl_make_certs` module which fails the build. Alternatively we could update `rabbitmq_trust_store`'s `system_SUITE` test to use the new changes in ct_helper