### PR TITLE
 Introduce a limit for how many virtual hosts can be created in a cluster (adapted for 3.11.x)

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -897,6 +897,19 @@ end}.
  end
 }.
 
+{mapping, "vhost_max", "rabbit.vhost_max",
+  [{datatype, [{atom, infinity}, integer]}]}.
+
+{translation, "rabbit.vhost_max",
+ fun(Conf) ->
+  case cuttlefish:conf_get("vhost_max", Conf, undefined) of
+      undefined -> cuttlefish:unset();
+      infinity  -> infinity;
+      Val when is_integer(Val) -> Val;
+      _         -> cuttlefish:invalid("should be a non-negative integer")
+  end
+ end
+}.
 
 {mapping, "max_message_size", "rabbit.max_message_size",
     [{datatype, integer}, {validators, ["max_message_size"]}]}.

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -898,7 +898,7 @@ end}.
 }.
 
 {mapping, "vhost_max", "rabbit.vhost_max",
-  [{datatype, [{atom, infinity}, integer]}]}.
+  [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
 
 {translation, "rabbit.vhost_max",
  fun(Conf) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -57,6 +57,8 @@
 -type arguments() :: queue_arguments | consumer_arguments.
 -type queue_type() :: rabbit_classic_queue | rabbit_quorum_queue | rabbit_stream_queue.
 
+-export_type([queue_type/0]).
+
 -define(STATE, ?MODULE).
 
 %% Recoverable mirrors shouldn't really be a generic one, but let's keep it here until

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -348,7 +348,7 @@ is_over_vhost_limit(Name, Limit) when is_integer(Limit) ->
             ErrorMsg = rabbit_misc:format("cannot create vhost '~ts': "
                                           "vhost limit '~tp' is reached",
                                           [Name, Limit]),
-            exit({vhost_precondition_failed, ErrorMsg})
+            exit({vhost_limit_exceeded, ErrorMsg})
     end.
 
 %% when definitions are loaded on boot, Username here will be ?INTERNAL_USER,

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -362,7 +362,7 @@ is_over_vhost_limit(Name, Limit) when is_integer(Limit) ->
             ok;
         true ->
             ErrorMsg = rabbit_misc:format("cannot create vhost '~ts': "
-                                          "vhost limit '~tp' is reached",
+                                          "vhost limit of ~tp is reached",
                                           [Name, Limit]),
             exit({vhost_limit_exceeded, ErrorMsg})
     end.

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -161,6 +161,7 @@ add(Name, Metadata, ActingUser) ->
     end.
 
 do_add(Name, Metadata, ActingUser) ->
+    ok = is_over_vhost_limit(Name),
     Description = maps:get(description, Metadata, undefined),
     Tags = maps:get(tags, Metadata, []),
 
@@ -332,6 +333,23 @@ put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
         undefined -> ok
     end,
     Result.
+
+is_over_vhost_limit(Name) ->
+    Limit = rabbit_misc:get_env(rabbit, vhost_max, infinity),
+    is_over_vhost_limit(Name, Limit).
+
+is_over_vhost_limit(_Name, infinity) ->
+    ok;
+is_over_vhost_limit(Name, Limit) when is_integer(Limit) ->
+    case length(list_names()) >= Limit of
+        false ->
+            ok;
+        true ->
+            ErrorMsg = rabbit_misc:format("cannot create vhost '~ts': "
+                                          "vhost limit '~tp' is reached",
+                                          [Name, Limit]),
+            exit({vhost_precondition_failed, ErrorMsg})
+    end.
 
 %% when definitions are loaded on boot, Username here will be ?INTERNAL_USER,
 %% which does not actually exist

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -287,9 +287,22 @@ delete(VHost, ActingUser) ->
     rabbit_vhost_sup_sup:delete_on_all_nodes(VHost),
     ok.
 
+-spec put_vhost(vhost:name(),
+    binary(),
+    vhost:tags(),
+    boolean(),
+    rabbit_types:username()) ->
+    'ok' | {'error', any()} | {'EXIT', any()}.
 put_vhost(Name, Description, Tags0, Trace, Username) ->
     put_vhost(Name, Description, Tags0, undefined, Trace, Username).
 
+-spec put_vhost(vhost:name(),
+    binary(),
+    vhost:unparsed_tags() | vhost:tags(),
+    rabbit_queue_type:queue_type(),
+    boolean(),
+    rabbit_types:username()) ->
+    'ok' | {'error', any()} | {'EXIT', any()}.
 put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
     Tags = case Tags0 of
       undefined   -> <<"">>;
@@ -334,10 +347,13 @@ put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
     end,
     Result.
 
+-spec is_over_vhost_limit(vhost:name()) -> 'ok' | no_return().
 is_over_vhost_limit(Name) ->
     Limit = rabbit_misc:get_env(rabbit, vhost_max, infinity),
     is_over_vhost_limit(Name, Limit).
 
+-spec is_over_vhost_limit(vhost:name(), 'infinity' | non_neg_integer())
+        -> 'ok' | no_return().
 is_over_vhost_limit(_Name, infinity) ->
     ok;
 is_over_vhost_limit(Name, Limit) when is_integer(Limit) ->

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -299,7 +299,7 @@ put_vhost(Name, Description, Tags0, Trace, Username) ->
 -spec put_vhost(vhost:name(),
     binary(),
     vhost:unparsed_tags() | vhost:tags(),
-    rabbit_queue_type:queue_type(),
+    rabbit_queue_type:queue_type() | 'undefined',
     boolean(),
     rabbit_types:username()) ->
     'ok' | {'error', any()} | {'EXIT', any()}.

--- a/deps/rabbit/src/vhost.erl
+++ b/deps/rabbit/src/vhost.erl
@@ -42,6 +42,11 @@
                       tags => [atom()],
                       metadata_key() => any()} | undefined).
 
+-type(description() :: binary()).
+-type(tag() :: atom()).
+-type(tags() :: [tag()]).
+-type(unparsed_tags() :: binary() | string() | atom()).
+
 -type vhost() :: vhost_v2().
 
 -record(vhost, {
@@ -68,6 +73,10 @@
 -export_type([name/0,
               metadata_key/0,
               metadata/0,
+              description/0,
+              tag/0,
+              unparsed_tags/0,
+              tags/0,
               vhost/0,
               vhost_v2/0,
               vhost_pattern/0,

--- a/deps/rabbit/test/per_node_limit_SUITE.erl
+++ b/deps/rabbit/test/per_node_limit_SUITE.erl
@@ -88,11 +88,11 @@ node_connection_limit(Config) ->
 
 vhost_limit(Config) ->
     set_vhost_limit(Config, 0),
-    {'EXIT',{vhost_precondition_failed, _}} = rabbit_ct_broker_helpers:add_vhost(Config, <<"foo">>),
+    {'EXIT',{vhost_limit_exceeded, _}} = rabbit_ct_broker_helpers:add_vhost(Config, <<"foo">>),
 
     set_vhost_limit(Config, 5),
     [ok = rabbit_ct_broker_helpers:add_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,4)],
-    {'EXIT',{vhost_precondition_failed, _}} = rabbit_ct_broker_helpers:add_vhost(Config, <<"5">>),
+    {'EXIT',{vhost_limit_exceeded, _}} = rabbit_ct_broker_helpers:add_vhost(Config, <<"5">>),
     [rabbit_ct_broker_helpers:delete_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,4)],
 
     set_vhost_limit(Config, infinity),

--- a/deps/rabbit/test/per_node_limit_SUITE.erl
+++ b/deps/rabbit/test/per_node_limit_SUITE.erl
@@ -21,7 +21,8 @@ all() ->
 groups() ->
     [
      {parallel_tests, [parallel], [
-                                   node_connection_limit
+                                   node_connection_limit,
+                                   vhost_limit
                                   ]}
     ].
 
@@ -58,6 +59,9 @@ end_per_group(_Group, Config) ->
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
+end_per_testcase(vhost_limit = Testcase, Config) ->
+    [rabbit_ct_broker_helpers:delete_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,4)],
+    rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
@@ -78,7 +82,25 @@ node_connection_limit(Config) ->
 
     set_node_limit(Config, infinity),
     C = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0),
-    true = is_pid(C).
+    true = is_pid(C),
+    close_all_connections([C]),
+    ok.
+
+vhost_limit(Config) ->
+    set_vhost_limit(Config, 0),
+    {'EXIT',{vhost_precondition_failed, _}} = rabbit_ct_broker_helpers:add_vhost(Config, <<"foo">>),
+
+    set_vhost_limit(Config, 5),
+    [ok = rabbit_ct_broker_helpers:add_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,4)],
+    {'EXIT',{vhost_precondition_failed, _}} = rabbit_ct_broker_helpers:add_vhost(Config, <<"5">>),
+    [rabbit_ct_broker_helpers:delete_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,4)],
+
+    set_vhost_limit(Config, infinity),
+    [ok = rabbit_ct_broker_helpers:add_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,4)],
+    ok = rabbit_ct_broker_helpers:add_vhost(Config, <<"5">>),
+    [rabbit_ct_broker_helpers:delete_vhost(Config, integer_to_binary(I)) || I <- lists:seq(1,5)],
+    ok.
+
 
 %% -------------------------------------------------------------------
 %% Implementation
@@ -97,3 +119,8 @@ set_node_limit(Config, Limit) ->
     rabbit_ct_broker_helpers:rpc(Config, 0,
                                  application,
                                  set_env, [rabbit, connection_max, Limit]).
+
+set_vhost_limit(Config, Limit) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0,
+                                 application,
+                                 set_env, [rabbit, vhost_max, Limit]).

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -72,6 +72,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
     {:error, ExitCodes.exit_usage(), "Unsupported default queue type"}
   end
 
+  def output({:badrpc, {:EXIT, {:vhost_precondition_failed, msg}}}, _opts) do
+    {:error, ExitCodes.exit_usage(), msg}
+  end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def usage,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -72,7 +72,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
     {:error, ExitCodes.exit_usage(), "Unsupported default queue type"}
   end
 
-  def output({:badrpc, {:EXIT, {:vhost_precondition_failed, msg}}}, _opts) do
+  def output({:badrpc, {:EXIT, {:vhost_limit_exceeded, msg}}}, _opts) do
     {:error, ExitCodes.exit_usage(), msg}
   end
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
@@ -70,7 +70,7 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
               case put_vhost(Name, Description, Tags, DefaultQT, Trace, Username) of
                   ok ->
                       {true, ReqData, Context};
-                  {'EXIT', {vhost_precondition_failed,
+                  {'EXIT', {vhost_limit_exceeded,
                             Explanation}} ->
                       rabbit_mgmt_util:bad_request(list_to_binary(Explanation), ReqData, Context);
                   {error, timeout} = E ->


### PR DESCRIPTION
This is #7798 adapted for the schema database API in `v3.11.x` (where `rabbit_db_*` modules are not available).

References #7777.