### PR TITLE
Pass the message to `rabbit_backing_queue:discard` callback 

### DIFF
--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -117,7 +117,7 @@
 
 %% Called to inform the BQ about messages which have reached the
 %% queue, but are not going to be further passed to BQ.
--callback discard(rabbit_types:msg_id(), pid(), flow(), state()) -> state().
+-callback discard(rabbit_types:basic_message(), pid(), flow(), state()) -> state().
 
 %% Return ids of messages which have been confirmed since the last
 %% invocation of this function (or initialisation).

--- a/deps/rabbit/src/rabbit_mirror_queue_master.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_master.erl
@@ -293,15 +293,16 @@ batch_publish_delivered(Publishes, ChPid, Flow,
     State1 = State #state { backing_queue_state = BQS1 },
     {AckTags, ensure_monitoring(ChPid, State1)}.
 
-discard(MsgId, ChPid, Flow, State = #state { gm                  = GM,
-                                             backing_queue       = BQ,
-                                             backing_queue_state = BQS,
-                                             seen_status         = SS }) ->
+discard(Message = #basic_message{id = MsgId},
+        ChPid, Flow, State = #state { gm                  = GM,
+                                      backing_queue       = BQ,
+                                      backing_queue_state = BQS,
+                                      seen_status         = SS }) ->
     false = maps:is_key(MsgId, SS), %% ASSERTION
-    ok = gm:broadcast(GM, {discard, ChPid, Flow, MsgId}),
+    ok = gm:broadcast(GM, {discard, ChPid, Flow, Message}),
     ensure_monitoring(ChPid,
                       State #state { backing_queue_state =
-                                         BQ:discard(MsgId, ChPid, Flow, BQS) }).
+                                         BQ:discard(Message, ChPid, Flow, BQS) }).
 
 dropwhile(Pred, State = #state{backing_queue       = BQ,
                                backing_queue_state = BQS }) ->

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -957,11 +957,12 @@ process_instruction({batch_publish_delivered, ChPid, Flow, Publishes}, State) ->
                end, State1 #state { backing_queue_state = BQS1 },
                MsgIdsAndAcks),
     {ok, State2};
-process_instruction({discard, ChPid, Flow, MsgId}, State) ->
+process_instruction({discard, ChPid, Flow,
+                     Msg = #basic_message { id = MsgId }}, State) ->
     maybe_flow_ack(ChPid, Flow),
     State1 = #state { backing_queue = BQ, backing_queue_state = BQS } =
         publish_or_discard(discarded, ChPid, MsgId, State),
-    BQS1 = BQ:discard(MsgId, ChPid, Flow, BQS),
+    BQS1 = BQ:discard(Msg, ChPid, Flow, BQS),
     {ok, State1 #state { backing_queue_state = BQS1 }};
 process_instruction({drop, Length, Dropped, AckRequired},
                     State = #state { backing_queue       = BQ,

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -588,7 +588,7 @@ batch_publish_delivered(Publishes, ChPid, Flow, State) ->
     State2 = ui(State1),
     {lists:reverse(SeqIds), a(maybe_update_rates(State2))}.
 
-discard(_MsgId, _ChPid, _Flow, State) -> State.
+discard(_Msg, _ChPid, _Flow, State) -> State.
 
 drain_confirmed(State = #vqstate { confirmed = C }) ->
     case sets:is_empty(C) of


### PR DESCRIPTION
## Proposed Changes

The `rabbit_backing_queue:discard` callback is passing the message ID to the implementer. This is often not enough to carry on some necessary work as it's seen in the `rabbit_priority_queue` [comment](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_priority_queue.erl#L252).

In my particular case, this makes it hard to fix the following issue:
https://github.com/noxdafox/rabbitmq-message-deduplication/issues/96

In the above issue a consumer starts consuming with `noAck` over an empty queue. A publisher publishes a single message which gets forwarded directly to the consumer. In this case, the `discard` callback is invoked instead of `publish_delivered` and therefore it's header is not removed from the deduplication cache.

Problem is the `discard` callback only forwards the message ID and not the whole message not providing enough context for the implementer.

This patch adjust the `rabbit_backing_queue` behaviour passing the whole message to the `discard` callback instead of its sole ID.

This implementation has some drawback as, when using mirrored queues, more data will now be exchanged between the master node and the slaves. This will be detrimental to empty HA queue performance.

Yet the following observations should be considered:
- This only applies when messages are consumed directly without acknowledgment from an empty queue
- HA/mirrored queues are not the ideal choice when high performance are a need
- The consumption without acknowledgment is a questionable pattern when combined with HA/mirrored queues
- HA/mirrored queues do not provide much value compared to normal ones when empty

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

