### PR TITLE
If a queue process is hibernated, consider it up

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1077,13 +1077,16 @@ list_local_names_down() ->
                               is_down(Q)].
 
 is_down(Q) ->
-    try
-        info(Q, [state]) == [{state, down}]
-    catch
-        _:_ ->
-            true
+    case rabbit_process:is_process_hibernated(amqqueue:get_pid(Q)) of
+        true -> false;
+        false ->
+            try
+                    info(Q, [state]) == [{state, down}]
+            catch
+                _:_ ->
+                    true
+            end
     end.
-
 
 -spec sample_local_queues() -> [amqqueue:amqqueue()].
 sample_local_queues() -> sample_n_by_name(list_local_names(), 300).

--- a/deps/rabbit/src/rabbit_process.erl
+++ b/deps/rabbit/src/rabbit_process.erl
@@ -9,6 +9,7 @@
 
 -export([on_running_node/1,
          is_process_alive/1,
+         is_process_hibernated/1,
          is_registered_process_alive/1]).
 
 -spec on_running_node(Pid) -> OnRunningNode when
@@ -75,3 +76,15 @@ is_process_alive({Name, Node}) when is_atom(Name) andalso is_atom(Node) ->
 
 is_registered_process_alive(Name) ->
     is_pid(whereis(Name)).
+
+-spec is_process_hibernated(Pid) -> IsHibernated when
+      Pid :: pid(),
+      IsHibernated :: boolean().
+%% @doc Indicates if the specified process is hibernated.
+%%
+%% @param Pid the PID or name of the process to check
+%% @returns true if the process is hibernated on one of the cluster members,
+%% false otherwise.
+
+is_process_hibernated(Pid) when is_pid(Pid) ->
+    {current_function,{erlang,hibernate,3}} == erlang:process_info(Pid, current_function).


### PR DESCRIPTION
`rabbit_core_metrics_gc` checks the status of all queues (and other things) every two minutes. With many queues, this can get pretty expensive. Systems with lots of queues will often have many of them idle and hibernated. Before this change `rabbit_core_metrics_gc` would wake up all of them, causing a memory spike. All of that just to check if their state isn't `down`.

With this change, a hibernated queue will be considered up. The effect is visible with many queues (100k in this example) -roughly 0.5GB lower memory usage during metrics GC. Here I have 3 metrics GC runs with this change and then 2 with this change reverted:

![Screenshot 2023-04-04 at 10 24 31](https://user-images.githubusercontent.com/9566114/229795801-dff8e576-7fe3-4517-934a-5221cff12222.png)
