### PR TITLE
Bazel build: Cowlib does not have a .app.src

### DIFF
--- a/bazel/BUILD.cowlib
+++ b/bazel/BUILD.cowlib
@@ -100,7 +100,6 @@ filegroup(
         "src/cow_uri.erl",
         "src/cow_uri_template.erl",
         "src/cow_ws.erl",
-        "src/cowlib.app.src",
     ],
 )
 


### PR DESCRIPTION
#7806