### PR TITLE
Regenerate BUILD.cowlib using 'bazel run gazelle-update-repos -- -args hex.pm/cowlib@2.12.1'

### DIFF
--- a/bazel/BUILD.cowlib
+++ b/bazel/BUILD.cowlib
@@ -68,7 +68,6 @@ erlang_bytecode(
         "src/cow_spdy.hrl",
     ],
     app_name = "cowlib",
-    beam = [],
     erlc_opts = "//:erlc_opts",
 )
 
@@ -119,14 +118,13 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "priv",
-    srcs = [],
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "licenses",
-    srcs = ["LICENSE"],
+    srcs = [
+        "LICENSE",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
This is the proper way of doing #7828 post #7806. Note that it also modifies Bazel workspace file and that had to be backed out.