### PR TITLE
Streams: make at-most-once dead lettering work

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -247,7 +247,7 @@ erlang_package.hex_package(
 
 erlang_package.git_package(
     repository = "rabbitmq/osiris",
-    tag = "v1.4.3",
+    tag = "v1.5.0",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.4.3
+dep_osiris = git https://github.com/rabbitmq/osiris v1.5.0
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.4.0
 


### PR DESCRIPTION
Previously osiris did not support uncorrelated writes which means we could not use a "stateless" queue type delivery and these were silently dropped.

This had the impact that at-most-once dead letter was not possible where the dead letter target is a stream.

This change bumps the osiris version that has the required API to allow for uncorrelated writes (osiris:write/2).

Currently there is no feature flag to control this as osiris writer processes just logs and drops any messages they don't understand.
