### PR TITLE
Fix stream import on startup

### DIFF
--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -594,8 +594,8 @@ create_or_get_in_mnesia(Q) ->
                           {error, not_found} ->
                               set_in_mnesia_tx(DurableQ, Q),
                               {created, Q};
-                          {ok, Q} ->
-                              {absent, Q, nodedown}
+                          {ok, QRecord} ->
+                              {absent, QRecord, nodedown}
                       end;
                   [ExistingQ] ->
                       {existing, ExistingQ}

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -425,7 +425,7 @@ ensure_coordinator_started() ->
     end.
 
 start_coordinator_cluster() ->
-    Nodes = rabbit_nodes:list_running(),
+    Nodes = rabbit_nodes:list_reachable(),
     rabbit_log:debug("Starting stream coordinator on nodes: ~w", [Nodes]),
     case ra:start_cluster(?RA_SYSTEM, [make_ra_conf(Node, Nodes) || Node <-  Nodes]) of
         {ok, Started, _} ->


### PR DESCRIPTION
This commit fixes 2 problems when importing definitions that contain streams on startup:
* use `rabbit_nodes:list_reachable/0` instead of `rabbit_nodes:list_running/0`. The latter returns an empty list at this point, which makes the startup of the stream coordinator Ra cluster fail. The former returns the cluster nodes, regardless of the status of the `rabbit` application (up for `list_running`), which is enough in our case.
* return the Mnesia record if it exists when trying to create a queue and do not expect the record to be exactly equal to the passed-in queue parameter.