### PR TITLE
Remove deprecated UAA oauth settings

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -5,7 +5,7 @@
 %%
 %% ----------------------------------------------------------------------------
 
-%% A prefix used for scopes in UAA to avoid scope collisions (or unintended overlap). It is an empty string by default.
+%% A prefix used for scopes to avoid scope collisions (or unintended overlap). It is an empty string by default.
 %%
 %% {resource_server_id, <<"my_rabbit_server">>},
 

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -432,20 +432,6 @@ end}.
 %% ===========================================================================
 %% Authorization
 
-%% Configure OAuth2 in the management ui to work with old versions of UAA (which versions?)
-{mapping, "management.enable_uaa", "rabbitmq_management.enable_uaa",
-    [{datatype, {enum, [true, false]}}]}.
-
-%% Your client application's identifier as registered with the OIDC/OAuth2. Deprecated, switch to oauth_client_id
-{mapping, "management.uaa_client_id", "rabbitmq_management.uaa_client_id",
-      [{datatype, string}]}.
-{mapping, "management.uaa_client_secret", "rabbitmq_management.uaa_client_secret",
-      [{datatype, string}]}.
-
-%% The URL of the OIDC/OAuth2 provider
-{mapping, "management.uaa_location", "rabbitmq_management.uaa_location",
-      [{datatype, string}]}.
-
 %% Enable OAuth2 in the management ui
 {mapping, "management.oauth_enabled", "rabbitmq_management.oauth_enabled",
     [{datatype, {enum, [true, false]}}]}.

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -28,21 +28,7 @@ function rabbit_base_uri() {
 }
 
 function auth_settings_apply_defaults(authSettings) {
-  if (authSettings.enable_uaa) {
 
-    if (!authSettings.oauth_provider_url) {
-      authSettings.oauth_provider_url = authSettings.uaa_location
-    }
-    if (!authSettings.oauth_client_id) {
-      authSettings.oauth_client_id = authSettings.uaa_client_id
-    }
-    if (!authSettings.oauth_client_secret) {
-      authSettings.oauth_client_secret = authSettings.uaa_client_secret
-    }
-    if (!authSettings.oauth_scopes) {
-      authSettings.oauth_scopes = "openid profile " + authSettings.oauth_resource_id + ".*";
-    }
-  }
   if (!authSettings.oauth_response_type) {
     authSettings.oauth_response_type = "code"; // although the default value in oidc client
   }
@@ -78,7 +64,7 @@ function oauth_initialize(authSettings) {
         authority: authSettings.oauth_provider_url,
         client_id: authSettings.oauth_client_id,
         response_type: authSettings.oauth_response_type,
-        scope: authSettings.oauth_scopes, // for uaa we may need to include <resource-server-id>.*
+        scope: authSettings.oauth_scopes,
         resource: authSettings.oauth_resource_id,
         redirect_uri: rabbit_base_uri() + "/js/oidc-oauth/login-callback.html",
         post_logout_redirect_uri: rabbit_base_uri() + "/",
@@ -96,13 +82,6 @@ function oauth_initialize(authSettings) {
       oidcSettings.metadataUrl = authSettings.oauth_metadata_url;
     }
 
-    if (authSettings.enable_uaa == true) {
-      // This is required for old versions of UAA because the newer ones do expose
-      // the end_session_endpoint on the oidc discovery endpoint, .a.k.a. metadataUrl
-      oidcSettings.metadataSeed = {
-        end_session_endpoint: authSettings.oauth_provider_url + "/logout.do"
-      }
-    }
     oidc.Log.setLevel(oidc.Log.DEBUG);
     oidc.Log.setLogger(console);
 

--- a/deps/rabbitmq_management/selenium/test/oauth/rabbitmq.conf
+++ b/deps/rabbitmq_management/selenium/test/oauth/rabbitmq.conf
@@ -1,7 +1,6 @@
 auth_backends.1 = rabbit_auth_backend_oauth2
 
 management.login_session_timeout = 1
-management.enable_uaa = true
 management.oauth_enabled = true
 management.oauth_client_id = rabbit_client_code
 management.oauth_scopes = ${OAUTH_SCOPES}

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
@@ -23,7 +23,6 @@ bootstrap_oauth(Req0, State) ->
   {ok, cowboy_req:reply(200, #{<<"content-type">> => <<"text/javascript; charset=utf-8">>}, JSContent, Req0), State}.
 
 authSettings() ->
-  EnableUAA = application:get_env(rabbitmq_management, enable_uaa, false),
   EnableOAUTH = application:get_env(rabbitmq_management, oauth_enabled, false),
   Data = case EnableOAUTH of
     true ->
@@ -45,7 +44,6 @@ authSettings() ->
                     json_field(oauth_enabled, false, true);
                   false ->
                     json_field(oauth_enabled, true) ++
-                    json_field(enable_uaa, EnableUAA) ++
                     json_field(oauth_client_id, OAuthClientId) ++
                     json_field(oauth_client_secret, OAuthClientSecret) ++
                     json_field(oauth_provider_url, OAuthProviderUrl) ++

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
@@ -25,7 +25,6 @@ content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 authSettings() ->
-  EnableUAA = application:get_env(rabbitmq_management, enable_uaa, false),
   EnableOAUTH = application:get_env(rabbitmq_management, oauth_enabled, false),
   case EnableOAUTH of
     true ->
@@ -48,7 +47,6 @@ authSettings() ->
                     false ->
                         append_oauth_optional_secret([
                          {oauth_enabled, true},
-                         {enable_uaa, rabbit_data_coercion:to_binary(EnableUAA)},
                          {oauth_client_id, rabbit_data_coercion:to_binary(OAuthClientId)},
                          {oauth_provider_url, rabbit_data_coercion:to_binary(OAuthProviderUrl)},
                          {oauth_scopes, rabbit_data_coercion:to_binary(OAuthScopes)},


### PR DESCRIPTION
## Proposed Changes

Since 3.9.x, RabbitMQ has replaced all OAuth2 settings with the prefix `uaa_` from the management plugin with other settings with the prefix `aouth_` . This PR removes those deprecated settings.
 
The corresponding doc changes have been already committed to `main` branch of https://github.com/rabbitmq/rabbitmq-website. Commit https://github.com/rabbitmq/rabbitmq-website/commit/6d8e3d497ccaf101439bbe1f9672e2c671cebaf7

This change should not affect any user. However, this is a breaking change because it removes settings which were valid in versions earlier than 3.9

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
