### PR TITLE
Mark per_user_connection_channel_limit_partitions_SUITE flaky

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -550,6 +550,7 @@ rabbitmq_integration_suite(
 rabbitmq_integration_suite(
     name = "per_user_connection_channel_limit_partitions_SUITE",
     size = "large",
+    flaky = True,
 )
 
 rabbitmq_integration_suite(
@@ -797,11 +798,11 @@ rabbitmq_suite(
 
 rabbitmq_suite(
     name = "rabbit_stream_sac_coordinator_SUITE",
-    deps = [
-        "//deps/rabbit_common:erlang_app",
-    ],
     runtime_deps = [
         "@meck//:erlang_app",
+    ],
+    deps = [
+        "//deps/rabbit_common:erlang_app",
     ],
 )
 
@@ -1052,10 +1053,10 @@ rabbitmq_integration_suite(
 rabbitmq_integration_suite(
     name = "vhost_SUITE",
     size = "medium",
-    flaky = True,
     additional_srcs = [
         "test/test_rabbit_event_handler.erl",
     ],
+    flaky = True,
 )
 
 rabbitmq_suite(

--- a/deps/rabbit/test/per_user_connection_channel_limit_partitions_SUITE.erl
+++ b/deps/rabbit/test/per_user_connection_channel_limit_partitions_SUITE.erl
@@ -32,7 +32,7 @@ groups() ->
 suite() ->
     [
       %% If a test hangs, no need to wait for 30 minutes.
-      {timetrap, {minutes, 8}}
+      {timetrap, {minutes, 5}}
     ].
 
 %% see partitions_SUITE


### PR DESCRIPTION
The suite creates and autoheals partitions, so I'm not convinced it's worth chasing the root cause of the flake, whatever it is