### PR TITLE
Fix dialyzer errors for rabbitmq_shovel on OTP 26

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,7 @@ load(
     "string_flag",
 )
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
-load("@rules_erlang//:dialyze.bzl", "plt")
+load("@rules_erlang//:dialyze.bzl", "DEFAULT_PLT_APPS", "plt")
 load("@rules_erlang//:shell.bzl", "shell")
 load("@rules_erlang//:erl_eval.bzl", "erl_eval")
 load("@bazel_gazelle//:def.bzl", "gazelle")
@@ -63,11 +63,7 @@ string_flag(
 
 plt(
     name = "base_plt",
-    dialyzer_opts = select({
-        "@erlang_config//:erlang_26": ["-Wno_unknown"],
-        "@erlang_config//:erlang_26_0-rc2": ["-Wno_unknown"],
-        "//conditions:default": [],
-    }),
+    apps = DEFAULT_PLT_APPS + ["compiler", "crypto"],
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -63,6 +63,11 @@ string_flag(
 
 plt(
     name = "base_plt",
+    dialyzer_opts = select({
+        "@erlang_config//:erlang_26": ["-Wno_unknown"],
+        "@erlang_config//:erlang_26_0-rc2": ["-Wno_unknown"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.9.11",
+    version = "3.9.12",
 )
 
 erlang_config = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_r
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.9.11",
+    tag = "3.9.12",
 )
 
 load("@rules_erlang//:internal_deps.bzl", "rules_erlang_internal_deps")

--- a/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
@@ -57,6 +57,7 @@ plt(
     libs = ["//deps/rabbitmq_cli:elixir"],
     plt = "//:base_plt",
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_shovel/BUILD.bazel
+++ b/deps/rabbitmq_shovel/BUILD.bazel
@@ -69,6 +69,7 @@ plt(
     apps = EXTRA_APPS,
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(


### PR DESCRIPTION
`-Wunknown` is on by default in OTP 26, so for some plugins we must now set `-Wno_unknown`