### PR TITLE
Add OTP 26.0-rc3 to the test matrix

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v3.12.x
       - v3.11.x
       - v3.10.x
       - v3.9.x

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v3.12.x
       - v3.11.x
       - bump-otp-for-oci
       - bump-rbe-*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v3.12.x
       - v3.11.x
       - v3.10.x
       - v3.9.x
@@ -36,6 +37,7 @@ jobs:
         otp_version_id:
         - 25_0
         - 25_3
+        - 26
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -82,6 +84,8 @@ jobs:
         - erlang_version: "25.0"
           elixir_version: 1.14.0
         - erlang_version: "25.3"
+          elixir_version: 1.14.0
+        - erlang_version: "26.0-rc3"
           elixir_version: 1.14.0
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Allows `--config=rbe-26` in bazel commands