### PR TITLE
Add OTP 26.0-rc3 config to bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -59,6 +59,9 @@ build:rbe-25_2 --platforms=//bazel/platforms:erlang_linux_25_2_platform
 build:rbe-25_3 --config=rbe
 build:rbe-25_3 --platforms=//bazel/platforms:erlang_linux_25_3_platform
 
+build:rbe-26 --config=rbe
+build:rbe-26 --platforms=//bazel/platforms:erlang_linux_26_platform
+
 # no-op config so that --config=local does not error
 build:local --color=auto
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,6 +69,12 @@ erlang_config.internal_erlang_from_github_release(
     version = "25.3",
 )
 
+erlang_config.internal_erlang_from_github_release(
+    name = "26",
+    sha256 = "ce962175c4d90161a7247d8e2e4ae36f9d8cc0214c8f52dba8ba84a82afc096f",
+    version = "26.0-rc3",
+)
+
 erlang_config.internal_erlang_from_http_archive(
     name = "git_master",
     strip_prefix = "otp-master",
@@ -114,6 +120,8 @@ register_toolchains(
     "@erlang_config//25_2:toolchain2",
     "@erlang_config//25_3:toolchain",
     "@erlang_config//25_3:toolchain2",
+    "@erlang_config//26:toolchain",
+    "@erlang_config//26:toolchain2",
     "@erlang_config//git_master:toolchain",
     "@erlang_config//git_master:toolchain2",
     "@elixir_config//external:toolchain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,6 +92,13 @@ http_file(
     urls = ["https://github.com/erlang/otp/archive/OTP-25.3.tar.gz"],
 )
 
+http_file(
+    name = "otp_src_26",
+    downloaded_file_path = "OTP-26.0-rc3.tar.gz",
+    sha256 = "f4fc2c5e1da56eb659003015ab80c42e50cef1129cca8c14457a522d1793498d",
+    urls = ["https://github.com/erlang/otp/archive/OTP-26.0-rc3.tar.gz"],
+)
+
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
     sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
@@ -132,6 +139,11 @@ erlang_config(
             name = "25_3",
             sha256 = "85c447efc1746740df4089d75bc0e47b88d5161d7c44e9fc4c20fa33ea5d19d7",
             version = "25.3",
+        ),
+        internal_erlang_from_github_release(
+            name = "26",
+            sha256 = "ce962175c4d90161a7247d8e2e4ae36f9d8cc0214c8f52dba8ba84a82afc096f",
+            version = "26.0-rc3",
         ),
         internal_erlang_from_http_archive(
             name = "git_master",

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -57,6 +57,15 @@ platform(
 )
 
 platform(
+    name = "erlang_linux_26_platform",
+    constraint_values = [
+        "@erlang_config//:erlang_26",
+        "@elixir_config//:elixir_1_14",
+    ],
+    parents = ["@rbe//config:platform"],
+)
+
+platform(
     name = "erlang_linux_git_master_platform",
     constraint_values = [
         "@erlang_config//:erlang_26",

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -125,6 +125,7 @@ container_image(
         "@erlang_config//:erlang_25_1": ["@otp_src_25_1//file"],
         "@erlang_config//:erlang_25_2": ["@otp_src_25_2//file"],
         "@erlang_config//:erlang_25_3": ["@otp_src_25_3//file"],
+        "@erlang_config//:erlang_26": ["@otp_src_26//file"],
     }),
 )
 


### PR DESCRIPTION
This makes it convenient to test OTP 26.0-rc3 via bazel RBE (`--config=rbe-26`)