### PR TITLE
Ignore warnings when building plt files for dependencies (OTP 26 build compatibility)

### DIFF
--- a/deps/amqp10_client/BUILD.bazel
+++ b/deps/amqp10_client/BUILD.bazel
@@ -68,6 +68,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/amqp_client/BUILD.bazel
+++ b/deps/amqp_client/BUILD.bazel
@@ -67,6 +67,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -211,6 +211,7 @@ plt(
     apps = plt_apps,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/BUILD.bazel
@@ -50,6 +50,7 @@ plt(
         "@systemd//:erlang_app",
         "@osiris//:erlang_app",
     ],
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbit_common/BUILD.bazel
+++ b/deps/rabbit_common/BUILD.bazel
@@ -117,6 +117,7 @@ plt(
     apps = EXTRA_APPS + ["mnesia"],
     plt = "//:base_plt",
     deps = RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -58,6 +58,7 @@ plt(
     libs = ["//deps/rabbitmq_cli:elixir"],
     plt = "//:base_plt",
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_auth_backend_cache/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_cache/BUILD.bazel
@@ -49,6 +49,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_auth_backend_http/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_http/BUILD.bazel
@@ -56,6 +56,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_auth_backend_ldap/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_ldap/BUILD.bazel
@@ -72,6 +72,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_auth_mechanism_ssl/BUILD.bazel
+++ b/deps/rabbitmq_auth_mechanism_ssl/BUILD.bazel
@@ -47,6 +47,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_aws/BUILD.bazel
+++ b/deps/rabbitmq_aws/BUILD.bazel
@@ -49,6 +49,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = BUILD_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -90,6 +90,7 @@ plt(
         "//deps/rabbit:erlang_app",
         "//deps/rabbit_common:erlang_app",
     ],
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
+++ b/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
@@ -46,6 +46,7 @@ plt(
     libs = ["//deps/rabbitmq_cli:elixir"],
     plt = "//:base_plt",
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_event_exchange/BUILD.bazel
+++ b/deps/rabbitmq_event_exchange/BUILD.bazel
@@ -33,6 +33,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_federation/BUILD.bazel
+++ b/deps/rabbitmq_federation/BUILD.bazel
@@ -52,6 +52,7 @@ plt(
     plt = "//:base_plt",
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_federation_management/BUILD.bazel
+++ b/deps/rabbitmq_federation_management/BUILD.bazel
@@ -47,6 +47,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_jms_topic_exchange/BUILD.bazel
+++ b/deps/rabbitmq_jms_topic_exchange/BUILD.bazel
@@ -49,6 +49,7 @@ plt(
     plt = "//:base_plt",
     apps = EXTRA_APPS,
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_management/BUILD.bazel
+++ b/deps/rabbitmq_management/BUILD.bazel
@@ -80,6 +80,7 @@ plt(
     plt = "//:base_plt",
     apps = EXTRA_APPS,
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_management_agent/BUILD.bazel
+++ b/deps/rabbitmq_management_agent/BUILD.bazel
@@ -69,6 +69,7 @@ plt(
     libs = ["//deps/rabbitmq_cli:elixir"],
     plt = "//:base_plt",
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -80,6 +80,7 @@ plt(
     apps = EXTRA_APPS,
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_peer_discovery_aws/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_aws/BUILD.bazel
@@ -43,6 +43,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_peer_discovery_common/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_common/BUILD.bazel
@@ -45,6 +45,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_peer_discovery_consul/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_consul/BUILD.bazel
@@ -39,6 +39,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_peer_discovery_etcd/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_etcd/BUILD.bazel
@@ -46,6 +46,7 @@ plt(
         "@eetcd//:erlang_app",
         RUNTIME_DEPS,
     ),
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_peer_discovery_k8s/BUILD.bazel
+++ b/deps/rabbitmq_peer_discovery_k8s/BUILD.bazel
@@ -39,6 +39,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_prometheus/BUILD.bazel
+++ b/deps/rabbitmq_prometheus/BUILD.bazel
@@ -48,6 +48,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_random_exchange/BUILD.bazel
+++ b/deps/rabbitmq_random_exchange/BUILD.bazel
@@ -37,6 +37,7 @@ plt(
     name = "base_plt",
     deps = BUILD_DEPS + DEPS,
     plt = "//:base_plt",
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_recent_history_exchange/BUILD.bazel
+++ b/deps/rabbitmq_recent_history_exchange/BUILD.bazel
@@ -42,6 +42,7 @@ plt(
     plt = "//:base_plt",
     apps = [ "mnesia" ],
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_sharding/BUILD.bazel
+++ b/deps/rabbitmq_sharding/BUILD.bazel
@@ -32,6 +32,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_shovel_management/BUILD.bazel
+++ b/deps/rabbitmq_shovel_management/BUILD.bazel
@@ -46,6 +46,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_stomp/BUILD.bazel
+++ b/deps/rabbitmq_stomp/BUILD.bazel
@@ -74,6 +74,7 @@ plt(
     plt = "//:base_plt",
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_stream/BUILD.bazel
+++ b/deps/rabbitmq_stream/BUILD.bazel
@@ -67,6 +67,7 @@ plt(
     ],
     libs = ["//deps/rabbitmq_cli:elixir"],
     deps = ["//deps/rabbitmq_cli:elixir"] + BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_stream_common/BUILD.bazel
+++ b/deps/rabbitmq_stream_common/BUILD.bazel
@@ -28,6 +28,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_stream_management/BUILD.bazel
+++ b/deps/rabbitmq_stream_management/BUILD.bazel
@@ -42,6 +42,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_top/BUILD.bazel
+++ b/deps/rabbitmq_top/BUILD.bazel
@@ -44,6 +44,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_tracing/BUILD.bazel
+++ b/deps/rabbitmq_tracing/BUILD.bazel
@@ -53,6 +53,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_trust_store/BUILD.bazel
+++ b/deps/rabbitmq_trust_store/BUILD.bazel
@@ -53,6 +53,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_web_dispatch/BUILD.bazel
+++ b/deps/rabbitmq_web_dispatch/BUILD.bazel
@@ -46,6 +46,7 @@ plt(
     apps = EXTRA_APPS,
     plt = "//:base_plt",
     deps = DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_web_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_web_mqtt/BUILD.bazel
@@ -63,6 +63,7 @@ plt(
     plt = "//:base_plt",
     apps = EXTRA_APPS,
     deps = BUILD_DEPS + DEPS + RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_web_mqtt_examples/BUILD.bazel
+++ b/deps/rabbitmq_web_mqtt_examples/BUILD.bazel
@@ -38,6 +38,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_web_stomp/BUILD.bazel
+++ b/deps/rabbitmq_web_stomp/BUILD.bazel
@@ -62,6 +62,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = BUILD_DEPS + DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(

--- a/deps/rabbitmq_web_stomp_examples/BUILD.bazel
+++ b/deps/rabbitmq_web_stomp_examples/BUILD.bazel
@@ -38,6 +38,7 @@ plt(
     name = "base_plt",
     plt = "//:base_plt",
     deps = RUNTIME_DEPS,
+    ignore_warnings = True,
 )
 
 dialyze(


### PR DESCRIPTION
Now that `-Wunknown` is on by default, building type information for dependencies produces many warnings. However, since they aren't warnings for the plugin itself, then can be ignored.

This is the continuation of #7894 , which it turns out was incomplete.