### PR TITLE
Introduce a way to update virtual host metadata using CLI tools

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
@@ -1,0 +1,16 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+defmodule RabbitMQ.CLI.Core.VirtualHosts do
+  def parse_tags(tags) do
+    case tags do
+      nil -> nil
+      val ->
+        String.split(tags, ",", trim: true)
+        |> Enum.map(&String.trim/1)
+        |> Enum.map(&String.to_atom/1)
+    end
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
@@ -6,7 +6,9 @@
 defmodule RabbitMQ.CLI.Core.VirtualHosts do
   def parse_tags(tags) do
     case tags do
-      nil -> nil
+      nil ->
+        nil
+
       val ->
         String.split(tags, ",", trim: true)
         |> Enum.map(&String.trim/1)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/virtual_hosts.ex
@@ -10,7 +10,7 @@ defmodule RabbitMQ.CLI.Core.VirtualHosts do
         nil
 
       val ->
-        String.split(tags, ",", trim: true)
+        String.split(val, ",", trim: true)
         |> Enum.map(&String.trim/1)
         |> Enum.map(&String.to_atom/1)
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
-  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers}
+  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers, VirtualHosts}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -25,7 +25,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
         tags: tags,
         default_queue_type: default_qt
       }) do
-    meta = %{description: desc, tags: parse_tags(tags), default_queue_type: default_qt}
+    meta = %{description: desc, tags: VirtualHosts.parse_tags(tags), default_queue_type: default_qt}
 
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
       vhost,
@@ -38,7 +38,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
       vhost,
       desc,
-      parse_tags(tags),
+      VirtualHosts.parse_tags(tags),
       Helpers.cli_acting_user()
     ])
   end
@@ -85,13 +85,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
 
   def banner([vhost], _), do: "Adding vhost \"#{vhost}\" ..."
 
-  #
-  # Implementation
-  #
-
-  def parse_tags(tags) do
-    String.split(tags, ",", trim: true)
-    |> Enum.map(&String.trim/1)
-    |> Enum.map(&String.to_atom/1)
-  end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -25,7 +25,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
         tags: tags,
         default_queue_type: default_qt
       }) do
-    meta = %{description: desc, tags: VirtualHosts.parse_tags(tags), default_queue_type: default_qt}
+    meta = %{
+      description: desc,
+      tags: VirtualHosts.parse_tags(tags),
+      default_queue_type: default_qt
+    }
 
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [
       vhost,
@@ -84,5 +88,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   def description(), do: "Creates a virtual host"
 
   def banner([vhost], _), do: "Adding vhost \"#{vhost}\" ..."
-
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
@@ -23,35 +23,53 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateVhostMetadataCommand do
   def validate(args, _) when length(args) == 0 do
     {:validation_failure, :not_enough_args}
   end
+
   def validate(args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end
+
   def validate([_vhost], opts) do
     m = :maps.with(@metadata_keys, opts)
+
     case map_size(m) do
-      0 -> {:validation_failure, :not_enough_args}
+      0 ->
+        {:validation_failure, :not_enough_args}
+
       _ ->
         # description and tags can be anything but default queue type must
         # be a value from a known set
         case m[:default_queue_type] do
-          nil -> :ok
-          "quorum" -> :ok
-          "stream" -> :ok
-          "classic" -> :ok
+          nil ->
+            :ok
+
+          "quorum" ->
+            :ok
+
+          "stream" ->
+            :ok
+
+          "classic" ->
+            :ok
+
           other ->
-            {:validation_failure, {:bad_arguments, "Default queue type must be one of: quorum, stream, classic. Provided: #{other}"}}
+            {:validation_failure,
+             {:bad_arguments,
+              "Default queue type must be one of: quorum, stream, classic. Provided: #{other}"}}
         end
     end
   end
+
   def validate(_, _), do: :ok
 
   def run([vhost], %{node: node_name} = opts) do
     meta = :maps.with(@metadata_keys, opts)
     tags = meta[:tags]
-    meta = case tags do
-      nil -> meta
-      other -> %{meta | tags: VirtualHosts.parse_tags(other)}
-    end
+
+    meta =
+      case tags do
+        nil -> meta
+        other -> %{meta | tags: VirtualHosts.parse_tags(other)}
+      end
 
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :update_metadata, [
       vhost,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
@@ -53,7 +53,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateVhostMetadataCommand do
 
           other ->
             {:validation_failure,
-             {:bad_arguments,
+             {:bad_argument,
               "Default queue type must be one of: quorum, stream, classic. Provided: #{other}"}}
         end
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_vhost_metadata_command.ex
@@ -1,0 +1,96 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.UpdateVhostMetadataCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers, VirtualHosts}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  @metadata_keys [:description, :tags, :default_queue_type]
+
+  def switches(), do: [description: :string, tags: :string, default_queue_type: :string]
+  def aliases(), do: [d: :description]
+
+  def merge_defaults(args, opts) do
+    {args, opts}
+  end
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def validate(args, _) when length(args) == 0 do
+    {:validation_failure, :not_enough_args}
+  end
+  def validate(args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+  def validate([_vhost], opts) do
+    m = :maps.with(@metadata_keys, opts)
+    case map_size(m) do
+      0 -> {:validation_failure, :not_enough_args}
+      _ ->
+        # description and tags can be anything but default queue type must
+        # be a value from a known set
+        case m[:default_queue_type] do
+          nil -> :ok
+          "quorum" -> :ok
+          "stream" -> :ok
+          "classic" -> :ok
+          other ->
+            {:validation_failure, {:bad_arguments, "Default queue type must be one of: quorum, stream, classic. Provided: #{other}"}}
+        end
+    end
+  end
+  def validate(_, _), do: :ok
+
+  def run([vhost], %{node: node_name} = opts) do
+    meta = :maps.with(@metadata_keys, opts)
+    tags = meta[:tags]
+    meta = case tags do
+      nil -> meta
+      other -> %{meta | tags: VirtualHosts.parse_tags(other)}
+    end
+
+    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :update_metadata, [
+      vhost,
+      meta,
+      Helpers.cli_acting_user()
+    ])
+  end
+
+  def output({:error, :invalid_queue_type}, _opts) do
+    {:error, ExitCodes.exit_usage(), "Unsupported default queue type"}
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage,
+    do:
+      "update_vhost_metadata <vhost> [--description <description>] [--tags \"<tag1>,<tag2>,<...>\"] [--default-queue-type <quorum|classic|stream>]"
+
+  def usage_additional() do
+    [
+      ["<vhost>", "Virtual host name"],
+      ["--description <description>", "Virtual host description"],
+      ["--tags <tag1,tag2>", "Comma-separated list of tags"],
+      [
+        "--default-queue-type <quorum|classic|stream>",
+        "Queue type to use if no type is explicitly provided by the client"
+      ]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.virtual_hosts()
+    ]
+  end
+
+  def help_section(), do: :virtual_hosts
+
+  def description(), do: "Updates metadata (tags, description, default queue type) a virtual host"
+
+  def banner([vhost], _), do: "Updating metadata of vhost \"#{vhost}\" ..."
+end

--- a/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_vhost_command_test.exs
@@ -78,7 +78,7 @@ defmodule AddVhostCommandTest do
   end
 
   @tag vhost: @vhost
-  test "run: vhost tags are conformed to a list", context do
+  test "run: vhost tags are coerced to a list", context do
     opts = Map.merge(context[:opts], %{description: "My vhost", tags: "my_tag"})
     assert @command.run([context[:vhost]], opts) == :ok
     record = list_vhosts() |> Enum.find(fn record -> record[:name] == context[:vhost] end)

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -59,24 +59,23 @@ defmodule UpdateVhostMetadataCommandTest do
                "Default queue type must be one of: quorum, stream, classic. Provided: unknown"}}
   end
 
-  @tag vhost: @vhost
   test "run: passing a valid vhost name and description succeeds", context do
-    add_vhost(context[:vhost])
+    add_vhost(@vhost)
     desc = "desc 2"
 
-    assert @command.run([context[:vhost]], Map.merge(context[:opts], %{desciption: desc})) == :ok
-    vh = find_vhost(context[:vhost])
+    assert @command.run([@vhost], Map.merge(context[:opts], %{desciption: desc})) == :ok
+    vh = find_vhost(@vhost)
 
     assert vh
     assert vh[:description] == desc
   end
 
   test "run: passing a valid vhost name and a set of tags succeeds", context do
-    add_vhost(context[:vhost])
+    add_vhost(@vhost)
     tags = "a1,b2,c3"
 
-    assert @command.run([context[:vhost]], Map.merge(context[:opts], %{tags: tags})) == :ok
-    vh = find_vhost(context[:vhost])
+    assert @command.run([@vhost], Map.merge(context[:opts], %{tags: tags})) == :ok
+    vh = find_vhost(@vhost)
 
     assert vh
     assert vh[:tags] == [:a1, :b2, :c3]
@@ -96,19 +95,17 @@ defmodule UpdateVhostMetadataCommandTest do
     assert match?({:badrpc, _}, @command.run(["na"], opts))
   end
 
-  @tag vhost: @vhost
   test "run: vhost tags are coerced to a list", context do
-    add_vhost(context[:vhost])
+    add_vhost(@vhost)
 
     opts = Map.merge(context[:opts], %{description: "My vhost", tags: "my_tag"})
-    assert @command.run([context[:vhost]], opts) == :ok
-    record = list_vhosts() |> Enum.find(fn record -> record[:name] == context[:vhost] end)
-    assert record[:tags] == [:my_tag]
+    assert @command.run([@vhost], opts) == :ok
+    vh = find_vhost(@vhost)
+    assert vh[:tags] == [:my_tag]
   end
 
-  @tag vhost: @vhost
   test "banner", context do
-    assert @command.banner([context[:vhost]], context[:opts]) =~
-             ~r/Update metadata of vhost \"#{context[:vhost]}\" \.\.\./
+    assert @command.banner([@vhost], context[:opts]) =~
+             ~r/Update metadata of vhost \"#{@vhost}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -90,7 +90,7 @@ defmodule UpdateVhostMetadataCommandTest do
     assert vh[:tags] == [:a1, :b2, :c3]
   end
 
-  test "run: attempt to use a non-existent virtual host fails" do
+  test "run: attempt to use a non-existent virtual host fails", context do
     vh = "a-non-existent-3882-vhost"
 
     assert match?(

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -106,6 +106,6 @@ defmodule UpdateVhostMetadataCommandTest do
 
   test "banner", context do
     assert @command.banner([@vhost], context[:opts]) =~
-             ~r/Update metadata of vhost \"#{@vhost}\" \.\.\./
+             ~r/Updating metadata of vhost/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -63,7 +63,7 @@ defmodule UpdateVhostMetadataCommandTest do
     add_vhost(@vhost)
     desc = "desc 2"
 
-    assert @command.run([@vhost], Map.merge(context[:opts], %{desciption: desc})) == :ok
+    assert @command.run([@vhost], Map.merge(context[:opts], %{description: desc})) == :ok
     vh = find_vhost(@vhost)
 
     assert vh

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -1,0 +1,113 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule UpdateVhostMetadataCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.UpdateVhostMetadataCommand
+  @vhost "update-metadata-test"
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+    {:ok, opts: %{node: get_rabbit_hostname()}}
+  end
+
+  setup context do
+    on_exit(context, fn -> delete_vhost(context[:vhost]) end)
+    :ok
+  end
+
+  test "validate: no arguments fails validation" do
+    assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: too many arguments fails validation" do
+    assert @command.validate(["test", "extra"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: virtual host name without options fails validation" do
+    assert @command.validate(["a-vhost"], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: virtual host name and one or more metadata options succeeds" do
+    assert @command.validate(["a-vhost"], %{description: "Used by team A"}) == :ok
+
+    assert @command.validate(["a-vhost"], %{
+             description: "Used by team A for QA purposes",
+             tags: "qa,team-a"
+           }) == :ok
+
+    assert @command.validate(["a-vhost"], %{
+             description: "Used by team A for QA purposes",
+             tags: "qa,team-a",
+             default_queue_type: "quorum"
+           }) == :ok
+  end
+
+  test "validate: unknown default queue type fails validation" do
+    assert @command.validate(["a-vhost"], %{
+             description: "Used by team A for QA purposes",
+             tags: "qa,team-a",
+             default_queue_type: "unknown"
+           }) == {:validation_failure, {:bad_argument, "Default queue type must be one of: quorum, stream, classic. Provided: unknown"}}
+  end
+
+  @tag vhost: @vhost
+  test "run: passing a valid vhost name and description succeeds", context do
+    add_vhost(context[:vhost])
+    desc = "desc 2"
+
+    assert @command.run([context[:vhost], %{desciption: desc}], context[:opts]) == :ok
+    vh = list_vhosts() |> Enum.filter(fn record -> record[:name] == context[:vhost] end) |> List.first
+    assert vh
+    assert vh[:description] == desc
+  end
+
+  test "run: passing a valid vhost name and a set of tags succeeds", context do
+    add_vhost(context[:vhost])
+    tags = "a1,b2,c3"
+
+    assert @command.run([context[:vhost], %{tags: tags}], context[:opts]) == :ok
+    vh = list_vhosts() |> Enum.filter(fn record -> record[:name] == context[:vhost] end) |> List.first
+    assert vh
+    assert vh[:tags] == [:a1, :b2, :c3]
+  end
+
+  test "run: attempt to use a non-existent virtual host fails" do
+    vh = "a-non-existent-3882-vhost"
+    assert match?({:error, {:no_such_vhost, _}}, @command.run([vh], %{description: "irrelevant", context[:opts]}))
+  end
+
+  test "run: attempt to use an unreachable node returns a nodedown" do
+    opts = %{node: :jake@thedog, timeout: 200, description: "does not matter"}
+    assert match?({:badrpc, _}, @command.run(["na"], opts))
+  end
+
+  @tag vhost: @vhost
+  test "run: adding the same host twice is idempotent", context do
+    add_vhost(context[:vhost])
+
+    assert @command.run([context[:vhost]], context[:opts]) == :ok
+    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 1
+  end
+
+  @tag vhost: @vhost
+  test "banner", context do
+    assert @command.banner([context[:vhost]], context[:opts]) =~
+             ~r/Update metadata of vhost \"#{context[:vhost]}\" \.\.\./
+  end
+
+  @tag vhost: @vhost
+  test "run: vhost tags are coerced to a list", context do
+    add_vhost(context[:vhost])
+
+    opts = Map.merge(context[:opts], %{description: "My vhost", tags: "my_tag"})
+    assert @command.run([context[:vhost]], opts) == :ok
+    record = list_vhosts() |> Enum.find(fn record -> record[:name] == context[:vhost] end)
+    assert record[:tags] == [:my_tag]
+  end
+end

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -65,12 +65,7 @@ defmodule UpdateVhostMetadataCommandTest do
     desc = "desc 2"
 
     assert @command.run([context[:vhost]], Map.merge(context[:opts], %{desciption: desc})) == :ok
-    IO.inspect(list_vhosts())
-
-    vh =
-      list_vhosts()
-      |> Enum.filter(fn record -> record[:name] == context[:vhost] end)
-      |> List.first()
+    vh = find_vhost(context[:vhost])
 
     assert vh
     assert vh[:description] == desc
@@ -81,11 +76,7 @@ defmodule UpdateVhostMetadataCommandTest do
     tags = "a1,b2,c3"
 
     assert @command.run([context[:vhost]], Map.merge(context[:opts], %{tags: tags})) == :ok
-
-    vh =
-      list_vhosts()
-      |> Enum.filter(fn record -> record[:name] == context[:vhost] end)
-      |> List.first()
+    vh = find_vhost(context[:vhost])
 
     assert vh
     assert vh[:tags] == [:a1, :b2, :c3]

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -65,6 +65,7 @@ defmodule UpdateVhostMetadataCommandTest do
     desc = "desc 2"
 
     assert @command.run([context[:vhost]], Map.merge(context[:opts], %{desciption: desc})) == :ok
+    IO.inspect(list_vhosts())
 
     vh =
       list_vhosts()
@@ -95,7 +96,7 @@ defmodule UpdateVhostMetadataCommandTest do
 
     assert match?(
              {:error, {:no_such_vhost, _}},
-             @command.run([vh], Maps.merge(context[:opts], %{description: "irrelevant"}))
+             @command.run([vh], Map.merge(context[:opts], %{description: "irrelevant"}))
            )
   end
 

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -61,7 +61,7 @@ defmodule UpdateVhostMetadataCommandTest do
     add_vhost(context[:vhost])
     desc = "desc 2"
 
-    assert @command.run([context[:vhost], %{desciption: desc}], context[:opts]) == :ok
+    assert @command.run([context[:vhost]], Map.merge(context[:opts], %{desciption: desc})) == :ok
     vh = list_vhosts() |> Enum.filter(fn record -> record[:name] == context[:vhost] end) |> List.first
     assert vh
     assert vh[:description] == desc
@@ -71,7 +71,7 @@ defmodule UpdateVhostMetadataCommandTest do
     add_vhost(context[:vhost])
     tags = "a1,b2,c3"
 
-    assert @command.run([context[:vhost], %{tags: tags}], context[:opts]) == :ok
+    assert @command.run([context[:vhost]], Map.merge(context[:opts], %{tags: tags})) == :ok
     vh = list_vhosts() |> Enum.filter(fn record -> record[:name] == context[:vhost] end) |> List.first
     assert vh
     assert vh[:tags] == [:a1, :b2, :c3]
@@ -79,26 +79,12 @@ defmodule UpdateVhostMetadataCommandTest do
 
   test "run: attempt to use a non-existent virtual host fails" do
     vh = "a-non-existent-3882-vhost"
-    assert match?({:error, {:no_such_vhost, _}}, @command.run([vh], %{description: "irrelevant", context[:opts]}))
+    assert match?({:error, {:no_such_vhost, _}}, @command.run([vh], Maps.merge(context[:opts], %{description: "irrelevant"})))
   end
 
   test "run: attempt to use an unreachable node returns a nodedown" do
     opts = %{node: :jake@thedog, timeout: 200, description: "does not matter"}
     assert match?({:badrpc, _}, @command.run(["na"], opts))
-  end
-
-  @tag vhost: @vhost
-  test "run: adding the same host twice is idempotent", context do
-    add_vhost(context[:vhost])
-
-    assert @command.run([context[:vhost]], context[:opts]) == :ok
-    assert list_vhosts() |> Enum.count(fn record -> record[:name] == context[:vhost] end) == 1
-  end
-
-  @tag vhost: @vhost
-  test "banner", context do
-    assert @command.banner([context[:vhost]], context[:opts]) =~
-             ~r/Update metadata of vhost \"#{context[:vhost]}\" \.\.\./
   end
 
   @tag vhost: @vhost
@@ -109,5 +95,11 @@ defmodule UpdateVhostMetadataCommandTest do
     assert @command.run([context[:vhost]], opts) == :ok
     record = list_vhosts() |> Enum.find(fn record -> record[:name] == context[:vhost] end)
     assert record[:tags] == [:my_tag]
+  end
+
+  @tag vhost: @vhost
+  test "banner", context do
+    assert @command.banner([context[:vhost]], context[:opts]) =~
+             ~r/Update metadata of vhost \"#{context[:vhost]}\" \.\.\./
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/update_vhost_metadata_command_test.exs
@@ -53,7 +53,10 @@ defmodule UpdateVhostMetadataCommandTest do
              description: "Used by team A for QA purposes",
              tags: "qa,team-a",
              default_queue_type: "unknown"
-           }) == {:validation_failure, {:bad_argument, "Default queue type must be one of: quorum, stream, classic. Provided: unknown"}}
+           }) ==
+             {:validation_failure,
+              {:bad_argument,
+               "Default queue type must be one of: quorum, stream, classic. Provided: unknown"}}
   end
 
   @tag vhost: @vhost
@@ -62,7 +65,12 @@ defmodule UpdateVhostMetadataCommandTest do
     desc = "desc 2"
 
     assert @command.run([context[:vhost]], Map.merge(context[:opts], %{desciption: desc})) == :ok
-    vh = list_vhosts() |> Enum.filter(fn record -> record[:name] == context[:vhost] end) |> List.first
+
+    vh =
+      list_vhosts()
+      |> Enum.filter(fn record -> record[:name] == context[:vhost] end)
+      |> List.first()
+
     assert vh
     assert vh[:description] == desc
   end
@@ -72,14 +80,23 @@ defmodule UpdateVhostMetadataCommandTest do
     tags = "a1,b2,c3"
 
     assert @command.run([context[:vhost]], Map.merge(context[:opts], %{tags: tags})) == :ok
-    vh = list_vhosts() |> Enum.filter(fn record -> record[:name] == context[:vhost] end) |> List.first
+
+    vh =
+      list_vhosts()
+      |> Enum.filter(fn record -> record[:name] == context[:vhost] end)
+      |> List.first()
+
     assert vh
     assert vh[:tags] == [:a1, :b2, :c3]
   end
 
   test "run: attempt to use a non-existent virtual host fails" do
     vh = "a-non-existent-3882-vhost"
-    assert match?({:error, {:no_such_vhost, _}}, @command.run([vh], Maps.merge(context[:opts], %{description: "irrelevant"})))
+
+    assert match?(
+             {:error, {:no_such_vhost, _}},
+             @command.run([vh], Maps.merge(context[:opts], %{description: "irrelevant"}))
+           )
   end
 
   test "run: attempt to use an unreachable node returns a nodedown" do

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -41,8 +41,19 @@ defmodule TestHelper do
     :rpc.call(get_rabbit_hostname(), :rabbit_nodes, :cluster_name, [])
   end
 
-  def add_vhost(name) do
-    :rpc.call(get_rabbit_hostname(), :rabbit_vhost, :add, [name, "acting-user"])
+  def add_vhost(name, meta \\ %{}) do
+    :rpc.call(get_rabbit_hostname(), :rabbit_vhost, :add, [name, meta, "acting-user"])
+  end
+
+  def find_vhost(name) do
+    case :rpc.call(get_rabbit_hostname(), :rabbit_vhost, :lookup, [name]) do
+      {:error, _} = err ->
+        err
+
+      vhost_rec ->
+        {:vhost, ^name, _limits, meta} = vhost_rec
+        %{meta | name: name}
+    end
   end
 
   def delete_vhost(name) do

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -51,8 +51,8 @@ defmodule TestHelper do
         err
 
       vhost_rec ->
-        {:vhost, ^name, _limits, meta} = vhost_rec
-        %{meta | name: name}
+        {:vhost, _name, limits, meta} = vhost_rec
+        Map.merge(meta, %{name: name, limits: limits})
     end
   end
 


### PR DESCRIPTION
This introduces a new CLI command, `rabbitmqctl update_vhost_metadata`, that can be used
to update tags, default queue type, and description of any existing virtual host:

``` shell
rabbitmqctl update_vhost_metadata vh1 --tags qa,quorum,team3,project2

rabbitmqctl update_vhost_metadata vh1 --description "QA env 1 for issue 37483"

rabbitmqctl update_vhost_metadata vh1 --description "QQs all the way" --default-queue-type "quorum"

rabbitmqctl update_vhost_metadata vh1 --description "streaming my brain out" --default-queue-type "stream"
```

Part of #7912, #7874
