### PR TITLE
Make it possible to configure per-node runtime parameter limits

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1153,6 +1153,14 @@ rabbitmq_integration_suite(
     size = "small",
 )
 
+rabbitmq_integration_suite(
+    name = "runtime_parameters_SUITE",
+    size = "small",
+    additional_srcs = [
+        "test/dummy_runtime_parameters.erl",
+    ],
+)
+
 assert_suites()
 
 filegroup(

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2472,6 +2472,25 @@ end}.
 {mapping, "quorum_queue.compute_checksums", "rabbit.quorum_compute_checksums", [
     {datatype, {enum, [true, false]}}]}.
 
+
+%%
+%% Runtime parameters
+%%
+
+{mapping, "runtime_parameters.limits.$category", "rabbit.runtime_parameters.limits", [
+    {datatype, integer},
+    {validators, ["non_negative_integer"]}
+]}.
+
+{translation, "rabbit.runtime_parameters.limits",
+    fun(Conf) ->
+        case cuttlefish_variable:filter_by_prefix("runtime_parameters.limits", Conf) of
+            [] -> cuttlefish:unset();
+            Ss -> [ {list_to_binary(Category), Limit} || {[_, _, Category], Limit} <- Ss ]
+        end
+    end
+}.
+
 % ===============================
 % Validators
 % ===============================

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -157,7 +157,7 @@ set_any0(VHost, Component, Name, Term, User) ->
             E
     end.
 
--spec is_within_limit(binary()) -> rabbit_types:ok_or_error(binary()).
+-spec is_within_limit(binary()) -> ok | {errors, list()}.
 
 is_within_limit(Component) ->
     Params = application:get_env(rabbit, runtime_parameters, []),

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -165,7 +165,7 @@ is_within_limit(Component) ->
     Limit = proplists:get_value(Component, Limits, -1),
     case Limit < 0 orelse count_component(Component) < Limit of
        true -> ok;
-       false -> {errors, [{"component ~ts is limited to ~tp per host", [Component, Limit]}]}
+       false -> {errors, [{"component ~ts is limited to ~tp per node", [Component, Limit]}]}
     end.
 
 count_component(Component) -> length(list_component(Component)).

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -904,12 +904,12 @@ credential_validator.regexp = ^abc\\d+",
 
   {runtime_parameters_limits,
   "
-   runtime_parameters.limits.b = 2
-   runtime_parameters.limits.a = 1
+   runtime_parameters.limits.federation = 2
+   runtime_parameters.limits.shovel = 1
   ",
    [{rabbit, [{runtime_parameters, [{limits, [
-       {<<"a">>, 1},
-       {<<"b">>, 2}
+       {<<"shovel">>, 1},
+       {<<"federation">>, 2}
      ]}]}]}],
    []},
 

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -899,6 +899,21 @@ credential_validator.regexp = ^abc\\d+",
    []},
 
   %%
+  %% Runtime parameters
+  %%
+
+  {runtime_parameters_limits,
+  "
+   runtime_parameters.limits.b = 2
+   runtime_parameters.limits.a = 1
+  ",
+   [{rabbit, [{runtime_parameters, [{limits, [
+       {<<"a">>, 1},
+       {<<"b">>, 2}
+     ]}]}]}],
+   []},
+
+  %%
   %% Deprecated features
   %%
 

--- a/deps/rabbit/test/dummy_runtime_parameters.erl
+++ b/deps/rabbit/test/dummy_runtime_parameters.erl
@@ -9,7 +9,7 @@
 -behaviour(rabbit_runtime_parameter).
 -behaviour(rabbit_policy_validator).
 
--include("rabbit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -export([validate/5, notify/5, notify_clear/4]).
 -export([register/0, unregister/0]).
@@ -40,10 +40,14 @@ notify_clear(_, _, _, _) -> ok.
 %----------------------------------------------------------------------------
 
 register_policy_validator() ->
+    rabbit_registry:register(operator_policy_validator, <<"testeven">>, ?MODULE),
+    rabbit_registry:register(operator_policy_validator, <<"testpos">>,  ?MODULE),
     rabbit_registry:register(policy_validator, <<"testeven">>, ?MODULE),
     rabbit_registry:register(policy_validator, <<"testpos">>,  ?MODULE).
 
 unregister_policy_validator() ->
+    rabbit_registry:unregister(operator_policy_validator, <<"testeven">>),
+    rabbit_registry:unregister(operator_policy_validator, <<"testpos">>),
     rabbit_registry:unregister(policy_validator, <<"testeven">>),
     rabbit_registry:unregister(policy_validator, <<"testpos">>).
 

--- a/deps/rabbit/test/runtime_parameters_SUITE.erl
+++ b/deps/rabbit/test/runtime_parameters_SUITE.erl
@@ -55,7 +55,7 @@ test_limits(Config) ->
 test_limits1(_Config) ->
     dummy_runtime_parameters:register(),
     application:set_env(rabbit, runtime_parameters, [{limits, [{<<"test">>, 1}]}]),
-    E  = {error_string, "Validation failed\n\ncomponent test is limited to 1 per host\n"},
+    E  = {error_string, "Validation failed\n\ncomponent test is limited to 1 per node\n"},
     ok = rabbit_runtime_parameters:set_any(<<"/">>, <<"test">>, <<"good">>, <<"">>, none),
     E  = rabbit_runtime_parameters:set_any(<<"/">>, <<"test">>, <<"good">>, <<"">>, none),
     dummy_runtime_parameters:unregister().

--- a/deps/rabbit/test/runtime_parameters_SUITE.erl
+++ b/deps/rabbit/test/runtime_parameters_SUITE.erl
@@ -1,0 +1,61 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2023-2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(runtime_parameters_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+        test_limits
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase},
+        {rmq_nodes_count, 1}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+test_limits(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE,
+                                 test_limits1, [Config]).
+
+test_limits1(_Config) ->
+    dummy_runtime_parameters:register(),
+    application:set_env(rabbit, runtime_parameters, [{limits, [{<<"test">>, 1}]}]),
+    E  = {error_string, "Validation failed\n\ncomponent test is limited to 1 per host\n"},
+    ok = rabbit_runtime_parameters:set_any(<<"/">>, <<"test">>, <<"good">>, <<"">>, none),
+    E  = rabbit_runtime_parameters:set_any(<<"/">>, <<"test">>, <<"good">>, <<"">>, none),
+    dummy_runtime_parameters:unregister().


### PR DESCRIPTION
## Proposed Changes

Introduces an arbitrary per-host runtime parameter limit, e.g.

```
runtime_parameters.limits.shovel = 0
runtime_parameters.limits.federation = 100
```

The limit can be set to any value, negative integers treated as "unlimited". There are no sanity checks, and I expect it to be used only by power-users.

Main purpose is resource management per #7856, although this hypothetically can be used to disable certain broker features outright.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it