### PR TITLE
Revert erlang:port_command/2 to gen_tcp:send/2 change

### DIFF
--- a/deps/rabbit_common/src/rabbit_net.erl
+++ b/deps/rabbit_common/src/rabbit_net.erl
@@ -168,22 +168,7 @@ port_command(Sock, Data) when ?IS_SSL(Sock) ->
         {error, Reason} -> erlang:error(Reason)
     end;
 port_command(Sock, Data) when is_port(Sock) ->
-    port_command_tcp(Sock, Data).
-
-%% gen_tcp:send/2 does a selective receive of {inet_reply, Sock, Status}
--if(?OTP_RELEASE < 26).
-%% Avoid costly selective receive.
-port_command_tcp(Sock, Data) ->
     erlang:port_command(Sock, Data).
--else.
-%% Selective receive is optimised: https://github.com/erlang/otp/issues/6455
-port_command_tcp(Sock, Data) ->
-    case gen_tcp:send(Sock, Data) of
-        ok -> self() ! {inet_reply, Sock, ok},
-              true;
-        {error, Reason} -> erlang:error(Reason)
-    end.
--endif.
 
 getopts(Sock, Options) when ?IS_SSL(Sock) ->
     ssl:getopts(Sock, Options);


### PR DESCRIPTION
Revert the change introduced in https://github.com/rabbitmq/rabbitmq-server/pull/7900

RabbitMQ 3.12 will require OTP 25 (not yet OTP 26).

The use of macro `OTP_RELEASE` was wrong because RabbitMQ can be compiled with OTP 25, but run with OTP 26. Macros are evaluated at compile time.

An alternative runtime equivalent would have been
```
1> erlang:system_info(otp_release).
"26"
```