### PR TITLE
Fix test case confirm_minority

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -657,6 +657,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                 {'DOWN', MRef, process, _, _} ->
                     ok
             after Timeout ->
+                    erlang:demonitor(MRef, [flush]),
                     ok = force_delete_queue(Servers)
             end,
             notify_decorators(QName, shutdown),


### PR DESCRIPTION
Demonitor when timing out waiting for quorum queue leader to be gone.

This commit fixes the failing test:
```
make -C deps/rabbit ct-publisher_confirms_parallel t=quorum_queue:confirm_minority
```

which caused the channel to crash:
```
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0> ** Reason for termination ==
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0> ** {function_clause,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>        [{rabbit_channel,handle_info,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>             [{'DOWN',#Ref<0.1252370609.3538681857.123766>,process,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {'%2F_quorum_queue_confirm_minority',
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      'rmq-ct-mnesia_store-1-21000@localhost'},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  shutdown},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>              {ch,{conf,running,rabbit_framing_amqp_0_9_1,58,<0.1240.0>,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      <0.2389.0>,<0.1240.0>,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      <<"127.0.0.1:42312 -> 127.0.0.1:21000">>,undefined,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      {user,<<"guest">>,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                          [administrator],
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                          [{rabbit_auth_backend_internal,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                               #Fun<rabbit_auth_backend_internal.3.61791021>}]},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      <<"/">>,<<>>,<0.1241.0>,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      [{<<"publisher_confirms">>,bool,true},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                       {<<"exchange_exchange_bindings">>,bool,true},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                       {<<"basic.nack">>,bool,true},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                       {<<"consumer_cancel_notify">>,bool,true},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                       {<<"connection.blocked">>,bool,true},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                       {<<"authentication_failure_close">>,bool,true}],
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                      none,0,134217728,1800000,#{},1000000000},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {lstate,<0.2390.0>,false},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  none,1,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {0,[],[]},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {state,#{},erlang},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  #{},#{},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {state,none,5000,undefined},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  false,1,
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {rabbit_confirms,undefined,#{}},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  [],[],none,flow,[],
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  {rabbit_queue_type,#{}},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>                  #Ref<0.1252370609.3538681858.121367>,false}],
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>             [{file,"rabbit_channel.erl"},{line,767}]},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>         {gen_server2,handle_msg,2,[{file,"gen_server2.erl"},{line,1067}]},
2023-04-18 12:03:28.476525+00:00 [error] <0.2391.0>         {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}
2023-04-18 12:03:
```

