### PR TITLE
Adjust `-include(...` in some tests to work with both bazel and make

### DIFF
--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -13,7 +13,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
--include("rabbit_fifo.hrl").
+-include("src/rabbit_fifo.hrl").
 
 %%%===================================================================
 %%% Common Test callbacks

--- a/deps/rabbit/test/rabbit_fifo_dlx_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_dlx_SUITE.erl
@@ -10,8 +10,8 @@
 -compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
--include("rabbit_fifo.hrl").
--include("rabbit_fifo_dlx.hrl").
+-include("src/rabbit_fifo.hrl").
+-include("src/rabbit_fifo_dlx.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 %%%===================================================================

--- a/deps/rabbit/test/rabbit_fifo_prop_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_prop_SUITE.erl
@@ -9,8 +9,8 @@
 -include_lib("proper/include/proper.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include("rabbit_fifo.hrl").
--include("rabbit_fifo_dlx.hrl").
+-include("src/rabbit_fifo.hrl").
+-include("src/rabbit_fifo_dlx.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -define(record_info(T,R),lists:zip(record_info(fields,T),tl(tuple_to_list(R)))).

--- a/deps/rabbit/test/rabbit_fifo_v0_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_v0_SUITE.erl
@@ -11,7 +11,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
--include("rabbit_fifo_v0.hrl").
+-include("src/rabbit_fifo_v0.hrl").
 
 %%%===================================================================
 %%% Common Test callbacks

--- a/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
@@ -8,7 +8,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
--include("rabbit_stream_coordinator.hrl").
+-include("src/rabbit_stream_coordinator.hrl").
 
 -define(STATE, rabbit_stream_coordinator).
 

--- a/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
@@ -19,7 +19,7 @@
 -compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
--include("rabbit_stream_sac_coordinator.hrl").
+-include("src/rabbit_stream_sac_coordinator.hrl").
 
 %%%===================================================================
 %%% Common Test callbacks


### PR DESCRIPTION
#6466 changed some includes in a way that was incompatible with the make build. This updates them to a form supported by both. rules_erlang will likely get an enhancement so that the original form prior to #6466 works as well.