### PR TITLE
CLI: make input ordering preditable when formatting a table

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/formatter_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/formatter_helpers.ex
@@ -48,10 +48,12 @@ defmodule RabbitMQ.CLI.Formatters.FormatterHelpers do
   def format_info_item(item, escaped \\ true)
 
   def format_info_item(map, escaped) when is_map(map) do
+    kv = to_predictably_ordered_keyword_list(map)
+
     [
       "\#\{",
       Enum.map(
-        map,
+        kv,
         fn {k, v} ->
           ["#{escape(k, escaped)} => ", format_info_item(v, escaped)]
         end
@@ -123,6 +125,14 @@ defmodule RabbitMQ.CLI.Formatters.FormatterHelpers do
 
   def format_info_item(value, _escaped) do
     :io_lib.format("~1000000000000tp", [value])
+  end
+
+  @spec to_predictably_ordered_keyword_list(Enumerable.t()) :: Keyword.t()
+  def to_predictably_ordered_keyword_list(input0) do
+    case input0 do
+      m when is_map(m) -> Enum.sort(Keyword.new(m))
+      other -> other
+    end
   end
 
   defp prettify_amqp_table(table, escaped) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/table.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/table.ex
@@ -18,7 +18,7 @@ defmodule RabbitMQ.CLI.Formatters.Table do
       fn
         [first | _] = element ->
           case FormatterHelpers.proplist?(first) or is_map(first) do
-            true -> element
+            true -> FormatterHelpers.to_predictably_ordered_keyword_list(element)
             false -> [element]
           end
 
@@ -38,7 +38,10 @@ defmodule RabbitMQ.CLI.Formatters.Table do
     )
   end
 
-  def format_output(output, options) do
+  def format_output(output0, options) do
+    # on Erlang 26, map entry ordering has changed, this avoids
+    # implicitly depending on map key order
+    output = FormatterHelpers.to_predictably_ordered_keyword_list(output0)
     maybe_header(output, options)
   end
 
@@ -61,6 +64,7 @@ defmodule RabbitMQ.CLI.Formatters.Table do
   defp format_output_1(output, options) when is_map(output) do
     escaped = escaped?(options)
     pad_to_header = pad_to_header?(options)
+
     format_line(output, escaped, pad_to_header)
   end
 

--- a/deps/rabbitmq_cli/test/core/table_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/core/table_formatter_test.exs
@@ -9,20 +9,6 @@ defmodule TableFormatterTest do
 
   @formatter RabbitMQ.CLI.Formatters.Table
 
-  test "format_output tab-separates map values" do
-    assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) == ["a\tb", "apple\tbeer"]
-
-    assert @formatter.format_output(%{a: :apple, b: :beer, c: 1}, %{}) == [
-             "a\tb\tc",
-             "apple\tbeer\t1"
-           ]
-
-    assert @formatter.format_output(%{a: "apple", b: 'beer', c: 1}, %{}) == [
-             "a\tb\tc",
-             "apple\t\"beer\"\t1"
-           ]
-  end
-
   test "format_output tab-separates keyword values" do
     assert @formatter.format_output([a: :apple, b: :beer], %{}) == ["a\tb", "apple\tbeer"]
 
@@ -35,15 +21,6 @@ defmodule TableFormatterTest do
              "a\tb\tc",
              "apple\t\"beer\"\t1"
            ]
-  end
-
-  test "format_stream tab-separates map values" do
-    assert @formatter.format_stream(
-             [%{a: :apple, b: :beer, c: 1}, %{a: "aadvark", b: 'bee', c: 2}],
-             %{}
-           )
-           |> Enum.to_list() ==
-             ["c\ta\tb", "1\tapple\tbeer", "2\taadvark\t\"bee\""]
   end
 
   test "format_stream tab-separates keyword values" do

--- a/deps/rabbitmq_cli/test/core/table_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/core/table_formatter_test.exs
@@ -43,7 +43,7 @@ defmodule TableFormatterTest do
              %{}
            )
            |> Enum.to_list() ==
-             ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
+             ["c\ta\tb", "1\tapple\tbeer", "2\taadvark\t\"bee\""]
   end
 
   test "format_stream tab-separates keyword values" do


### PR DESCRIPTION
if the input is given as a map.

References #7931, #7921
