### PR TITLE
OTP26 compatibility: `{verify_none}`

### DIFF
--- a/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
@@ -74,7 +74,7 @@ proxy_protocol_tls(Config) ->
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
     ok = inet:send(Socket, "PROXY TCP4 192.168.1.1 192.168.1.2 80 81\r\n"),
-    {ok, SslSocket} = ssl:connect(Socket, [], ?TIMEOUT),
+    {ok, SslSocket} = ssl:connect(Socket, [{verify, verify_none}], ?TIMEOUT),
     [ok = ssl:send(SslSocket, amqp_1_0_frame(FrameType))
         || FrameType <- [header_sasl, sasl_init, header_amqp, open, 'begin']],
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),

--- a/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
@@ -78,7 +78,7 @@ proxy_protocol_tls(Config) ->
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
     ok = inet:send(Socket, "PROXY TCP4 192.168.1.1 192.168.1.2 80 81\r\n"),
-    {ok, SslSocket} = ssl:connect(Socket, [], ?TIMEOUT),
+    {ok, SslSocket} = ssl:connect(Socket, [{verify, verify_none}], ?TIMEOUT),
     ok = ssl:send(SslSocket, mqtt_3_1_1_connect_packet()),
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
     timer:sleep(10),

--- a/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
@@ -78,7 +78,7 @@ proxy_protocol_tls(Config) ->
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
     ok = inet:send(Socket, "PROXY TCP4 192.168.1.1 192.168.1.2 80 81\r\n"),
-    {ok, SslSocket} = ssl:connect(Socket, [], ?TIMEOUT),
+    {ok, SslSocket} = ssl:connect(Socket, [{verify, verify_none}], ?TIMEOUT),
     ok = ssl:send(SslSocket, stomp_connect_frame()),
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,

--- a/deps/rabbitmq_stream/test/commands_SUITE.erl
+++ b/deps/rabbitmq_stream/test/commands_SUITE.erl
@@ -769,9 +769,13 @@ start_stream_tls_connection(Port) ->
     start_stream_connection(ssl, Port).
 
 start_stream_connection(Transport, Port) ->
+    TlsOpts = case Transport of
+        ssl -> [{verify, verify_none}];
+        _   -> []
+      end,
     {ok, S} =
         Transport:connect("localhost", Port,
-                          [{active, false}, {mode, binary}]),
+                          [{active, false}, {mode, binary}] ++ TlsOpts),
     C0 = rabbit_stream_core:init(0),
     C1 = rabbit_stream_SUITE:test_peer_properties(Transport, S, C0),
     C = rabbit_stream_SUITE:test_authenticate(Transport, S, C1),

--- a/deps/rabbitmq_web_mqtt/test/src/rfc6455_client.erl
+++ b/deps/rabbitmq_web_mqtt/test/src/rfc6455_client.erl
@@ -103,9 +103,12 @@ close(WS, WsReason) ->
 start_conn(State = #state{transport = Transport}, AuthInfo, Protocols, TcpPreface) ->
     {ok, Socket} = case TcpPreface of
         <<>> ->
+            TlsOpts = case Transport of
+                ssl -> [{verify, verify_none}];
+                _   -> []
+              end,
             Transport:connect(State#state.host, State#state.port,
-                              [binary,
-                               {packet, 0}]);
+                              [binary, {packet, 0}] ++ TlsOpts);
         _ ->
             {ok, Socket0} = gen_tcp:connect(State#state.host, State#state.port,
                                             [binary,

--- a/deps/rabbitmq_web_stomp/test/src/rfc6455_client.erl
+++ b/deps/rabbitmq_web_stomp/test/src/rfc6455_client.erl
@@ -87,9 +87,12 @@ close(WS, WsReason) ->
 start_conn(State = #state{transport = Transport}, AuthInfo, Protocols, TcpPreface) ->
     {ok, Socket} = case TcpPreface of
         <<>> ->
+            TlsOpts = case Transport of
+                ssl -> [{verify, verify_none}];
+                _   -> []
+              end,
             Transport:connect(State#state.host, State#state.port,
-                              [binary,
-                               {packet, 0}]);
+                              [binary, {packet, 0}] ++ TlsOpts);
         _ ->
             {ok, Socket0} = gen_tcp:connect(State#state.host, State#state.port,
                                             [binary,


### PR DESCRIPTION
`{verify, verify_none}` in a few more tests for OTP26 compatibility

Note: OTP26 compatibility is still work in progress