### PR TITLE
Configure Oauth scope prefix

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -5,8 +5,16 @@
 %%
 %% ----------------------------------------------------------------------------
 
-%% A prefix used for scopes to avoid scope collisions (or unintended overlap). It is an empty string by default.
+%% OAuth Resource identity. Usage:
+%% - This is the identity of a RabbitMQ server/cluster used as the
+%% recipient of JWT Tokens (see audience claim, https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+%% - This is also the resource identifier used by RabbitMQ server/cluster in the authorization and access token
+%% requests (https://datatracker.ietf.org/doc/html/draft-ietf-oauth-resource-indicators-05#page-3)
 %%
+%% Up to version 3.12, RabbitMQ's scopes followed this pattern : <resource_server_id>.<scope>.
+%% Nowadays, there is a new setting called scope_prefix and RabbitMQ's scopes follow this pattern instead:
+%% <scope_prefix><scope>. Note that there is no dot in between.
+%% The default value of this setting is `<resource_server_id>.`.
 %% {resource_server_id, <<"my_rabbit_server">>},
 
 {mapping,
@@ -19,6 +27,20 @@
  fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.resource_server_id", Conf))
  end}.
 
+%% A prefix used for scopes to avoid scope collisions (or unintended overlap). If not configured,
+%% it is defaulted to `<resource_server_id>.` to maintain backward compatibility. Empty string is a permitted value.
+%%
+%% {scope_prefix, <<"api:/rabbitmq:">>},
+
+{mapping,
+ "auth_oauth2.scope_prefix",
+ "rabbitmq_auth_backend_oauth2.scope_prefix",
+ [{datatype, string}]}.
+
+{translation,
+ "rabbitmq_auth_backend_oauth2.scope_prefix",
+ fun(Conf) -> list_to_binary(cuttlefish:conf_get("auth_oauth2.scope_prefix", Conf))
+ end}.
 
 %% An identifier used for JWT Tokens compliant with Rich Authorization Request spec
 %% RabbitMq uses this field as discriminator to filter out permissions meant for RabbitMQ

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -507,7 +507,7 @@ validate_payload(#{?SCOPE_JWT_FIELD := Scope, ?AUD_JWT_FIELD := Aud} = DecodedTo
         ok           -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ScopePrefix)}};
         {error, Err} -> {refused, {invalid_aud, Err}}
     end;
-validate_payload(#{?SCOPE_JWT_FIELD := Scope} = DecodedToken, ResourceServerId, ScopePrefix) ->
+validate_payload(#{?SCOPE_JWT_FIELD := Scope} = DecodedToken, _ResourceServerId, ScopePrefix) ->
   case application:get_env(?APP, ?VERIFY_AUD, true) of
     true -> {error, {badarg, {aud_field_is_missing}}};
     false -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ScopePrefix)}}

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -33,6 +33,7 @@
 
 -define(APP, rabbitmq_auth_backend_oauth2).
 -define(RESOURCE_SERVER_ID, resource_server_id).
+-define(SCOPE_PREFIX, scope_prefix).
 %% a term defined for Rich Authorization Request tokens to identify a RabbitMQ permission
 -define(RESOURCE_SERVER_TYPE, resource_server_type).
 %% verify server_server_id aud field is on the aud field
@@ -498,23 +499,23 @@ post_process_payload_in_rich_auth_request_format(#{<<"authorization_details">> :
 validate_payload(#{?SCOPE_JWT_FIELD := _Scope } = DecodedToken) ->
     ResourceServerEnv = application:get_env(?APP, ?RESOURCE_SERVER_ID, <<>>),
     ResourceServerId = rabbit_data_coercion:to_binary(ResourceServerEnv),
-    validate_payload(DecodedToken, ResourceServerId).
+    ScopePrefix = application:get_env(?APP, ?SCOPE_PREFIX, <<ResourceServerId/binary, ".">>),
+    validate_payload(DecodedToken, ResourceServerId, ScopePrefix).
 
-validate_payload(#{?SCOPE_JWT_FIELD := Scope, ?AUD_JWT_FIELD := Aud} = DecodedToken, ResourceServerId) ->
+validate_payload(#{?SCOPE_JWT_FIELD := Scope, ?AUD_JWT_FIELD := Aud} = DecodedToken, ResourceServerId, ScopePrefix) ->
     case check_aud(Aud, ResourceServerId) of
-        ok           -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ResourceServerId)}};
+        ok           -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ScopePrefix)}};
         {error, Err} -> {refused, {invalid_aud, Err}}
     end;
-validate_payload(#{?SCOPE_JWT_FIELD := Scope} = DecodedToken, ResourceServerId) ->
+validate_payload(#{?SCOPE_JWT_FIELD := Scope} = DecodedToken, ResourceServerId, ScopePrefix) ->
   case application:get_env(?APP, ?VERIFY_AUD, true) of
     true -> {error, {badarg, {aud_field_is_missing}}};
-    false -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ResourceServerId)}}
+    false -> {ok, DecodedToken#{?SCOPE_JWT_FIELD => filter_scopes(Scope, ScopePrefix)}}
   end.
 
 filter_scopes(Scopes, <<"">>) -> Scopes;
-filter_scopes(Scopes, ResourceServerId)  ->
-    PrefixPattern = <<ResourceServerId/binary, ".">>,
-    matching_scopes_without_prefix(Scopes, PrefixPattern).
+filter_scopes(Scopes, ScopePrefix)  ->
+    matching_scopes_without_prefix(Scopes, ScopePrefix).
 
 check_aud(_, <<>>)    -> ok;
 check_aud(Aud, ResourceServerId) ->

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -1,6 +1,7 @@
 [
   {oauth2_pem_config2,
        "auth_oauth2.resource_server_id = new_resource_server_id
+        auth_oauth2.scope_prefix = new_resource_server_id.
         auth_oauth2.resource_server_type = new_resource_server_type
         auth_oauth2.additional_scopes_key = my_custom_scope_key
         auth_oauth2.preferred_username_claims.1 = user_name
@@ -22,6 +23,7 @@
         [
         {rabbitmq_auth_backend_oauth2, [
             {resource_server_id,<<"new_resource_server_id">>},
+            {scope_prefix,<<"new_resource_server_id.">>},
             {resource_server_type,<<"new_resource_server_type">>},
             {extra_scopes_source, <<"my_custom_scope_key">>},
             {preferred_username_claims, [<<"user_name">>, <<"username">>, <<"email">>]},

--- a/deps/rabbitmq_auth_backend_oauth2/test/scope_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/scope_SUITE.erl
@@ -20,7 +20,7 @@ all() ->
         permission_resource,
         permission_topic
     ].
-
+  
 variable_expansion(_Config) ->
     Scenarios = [
       { "Emtpy Scopes",
@@ -31,7 +31,7 @@ variable_expansion(_Config) ->
       },
       { "No Scopes",
         #{
-           <<"client_id">> => <<"some_client">>      
+           <<"client_id">> => <<"some_client">>
          }, <<"default">>, []
       },
       { "Expand token's var and vhost",

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -40,6 +40,7 @@ all() ->
         test_post_process_token_payload_complex_claims,
         test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field,
         test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_scope_field,
+        test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field_and_custom_scope_prefix,
         test_unsuccessful_access_with_a_token_that_uses_missing_scope_alias_in_scope_field,
         test_successful_access_with_a_token_that_uses_single_scope_alias_in_extra_scope_source_field,
         test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_extra_scope_source_field,
@@ -721,6 +722,49 @@ test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field(
     application:unset_env(rabbitmq_auth_backend_oauth2, key_config),
     application:unset_env(rabbitmq_auth_backend_oauth2, resource_server_id).
 
+
+test_successful_access_with_a_token_that_uses_single_scope_alias_in_scope_field_and_custom_scope_prefix(_) ->
+    Jwk = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
+    application:set_env(rabbitmq_auth_backend_oauth2, key_config, UaaEnv),
+    application:set_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<"rabbitmq">>),
+    application:set_env(rabbitmq_auth_backend_oauth2, scope_prefix, <<>>),
+    Alias = <<"client-alias-1">>,
+    application:set_env(rabbitmq_auth_backend_oauth2, scope_aliases, #{
+        Alias => [
+            <<"configure:vhost/one">>,
+            <<"write:vhost/two">>,
+            <<"read:vhost/one">>,
+            <<"read:vhost/two">>,
+            <<"read:vhost/two/abc">>,
+            <<"tag:management">>,
+            <<"tag:custom">>
+        ]
+    }),
+
+    VHost = <<"vhost">>,
+    Username = <<"username">>,
+    Token    = ?UTIL_MOD:sign_token_hs(?UTIL_MOD:token_with_sub(
+      ?UTIL_MOD:token_with_scope_alias_in_scope_field(Alias), Username), Jwk),
+
+    {ok, #auth_user{username = Username, tags = [custom, management]} = AuthUser} =
+        rabbit_auth_backend_oauth2:user_login_authentication(Username, [{password, Token}]),
+    assert_vhost_access_granted(AuthUser, VHost),
+    assert_vhost_access_denied(AuthUser, <<"some-other-vhost">>),
+
+    assert_resource_access_granted(AuthUser, VHost, <<"one">>, configure),
+    assert_resource_access_granted(AuthUser, VHost, <<"one">>, read),
+    assert_resource_access_granted(AuthUser, VHost, <<"two">>, read),
+    assert_resource_access_granted(AuthUser, VHost, <<"two">>, write),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, configure),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, read),
+    assert_resource_access_denied(AuthUser, VHost, <<"three">>, write),
+
+    application:unset_env(rabbitmq_auth_backend_oauth2, scope_aliases),
+    application:unset_env(rabbitmq_auth_backend_oauth2, key_config),
+    application:unset_env(rabbitmq_auth_backend_oauth2, scope_prefix),
+    application:unset_env(rabbitmq_auth_backend_oauth2, resource_server_id).
+
 test_successful_access_with_a_token_that_uses_multiple_scope_aliases_in_scope_field(_) ->
     Jwk = ?UTIL_MOD:fixture_jwk(),
     UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
@@ -1216,7 +1260,7 @@ test_validate_payload_with_scope_prefix(_) ->
                     <<"scope">> => [<<"some-prefix::foo">>, <<"foo.bar">>, <<"some-prefix::other.third">> ]},
                  [<<"foo">>, <<"other.third">>]
                  }
-                 
+
                ],
 
   lists:map(fun({ ScopePrefix, Token, ExpectedScopes}) ->


### PR DESCRIPTION
RabbitMQ OAuth2 plugin uses the `resource_server_id` :
- to validate `audience` (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)
- as `resource` parameter to authorize a user and get an access token  (https://datatracker.ietf.org/doc/html/draft-ietf-oauth-resource-indicators-05#page-3)
- as the prefix for all RabbitMQ's scopes

Scopes do not necessarily must have a prefix. Prefixes are necessary, at least, in this situations:
- to avoid scope collision. For instance, in UAA, all scopes are defined in the same namespace so scopes must prefixed to avoid scope collision with other resources.
- to conform with Idp conventions. For instance, in Azure, all scopes must always carry a prefix which follows the pattern `api://<app_id>.`. 

Clearly, the scopes' prefix does not necessarily match either the `audience` claim or the `resource` parameter.  

## Proposed Changes

Therefore, there is a new setting called `scope_prefix`. It can be an empty string meaning that the scopes are the raw RabbitMQ scopes, e.g. `configure:*/*` or it can be any prefix. But it is very important to know that the final scope follows the format: <scope_prefix><rabbitmq_scope> . See that there are no separator character. 

In order to keep existing configuration working without making further changes, RabbitMQ defaults `scope_prefix` to `<resource_server_id>.`. See that RabbitMQ maintains the dot character in the prefix. 
 
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

This PR is accompanied by a doc's [PR](https://github.com/rabbitmq/rabbitmq-website/pull/1655) 