### PR TITLE
OTP26 compatibility

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -34,9 +34,9 @@ jobs:
       matrix:
         include:
           - image_tag_suffix: otp-min-bazel
-            otp_version_id: 25_0
-          - image_tag_suffix: otp-max-bazel
             otp_version_id: 25_3
+          - image_tag_suffix: otp-max-bazel
+            otp_version_id: 26
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -76,7 +76,7 @@ jobs:
           echo "elixir=$(cat bazel-bin/elixir_version.txt)" >> $GITHUB_OUTPUT
 
       - name: Configure OTP & Elixir
-        uses: erlef/setup-beam@v1.15
+        uses: erlef/setup-beam@v1.15.3
         with:
           otp-version: ${{ steps.load-info.outputs.otp }}
           elixir-version: ${{ steps.load-info.outputs.elixir }}

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v3
     - name: CONFIGURE ERLANG
-      uses: erlef/setup-beam@v1.15
+      uses: erlef/setup-beam@v1.15.3
       with:
         otp-version: ${{ matrix.erlang_version }}
         elixir-version: ${{ matrix.elixir_version }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -400,8 +400,8 @@ erlang_dev_package.hex_package(
 erlang_dev_package.git_package(
     name = "emqtt",
     build_file = "@rabbitmq-server//bazel:BUILD.emqtt",
-    repository = "emqx/emqtt",
-    tag = "1.8.2",
+    repository = "rabbitmq/emqtt",
+    tag = "otp-26-compatibility",
 )
 
 erlang_dev_package.git_package(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -401,7 +401,7 @@ erlang_dev_package.git_package(
     name = "emqtt",
     build_file = "@rabbitmq-server//bazel:BUILD.emqtt",
     repository = "rabbitmq/emqtt",
-    tag = "otp-26-compatibility",
+    branch = "otp-26-compatibility",
 )
 
 erlang_dev_package.git_package(

--- a/bazel/BUILD.emqtt
+++ b/bazel/BUILD.emqtt
@@ -45,24 +45,9 @@ erlang_bytecode(
         "src/emqtt_sock.erl",
         "src/emqtt_ws.erl",
     ],
-    outs = [
-        "ebin/emqtt.beam",
-        "ebin/emqtt_cli.beam",
-        "ebin/emqtt_frame.beam",
-        "ebin/emqtt_inflight.beam",
-        "ebin/emqtt_props.beam",
-        "ebin/emqtt_quic.beam",
-        "ebin/emqtt_quic_connection.beam",
-        "ebin/emqtt_quic_stream.beam",
-        "ebin/emqtt_secret.beam",
-        "ebin/emqtt_sock.beam",
-        "ebin/emqtt_ws.beam",
-    ],
-    hdrs = [
-        "include/emqtt.hrl",
-        "include/logger.hrl",
-    ],
+    hdrs = [":public_and_private_hdrs"],
     app_name = "emqtt",
+    dest = "ebin",
     erlc_opts = "//:erlc_opts",
 )
 
@@ -94,6 +79,7 @@ filegroup(
 filegroup(
     name = "private_hdrs",
     testonly = True,
+    srcs = glob(["src/**/*.hrl"]),
 )
 
 filegroup(
@@ -108,6 +94,7 @@ filegroup(
 filegroup(
     name = "priv",
     testonly = True,
+    srcs = glob(["priv/**/*"]),
 )
 
 filegroup(
@@ -143,6 +130,8 @@ erlang_app(
     hdrs = [":public_hdrs"],
     app_name = "emqtt",
     beam_files = [":beam_files"],
+    license_files = [":license_files"],
+    priv = [":priv"],
     deps = [
         "@cowlib//:erlang_app",
         "@getopt//:erlang_app",
@@ -154,4 +143,10 @@ alias(
     name = "emqtt",
     actual = ":erlang_app",
     visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "license_files",
+    testonly = True,
+    srcs = glob(["LICENSE*"]),
 )

--- a/deps/rabbit/src/rabbit_time_travel_dbg.erl
+++ b/deps/rabbit/src/rabbit_time_travel_dbg.erl
@@ -47,7 +47,7 @@ print() ->
     ok.
 
 stop() ->
-    dbg:stop_clear(),
+    dbg:stop(),
     ?MODULE ! stop,
     ok.
 

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -15,7 +15,7 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 dep_jose = git https://github.com/michaelklishin/erlang-jose mk-thoas-support
 dep_base64url = hex 1.0.1
 
-dep_emqtt = git https://github.com/emqx/emqtt.git 1.8.2
+dep_emqtt = git https://github.com/rabbitmq/emqtt.git otp-26-compatibility
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -43,7 +43,7 @@ DEPS = ranch rabbit_common rabbit amqp_client ra
 TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_web_mqtt
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_emqtt = git https://github.com/emqx/emqtt.git 1.8.2
+dep_emqtt = git https://github.com/rabbitmq/emqtt.git otp-26-compatibility
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/deps/rabbitmq_trust_store/test/system_SUITE.erl
+++ b/deps/rabbitmq_trust_store/test/system_SUITE.erl
@@ -297,7 +297,8 @@ validate_chain1(Config) ->
     %% Then: the connection is successful.
     {ok, Con} = amqp_connection:start(#amqp_params_network{host = Host,
                                                            port = Port,
-                                                           ssl_options = [{cacerts, RootCerts},
+                                                           ssl_options = [{verify, verify_peer},
+                                                                          {cacerts, RootCerts},
                                                                           {cert, CertTrusted},
                                                                           {key, KeyTrusted}]}),
     %% Clean: client & server TLS/TCP

--- a/deps/rabbitmq_trust_store/test/system_SUITE.erl
+++ b/deps/rabbitmq_trust_store/test/system_SUITE.erl
@@ -221,7 +221,9 @@ validation_success_for_AMQP_client1(Config) ->
                                                            port = Port,
                                                            ssl_options = [{cacerts, [Root]},
                                                                           {cert, Certificate},
-                                                                          {key, Key}]}),
+                                                                          {key, Key},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
 
     %% Clean: client & server TLS/TCP.
     ok = amqp_connection:close(Con),
@@ -255,7 +257,9 @@ validation_failure_for_AMQP_client1(Config) ->
                                    port = Port,
                                    ssl_options = [{cacerts, RootCerts},
                                                   {cert, CertOther},
-                                                  {key, KeyOther}]}),
+                                                  {key, KeyOther},
+                                                  {verify, verify_none},
+                                                  {versions, ['tlsv1.2']}]}),
     case Error of
         %% Expected error from amqp_client.
         ?SERVER_REJECT_CLIENT -> ok;
@@ -297,10 +301,11 @@ validate_chain1(Config) ->
     %% Then: the connection is successful.
     {ok, Con} = amqp_connection:start(#amqp_params_network{host = Host,
                                                            port = Port,
-                                                           ssl_options = [{verify, verify_peer},
-                                                                          {cacerts, RootCerts},
+                                                           ssl_options = [{cacerts, RootCerts},
                                                                           {cert, CertTrusted},
-                                                                          {key, KeyTrusted}]}),
+                                                                          {key, KeyTrusted},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
     %% Clean: client & server TLS/TCP
     ok = amqp_connection:close(Con),
     ok = rabbit_networking:stop_tcp_listener(Port).
@@ -360,7 +365,9 @@ validate_longer_chain1(Config) ->
                                                            port = Port,
                                                            ssl_options = [{cacerts, [CertInter|ServerCACerts]},
                                                                           {cert, CertTrusted},
-                                                                          {key, KeyTrusted}]}),
+                                                                          {key, KeyTrusted},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
 
     %% When: a client connects and present `RootTrusted` and `CertInter` as well as the `CertTrusted`
     %% Then: the connection is successful.
@@ -368,7 +375,9 @@ validate_longer_chain1(Config) ->
                                                             port = Port,
                                                             ssl_options = [{cacerts, [RootCA, CertInter|ServerCACerts]},
                                                                            {cert, CertTrusted},
-                                                                           {key, KeyTrusted}]}),
+                                                                           {key, KeyTrusted},
+                                                                           {verify, verify_none},
+                                                                           {versions, ['tlsv1.2']}]}),
 
     %% When: a client connects and present `CertInter` and `RootCA` as well as the `CertTrusted`
     %% Then: the connection is successful.
@@ -376,7 +385,9 @@ validate_longer_chain1(Config) ->
                                                             port = Port,
                                                             ssl_options = [{cacerts, [CertInter, RootCA|ServerCACerts]},
                                                                            {cert, CertTrusted},
-                                                                           {key, KeyTrusted}]}),
+                                                                           {key, KeyTrusted},
+                                                                           {verify, verify_none},
+                                                                           {versions, ['tlsv1.2']}]}),
 
     % %% When: a client connects and present `CertInter` and `RootCA` but NOT `CertTrusted`
     % %% Then: the connection is not succcessful
@@ -385,7 +396,9 @@ validate_longer_chain1(Config) ->
                                     port = Port,
                                     ssl_options = [{cacerts, [RootCA|ServerCACerts]},
                                                    {cert, CertInter},
-                                                   {key, KeyInter}]}),
+                                                   {key, KeyInter},
+                                                   {verify, verify_none},
+                                                   {versions, ['tlsv1.2']}]}),
     case Error1 of
         %% Expected error from amqp_client.
         ?SERVER_REJECT_CLIENT -> ok;
@@ -408,7 +421,9 @@ validate_longer_chain1(Config) ->
                                     port = Port,
                                     ssl_options = [{cacerts, [RootCA, CertInter|ServerCACerts]},
                                                    {cert, CertUntrusted},
-                                                   {key, KeyUntrusted}]}),
+                                                   {key, KeyUntrusted},
+                                                   {verify, verify_none},
+                                                   {versions, ['tlsv1.2']}]}),
     case Error2 of
         %% Expected error from amqp_client.
         {tls_alert, "bad certificate"} -> ok;
@@ -455,7 +470,9 @@ validate_chain_without_whitelisted1(Config) ->
                                    port = Port,
                                    ssl_options = [{cacerts, RootCerts},
                                                   {cert, CertUntrusted},
-                                                  {key, KeyUntrusted}]}),
+                                                  {key, KeyUntrusted},
+                                                  {verify, verify_none},
+                                                  {versions, ['tlsv1.2']}]}),
     case Error of
         %% Expected error from amqp_client.
         ?SERVER_REJECT_CLIENT -> ok;
@@ -500,7 +517,9 @@ whitelisted_certificate_accepted_from_AMQP_client_regardless_of_validation_to_ro
                                                            port = Port,
                                                            ssl_options = [{cacerts, RootCerts},
                                                                           {cert, CertTrusted},
-                                                                          {key, KeyTrusted}]}),
+                                                                          {key, KeyTrusted},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
     %% Clean: client & server TLS/TCP
     ok = amqp_connection:close(Con),
     ok = rabbit_networking:stop_tcp_listener(Port).
@@ -539,7 +558,9 @@ removed_certificate_denied_from_AMQP_client1(Config) ->
                                    port = Port,
                                    ssl_options = [{cacerts, RootCerts},
                                                   {cert, CertOther},
-                                                  {key, KeyOther}]}),
+                                                  {key, KeyOther},
+                                                  {verify, verify_none},
+                                                  {versions, ['tlsv1.2']}]}),
     case Error of
         %% Expected error from amqp_client.
         ?SERVER_REJECT_CLIENT -> ok;
@@ -589,7 +610,9 @@ installed_certificate_accepted_from_AMQP_client1(Config) ->
                                                            port = Port,
                                                            ssl_options = [{cacerts, RootCerts},
                                                                           {cert, CertOther},
-                                                                          {key, KeyOther}]}),
+                                                                          {key, KeyOther},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
 
     %% Clean: Client & server TLS/TCP
     ok = amqp_connection:close(Con),
@@ -636,13 +659,17 @@ whitelist_directory_DELTA1(Config) ->
                                                              port = Port,
                                                              ssl_options = [{cacerts, RootCerts},
                                                                             {cert, CertListed1},
-                                                                            {key, KeyListed1}]}),
+                                                                            {key, KeyListed1},
+                                                                            {verify, verify_none},
+                                                                            {versions, ['tlsv1.2']}]}),
     {error, Error} = amqp_connection:start(
               #amqp_params_network{host = Host,
                                    port = Port,
                                    ssl_options = [{cacerts, RootCerts},
                                                   {cert, CertRevoked},
-                                                  {key, KeyRevoked}]}),
+                                                  {key, KeyRevoked},
+                                                  {verify, verify_none},
+                                                  {versions, ['tlsv1.2']}]}),
     case Error of
         %% Expected error from amqp_client.
         ?SERVER_REJECT_CLIENT -> ok;
@@ -661,7 +688,9 @@ whitelist_directory_DELTA1(Config) ->
                                                              port = Port,
                                                              ssl_options = [{cacerts, RootCerts},
                                                                             {cert, CertListed2},
-                                                                            {key, KeyListed2}]}),
+                                                                            {key, KeyListed2},
+                                                                            {verify, verify_none},
+                                                                            {versions, ['tlsv1.2']}]}),
     %% Clean: delete certificate file, close client & server
     %% TLS/TCP
     ok = amqp_connection:close(Conn1),
@@ -698,14 +727,18 @@ replaced_whitelisted_certificate_should_be_accepted1(Config) ->
                                                 port = Port,
                                                 ssl_options = [{cacerts, RootCerts},
                                                                {cert, CertFirst},
-                                                               {key, KeyFirst}]}),
+                                                               {key, KeyFirst},
+                                                               {verify, verify_none},
+                                                               {versions, ['tlsv1.2']}]}),
     %% verify the other certificate is not accepted
     {error, Error1} = amqp_connection:start(
                #amqp_params_network{host = Host,
                                     port = Port,
                                     ssl_options = [{cacerts, RootCerts},
                                                    {cert, CertUpdated},
-                                                   {key, KeyUpdated}]}),
+                                                   {key, KeyUpdated},
+                                                   {verify, verify_none},
+                                                   {versions, ['tlsv1.2']}]}),
     case Error1 of
         %% Expected error from amqp_client.
         ?SERVER_REJECT_CLIENT -> ok;
@@ -733,6 +766,8 @@ replaced_whitelisted_certificate_should_be_accepted1(Config) ->
                                     ssl_options = [{cacerts, RootCerts},
                                                    {cert, CertFirst},
                                                    {key, KeyFirst},
+                                                   {verify, verify_none},
+                                                   {versions, ['tlsv1.2']},
                                                    %% disable ssl session caching
                                                    %% as this ensures the cert
                                                    %% will be re-verified by the
@@ -756,6 +791,8 @@ replaced_whitelisted_certificate_should_be_accepted1(Config) ->
                                                 ssl_options = [{cacerts, RootCerts},
                                                                {cert, CertUpdated},
                                                                {key, KeyUpdated},
+                                                               {verify, verify_none},
+                                                               {versions, ['tlsv1.2']},
                                                                {reuse_sessions, false}]}),
     ok = amqp_connection:close(Con2),
     %% Clean: server TLS/TCP.
@@ -803,7 +840,9 @@ ignore_corrupt_cert1(Config) ->
                                                            port = Port,
                                                            ssl_options = [{cacerts, RootCerts},
                                                                           {cert, CertTrusted},
-                                                                          {key, KeyTrusted}]}),
+                                                                          {key, KeyTrusted},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
     %% Clean: client & server TLS/TCP
     ok = amqp_connection:close(Con),
     ok = rabbit_networking:stop_tcp_listener(Port).
@@ -839,7 +878,9 @@ ignore_same_cert_with_different_name1(Config) ->
                                                            port = Port,
                                                            ssl_options = [{cacerts, RootCerts},
                                                                           {cert, CertTrusted},
-                                                                          {key, KeyTrusted}]}),
+                                                                          {key, KeyTrusted},
+                                                                          {verify, verify_none},
+                                                                          {versions, ['tlsv1.2']}]}),
     %% Clean: client & server TLS/TCP
     ok = amqp_connection:close(Con),
     ok = rabbit_networking:stop_tcp_listener(Port).

--- a/deps/rabbitmq_web_mqtt/Makefile
+++ b/deps/rabbitmq_web_mqtt/Makefile
@@ -24,7 +24,7 @@ TEST_DEPS = emqtt rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_manage
 # See rabbitmq-components.mk.
 BUILD_DEPS += ranch
 
-dep_emqtt = git https://github.com/emqx/emqtt.git 1.8.2
+dep_emqtt = git https://github.com/rabbitmq/emqtt.git otp-26-compatibility
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk


### PR DESCRIPTION
With these changes, we expect to pass all tests on OTP25 and OTP26.

This doesn't yet mean we are fully OTP26-compatible.