### PR TITLE
Do not run windows tests in github actions on any pushes

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -3,9 +3,6 @@ on:
   schedule:
   - cron: '0 2 * * *'
   workflow_dispatch:
-  push:
-    paths:
-    - .github/workflows/test-windows.yaml
 jobs:
   test:
     name: Test Windows OTP26


### PR DESCRIPTION
while there was a filter to restrict the build-on-push to the windows workflow itself, it's not worth the side effect of having the workflow run unexpectedly on backports