### PR TITLE
Add ha-sync-mode as an operator policy

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -776,6 +776,10 @@ end}.
     {datatype, [integer, {list, string}]}
 ]}.
 
+{mapping, "default_policies.operator.$id.classic_queues.ha_sync_mode", "rabbit.default_policies.operator", [
+    {datatype, string}
+]}.
+
 {translation, "rabbit.default_policies.operator", fun(Conf) ->
     Props = rabbit_cuttlefish:aggregate_props(
                 Conf,

--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -55,9 +55,13 @@
      {mfa, {rabbit_registry, register,
             [operator_policy_validator, <<"ha-params">>, ?MODULE]}},
      {mfa, {rabbit_registry, register,
+            [operator_policy_validator, <<"ha-sync-mode">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
             [policy_merge_strategy, <<"ha-mode">>, ?MODULE]}},
      {mfa, {rabbit_registry, register,
             [policy_merge_strategy, <<"ha-params">>, ?MODULE]}},
+     {mfa, {rabbit_registry, register,
+            [policy_merge_strategy, <<"ha-sync-mode">>, ?MODULE]}},
      {requires, rabbit_registry},
      {enables, recovery}]}).
 
@@ -869,6 +873,8 @@ merge_policy_value(<<"ha-mode">>, _Val, <<"all">> = OpVal) ->
 merge_policy_value(<<"ha-mode">>, <<"exactly">> = Val, _OpVal) ->
     Val;
 merge_policy_value(<<"ha-mode">>, _Val, <<"exactly">> = OpVal) ->
+    OpVal;
+merge_policy_value(<<"ha-sync-mode">>, _Val, OpVal) ->
     OpVal;
 %% Both values are integers, both are ha-mode 'exactly'
 merge_policy_value(<<"ha-params">>, Val, OpVal) when is_integer(Val)

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -142,11 +142,14 @@ ssl_options.fail_if_no_peer_cert = true",
   default_policies.operator.a.vhost_pattern = banana
   default_policies.operator.a.classic_queues.ha_mode = exactly
   default_policies.operator.a.classic_queues.ha_params = 2
+  default_policies.operator.a.classic_queues.ha_sync_mode = automatic
+
  ",
   [{rabbit, [{default_policies, [{operator, [
       {<<"a">>, [{<<"expires">>, 3600000},
                  {<<"ha_mode">>, "exactly"},
                  {<<"ha_params">>, 2},
+                 {<<"ha_sync_mode">>, "automatic"},
                  {<<"queue_pattern">>, "apple"},
                  {<<"vhost_pattern">>, "banana"}]}]}]}]}],
   []},

--- a/deps/rabbit/test/policy_SUITE.erl
+++ b/deps/rabbit/test/policy_SUITE.erl
@@ -168,12 +168,13 @@ target_count_policy(Config) ->
                       {<<"ha-params">>, BNodes}],
     NodesPolicyOne = [{<<"ha-mode">>, <<"nodes">>},
                       {<<"ha-params">>, [hd(BNodes)]}],
+    SyncModePolicyAuto = [{<<"ha-mode">>, <<"all">>}, {<<"ha-sync-mode">>, <<"automatic">>}],
+    SyncModePolicyMan = [{<<"ha-mode">>, <<"all">>}, {<<"ha-sync-mode">>, <<"manual">>}],
 
     %% ALL has precedence
     Opts = #{config => Config,
              server => Server,
              qname  => QName},
-
     verify_policies(AllPolicy, ExactlyPolicyTwo, [{<<"ha-mode">>, <<"all">>}], Opts),
 
     verify_policies(ExactlyPolicyTwo, AllPolicy, [{<<"ha-mode">>, <<"all">>}], Opts),
@@ -181,6 +182,10 @@ target_count_policy(Config) ->
     verify_policies(AllPolicy, NodesPolicyAll, [{<<"ha-mode">>, <<"all">>}], Opts),
 
     verify_policies(NodesPolicyAll, AllPolicy, [{<<"ha-mode">>, <<"all">>}], Opts),
+
+    %% %% Sync mode OperPolicy has precedence
+    verify_policies(SyncModePolicyMan, SyncModePolicyAuto, [{<<"ha-sync-mode">>, <<"automatic">>}], Opts),
+    verify_policies(SyncModePolicyAuto, SyncModePolicyMan, [{<<"ha-sync-mode">>, <<"manual">>}], Opts),
 
     %% exactly has precedence over nodes
     verify_policies(ExactlyPolicyTwo, NodesPolicyAll,[{<<"ha-mode">>, <<"exactly">>}, {<<"ha-params">>, 2}], Opts),


### PR DESCRIPTION
## Proposed Changes

Similar to how we added ha_mode and ha_sync_mode to operator policies, this change adds ha_sync_mode as well.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
