### PR TITLE
Keep storing MQTT client IDs as lists in Ra

### DIFF
--- a/deps/rabbitmq_mqtt/include/mqtt_machine.hrl
+++ b/deps/rabbitmq_mqtt/include/mqtt_machine.hrl
@@ -5,12 +5,21 @@
 %% Copyright (c) 2020-2023 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
+%% A client ID that is tracked in Ra is a list of bytes
+%% as returned by binary_to_list/1 in
+%% https://github.com/rabbitmq/rabbitmq-server/blob/48467d6e1283b8d81e52cfd49c06ea4eaa31617d/deps/rabbitmq_mqtt/src/rabbit_mqtt_frame.erl#L137
+%% prior to 3.12.0.
+%% This has two downsides:
+%% 1. Lists consume more memory than binaries (when tracking many clients).
+%% 2. This violates the MQTT spec which states
+%%    "The ClientId MUST be a UTF-8 encoded string as defined in Section 1.5.3 [MQTT-3.1.3-4]." [v4 3.1.3.1]
+%% However, for backwards compatibility, we leave the client ID as a list of bytes in the Ra machine state because
+%% feature flag delete_ra_cluster_mqtt_node introduced in 3.12.0 will delete the Ra cluster anyway.
+-type client_id() :: [byte()].
+
 -record(machine_state, {
-          %% client ID to connection PID
-          client_ids = #{},
-          %% connection PID to list of client IDs
-          pids = #{},
+          client_ids = #{} :: #{client_id() => Connection :: pid()},
+          pids = #{} :: #{Connection :: pid() => [client_id(), ...]},
           %% add acouple of fields for future extensibility
           reserved_1,
           reserved_2}).
-

--- a/deps/rabbitmq_mqtt/src/mqtt_machine.erl
+++ b/deps/rabbitmq_mqtt/src/mqtt_machine.erl
@@ -22,7 +22,6 @@
 -type config() :: map().
 
 -type reply() :: {ok, term()} | {error, term()}.
--type client_id() :: term().
 
 -type command() :: {register, client_id(), pid()} |
                    {unregister, client_id(), pid()} |

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl
@@ -13,7 +13,7 @@
          list/0, list_pids/0, leave/1]).
 
 %%----------------------------------------------------------------------------
--spec register(term(), pid()) -> {ok, reference()} | {error, term()}.
+-spec register(client_id(), pid()) -> {ok, reference()} | {error, term()}.
 register(ClientId, Pid) ->
     {ClusterName, _} = NodeId = mqtt_node:server_id(),
     case ra_leaderboard:lookup_leader(ClusterName) of
@@ -28,7 +28,7 @@ register(ClientId, Pid) ->
             register(Leader, ClientId, Pid)
     end.
 
--spec register(ra:server_id(), term(), pid()) ->
+-spec register(ra:server_id(), client_id(), pid()) ->
     {ok, reference()} | {error, term()}.
 register(ServerId, ClientId, Pid) ->
     Corr = make_ref(),
@@ -36,7 +36,7 @@ register(ServerId, ClientId, Pid) ->
     erlang:send_after(5000, self(), {ra_event, undefined, register_timeout}),
     {ok, Corr}.
 
--spec unregister(binary(), pid()) -> ok.
+-spec unregister(client_id(), pid()) -> ok.
 unregister(ClientId, Pid) ->
     {ClusterName, _} = mqtt_node:server_id(),
     case ra_leaderboard:lookup_leader(ClusterName) of

--- a/deps/rabbitmq_mqtt/test/ff_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/ff_SUITE.erl
@@ -83,13 +83,13 @@ delete_ra_cluster_mqtt_node(Config) ->
                  rabbit_ct_broker_helpers:enable_feature_flag(Config, FeatureFlag)),
 
     %% Ra processes should be gone
-    rabbit_ct_helpers:eventually(
+    eventually(
       ?_assert(lists:all(fun(Pid) -> Pid =:= undefined end,
                          rabbit_ct_broker_helpers:rpc_all(Config, erlang, whereis, [mqtt_node])))),
     %% new client ID tracking works
     ?assertEqual(1, length(util:all_connection_pids(Config))),
-    ?assert(erlang:is_process_alive(C)),
-    ok = emqtt:disconnect(C).
+    ok = emqtt:disconnect(C),
+    eventually(?_assertEqual(0, length(util:all_connection_pids(Config)))).
 
 rabbit_mqtt_qos0_queue(Config) ->
     FeatureFlag = ?FUNCTION_NAME,


### PR DESCRIPTION
Up to 3.11.x an MQTT client ID is tracked in Ra
as a list of bytes as returned by binary_to_list/1 in https://github.com/rabbitmq/rabbitmq-server/blob/48467d6e1283b8d81e52cfd49c06ea4eaa31617d/deps/rabbitmq_mqtt/src/rabbit_mqtt_frame.erl#L137

This has two downsides:
1. Lists consume more memory than binaries (when tracking many clients).
2. It violates the MQTT spec which states "The ClientId MUST be a UTF-8 encoded string as defined in Section 1.5.3 [MQTT-3.1.3-4]." [v4 3.1.3.1]

Therefore, the original idea was to always store MQTT client IDs as binaries starting with Native MQTT in 3.12.
However, this leads to client ID tracking misbehaving in mixed version clusters since new nodes would register client IDs as binaries and old nodes would register client IDs as lists. This means that a client registering on a new node with the same client ID as a connection to the old node did not terminate the connection on the old node.

Therefore, for backwards compatibility, we leave the client ID as a list of bytes in the Ra machine state because the feature flag delete_ra_cluster_mqtt_node introduced in v3.12 will delete the Ra cluster anyway and the new client ID tracking via pg local will store client IDs as binaries.

An interesting side note learned here is that the compiled file rabbit_mqtt_collector must not be changed. This commit only modifies function specs. However as soon as the compiled code is changed, this module becomes a new version. The new version causes [the anonymous ra query function](https://github.com/rabbitmq/rabbitmq-server/blob/57058d24c73d4b2a36744db1f8246674b2a352a5/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl#L50) to fail in mixed clusters: When the old node does a ra:leader_query where the leader is on the new node, the query function fails on the new node with `badfun` because the new node does not have the same module version. For more context, read:
https://web.archive.org/web/20181017104411/http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html