### PR TITLE
Update Cowboy to 2.10.0 for OTP-26

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -158,8 +158,8 @@ erlang_package.hex_package(
 erlang_package.hex_package(
     name = "cowboy",
     build_file = "@rabbitmq-server//bazel:BUILD.cowboy",
-    sha256 = "4643e4fba74ac96d4d152c75803de6fad0b3fa5df354c71afdd6cbeeb15fac8a",
-    version = "2.8.0",
+    sha256 = "3afdccb7183cc6f143cb14d3cf51fa00e53db9ec80cdcd525482f5e99bc41d6b",
+    version = "2.10.0",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbitmq_web_dispatch/Makefile
+++ b/deps/rabbitmq_web_dispatch/Makefile
@@ -10,8 +10,6 @@ LOCAL_DEPS = inets
 DEPS = rabbit_common rabbit cowboy
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
 
-dep_cowboy = hex 2.0.0
-
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -111,7 +111,7 @@ dep_toke                              = git_rmq           toke $(current_rmq_ref
 # possible to work with rabbitmq-public-umbrella.
 
 dep_accept = hex 0.3.5
-dep_cowboy = hex 2.8.0
+dep_cowboy = hex 2.10.0
 dep_cowlib = hex 2.12.1
 dep_looking_glass = git https://github.com/rabbitmq/looking_glass.git master
 dep_prometheus = hex 4.10.0


### PR DESCRIPTION
We already were using Cowlib 2.12.1 and therefore were compatible with OTP-26. This simply updates Cowboy to the version that depends on Cowlib 2.12.1.