### PR TITLE
Improve validation of commands that accept replica candidate nodes as arguments

### DIFF
--- a/deps/rabbit/test/rabbitmq_queues_cli_integration_SUITE.erl
+++ b/deps/rabbit/test/rabbitmq_queues_cli_integration_SUITE.erl
@@ -120,8 +120,8 @@ grow_invalid_node_filtered(Config) ->
     #'queue.declare_ok'{} = declare_qq(Ch, QName, Args),
     DummyNode = not_really_a_node@nothing,
     publish_confirm(Ch, QName),
-    {ok, Out1} = rabbitmq_queues(Config, 0, ["grow", DummyNode, "all"]),
-    ?assertNotMatch(#{{"/", "grow-err"} := _}, parse_result(Out1)),
+    %% validated as of rabbitmq-server#8007
+    {error, _ExitCode, _} = rabbitmq_queues(Config, 0, ["grow", DummyNode, "all"]),
     ok.
 
 parse_result(S) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/exit_codes.ex
@@ -42,6 +42,7 @@ defmodule RabbitMQ.CLI.Core.ExitCodes do
   # a special case of bad_argument
   def exit_code_for({:no_such_vhost, _}), do: exit_dataerr()
   def exit_code_for({:no_such_user, _}), do: exit_nouser()
+  def exit_code_for(:not_found), do: exit_dataerr()
   def exit_code_for({:badrpc_multi, :timeout, _}), do: exit_tempfail()
   def exit_code_for({:badrpc, :timeout}), do: exit_tempfail()
   def exit_code_for({:badrpc, {:timeout, _}}), do: exit_tempfail()

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/exit_codes.ex
@@ -43,6 +43,8 @@ defmodule RabbitMQ.CLI.Core.ExitCodes do
   def exit_code_for({:no_such_vhost, _}), do: exit_dataerr()
   def exit_code_for({:no_such_user, _}), do: exit_nouser()
   def exit_code_for(:not_found), do: exit_dataerr()
+  def exit_code_for({:not_found, _vhost, _name}), do: exit_dataerr()
+  def exit_code_for({:not_found, _object_type, _vhost, _name}), do: exit_dataerr()
   def exit_code_for({:badrpc_multi, :timeout, _}), do: exit_tempfail()
   def exit_code_for({:badrpc, :timeout}), do: exit_tempfail()
   def exit_code_for({:badrpc, {:timeout, _}}), do: exit_tempfail()

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/helpers.ex
@@ -77,6 +77,11 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
+  def cluster_member?(target_node, node_to_check, timeout \\ 30_000) do
+    node_to_check_a = DataCoercion.to_atom(node_to_check)
+    Enum.member?(nodes_in_cluster(target_node, timeout), node_to_check_a)
+  end
+
   def node_running?(node) do
     :net_adm.ping(node) == :pong
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
@@ -47,6 +47,13 @@ defmodule RabbitMQ.CLI.Core.Validators do
     end
   end
 
+  def existing_cluster_member([potential_member | _], %{node: node_name}) do
+    case Helpers.cluster_member?(node_name, potential_member) do
+      false -> {:validation_failure, {:not_a_cluster_member, potential_member}}
+      true -> :ok
+    end
+  end
+
   def data_dir_is_set(_, opts) do
     case require_data_dir(opts) do
       :ok -> :ok

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
@@ -54,6 +54,14 @@ defmodule RabbitMQ.CLI.Core.Validators do
     end
   end
 
+  def existing_cluster_member(args, %{node: node_name}, extract_member) do
+    potential_member = extract_member.(args)
+    case Helpers.cluster_member?(node_name, potential_member) do
+      false -> {:validation_failure, {:not_a_cluster_member, potential_member}}
+      true -> :ok
+    end
+  end
+
   def data_dir_is_set(_, opts) do
     case require_data_dir(opts) do
       :ok -> :ok

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/validators.ex
@@ -56,6 +56,7 @@ defmodule RabbitMQ.CLI.Core.Validators do
 
   def existing_cluster_member(args, %{node: node_name}, extract_member) do
     potential_member = extract_member.(args)
+
     case Helpers.cluster_member?(node_name, potential_member) do
       false -> {:validation_failure, {:not_a_cluster_member, potential_member}}
       true -> :ok

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
@@ -49,6 +49,9 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommand do
       {:error, :classic_queue_not_supported} ->
         {:error, "Cannot add members to a classic queue"}
 
+      {:error, :not_found} ->
+        {:error, {:not_found, :queue, vhost, name}}
+
       other ->
         other
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
@@ -30,8 +30,8 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommand do
     Validators.chain(
       [
         &Validators.rabbit_is_running/2,
-        fn (args, opts) ->
-          extractor = fn([_, val]) -> val end
+        fn args, opts ->
+          extractor = fn [_, val] -> val end
           Validators.existing_cluster_member(args, opts, extractor)
         end
       ],

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
@@ -30,7 +30,10 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommand do
     Validators.chain(
       [
         &Validators.rabbit_is_running/2,
-        &Validators.existing_cluster_member/2
+        fn (args, opts) ->
+          extractor = fn([_, val]) -> val end
+          Validators.existing_cluster_member(args, opts, extractor)
+        end
       ],
       [args, opts]
     )

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommand do
-  alias RabbitMQ.CLI.Core.DocGuide
+  alias RabbitMQ.CLI.Core.{DocGuide, Validators}
   import RabbitMQ.CLI.Core.DataCoercion
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/add_member_command.ex
@@ -25,7 +25,16 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommand do
 
   use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
   use RabbitMQ.CLI.Core.AcceptsTwoPositionalArguments
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def validate_execution_environment(args, opts) do
+    Validators.chain(
+      [
+        &Validators.rabbit_is_running/2,
+        &Validators.existing_cluster_member/2
+      ],
+      [args, opts]
+    )
+  end
 
   def run([name, node] = _args, %{vhost: vhost, node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :add_member, [

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/delete_member_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/delete_member_command.ex
@@ -26,6 +26,9 @@ defmodule RabbitMQ.CLI.Queues.Commands.DeleteMemberCommand do
       {:error, :classic_queue_not_supported} ->
         {:error, "Cannot add members to a classic queue"}
 
+      {:error, :not_found} ->
+        {:error, {:not_found, :queue, vhost, name}}
+
       other ->
         other
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/grow_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/grow_command.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
-  alias RabbitMQ.CLI.Core.DocGuide
+  alias RabbitMQ.CLI.Core.{DocGuide, Validators}
   import RabbitMQ.CLI.Core.DataCoercion
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -44,7 +44,15 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommand do
     end
   end
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  def validate_execution_environment(args, opts) do
+    Validators.chain(
+      [
+        &Validators.rabbit_is_running/2,
+        &Validators.existing_cluster_member/2
+      ],
+      [args, opts]
+    )
+  end
 
   def run([node, strategy], %{
         node: node_name,

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -393,6 +393,9 @@ defmodule RabbitMQCtl do
   defp format_validation_error(:unsupported_formatter),
     do: "the requested formatter is not supported by this command"
 
+  defp format_validation_error({:not_a_cluster_member, potential_member}),
+    do: "node #{potential_member} is not a member of the cluster"
+
   defp format_validation_error(err), do: inspect(err)
 
   @spec exit_program(integer()) :: no_return()

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -469,7 +469,8 @@ defmodule RabbitMQCtl do
   end
 
   defp format_error({:error, :not_found = result}, _opts, _) do
-    {:error, ExitCodes.exit_code_for(result), "Object (queue, stream, exchange, etc) was not found"}
+    {:error, ExitCodes.exit_code_for(result),
+     "Object (queue, stream, exchange, etc) was not found"}
   end
 
   defp format_error(

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -468,6 +468,16 @@ defmodule RabbitMQCtl do
     {:error, ExitCodes.exit_code_for(result), "Virtual host '#{vhost}' does not exist"}
   end
 
+  defp format_error({:error, {:not_found, vhost, name} = result}, _opts, _) do
+    {:error, ExitCodes.exit_code_for(result),
+     "Object (queue, stream, exchange, etc) '#{name}' was not found in virtual host '#{vhost}}'"}
+  end
+
+  defp format_error({:error, {:not_found, object_type, vhost, name} = result}, _opts, _) do
+    {:error, ExitCodes.exit_code_for(result),
+     "#{object_type} '#{name}' was not found in virtual host '#{vhost}}'"}
+  end
+
   defp format_error({:error, :not_found = result}, _opts, _) do
     {:error, ExitCodes.exit_code_for(result),
      "Object (queue, stream, exchange, etc) was not found"}

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -470,12 +470,12 @@ defmodule RabbitMQCtl do
 
   defp format_error({:error, {:not_found, vhost, name} = result}, _opts, _) do
     {:error, ExitCodes.exit_code_for(result),
-     "Object (queue, stream, exchange, etc) '#{name}' was not found in virtual host '#{vhost}}'"}
+     "Object (queue, stream, exchange, etc) '#{name}' was not found in virtual host '#{vhost}'"}
   end
 
   defp format_error({:error, {:not_found, object_type, vhost, name} = result}, _opts, _) do
     {:error, ExitCodes.exit_code_for(result),
-     "#{object_type} '#{name}' was not found in virtual host '#{vhost}}'"}
+     "#{object_type} '#{name}' was not found in virtual host '#{vhost}'"}
   end
 
   defp format_error({:error, :not_found = result}, _opts, _) do

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -468,6 +468,10 @@ defmodule RabbitMQCtl do
     {:error, ExitCodes.exit_code_for(result), "Virtual host '#{vhost}' does not exist"}
   end
 
+  defp format_error({:error, :not_found = result}, _opts, _) do
+    {:error, ExitCodes.exit_code_for(result), "Object (queue, stream, exchange, etc) was not found"}
+  end
+
   defp format_error(
          {:error, {:incompatible_version, local_version, remote_version} = result},
          _opts,


### PR DESCRIPTION
Specifically `rabbitmq-queues grow` and `rabbitmq-queues add_member`. Note that I intentionally
did not do the same for `shrink` and `delete_member`, as it may be reasonable to support
scenarios where they would be used with permanently lost or decommissioned nodes.
Well, this does not make that much sense for `shrink` but for `delete_member`, it might.

## QA Procedure

1. Start a node with `bazel run broker`
2. Run `bazel run rabbitmq-queues -- grow unknown@{hostname} all` and see what error it reports
3. Run `bazel run rabbitmq-queues -- grow rabbit@{hostname} all`
4. Run `bazel run rabbitmq-queues -- add_member "qq.1" unknown@{hostname}` and see what error it reports
5. Run `bazel run rabbitmq-queues -- add_member "qq.1" rabbit@{hostname}` and observe an improved error
6. Declare a quorum queue "qq.1" in the default virtual host
7. Run `bazel run rabbitmq-queues -- add_member "qq.1" rabbit@{hostname}` one more time

## Other

Closes #8007.