### PR TITLE
Add MQTT client id to connection closed event

### DIFF
--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -50,7 +50,8 @@
          messages_unacknowledged
         ]).
 
--define(CREATION_EVENT_KEYS,
+%% Connection opened or closed.
+-define(EVENT_KEYS,
         ?ITEMS ++
         [name,
          client_properties,


### PR DESCRIPTION
As requested in https://github.com/rabbitmq/rabbitmq-server/discussions/6331#discussioncomment-5796154 include all infos that were emitted in the MQTT connection created event also in the MQTT connection closed event.
This ensures infos such as MQTT client ID are part of the connection closed event.
Therefore, it's easy for the user to correlate between the two event types.
Note that the MQTT plugin emits connection created and connection closed events only if the CONNECT packet was successfully processed, i.e.authentication was successful.