### PR TITLE
Support TLS-only listener for Prometheus

### DIFF
--- a/deps/rabbitmq_prometheus/BUILD.bazel
+++ b/deps/rabbitmq_prometheus/BUILD.bazel
@@ -22,7 +22,9 @@ APP_NAME = "rabbitmq_prometheus"
 APP_MODULE = "rabbit_prometheus_app"
 
 APP_ENV = """[
-	{return_per_object_metrics, false}
+	    {return_per_object_metrics, false},
+	    {tcp_config, [{port, 15692}]},
+	    {ssl_config, []}
 ]"""
 
 all_beam_files(name = "all_beam_files")

--- a/deps/rabbitmq_prometheus/Makefile
+++ b/deps/rabbitmq_prometheus/Makefile
@@ -1,5 +1,7 @@
 define PROJECT_ENV
 [
+	{tcp_config, [{port, 15692}]},
+	{ssl_config, []},
 	{return_per_object_metrics, false}
 ]
 endef

--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -26,11 +26,26 @@
 %% {tcp_config, [{port,     15692},
 %%               {ip,       "127.0.0.1"}]}
 
+{mapping, "prometheus.tcp.listener", "rabbitmq_prometheus.tcp_config",
+    [{datatype, [{enum, [none]}, ip]}]}.
 {mapping, "prometheus.tcp.port", "rabbitmq_prometheus.tcp_config.port",
     [{datatype, integer}]}.
 {mapping, "prometheus.tcp.ip", "rabbitmq_prometheus.tcp_config.ip",
     [{datatype, string},
      {validators, ["is_ip"]}]}.
+
+{translation,
+    "rabbitmq_prometheus.tcp_config",
+    fun(Conf) ->
+        Setting = cuttlefish:conf_get("prometheus.tcp.listener", Conf, undefined),
+        case Setting of
+            none      -> [];
+            undefined -> [{port, 15692}];
+            {Ip, Port} when is_list(Ip), is_integer(Port) ->
+                [{ip, Ip}, {port, Port}]
+        end
+    end
+}.
 
 {mapping, "prometheus.tcp.compress", "rabbitmq_prometheus.tcp_config.cowboy_opts.compress",
     [{datatype, {enum, [true, false]}}]}.
@@ -44,7 +59,6 @@
     [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
 {mapping, "prometheus.tcp.max_keepalive", "rabbitmq_prometheus.tcp_config.cowboy_opts.max_keepalive",
     [{datatype, integer}, {validators, ["non_negative_integer"]}]}.
-
 
 %% HTTPS (TLS) listener options ========================================================
 

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -107,6 +107,22 @@
     ], [rabbitmq_prometheus]
    },
 
+   {tcp_listener,
+    "prometheus.tcp.listener = 192.1.1.2:15676",
+    [{rabbitmq_prometheus,[
+                           {tcp_config,[
+                                        {ip, "192.1.1.2"},
+                                        {port,15676}
+                                       ]}
+                          ]}],
+    [rabbitmq_prometheus]},
+
+   {tcp_listener_none,
+    "prometheus.tcp.listener = none",
+    [{rabbitmq_prometheus,[
+                           {tcp_config,[]}
+                          ]}],
+    [rabbitmq_prometheus]},
 
    %%
    %% TLS listener


### PR DESCRIPTION
## Proposed Changes

Closes: #8095 

Prometheus tcp listener can be turned off by setting `prometheus.tcp.listener = none`
Config schema follows what's been done for web_mqtt and web_stomp.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

