### PR TITLE
Adopt otp 25.0.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,11 +5,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_r
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
     ],
-    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")


### PR DESCRIPTION
Automated changes created by https://github.com/rabbitmq/rabbitmq-server/actions/runs/4964770091 using the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action in the Update OTP Patch Versions for Bazel Based Workflows workflow.