### PR TITLE
Exclude nested deps fetched by make from gazelle

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,6 +65,7 @@ exports_files([
 # gazelle:exclude deps/sysmon_handler
 # gazelle:exclude deps/systemd
 # gazelle:exclude deps/thoas
+# gazelle:exclude deps/*/deps
 # gazelle:exclude packaging
 # gazelle:exclude PACKAGES
 # gazelle:exclude logs


### PR DESCRIPTION
Depending on where `make` is run, `deps/*` may be generated not just at the top level, but in subdirectories. If gazelle is run after doing so, it will find those deps and try to generate rules from them. Such rules will be broken anyway in some cases due to the other overrides we have set for the top level `deps` dir, and the files won't show with `git diff` since the generated `BUILD.bazel` files are inside gitignored directories. One such error from this scenario is:

```deps/rabbitmq_cli/deps/recon/BUILD.bazel:10:13: in beam attribute of erlang_app_info rule //deps/rabbitmq_cli/deps/recon:test_erlang_app: target '//deps/rabbitmq_cli/deps/recon:test_beam_files' does not exist. Since this rule was created by the macro 'rabbitmq_app', the error might have been caused by the macro implementation```

This adds and additional gazelle ignore statement so that these nested deps directories are ignored by gazelle