### PR TITLE
UnsubscribeResponse in stream protocol doc

### DIFF
--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -451,6 +451,12 @@ Unsubscribe => Key Version CorrelationId SubscriptionId
   Version => uint16
   CorrelationId => uint32
   SubscriptionId => uint8
+  
+UnsubscribeResponse => Key Version CorrelationId ResponseCode
+  Key => uint16 // 0x800c
+  Version => uint16
+  CorrelationId => uint32
+  ResponseCode => uint16
 ```
 
 === Create


### PR DESCRIPTION
## Proposed Changes

UnsubscribeResponse is missing from stream protocol doc

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

