### PR TITLE
Stream server side filtering

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1,4 +1,4 @@
-%% This Source Code Form is subject to the terms of the Mozilla Public
+% This Source Code Form is subject to the terms of the Mozilla Public
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
@@ -834,26 +834,27 @@ check_arguments_key(QueueName, QueueType, Args, InvalidArgs) ->
                   end, Args).
 
 declare_args() ->
-    [{<<"x-expires">>,                 fun check_expires_arg/2},
-     {<<"x-message-ttl">>,             fun check_message_ttl_arg/2},
-     {<<"x-dead-letter-exchange">>,    fun check_dlxname_arg/2},
+    [{<<"x-expires">>, fun check_expires_arg/2},
+     {<<"x-message-ttl">>, fun check_message_ttl_arg/2},
+     {<<"x-dead-letter-exchange">>, fun check_dlxname_arg/2},
      {<<"x-dead-letter-routing-key">>, fun check_dlxrk_arg/2},
-     {<<"x-dead-letter-strategy">>,    fun check_dlxstrategy_arg/2},
-     {<<"x-max-length">>,              fun check_non_neg_int_arg/2},
-     {<<"x-max-length-bytes">>,        fun check_non_neg_int_arg/2},
-     {<<"x-max-in-memory-length">>,    fun check_non_neg_int_arg/2},
-     {<<"x-max-in-memory-bytes">>,     fun check_non_neg_int_arg/2},
-     {<<"x-max-priority">>,            fun check_max_priority_arg/2},
-     {<<"x-overflow">>,                fun check_overflow/2},
-     {<<"x-queue-mode">>,              fun check_queue_mode/2},
-     {<<"x-queue-version">>,           fun check_queue_version/2},
-     {<<"x-single-active-consumer">>,  fun check_single_active_consumer_arg/2},
-     {<<"x-queue-type">>,              fun check_queue_type/2},
-     {<<"x-quorum-initial-group-size">>,     fun check_initial_cluster_size_arg/2},
-     {<<"x-max-age">>,                 fun check_max_age_arg/2},
-     {<<"x-stream-max-segment-size-bytes">>,        fun check_non_neg_int_arg/2},
-     {<<"x-initial-cluster-size">>,    fun check_initial_cluster_size_arg/2},
-     {<<"x-queue-leader-locator">>,    fun check_queue_leader_locator_arg/2}].
+     {<<"x-dead-letter-strategy">>, fun check_dlxstrategy_arg/2},
+     {<<"x-max-length">>, fun check_non_neg_int_arg/2},
+     {<<"x-max-length-bytes">>, fun check_non_neg_int_arg/2},
+     {<<"x-max-in-memory-length">>, fun check_non_neg_int_arg/2},
+     {<<"x-max-in-memory-bytes">>, fun check_non_neg_int_arg/2},
+     {<<"x-max-priority">>, fun check_max_priority_arg/2},
+     {<<"x-overflow">>, fun check_overflow/2},
+     {<<"x-queue-mode">>, fun check_queue_mode/2},
+     {<<"x-queue-version">>, fun check_queue_version/2},
+     {<<"x-single-active-consumer">>, fun check_single_active_consumer_arg/2},
+     {<<"x-queue-type">>, fun check_queue_type/2},
+     {<<"x-quorum-initial-group-size">>, fun check_initial_cluster_size_arg/2},
+     {<<"x-max-age">>, fun check_max_age_arg/2},
+     {<<"x-stream-max-segment-size-bytes">>, fun check_non_neg_int_arg/2},
+     {<<"x-stream-filter-size-bytes">>, fun check_non_neg_int_arg/2},
+     {<<"x-initial-cluster-size">>, fun check_initial_cluster_size_arg/2},
+     {<<"x-queue-leader-locator">>, fun check_queue_leader_locator_arg/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
                    {<<"x-cancel-on-ha-failover">>, fun check_bool_arg/2},

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -113,3 +113,10 @@
       stability     => stable,
       depends_on    => [stream_single_active_consumer]
      }}).
+
+-rabbit_feature_flag(
+   {stream_filtering,
+    #{desc          => "Support for stream filtering.",
+      stability     => stable,
+      depends_on    => [stream_queue]
+     }}).

--- a/deps/rabbit/src/rabbit_policies.erl
+++ b/deps/rabbit/src/rabbit_policies.erl
@@ -44,6 +44,7 @@ register() ->
                           {policy_validator, <<"delivery-limit">>},
                           {policy_validator, <<"max-age">>},
                           {policy_validator, <<"stream-max-segment-size-bytes">>},
+                          {policy_validator, <<"stream-filter-size-bytes">>},
                           {policy_validator, <<"queue-leader-locator">>},
                           {policy_validator, <<"initial-cluster-size">>},
                           {operator_policy_validator, <<"expires">>},
@@ -195,7 +196,13 @@ validate_policy0(<<"stream-max-segment-size-bytes">>, Value)
   when is_integer(Value), Value >= 0, Value =< ?MAX_STREAM_MAX_SEGMENT_SIZE ->
     ok;
 validate_policy0(<<"stream-max-segment-size-bytes">>, Value) ->
-    {error, "~tp is not a valid segment size", [Value]}.
+    {error, "~tp is not a valid segment size", [Value]};
+
+validate_policy0(<<"stream-filter-size-bytes">>, Value)
+  when is_integer(Value), Value >= 16, Value =< 255 ->
+    ok;
+validate_policy0(<<"stream-filter-size-bytes">>, Value) ->
+    {error, "~tp is not a valid filter size. Valid range is 16-255", [Value]}.
 
 merge_policy_value(<<"message-ttl">>, Val, OpVal)      -> min(Val, OpVal);
 merge_policy_value(<<"max-length">>, Val, OpVal)       -> min(Val, OpVal);

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -47,7 +47,8 @@
 -export([update_stream_conf/2]).
 -export([readers/1]).
 
--export([parse_offset_arg/1]).
+-export([parse_offset_arg/1,
+         filter_spec/1]).
 
 -export([status/2,
          tracking_status/2,
@@ -72,7 +73,8 @@
                  max :: non_neg_integer(),
                  start_offset = 0 :: non_neg_integer(),
                  listening_offset = 0 :: non_neg_integer(),
-                 log :: undefined | osiris_log:state()}).
+                 log :: undefined | osiris_log:state(),
+                 reader_options :: osiris:reader_options()}).
 
 -record(stream_client, {stream_id :: string(),
                         name :: term(),
@@ -83,7 +85,8 @@
                         soft_limit :: non_neg_integer(),
                         slow = false :: boolean(),
                         readers = #{} :: #{term() => #stream{}},
-                        writer_id :: binary()
+                        writer_id :: binary(),
+                        filtering_supported :: boolean()
                        }).
 
 -import(rabbit_queue_type_util, [args_policy_lookup/3]).
@@ -233,7 +236,8 @@ consume(Q, #{no_ack := true}, _)
 consume(Q, #{limiter_active := true}, _State)
   when ?amqqueue_is_stream(Q) ->
     {error, global_qos_not_supported_for_queue_type};
-consume(Q, Spec, QState0) when ?amqqueue_is_stream(Q) ->
+consume(Q, Spec,
+        #stream_client{filtering_supported = FilteringSupported} = QState0) when ?amqqueue_is_stream(Q) ->
     %% Messages should include the offset as a custom header.
     case check_queue_exists_in_local_node(Q) of
         ok ->
@@ -258,7 +262,14 @@ consume(Q, Spec, QState0) when ?amqqueue_is_stream(Q) ->
                     %% really it should be sent by the stream queue process like classic queues
                     %% do
                     maybe_send_reply(ChPid, OkMsg),
-                    begin_stream(QState0, ConsumerTag, OffsetSpec, ConsumerPrefetchCount)
+                    FilterSpec = filter_spec(Args),
+                    case {FilterSpec, FilteringSupported} of
+                        {#{filter_spec := _}, false} ->
+                            {protocol_error, precondition_failed, "Filtering is not supported", []};
+                        _ ->
+                            begin_stream(QState0, ConsumerTag, OffsetSpec,
+                                         ConsumerPrefetchCount, FilterSpec)
+                    end
             end;
         Err ->
             Err
@@ -292,6 +303,35 @@ parse_offset_arg({_, V}) ->
 parse_offset_arg(V) ->
     {error, {invalid_offset_arg, V}}.
 
+filter_spec(Args) ->
+    Filters = case lists:keysearch(<<"x-stream-filter">>, 1, Args) of
+                  {value, {_, array, FilterValues}} ->
+                      lists:foldl(fun({longstr, V}, Acc) ->
+                                          [V] ++ Acc;
+                                     (_, Acc) ->
+                                          Acc
+                                  end, [], FilterValues);
+                  {value, {_, longstr, FilterValue}} ->
+                      [FilterValue];
+                  _ ->
+                      undefined
+              end,
+    MatchUnfiltered = case lists:keysearch(<<"x-stream-match-unfiltered">>, 1, Args) of
+                          {value, {_, bool, Match}} when is_list(Filters) ->
+                              Match;
+                          _ when is_list(Filters) ->
+                              false;
+                          _ ->
+                              undefined
+                      end,
+    case MatchUnfiltered of
+        undefined ->
+            #{};
+        MU ->
+            #{filter_spec =>
+              #{filters => Filters, match_unfiltered => MU}}
+    end.
+
 get_local_pid(#stream_client{local_pid = Pid} = State)
   when is_pid(Pid) ->
     {Pid, State};
@@ -309,14 +349,14 @@ get_local_pid(#stream_client{stream_id = StreamId,
     end.
 
 begin_stream(#stream_client{name = QName, readers = Readers0} = State0,
-             Tag, Offset, Max) ->
+             Tag, Offset, Max, Options) ->
     {LocalPid, State} = get_local_pid(State0),
     case LocalPid of
         undefined ->
             {error, no_local_stream_replica_available};
         _ ->
             CounterSpec = {{?MODULE, QName, Tag, self()}, []},
-            {ok, Seg0} = osiris:init_reader(LocalPid, Offset, CounterSpec),
+            {ok, Seg0} = osiris:init_reader(LocalPid, Offset, CounterSpec, Options),
             NextOffset = osiris_log:next_offset(Seg0) - 1,
             osiris:register_offset_listener(LocalPid, NextOffset),
             %% TODO: avoid double calls to the same process
@@ -331,7 +371,8 @@ begin_stream(#stream_client{name = QName, readers = Readers0} = State0,
                            start_offset = StartOffset,
                            listening_offset = NextOffset,
                            log = Seg0,
-                           max = Max},
+                           max = Max,
+                           reader_options = Options},
             {ok, State#stream_client{local_pid = LocalPid,
                                      readers = Readers0#{Tag => Str0}}}
     end.
@@ -383,7 +424,8 @@ deliver(QSs, #delivery{message = Msg, confirm = Confirm} = Delivery) ->
     lists:foldl(
       fun({Q, stateless}, {Qs, Actions}) ->
               LeaderPid = amqqueue:get_pid(Q),
-              ok = osiris:write(LeaderPid, msg_to_iodata(Msg)),
+              ok = osiris:write(LeaderPid,
+                                stream_message(Msg, filtering_supported())),
               {Qs, Actions};
          ({Q, S0}, {Qs, Actions}) ->
               {S, As} = deliver(Confirm, Delivery, S0),
@@ -397,8 +439,10 @@ deliver(_Confirm, #delivery{message = Msg, msg_seq_no = MsgId},
                        next_seq = Seq,
                        correlation = Correlation0,
                        soft_limit = SftLmt,
-                       slow = Slow0} = State) ->
-    ok = osiris:write(LeaderPid, WriterId, Seq, msg_to_iodata(Msg)),
+                       slow = Slow0,
+                       filtering_supported = FilteringSupported} = State) ->
+    ok = osiris:write(LeaderPid, WriterId, Seq,
+                      stream_message(Msg, FilteringSupported)),
     Correlation = case MsgId of
                       undefined ->
                           Correlation0;
@@ -414,6 +458,25 @@ deliver(_Confirm, #delivery{message = Msg, msg_seq_no = MsgId},
     {State#stream_client{next_seq = Seq + 1,
                          correlation = Correlation,
                          slow = Slow}, Actions}.
+
+stream_message(Msg, _FilteringSupported = true) ->
+    MsgData = msg_to_iodata(Msg),
+    case filter_header(Msg) of
+        {_, longstr, Value} ->
+            {Value, MsgData};
+        _ ->
+            MsgData
+    end;
+stream_message(Msg, _FilteringSupported = false) ->
+    msg_to_iodata(Msg).
+
+filter_header(Msg) ->
+    basic_header(<<"x-stream-filter-value">>, Msg).
+
+basic_header(Key, #basic_message{content = Content}) ->
+    Headers = rabbit_basic:extract_headers(Content),
+    rabbit_basic:header(Key, Headers).
+
 
 -spec dequeue(_, _, _, _, client()) -> no_return().
 dequeue(_, _, _, _, #stream_client{name = Name}) ->
@@ -462,12 +525,14 @@ handle_event(_QName, {stream_local_member_change, Pid}, #stream_client{local_pid
 handle_event(_QName, {stream_local_member_change, Pid}, State = #stream_client{name = QName,
                                                                        readers = Readers0}) ->
     rabbit_log:debug("Local member change event for ~tp", [QName]),
-    Readers1 = maps:fold(fun(T, #stream{log = Log0} = S0, Acc) ->
+    Readers1 = maps:fold(fun(T, #stream{log = Log0, reader_options = Options} = S0, Acc) ->
                                  Offset = osiris_log:next_offset(Log0),
                                  osiris_log:close(Log0),
                                  CounterSpec = {{?MODULE, QName, self()}, []},
-                                 rabbit_log:debug("Re-creating Osiris reader for consumer ~tp at offset ~tp", [T, Offset]),
-                                 {ok, Log1} = osiris:init_reader(Pid, Offset, CounterSpec),
+                                 rabbit_log:debug("Re-creating Osiris reader for consumer ~tp at offset ~tp "
+                                                  " with options ~tp",
+                                                  [T, Offset, Options]),
+                                 {ok, Log1} = osiris:init_reader(Pid, Offset, CounterSpec, Options),
                                  NextOffset = osiris_log:next_offset(Log1) - 1,
                                  rabbit_log:debug("Registering offset listener at offset ~tp", [NextOffset]),
                                  osiris:register_offset_listener(Pid, NextOffset),
@@ -775,7 +840,8 @@ init(Q) when ?is_amqqueue(Q) ->
                                 name = amqqueue:get_name(Q),
                                 leader = Leader,
                                 writer_id = WriterId,
-                                soft_limit = SoftLimit}};
+                                soft_limit = SoftLimit,
+                                filtering_supported = filtering_supported()}};
         {ok, stream_not_found, _} ->
             {error, stream_not_found};
         {error, coordinator_unavailable} = E ->
@@ -1056,7 +1122,8 @@ notify_decorators(Q) when ?is_amqqueue(Q) ->
 
 resend_all(#stream_client{leader = LeaderPid,
                           writer_id = WriterId,
-                          correlation = Corrs} = State) ->
+                          correlation = Corrs,
+                          filtering_supported = FilteringSupported} = State) ->
     Msgs = lists:sort(maps:values(Corrs)),
     case Msgs of
         [] -> ok;
@@ -1065,7 +1132,8 @@ resend_all(#stream_client{leader = LeaderPid,
                              [Seq, maps:size(Corrs)])
     end,
     [begin
-         ok = osiris:write(LeaderPid, WriterId, Seq, msg_to_iodata(Msg))
+         ok = osiris:write(LeaderPid, WriterId, Seq,
+                           stream_message(Msg, FilteringSupported))
      end || {Seq, Msg} <- Msgs],
     State.
 
@@ -1098,3 +1166,6 @@ list_with_minimum_quorum() ->
                  end, rabbit_amqqueue:list_local_stream_queues()).
 
 is_stateful() -> true.
+
+filtering_supported() ->
+    rabbit_feature_flags:is_enabled(stream_filtering).

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -74,7 +74,7 @@
                  start_offset = 0 :: non_neg_integer(),
                  listening_offset = 0 :: non_neg_integer(),
                  log :: undefined | osiris_log:state(),
-                 reader_options :: osiris:reader_options()}).
+                 reader_options :: map()}).
 
 -record(stream_client, {stream_id :: string(),
                         name :: term(),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -234,6 +234,15 @@ init_per_testcase(TestCase, Config)
         _ ->
             init_test_case(TestCase, Config)
     end;
+init_per_testcase(TestCase, Config)
+  when TestCase == filtering ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "filtering should not be used in mixed-version clusters"};
+        _ ->
+            init_test_case(TestCase, Config)
+    end;
+
 init_per_testcase(TestCase, Config) ->
     init_test_case(TestCase, Config).
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -209,6 +209,9 @@ var HELP = {
     'queue-stream-max-segment-size-bytes':
       'Total segment size for stream segments on disk.<br/>(Sets the x-stream-max-segment-size-bytes argument.)',
 
+    'queue-stream-max-segment-size-bytes':
+      'Size of the filter data attached to each stream chunk.<br/>(Sets the x-stream-filter-size-bytes argument.)',
+
     'queue-auto-delete':
       'If yes, the queue will delete itself after at least one consumer has connected, and then all consumers have disconnected.',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -141,6 +141,8 @@
                   <span class="help" id="queue-max-age"></span> |
                   <span class="argument-link" field="definition" key="stream-max-segment-size-bytes" type="number">Max segment size in bytes</span>
                   <span class="help" id="queue-stream-max-segment-size-bytes"></span> |
+                  <span class="argument-link" field="definition" key="stream-filter-size-bytes" type="number">Filter size in bytes. Valid range: 16-255</span>
+                  <span class="help" id="queue-stream-filter-size-bytes"></span> |
                   <span class="argument-link" field="definition" key="queue-leader-locator" type="string">Leader locator</span>
                   <span class="help" id="queue-leader-locator"></span>
                 </td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -341,6 +341,7 @@
                 <% if (queue_type == "stream") { %>
                   <span class="argument-link" field="arguments" key="x-max-age" type="string">Max time retention</span><span class="help" id="queue-max-age"></span>
                   | <span class="argument-link" field="arguments" key="x-stream-max-segment-size-bytes" type="number">Max segment size in bytes</span><span class="help" id="queue-stream-max-segment-size-bytes"></span>
+                  | <span class="argument-link" field="arguments" key="x-stream-filter-size-bytes" type="number">Filter size (per chunk) in bytes</span><span class="help" id="queue-stream-filter-size-bytes"></span>
                   | <span class="argument-link" field="arguments" key="x-initial-cluster-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span>
                 <% } %>
                 <% if (queue_type != "classic") { %>

--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -252,6 +252,8 @@ DeclarePublisherResponse => Key Version CorrelationId ResponseCode
 
 === Publish
 
+Version 1
+
 ```
 Publish => Key Version PublisherId PublishedMessages
   Key => uint16 // 0x0002
@@ -260,6 +262,20 @@ Publish => Key Version PublisherId PublishedMessages
   PublishedMessages => [PublishedMessage]
   PublishedMessage => PublishingId Message
   PublishingId => uint64
+  Message => bytes
+```
+
+Version 2
+
+```
+Publish => Key Version PublisherId PublishedMessages
+  Key => uint16 // 0x0002
+  Version => uint16
+  PublisherId => uint8
+  PublishedMessages => [PublishedMessage]
+  PublishedMessage => PublishingId Message
+  PublishingId => uint64
+  FilterValue => string
   Message => bytes
 ```
 

--- a/deps/rabbitmq_stream/docs/PROTOCOL.adoc
+++ b/deps/rabbitmq_stream/docs/PROTOCOL.adoc
@@ -357,6 +357,13 @@ Subscribe => Key Version CorrelationId SubscriptionId Stream OffsetSpecification
 NB: Timestamp is https://www.erlang.org/doc/apps/erts/time_correction.html#Erlang_System_Time[Erlang system time],
 milliseconds from epoch
 
+Supported properties:
+
+* `single-active-consumer`: set to `true` to enable https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-single-active-consumer-for-streams/[single active consumer] for this subscription.
+* `super-stream`: set to the name of the super stream the subscribed is a partition of.
+* `filter.` (e.g. `filter.0`, `filter.1`, etc): prefix to use to define filter values for the subscription.
+* `match-unfiltered`: whether to return messages without any filter value or not.
+
 === Deliver
 
 Version 1

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -170,6 +170,12 @@ stream_queue_arguments(ArgumentsAcc,
                              Value}]
                            ++ ArgumentsAcc,
                            maps:remove(<<"queue-leader-locator">>, Arguments));
+stream_queue_arguments(ArgumentsAcc,
+                       #{<<"stream-filter-size-bytes">> := Value} = Arguments) ->
+    stream_queue_arguments([{<<"x-stream-filter-size-bytes">>, long,
+                             binary_to_integer(Value)}]
+                           ++ ArgumentsAcc,
+                           maps:remove(<<"stream-filter-size-bytes">>, Arguments));
 stream_queue_arguments(ArgumentsAcc, _Arguments) ->
     ArgumentsAcc.
 
@@ -191,6 +197,11 @@ validate_stream_queue_arguments([{<<"x-queue-leader-locator">>,
         false ->
             error
     end;
+validate_stream_queue_arguments([{<<"x-stream-filter-size-bytes">>, long,
+                                  FilterSize}
+                                 | _])
+    when FilterSize < 16 orelse FilterSize > 255 ->
+    error;
 validate_stream_queue_arguments([_ | T]) ->
     validate_stream_queue_arguments(T).
 

--- a/deps/rabbitmq_stream/test/commands_SUITE.erl
+++ b/deps/rabbitmq_stream/test/commands_SUITE.erl
@@ -698,6 +698,7 @@ subscribe(S, SubId, Stream, SubProperties, C) ->
                                        SubId,
                                        Stream,
                                        SubProperties,
+                                       ?RESPONSE_CODE_OK,
                                        C).
 
 subscribe(S, SubId, Stream, C) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -33,7 +33,8 @@ all() ->
 
 groups() ->
     [{single_node, [],
-      [test_stream,
+      [filtering_ff, %% must stay at the top, feature flag disabled for this one
+       test_stream,
        test_stream_tls,
        test_publish_v2,
        test_gc_consumers,
@@ -72,6 +73,22 @@ init_per_group(Group, Config)
                          {rabbitmq_ct_tls_verify, verify_none},
                          {rabbitmq_stream, verify_none}
                         ]),
+    %% filtering feature flag disabled for the first test,
+    %% then enabled in the end_per_testcase function
+    ExtraSetupSteps =
+        case Group of
+            single_node ->
+                [fun(StepConfig) ->
+                    rabbit_ct_helpers:merge_app_env(StepConfig,
+                                                    {rabbit,
+                                                     [{forced_feature_flags_on_init,
+                                                       [stream_queue,
+                                                        stream_sac_coordinator_unblock_group,
+                                                        stream_single_active_consumer]}]})
+                 end];
+            _ ->
+                []
+        end,
     rabbit_ct_helpers:run_setup_steps(
       Config1,
       [fun(StepConfig) ->
@@ -86,6 +103,7 @@ init_per_group(Group, Config)
                                                 [{connection_negotiation_step_timeout,
                                                   500}]})
        end]
+      ++ ExtraSetupSteps
       ++ rabbit_ct_broker_helpers:setup_steps());
 init_per_group(cluster = Group, Config) ->
     Config1 = rabbit_ct_helpers:set_config(
@@ -123,6 +141,13 @@ init_per_testcase(close_connection_on_consumer_update_timeout = TestCase, Config
 init_per_testcase(TestCase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, TestCase).
 
+end_per_testcase(filtering_ff = TestCase, Config) ->
+    _ = rabbit_ct_broker_helpers:rpc(Config,
+                                     0,
+                                     rabbit_feature_flags,
+                                     enable,
+                                     [stream_filtering]),
+    rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(close_connection_on_consumer_update_timeout = TestCase, Config) ->
     ok = rabbit_ct_broker_helpers:rpc(Config,
                                       0,
@@ -132,6 +157,32 @@ end_per_testcase(close_connection_on_consumer_update_timeout = TestCase, Config)
     rabbit_ct_helpers:testcase_finished(Config, TestCase);
 end_per_testcase(TestCase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, TestCase).
+
+filtering_ff(Config) ->
+    Stream = atom_to_binary(?FUNCTION_NAME, utf8),
+    Transport = gen_tcp,
+    Port = get_stream_port(Config),
+    Opts = [{active, false}, {mode, binary}],
+    {ok, S} = Transport:connect("localhost", Port, Opts),
+    C0 = rabbit_stream_core:init(0),
+    C1 = test_peer_properties(Transport, S, C0),
+    C2 = test_authenticate(Transport, S, C1),
+    C3 = test_create_stream(Transport, S, Stream, C2),
+    PublisherId = 42,
+    C4 = test_declare_publisher(Transport, S, PublisherId, Stream, C3),
+    Body = <<"hello">>,
+    C5 = test_publish_confirm(Transport, S, publish_v2, PublisherId, Body,
+                               publish_error, C4),
+    SubscriptionId = 42,
+    C6 = test_subscribe(Transport, S, SubscriptionId, Stream,
+                        #{<<"filter.0">> => <<"foo">>},
+                        ?RESPONSE_CODE_PRECONDITION_FAILED,
+                        C5),
+
+    C7 = test_delete_stream(Transport, S, Stream, C6),
+    _C8 = test_close(Transport, S, C7),
+    closed = wait_for_socket_close(Transport, S, 10),
+    ok.
 
 test_global_counters(Config) ->
     Stream = atom_to_binary(?FUNCTION_NAME, utf8),
@@ -188,11 +239,14 @@ test_publish_v2(Config) ->
     PublisherId = 42,
     C4 = test_declare_publisher(Transport, S, PublisherId, Stream, C3),
     Body = <<"hello">>,
-    C5 = test_publish_confirm(Transport, S, publish_v2, PublisherId, Body, C4),
-    C6 = test_publish_confirm(Transport, S, publish_v2, PublisherId, Body, C5),
+    C5 = test_publish_confirm(Transport, S, publish_v2, PublisherId, Body,
+                              publish_confirm, C4),
+    C6 = test_publish_confirm(Transport, S, publish_v2, PublisherId, Body,
+                              publish_confirm, C5),
     SubscriptionId = 42,
     C7 = test_subscribe(Transport, S, SubscriptionId, Stream,
                         #{<<"filter.0">> => <<"foo">>},
+                        ?RESPONSE_CODE_OK,
                         C6),
     C8 = test_deliver(Transport, S, SubscriptionId, 0, Body, C7),
     C8b = test_deliver(Transport, S, SubscriptionId, 1, Body, C8),
@@ -419,6 +473,7 @@ close_connection_on_consumer_update_timeout(Config) ->
     C4 = test_subscribe(Transport, S, SubId, Stream,
                         #{<<"single-active-consumer">> => <<"true">>,
                           <<"name">> => <<"foo">>},
+                        ?RESPONSE_CODE_OK,
                         C3),
     {Cmd, _C5} = receive_commands(Transport, S, C4),
     ?assertMatch({request, _, {consumer_update, SubId, true}}, Cmd),
@@ -681,18 +736,21 @@ test_declare_publisher(Transport, S, PublisherId, Stream, C0) ->
     C.
 
 test_publish_confirm(Transport, S, PublisherId, Body, C0) ->
-    test_publish_confirm(Transport, S, publish, PublisherId, Body, C0).
+    test_publish_confirm(Transport, S, publish, PublisherId, Body,
+                         publish_confirm, C0).
 
-test_publish_confirm(Transport, S, publish = PublishCmd, PublisherId, Body, C0) ->
+test_publish_confirm(Transport, S, publish = PublishCmd, PublisherId, Body,
+                     ExpectedConfirmCommand,C0) ->
     BodySize = byte_size(Body),
     Messages = [<<1:64, 0:1, BodySize:31, Body:BodySize/binary>>],
     PublishFrame =
         rabbit_stream_core:frame({PublishCmd, PublisherId, 1, Messages}),
     ok = Transport:send(S, PublishFrame),
     {Cmd, C} = receive_commands(Transport, S, C0),
-    ?assertMatch({publish_confirm, PublisherId, [1]}, Cmd),
+    ?assertMatch({ExpectedConfirmCommand, PublisherId, [1]}, Cmd),
     C;
-test_publish_confirm(Transport, S, publish_v2 = PublishCmd, PublisherId, Body, C0) ->
+test_publish_confirm(Transport, S, publish_v2 = PublishCmd, PublisherId, Body,
+                     ExpectedConfirmCommand, C0) ->
     BodySize = byte_size(Body),
     FilterValue = <<"foo">>,
     FilterValueSize = byte_size(FilterValue),
@@ -702,7 +760,12 @@ test_publish_confirm(Transport, S, publish_v2 = PublishCmd, PublisherId, Body, C
         rabbit_stream_core:frame({PublishCmd, PublisherId, 1, Messages}),
     ok = Transport:send(S, PublishFrame),
     {Cmd, C} = receive_commands(Transport, S, C0),
-    ?assertMatch({publish_confirm, PublisherId, [1]}, Cmd),
+    case ExpectedConfirmCommand of
+        publish_confirm ->
+            ?assertMatch({ExpectedConfirmCommand, PublisherId, [1]}, Cmd);
+        publish_error ->
+            ?assertMatch({ExpectedConfirmCommand, PublisherId, _, [1]}, Cmd)
+    end,
     C.
 
 test_subscribe(Transport, S, SubscriptionId, Stream, C0) ->
@@ -711,6 +774,7 @@ test_subscribe(Transport, S, SubscriptionId, Stream, C0) ->
                    SubscriptionId,
                    Stream,
                    #{<<"random">> => <<"thing">>},
+                   ?RESPONSE_CODE_OK,
                    C0).
 
 test_subscribe(Transport,
@@ -718,6 +782,7 @@ test_subscribe(Transport,
                SubscriptionId,
                Stream,
                SubscriptionProperties,
+               ExpectedResponseCode,
                C0) ->
     SubCmd =
         {request, 1,
@@ -725,7 +790,7 @@ test_subscribe(Transport,
     SubscribeFrame = rabbit_stream_core:frame(SubCmd),
     ok = Transport:send(S, SubscribeFrame),
     {Cmd, C} = receive_commands(Transport, S, C0),
-    ?assertMatch({response, 1, {subscribe, ?RESPONSE_CODE_OK}}, Cmd),
+    ?assertMatch({response, 1, {subscribe, ExpectedResponseCode}}, Cmd),
     C.
 
 test_unsubscribe(Transport, Socket, SubscriptionId, C0) ->

--- a/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_utils_SUITE.erl
@@ -17,7 +17,7 @@ suite() ->
     [{timetrap, {seconds, 30}}].
 
 groups() ->
-    [{tests, [], [sort_partitions, filter_spec]}].
+    [{tests, [], [sort_partitions, filter_spec, filter_defined]}].
 
 init_per_suite(Config) ->
     Config.
@@ -65,7 +65,17 @@ sort_partitions(_Config) ->
                                                                          0)])]),
     ok.
 
-filter_spec(_Config) ->
+filter_defined(_) ->
+    [?assertEqual(Expected, rabbit_stream_utils:filter_defined(Properties))
+     || {Properties, Expected} <- [
+        {#{<<"filter.1">> => <<"">>}, true},
+        {#{<<"filter.1">> => <<"">>,
+           <<"sac">> => <<"false">>}, true},
+        {#{<<"foo">> => <<"bar">>}, false},
+        {#{}, false},
+        {undefined, false}]].
+
+filter_spec(_) ->
     [begin
          FilterSpec = rabbit_stream_utils:filter_spec(Properties),
          ?assert(maps:is_key(filter_spec, FilterSpec)),

--- a/deps/rabbitmq_stream_common/test/rabbit_stream_core_SUITE.erl
+++ b/deps/rabbitmq_stream_common/test/rabbit_stream_core_SUITE.erl
@@ -50,6 +50,7 @@ end_per_testcase(_TestCase, _Config) ->
 
 roundtrip(_Config) ->
     test_roundtrip({publish, 42, 1, <<"payload">>}),
+    test_roundtrip({publish_v2, 42, 1, <<"payload">>}),
     test_roundtrip({publish_confirm, 42, [1, 2, 3]}),
 
     test_roundtrip({publish_error,


### PR DESCRIPTION
This PR implements an approach to server side consumer filtering of streams to allow consumers that are only interested in a subset of the data in a given stream to reduce the amount of unwanted data that is sent to the client application.

The filtering is done at the chunk level and is probabilistic. False positives are possible but false negatives are not. I.e. a consumer would still need to do client side filtering in addition to the broker side filtering. This can be a client feature or done per application.

The broker will never interpret _or_ filter on individual messages. It can only be done at the chunk level.

To do the filtering the stream will for each chunk (batch of messages) written calculate a bloom filter over all the messages that include a filter value. This bloom filter data will be written immediately after the header and if present and if the consumer includes a filter value it will calculate a bloom filter hash for the consumer filter and match this against the chunk filter and only deliver the chunk to the client _if_ it is a match.

The per chunk bloom filter size can be varied between 16 and 255 bytes depending on the expected number of overlapping filter values a stream will contain. The osiris default is 16 bytes (the smallest size).

A 16 byte bloom filter can filter around 50 different filter values with a false positive probability of ~30%.
A 255 byte bloom filter can filter around 800 values at the same false positive probability.

It is worth noting that a chunk without any messages that included a filter value will not be delivered to a consumer that includes a filter. Hence a consumer that is interested in any messages that may not contain a filter value needs to also not include a filter value. This is an important consideration for existing stream after an upgrade. There is no way to retro fit a filter value onto existing data.

- [x] Osiris API and implementation draft
- [x] Osiris finalisation
- [x] Stream bloom filter size configuration
- [x] Stream protocol consumer API
- [x] Stream protocol publisher API
- [x] AMQP Publisher API
      - Perhaps using a custom header `x-stream-filter-value`
- [x] (AMQP consumer API)
      - Perhaps using a custom consumer arg `x-stream-filter`
- [x] Feature flag