### PR TITLE
Use erlang 26.0 instead of rc3 in bazel

### DIFF
--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -17,6 +17,7 @@ jobs:
         - "25.1"
         - "25.2"
         - "25.3"
+        - "26.0"
         include:
         - erlang_version: "24.3"
           name: '24'
@@ -49,6 +50,12 @@ jobs:
             backport-v3.12.x
             backport-v3.11.x
             backport-v3.10.x
+        - erlang_version: "26.0"
+          name: '26'
+          branch: main
+          labels: |
+            backport-v3.12.x
+            backport-v3.11.x
     timeout-minutes: 10
     env:
       branch: bump-otp-${{ matrix.erlang_version }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -71,8 +71,8 @@ erlang_config.internal_erlang_from_github_release(
 
 erlang_config.internal_erlang_from_github_release(
     name = "26",
-    sha256 = "ce962175c4d90161a7247d8e2e4ae36f9d8cc0214c8f52dba8ba84a82afc096f",
-    version = "26.0-rc3",
+    sha256 = "3ff3c53d7ef9a45b5720e95b8756269c1a1b58eb51accc992ca97522fdb234d4",
+    version = "26.0",
 )
 
 erlang_config.internal_erlang_from_http_archive(


### PR DESCRIPTION
Now that 26.0 has been released