### PR TITLE
Show classic queue storage version on Mgmt UI queue page

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -194,6 +194,9 @@ function args_to_features(obj) {
     if (obj.messages_delayed != undefined){
         res['messages delayed'] = obj.messages_delayed;
     }
+    if (obj.backing_queue_status && obj.backing_queue_status.version){
+	res['queue storage version'] = obj.backing_queue_status.version
+    }
     return res;
 }
 


### PR DESCRIPTION
## Proposed Changes

Expose classic queue version directly in the management UI in the "Features" section. 
I'm looking for feedback on the following caveats:
- the version is not available when management stats are disabled (I think this is fine as the version comes from the queue process (indirectly) and when stats are disabled, intentionaly no queue process is contacted and all data comes from queue definitions only)
- the row is redundant if the queue has an explicit `x-queue-version` argument or a policy with `queue-version` (should the row be hidden in these cases? On the other hand if both an arg and a policy is defined with different versions, the explicit row makes it clear what is the effective version)

Proposed on slack https://rabbitmq.slack.com/archives/CLJQL6KQB/p1684338258606269

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
