### PR TITLE
Move dep_credentials_obfuscation to rabbitmq-components.mk

### DIFF
--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -28,8 +28,6 @@ endef
 LOCAL_DEPS = compiler crypto public_key sasl ssl syntax_tools tools xmerl
 DEPS = thoas recon credentials_obfuscation
 
-dep_credentials_obfuscation = hex 3.4.0
-
 # Variables and recipes in development.*.mk are meant to be used from
 # any Git clone. They are excluded from the files published to Hex.pm.
 # Generated files are published to Hex.pm however so people using this

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -113,6 +113,7 @@ dep_toke                              = git_rmq           toke $(current_rmq_ref
 dep_accept = hex 0.3.5
 dep_cowboy = hex 2.10.0
 dep_cowlib = hex 2.12.1
+dep_credentials_obfuscation = hex 3.4.0
 dep_looking_glass = git https://github.com/rabbitmq/looking_glass.git master
 dep_prometheus = hex 4.10.0
 dep_ra = hex 2.6.1


### PR DESCRIPTION
Potential fix for publishing to hex.pm