### PR TITLE
Fix rabbit_stream_queue:get_counters querying writer last

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -271,7 +271,7 @@ query_pid(StreamId, MFA) when is_list(StreamId) ->
 -spec stream_overview(stream_id()) ->
     {ok, #{epoch := osiris:epoch(),
            members := #{node() := #{state := term(),
-                                    role := writer | replica,
+                                    role := {writer | replica, osiris:epoch()},
                                     current := term(),
                                     target := running | stopped}},
            num_listeners := non_neg_integer(),

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -672,7 +672,7 @@ is_writer(_Member) -> false.
 
 get_counters(Q) ->
     #{name := StreamId} = amqqueue:get_type_state(Q),
-    {ok, #{members := Members}} = rabbit_stream_coordinator:stream_overview(StreamId),
+    {ok, Members} = rabbit_stream_coordinator:members(StreamId),
     %% split members to query the writer last
     %% this minimizes the risk of confusing output where replicas are ahead of the writer
     Writer = maps:keys(maps:filter(fun (_, M) -> is_writer(M) end, Members)),


### PR DESCRIPTION
## Proposed Changes

`rabbit_steam_coordinator:stream_overview/1` returns the member in
different format than `members/1`, resulting in `is_writer/1` never
matching. This was changed in PR https://github.com/rabbitmq/rabbitmq-server/pull/6440. This prevents getting counters
from stream writer last as intended by PR https://github.com/rabbitmq/rabbitmq-server/pull/6442.

Tracing while calling `rabbitmq-queues stream_status sq1`
```
> recon_trace:calls({rabbit_stream_queue, is_writer, return_trace}, 20,[{scope,local}]).
1

23:42:05.259202 <0.21224.0> rabbit_stream_queue:is_writer(#{state=>{running,1,<0.1735.0>}, current=>undefined, role=>{writer,1}, target=>running})

23:42:05.259621 <0.21224.0> rabbit_stream_queue:is_writer/1 --> false
...
```

Let me know if the change from `members/1` to `stream_overview/1` was intentional and I can rework this change.

#6440 was only included in 3.12. (This is not a big issue but) this change makes a followup PR of mine easier to be applied to both 3.12 and 3.10/3.11.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
