### PR TITLE
Don't crash stream_status cmd if member node is down

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -271,7 +271,7 @@ query_pid(StreamId, MFA) when is_list(StreamId) ->
 -spec stream_overview(stream_id()) ->
     {ok, #{epoch := osiris:epoch(),
            members := #{node() := #{state := term(),
-                                    role := writer | replica,
+                                    role := {writer | replica, osiris:epoch()},
                                     current := term(),
                                     target := running | stopped}},
            num_listeners := non_neg_integer(),

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -688,7 +688,7 @@ get_counters(Q) ->
 safe_get_overview(Node, QName) ->
     case rpc:call(Node, ?MODULE, get_overview, [QName]) of
         {badrpc, _} ->
-            #{node => Node};
+            undefined;
         Result ->
             Result
     end.

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -650,7 +650,7 @@ status(Vhost, QueueName) ->
             {error, quorum_queue_not_supported};
         {ok, Q} when ?amqqueue_is_stream(Q) ->
             [begin
-                 [{role, Role},
+                 [get_key(role, C),
                   get_key(node, C),
                   get_key(epoch, C),
                   get_key(offset, C),
@@ -658,7 +658,7 @@ status(Vhost, QueueName) ->
                   get_key(first_offset, C),
                   get_key(readers, C),
                   get_key(segments, C)]
-             end || {Role, C} <- get_counters(Q)];
+             end || C <- get_counters(Q)];
         {error, not_found} = E ->
             E
     end.
@@ -666,33 +666,38 @@ status(Vhost, QueueName) ->
 get_key(Key, Cnt) ->
     {Key, maps:get(Key, Cnt, undefined)}.
 
--spec is_writer({pid() | undefined, writer | replica}) -> boolean().
-is_writer({_, writer}) -> true;
-is_writer(_Member) -> false.
+-spec get_role({pid() | undefined, writer | replica}) -> writer | replica.
+get_role({_, Role}) -> Role.
 
 get_counters(Q) ->
     #{name := StreamId} = amqqueue:get_type_state(Q),
     {ok, Members} = rabbit_stream_coordinator:members(StreamId),
     %% split members to query the writer last
     %% this minimizes the risk of confusing output where replicas are ahead of the writer
-    Writer = maps:keys(maps:filter(fun (_, M) -> is_writer(M) end, Members)),
-    Replicas = maps:keys(maps:filter(fun (_, M) -> not is_writer(M) end, Members)),
+    NodeRoles = [{Node, get_role(M)} || {Node, M} <- maps:to_list(Members)],
+    {Writer, Replicas} = lists:partition(fun({_, Role}) -> Role =:= writer end, NodeRoles),
     QName = amqqueue:get_name(Q),
-    Counters0 = [begin
-                    safe_get_overview(Node, QName)
-                 end || Node <- lists:append(Replicas, Writer)],
-    Counters1 = lists:filter(fun (X) -> X =/= undefined end, Counters0),
+    Counters = [safe_get_overview(Node, QName, Role)
+                || {Node, Role} <- lists:append(Replicas, Writer)],
     %% sort again in the original order (by node)
-    lists:sort(fun ({_, M1}, {_, M2}) -> maps:get(node, M1) < maps:get(node, M2) end, Counters1).
+    lists:sort(fun (M1, M2) -> maps:get(node, M1) < maps:get(node, M2) end, Counters).
 
-safe_get_overview(Node, QName) ->
+-spec safe_get_overview(node(), rabbit_amqqueue:name(), writer | reader) ->
+          map().
+safe_get_overview(Node, QName, Role) ->
     case rpc:call(Node, ?MODULE, get_overview, [QName]) of
         {badrpc, _} ->
-            undefined;
-        Result ->
-            Result
+            #{role => Role,
+              node => Node};
+        undefined ->
+            #{role => Role,
+              node => Node};
+        {Role, C} ->
+            C#{role => Role}
     end.
 
+-spec get_overview(rabbit_amqqueue:name()) ->
+          {writer | reader, map()} | undefined.
 get_overview(QName) ->
     case osiris_counters:overview({osiris_writer, QName}) of
         undefined ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -672,7 +672,7 @@ is_writer(_Member) -> false.
 
 get_counters(Q) ->
     #{name := StreamId} = amqqueue:get_type_state(Q),
-    {ok, #{members := Members}} = rabbit_stream_coordinator:stream_overview(StreamId),
+    {ok, Members} = rabbit_stream_coordinator:members(StreamId),
     %% split members to query the writer last
     %% this minimizes the risk of confusing output where replicas are ahead of the writer
     Writer = maps:keys(maps:filter(fun (_, M) -> is_writer(M) end, Members)),


### PR DESCRIPTION
## Proposed Changes

This PR is based on #8269, but the last two commits apply cleanly on v3.11.x as well.

- commit "Don't crash stream_status cmd if member node is down" fixes a crash when one of the member nodes of a stream is down
  (started 3 node cluster locally with `make start-cluster`, created a stream queue `sq1` with 3 members, one on each node, then stoppped `rabbit-3`)
```
sbin/rabbitmq-queues --node rabbit-1@Peters-MacBook-Pro stream_status sq1
Status of stream sq1 on node rabbit-1@Peters-MacBook-Pro ...
Error:
{:function_clause, [{:rabbit_stream_queue, :"-get_counters/1-fun-4-", [{:replica, %{node: :"rabbit-2@Peters-MacBook-Pro", offset: 1, chunks: 2, epoch: 1, first_offset: 0, readers: 0, segments: 1, committed_offset: 1, first_timestamp: 0, forced_gcs: 2800, packets: 2}}, %{node: :"rabbit-3@Peters-MacBook-Pro"}], [file: 'rabbit_stream_queue.erl', line: 686]}, {:lists, :sort, 2, [file: 'lists.erl', line: 1210]}, {:rabbit_stream_queue, :status, 2, [file: 'rabbit_stream_queue.erl', line: 661]}]}
```

The crash was revealed by PR #6442, before that the map returned by the badrpc case was implicitly filtered out by the list comprehension in `status/2`.

- commit "Extend stream_status to list down members as well" makes `stream_status` command also print a line for each member which is down, with undefined counter values
```
% sbin/rabbitmq-queues --node rabbit-2@`hostname -s` stream_status sq1
Status of stream sq1 on node rabbit-2@Peters-MacBook-Pro ...
┌─────────┬─────────────────────────────┬───────────┬───────────┬──────────────────┬──────────────┬───────────┬───────────┐
│ role    │ node                        │ epoch     │ offset    │ committed_offset │ first_offset │ readers   │ segments  │
├─────────┼─────────────────────────────┼───────────┼───────────┼──────────────────┼──────────────┼───────────┼───────────┤
│ replica │ rabbit-1@Peters-MacBook-Pro │ 5         │ 2         │ 2                │ 0            │ 0         │ 1         │
├─────────┼─────────────────────────────┼───────────┼───────────┼──────────────────┼──────────────┼───────────┼───────────┤
│ writer  │ rabbit-2@Peters-MacBook-Pro │ 5         │ 2         │ 2                │ 0            │ 1         │ 1         │
├─────────┼─────────────────────────────┼───────────┼───────────┼──────────────────┼──────────────┼───────────┼───────────┤
│ replica │ rabbit-3@Peters-MacBook-Pro │ undefined │ undefined │ undefined        │ undefined    │ undefined │ undefined │
└─────────┴─────────────────────────────┴───────────┴───────────┴──────────────────┴──────────────┴───────────┴───────────┘
```
Let me know if this second change is not desirable, and `stream_status` should only print reachable members.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
