### PR TITLE
Adjust test cert generation in rabbitmq_ct_helpers

### DIFF
--- a/deps/rabbitmq_ct_helpers/tools/tls-certs/openssl.cnf.in
+++ b/deps/rabbitmq_ct_helpers/tools/tls-certs/openssl.cnf.in
@@ -49,12 +49,11 @@ keyUsage = keyCertSign, cRLSign
 [ client_ca_extensions ]
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
-extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 
 [ server_ca_extensions ]
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
-extendedKeyUsage = 1.3.6.1.5.5.7.3.1
+extendedKeyUsage = serverAuth
 subjectAltName   = @server_alt_names
 
 [ server_alt_names ]


### PR DESCRIPTION
In some cases with OTP 26 `{bad_cert,invalid_ext_key_usage}` handshake failures would occur. This change seems to fix that.