### PR TITLE
Disaster recovery: force shrink all quorum queues to a 1-node cluster

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -334,6 +334,13 @@ rabbitmq_integration_suite(
 )
 
 rabbitmq_integration_suite(
+    name = "clustering_recovery_SUITE",
+    size = "medium",
+    shard_count = 2,
+    sharding_method = "case",
+)
+
+rabbitmq_integration_suite(
     name = "config_schema_SUITE",
     size = "medium",
     data = [

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -814,6 +814,15 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         deps = ["//deps/amqp_client:erlang_app"],
     )
     erlang_bytecode(
+        name = "clustering_recovery_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/clustering_recovery_SUITE.erl"],
+        outs = ["test/clustering_recovery_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+        deps = ["//deps/amqp_client:erlang_app"],
+    )
+    erlang_bytecode(
         name = "config_schema_SUITE_beam_files",
         testonly = True,
         srcs = ["test/config_schema_SUITE.erl"],

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -66,6 +66,9 @@
          declare/2,
          is_stateful/0]).
 
+-export([force_shrink_member_to_current_member/2,
+         force_all_queues_shrink_member_to_current_member/0]).
+
 -import(rabbit_queue_type_util, [args_policy_lookup/3,
                                  qname_to_internal_name/1]).
 
@@ -1717,3 +1720,41 @@ erpc_call(Node, M, F, A, Timeout) ->
     end.
 
 is_stateful() -> true.
+
+force_shrink_member_to_current_member(VHost, Name) ->
+    rabbit_log:warning("Disaster recovery procedure: shrinking ~p queue at vhost ~p to a single node cluster", [Name, VHost]),
+    Node = node(),
+    QName = rabbit_misc:r(VHost, queue, Name),
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} when ?is_amqqueue(Q) ->
+            {RaName, _} = amqqueue:get_pid(Q),
+            ok = ra_server_proc:force_shrink_members_to_current_member({RaName, Node}),
+            Fun = fun (Q0) ->
+                          TS0 = amqqueue:get_type_state(Q0),
+                          TS = TS0#{nodes => [Node]},
+                          amqqueue:set_type_state(Q, TS)
+                  end,
+            _ = rabbit_amqqueue:update(QName, Fun),
+            rabbit_log:warning("Disaster recovery procedure: shrinking finished");
+        _ ->
+            rabbit_log:warning("Disaster recovery procedure: shrinking failed, queue ~p not found at vhost ~p", [Name, VHost]),
+            {error, not_found}
+    end.
+
+force_all_queues_shrink_member_to_current_member() ->
+    rabbit_log:warning("Disaster recovery procedure: shrinking all quorum queues to a single node cluster"),
+    Node = node(),
+    [begin
+         QName = amqqueue:get_name(Q),
+         {RaName, _} = amqqueue:get_pid(Q),
+         rabbit_log:warning("Disaster recovery procedure: shrinking queue ~p", [QName]),
+         ok = ra_server_proc:force_shrink_members_to_current_member({RaName, Node}),
+         Fun = fun (Q) ->
+                       TS0 = amqqueue:get_type_state(Q),
+                       TS = TS0#{nodes => [Node]},
+                       amqqueue:set_type_state(Q, TS)
+               end,
+         _ = rabbit_amqqueue:update(QName, Fun)
+     end || Q <- rabbit_amqqueue:list(), amqqueue:get_type(Q) == ?MODULE],
+    rabbit_log:warning("Disaster recovery procedure: shrinking finished"),
+    ok.

--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -1,0 +1,187 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(clustering_recovery_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+     {group, mnesia_store}
+    ].
+
+groups() ->
+    [{mnesia_store, [], [
+                         {clustered_3_nodes, [],
+                          [{cluster_size_3, [], [
+                                                 force_shrink_quorum_queue,
+                                                 force_shrink_all_quorum_queues
+                                                ]}
+                          ]}
+                        ]}
+    ].
+
+suite() ->
+    [
+      %% If a testcase hangs, no need to wait for 30 minutes.
+      {timetrap, {minutes, 5}}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(mnesia_store, Config) ->
+    Config;
+init_per_group(clustered_3_nodes, Config) ->
+    rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, true}]);
+init_per_group(cluster_size_3, Config) ->
+    rabbit_ct_helpers:set_config(Config, [{rmq_nodes_count, 3}]).
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    ClusterSize = ?config(rmq_nodes_count, Config),
+    TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase},
+        {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}},
+        {keep_pid_file_on_exit, true}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testcases
+%% -------------------------------------------------------------------
+
+force_shrink_all_quorum_queues(Config) ->
+    [Rabbit, Hare, Bunny] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    
+    QName1 = quorum_test_queue(1),
+    QName2 = quorum_test_queue(2),
+    QName3 = quorum_test_queue(3),
+    Args = [{<<"x-queue-type">>, longstr, <<"quorum">>}],
+    declare_and_publish_to_queue(Config, Rabbit, QName1, Args),
+    declare_and_publish_to_queue(Config, Rabbit, QName2, Args),
+    declare_and_publish_to_queue(Config, Rabbit, QName3, Args),
+
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Hare),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Bunny),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Rabbit),
+    ?assertExit(
+       {{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+       amqp_channel:subscribe(Ch, #'basic.consume'{queue = QName1,
+                                                   consumer_tag = <<"ctag">>},
+                              self())),
+    
+    ok = rabbit_ct_broker_helpers:rpc(Config, Rabbit, rabbit_quorum_queue, force_all_queues_shrink_member_to_current_member, []),
+
+    ok = consume_from_queue(Config, Rabbit, QName1),
+    ok = consume_from_queue(Config, Rabbit, QName2),
+    ok = consume_from_queue(Config, Rabbit, QName3),
+
+    ok.
+
+force_shrink_quorum_queue(Config) ->
+    [Rabbit, Hare, Bunny] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    
+    QName1 = quorum_test_queue(1),
+    Args = [{<<"x-queue-type">>, longstr, <<"quorum">>}],
+    declare_and_publish_to_queue(Config, Rabbit, QName1, Args),
+
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Hare),
+    ok = rabbit_ct_broker_helpers:stop_node(Config, Bunny),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Rabbit),
+    ?assertExit(
+       {{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+       amqp_channel:subscribe(Ch, #'basic.consume'{queue = QName1,
+                                                   consumer_tag = <<"ctag">>},
+                              self())),
+    
+    ok = rabbit_ct_broker_helpers:rpc(Config, Rabbit, rabbit_quorum_queue, force_shrink_member_to_current_member, [<<"/">>, QName1]),
+
+    ok = consume_from_queue(Config, Rabbit, QName1),
+
+    ok.
+
+%% -------------------------------------------------------------------
+%% Internal utils
+%% -------------------------------------------------------------------
+declare_and_publish_to_queue(Config, Node, QName, Args) ->
+    {Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, Node),
+    declare(Ch, QName, Args),
+    publish_many(Ch, QName, 10),
+    rabbit_ct_client_helpers:close_connection_and_channel(Conn, Ch).
+
+quorum_test_queue(Number) ->
+    list_to_binary(io_lib:format("quorum_queue_~p", [Number])).
+
+declare(Ch, Name, Args) ->
+    Res = amqp_channel:call(Ch, #'queue.declare'{durable = true,
+                                                 queue   = Name,
+                                                 arguments = Args}),
+    amqp_channel:call(Ch, #'queue.bind'{queue    = Name,
+                                        exchange = <<"amq.fanout">>}),
+    Res.
+
+consume_from_queue(Config, Node, QName) ->
+    {Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, Node),
+    subscribe(Ch, QName),
+    consume(10),
+    rabbit_ct_client_helpers:close_connection_and_channel(Conn, Ch).
+
+publish_many(Ch, QName, N) ->
+    amqp_channel:call(Ch, #'confirm.select'{}),
+    [amqp_channel:cast(Ch, #'basic.publish'{routing_key = QName},
+                       #amqp_msg{props = #'P_basic'{delivery_mode = 2}})
+     || _ <- lists:seq(1, N)],
+    amqp_channel:wait_for_confirms(Ch).
+
+subscribe(Ch, QName) ->
+    CTag = <<"ctag">>,
+    amqp_channel:subscribe(Ch, #'basic.consume'{queue = QName,
+                                                consumer_tag = CTag},
+                           self()),
+    receive
+        #'basic.consume_ok'{consumer_tag = CTag} ->
+            ok
+    after 10000 ->
+            exit(consume_ok_timeout)
+    end.
+
+consume(0) ->
+    ok;
+consume(N) ->
+    receive
+        {#'basic.deliver'{consumer_tag = <<"ctag">>}, _} ->
+            consume(N - 1)
+    after 10000 ->
+            exit(deliver_timeout)
+    end.


### PR DESCRIPTION
In case of a catastrophic failure, this function can be used to force all quorum queues to shrink the membership to the current node. It is meant just for disaster recovery scenarios, where the rest of the cluster is irrecoverable and there are quorum queues in minority that hold important data that must be recovered.

Usage:
`rabbitmqctl eval 'rabbit_quorum_queue:force_all_queues_shrink_member_to_current_member().'`