### PR TITLE
Emit only AMQP connections

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -523,7 +523,7 @@ emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
 emit_connection_info_local(Items, Ref, AggregatorPid) ->
     rabbit_control_misc:emitting_map_with_exit_handler(
       AggregatorPid, Ref, fun(Q) -> connection_info(Q, Items) end,
-      connections_local() ++ local_non_amqp_connections()).
+      connections_local()).
 
 -spec close_connection(pid(), string()) -> 'ok'.
 


### PR DESCRIPTION
Apparently added by mistake in #7981.

References #8327.