### PR TITLE
Handle missing guids on in node_monitor

### DIFF
--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -413,7 +413,7 @@ handle_call(_Request, _From, State) ->
     {noreply, State}.
 
 handle_cast(notify_node_up, State = #state{guid = GUID}) ->
-    Nodes = rabbit_nodes:list_running() -- [node()],
+    Nodes = rabbit_nodes:list_reachable() -- [node()],
     gen_server:abcast(Nodes, ?SERVER,
                       {node_up, node(), rabbit_db_cluster:node_type(), GUID}),
     %% register other active rabbits with this rabbit


### PR DESCRIPTION
## Proposed Changes

On `main` and 3.12.x a recent change in node_monitor can prevent partial partition detection when a previous partition handling starts multiple nodes at the same time.

When two or more nodes start at the same time, we have to use the list of running mnesia nodes instead of the fully running rabbit nodes. When a node is in the node_monitor's init stage, it isn't counted as a fully running rabbit node. This means that its GUID isn't sent to the other node starting up. This race condition means that the node_monitor will not do anything with a node_down event, because the down node will be missing from the GUID map.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

To reproduce:
1. Set up a 3-node cluster with pause_minority.
2. Create a partial partition and wait for two of the nodes to stop as expected.
3. Remove the partial partition and observe that both stopped nodes start up.
4. Check that the node monitor state on the newly started nodes doesn't contain the correct guids by running `rabbitmqctl eval 'sys:get_state(rabbit_node_monitor).'`
5. Create another partitial partition on the same node and observe that none of the nodes don't stop as expected. This is a split brain situation, so any changes on the partitioned node will result in inconsistent mnesia.
6. Remove the partial partition and observe the mnesia running partition even.

With the fix the second partition also works as expected, i.e. two nodes stop in the cluster.
(We didn't verify it, but this can be a potential issue with regular node start ups too. When more than one node start up at the same time e.g. after a full partition, automated maintenance activities, docker compose starts.)