### PR TITLE
Use 3.12.6 for the secondary umbrella

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -487,7 +487,7 @@ secondary_umbrella = use_extension(
 
 use_repo(
     secondary_umbrella,
-    "rabbitmq-server-generic-unix-3.11",
+    "rabbitmq-server-generic-unix-3.12",
 )
 
 hex = use_extension(

--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -25,12 +25,12 @@ EOF
 
 def secondary_umbrella():
     http_archive(
-        name = "rabbitmq-server-generic-unix-3.11",
+        name = "rabbitmq-server-generic-unix-3.12",
         build_file = "@//:BUILD.package_generic_unix",
         patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-        strip_prefix = "rabbitmq_server-3.11.18",
+        strip_prefix = "rabbitmq_server-3.12.3",
         # This file is produced just in time by the test-mixed-versions.yaml GitHub Actions workflow.
         urls = [
-            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/rbe-25_3/package-generic-unix-for-mixed-version-testing-v3.11.18.tar.xz",
+            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/rbe-25_3/package-generic-unix-for-mixed-version-testing-v3.12.3.tar.xz",
         ],
     )

--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -28,9 +28,9 @@ def secondary_umbrella():
         name = "rabbitmq-server-generic-unix-3.12",
         build_file = "@//:BUILD.package_generic_unix",
         patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-        strip_prefix = "rabbitmq_server-3.12.3",
+        strip_prefix = "rabbitmq_server-3.12.6",
         # This file is produced just in time by the test-mixed-versions.yaml GitHub Actions workflow.
         urls = [
-            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/rbe-25_3/package-generic-unix-for-mixed-version-testing-v3.12.3.tar.xz",
+            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/rbe-25_3/package-generic-unix-for-mixed-version-testing-v3.12.6.tar.xz",
         ],
     )

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -283,12 +283,12 @@ def rabbitmq_integration_suite(
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),
             "RABBITMQ_QUEUES": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-queues".format(package),
-            "RABBITMQ_RUN_SECONDARY": "$(location @rabbitmq-server-generic-unix-3.11//:rabbitmq-run)",
+            "RABBITMQ_RUN_SECONDARY": "$(location @rabbitmq-server-generic-unix-3.12//:rabbitmq-run)",
             "LANG": "C.UTF-8",
         }.items() + test_env.items()),
         tools = [
             ":rabbitmq-for-tests-run",
-            "@rabbitmq-server-generic-unix-3.11//:rabbitmq-run",
+            "@rabbitmq-server-generic-unix-3.12//:rabbitmq-run",
         ] + tools,
         deps = assumed_deps + deps + runtime_deps,
         **kwargs


### PR DESCRIPTION
Set the secondary umbrella for mixed version testing to the latest v3.12.x