### PR TITLE
When available, use user-provided ip address for listener metadata

### DIFF
--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_registry.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_registry.erl
@@ -157,8 +157,17 @@ listener_info(Listener) ->
                        P
                end,
     Port = pget(port, Listener),
-    [{IPAddress, _Port, _Family} | _]
-        = rabbit_networking:tcp_listener_addresses(Port),
+    IPAddress = case rabbit_misc:pget(ip, Listener) of
+                    undefined ->
+                        [{AutoIPAddress, _Port, _Family} | _]
+                            = rabbit_networking:tcp_listener_addresses(Port),
+                        AutoIPAddress;
+                    IP when is_tuple(IP) ->
+                        IP;
+                    IP when is_list(IP) ->
+                        {ok, ParsedIP} = inet_parse:address(IP),
+                        ParsedIP
+                end,
     [{Protocol, IPAddress, Port}].
 
 lookup_dispatch(Lsnr) ->

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
@@ -143,10 +143,20 @@ start_tls_listener(TLSConf0, CowboyOpts) ->
 
 listener_started(Protocol, Listener) ->
     Port = rabbit_misc:pget(port, Listener),
-    [rabbit_networking:tcp_listener_started(Protocol, Listener,
-                                            IPAddress, Port)
-     || {IPAddress, _Port, _Family}
-        <- rabbit_networking:tcp_listener_addresses(Port)],
+    case rabbit_misc:pget(ip, Listener) of
+        undefined ->
+            [rabbit_networking:tcp_listener_started(Protocol, Listener,
+                                                    IPAddress, Port)
+             || {IPAddress, _Port, _Family}
+                    <- rabbit_networking:tcp_listener_addresses(Port)];
+        IP when is_tuple(IP) ->
+            rabbit_networking:tcp_listener_started(Protocol, Listener,
+                                                   IP, Port);
+        IP when is_list(IP) ->
+            {ok, ParsedIP} = inet_parse:address(IP),
+            rabbit_networking:tcp_listener_started(Protocol, Listener,
+                                                   ParsedIP, Port)
+    end,
     ok.
 
 get_tcp_conf(TCPConf0) ->

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_listener.erl
@@ -165,10 +165,20 @@ start_tls_listener(TLSConf0, CowboyOpts0, Routes) ->
 
 listener_started(Protocol, Listener) ->
     Port = rabbit_misc:pget(port, Listener),
-    [rabbit_networking:tcp_listener_started(Protocol, Listener,
-                                            IPAddress, Port)
-     || {IPAddress, _Port, _Family}
-        <- rabbit_networking:tcp_listener_addresses(Port)],
+    case rabbit_misc:pget(ip, Listener) of
+        undefined ->
+            [rabbit_networking:tcp_listener_started(Protocol, Listener,
+                                                    IPAddress, Port)
+             || {IPAddress, _Port, _Family}
+                    <- rabbit_networking:tcp_listener_addresses(Port)];
+        IP when is_tuple(IP) ->
+            rabbit_networking:tcp_listener_started(Protocol, Listener,
+                                                   IP, Port);
+        IP when is_list(IP) ->
+            {ok, ParsedIP} = inet_parse:address(IP),
+            rabbit_networking:tcp_listener_started(Protocol, Listener,
+                                                   ParsedIP, Port)
+    end,
     ok.
 
 get_env(Key, Default) ->


### PR DESCRIPTION
Closes #8242, references #6852.

## Proposed Changes

Currently for web-related listeners user-provided ip-address is simply ignored when listener metadata saved. 
This patch attempts to fix. It employs intentional copypasta style, because refactoring all this is a much bigger effort it seems.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

With this config:
```
[{rabbit, [{tcp_listeners, [{"localhost", 5672}]}]},
 {rabbitmq_web_stomp, [{tcp_config, [{ip, "127.0.0.1"}]}]},
 {rabbitmq_web_mqtt, [{tcp_config, [{ip, "127.0.0.1"}]}]},
 {rabbitmq_prometheus, [{tcp_config, [{ip, "127.0.0.1"}]}]},
 {rabbitmq_management,[{tcp_config, [{ip, "127.0.0.1"}]}]}].
```

I was getting that: 

```
Asking node rabbit@arch to report its protocol listeners ...
Interface: [::], port: 15672, protocol: http, purpose: HTTP API
Interface: [::], port: 1883, protocol: mqtt, purpose: MQTT
Interface: [::], port: 15675, protocol: http/web-mqtt, purpose: MQTT over WebSockets
Interface: [::], port: 61613, protocol: stomp, purpose: STOMP
Interface: [::], port: 15674, protocol: http/web-stomp, purpose: STOMP over WebSockets
Interface: [::], port: 15670, protocol: http, purpose: HTTP API
Interface: [::], port: 5552, protocol: stream, purpose: stream
Interface: [::], port: 15692, protocol: http/prometheus, purpose: Prometheus exporter API over HTTP
Interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication
Interface: 127.0.0.1, port: 5672, protocol: amqp, purpose: AMQP 0-9-1 and AMQP 1.0
Interface: [::1], port: 5672, protocol: amqp, purpose: AMQP 0-9-1 and AMQP 1.0

```

Now getting this: 

```
Asking node rabbit@arch to report its protocol listeners ...
Interface: 127.0.0.1, port: 15672, protocol: http, purpose: HTTP API
Interface: [::], port: 1883, protocol: mqtt, purpose: MQTT
Interface: 127.0.0.1, port: 15675, protocol: http/web-mqtt, purpose: MQTT over WebSockets
Interface: [::], port: 61613, protocol: stomp, purpose: STOMP
Interface: 127.0.0.1, port: 15674, protocol: http/web-stomp, purpose: STOMP over WebSockets
Interface: [::], port: 15670, protocol: http, purpose: HTTP API
Interface: [::], port: 5552, protocol: stream, purpose: stream
Interface: 127.0.0.1, port: 15692, protocol: http/prometheus, purpose: Prometheus exporter API over HTTP
Interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication
Interface: 127.0.0.1, port: 5672, protocol: amqp, purpose: AMQP 0-9-1 and AMQP 1.0
Interface: [::1], port: 5672, protocol: amqp, purpose: AMQP 0-9-1 and AMQP 1.0
```
