### PR TITLE
ca-certificates are needed for k8s peer plugin

### DIFF
--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -32,6 +32,7 @@ BUILD_DEPS_PACKAGES = [
 
 REQUIRED_PACKAGES = [
     "gosu",
+    "ca-certificates",
 ]
 
 CONVENIENCE_PACKAGES = [


### PR DESCRIPTION
ca-certificates are needed for k8s peer discovery plugin. Without them, any OTP26 deployment fails with:

```
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0> Exception during startup:
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0> error:{badmatch,{error,enoent}}
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>     pubkey_os_cacerts:get/0, line 38
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>     httpc:ssl_verify_host_options/1, line 476
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>     httpc:http_options_default/0, line 1012
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>     httpc:http_options/1, line 927
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>     httpc:handle_request/9, line 771
2023-05-22 11:40:20.046254+00:00 [error] <0.242.0>     rabbit_peer_discovery_httpc:get/7, line 146
```