### PR TITLE
Make scopes optional for oauth2 authentication

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
@@ -84,6 +84,15 @@ token_with_scopes_and_expiration(Scopes, Expiration) ->
       <<"aud">> => [<<"rabbitmq">>],
       <<"scope">> => Scopes}.
 
+token_without_scopes() ->
+    %% expiration is a timestamp with precision in seconds
+    #{
+      <<"kid">> => <<"token-key">>,
+      <<"iss">> => <<"unit_test">>,
+      <<"foo">> => <<"bar">>,
+      <<"aud">> => [<<"rabbitmq">>]
+      }.
+
 fixture_token() ->
     fixture_token([]).
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/scope_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/scope_SUITE.erl
@@ -20,7 +20,7 @@ all() ->
         permission_resource,
         permission_topic
     ].
-  
+
 variable_expansion(_Config) ->
     Scenarios = [
       { "Emtpy Scopes",


### PR DESCRIPTION
## Proposed Changes

Gracefully handle tokens which do not have scopes. When RabbitMQ is only used for authentication, not having scopes should not be an issue. And for authorization or access control, not having scopes is like having empty. scopes. 

Fixed #8391 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

The OAuth2 tutorial also demonstrates this use case: https://github.com/rabbitmq/rabbitmq-oauth2-tutorial#authn-with-oauth-authz-with-internal

