### PR TITLE
Add `bazel run rabbitmq-upgrade`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -204,6 +204,11 @@ rabbitmqctl(
     home = ":broker-home",
 )
 
+rabbitmqctl(
+    name = "rabbitmq-upgrade",
+    home = ":broker-home",
+)
+
 shell(
     name = "repl",
     deps = PLUGINS,


### PR DESCRIPTION
Adds a bazel shortcut for the command