### PR TITLE
rabbit_networking:ranch_ref/1: use the user-provided IP address/interface

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -223,7 +223,24 @@ ranch_ref(#listener{port = Port}) ->
     {acceptor, IPAddress, Port};
 ranch_ref(Listener) when is_list(Listener) ->
     Port = rabbit_misc:pget(port, Listener),
-    [{IPAddress, Port, _Family} | _] = tcp_listener_addresses(Port),
+    IPAddress = case rabbit_misc:pget(ip, Listener) of
+        undefined ->
+            [{Value, _Port, _Family} | _] = tcp_listener_addresses(Port),
+            Value;
+        Value when is_list(Value) ->
+            %% since we only use this function to parse the address, only one result should
+            %% be returned
+            [{Parsed, _Family} | _] = gethostaddr(Value, auto),
+            Parsed;
+        Value when is_binary(Value) ->
+            Str = rabbit_data_coercion:to_list(Value),
+            %% since we only use this function to parse the address, only one result should
+            %% be returned
+            [{Parsed, _Family} | _] = gethostaddr(Str, auto),
+            Parsed;
+        Value when is_tuple(Value) ->
+            Value
+    end,
     {acceptor, IPAddress, Port};
 ranch_ref(undefined) ->
     undefined.
@@ -692,6 +709,7 @@ getaddr(Host, Family) ->
         {error, _}      -> gethostaddr(Host, Family)
     end.
 
+-spec gethostaddr(string(), inet:address_family() | 'auto') -> [{inet:ip_address(), inet:address_family()}].
 gethostaddr(Host, auto) ->
     Lookups = [{Family, inet:getaddr(Host, Family)} || Family <- [inet, inet6]],
     case [{IP, Family} || {Family, {ok, IP}} <- Lookups] of


### PR DESCRIPTION
Otherwise the ref is miscalculated and certain code paths that depend on the ref correctness will fail. For example,
`rabbit_maintenance:{suspend,resume}_all_client_listeners/0`.

The issue was exposed by the changes in #8353, which shipped in `3.11.17`.
Closes #8415.

Pair: @lhoguin
