### PR TITLE
Fix /api/connections/username/{username} internal errors

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection_user_name.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection_user_name.erl
@@ -44,8 +44,8 @@ delete_resource({ok, Username, UserConns}, ReqData, Context) ->
 
 is_authorized(ReqData, Context) ->
     try
-        UserConns = list_user_connections(ReqData),
-        rabbit_mgmt_util:is_authorized_user(ReqData, Context, UserConns)
+        {ok, Username, _UserConns} = list_user_connections(ReqData),
+        rabbit_mgmt_util:is_authorized_user(ReqData, Context, [{user, Username}])
     catch
         {error, invalid_range_parameters, Reason} ->
             rabbit_mgmt_util:bad_request(iolist_to_binary(Reason), ReqData, Context)


### PR DESCRIPTION
Closes #8482, references #5319.

Calling `GET /api/connections/username/{username}` as a policymaker/management user leads to a 500 internal error.

Calling DETETE on  `/api/connections/username/{username}` as policymaker/monitor/management user leads to 500 internal error.

rabbit_mgmt_wm_connection_user_name calls `rabbit_mgmt_util:is_authorized_user/3` with a tuple as the 3rd argument, but it needs to be list with tuples. 
