### PR TITLE
CQ shared store write optimisations

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -855,6 +855,9 @@ requeue_and_run(AckTags, State = #q{backing_queue       = BQ,
 
 fetch(AckRequired, State = #q{backing_queue       = BQ,
                               backing_queue_state = BQS}) ->
+    %% @todo We should first drop expired messages then fetch
+    %%       the message, not the other way around. Otherwise
+    %%       we will send expired messages at times.
     {Result, BQS1} = BQ:fetch(AckRequired, BQS),
     State1 = drop_expired_msgs(State#q{backing_queue_state = BQS1}),
     {Result, maybe_send_drained(Result =:= empty, State1)}.

--- a/deps/rabbit/src/rabbit_msg_file.erl
+++ b/deps/rabbit/src/rabbit_msg_file.erl
@@ -7,7 +7,7 @@
 
 -module(rabbit_msg_file).
 
--export([append/3, read/2, pread/2, pread/3, scan/4]).
+-export([scan/4]).
 
 %%----------------------------------------------------------------------------
 
@@ -33,80 +33,6 @@
             A).
 
 %%----------------------------------------------------------------------------
-
--spec append(io_device(), rabbit_types:msg_id(), msg()) ->
-          rabbit_types:ok_or_error2(msg_size(), any()).
-
-append(FileHdl, MsgId, MsgBody)
-  when is_binary(MsgId) andalso size(MsgId) =:= ?MSG_ID_SIZE_BYTES ->
-    %% @todo I think we are actually writing MsgId TWICE: once in
-    %%       the header, once in the body. Might be better to reduce
-    %%       the size of the body...
-    MsgBodyBin  = term_to_binary(MsgBody),
-    MsgBodyBinSize = size(MsgBodyBin),
-    Size = MsgBodyBinSize + ?MSG_ID_SIZE_BYTES,
-    case file_handle_cache:append(FileHdl,
-                                  <<Size:?INTEGER_SIZE_BITS,
-                                    MsgId:?MSG_ID_SIZE_BYTES/binary,
-                                    MsgBodyBin:MsgBodyBinSize/binary,
-                                    ?WRITE_OK_MARKER:?WRITE_OK_SIZE_BITS>>) of
-        ok -> {ok, Size + ?FILE_PACKING_ADJUSTMENT};
-        KO -> KO
-    end.
-
--spec read(io_device(), msg_size()) ->
-          rabbit_types:ok_or_error2({rabbit_types:msg_id(), msg()},
-                                    any()).
-
-read(FileHdl, TotalSize) ->
-    Size = TotalSize - ?FILE_PACKING_ADJUSTMENT,
-    BodyBinSize = Size - ?MSG_ID_SIZE_BYTES,
-    case file_handle_cache:read(FileHdl, TotalSize) of
-        {ok, <<Size:?INTEGER_SIZE_BITS,
-               MsgId:?MSG_ID_SIZE_BYTES/binary,
-               MsgBodyBin:BodyBinSize/binary,
-               ?WRITE_OK_MARKER:?WRITE_OK_SIZE_BITS>>} ->
-            {ok, {MsgId, binary_to_term(MsgBodyBin)}};
-        KO -> KO
-    end.
-
--spec pread(io_device(), position(), msg_size()) ->
-            rabbit_types:ok_or_error2({rabbit_types:msg_id(), msg()},
-                                      any()).
-
-pread(FileHdl, Offset, TotalSize) ->
-    Size = TotalSize - ?FILE_PACKING_ADJUSTMENT,
-    BodyBinSize = Size - ?MSG_ID_SIZE_BYTES,
-    case file:pread(FileHdl, Offset, TotalSize) of
-        {ok, <<Size:?INTEGER_SIZE_BITS,
-               MsgId:?MSG_ID_SIZE_BYTES/binary,
-               MsgBodyBin:BodyBinSize/binary,
-               ?WRITE_OK_MARKER:?WRITE_OK_SIZE_BITS>>} ->
-            {ok, {MsgId, binary_to_term(MsgBodyBin)}};
-        KO -> KO
-    end.
-
--spec pread(io_device(), [{position(), msg_size()}]) ->
-            {ok, [msg()]} | {error, any()} | eof.
-
-pread(FileHdl, LocNums) ->
-    case file:pread(FileHdl, LocNums) of
-        {ok, DataL} -> {ok, pread_parse(DataL)};
-        KO -> KO
-    end.
-
-pread_parse([<<Size:?INTEGER_SIZE_BITS,
-               _MsgId:?MSG_ID_SIZE_BYTES/binary,
-               Rest0/bits>>|Tail]) ->
-    BodyBinSize = Size - ?MSG_ID_SIZE_BYTES,
-    <<MsgBodyBin:BodyBinSize/binary,
-      ?WRITE_OK_MARKER:?WRITE_OK_SIZE_BITS,
-      Rest/bits>> = Rest0,
-    [binary_to_term(MsgBodyBin)|pread_parse([Rest|Tail])];
-pread_parse([<<>>]) ->
-    [];
-pread_parse([<<>>|Tail]) ->
-    pread_parse(Tail).
 
 -spec scan(io_device(), file_size(), message_accumulator(A), A) ->
           {'ok', A, position()}.

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -1001,7 +1001,7 @@ internal_sync(State = #msstate { current_file_handle = CurHdl,
                                  clients             = Clients,
                                  cref_to_msg_ids     = CTM }) ->
     State1 = stop_sync_timer(State),
-    writer_flush(CurHdl),
+    ok = writer_flush(CurHdl),
     %% We confirm all pending messages because we know they are
     %% either on disk when we flush the current write file; or
     %% were removed by the queue already.


### PR DESCRIPTION
Another round of CQ shared message store optimisations and refactors, this time around writes.

The first commit is more a refactor than anything, although no longer calling fsync does help in some scenarios. The second commit should provide a noticeable boost in performance when there are no consumers.

@mkuratczyk I have renamed the branch.