### PR TITLE
Rename a couple of management UI tabs

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -43,7 +43,7 @@ var NAVIGATION = {'Overview':    ['#/',            "management"],
                   'Connections': ['#/connections', "management", true],
                   'Channels':    ['#/channels',    "management", true],
                   'Exchanges':   ['#/exchanges',   "management", true],
-                  'Queues':      ['#/queues',      "management", true],
+                  'Queues and Streams': ['#/queues',      "management", true],
                   'Admin':
                     [{'Users':         ['#/users',              "administrator"],
                       'Virtual Hosts': ['#/vhosts',             "administrator"],

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -366,7 +366,7 @@ function update_navigation() {
         }
         if (show(path)) {
           if (val.length < 3 || ( val[2] && ac.canAccessVhosts() )) {
-            l1 += '<li id="' + k + '"><a href="' + nav(path) + '"' +
+            l1 += '<li id="' + navigation_tab_id(k) + '"><a href="' + nav(path) + '"' +
                 (selected ? ' class="selected"' : '') + '>' + k + '</a></li>'
           }
         }
@@ -382,6 +382,10 @@ function update_navigation() {
 
     replace_content('tabs', l1);
     replace_content('rhs', l2);
+}
+
+function navigation_tab_id(value) {
+    return value.toLowerCase().replaceAll(/\s/g, "-")
 }
 
 function nav(pair) {

--- a/deps/rabbitmq_management/selenium/test/basic-auth/ac-administrator-without-vhost-permissions.js
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/ac-administrator-without-vhost-permissions.js
@@ -29,7 +29,7 @@ describe('administrator user without any vhosts permissions', function () {
     await overview.waitForQueuesTab()
     await overview.waitForExchangesTab()
     await overview.waitForAdminTab()
-    await overview.waitForStreamTab()
+    await overview.waitForStreamConnectionsTab()
   })
   it('can access all Admin menu options', async function () {
     await overview.clickOnAdminTab()

--- a/deps/rabbitmq_management/selenium/test/basic-auth/ac-management-without-vhost-permissions.js
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/ac-management-without-vhost-permissions.js
@@ -28,7 +28,7 @@ describe('management user without any vhosts permissions', function () {
     assert.rejects(overview.waitForQueuesTab())
     assert.rejects(overview.waitForExchangesTab())
     assert.rejects(overview.waitForAdminTab())
-    assert.rejects(overview.waitForStreamTab())
+    assert.rejects(overview.waitForStreamConnectionsTab())
   })
 
   it('cannot see nor choose any available vhost', async function () {

--- a/deps/rabbitmq_management/selenium/test/basic-auth/ac-monitoring-without-vhost-permissions.js
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/ac-monitoring-without-vhost-permissions.js
@@ -29,7 +29,7 @@ describe('monitoring user without any vhosts permissions', function () {
     await overview.waitForQueuesTab()
     await overview.waitForExchangesTab()
     await overview.waitForAdminTab()
-    await overview.waitForStreamTab()
+    await overview.waitForStreamConnectionsTab()
   })
   it('can access all Admin menu options', async function () {
     await overview.clickOnAdminTab()

--- a/deps/rabbitmq_management/selenium/test/pageobjects/BasePage.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/BasePage.js
@@ -11,7 +11,7 @@ const CHANNELS_TAB = By.css('div#menu ul#tabs li#channels')
 const QUEUES_AND_STREAMS_TAB = By.css('div#menu ul#tabs li#queues-and-streams')
 const EXCHANGES_TAB = By.css('div#menu ul#tabs li#exchanges')
 const ADMIN_TAB = By.css('div#menu ul#tabs li#admin')
-const STREAM_CONNECTIONS_TAB = By.css('div#menu ul#tabs li#stream')
+const STREAM_CONNECTIONS_TAB = By.css('div#menu ul#tabs li#stream-connections')
 
 module.exports = class BasePage {
   driver
@@ -83,7 +83,7 @@ module.exports = class BasePage {
   async clickOnStreamTab () {
     return this.click(STREAM_CONNECTIONS_TAB)
   }
-  async waitForStreamTab() {
+  async waitForStreamConnectionsTab() {
     return this.waitForDisplayed(STREAM_CONNECTIONS_TAB)
   }
 

--- a/deps/rabbitmq_management/selenium/test/pageobjects/BasePage.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/BasePage.js
@@ -5,13 +5,13 @@ const USER = By.css('li#logout')
 const LOGOUT_FORM = By.css('li#logout form')
 const SELECT_VHOSTS = By.css('select#show-vhost')
 
-const OVERVIEW_TAB = By.css('div#menu ul#tabs li#Overview')
-const CONNECTION_TAB = By.css('div#menu ul#tabs li#Connections')
-const CHANNELS_TAB = By.css('div#menu ul#tabs li#Channels')
-const QUEUES_TAB = By.css('div#menu ul#tabs li#Queues')
-const EXCHANGES_TAB = By.css('div#menu ul#tabs li#Exchanges')
-const ADMIN_TAB = By.css('div#menu ul#tabs li#Admin')
-const STREAM_TAB = By.css('div#menu ul#tabs li#Stream')
+const OVERVIEW_TAB = By.css('div#menu ul#tabs li#overview')
+const CONNECTIONS_TAB = By.css('div#menu ul#tabs li#connections')
+const CHANNELS_TAB = By.css('div#menu ul#tabs li#channels')
+const QUEUES_AND_STREAMS_TAB = By.css('div#menu ul#tabs li#queues-and-streams')
+const EXCHANGES_TAB = By.css('div#menu ul#tabs li#exchanges')
+const ADMIN_TAB = By.css('div#menu ul#tabs li#admin')
+const STREAM_CONNECTIONS_TAB = By.css('div#menu ul#tabs li#stream')
 
 module.exports = class BasePage {
   driver
@@ -42,14 +42,14 @@ module.exports = class BasePage {
   }
 
   async clickOnOverviewTab () {
-    return this.click(CONNECTION_TAB)
+    return this.click(CONNECTIONS_TAB)
   }
 
   async clickOnConnectionsTab () {
-    return this.click(CONNECTION_TAB)
+    return this.click(CONNECTIONS_TAB)
   }
   async waitForConnectionsTab() {
-    return this.waitForDisplayed(CONNECTION_TAB)
+    return this.waitForDisplayed(CONNECTIONS_TAB)
   }
 
   async clickOnAdminTab () {
@@ -74,17 +74,17 @@ module.exports = class BasePage {
   }
 
   async clickOnQueuesTab () {
-    return this.click(QUEUES_TAB)
+    return this.click(QUEUES_AND_STREAMS_TAB)
   }
   async waitForQueuesTab() {
-    return this.waitForDisplayed(QUEUES_TAB)
+    return this.waitForDisplayed(QUEUES_AND_STREAMS_TAB)
   }
 
   async clickOnStreamTab () {
-    return this.click(STREAM_TAB)
+    return this.click(STREAM_CONNECTIONS_TAB)
   }
   async waitForStreamTab() {
-    return this.waitForDisplayed(STREAM_TAB)
+    return this.waitForDisplayed(STREAM_CONNECTIONS_TAB)
   }
 
   async getSelectableVhosts() {

--- a/deps/rabbitmq_stream_management/priv/www/js/stream.js
+++ b/deps/rabbitmq_stream_management/priv/www/js/stream.js
@@ -32,7 +32,7 @@ dispatcher_add(function(sammy) {
     });
 });
 
-NAVIGATION['Stream'] = ['#/stream/connections', "monitoring"];
+NAVIGATION['Stream Connections'] = ['#/stream/connections', "monitoring"];
 
 var ALL_STREAM_CONNECTION_COLUMNS =
      {'Overview': [['user',   'User name', true],


### PR DESCRIPTION
 * Queues => Queues and Streams
 * Stream => Stream Connections

to better reflect what they display in modern versions.

Per discussion with the team.

To get there, we have to change the naming scheme for the navigation menu ids,
and update Selenium tests accordingly.

Hopefully nothing else depends on those
selectors. A few plugins I've verified do not:

 * `rabbitmq_stream_management`
 * `rabbitmq_shovel_management`
 * `rabbitmq_federation_management`
 * `rabbitmq_top`
