### PR TITLE
Remove the buildbuddy toolchain from the workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -215,17 +215,6 @@ load("//bazel/bzlmod:secondary_umbrella.bzl", "secondary_umbrella")
 
 secondary_umbrella()
 
-load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
-
-buildbuddy_deps()
-
-load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
-
-buildbuddy(
-    name = "buildbuddy_toolchain",
-    llvm = True,
-)
-
 git_repository(
     name = "rbe",
     branch = "linux-rbe",


### PR DESCRIPTION
It is not needed since we have our own equivalent, @rbe (https://github.com/rabbitmq/rbe-erlang-platform.git)