### PR TITLE
Add bazel flags suggested by buildbuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,8 @@ build:buildbuddy --experimental_remote_cache_async
 build:buildbuddy --noslim_profile
 build:buildbuddy --experimental_profile_include_target_label
 build:buildbuddy --experimental_profile_include_primary_output
+build:buildbuddy --experimental_remote_build_event_upload=minimal
+build:buildbuddy --nolegacy_important_outputs
 
 # buildbuddy implies remote cache, so ct_logdir is restored to its default for reproducibility
 build:buildbuddy --@rules_erlang//:ct_logdir=


### PR DESCRIPTION
These are visible when a build is viewed in buildbuddy. Should make builds a little more traffic efficient.