### PR TITLE
Use OTP 26 features

### DIFF
--- a/.github/workflows/check-build-system-equivalence.yaml
+++ b/.github/workflows/check-build-system-equivalence.yaml
@@ -4,7 +4,7 @@ on:
   - cron: '0 2 * * *'
   workflow_dispatch:
 env:
-  erlang_version: 25.3
+  erlang_version: 26.0
   elixir_version: 1.14
   VERSION: 3.13.0
   PLUGINS: amqp10_common amqp10_client rabbitmq_amqp1_0 rabbitmq_auth_backend_cache rabbitmq_auth_backend_http rabbitmq_auth_backend_ldap rabbitmq_auth_backend_oauth2 rabbitmq_auth_mechanism_ssl rabbitmq_consistent_hash_exchange rabbitmq_event_exchange rabbitmq_federation rabbitmq_jms_topic_exchange rabbitmq_mqtt rabbitmq_random_exchange rabbitmq_recent_history_exchange rabbitmq_sharding rabbitmq_shovel rabbitmq_stomp rabbitmq_stream rabbitmq_trust_store rabbitmq_web_dispatch rabbitmq_management_agent rabbitmq_management rabbitmq_prometheus rabbitmq_federation_management rabbitmq_shovel_management rabbitmq_stream_management rabbitmq_top rabbitmq_tracing rabbitmq_web_mqtt rabbitmq_web_mqtt_examples rabbitmq_web_stomp rabbitmq_web_stomp_examples rabbitmq_aws rabbitmq_peer_discovery_common rabbitmq_peer_discovery_aws rabbitmq_peer_discovery_k8s rabbitmq_peer_discovery_consul rabbitmq_peer_discovery_etcd

--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -22,8 +22,6 @@ jobs:
   # For example, for Git commit SHA '111aaa' and branch name 'main' and maximum supported Erlang major version '26',
   # the following tags will be pushed to Dockerhub:
   #
-  # * 111aaa-otp-min (image OTP 25)
-  # * main-otp-min (image OTP 25)
   # * 111aaa-otp-max (image OTP 26)
   # * main-otp-max (image OTP 26)
 
@@ -33,8 +31,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_tag_suffix: otp-min-bazel
-            otp_version_id: 25_3
           - image_tag_suffix: otp-max-bazel
             otp_version_id: 26
     steps:

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         otp_version_id:
-        - "25_3"
+        - "26"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY
@@ -171,7 +171,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - erlang_version: "25.3"
+        - erlang_version: "26.0"
           elixir_version: 1.14.5
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         otp_version_id:
-        - 25_3
         - 26
     timeout-minutes: 120
     steps:
@@ -82,8 +81,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - erlang_version: "25.3"
-          elixir_version: 1.14.5
         - erlang_version: "26.0"
           elixir_version: 1.14.5
     timeout-minutes: 60

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
@@ -6,8 +6,8 @@
 
 -export([check/1]).
 
--define(OTP_MINIMUM, "25.0").
--define(ERTS_MINIMUM, "13.0").
+-define(OTP_MINIMUM, "26.0").
+-define(ERTS_MINIMUM, "14.0").
 
 check(_Context) ->
     ?LOG_DEBUG(

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -77,7 +77,6 @@ start_rabbitmq_server() {
         -syslog logger '[]' \
         -syslog syslog_error_logger false \
         -kernel prevent_overlapping_partitions false \
-        -enable-feature maybe_expr \
         "$@"
 }
 

--- a/deps/rabbit/scripts/rabbitmq-server.bat
+++ b/deps/rabbit/scripts/rabbitmq-server.bat
@@ -71,7 +71,6 @@ if "!RABBITMQ_ALLOW_INPUT!"=="" (
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
 -kernel prevent_overlapping_partitions false ^
--enable-feature maybe_expr ^
 !STAR!
 
 if ERRORLEVEL 1 (

--- a/deps/rabbit/scripts/rabbitmq-service.bat
+++ b/deps/rabbit/scripts/rabbitmq-service.bat
@@ -201,7 +201,6 @@ set ERLANG_SERVICE_ARGUMENTS= ^
 -syslog logger [] ^
 -syslog syslog_error_logger false ^
 -kernel prevent_overlapping_partitions false ^
--enable-feature maybe_expr ^
 !STARVAR!
 
 set ERLANG_SERVICE_ARGUMENTS=!ERLANG_SERVICE_ARGUMENTS:\=\\!

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1000,7 +1000,7 @@ cluster_state(Name) ->
     case whereis(Name) of
         undefined -> down;
         _ ->
-            case ets_lookup_element(ra_state, Name, 2, undefined) of
+            case ets:lookup_element(ra_state, Name, 2, undefined) of
                 recover ->
                     recovering;
                 _ ->
@@ -1397,10 +1397,10 @@ i(messages, Q) when ?is_amqqueue(Q) ->
     quorum_messages(QName);
 i(messages_ready, Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    ets_lookup_element(queue_coarse_metrics, QName, 2, 0);
+    ets:lookup_element(queue_coarse_metrics, QName, 2, 0);
 i(messages_unacknowledged, Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    ets_lookup_element(queue_coarse_metrics, QName, 3, 0);
+    ets:lookup_element(queue_coarse_metrics, QName, 3, 0);
 i(policy, Q) ->
     case rabbit_policy:name(Q) of
         none   -> '';
@@ -1418,7 +1418,7 @@ i(effective_policy_definition, Q) ->
     end;
 i(consumers, Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    Consumers = ets_lookup_element(queue_metrics, QName, 2, []),
+    Consumers = ets:lookup_element(queue_metrics, QName, 2, []),
     proplists:get_value(consumers, Consumers, 0);
 i(memory, Q) when ?is_amqqueue(Q) ->
     {Name, _} = amqqueue:get_pid(Q),
@@ -1440,7 +1440,7 @@ i(state, Q) when ?is_amqqueue(Q) ->
     end;
 i(local_state, Q) when ?is_amqqueue(Q) ->
     {Name, _} = amqqueue:get_pid(Q),
-    ets_lookup_element(ra_state, Name, 2, not_member);
+    ets:lookup_element(ra_state, Name, 2, not_member);
 i(garbage_collection, Q) when ?is_amqqueue(Q) ->
     {Name, _} = amqqueue:get_pid(Q),
     try
@@ -1517,7 +1517,7 @@ open_files(Name) ->
         undefined ->
             {node(), 0};
         Pid ->
-            {node(), ets_lookup_element(ra_open_file_metrics, Pid, 2, 0)}
+            {node(), ets:lookup_element(ra_open_file_metrics, Pid, 2, 0)}
     end.
 
 leader(Q) when ?is_amqqueue(Q) ->
@@ -1576,7 +1576,7 @@ is_process_alive(Name, Node) ->
 -spec quorum_messages(rabbit_amqqueue:name()) -> non_neg_integer().
 
 quorum_messages(QName) ->
-    ets_lookup_element(queue_coarse_metrics, QName, 4, 0).
+    ets:lookup_element(queue_coarse_metrics, QName, 4, 0).
 
 quorum_ctag(Int) when is_integer(Int) ->
     integer_to_binary(Int);
@@ -1694,14 +1694,6 @@ prepare_content(Content) ->
     %% expiration is set. Therefore, leave properties decoded so that
     %% rabbit_fifo can directly parse it without having to decode again.
     Content.
-
-ets_lookup_element(Tbl, Key, Pos, Default) ->
-    try ets:lookup_element(Tbl, Key, Pos) of
-        V -> V
-    catch
-        _:badarg ->
-            Default
-    end.
 
 erpc_call(Node, M, F, A, _Timeout)
   when Node =:= node()  ->

--- a/deps/rabbit/src/rabbit_router.erl
+++ b/deps/rabbit/src/rabbit_router.erl
@@ -32,4 +32,4 @@ match_bindings(SrcName, Match) ->
     match_result().
 
 match_routing_key(SrcName, RoutingKeys) ->
-    rabbit_db_binding:match_routing_key(SrcName, RoutingKeys, false).
+    rabbit_db_binding:match_routing_key(SrcName, RoutingKeys).

--- a/deps/rabbit/test/rabbit_db_binding_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_binding_SUITE.erl
@@ -322,10 +322,10 @@ match_routing_key1(_Config) ->
     Exchange2 = #exchange{name = XName2, durable = true},
     Binding = #binding{source = XName1, key = <<"*.*">>, destination = XName2,
                        args = #{foo => bar}},
-    ?assertEqual([], rabbit_db_binding:match_routing_key(XName1, [<<"a.b.c">>], false)),
+    ?assertEqual([], rabbit_db_binding:match_routing_key(XName1, [<<"a.b.c">>])),
     ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(Exchange1)),
     ?assertMatch({new, #exchange{}}, rabbit_db_exchange:create_or_get(Exchange2)),
     ?assertMatch(ok, rabbit_db_binding:create(Binding, fun(_, _) -> ok end)),
-    ?assertEqual([], rabbit_db_binding:match_routing_key(XName1, [<<"a.b.c">>], false)),
-    ?assertEqual([XName2], rabbit_db_binding:match_routing_key(XName1, [<<"a.b">>], false)),
+    ?assertEqual([], rabbit_db_binding:match_routing_key(XName1, [<<"a.b.c">>])),
+    ?assertEqual([XName2], rabbit_db_binding:match_routing_key(XName1, [<<"a.b">>])),
     passed.

--- a/deps/rabbit_common/src/rabbit_writer.erl
+++ b/deps/rabbit_common/src/rabbit_writer.erl
@@ -265,10 +265,6 @@ handle_message({send_command_and_notify, QPid, ChPid, MethodRecord, Content},
 handle_message({'DOWN', _MRef, process, QPid, _Reason}, State) ->
     rabbit_amqqueue_common:notify_sent_queue_down(QPid),
     State;
-handle_message({inet_reply, _, ok}, State) ->
-    rabbit_event:ensure_stats_timer(State, #wstate.stats_timer, emit_stats);
-handle_message({inet_reply, _, Status}, _State) ->
-    exit({writer, send_failed, Status});
 handle_message(emit_stats, State = #wstate{reader = ReaderPid}) ->
     ReaderPid ! ensure_stats,
     rabbit_event:reset_stats_timer(State, #wstate.stats_timer);
@@ -381,33 +377,15 @@ maybe_flush(State = #wstate{pending = Pending}) ->
 
 internal_flush(State = #wstate{pending = []}) ->
     State;
-internal_flush(State = #wstate{sock = Sock, pending = Pending}) ->
-    ok = port_cmd(Sock, lists:reverse(Pending)),
-    State#wstate{pending = []}.
-
-%% gen_tcp:send/2 does a selective receive of {inet_reply, Sock,
-%% Status} to obtain the result. That is bad when it is called from
-%% the writer since it requires scanning of the writers possibly quite
-%% large message queue.
-%%
-%% So instead we lift the code from prim_inet:send/2, which is what
-%% gen_tcp:send/2 calls, do the first half here and then just process
-%% the result code in handle_message/2 as and when it arrives.
-%%
-%% This means we may end up happily sending data down a closed/broken
-%% socket, but that's ok since a) data in the buffers will be lost in
-%% any case (so qualitatively we are no worse off than if we used
-%% gen_tcp:send/2), and b) we do detect the changed socket status
-%% eventually, i.e. when we get round to handling the result code.
-%%
-%% Also note that the port has bounded buffers and port_command blocks
-%% when these are full. So the fact that we process the result
-%% asynchronously does not impact flow control.
-port_cmd(Sock, Data) ->
-    true = try rabbit_net:port_command(Sock, Data)
-           catch error:Error -> exit({writer, send_failed, Error})
-           end,
-    ok.
+internal_flush(State0 = #wstate{sock = Sock, pending = Pending}) ->
+    case rabbit_net:send(Sock, lists:reverse(Pending)) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            exit({writer, send_failed, Reason})
+    end,
+    State = State0#wstate{pending = []},
+    rabbit_event:ensure_stats_timer(State, #wstate.stats_timer, emit_stats).
 
 %% Some processes (channel, writer) can get huge amounts of binary
 %% garbage when processing huge messages at high speed (since we only

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_data.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_data.erl
@@ -367,12 +367,11 @@ match_consumer_spec(Id) ->
 match_queue_consumer_spec(Id) ->
     [{{{'$1', '_', '_'}, '_'}, [{'==', {Id}, '$1'}], ['$_']}].
 
-lookup_element(Table, Key) -> lookup_element(Table, Key, 2).
+lookup_element(Table, Key) ->
+    lookup_element(Table, Key, 2).
 
 lookup_element(Table, Key, Pos) ->
-    try ets:lookup_element(Table, Key, Pos)
-    catch error:badarg -> []
-    end.
+    ets:lookup_element(Table, Key, Pos, []).
 
 -spec lookup_smaller_sample(atom(), any()) -> maybe_slide().
 lookup_smaller_sample(Table, Id) ->

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -4,7 +4,6 @@ load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
     "BROKER_VERSION_REQUIREMENTS_ANY",
-    "ENABLE_FEATURE_MAYBE_EXPR",
     "RABBITMQ_DIALYZER_OPTS",
     "assert_suites",
     "broker_for_integration_suites",
@@ -122,7 +121,6 @@ eunit(
         ":test_event_recorder_beam",
         ":test_util_beam",
     ],
-    erl_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
     target = ":test_erlang_app",
 )
 

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -46,7 +46,7 @@ adapter_name(State) ->
   #stomp_configuration{},
   {SendFun, AdapterInfo, SSLLoginName, PeerAddr})
     -> #proc_state{}
-  when SendFun :: fun((atom(), binary()) -> term()),
+  when SendFun :: fun((binary()) -> term()),
        AdapterInfo :: #amqp_adapter_info{},
        SSLLoginName :: atom() | binary(),
        PeerAddr :: inet:ip_address().
@@ -1174,7 +1174,7 @@ send_frame(Command, Headers, BodyFragments, State) ->
 
 send_frame(Frame, State = #proc_state{send_fun = SendFun,
                                  trailing_lf = TrailingLF}) ->
-    SendFun(async, rabbit_stomp_frame:serialize(Frame, TrailingLF)),
+    SendFun(rabbit_stomp_frame:serialize(Frame, TrailingLF)),
     State.
 
 send_error_frame(Message, ExtraHeaders, Format, Args, State) ->

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -110,7 +110,7 @@ close_connection(Pid, Reason) ->
 
 init_processor_state(#state{socket=Sock, peername=PeerAddr, auth_hd=AuthHd}) ->
     Self = self(),
-    SendFun = fun (_Sync, Data) ->
+    SendFun = fun(Data) ->
                       Self ! {send, Data},
                       ok
               end,

--- a/erlang.mk
+++ b/erlang.mk
@@ -6667,8 +6667,7 @@ CT_RUN = ct_run \
 	-noinput \
 	-pa $(CURDIR)/ebin $(TEST_DIR) \
 	-dir $(TEST_DIR) \
-	-logdir $(CT_LOGS_DIR) \
-	-enable-feature maybe_expr
+	-logdir $(CT_LOGS_DIR)
 
 ifeq ($(CT_SUITES),)
 ct: $(if $(IS_APP)$(ROOT_DIR),,apps-ct)

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -22,8 +22,6 @@ STARTS_BACKGROUND_BROKER_TAG = "starts-background-broker"
 
 MIXED_VERSION_CLUSTER_TAG = "mixed-version-cluster"
 
-ENABLE_FEATURE_MAYBE_EXPR = "-enable-feature maybe_expr"
-
 RABBITMQ_ERLC_OPTS = DEFAULT_ERLC_OPTS + [
     "-DINSTR_MOD=gm",
 ]
@@ -182,7 +180,6 @@ def rabbitmq_suite(
     ct_test(
         name = name,
         compiled_suites = [":{}_beam_files".format(name)] + additional_beam,
-        ct_run_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
         data = native.glob(["test/{}_data/**/*".format(name)]) + data,
         test_env = dict({
             "RABBITMQ_CT_SKIP_AS_ERROR": "true",
@@ -242,7 +239,6 @@ def rabbitmq_integration_suite(
         suite_name = name,
         compiled_suites = [":{}_beam_files".format(name)] + additional_beam,
         tags = tags + [STARTS_BACKGROUND_BROKER_TAG],
-        ct_run_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
         data = native.glob(["test/{}_data/**/*".format(name)]) + data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",
@@ -265,7 +261,6 @@ def rabbitmq_integration_suite(
         suite_name = name,
         compiled_suites = [":{}_beam_files".format(name)] + additional_beam,
         tags = tags + [STARTS_BACKGROUND_BROKER_TAG, MIXED_VERSION_CLUSTER_TAG],
-        ct_run_extra_args = [ENABLE_FEATURE_MAYBE_EXPR],
         data = native.glob(["test/{}_data/**/*".format(name)]) + data,
         test_env = dict({
             "SKIP_MAKE_TEST_DIST": "true",


### PR DESCRIPTION
See commit messages.
RabbitMQ 3.13 will require OTP 26 as minimum required version.
The OTP 25 GitHub Action tests are expected to fail.