### PR TITLE
bazel {start,stop}-cluster: allow node index ranges for more control

### DIFF
--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -248,8 +248,9 @@ case $CMD in
             while ps -p "$pid" >/dev/null 2>&1; do sleep 1; done
         ;;
     start-cluster)
-        nodes=${NODES:=3}
-        for ((n=0; n < nodes; n++))
+        start_index=${NODES_START_INDEX:=0}
+        nodes=${NODES:=3}+$start_index
+        for ((n=start_index; n < nodes; n++))
         do
             setup_node_env "$n"
 
@@ -280,8 +281,9 @@ case $CMD in
         done
         ;;
     stop-cluster)
-        nodes=${NODES:=3}
-        for ((n=nodes-1; n >= 0; n--))
+        start_index=${NODES_START_INDEX:=0}
+        nodes=${NODES:=3}+$start_index
+        for ((n=nodes-1; n >= start_index; n--))
         do
             "$RABBITMQCTL" -n "rabbit-$n@$HOSTNAME" stop
         done


### PR DESCRIPTION
## Proposed Changes

Optional 'start_index' to start|stop-cluster command for testing.

A very small, hopefully non-intrusive change, that allows you to add/remove 'ranges' of nodes to a cluster.

Its been useful for manual testing, adding nodes to already started clusters etc.

The default behavior of start-cluster/stop-cluster is the same.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
