### PR TITLE
Show nodes in maintenance mode in UI

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/node.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/node.ejs
@@ -13,6 +13,12 @@
 <div class="hider">
   <div class="box">
   <table class="facts facts-l">
+<% if (node.drained) { %>
+    <tr>
+      <th>Status</th>
+      <td><abbr class="status-yellow" title="Broker is in maintenance mode.">In maintenance mode</abbr></td>
+    </tr>
+<% } %>
     <tr>
       <th>Uptime</th>
       <td><%= fmt_uptime(node.uptime) %></td>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
@@ -190,6 +190,9 @@
   <% } %>
   <% if (show_column('overview', 'info')) { %>
      <td>
+       <% if (node.drained) { %>
+         <abbr class="status-yellow" title="Broker in maintenance mode">maint.mode</abbr>
+       <% } %>
          <abbr title="Message rates"><%= fmt_string(node.rates_mode) %></abbr>
        <% if (node.type == 'disc') { %>
          <abbr title="Broker definitions are held on disc.">disc</abbr>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_node.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_node.erl
@@ -63,7 +63,7 @@ node_data(Node, ReqData) ->
     Nodes = proplists:get_value(nodes, S),
     Running = proplists:get_value(running_nodes, S),
     Type = find_type(Node, Nodes),
-    Basic = [[{name, Node}, {running, lists:member(Node, Running)}, {type, Type}]],
+    Basic = [[{name, Node}, {running, lists:member(Node, Running)}, {type, Type}, {drained, rabbit_maintenance:is_being_drained_local_read(Node)}]],
     case rabbit_mgmt_util:disable_stats(ReqData) of
         false ->
             rabbit_mgmt_db:augment_nodes(Basic, rabbit_mgmt_util:range_ceil(ReqData));

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_nodes.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_nodes.erl
@@ -51,5 +51,5 @@ all_nodes_raw() ->
     Nodes = proplists:get_value(nodes, S),
     Types = proplists:get_keys(Nodes),
     Running = proplists:get_value(running_nodes, S),
-    [[{name, Node}, {type, Type}, {running, lists:member(Node, Running)}] ||
+    [[{name, Node}, {type, Type}, {running, lists:member(Node, Running)}, {drained, rabbit_maintenance:is_being_drained_local_read(Node)}] ||
         Type <- Types, Node <- proplists:get_value(Type, Nodes)].


### PR DESCRIPTION
## Proposed Changes
See #8558

Add maintenance mode info in overview info field, and as new 'Status' row in node overview.

Not sure if this is already fixed though, but since I wanted to get some insight in how the UI works, I thought I'd spend
a little time. If its already fixed, throw this PR away :)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
Overview:
![image](https://github.com/rabbitmq/rabbitmq-server/assets/248800/51f16e3a-b52d-4433-932d-8af0aeb25a2e)

Node view:
![image](https://github.com/rabbitmq/rabbitmq-server/assets/248800/e5e8ab29-d433-41bc-ac5c-6784e7593254)

