### PR TITLE
Use a specific erlang version for the secondary umbrella

### DIFF
--- a/BUILD.package_generic_unix
+++ b/BUILD.package_generic_unix
@@ -21,6 +21,7 @@ rabbitmq_package_generic_unix(
 rabbitmq_run(
     name = "rabbitmq-run",
     home = ":broker-home",
+    otp = "@erlang_config//25_3:erlang_25_3_toolchain",
     visibility = ["//visibility:public"],
 )
 

--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -222,6 +222,14 @@ export RABBITMQ_SCRIPTS_DIR \
 
 HOSTNAME="$(hostname -s)"
 
+# install pre-built erlang if necessary
+if [[ ! -d '{ERLANG_HOME}' ]]; then
+    printf 'Extracting OTP from {ERLANG_TAR}\n'
+    tar --extract --directory / --file "$BASE_DIR"/'{ERLANG_TAR}'
+    printf "done.\n"
+    export PATH='{ERLANG_HOME}/bin':$PATH
+fi
+
 case $CMD in
     run-broker)
         setup_node_env


### PR DESCRIPTION
rather than selecting it dynamically via toolchain resolution

Requires a rules_erlang version with
https://github.com/rabbitmq/rules_erlang/pull/214 merged

In it's current form this will probably break local execution of mixed version tests. Further updates are needed so that with local execution, the old behavior is restored