### PR TITLE
Quorum queues: handle_tick bugfix

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1031,13 +1031,14 @@ handle_aux(_RaftState, cast, {#return{msg_ids = MsgIds,
         _ ->
             {no_reply, Aux0, Log0}
     end;
-handle_aux(leader, _, {handle_tick, Args},
+handle_aux(leader, _, {handle_tick, [QName, Overview, Nodes]},
            #?AUX{tick_pid = Pid} = Aux, Log, _) ->
     NewPid =
         case process_is_alive(Pid) of
             false ->
                 %% No active TICK pid
-                spawn(rabbit_quorum_queue, handle_tick, Args);
+                %% this function spawns and returns the tick process pid
+                rabbit_quorum_queue:handle_tick(QName, Overview, Nodes);
             true ->
                 %% Active TICK pid, do nothing
                 Pid


### PR DESCRIPTION
#7668 addressed the issue where multiple tick processes could be spawned should the previous one take longer than the tick interval. This didn't quite work as the rabbit_quorum_queue:handle_tick/3 function spawns it's own process to do the work which isn't the process that the aux tick handler checks before spawning.
