### PR TITLE
Drop a particularly flaky CMQ test

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -334,7 +334,7 @@ rabbitmq_integration_suite(
     name = "clustering_management_SUITE",
     size = "large",
     flaky = True,
-    shard_count = 19,
+    shard_count = 18,
     sharding_method = "case",
 )
 

--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -19,8 +19,7 @@ all() ->
     [
       {group, unclustered_2_nodes},
       {group, unclustered_3_nodes},
-      {group, clustered_2_nodes},
-      {group, clustered_4_nodes}
+      {group, clustered_2_nodes}
     ].
 
 groups() ->


### PR DESCRIPTION
Since CMQs are on their way out, we are only willing to spend so much time on it.

The test covers a scenario where four nodes are stopped, then one force booted and then immediately removed from the cluster. In other words, a scenario that's quite unrealistic.
