### PR TITLE
Osiris v1.6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -262,7 +262,7 @@ erlang_package.hex_package(
 
 erlang_package.git_package(
     repository = "rabbitmq/osiris",
-    tag = "v1.5.1",
+    tag = "v1.6.0",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -149,7 +149,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.5.1
+dep_osiris = git https://github.com/rabbitmq/osiris v1.6.0
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.4.0
 


### PR DESCRIPTION
This version contains support for the new chunk filtering feature (not implemented in this PR).

Also some improvements to replica init failures.
