### PR TITLE
Replace @rabbitmq.com addresses with rabbitmq-core@groups.vmware.com

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 Team RabbitMQ will investigate all responsibly disclosed vulnerabilities that affect
-a recent version in one of the [supported release series](https://www.rabbitmq.com/versions.html). 
+a recent version in one of the [supported release series](https://www.rabbitmq.com/versions.html).
 We ask all reporters to provide a reasonable amount of information that can be used to reproduce
 the observed behavior.
 
@@ -10,7 +10,7 @@ the observed behavior.
 RabbitMQ Core team really appreciates responsible vulnerability reports
 from security researchers and our user community.
 
-To responsibly disclose a vulnerability, please use [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) or email `security@rabbitmq.com` or
+To responsibly disclose a vulnerability, please use [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) or email `rabbitmq-core@groups.vmware.com` or
 [sign up for RabbitMQ community Slack](https://rabbitmq-slack.herokuapp.com) and
 send a DM to @michaelklishin. For reports received via Slack, a separate private
 channel will be set up so that multiple RabbitMQ maintainers can access the disclosed
@@ -29,7 +29,7 @@ A received vulnerability report will be acknowledged by a RabbitMQ core team or 
 
 As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
 
-### When Should I Report a Vulnerability? 
+### When Should I Report a Vulnerability?
 
  * You think you discovered a potential security vulnerability in RabbitMQ
  * You think you discovered a potential security vulnerability in one of RabbitMQ client libraries or dependencies

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting a project maintainer at [info@rabbitmq.com](mailto:info@rabbitmq.com). All complaints will
+contacting a project maintainer at [rabbitmq-core@groups.vmware.com](mailto:rabbitmq-core@groups.vmware.com). All complaints will
 be reviewed and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. Maintainers are obligated to maintain confidentiality
 with regard to the reporter of an incident.

--- a/LICENSE
+++ b/LICENSE
@@ -5,4 +5,4 @@ Some RabbitMQ server OCF files are licensed under the Apache Software License 2.
 For the ASL2, please see LICENSE-APACHE2.
 
 If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+rabbitmq-core@groups.vmware.com.

--- a/deps/amqp10_client/LICENSE
+++ b/deps/amqp10_client/LICENSE
@@ -1,4 +1,4 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
 If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+rabbitmq-core@groups.vmware.com.

--- a/deps/amqp10_common/LICENSE
+++ b/deps/amqp10_common/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ AMQP 1.0 commons library, is licensed under the MPL 2.0. For
 the MPL, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/amqp_client/LICENSE
+++ b/deps/amqp_client/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbit/LICENSE
+++ b/deps/rabbit/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ server is licensed under the MPL 2.0. For
 the MPL, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbit/SECURITY.md
+++ b/deps/rabbit/SECURITY.md
@@ -10,15 +10,15 @@ Vulnerabilities reported for versions out of support will not be investigated.
 
 ## Reporting a Vulnerability
 
-Please responsibly disclosure vulnerabilities to `security@rabbitmq.com` and include the following information:
+Please responsibly disclosure vulnerabilities to `rabbitmq-core@groups.vmware.com` and include the following information:
 
  * RabbitMQ and Erlang versions used
  * Operating system used
  * A set of steps to reproduce the observed behavior
  * An archive produced by [rabbitmq-collect-env](https://github.com/rabbitmq/support-tools/blob/main/scripts/rabbitmq-collect-env)
- 
+
  RabbitMQ core team will get back to you after we have triaged the issue. If there's no sufficient reproduction
  information available, we won't be able to act on the report.
- 
+
  RabbitMQ core team does not have a security vulnerability bounty programme at this time.
- 
+

--- a/deps/rabbit/docs/rabbitmq-diagnostics.8
+++ b/deps/rabbit/docs/rabbitmq-diagnostics.8
@@ -723,4 +723,4 @@ in
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-echopid.8
+++ b/deps/rabbit/docs/rabbitmq-echopid.8
@@ -67,4 +67,4 @@ The short-name form of the RabbitMQ node name.
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-env.conf.5
+++ b/deps/rabbit/docs/rabbitmq-env.conf.5
@@ -84,4 +84,4 @@ file RabbitMQ configuration file location is changed to "/data/services/rabbitmq
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-plugins.8
+++ b/deps/rabbit/docs/rabbitmq-plugins.8
@@ -252,4 +252,4 @@ plugin and its dependencies and disables everything else:
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-queues.8
+++ b/deps/rabbit/docs/rabbitmq-queues.8
@@ -202,4 +202,4 @@ Example:
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-server.8
+++ b/deps/rabbit/docs/rabbitmq-server.8
@@ -96,4 +96,4 @@ For example, runs RabbitMQ AMQP server in the background:
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-service.8
+++ b/deps/rabbit/docs/rabbitmq-service.8
@@ -150,4 +150,4 @@ is to discard the server output.
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-streams.8
+++ b/deps/rabbit/docs/rabbitmq-streams.8
@@ -438,4 +438,4 @@ for each consumer attached to the stream-1 stream and belonging to the stream-1 
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmq-upgrade.8
+++ b/deps/rabbit/docs/rabbitmq-upgrade.8
@@ -127,4 +127,4 @@ To learn more, see the
 .\" ------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -2603,4 +2603,4 @@ Reset stats database for all nodes in the cluster.
 .\" ------------------------------------------------------------------------------------------------
 .Sh AUTHOR
 .\" ------------------------------------------------------------------------------------------------
-.An The RabbitMQ Team Aq Mt info@rabbitmq.com
+.An The RabbitMQ Team Aq Mt rabbitmq-core@groups.vmware.com

--- a/deps/rabbit_common/LICENSE
+++ b/deps/rabbit_common/LICENSE
@@ -7,5 +7,4 @@ Mochi Media, Inc and licensed under a MIT license, see LICENSE-MIT-Mochi.
 The files 'rabbit_semver.erl' and 'rabbit_semver_parser.erl' are Copyright (c) 2011
 Erlware, LLC and licensed under a MIT license, see LICENSE-MIT-Erlware-Commons.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_amqp1_0/LICENSE
+++ b/deps/rabbitmq_amqp1_0/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_auth_backend_cache/LICENSE
+++ b/deps/rabbitmq_auth_backend_cache/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_auth_backend_http/LICENSE
+++ b/deps/rabbitmq_auth_backend_http/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_spring_boot/pom.xml
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_spring_boot/pom.xml
@@ -14,7 +14,7 @@
 
     <developers>
         <developer>
-            <email>info@rabbitmq.com</email>
+            <email>rabbitmq-core@groups.vmware.com</email>
             <name>Team RabbitMQ</name>
             <organization>VMware, Inc. or its affiliates.</organization>
             <organizationUrl>https://rabbitmq.com</organizationUrl>

--- a/deps/rabbitmq_auth_backend_ldap/LICENSE
+++ b/deps/rabbitmq_auth_backend_ldap/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_auth_backend_oauth2/LICENSE
+++ b/deps/rabbitmq_auth_backend_oauth2/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_auth_mechanism_ssl/LICENSE
+++ b/deps/rabbitmq_auth_mechanism_ssl/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_cli/LICENSE
+++ b/deps/rabbitmq_cli/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_codegen/LICENSE
+++ b/deps/rabbitmq_codegen/LICENSE
@@ -2,5 +2,5 @@ This package, the RabbitMQ code generation library and associated
 files, is licensed under the MPL 2.0. For the MPL 2.0, please see
 LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at 
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at
+rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_consistent_hash_exchange/LICENSE
+++ b/deps/rabbitmq_consistent_hash_exchange/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_ct_client_helpers/LICENSE
+++ b/deps/rabbitmq_ct_client_helpers/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_ct_helpers/LICENSE
+++ b/deps/rabbitmq_ct_helpers/LICENSE
@@ -8,5 +8,5 @@ For the Mozilla Public License, please see the file LICENSE-MPL-RabbitMQ.
 For attribution of copyright and other details of provenance, please
 refer to the source code.
 
-If you have any questions regarding licensing, please contact us at 
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at
+rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_event_exchange/LICENSE
+++ b/deps/rabbitmq_event_exchange/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_federation/LICENSE
+++ b/deps/rabbitmq_federation/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_federation_management/LICENSE
+++ b/deps/rabbitmq_federation_management/LICENSE
@@ -9,5 +9,4 @@ Sammy      - https://code.quirkey.com/sammy/           - MIT license, see LICENS
 cowboy     - https://github.com/ninenines/cowboy       - ISC license
 base64.js  - https://code.google.com/p/stringencoders/ - BSD license, see LICENSE-BSD-base64js
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_jms_topic_exchange/LICENSE
+++ b/deps/rabbitmq_jms_topic_exchange/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_management/LICENSE
+++ b/deps/rabbitmq_management/LICENSE
@@ -13,4 +13,4 @@ This package makes use of the following third party libraries:
 | Sammy          | https://code.quirkey.com/sammy/                         | MIT           | LICENSE-MIT-Sammy        |
 | jQuery         | https://jquery.com/                                     | MIT           | LICENSE-MIT-jQuery       |
 
-If you have any questions regarding licensing, please contact us at info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_management_agent/LICENSE
+++ b/deps/rabbitmq_management_agent/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_mqtt/LICENSE
+++ b/deps/rabbitmq_mqtt/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_peer_discovery_aws/LICENSE
+++ b/deps/rabbitmq_peer_discovery_aws/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_peer_discovery_common/LICENSE
+++ b/deps/rabbitmq_peer_discovery_common/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_peer_discovery_consul/LICENSE
+++ b/deps/rabbitmq_peer_discovery_consul/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_peer_discovery_etcd/LICENSE
+++ b/deps/rabbitmq_peer_discovery_etcd/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_peer_discovery_k8s/LICENSE
+++ b/deps/rabbitmq_peer_discovery_k8s/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_prometheus/LICENSE
+++ b/deps/rabbitmq_prometheus/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_random_exchange/LICENSE
+++ b/deps/rabbitmq_random_exchange/LICENSE
@@ -8,5 +8,5 @@ For the Mozilla Public License, please see the file LICENSE-MPL-RabbitMQ.
 For attribution of copyright and other details of provenance, please
 refer to the source code.
 
-If you have any questions regarding licensing, please contact us at 
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at
+rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_recent_history_exchange/LICENSE
+++ b/deps/rabbitmq_recent_history_exchange/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_sharding/LICENSE
+++ b/deps/rabbitmq_sharding/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_shovel/LICENSE
+++ b/deps/rabbitmq_shovel/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_shovel_management/LICENSE
+++ b/deps/rabbitmq_shovel_management/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_stomp/LICENSE
+++ b/deps/rabbitmq_stomp/LICENSE
@@ -1,4 +1,3 @@
 This package is licensed under the MPL 2.0. For the MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_stream/LICENSE
+++ b/deps/rabbitmq_stream/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ server is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
@@ -18,7 +18,7 @@
 
     <developers>
         <developer>
-            <email>info@rabbitmq.com</email>
+            <email>rabbitmq-core@groups.vmware.com</email>
             <name>Team RabbitMQ</name>
             <organization>VMware, Inc. or its affiliates.</organization>
             <organizationUrl>https://rabbitmq.com</organizationUrl>

--- a/deps/rabbitmq_stream_common/LICENSE
+++ b/deps/rabbitmq_stream_common/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ server is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_stream_management/LICENSE
+++ b/deps/rabbitmq_stream_management/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ server is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
@@ -18,7 +18,7 @@
 
     <developers>
         <developer>
-            <email>info@rabbitmq.com</email>
+            <email>rabbitmq-core@groups.vmware.com</email>
             <name>Team RabbitMQ</name>
             <organization>VMware, Inc. or its affiliates.</organization>
             <organizationUrl>https://rabbitmq.com</organizationUrl>

--- a/deps/rabbitmq_top/LICENSE
+++ b/deps/rabbitmq_top/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ Top plugin, is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_tracing/LICENSE
+++ b/deps/rabbitmq_tracing/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ Tracing plugin, is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_trust_store/LICENSE
+++ b/deps/rabbitmq_trust_store/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ Trust Store plugin, is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_web_dispatch/LICENSE
+++ b/deps/rabbitmq_web_dispatch/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ HTTP dispatcher library, is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_web_mqtt/LICENSE
+++ b/deps/rabbitmq_web_mqtt/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ MQTT-over-WebSockets plugin, is licensed under the MPL 2.0. For the
 MPL 2.0, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_web_mqtt_examples/LICENSE
+++ b/deps/rabbitmq_web_mqtt_examples/LICENSE
@@ -5,5 +5,4 @@ priv/mqttws31.js is a part of the Paho project
 (https://eclipse.org/paho/clients/js/) and is released under
 the EPL and the EDL.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_web_stomp/LICENSE
+++ b/deps/rabbitmq_web_stomp/LICENSE
@@ -1,5 +1,4 @@
 This package, the RabbitMQ STOMP-over-WebSockets plugin, is licensed under the MPL 2.0. For
 the MPL, please see LICENSE-MPL-RabbitMQ.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/deps/rabbitmq_web_stomp_examples/LICENSE
+++ b/deps/rabbitmq_web_stomp_examples/LICENSE
@@ -5,5 +5,4 @@ priv/stomp.js is a part of stomp-websocket project
 (https://github.com/jmesnil/stomp-websocket) and is released under
 APL2. For the license see LICENSE-APL2-Stomp-Websocket.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.

--- a/packaging/common/LICENSE.head
+++ b/packaging/common/LICENSE.head
@@ -1,5 +1,4 @@
 This package, the RabbitMQ server is licensed under the MPL2.0.
 
-If you have any questions regarding licensing, please contact us at
-info@rabbitmq.com.
+If you have any questions regarding licensing, please contact us at rabbitmq-core@groups.vmware.com.
 


### PR DESCRIPTION
Don't ask why we have to do it. Because reasons!
