### PR TITLE
Add log message during quorum queue recovery

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -576,6 +576,9 @@ recover(_Vhost, Queues) ->
                    {error, Err1}
                      when Err1 == not_started orelse
                           Err1 == name_not_registered ->
+                       rabbit_log:info("recover: Quorum queue '~ts' configured member was not found on node"
+                                       "Info ~s. Starting member as new member",
+                                       [rabbit_misc:rs(QName), Err1]),
                        % queue was never started on this node
                        % so needs to be started from scratch.
                        Machine = ra_machine(Q0),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -576,8 +576,8 @@ recover(_Vhost, Queues) ->
                    {error, Err1}
                      when Err1 == not_started orelse
                           Err1 == name_not_registered ->
-                       rabbit_log:info("recover: Quorum queue '~ts' configured member was not found on node"
-                                       "Info ~s. Starting member as new member",
+                       rabbit_log:info("Quorum queue recovery: configured member of ~ts was not found on this node. Starting member as a new one. "
+                                       "Context: ~s",
                                        [rabbit_misc:rs(QName), Err1]),
                        % queue was never started on this node
                        % so needs to be started from scratch.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -576,8 +576,8 @@ recover(_Vhost, Queues) ->
                    {error, Err1}
                      when Err1 == not_started orelse
                           Err1 == name_not_registered ->
-                       rabbit_log:info("Quorum queue recovery: configured member of ~ts was not found on this node. Starting member as a new one. "
-                                       "Context: ~s",
+                       rabbit_log:warning("Quorum queue recovery: configured member of ~ts was not found on this node. Starting member as a new one. "
+                                          "Context: ~s",
                                        [rabbit_misc:rs(QName), Err1]),
                        % queue was never started on this node
                        % so needs to be started from scratch.


### PR DESCRIPTION
When a configured member is not found on a node and has to be started as a new member.

This can happen if a quorum queue is declared when only two nodes are reachable out of three.
