### PR TITLE
CQ: Drop expired messages before fetching

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -853,14 +853,13 @@ requeue_and_run(AckTags, State = #q{backing_queue       = BQ,
     {_Dropped, State1} = maybe_drop_head(State#q{backing_queue_state = BQS1}),
     run_message_queue(maybe_send_drained(WasEmpty, drop_expired_msgs(State1))).
 
-fetch(AckRequired, State = #q{backing_queue       = BQ,
-                              backing_queue_state = BQS}) ->
-    %% @todo We should first drop expired messages then fetch
-    %%       the message, not the other way around. Otherwise
-    %%       we will send expired messages at times.
+fetch(AckRequired, State) ->
+    State1 = drop_expired_msgs(State),
+    #q{ backing_queue       = BQ,
+        backing_queue_state = BQS } = State1,
     {Result, BQS1} = BQ:fetch(AckRequired, BQS),
-    State1 = drop_expired_msgs(State#q{backing_queue_state = BQS1}),
-    {Result, maybe_send_drained(Result =:= empty, State1)}.
+    {Result, maybe_send_drained(Result =:= empty,
+                                State1#q{ backing_queue_state = BQS1 })}.
 
 ack(AckTags, ChPid, State) ->
     subtract_acks(ChPid, AckTags, State,


### PR DESCRIPTION
Otherwise we may send expired messages when a consumer connects in some cases.