### PR TITLE
Avoid secondary umbrella archive collisions in actions

### DIFF
--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -33,7 +33,7 @@ jobs:
     name: Prepare Artifacts
     runs-on: ubuntu-20.04
     env:
-      # otp-min
+      # otp-min, must also match the subdir in the secondary_umbrella.bzl
       otp_version_id: 25_3
     steps:
     - name: CHECKOUT REPOSITORY
@@ -105,7 +105,7 @@ jobs:
         mkdir ${OUTPUT_DIR}
         cp \
           bazel-bin/package-generic-unix.tar.xz \
-          ${OUTPUT_DIR}/package-generic-unix-for-mixed-version-testing-v${{ steps.check.outputs.version }}.tar.xz
+          ${OUTPUT_DIR}/rbe-${{ env.otp_version_id }}/package-generic-unix-for-mixed-version-testing-v${{ steps.check.outputs.version }}.tar.xz
     - name: UPLOAD THE ARCHIVE TO S3
       if: env.exists != 'true'
       uses: jakejarvis/s3-sync-action@v0.5.1

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -32,9 +32,6 @@ jobs:
   ensure-mixed-version-archive:
     name: Prepare Artifacts
     runs-on: ubuntu-20.04
-    env:
-      # otp-min, must also match the subdir in the secondary_umbrella.bzl
-      otp_version_id: 25_3
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v3
@@ -60,9 +57,13 @@ jobs:
         fi
         echo "exists=${exists}" | tee $GITHUB_ENV
 
+        OTP_VERSION_ID=${ARCHIVE_URL#*secondary-umbrellas/rbe-}
+        OTP_VERSION_ID=${OTP_VERSION_ID%*/package-generic-unix-for-mixed-version-testing-v*.tar.xz}
+        echo "otp_version_id=${OTP_VERSION_ID}" | tee -a $GITHUB_OUTPUT
+
         VERSION=${ARCHIVE_URL#*package-generic-unix-for-mixed-version-testing-v}
         VERSION=${VERSION%*.tar.xz}
-        echo "version=${VERSION}" | tee $GITHUB_OUTPUT
+        echo "version=${VERSION}" | tee -a $GITHUB_OUTPUT
     - name: CHECKOUT REPOSITORY (MIXED VERSION)
       if: env.exists != 'true'
       uses: actions/checkout@v3
@@ -97,15 +98,15 @@ jobs:
 
         sed -i"_orig" -E "/APP_VERSION/ s/3\.[0-9]+\.[0-9]+/${{ steps.check.outputs.version }}/" rabbitmq.bzl
         bazelisk build :package-generic-unix \
-          --config=rbe-${{ env.otp_version_id }} \
+          --config=rbe-${{ steps.check.outputs.otp_version_id }} \
           --test_build \
           --verbose_failures
 
         OUTPUT_DIR=${{ github.workspace }}/output
-        mkdir ${OUTPUT_DIR}
+        mkdir -p ${OUTPUT_DIR}/rbe-${{ steps.check.outputs.otp_version_id }}
         cp \
           bazel-bin/package-generic-unix.tar.xz \
-          ${OUTPUT_DIR}/rbe-${{ env.otp_version_id }}/package-generic-unix-for-mixed-version-testing-v${{ steps.check.outputs.version }}.tar.xz
+          ${OUTPUT_DIR}/rbe-${{ steps.check.outputs.otp_version_id }}/package-generic-unix-for-mixed-version-testing-v${{ steps.check.outputs.version }}.tar.xz
     - name: UPLOAD THE ARCHIVE TO S3
       if: env.exists != 'true'
       uses: jakejarvis/s3-sync-action@v0.5.1

--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -31,6 +31,6 @@ def secondary_umbrella():
         strip_prefix = "rabbitmq_server-3.11.18",
         # This file is produced just in time by the test-mixed-versions.yaml GitHub Actions workflow.
         urls = [
-            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/package-generic-unix-for-mixed-version-testing-v3.11.18.tar.xz",
+            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/rbe-25_3/package-generic-unix-for-mixed-version-testing-v3.11.18.tar.xz",
         ],
     )


### PR DESCRIPTION
`secondary-umbrellas/rbe-${otp_version_id}/package-generic-unix-for-mixed-version-testing-v${version }.tar.xz`

Makes the version of otp used for compiling the archive predictable in tests