### PR TITLE
Add support for LOCAL proxy header

### DIFF
--- a/deps/rabbit/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbit/test/proxy_protocol_SUITE.erl
@@ -21,8 +21,9 @@ all() ->
 
 groups() -> [
         {sequential_tests, [], [
-            proxy_protocol,
-            proxy_protocol_tls
+            proxy_protocol_v1,
+            proxy_protocol_v1_tls,
+            proxy_protocol_v2_local
         ]}
     ].
 
@@ -55,7 +56,7 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-proxy_protocol(Config) ->
+proxy_protocol_v1(Config) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
@@ -68,7 +69,7 @@ proxy_protocol(Config) ->
     gen_tcp:close(Socket),
     ok.
 
-proxy_protocol_tls(Config) ->
+proxy_protocol_v1_tls(Config) ->
     app_utils:start_applications([asn1, crypto, public_key, ssl]),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp_tls),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
@@ -80,6 +81,23 @@ proxy_protocol_tls(Config) ->
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    gen_tcp:close(Socket),
+    ok.
+
+proxy_protocol_v2_local(Config) ->
+    ProxyInfo = #{
+        command => local,
+        version => 2
+    },
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
+        [binary, {active, false}, {packet, raw}]),
+    ok = inet:send(Socket, ranch_proxy_header:header(ProxyInfo)),
+    ok = inet:send(Socket, <<"AMQP", 0, 0, 9, 1>>),
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
+    ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
@@ -20,8 +20,9 @@ all() ->
 
 groups() -> [
         {sequential_tests, [], [
-            proxy_protocol,
-            proxy_protocol_tls
+            proxy_protocol_v1,
+            proxy_protocol_v1_tls,
+            proxy_protocol_v2_local
         ]}
     ].
 
@@ -54,7 +55,7 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-proxy_protocol(Config) ->
+proxy_protocol_v1(Config) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
@@ -68,7 +69,7 @@ proxy_protocol(Config) ->
     gen_tcp:close(Socket),
     ok.
 
-proxy_protocol_tls(Config) ->
+proxy_protocol_v1_tls(Config) ->
     app_utils:start_applications([asn1, crypto, public_key, ssl]),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp_tls),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
@@ -84,6 +85,25 @@ proxy_protocol_tls(Config) ->
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
+
+proxy_protocol_v2_local(Config) ->
+    ProxyInfo = #{
+        command => local,
+        version => 2
+    },
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
+        [binary, {active, false}, {packet, raw}]),
+    ok = inet:send(Socket, ranch_proxy_header:header(ProxyInfo)),
+    [ok = inet:send(Socket, amqp_1_0_frame(FrameType))
+        || FrameType <- [header_sasl, sasl_init, header_amqp, open, 'begin']],
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
+    ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
+    gen_tcp:close(Socket),
+    ok.
+
 
 %% hex frames to send to have the connection recorded in RabbitMQ
 %% use wireshark with one of the Java tests to record those

--- a/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
@@ -26,8 +26,9 @@ groups() ->
 
 tests() ->
     [
-     proxy_protocol,
-     proxy_protocol_tls
+     proxy_protocol_v1,
+     proxy_protocol_v1_tls,
+     proxy_protocol_v2_local
     ].
 
 init_per_suite(Config) ->
@@ -66,7 +67,7 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-proxy_protocol(Config) ->
+proxy_protocol_v1(Config) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
@@ -79,7 +80,7 @@ proxy_protocol(Config) ->
     gen_tcp:close(Socket),
     ok.
 
-proxy_protocol_tls(Config) ->
+proxy_protocol_v1_tls(Config) ->
     app_utils:start_applications([asn1, crypto, public_key, ssl]),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt_tls),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
@@ -91,6 +92,23 @@ proxy_protocol_tls(Config) ->
     timer:sleep(10),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    gen_tcp:close(Socket),
+    ok.
+
+proxy_protocol_v2_local(Config) ->
+    ProxyInfo = #{
+        command => local,
+        version => 2
+    },
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mqtt),
+    {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
+        [binary, {active, false}, {packet, raw}]),
+    ok = inet:send(Socket, ranch_proxy_header:header(ProxyInfo)),
+    ok = inet:send(Socket, connect_packet(Config)),
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
+    timer:sleep(10),
+    ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/proxy_protocol_SUITE.erl
@@ -21,8 +21,9 @@ all() ->
 groups() ->
     [
         {non_parallel_tests, [], [
-            proxy_protocol,
-            proxy_protocol_tls
+            proxy_protocol_v1,
+            proxy_protocol_v1_tls,
+            proxy_protocol_v2_local
         ]}
     ].
 
@@ -59,7 +60,7 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-proxy_protocol(Config) ->
+proxy_protocol_v1(Config) ->
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
         [binary, {active, false}, {packet, raw}]),
@@ -72,7 +73,7 @@ proxy_protocol(Config) ->
     gen_tcp:close(Socket),
     ok.
 
-proxy_protocol_tls(Config) ->
+proxy_protocol_v1_tls(Config) ->
     app_utils:start_applications([asn1, crypto, public_key, ssl]),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp_tls),
     {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
@@ -84,6 +85,23 @@ proxy_protocol_tls(Config) ->
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    gen_tcp:close(Socket),
+    ok.
+
+proxy_protocol_v2_local(Config) ->
+    ProxyInfo = #{
+        command => local,
+        version => 2
+    },
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
+    {ok, Socket} = gen_tcp:connect({127,0,0,1}, Port,
+        [binary, {active, false}, {packet, raw}]),
+    ok = inet:send(Socket, ranch_proxy_header:header(ProxyInfo)),
+    ok = inet:send(Socket, stomp_connect_frame()),
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
+    ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 

--- a/deps/rabbitmq_web_mqtt/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/proxy_protocol_SUITE.erl
@@ -25,7 +25,8 @@ all() ->
 
 groups() ->
     Tests = [
-        proxy_protocol
+        proxy_protocol_v1,
+        proxy_protocol_v2_local
     ],
     [{https_tests, [], Tests},
      {http_tests, [], Tests}].
@@ -77,7 +78,7 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-proxy_protocol(Config) ->
+proxy_protocol_v1(Config) ->
     PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
 
     Protocol = ?config(protocol, Config),
@@ -89,6 +90,26 @@ proxy_protocol(Config) ->
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    {close, _} = rfc6455_client:close(WS),
+    ok.
+
+proxy_protocol_v2_local(Config) ->
+    ProxyInfo = #{
+        command => local,
+        version => 2
+    },
+
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+
+    Protocol = ?config(protocol, Config),
+    WS = rfc6455_client:new(Protocol ++ "://127.0.0.1:" ++ PortStr ++ "/ws", self(),
+        undefined, ["mqtt"], ranch_proxy_header:header(ProxyInfo)),
+    {ok, _} = rfc6455_client:open(WS),
+    rfc6455_client:send_binary(WS, rabbit_ws_test_util:mqtt_3_1_1_connect_packet()),
+    {binary, _P} = rfc6455_client:recv(WS),
+    ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
     {close, _} = rfc6455_client:close(WS),
     ok.
 

--- a/deps/rabbitmq_web_stomp/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/proxy_protocol_SUITE.erl
@@ -26,7 +26,8 @@ all() ->
 
 groups() ->
     Tests = [
-        proxy_protocol
+        proxy_protocol_v1,
+        proxy_protocol_v2_local
     ],
     [{https_tests, [], Tests},
      {http_tests, [], Tests}].
@@ -78,7 +79,7 @@ init_per_testcase(Testcase, Config) ->
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
-proxy_protocol(Config) ->
+proxy_protocol_v1(Config) ->
     Port = list_to_integer(rabbit_ws_test_util:get_web_stomp_port_str(Config)),
     PortStr = integer_to_list(Port),
 
@@ -92,6 +93,28 @@ proxy_protocol(Config) ->
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    {close, _} = rfc6455_client:close(WS),
+    ok.
+
+proxy_protocol_v2_local(Config) ->
+    ProxyInfo = #{
+        command => local,
+        version => 2
+    },
+
+    Port = list_to_integer(rabbit_ws_test_util:get_web_stomp_port_str(Config)),
+    PortStr = integer_to_list(Port),
+
+    Protocol = ?config(protocol, Config),
+    WS = rfc6455_client:new(Protocol ++ "://127.0.0.1:" ++ PortStr ++ "/ws", self(),
+        undefined, [], ranch_proxy_header:header(ProxyInfo)),
+    {ok, _} = rfc6455_client:open(WS),
+    Frame = stomp:marshal("CONNECT", [{"login","guest"}, {"passcode", "guest"}], <<>>),
+    rfc6455_client:send(WS, Frame),
+    {ok, _P} = rfc6455_client:recv(WS),
+    ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, connection_name, []),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
     {close, _} = rfc6455_client:close(WS),
     ok.
 


### PR DESCRIPTION
This is what the proxy uses for health checks. In those cases we use the socket's IP/ports for the connection name as we have nothing else we can use.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)

Depends on what we consider #8654 to be.