### PR TITLE
Deprecate features in the code for RabbitMQ 4.0

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -804,6 +804,11 @@ rabbitmq_integration_suite(
 )
 
 rabbitmq_integration_suite(
+    name = "rabbitmq_4_0_deprecations_SUITE",
+    size = "large",
+)
+
+rabbitmq_integration_suite(
     name = "rabbitmq_queues_cli_integration_SUITE",
     size = "medium",
 )

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -1963,3 +1963,12 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp_client:erlang_app"],
     )
+    erlang_bytecode(
+        name = "rabbitmq_4_0_deprecations_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/rabbitmq_4_0_deprecations_SUITE.erl"],
+        outs = ["test/rabbitmq_4_0_deprecations_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+        deps = ["//deps/amqp_client:erlang_app"],
+    )

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -193,12 +193,6 @@
                    [{description, "core initialized"},
                     {requires,    kernel_ready}]}).
 
--rabbit_boot_step({deprecate_cmqs,
-                   [{description, "checks whether mirrored queues are disabled"},
-                    {mfa, {rabbit_mirror_queue_misc, prevent_startup_when_mirroring_is_disabled_but_configured, []}},
-                    {requires, [database]},
-                    {enables, [recovery]}]}).
-
 -rabbit_boot_step({recovery,
                    [{description, "exchange, queue and binding recovery"},
                     {mfa,         {rabbit, recover, []}},

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -929,9 +929,9 @@ credential_validator.regexp = ^abc\\d+",
   %%
 
   {deprecated_features_cmq,
-   "deprecated_features.permit.classic_mirrored_queues = false",
+   "deprecated_features.permit.classic_queue_mirroring = false",
    [{rabbit, [
-      {permit_deprecated_features, #{classic_mirrored_queues => false}}
+      {permit_deprecated_features, #{classic_queue_mirroring => false}}
      ]}],
    []},
 

--- a/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
+++ b/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
@@ -1,0 +1,182 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbitmq_4_0_deprecations_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+-export([suite/0,
+         all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2,
+
+         when_global_qos_is_permitted_by_default/1,
+         when_global_qos_is_not_permitted_from_conf/1
+        ]).
+
+suite() ->
+    [{timetrap, {minutes, 5}}].
+
+all() ->
+    [
+     {group, global_qos}
+    ].
+
+groups() ->
+    [
+     {global_qos, [],
+      [when_global_qos_is_permitted_by_default,
+       when_global_qos_is_not_permitted_from_conf]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    logger:set_primary_config(level, debug),
+    rabbit_ct_helpers:run_setup_steps(
+      Config,
+      [fun rabbit_ct_helpers:redirect_logger_to_ct_logs/1]).
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(global_qos, Config) ->
+    rabbit_ct_helpers:set_config(Config, {rmq_nodes_count, 1});
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, Config) ->
+    Config.
+
+init_per_testcase(
+  when_global_qos_is_not_permitted_from_conf = Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:merge_app_env(
+                Config,
+                {rabbit,
+                 [{permit_deprecated_features, #{global_qos => false}}]}),
+    init_per_testcase1(Testcase, Config1);
+init_per_testcase(Testcase, Config) ->
+    init_per_testcase1(Testcase, Config).
+
+init_per_testcase1(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    ClusterSize = ?config(rmq_nodes_count, Config),
+    TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase},
+        {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}},
+        {keep_pid_file_on_exit, true}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Global QoS.
+%% -------------------------------------------------------------------
+
+when_global_qos_is_permitted_by_default(Config) ->
+    [NodeA] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    ExistingServerChs = list_server_channels(Config, NodeA),
+    ClientCh = rabbit_ct_client_helpers:open_channel(Config, NodeA),
+    [ServerCh] = list_server_channels(Config, NodeA) -- ExistingServerChs,
+
+    ?assertNot(is_prefetch_limited(ServerCh)),
+
+    %% It's possible to request global QoS and it is accepted by the server.
+    ?assertMatch(
+       #'basic.qos_ok'{},
+       amqp_channel:call(
+         ClientCh,
+         #'basic.qos'{global = true, prefetch_count = 10})),
+    ?assert(is_prefetch_limited(ServerCh)),
+
+    ?assert(
+       log_file_contains_message(
+         Config, NodeA,
+         ["Deprecated features: `global_qos`: Feature `global_qos` is deprecated",
+          "By default, this feature can still be used for now."])).
+
+when_global_qos_is_not_permitted_from_conf(Config) ->
+    [NodeA] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    ExistingServerChs = list_server_channels(Config, NodeA),
+    ClientCh = rabbit_ct_client_helpers:open_channel(Config, NodeA),
+    [ServerCh] = list_server_channels(Config, NodeA) -- ExistingServerChs,
+
+    ?assertNot(is_prefetch_limited(ServerCh)),
+
+    %% It's possible to request global QoS but it is ignored by the server.
+    ?assertMatch(
+       #'basic.qos_ok'{},
+       amqp_channel:call(
+         ClientCh,
+         #'basic.qos'{global = true, prefetch_count = 10})),
+    ?assertNot(is_prefetch_limited(ServerCh)),
+
+    ?assert(
+       log_file_contains_message(
+         Config, NodeA,
+         ["Deprecated features: `global_qos`: Feature `global_qos` is deprecated",
+          "Its use is not permitted per the configuration"])).
+
+list_server_channels(Config, Node) ->
+    rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_channel, list, []).
+
+is_prefetch_limited(ServerCh) ->
+    GenServer2State = sys:get_state(ServerCh),
+    ChState = element(4, GenServer2State),
+    ct:pal("Server channel (~p) state: ~p", [ServerCh, ChState]),
+    LimiterState = element(3, ChState),
+    element(3, LimiterState).
+
+%% -------------------------------------------------------------------
+%% Helpers.
+%% -------------------------------------------------------------------
+
+log_file_contains_message(Config, Node, Messages) ->
+    _ = catch rabbit_ct_broker_helpers:rpc(
+                Config, Node, rabbit_logger_std_h, filesync, [rmq_1_file_1]),
+    _ = catch rabbit_ct_broker_helpers:rpc(
+                Config, Node, rabbit_logger_std_h, filesync, [rmq_2_file_1]),
+    LogLocations = rabbit_ct_broker_helpers:rpc(
+                     Config, Node, rabbit, log_locations, []),
+    LogFiles = [LogLocation ||
+                LogLocation <- LogLocations,
+                filelib:is_regular(LogLocation)],
+    ?assertNotEqual([], LogFiles),
+    lists:any(
+      fun(LogFile) ->
+              {ok, Content} = file:read_file(LogFile),
+              find_messages(Content, Messages)
+      end, LogFiles).
+
+find_messages(Content, [Message | Rest]) ->
+    case string:find(Content, Message) of
+        nomatch   -> false;
+        Remaining -> find_messages(Remaining, Rest)
+    end;
+find_messages(_Content, []) ->
+    true.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_app.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_app.erl
@@ -27,10 +27,10 @@
                     {mfa,         {rabbit_mgmt_load_definitions, boot, []}}]}).
 
 start(_Type, _StartArgs) ->
-    case application:get_env(rabbitmq_management_agent, disable_metrics_collector, false) of
-        false ->
-            start();
+    case rabbit_mgmt_agent_config:is_metrics_collector_enabled() of
         true ->
+            start();
+        false ->
             rabbit_log:warning("Metrics collection disabled in management agent, "
                                "management only interface started", []),
             start()

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -7,12 +7,21 @@
 
 -module(rabbit_mgmt_features).
 
--export([is_op_policy_updating_disabled/0]).
+-export([is_op_policy_updating_disabled/0,
+         are_stats_enabled/0]).
 
 is_op_policy_updating_disabled() ->
     case get_restriction([operator_policy_changes, disabled]) of
         true -> true;
         _ -> false
+    end.
+
+are_stats_enabled() ->
+    DisabledFromConf = application:get_env(
+      rabbitmq_management, disable_management_stats, false),
+    case DisabledFromConf of
+        true -> false;
+        _    -> rabbit_mgmt_agent_config:is_metrics_collector_permitted()
     end.
 
 %% Private

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -135,8 +135,9 @@ disable_stats(ReqData) ->
                    <<"true">> -> true;
                    _ -> false
                end,
-    MgmtOnly orelse get_bool_env(rabbitmq_management, disable_management_stats, false)
-        orelse get_bool_env(rabbitmq_management_agent, disable_metrics_collector, false).
+    MgmtOnly orelse
+    not rabbit_mgmt_agent_config:is_metrics_collector_enabled() orelse
+    not rabbit_mgmt_features:are_stats_enabled().
 
 enable_queue_totals(ReqData) ->
     EnableTotals = case qs_val(<<"enable_queue_totals">>, ReqData) of

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_agent_config.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_agent_config.erl
@@ -7,6 +7,14 @@
 -module(rabbit_mgmt_agent_config).
 
 -export([get_env/1, get_env/2]).
+-export([is_metrics_collector_enabled/0,
+         is_metrics_collector_permitted/0]).
+
+-rabbit_deprecated_feature(
+   {management_metrics_collection,
+    #{deprecation_phase => permitted_by_default,
+      doc_url => "https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#disable-metrics-delivery-via-the-management-api--ui"
+     }}).
 
 %% some people have reasons to only run with the agent enabled:
 %% make it possible for them to configure key management app
@@ -20,3 +28,15 @@ get_env(Key, Default) ->
     rabbit_misc:get_env(rabbitmq_management, Key,
                         rabbit_misc:get_env(rabbitmq_management_agent, Key,
                                             Default)).
+
+is_metrics_collector_enabled() ->
+    DisabledFromConf = application:get_env(
+      rabbitmq_management_agent, disable_metrics_collector, false),
+    case DisabledFromConf of
+        true -> false;
+        _    -> is_metrics_collector_permitted()
+    end.
+
+is_metrics_collector_permitted() ->
+    FeatureName = management_metrics_collection,
+    rabbit_deprecated_features:is_permitted(FeatureName).

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_agent_sup.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_agent_sup.erl
@@ -34,8 +34,8 @@ start_link() ->
 
 
 maybe_enable_metrics_collector() ->
-    case application:get_env(rabbitmq_management_agent, disable_metrics_collector, false) of
-        false ->
+    case rabbit_mgmt_agent_config:is_metrics_collector_enabled() of
+        true ->
             ok = pg:join(?MANAGEMENT_PG_SCOPE, ?MANAGEMENT_PG_GROUP, self()),
             ST = {rabbit_mgmt_storage, {rabbit_mgmt_storage, start_link, []},
                   permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_storage]},
@@ -52,6 +52,6 @@ maybe_enable_metrics_collector() ->
             GC = {rabbit_mgmt_gc, {rabbit_mgmt_gc, start_link, []},
           permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_gc]},
             [ST, MD, GC | MC ++ MGC];
-        true ->
+        false ->
             []
     end.


### PR DESCRIPTION
### Why

A number of [features were deprecated in August 2021](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/). This was a public announcement, but people actually using RabbitMQ may not pay attention to this kind of communication.

A Deprecated features subsystem was introduced in #7390. It allows to implement a deprecation in the code so that users get warnings and errors from RabbitMQ itself. This increases the chance they are aware that they rely on a feature that is going away.

### How

This branch has one commit per deprecated feature. Each commit declares the deprecated feature and uses the subsystem to test if the feature is permitted.

Here is the list of deprecated features:

* [x] [Management plugin metrics collection](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#disable-metrics-delivery-via-the-management-api--ui)
* [x] [Global QoS](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#removal-of-global-qos)
* [x] [RAM nodes](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#removal-of-ram-nodes)
* [x] [Classic queue mirroring](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#removal-of-classic-queue-mirroring)
* [x] [Transient non-exclusive queues](https://blog.rabbitmq.com/posts/2021/08/4.0-deprecation-announcements/#removal-of-transient-non-exclusive-queues)

Deprecated features can be turned off from the configuration file using any or all of the following configuration parameters:

```ini
deprecated_features.permit.management_metrics_collection = false
deprecated_features.permit.global_qos = false
deprecated_features.permit.ram_node_type = false
deprecated_features.permit.classic_queue_mirroring = false
deprecated_features.permit.transient_nonexcl_queues = false
```

These configuration parameters are only evaluated when the node starts, not at runtime.

Below, you will find the behavior to expect once a deprecated feature is not permitted.

#### Management plugin metrics collection

Management metrics collection can be turned off anytime, there are no conditions to do that.

Once management metrics collection is turned off, the management API will not report any metrics and the UI will show empty graphs. This is the same behavior than when `management_agent.disable_metrics_collector` is set to `false` in the configuration.

#### Global QoS

Global QoS can be turned off anytime, there are no conditions to do that.

Once global QoS is turned off, the prefetch setting will always be considered as non-global (i.e. per-consumer). A warning message will be logged if the default prefetch setting enables global QoS or anytime a client requests a global QoS on the channel.

#### RAM nodes

RAM nodes can be turned off anytime, there are no conditions to do that.

Once RAM nodes are turned off:
* An existing node previously created as a RAM node will change itself to a disc node during boot.
* If a new node is added to the cluster using peer discovery or the CLI, it will be as a disc node and a warning will be logged if the requested node type is RAM.
* The `change_cluster_node_type` CLI command will reject a change to a RAM node with an error.

#### Classic queue mirroring

To turn off classic queue mirroring, there must be no classic mirrored queues declared and no HA policy defined. A node with classic mirrored queues will refuse to start if classic queue mirroring is turned off.

Once classic queue mirroring is turned off, users will not be able to declare HA policies. Trying to do that from the CLI or the management API will be rejected with a warning in the logs. This impacts clustering too: a node with classic queue mirroring turned off will only cluster with another node which has no HA policy or has classic queue mirroring turned off.

#### Transient non-exclusive queues

Non-exclusive transient queues can be turned off anytime, there are no conditions to do that.

Once non-exclusive transient queues are turned off, declaring a new queue with those arguments will be rejected with a protocol error.