### PR TITLE
Use same AMQP 0.9.1 header for correlation ID

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -2177,7 +2177,8 @@ mqtt_props_to_amqp_props(Props, Qos, Retain) ->
                  P3#'P_basic'{correlation_id = Corr};
              #{'Correlation-Data' := Corr}
                when byte_size(Corr) > ?AMQP_091_SHORT_STR_MAX_SIZE ->
-                 P3#'P_basic'{headers = [{<<"x-correlation">>, longstr, Corr} | P3#'P_basic'.headers]};
+                 P3#'P_basic'{headers = [{<<"x-correlation-id">>, longstr, Corr}
+                                         | P3#'P_basic'.headers]};
              _ ->
                  P3
          end,
@@ -2267,8 +2268,8 @@ amqp_props_to_mqtt_props(
              C when is_list(C) ->
                  P3#{'Correlation-Data' => list_to_binary(C)};
              _ ->
-                 case rabbit_basic:header(<<"x-correlation">>, Headers) of
-                     {<<"x-correlation">>, longstr, C}
+                 case rabbit_basic:header(<<"x-correlation-id">>, Headers) of
+                     {<<"x-correlation-id">>, longstr, C}
                        when is_binary(C) ->
                          P3#{'Correlation-Data' => C};
                      _ ->

--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -506,7 +506,7 @@ events(Config) ->
     Qos = 0,
     MqttTopic = <<"my/topic">>,
     AmqpTopic = <<"my.topic">>,
-    {ok, _, _} = emqtt:subscribe(C, MqttTopic, Qos),
+    {ok, _, [Qos]} = emqtt:subscribe(C, MqttTopic, Qos),
 
     QueueNameBin = <<"mqtt-subscription-", ClientId/binary, "qos0">>,
     QueueName = {resource, <<"/">>, queue, QueueNameBin},

--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -1314,7 +1314,7 @@ block(Config) ->
 block_only_publisher(Config) ->
     Topic = atom_to_binary(?FUNCTION_NAME),
 
-    Opts = [{ack_timeout, 1}],
+    Opts = [{ack_timeout, 2}],
     Con = connect(<<"background-connection">>, Config, Opts),
     Sub = connect(<<"subscriber-connection">>, Config, Opts),
     Pub = connect(<<"publisher-connection">>, Config, Opts),

--- a/deps/rabbitmq_mqtt/test/util.erl
+++ b/deps/rabbitmq_mqtt/test/util.erl
@@ -99,7 +99,7 @@ get_global_counters(Config, Proto, Node, QType) ->
              rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_global_counters, overview, [])).
 
 get_events(Node) ->
-    timer:sleep(300), %% events are sent and processed asynchronously
+    timer:sleep(500), %% events are sent and processed asynchronously
     Result = gen_event:call({rabbit_event, Node}, event_recorder, take_state),
     ?assert(is_list(Result)),
     Result.


### PR DESCRIPTION
For correlation IDs greater than 255 bytes, AMQP 1.0 to AMQP 0.9.1 conversion puts the correlation ID into an AMQP 0.9.1 header called `x-correlation-id`, see
https://github.com/rabbitmq/rabbitmq-server/blob/a17b28ec618cdf79a29fa520748dbe340561e197/deps/rabbit/src/rabbit_msg_record.erl#L380
Let's use the same key for the MQTT 5.0 to AMQP 0.9.1 conversion.