### PR TITLE
Display MQTT 5 CONNECT User Property in Management UI

### DIFF
--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -37,6 +37,7 @@
         [
          client_id,
          conn_name,
+         user_property,
          connection_state,
          ssl_login_name,
          recv_cnt,

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl
@@ -14,6 +14,7 @@
 -type property_name() :: atom().
 -type property_value() :: any().
 -type properties() :: #{property_name() := property_value()}.
+-type user_property() :: [{binary(), binary()}].
 
 -define(TWO_BYTE_INTEGER_MAX, 16#FFFF).
 %% Packet identifier is a non zero two byte integer.


### PR DESCRIPTION
Display MQTT 5 CONNECT User Property in Management UI and CLI as requested in https://github.com/rabbitmq/rabbitmq-server/issues/2554#issuecomment-1604205277

[v5 3.1.2.11.8]
> User Properties on the CONNECT packet can be used to send connection related properties from the Client to the Server. The meaning of these properties is not defined by this specification.

It makes sense to display the User Property of the CONNECT packet in the Management UI in the connection's Client Properties.

Example:
```
mqttx conn --client-id client-1 --user-properties "name 1: value 1" --user-properties "name 2: value 2"
mqttx conn --client-id client-2
```

CLI output:
```
rabbitmqctl list_mqtt_connections client_id conn_name user_property --formatter=json | jq .
[
  {
    "client_id": "client-2",
    "conn_name": "127.0.0.1:21898 -> 127.0.0.1:1883",
    "user_property": []
  },
  {
    "client_id": "client-1",
    "conn_name": "127.0.0.1:21826 -> 127.0.0.1:1883",
    "user_property": [
      [
        "name 1",
        "value 1"
      ],
      [
        "name 2",
        "value 2"
      ]
    ]
  }
]
```

Management UI:
<img width="828" alt="Screenshot 2023-06-26 at 12 15 48" src="https://github.com/rabbitmq/rabbitmq-server/assets/12648310/b4876f75-2745-4e63-a9db-7e318dd08d08">
