### PR TITLE
Gracefully close shovel if destination exchange not found

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
@@ -263,7 +263,7 @@ handle_source({'EXIT', Conn, Reason},
               #{source := #{current := {Conn, _, _}}}) ->
     {stop, {inbound_conn_died, Reason}};
 
-handle_source({'EXIT', _Pid, {shutdown, {server_initiated_close, ?PRECONDITION_FAILED, Reason}}}, _State) ->
+handle_source({'EXIT', _Pid, {shutdown, {server_initiated_close, _, Reason}}}, _State) ->
     {stop, {inbound_link_or_channel_closure, Reason}};
 
 handle_source(_Msg, _State) ->
@@ -288,7 +288,7 @@ handle_dest(#'basic.cancel'{}, #{name := Name}) ->
 handle_dest({'EXIT', Conn, Reason}, #{dest := #{current := {Conn, _, _}}}) ->
     {stop, {outbound_conn_died, Reason}};
 
-handle_dest({'EXIT', _Pid, {shutdown, {server_initiated_close, ?PRECONDITION_FAILED, Reason}}}, _State) ->
+handle_dest({'EXIT', _Pid, {shutdown, {server_initiated_close, _, Reason}}}, _State) ->
     {stop, {outbound_link_or_channel_closure, Reason}};
 
 handle_dest(#'connection.blocked'{}, State) ->

--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -202,7 +202,7 @@ handle_source({'EXIT', Conn, Reason},
               #{source := #{current := #{conn := Conn}}}) ->
     {stop, {outbound_conn_died, Reason}};
 
-handle_source({'EXIT', _Pid, {shutdown, {server_initiated_close, ?PRECONDITION_FAILED, Reason}}}, _State) ->
+handle_source({'EXIT', _Pid, {shutdown, {server_initiated_close, _, Reason}}}, _State) ->
     {stop, {inbound_link_or_channel_closure, Reason}};
 
 handle_source(_Msg, _State) ->
@@ -260,7 +260,7 @@ handle_dest({'EXIT', Conn, Reason},
             #{dest := #{current := #{conn := Conn}}}) ->
     {stop, {outbound_conn_died, Reason}};
 
-handle_dest({'EXIT', _Pid, {shutdown, {server_initiated_close, ?PRECONDITION_FAILED, Reason}}}, _State) ->
+handle_dest({'EXIT', _Pid, {shutdown, {server_initiated_close, _, Reason}}}, _State) ->
     {stop, {outbound_link_or_channel_closure, Reason}};
 
 handle_dest(_Msg, _State) ->

--- a/deps/rabbitmq_shovel/test/dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/dynamic_SUITE.erl
@@ -31,6 +31,7 @@ groups() ->
           set_empty_properties_using_map,
           headers,
           exchange,
+          missing_dest_exchange,
           restart,
           change_definition,
           autodelete,
@@ -261,6 +262,36 @@ exchange(Config) ->
               publish_expect(Ch, <<"amq.direct">>, <<"test-key">>,
                              <<"queue">>, <<"hello">>)
       end).
+
+
+missing_dest_exchange(Config) ->
+    with_ch(Config,
+        fun (Ch) ->
+            amqp_channel:call(
+            Ch, #'queue.declare'{queue = <<"src">>, % E: record 'queue.declare' undefined
+                                    durable = true}),
+            amqp_channel:call(
+            Ch, #'queue.declare'{queue = <<"dest">>, % E: record 'queue.declare' undefined
+                                    durable = true}),
+            amqp_channel:call(
+            Ch, #'queue.bind'{queue = <<"src">>, % E: record 'queue.bind' undefined
+                                exchange = <<"amq.direct">>,
+                                routing_key = <<"src-key">>}),
+            shovel_test_utils:set_param(Config,
+                        <<"test">>, [{<<"src-queue">>, <<"src">>},
+                                        {<<"dest-exchange">>, <<"dest-ex">>},
+                                        {<<"dest-exchange-key">>, <<"dest-key">>},
+                                        {<<"src-prefetch-count">>, 1}]),
+            publish(Ch, <<"amq.direct">>, <<"src-key">>, <<"hello">>),
+            expect_empty(Ch, <<"src">>),
+            amqp_channel:call(
+            Ch, #'exchange.declare'{exchange = <<"dest-ex">>}), % E: record 'exchange.declare' undefined
+            amqp_channel:call(
+            Ch, #'queue.bind'{queue = <<"dest">>, % E: record 'queue.bind' undefined
+                                exchange = <<"dest-ex">>,
+                                routing_key = <<"dest-key">>}),
+            publish_expect(Ch, <<"amq.direct">>, <<"src-key">>, <<"dest">>, <<"hello!">>)
+end).
 
 restart(Config) ->
     with_ch(Config,


### PR DESCRIPTION
## Proposed Changes

This PR fixes a bug where if destination exchange aren't present, and prefetch_count is met with unacked messages, shovel won't automatically reconnect when destination exchange is created. I couldn't find a current issue # for it, but we came across it internally during a DR exercise.

Steps to reproduce (also included in test):
1. Create shovel, set prefetch=x, destination exchange to an non-existing exchange.
2. publish x messages
3. create the destination exchange. Shovel will need to be restarted for messages to move.

Originally we wanted to handle `?NOT_FOUND` similar to `?PRECONDITION_FAILED` in https://github.com/rabbitmq/rabbitmq-server/pull/5243, however using anonymous variable we can catch both in one line. Wdyt? 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
