### PR TITLE
Fix combination of `amqqueue:get_pid/1` and `node/1`

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -121,7 +121,7 @@ delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_classic(Q) ->
             {ok, 0}
     end.
 
-is_recoverable(Q) when ?is_amqqueue(Q) ->
+is_recoverable(Q) when ?is_amqqueue(Q) and ?amqqueue_is_classic(Q) ->
     Node = node(),
     Node =:= amqqueue:qnode(Q) andalso
     %% Terminations on node down will not remove the rabbit_queue

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -123,7 +123,7 @@ delete(Q, IfUnused, IfEmpty, ActingUser) when ?amqqueue_is_classic(Q) ->
 
 is_recoverable(Q) when ?is_amqqueue(Q) ->
     Node = node(),
-    Node =:= node(amqqueue:get_pid(Q)) andalso
+    Node =:= amqqueue:qnode(Q) andalso
     %% Terminations on node down will not remove the rabbit_queue
     %% record if it is a mirrored queue (such info is now obtained from
     %% the policy). Thus, we must check if the local pid is alive

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -554,7 +554,7 @@ reductions(Name) ->
             0
     end.
 
-is_recoverable(Q) ->
+is_recoverable(Q) when ?is_amqqueue(Q) and ?amqqueue_is_quorum(Q) ->
     Node = node(),
     Nodes = get_nodes(Q),
     lists:member(Node, Nodes).


### PR DESCRIPTION
Fixes #8746
