### PR TITLE
Add elixir 1.15.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -111,6 +111,12 @@ elixir_config.internal_elixir_from_github_release(
     version = "1.14.5",
 )
 
+elixir_config.internal_elixir_from_github_release(
+    name = "1_15",
+    sha256 = "0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a",
+    version = "1.15.0",
+)
+
 use_repo(
     elixir_config,
     "elixir_config",
@@ -134,6 +140,7 @@ register_toolchains(
     "@elixir_config//external:toolchain",
     "@elixir_config//1_13:toolchain",
     "@elixir_config//1_14:toolchain",
+    "@elixir_config//1_15:toolchain",
 )
 
 erlang_package = use_extension(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.10.5",
+    version = "3.11.1",
 )
 
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -113,8 +113,8 @@ elixir_config.internal_elixir_from_github_release(
 
 elixir_config.internal_elixir_from_github_release(
     name = "1_15",
-    sha256 = "0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a",
-    version = "1.15.0",
+    sha256 = "3cfadca57c3092ccbd3ec3f17e5eab529bbd2946f50e4941a903c55c39e3c5f5",
+    version = "1.15.2",
 )
 
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -440,8 +440,8 @@ erlang_dev_package.hex_package(
 erlang_dev_package.hex_package(
     name = "x509",
     build_file = "@rabbitmq-server//bazel:BUILD.x509",
-    sha256 = "5ff9c79e77d64a62ccffd90aaeb23e8f5b6e47844ef7bc8fed931ecf238662e0",
-    version = "0.7.0",
+    sha256 = "3604125d6a0171da6e8a935810b58c999fccab0e3d20b2ed28d97fa2d9e2f6b4",
+    version = "0.8.7",
 )
 
 use_repo(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -389,6 +389,8 @@ erlang_dev_package.hex_package(
     build_file = "@rabbitmq-server//bazel:BUILD.amqp",
     sha256 = "b6d926770e4508e30e3e9e476c57b6c8aeda44f7715663bdc38935620ce5be6f",
     version = "2.1.1",
+    patch_args = ["-p1"],
+    patches = ["@rabbitmq-server//bazel:amqp.patch"],
 )
 
 erlang_dev_package.git_package(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,6 +182,11 @@ elixir_config(
             sha256 = "2ea249566c67e57f8365ecdcd0efd9b6c375f57609b3ac2de326488ac37c8ebd",
             version = "1.14.5",
         ),
+        internal_elixir_from_github_release(
+            name = "1_15",
+            sha256 = "0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a",
+            version = "1.15.0",
+        ),
     ],
     rabbitmq_server_workspace = "@",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ rules_pkg_dependencies()
 git_repository(
     name = "rules_erlang",
     remote = "https://github.com/rabbitmq/rules_erlang.git",
-    tag = "3.10.5",
+    tag = "3.11.1",
 )
 
 load("@rules_erlang//:internal_deps.bzl", "rules_erlang_internal_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -184,8 +184,8 @@ elixir_config(
         ),
         internal_elixir_from_github_release(
             name = "1_15",
-            sha256 = "0f4df7574a5f300b5c66f54906222cd46dac0df7233ded165bc8e80fd9ffeb7a",
-            version = "1.15.0",
+            sha256 = "3cfadca57c3092ccbd3ec3f17e5eab529bbd2946f50e4941a903c55c39e3c5f5",
+            version = "1.15.2",
         ),
     ],
     rabbitmq_server_workspace = "@",

--- a/bazel/amqp.patch
+++ b/bazel/amqp.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/amqp/core.ex b/lib/amqp/core.ex
+index a7302aa..abf2be6 100644
+--- a/lib/amqp/core.ex
++++ b/lib/amqp/core.ex
+@@ -3,6 +3,10 @@ defmodule AMQP.Core do
+ 
+   require Record
+ 
++  # Elixir 1.15 compiler optimizations require that we explicitly
++  # add the rabbit_common code path
++  true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"rabbit_common/ebin"))
++
+   Record.defrecord(
+     :p_basic,
+     :P_basic,

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -60,7 +60,7 @@ platform(
     name = "erlang_linux_26_platform",
     constraint_values = [
         "@erlang_config//:erlang_26",
-        "@elixir_config//:elixir_1_14",
+        "@elixir_config//:elixir_1_15",
     ],
     parents = ["@rbe//config:platform"],
 )
@@ -69,7 +69,7 @@ platform(
     name = "erlang_linux_git_master_platform",
     constraint_values = [
         "@erlang_config//:erlang_27_unknown",
-        "@elixir_config//:elixir_1_14",
+        "@elixir_config//:elixir_1_15",
     ],
     parents = ["@rbe//config:platform"],
 )

--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -81,8 +81,14 @@ rabbitmqctl_check_formatted_test(
     ]),
     data = glob(["test/fixtures/**/*"]),
     target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//os:macos"],
-        "//conditions:default": ["@platforms//os:linux"],
+        "@platforms//os:macos": [
+            "@platforms//os:macos",
+            "@elixir_config//:elixir_1_15",
+        ],
+        "//conditions:default": [
+            "@platforms//os:linux",
+            "@elixir_config//:elixir_1_15",
+        ],
     }),
 )
 

--- a/deps/rabbitmq_cli/config/config.exs
+++ b/deps/rabbitmq_cli/config/config.exs
@@ -24,7 +24,7 @@ import Config
 #
 # Or configure a 3rd-party app:
 #
-config :logger, level: :warn, console: [device: :standard_error]
+config :logger, level: :warning, console: [device: :standard_error]
 #
 
 # It is also possible to import configuration files, relative to this

--- a/deps/rabbitmq_cli/lib/rabbit_common/records.ex
+++ b/deps/rabbitmq_cli/lib/rabbit_common/records.ex
@@ -10,7 +10,7 @@ defmodule RabbitCommon.Records do
 
   # Elixir 1.15 compiler optimizations require that we explicitly
   # add the rabbit_common code path
-  true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"rabbit_common/ebin"))
+  true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit_common", "ebin"]))
 
   # Important: amqqueue records must not be used directly since they are versioned
   #            for mixed version cluster compatibility. Convert records

--- a/deps/rabbitmq_cli/lib/rabbit_common/records.ex
+++ b/deps/rabbitmq_cli/lib/rabbit_common/records.ex
@@ -8,6 +8,10 @@ defmodule RabbitCommon.Records do
   require Record
   import Record, only: [defrecord: 2, extract: 2]
 
+  # Elixir 1.15 compiler optimizations require that we explicitly
+  # add the rabbit_common code path
+  :true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"rabbit_common/ebin"))
+
   # Important: amqqueue records must not be used directly since they are versioned
   #            for mixed version cluster compatibility. Convert records
   #            to maps on the server end to access the fields of those records. MK.

--- a/deps/rabbitmq_cli/lib/rabbit_common/records.ex
+++ b/deps/rabbitmq_cli/lib/rabbit_common/records.ex
@@ -10,7 +10,7 @@ defmodule RabbitCommon.Records do
 
   # Elixir 1.15 compiler optimizations require that we explicitly
   # add the rabbit_common code path
-  :true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"rabbit_common/ebin"))
+  true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"rabbit_common/ebin"))
 
   # Important: amqqueue records must not be used directly since they are versioned
   #            for mixed version cluster compatibility. Convert records

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/code_path.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/code_path.ex
@@ -61,9 +61,9 @@ defmodule RabbitMQ.CLI.Core.CodePath do
 
     case :erl_prim_loader.list_dir(app_dir) do
       {:ok, list} ->
-        case Enum.member?(list, 'ebin') do
+        case Enum.member?(list, ~c"ebin") do
           true ->
-            ebin_dir = :filename.join(app_dir, 'ebin')
+            ebin_dir = :filename.join(app_dir, ~c"ebin")
             Code.append_path(ebin_dir)
 
           false ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/config.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/config.ex
@@ -44,7 +44,7 @@ defmodule RabbitMQ.CLI.Core.Config do
 
   def normalise(:longnames, true), do: :longnames
   def normalise(:longnames, "true"), do: :longnames
-  def normalise(:longnames, 'true'), do: :longnames
+  def normalise(:longnames, ~c"true"), do: :longnames
   def normalise(:longnames, "\"true\""), do: :longnames
   def normalise(:longnames, _val), do: :shortnames
   def normalise(_, value), do: value

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
@@ -13,6 +13,11 @@ defmodule RabbitMQ.CLI.Core.Listeners do
   # API
   #
 
+  # Elixir 1.15 compiler optimizations require that we explicitly
+  # add the public_key code path
+  [public_key] = :filelib.wildcard(:filename.join(:code.lib_dir(), ~c"public_key-*/ebin"))
+  :true = :code.add_path(public_key)
+
   defrecord :certificate,
             :Certificate,
             extract(:Certificate, from_lib: "public_key/include/public_key.hrl")

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
@@ -13,10 +13,10 @@ defmodule RabbitMQ.CLI.Core.Listeners do
   # API
   #
 
-  # Elixir 1.15 compiler optimizations require that we explicitly
-  # add the public_key code path
-  [public_key] = :filelib.wildcard(:filename.join(:code.lib_dir(), ~c"public_key-*/ebin"))
-  true = :code.add_path(public_key)
+  # TODO: Remove when we require Elixir 1.15
+  if function_exported?(Mix, :ensure_application!, 1) do
+    Mix.ensure_application!(:public_key)
+  end
 
   defrecord :certificate,
             :Certificate,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
@@ -16,7 +16,7 @@ defmodule RabbitMQ.CLI.Core.Listeners do
   # Elixir 1.15 compiler optimizations require that we explicitly
   # add the public_key code path
   [public_key] = :filelib.wildcard(:filename.join(:code.lib_dir(), ~c"public_key-*/ebin"))
-  :true = :code.add_path(public_key)
+  true = :code.add_path(public_key)
 
   defrecord :certificate,
             :Certificate,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -84,7 +84,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
   #
 
   def addressing_local_node?(_, remote_hostname) when remote_hostname == :localhost, do: true
-  def addressing_local_node?(_, remote_hostname) when remote_hostname == 'localhost', do: true
+  def addressing_local_node?(_, remote_hostname) when remote_hostname == ~c"localhost", do: true
   def addressing_local_node?(_, remote_hostname) when remote_hostname == "localhost", do: true
 
   def addressing_local_node?(local_hostname, remote_hostname) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -155,7 +155,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   end
 
   defp wait_for_pid_funs(node_name, app_names, timeout, quiet) do
-    app_names_formatted = :io_lib.format('~p', [app_names])
+    app_names_formatted = :io_lib.format(~c"~p", [app_names])
 
     [
       log_param(

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
@@ -47,11 +47,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.RemoteShellCommand do
   defp start_shell_on_otp_25(node_name) do
     _ = Supervisor.terminate_child(:kernel_sup, :user)
     Process.flag(:trap_exit, true)
-    user_drv = :user_drv.start(['tty_sl -c -e', {node_name, :shell, :start, []}])
+    user_drv = :user_drv.start([~c"tty_sl -c -e", {node_name, :shell, :start, []}])
     Process.link(user_drv)
 
     receive do
-      {'EXIT', _user_drv, _} ->
+      {~c"EXIT", _user_drv, _} ->
         {:ok, "Disconnected from #{node_name}."}
     end
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/csv.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/csv.ex
@@ -94,9 +94,9 @@ defmodule RabbitMQ.CLI.Formatters.Csv do
   end
 end
 
-  # Elixir 1.15 compiler optimizations require that we explicitly
-  # add the csv code path
-  :true = :code.add_path(:filename.join([~c"_build", Atom.to_charlist(Mix.env()), ~c"lib/csv/ebin"]))
+# Elixir 1.15 compiler optimizations require that we explicitly
+# add the csv code path
+true = :code.add_path(:filename.join([~c"_build", Atom.to_charlist(Mix.env()), ~c"lib/csv/ebin"]))
 
 defimpl CSV.Encode, for: PID do
   def encode(pid, env \\ []) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/csv.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/csv.ex
@@ -96,7 +96,7 @@ end
 
 # Elixir 1.15 compiler optimizations require that we explicitly
 # add the csv code path
-true = :code.add_path(:filename.join([~c"_build", Atom.to_charlist(Mix.env()), ~c"lib/csv/ebin"]))
+true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "csv", "ebin"]))
 
 defimpl CSV.Encode, for: PID do
   def encode(pid, env \\ []) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/csv.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/csv.ex
@@ -94,6 +94,10 @@ defmodule RabbitMQ.CLI.Formatters.Csv do
   end
 end
 
+  # Elixir 1.15 compiler optimizations require that we explicitly
+  # add the csv code path
+  :true = :code.add_path(:filename.join([~c"_build", Atom.to_charlist(Mix.env()), ~c"lib/csv/ebin"]))
+
 defimpl CSV.Encode, for: PID do
   def encode(pid, env \\ []) do
     FormatterHelpers.format_info_item(pid)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
@@ -12,6 +12,10 @@ defmodule RabbitMQ.CLI.Formatters.PrettyTable do
   require Record
   import Record
 
+  # Elixir 1.15 compiler optimizations require that we explicitly
+  # add the stdout_formatter code path
+  :true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"stdout_formatter/ebin"))
+
   defrecord :table,
             extract(:table,
               from_lib: "stdout_formatter/include/stdout_formatter.hrl"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
@@ -14,7 +14,7 @@ defmodule RabbitMQ.CLI.Formatters.PrettyTable do
 
   # Elixir 1.15 compiler optimizations require that we explicitly
   # add the stdout_formatter code path
-  :true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"stdout_formatter/ebin"))
+  true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"stdout_formatter/ebin"))
 
   defrecord :table,
             extract(:table,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/pretty_table.ex
@@ -14,7 +14,7 @@ defmodule RabbitMQ.CLI.Formatters.PrettyTable do
 
   # Elixir 1.15 compiler optimizations require that we explicitly
   # add the stdout_formatter code path
-  true = :code.add_path(:filename.join(:os.getenv(~c"DEPS_DIR"), ~c"stdout_formatter/ebin"))
+  true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "stdout_formatter", "ebin"]))
 
   defrecord :table,
             extract(:table,

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -628,7 +628,7 @@ defmodule RabbitMQCtl do
   ## {:fun, fun} - run a custom function to enable distribution.
   ## custom mode is usefult for commands which should have specific node name.
   ## Runs code if distribution is successful, or not needed.
-  @spec maybe_with_distribution(module(), options(), (() -> command_result())) :: command_result()
+  @spec maybe_with_distribution(module(), options(), (-> command_result())) :: command_result()
   defp maybe_with_distribution(command, options, code) do
     try do
       maybe_with_distribution_without_catch(command, options, code)

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -135,6 +135,7 @@ defmodule RabbitMQCtl.MixfileBase do
     end
 
     make_cmd = System.get_env("MAKE", "make")
+    fake_cmd = "true"
     is_bazel = System.get_env("IS_BAZEL") != nil
 
     [
@@ -149,17 +150,17 @@ defmodule RabbitMQCtl.MixfileBase do
       {
         :stdout_formatter,
         path: Path.join(deps_dir, "stdout_formatter"),
-        compile: if(is_bazel, do: false, else: make_cmd)
+        compile: if(is_bazel, do: fake_cmd, else: make_cmd)
       },
       {
         :observer_cli,
         path: Path.join(deps_dir, "observer_cli"),
-        compile: if(is_bazel, do: false, else: make_cmd)
+        compile: if(is_bazel, do: fake_cmd, else: make_cmd)
       },
       {
         :rabbit_common,
         path: Path.join(deps_dir, "rabbit_common"),
-        compile: if(is_bazel, do: false, else: make_cmd),
+        compile: if(is_bazel, do: fake_cmd, else: make_cmd),
         override: true
       }
     ] ++
@@ -185,7 +186,7 @@ defmodule RabbitMQCtl.MixfileBase do
             {
               :amqp_client,
               path: Path.join(deps_dir, "amqp_client"),
-              compile: if(is_bazel, do: false, else: make_cmd),
+              compile: if(is_bazel, do: fake_cmd, else: make_cmd),
               override: true
             }
           ]

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -176,6 +176,12 @@ defmodule RabbitMQCtl.MixfileBase do
               path: Path.join(deps_dir, "dialyxir"), runtime: false
             },
             {
+              :rabbit,
+              path: Path.join(deps_dir, "rabbit"),
+              compile: if(is_bazel, do: fake_cmd, else: make_cmd),
+              override: true
+            },
+            {
               :temp,
               path: Path.join(deps_dir, "temp")
             },

--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -122,11 +122,6 @@ export ERL_COMPILER_OPTIONS=deterministic
 for archive in {archives}; do
     "${{ABS_ELIXIR_HOME}}"/bin/mix archive.install --force $ORIGINAL_DIR/$archive
 done
-for d in {precompiled_deps}; do
-    mkdir -p _build/${{MIX_ENV}}/lib/$d
-    ln -s ${{DEPS_DIR}}/$d/ebin _build/${{MIX_ENV}}/lib/$d
-    ln -s ${{DEPS_DIR}}/$d/include _build/${{MIX_ENV}}/lib/$d
-done
 "${{ABS_ELIXIR_HOME}}"/bin/mix deps.compile
 "${{ABS_ELIXIR_HOME}}"/bin/mix compile
 "${{ABS_ELIXIR_HOME}}"/bin/mix escript.build

--- a/deps/rabbitmq_cli/rabbitmqctl.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl.bzl
@@ -38,19 +38,35 @@ def deps_dir_contents(ctx, deps, dir):
     files = []
     for dep in deps:
         lib_info = dep[ErlangAppInfo]
-        for src in lib_info.include + lib_info.beam + lib_info.srcs:
+        files_by_path = {}
+        for src in lib_info.include + lib_info.srcs:
             if not src.is_directory:
                 rp = additional_file_dest_relative_path(dep.label, src)
+                files_by_path[rp] = src
+            else:
+                fail("unexpected directory in", lib_info)
+        for rp, src in files_by_path.items():
+            f = ctx.actions.declare_file(path_join(
+                dir,
+                lib_info.app_name,
+                rp,
+            ))
+            ctx.actions.symlink(
+                output = f,
+                target_file = src,
+            )
+            files.extend([f, src])
+        for beam in lib_info.beam:
+            if not beam.is_directory:
                 f = ctx.actions.declare_file(path_join(
-                    dir,
-                    lib_info.app_name,
-                    rp,
-                ))
+                    dir, lib_info.app_name, "ebin", beam.basename))
                 ctx.actions.symlink(
                     output = f,
-                    target_file = src,
+                    target_file = beam,
                 )
-                files.extend([src, f])
+                files.extend([f, beam])
+            else:
+                fail("unexpected directory in", lib_info)
     return files
 
 def _impl(ctx):

--- a/deps/rabbitmq_cli/rabbitmqctl_test.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_test.bzl
@@ -100,18 +100,8 @@ export ERL_COMPILER_OPTIONS=deterministic
 for archive in {archives}; do
     "${{ABS_ELIXIR_HOME}}"/bin/mix archive.install --force $INITIAL_DIR/$archive
 done
-for d in {precompiled_deps}; do
-    mkdir -p _build/${{MIX_ENV}}/lib/$d
-    ln -s ${{DEPS_DIR}}/$d/ebin _build/${{MIX_ENV}}/lib/$d
-    ln -s ${{DEPS_DIR}}/$d/include _build/${{MIX_ENV}}/lib/$d
-done
 "${{ABS_ELIXIR_HOME}}"/bin/mix deps.compile
 "${{ABS_ELIXIR_HOME}}"/bin/mix compile
-
-# due to https://github.com/elixir-lang/elixir/issues/7699 we
-# "run" the tests, but skip them all, in order to trigger
-# compilation of all *_test.exs files before we actually run them
-"${{ABS_ELIXIR_HOME}}"/bin/mix test --exclude test
 
 export TEST_TMPDIR=${{TEST_UNDECLARED_OUTPUTS_DIR}}
 
@@ -173,11 +163,6 @@ for %%a in ({archives}) do (
     set ARCH=%TEST_SRCDIR%/%TEST_WORKSPACE%/%%a
     set ARCH=%ARCH:/=\\%
     "{elixir_home}\\bin\\mix" archive.install --force %ARCH% || goto :error
-)
-for %%d in ({precompiled_deps}) do (
-    mkdir _build\\%MIX_ENV%\\lib\\%%d
-    robocopy %DEPS_DIR%\\%%d\\ebin _build\\%MIX_ENV%\\lib\\%%d /E /NFL /NDL /NJH /NJS /nc /ns /np
-    robocopy %DEPS_DIR%\\%%d\\include _build\\%MIX_ENV%\\lib\\%%d /E /NFL /NDL /NJH /NJS /nc /ns /np
 )
 "{elixir_home}\\bin\\mix" deps.compile || goto :error
 "{elixir_home}\\bin\\mix" compile || goto :error

--- a/deps/rabbitmq_cli/test/core/default_output_test.exs
+++ b/deps/rabbitmq_cli/test/core/default_output_test.exs
@@ -21,8 +21,8 @@ defmodule DefaultOutputTest do
   end
 
   test "enumerable is passed as stream" do
-    assert match?({:stream, 'list'}, ExampleCommand.output({:ok, 'list'}, %{}))
-    assert match?({:stream, 'list'}, ExampleCommand.output('list', %{}))
+    assert match?({:stream, ~c"list"}, ExampleCommand.output({:ok, ~c"list"}, %{}))
+    assert match?({:stream, ~c"list"}, ExampleCommand.output(~c"list", %{}))
 
     assert match?({:stream, [1, 2, 3]}, ExampleCommand.output({:ok, [1, 2, 3]}, %{}))
     assert match?({:stream, [1, 2, 3]}, ExampleCommand.output([1, 2, 3], %{}))
@@ -53,13 +53,13 @@ defmodule DefaultOutputTest do
   test "error_string is converted to string" do
     assert match?(
              {:error, "I am charlist"},
-             ExampleCommand.output({:error_string, 'I am charlist'}, %{})
+             ExampleCommand.output({:error_string, ~c"I am charlist"}, %{})
            )
   end
 
   test "error is formatted" do
     {:error, "I am formatted \"string\""} =
-      ExampleCommand.output({:error, 'I am formatted ~p', ['string']}, %{})
+      ExampleCommand.output({:error, ~c"I am formatted ~p", [~c"string"]}, %{})
   end
 
   test "non atom value is ok" do

--- a/deps/rabbitmq_cli/test/core/helpers_test.exs
+++ b/deps/rabbitmq_cli/test/core/helpers_test.exs
@@ -122,8 +122,8 @@ defmodule HelpersTest do
     rabbitmq_home = :rabbit_misc.rpc_call(node(), :code, :lib_dir, [:rabbit])
     opts = %{plugins_dir: to_string(plugins_directory_03), rabbitmq_home: rabbitmq_home}
 
-    desc = 'A mock RabbitMQ plugin to be used in tests'
-    vsn = '0.1.0'
+    desc = ~c"A mock RabbitMQ plugin to be used in tests"
+    vsn = ~c"0.1.0"
 
     assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_03, desc, vsn}) ==
              false
@@ -138,8 +138,8 @@ defmodule HelpersTest do
     rabbitmq_home = :rabbit_misc.rpc_call(node(), :code, :lib_dir, [:rabbit])
     opts = %{plugins_dir: to_string(plugins_directory_04), rabbitmq_home: rabbitmq_home}
 
-    desc = 'A mock RabbitMQ plugin to be used in tests'
-    vsn = 'rolling'
+    desc = ~c"A mock RabbitMQ plugin to be used in tests"
+    vsn = ~c"rolling"
 
     assert Enum.member?(Application.loaded_applications(), {:mock_rabbitmq_plugins_04, desc, vsn}) ==
              false

--- a/deps/rabbitmq_cli/test/core/table_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/core/table_formatter_test.exs
@@ -17,7 +17,7 @@ defmodule TableFormatterTest do
              "apple\tbeer\t1"
            ]
 
-    assert @formatter.format_output([a: "apple", b: 'beer', c: 1], %{}) == [
+    assert @formatter.format_output([a: "apple", b: ~c"beer", c: 1], %{}) == [
              "a\tb\tc",
              "apple\t\"beer\"\t1"
            ]
@@ -25,7 +25,7 @@ defmodule TableFormatterTest do
 
   test "format_stream tab-separates keyword values" do
     assert @formatter.format_stream(
-             [[a: :apple, b: :beer, c: 1], [a: "aadvark", b: 'bee', c: 2]],
+             [[a: :apple, b: :beer, c: 1], [a: "aadvark", b: ~c"bee", c: 2]],
              %{}
            )
            |> Enum.to_list() ==

--- a/deps/rabbitmq_cli/test/ctl/clear_global_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_global_parameter_command_test.exs
@@ -44,7 +44,7 @@ defmodule ClearGlobalParameterCommandTest do
     assert @command.run(
              [context[:key]],
              context[:opts]
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do

--- a/deps/rabbitmq_cli/test/ctl/clear_operator_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_operator_policy_command_test.exs
@@ -67,7 +67,7 @@ defmodule ClearOperatorPolicyCommandTest do
     assert @command.run(
              [context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   test "run: an unreachable node throws a badrpc" do
@@ -96,7 +96,7 @@ defmodule ClearOperatorPolicyCommandTest do
     assert @command.run(
              [context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   @tag key: @key, pattern: @pattern, value: @value, vhost: @vhost

--- a/deps/rabbitmq_cli/test/ctl/clear_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_parameter_command_test.exs
@@ -65,7 +65,7 @@ defmodule ClearParameterCommandTest do
     assert @command.run(
              [context[:component_name], context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
@@ -94,7 +94,7 @@ defmodule ClearParameterCommandTest do
     assert @command.run(
              [context[:component_name], context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
 
     assert list_parameters(context[:vhost]) == []
   end
@@ -106,7 +106,7 @@ defmodule ClearParameterCommandTest do
     assert @command.run(
              [context[:component_name], context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   @tag component_name: @component_name, key: @key, value: @value, vhost: @vhost

--- a/deps/rabbitmq_cli/test/ctl/clear_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_policy_command_test.exs
@@ -69,7 +69,7 @@ defmodule ClearPolicyCommandTest do
     assert @command.run(
              [context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   test "run: an unreachable node throws a badrpc" do
@@ -98,7 +98,7 @@ defmodule ClearPolicyCommandTest do
     assert @command.run(
              [context[:key]],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   @tag key: @key, pattern: @pattern, value: @value, vhost: @vhost

--- a/deps/rabbitmq_cli/test/ctl/clear_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/clear_vhost_limits_command_test.exs
@@ -83,7 +83,7 @@ defmodule ClearVhostLimitsCommandTest do
     assert @command.run(
              [],
              vhost_opts
-           ) == {:error_string, 'Parameter does not exist'}
+           ) == {:error_string, ~c"Parameter does not exist"}
   end
 
   @tag vhost: @vhost

--- a/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
@@ -19,7 +19,7 @@ defmodule EnableFeatureFlagCommandTest do
 
     new_feature_flags = %{
       @feature_flag => %{
-        desc: 'My feature flag',
+        desc: ~c"My feature flag",
         provided_by: :EnableFeatureFlagCommandTest,
         stability: :stable
       }

--- a/deps/rabbitmq_cli/test/ctl/list_feature_flags_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_feature_flags_command_test.exs
@@ -21,12 +21,12 @@ defmodule ListFeatureFlagsCommandTest do
 
     new_feature_flags = %{
       @flag1 => %{
-        desc: 'My feature flag #1',
+        desc: ~c"My feature flag #1",
         provided_by: :ListFeatureFlagsCommandTest,
         stability: :stable
       },
       @flag2 => %{
-        desc: 'My feature flag #2',
+        desc: ~c"My feature flag #2",
         provided_by: :ListFeatureFlagsCommandTest,
         stability: :stable
       }

--- a/deps/rabbitmq_cli/test/ctl/set_operator_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_operator_policy_command_test.exs
@@ -127,7 +127,7 @@ defmodule SetOperatorPolicyCommandTest do
              context[:opts]
            ) ==
              {:error_string,
-              'Validation failed\n\n[{<<"foo">>,<<"bar">>}] are not recognised policy settings\n'}
+              ~c"Validation failed\n\n[{<<\"foo\">>,<<\"bar\">>}] are not recognised policy settings\n"}
 
     assert list_operator_policies(context[:vhost]) == []
   end
@@ -137,7 +137,7 @@ defmodule SetOperatorPolicyCommandTest do
     assert @command.run(
              [context[:key], context[:pattern], context[:value]],
              context[:opts]
-           ) == {:error_string, 'Validation failed\n\nno policy provided\n'}
+           ) == {:error_string, ~c"Validation failed\n\nno policy provided\n"}
 
     assert list_operator_policies(context[:vhost]) == []
   end

--- a/deps/rabbitmq_cli/test/ctl/set_parameter_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_parameter_command_test.exs
@@ -91,7 +91,7 @@ defmodule SetParameterCommandTest do
              context[:opts]
            ) ==
              {:error_string,
-              'Validation failed\n\ncomponent #{context[:component_name]} not found\n'}
+              ~c"Validation failed\n\ncomponent #{context[:component_name]} not found\n"}
 
     assert list_parameters(context[:vhost]) == []
   end
@@ -124,7 +124,8 @@ defmodule SetParameterCommandTest do
     assert @command.run(
              [context[:component_name], context[:key], context[:value]],
              context[:opts]
-           ) == {:error_string, 'Validation failed\n\nKey "uri" not found in reconnect-delay\n'}
+           ) ==
+             {:error_string, ~c"Validation failed\n\nKey \"uri\" not found in reconnect-delay\n"}
 
     assert list_parameters(context[:vhost]) == []
   end

--- a/deps/rabbitmq_cli/test/ctl/set_permissions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_permissions_command_test.exs
@@ -99,7 +99,7 @@ defmodule SetPermissionsCommandTest do
     assert @command.run(
              [context[:user], "^#{context[:user]}-.*", ".*", "*"],
              context[:opts]
-           ) == {:error, {:invalid_regexp, '*', {'nothing to repeat', 0}}}
+           ) == {:error, {:invalid_regexp, ~c"*", {~c"nothing to repeat", 0}}}
 
     # asserts that the failed command didn't change anything
     u = Enum.find(list_permissions(context[:vhost]), fn x -> x[:user] == context[:user] end)

--- a/deps/rabbitmq_cli/test/ctl/set_permissions_globally_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_permissions_globally_command_test.exs
@@ -100,7 +100,7 @@ defmodule SetPermissionsGloballyCommandTest do
     assert @command.run(
              [context[:user], "^#{context[:user]}-.*", ".*", "*"],
              context[:opts]
-           ) == {:error, {:invalid_regexp, '*', {'nothing to repeat', 0}}}
+           ) == {:error, {:invalid_regexp, ~c"*", {~c"nothing to repeat", 0}}}
 
     # asserts that the failed command didn't change anything
     p4 = Enum.find(list_permissions(@vhost1), fn x -> x[:user] == context[:user] end)

--- a/deps/rabbitmq_cli/test/ctl/set_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_policy_command_test.exs
@@ -129,7 +129,7 @@ defmodule SetPolicyCommandTest do
              context[:opts]
            ) ==
              {:error_string,
-              'Validation failed\n\n[{<<"foo">>,<<"bar">>}] are not recognised policy settings\n'}
+              ~c"Validation failed\n\n[{<<\"foo\">>,<<\"bar\">>}] are not recognised policy settings\n"}
 
     assert list_policies(context[:vhost]) == []
   end
@@ -139,7 +139,7 @@ defmodule SetPolicyCommandTest do
     assert @command.run(
              [context[:key], context[:pattern], context[:value]],
              context[:opts]
-           ) == {:error_string, 'Validation failed\n\nno policy provided\n'}
+           ) == {:error_string, ~c"Validation failed\n\nno policy provided\n"}
 
     assert list_policies(context[:vhost]) == []
   end

--- a/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
@@ -115,7 +115,7 @@ defmodule SetUserLimitsCommandTest do
     assert @command.run(
              [context[:user], "{\"foo\":\"bar\"}"],
              context[:opts]
-           ) == {:error_string, 'Unrecognised terms [{<<"foo">>,<<"bar">>}] in user-limits'}
+           ) == {:error_string, ~c"Unrecognised terms [{<<\"foo\">>,<<\"bar\">>}] in user-limits"}
 
     assert get_user_limits(context[:user]) == %{}
   end

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
@@ -108,7 +108,7 @@ defmodule SetVhostLimitsCommandTest do
              context[:opts]
            ) ==
              {:error_string,
-              'Validation failed\n\nUnrecognised terms [{<<"foo">>,<<"bar">>}] in limits\n'}
+              ~c"Validation failed\n\nUnrecognised terms [{<<\"foo\">>,<<\"bar\">>}] in limits\n"}
 
     assert get_vhost_limits(context[:vhost]) == %{}
   end

--- a/deps/rabbitmq_cli/test/diagnostics/check_port_connectivity_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_port_connectivity_command_test.exs
@@ -57,7 +57,7 @@ defmodule CheckPortConnectivityCommandTest do
   # note: it's run/2 that filters out non-local alarms
   test "output: when check failed to connect to a port, returns a failure", context do
     failure =
-      {:listener, :rabbit@mercurio, :lolz, 'mercurio', {0, 0, 0, 0, 0, 0, 0, 0}, 7_761_613,
+      {:listener, :rabbit@mercurio, :lolz, ~c"mercurio", {0, 0, 0, 0, 0, 0, 0, 0}, 7_761_613,
        [backlog: 128, nodelay: true]}
 
     assert match?({:error, _}, @command.output({false, [failure]}, context[:opts]))

--- a/deps/rabbitmq_cli/test/diagnostics/log_tail_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/log_tail_command_test.exs
@@ -117,7 +117,7 @@ defmodule LogTailCommandTest do
 
     Enum.map(logs, fn log ->
       case log do
-        '<stdout>' -> :ok
+        ~c"<stdout>" -> :ok
         _ -> File.write(log, "")
       end
     end)

--- a/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/disable_plugins_command_test.exs
@@ -264,7 +264,7 @@ defmodule DisablePluginsCommandTest do
   end
 
   test "formats enabled plugins mismatch errors", context do
-    err = {:enabled_plugins_mismatch, '/tmp/a/cli/path', '/tmp/a/server/path'}
+    err = {:enabled_plugins_mismatch, ~c"/tmp/a/cli/path", ~c"/tmp/a/server/path"}
 
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"} ==

--- a/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/enable_plugins_command_test.exs
@@ -313,7 +313,7 @@ defmodule EnablePluginsCommandTest do
   end
 
   test "output: formats enabled plugins mismatch errors", context do
-    err = {:enabled_plugins_mismatch, '/tmp/a/cli/path', '/tmp/a/server/path'}
+    err = {:enabled_plugins_mismatch, ~c"/tmp/a/cli/path", ~c"/tmp/a/server/path"}
 
     assert {:error, ExitCodes.exit_dataerr(),
             "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"} ==

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -356,13 +356,13 @@ defmodule ListPluginsCommandTest do
         name: :mock_rabbitmq_plugins_01,
         enabled: :not_enabled,
         running: false,
-        version: '0.2.0'
+        version: ~c"0.2.0"
       },
       %{
         name: :mock_rabbitmq_plugins_02,
         enabled: :not_enabled,
         running: false,
-        version: '0.2.0'
+        version: ~c"0.2.0"
       },
       %{name: :rabbitmq_federation, enabled: :enabled, running: true},
       %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
@@ -395,14 +395,14 @@ defmodule ListPluginsCommandTest do
         name: :mock_rabbitmq_plugins_01,
         enabled: :not_enabled,
         running: false,
-        version: '0.2.0'
+        version: ~c"0.2.0"
       },
       %{
         name: :mock_rabbitmq_plugins_02,
         enabled: :enabled,
         running: true,
-        version: '0.1.0',
-        running_version: '0.1.0'
+        version: ~c"0.1.0",
+        running_version: ~c"0.1.0"
       },
       %{name: :rabbitmq_federation, enabled: :enabled, running: true},
       %{name: :rabbitmq_stomp, enabled: :enabled, running: true}
@@ -425,14 +425,14 @@ defmodule ListPluginsCommandTest do
         name: :mock_rabbitmq_plugins_01,
         enabled: :not_enabled,
         running: false,
-        version: '0.2.0'
+        version: ~c"0.2.0"
       },
       %{
         name: :mock_rabbitmq_plugins_02,
         enabled: :enabled,
         running: true,
-        version: '0.2.0',
-        running_version: '0.1.0'
+        version: ~c"0.2.0",
+        running_version: ~c"0.1.0"
       },
       %{name: :rabbitmq_federation, enabled: :enabled, running: true},
       %{name: :rabbitmq_stomp, enabled: :enabled, running: true}

--- a/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
@@ -19,35 +19,35 @@ defmodule PluginsFormatterTest do
               name: :amqp_client,
               enabled: :implicit,
               running: true,
-              version: '3.7.0',
+              version: ~c"3.7.0",
               running_version: nil
             },
             %{
               name: :mock_rabbitmq_plugins_01,
               enabled: :not_enabled,
               running: false,
-              version: '0.2.0',
+              version: ~c"0.2.0",
               running_version: nil
             },
             %{
               name: :mock_rabbitmq_plugins_02,
               enabled: :enabled,
               running: true,
-              version: '0.2.0',
-              running_version: '0.1.0'
+              version: ~c"0.2.0",
+              running_version: ~c"0.1.0"
             },
             %{
               name: :rabbitmq_federation,
               enabled: :enabled,
               running: true,
-              version: '3.7.0',
+              version: ~c"3.7.0",
               running_version: nil
             },
             %{
               name: :rabbitmq_stomp,
               enabled: :enabled,
               running: true,
-              version: '3.7.0',
+              version: ~c"3.7.0",
               running_version: nil
             }
           ],
@@ -75,35 +75,35 @@ defmodule PluginsFormatterTest do
               name: :amqp_client,
               enabled: :implicit,
               running: true,
-              version: '3.7.0',
+              version: ~c"3.7.0",
               running_version: nil
             },
             %{
               name: :mock_rabbitmq_plugins_01,
               enabled: :not_enabled,
               running: false,
-              version: '0.2.0',
+              version: ~c"0.2.0",
               running_version: nil
             },
             %{
               name: :mock_rabbitmq_plugins_02,
               enabled: :enabled,
               running: true,
-              version: '0.2.0',
-              running_version: '0.1.0'
+              version: ~c"0.2.0",
+              running_version: ~c"0.1.0"
             },
             %{
               name: :rabbitmq_federation,
               enabled: :enabled,
               running: true,
-              version: '3.7.0',
+              version: ~c"3.7.0",
               running_version: nil
             },
             %{
               name: :rabbitmq_stomp,
               enabled: :enabled,
               running: true,
-              version: '3.7.0',
+              version: ~c"3.7.0",
               running_version: nil
             }
           ],

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -4,15 +4,32 @@
 ##
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
-four_hours = 240 * 60 * 1000
+ten_minutes = 10 * 60 * 1000
 
 ExUnit.configure(
   exclude: [disabled: true],
-  module_load_timeout: four_hours,
-  timeout: four_hours
+  module_load_timeout: ten_minutes,
+  timeout: ten_minutes
 )
 
 ExUnit.start()
+
+# Elixir 1.15 compiler optimizations seem to require that we explicitly add to the code path
+true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit_common", "ebin"]))
+true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit", "ebin"]))
+
+true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "amqp", "ebin"]))
+true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "json", "ebin"]))
+true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "x509", "ebin"]))
+
+if function_exported?(Mix, :ensure_application!, 1) do
+  Mix.ensure_application!(:mnesia)
+  Mix.ensure_application!(:os_mon)
+  Mix.ensure_application!(:public_key)
+  Mix.ensure_application!(:runtime_tools)
+  Mix.ensure_application!(:sasl)
+  Mix.ensure_application!(:xmerl)
+end
 
 defmodule TestHelper do
   import ExUnit.Assertions


### PR DESCRIPTION
This adds elixir 1.15.2 to the build matrix for OTP 26

1.15.x's adjustments to compilation required a number of code changes to allow the bazel build to work, by dynamically adding to the code path.