### PR TITLE
rabbit_feature_flags: Reset the registry before the boot-time init

### DIFF
--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -497,6 +497,11 @@ is_permitted_in_configuration(FeatureName, Default) ->
     Settings = application:get_env(rabbit, permit_deprecated_features, #{}),
     case maps:get(FeatureName, Settings, undefined) of
         undefined ->
+            ?LOG_DEBUG(
+               "Deprecated features: `~ts`: `permit_deprecated_features` "
+               "map unset in configuration, using default",
+               [FeatureName],
+               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
             Default;
         Default ->
             PermittedStr = case Default of

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -18,7 +18,8 @@
          initialize_registry/1,
          initialize_registry/3,
          acquire_state_change_lock/0,
-         release_state_change_lock/0]).
+         release_state_change_lock/0,
+         reset_registry/0]).
 
 -ifdef(TEST).
 -export([registry_loading_lock/0,
@@ -784,3 +785,15 @@ do_purge_old_registry(Mod) ->
         true  -> ok;
         false -> do_purge_old_registry(Mod)
     end.
+
+-spec reset_registry() -> ok.
+
+reset_registry() ->
+    ?LOG_DEBUG(
+       "Feature flags: resetting loaded registry",
+       [],
+       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    _ = code:purge(rabbit_ff_registry),
+    _ = code:delete(rabbit_ff_registry),
+    ?assertNot(rabbit_ff_registry:is_registry_initialized()),
+    ok.

--- a/deps/rabbit/src/rabbit_prelaunch_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_prelaunch_feature_flags.erl
@@ -19,6 +19,13 @@ setup(#{feature_flags_file := FFFile}) ->
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     case filelib:ensure_dir(FFFile) of
         ok ->
+            %% On boot, we know that there should be no registry loaded at
+            %% first. There could be a loaded registry around during a
+            %% stop_app/start_app, so reset it here. This ensures that e.g.
+            %% any change to the configuration file w.r.t. deprecated features
+            %% are taken into account.
+            rabbit_ff_registry_factory:reset_registry(),
+
             ?LOG_DEBUG(
                "Initializing feature flags registry", [],
                #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),


### PR DESCRIPTION
### Why

After a `stop_app` + `start_app`, the feature flags registry is left loaded. If the deprecated features are reconfigured in the configuration file in between, their new state won't be taken into account if the registry initialization is skipped because it is already loaded.

Therefore, we need to reset the registry before we proceed with the first initialization. That's ok because feature flags states were saved to disc already. It will be restored correctly like if the Erlang node was fully stopped and restarted.

### How

We unload the `rabbit_ff_registry` module just before we initialize it again in `rabbit_prelaunch_feature_flags`.