### PR TITLE
Explicitly set HOME in `elixir_build` rule

### DIFF
--- a/bazel/elixir/elixir_build.bzl
+++ b/bazel/elixir/elixir_build.bzl
@@ -64,6 +64,7 @@ fi
 {maybe_install_erlang}
 
 export PATH="{erlang_home}"/bin:${{PATH}}
+export HOME="$(mktemp -d)"
 
 ABS_BUILD_DIR=$PWD/{build_path}
 ABS_RELEASE_DIR=$PWD/{release_path}


### PR DESCRIPTION
It's not guaranteed to be set, so it's better to be explicit with a temp dir