### PR TITLE
CLI: Rename disk space monitoring commands

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/activate_free_disk_space_monitoring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/activate_free_disk_space_monitoring_command.ex
@@ -4,7 +4,7 @@
 ##
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Ctl.Commands.DisableFreeDiskSpaceMonitoringCommand do
+defmodule RabbitMQ.CLI.Ctl.Commands.ActivateFreeDiskSpaceMonitoringCommand do
   alias RabbitMQ.CLI.Core.DocGuide
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -36,14 +36,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DisableFreeDiskSpaceMonitoringCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_disk_monitor, :set_enabled, [false], timeout)
+    :rabbit_misc.rpc_call(node_name, :rabbit_disk_monitor, :set_enabled, [true], timeout)
   end
 
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.String
 
-  def usage, do: "disable_free_disk_space_monitoring"
+  def usage, do: "activate_free_disk_space_monitoring"
 
   def usage_doc_guides() do
     [
@@ -54,8 +54,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DisableFreeDiskSpaceMonitoringCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Disables free disk space monitoring on a node"
+  def description(), do: "[Re-]activates free disk space monitoring on a node"
 
   def banner(_, %{node: node_name}),
-    do: "Disabling free disk space monitoring on node #{node_name}..."
+    do: "[Re-]activating free disk space monitoring on node #{node_name}..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/deactivate_free_disk_space_monitoring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/deactivate_free_disk_space_monitoring_command.ex
@@ -4,7 +4,7 @@
 ##
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Ctl.Commands.EnableFreeDiskSpaceMonitoringCommand do
+defmodule RabbitMQ.CLI.Ctl.Commands.DeactivateFreeDiskSpaceMonitoringCommand do
   alias RabbitMQ.CLI.Core.DocGuide
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -36,14 +36,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnableFreeDiskSpaceMonitoringCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_disk_monitor, :set_enabled, [true], timeout)
+    :rabbit_misc.rpc_call(node_name, :rabbit_disk_monitor, :set_enabled, [false], timeout)
   end
 
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.String
 
-  def usage, do: "enable_free_disk_space_monitoring"
+  def usage, do: "deactivate_free_disk_space_monitoring"
 
   def usage_doc_guides() do
     [
@@ -54,8 +54,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnableFreeDiskSpaceMonitoringCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "[Re-]enables free disk space monitoring on a node"
+  def description(), do: "Deactivates free disk space monitoring on a node"
 
   def banner(_, %{node: node_name}),
-    do: "[Re-]enabling free disk space monitoring on node #{node_name}..."
+    do: "Deactivating free disk space monitoring on node #{node_name}..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -628,7 +628,7 @@ defmodule RabbitMQCtl do
   ## {:fun, fun} - run a custom function to enable distribution.
   ## custom mode is usefult for commands which should have specific node name.
   ## Runs code if distribution is successful, or not needed.
-  @spec maybe_with_distribution(module(), options(), (() -> command_result())) :: command_result()
+  @spec maybe_with_distribution(module(), options(), (-> command_result())) :: command_result()
   defp maybe_with_distribution(command, options, code) do
     try do
       maybe_with_distribution_without_catch(command, options, code)

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -628,7 +628,7 @@ defmodule RabbitMQCtl do
   ## {:fun, fun} - run a custom function to enable distribution.
   ## custom mode is usefult for commands which should have specific node name.
   ## Runs code if distribution is successful, or not needed.
-  @spec maybe_with_distribution(module(), options(), (-> command_result())) :: command_result()
+  @spec maybe_with_distribution(module(), options(), (() -> command_result())) :: command_result()
   defp maybe_with_distribution(command, options, code) do
     try do
       maybe_with_distribution_without_catch(command, options, code)

--- a/deps/rabbitmq_cli/test/ctl/activate_disk_free_space_monitoring_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/activate_disk_free_space_monitoring_command_test.exs
@@ -4,11 +4,11 @@
 ##
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule EnableDiskFreeSpaceMonitoringCommandTest do
+defmodule ActivateDiskFreeSpaceMonitoringCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands.EnableFreeDiskSpaceMonitoringCommand
+  @command RabbitMQ.CLI.Ctl.Commands.ActivateFreeDiskSpaceMonitoringCommand
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -35,6 +35,6 @@ defmodule EnableDiskFreeSpaceMonitoringCommandTest do
 
   test "banner", context do
     assert @command.banner([], context[:opts]) =~
-             ~r/\[Re\-\]enabling free disk space monitoring on node/
+             ~r/\[Re\-\]activating free disk space monitoring on node/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/deactivate_disk_free_space_monitoring_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/deactivate_disk_free_space_monitoring_command_test.exs
@@ -34,6 +34,7 @@ defmodule DeactivateDiskFreeSpaceMonitoringCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts]) =~ ~r/Deactivating free disk space monitoring on node/
+    assert @command.banner([], context[:opts]) =~
+             ~r/Deactivating free disk space monitoring on node/
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/deactivate_disk_free_space_monitoring_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/deactivate_disk_free_space_monitoring_command_test.exs
@@ -4,11 +4,11 @@
 ##
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule DisableDiskFreeSpaceMonitoringCommandTest do
+defmodule DeactivateDiskFreeSpaceMonitoringCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Ctl.Commands.DisableFreeDiskSpaceMonitoringCommand
+  @command RabbitMQ.CLI.Ctl.Commands.DeactivateFreeDiskSpaceMonitoringCommand
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -34,6 +34,6 @@ defmodule DisableDiskFreeSpaceMonitoringCommandTest do
   end
 
   test "banner", context do
-    assert @command.banner([], context[:opts]) =~ ~r/Disabling free disk space monitoring on node/
+    assert @command.banner([], context[:opts]) =~ ~r/Deactivating free disk space monitoring on node/
   end
 end


### PR DESCRIPTION
This is a cosmetic renaming change for a not-yet-released pair of commands. Per some internal naming discussions on Slack.

References #8740, #8741, #8743.