### PR TITLE
Drop deprecated set-output github actions command in oci-base.yaml

### DIFF
--- a/.github/workflows/oci-base.yaml
+++ b/.github/workflows/oci-base.yaml
@@ -36,9 +36,9 @@ jobs:
         id: authorized
         run: |
           if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]; then
-            echo "::set-output name=PUSH::true"
+            echo "PUSH=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=PUSH::false"
+            echo "PUSH=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Login to DockerHub


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/