### PR TITLE
Add the possibility of registering custom queue types

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1095,15 +1095,21 @@ check_queue_version(Val, Args) ->
     end.
 
 -define(KNOWN_QUEUE_TYPES, [<<"classic">>, <<"quorum">>, <<"stream">>]).
+known_queue_types() ->
+    Registered = rabbit_registry:lookup_all(queue),
+    {QueueTypes, _} = lists:unzip(Registered),
+    QTypeBins = lists:map(fun(X) -> atom_to_binary(X) end, QueueTypes),
+    ?KNOWN_QUEUE_TYPES ++ QTypeBins.
+
 check_queue_type({longstr, Val}, _Args) ->
-    case lists:member(Val, ?KNOWN_QUEUE_TYPES) of
+    case lists:member(Val, known_queue_types()) of
         true  -> ok;
         false -> {error, rabbit_misc:format("unsupported queue type '~ts'", [Val])}
     end;
 check_queue_type({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}};
 check_queue_type(Val, _Args) when is_binary(Val) ->
-    case lists:member(Val, ?KNOWN_QUEUE_TYPES) of
+    case lists:member(Val, known_queue_types()) of
         true  -> ok;
         false -> {error, rabbit_misc:format("unsupported queue type '~ts'", [Val])}
     end;

--- a/deps/rabbit_common/src/rabbit_registry.erl
+++ b/deps/rabbit_common/src/rabbit_registry.erl
@@ -124,6 +124,7 @@ sanity_check_module(ClassModule, Module) ->
 % rabbit_registry_class behaviour itself: export added_to_rabbit_registry/2
 % and removed_from_rabbit_registry/1 functions.
 class_module(exchange)            -> rabbit_exchange_type;
+class_module(queue)               -> rabbit_queue_type;
 class_module(auth_mechanism)      -> rabbit_auth_mechanism;
 class_module(runtime_parameter)   -> rabbit_runtime_parameter;
 class_module(exchange_decorator)  -> rabbit_exchange_decorator;


### PR DESCRIPTION
## Proposed Changes

With the addition of the queue_type API the ability to create custom queue types became possible. With this small change plugin creators can implement their own special queues without interfering with core RabbitMQ functionality. 

We think this would be a really useful addition to extend RabbitMQ.

Let us know what you think. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
