### PR TITLE
Fix MQTT test flake

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -906,8 +906,8 @@ non_clean_sess_reconnect_qos0_and_qos1(Config) ->
                  get_global_counters(Config)),
 
     ok = emqtt:disconnect(C1),
-    ?assertMatch(#{consumers := 0},
-                 get_global_counters(Config)),
+    eventually(?_assertMatch(#{consumers := 0},
+                             get_global_counters(Config))),
 
     {ok, _} = emqtt:publish(Pub, Topic0, <<"msg-0">>, qos1),
     {ok, _} = emqtt:publish(Pub, Topic1, <<"msg-1">>, qos1),


### PR DESCRIPTION
```
//deps/rabbitmq_mqtt:shared_SUITE-mixed
--test_env FOCUS="-group [web_mqtt,v4,cluster_size_1]
-case non_clean_sess_reconnect_qos0_and_qos1"
```

was flaky.

The DISCONNECT packet is sent aysnc from client to server.

See
https://github.com/rabbitmq/rabbitmq-server/actions/runs/5553886147/attempts/1?pr=5077 for an instance of that flake.