### PR TITLE
Rename to x-opt-reply-to-topic

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -2167,7 +2167,7 @@ mqtt_props_to_amqp_props(Props, Qos, Retain) ->
                  %% the binary queue name in AMQP 0.9.1: "One of the standard message properties is
                  %% Reply-To, which is designed specifically for carrying the name of reply queues."
                  %% Therefore, we add a custom header.
-                 P2#'P_basic'{headers = [{<<"x-reply-to-topic">>, longstr,
+                 P2#'P_basic'{headers = [{<<"x-opt-reply-to-topic">>, longstr,
                                           %% Convert such that an AMQP consumer can respond.
                                           mqtt_to_amqp(Topic)} |
                                          P2#'P_basic'.headers]};
@@ -2258,8 +2258,8 @@ amqp_props_to_mqtt_props(
              _ ->
                  P1
          end,
-    P3 = case rabbit_basic:header(<<"x-reply-to-topic">>, Headers) of
-             {<<"x-reply-to-topic">>, longstr, Topic}
+    P3 = case rabbit_basic:header(<<"x-opt-reply-to-topic">>, Headers) of
+             {<<"x-opt-reply-to-topic">>, longstr, Topic}
                when is_binary(Topic) ->
                  P2#{'Response-Topic' => amqp_to_mqtt(Topic)};
              _ ->

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -1328,7 +1328,7 @@ publish_property_mqtt_to_amqp091(Config) ->
                                   correlation_id = Correlation,
                                   delivery_mode = 2,
                                   headers = Headers}}} = amqp_channel:call(Ch, #'basic.get'{queue = Q}),
-    {<<"x-reply-to-topic">>, longstr, AmqpResponseTopic} = rabbit_basic:header(<<"x-reply-to-topic">>, Headers),
+    {<<"x-opt-reply-to-topic">>, longstr, AmqpResponseTopic} = rabbit_basic:header(<<"x-opt-reply-to-topic">>, Headers),
     ReplyPayload = <<"{\"my\" : \"reply\"}">>,
     amqp_channel:call(Ch, #'basic.publish'{exchange = <<"amq.topic">>,
                                            routing_key = AmqpResponseTopic},


### PR DESCRIPTION
due to AMQP 1.0 spec:
> The annotations type is a map where the keys are restricted to be of type symbol or of type ulong.
All ulong keys, and all symbolic keys except those beginning with "x-" are reserved. Keys beginning with "x-opt-" MUST be ignored if not understood. On receiving an annotation key which is not understood, and which does not begin with "x-opt", the receiving AMQP container MUST detach the link with a not-implemented error.

So, for new headers being introduced it makes sense to comply with that AMQP 1.0 requirement. We don't want the receiver to force to understand this header.