### PR TITLE
Do not force mix format check as part of build

### DIFF
--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -209,21 +209,18 @@ defmodule RabbitMQCtl.MixfileBase do
         "deps.compile"
       ],
       make_app: [
-        "format --check-formatted",
         "compile",
         "escript.build"
       ],
       make_all: [
         "deps.get",
         "deps.compile",
-        "format --check-formatted",
         "compile",
         "escript.build"
       ],
       make_all_in_src_archive: [
         "deps.get --only prod",
         "deps.compile",
-        "format --check-formatted",
         "compile",
         "escript.build"
       ]


### PR DESCRIPTION
It makes joint 1.14/1.15 elixir compatibility too impractical

the format check is still performed in ci by bazel

`cd deps/rabbitmq_cli && mix format` will still work just fine (but should only be performed with the latest elixir, since `mix format` does not produce compatible results across elixir minors)