### PR TITLE
Fix `rabbitmq-env-conf.bat` parsing

### DIFF
--- a/deps/rabbit_common/test/rabbit_env_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_env_SUITE.erl
@@ -58,7 +58,8 @@
          check_log_process_env/1,
          check_log_context/1,
          check_get_used_env_vars/1,
-         check_parse_conf_env_file_output/1
+         check_parse_conf_env_file_output/1,
+         check_parse_conf_env_file_output_win32/1
         ]).
 
 all() ->
@@ -101,7 +102,8 @@ all() ->
      check_log_process_env,
      check_log_context,
      check_get_used_env_vars,
-     check_parse_conf_env_file_output
+     check_parse_conf_env_file_output,
+     check_parse_conf_env_file_output_win32
     ].
 
 suite() ->
@@ -1104,6 +1106,26 @@ get_default_nodename() ->
               "rabbit@\\1",
               [{return, list}]),
     list_to_atom(NodeS).
+
+check_parse_conf_env_file_output_win32(_) ->
+    ?assertEqual(
+       #{},
+       rabbit_env:parse_conf_env_file_output_win32(
+         [],
+         #{}
+        )),
+    ?assertEqual(
+       #{"UNQUOTED" => "a",
+         "UNICODE" => [39, 43, 43, 32, 1550, 32, 39],
+         "DOUBLE_QUOTED" => "c"},
+       rabbit_env:parse_conf_env_file_output_win32(
+         %% a relatively rarely used Unicode character
+         ["++ ؎ ",
+          "UNQUOTED=a",
+          "UNICODE='++ ؎ '",
+          "DOUBLE_QUOTED=\"c\""],
+         #{}
+        )).
 
 check_parse_conf_env_file_output(_) ->
     ?assertEqual(


### PR DESCRIPTION
Due to how the `echo` statement adds a space character, the output marker was not found while parsing the output of
`rabbitmq-env-conf.bat`. This, in turn, resulted in _none_ of the environment variables defined there being re-exported.

In addition, the parsing of the output did not succeed as the default is to expect `sh`-style output.

It is rare for users to use this file on Windows which is how this behavior has not been noticed in years.

Related to:
* https://pivotal-esc.atlassian.net/browse/VESC-1077
* https://vmware.slack.com/archives/C0RDGG81Z/p1689274725888439
* https://github.com/rabbitmq/rabbitmq-server/pull/5486 (tangentially related)