### PR TITLE
Use elixir 1.15.2 with windows

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
         - erlang_version: "26.0"
-          elixir_version: "1.14.5"
+          elixir_version: "1.15.2"
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY


### PR DESCRIPTION
The windows github action workflow appears to hang while it checks what elixir version is available