### PR TITLE
CLI: set OTP logger log level to 'error'

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -36,7 +36,7 @@ defmodule RabbitMQCtl do
   def main(unparsed_command) do
     # silence Erlang/OTP's standard library warnings, it's acceptable for CLI tools,
     # see rabbitmq/rabbitmq-server#8912
-    :logger.set_primary_config(:level, :error)
+    _ = :logger.set_primary_config(:level, :error)
 
     exec_command(unparsed_command, &process_output/3)
     |> handle_shutdown


### PR DESCRIPTION
Closes #8912