### PR TITLE
Remove amqp_client dep from rabbitmq_mqtt

### DIFF
--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -67,8 +67,6 @@ test_suite_beam_files(name = "test_suite_beam_files")
 
 # gazelle:erlang_app_extra_app ssl
 
-# gazelle:erlang_app_dep amqp_client
-
 rabbitmq_app(
     name = "erlang_app",
     srcs = [":all_srcs"],
@@ -83,7 +81,6 @@ rabbitmq_app(
     license_files = [":license_files"],
     priv = [":priv"],
     deps = [
-        "//deps/amqp_client:erlang_app",
         "//deps/rabbit:erlang_app",
         "//deps/rabbit_common:erlang_app",
         "@ra//:erlang_app",

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -44,8 +44,8 @@ BUILD_WITHOUT_QUIC=1
 export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = ssl
-DEPS = ranch rabbit_common rabbit amqp_client ra
-TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_web_mqtt
+DEPS = ranch rabbit_common rabbit ra
+TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_web_mqtt amqp_client
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
 dep_emqtt = git https://github.com/rabbitmq/emqtt.git master


### PR DESCRIPTION
Since Native MQTT in 3.12 the MQTT plugin does not depend on AMQP 0.9.1 client anymore. Such a dependency is only needed for the MQTT tests.