### PR TITLE
implement recover and arguments for custom queue types

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1094,22 +1094,15 @@ check_queue_version(Val, Args) ->
         Error            -> Error
     end.
 
--define(KNOWN_QUEUE_TYPES, [<<"classic">>, <<"quorum">>, <<"stream">>]).
-known_queue_types() ->
-    Registered = rabbit_registry:lookup_all(queue),
-    {QueueTypes, _} = lists:unzip(Registered),
-    QTypeBins = lists:map(fun(X) -> atom_to_binary(X) end, QueueTypes),
-    ?KNOWN_QUEUE_TYPES ++ QTypeBins.
-
 check_queue_type({longstr, Val}, _Args) ->
-    case lists:member(Val, known_queue_types()) of
+    case lists:member(Val, rabbit_queue_type:known_queue_type_names()) of
         true  -> ok;
         false -> {error, rabbit_misc:format("unsupported queue type '~ts'", [Val])}
     end;
 check_queue_type({Type,    _}, _Args) ->
     {error, {unacceptable_type, Type}};
 check_queue_type(Val, _Args) when is_binary(Val) ->
-    case lists:member(Val, known_queue_types()) of
+    case lists:member(Val, rabbit_queue_type:known_queue_type_names()) of
         true  -> ok;
         false -> {error, rabbit_misc:format("unsupported queue type '~ts'", [Val])}
     end;

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -54,7 +54,9 @@
 
 -export([
          added_to_rabbit_registry/2,
-         removed_from_rabbit_registry/1
+         removed_from_rabbit_registry/1,
+         known_queue_type_names/0,
+         known_queue_type_modules/0
         ]).
 
 -type queue_name() :: rabbit_amqqueue:name().
@@ -72,7 +74,8 @@
 -define(DOWN_KEYS, [name, durable, auto_delete, arguments, pid, recoverable_slaves, type, state]).
 
 %% TODO resolve all registered queue types from registry
--define(QUEUE_TYPES, [rabbit_classic_queue, rabbit_quorum_queue, rabbit_stream_queue]).
+-define(QUEUE_MODULES, [rabbit_classic_queue, rabbit_quorum_queue, rabbit_stream_queue]).
+-define(KNOWN_QUEUE_TYPES, [<<"classic">>, <<"quorum">>, <<"stream">>]).
 
 %% anything that the host process needs to do on behalf of the queue type session
 -type action() ::
@@ -366,7 +369,7 @@ is_server_named_allowed(Type) ->
 arguments(ArgumentType) ->
     Args0 = lists:map(fun(T) ->
                               maps:get(ArgumentType, T:capabilities(), [])
-                      end, ?QUEUE_TYPES),
+                      end, known_queue_type_modules()),
     Args = lists:flatten(Args0),
     lists:usort(Args).
 
@@ -435,7 +438,7 @@ is_recoverable(Q) ->
     {Recovered :: [amqqueue:amqqueue()],
      Failed :: [amqqueue:amqqueue()]}.
 recover(VHost, Qs) ->
-    ByType0 = maps:from_keys(?QUEUE_TYPES, []),
+    ByType0 = maps:from_keys(known_queue_type_modules(), []),
     ByType = lists:foldl(
                fun (Q, Acc) ->
                        T = amqqueue:get_type(Q),
@@ -684,3 +687,16 @@ qref(#resource{kind = queue} = QName) ->
     QName;
 qref(Q) when ?is_amqqueue(Q) ->
     amqqueue:get_name(Q).
+
+-spec known_queue_type_modules() -> [module()].
+known_queue_type_modules() ->
+    Registered = rabbit_registry:lookup_all(queue),
+    {_, Modules} = lists:unzip(Registered),
+    ?QUEUE_MODULES ++ Modules.
+
+-spec known_queue_type_names() -> [binary()].
+known_queue_type_names() ->
+    Registered = rabbit_registry:lookup_all(queue),
+    {QueueTypes, _} = lists:unzip(Registered),
+    QTypeBins = lists:map(fun(X) -> atom_to_binary(X) end, QueueTypes),
+    ?KNOWN_QUEUE_TYPES ++ QTypeBins.


### PR DESCRIPTION
Call the registry for the list of available queue types and modules instead using only the hardcoded values.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

There are a few other things which may not be working yet, for example policies, [stopping a vhost](https://github.com/rabbitmq/rabbitmq-server/blob/7d7cb824d01985626783c44d1c1d14bec4c22e04/deps/rabbit/src/rabbit_amqqueue.erl#L146-L151), [cleanup functions](https://github.com/rabbitmq/rabbitmq-server/blob/7d7cb824d01985626783c44d1c1d14bec4c22e04/deps/rabbit/src/rabbit_amqqueue.erl#L1585-L1590),some CLI commands, peer discovery. 
