### PR TITLE
rabbit_db: Fall back to `rabbit_mnesia` if functions are undefined in remote nodes

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
@@ -29,16 +29,32 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangeClusterNodeTypeCommand do
 
   def run([node_type_arg], %{node: node_name}) do
     normalized_type = normalize_type(String.to_atom(node_type_arg))
-    current_type = :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :node_type, [])
+
+    current_type =
+      case :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :node_type, []) do
+        {:badrpc, {:EXIT, {:undef, _}}} ->
+          :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :node_type, [])
+
+        ret ->
+          ret
+      end
 
     case current_type do
       ^normalized_type ->
         {:ok, "Node type is already #{normalized_type}"}
 
       _ ->
-        :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :change_node_type, [
-          normalized_type
-        ])
+        case :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :change_node_type, [
+               normalized_type
+             ]) do
+          {:badrpc, {:EXIT, {:undef, _}}} ->
+            :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :change_cluster_node_type, [
+              normalized_type
+            ])
+
+          ret ->
+            ret
+        end
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -14,7 +14,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
   def run([], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_db, :force_reset, [])
+    case :rabbit_misc.rpc_call(node_name, :rabbit_db, :force_reset, []) do
+      {:badrpc, {:EXIT, {:undef, _}}} ->
+        :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :force_reset, [])
+
+      ret ->
+        ret
+    end
   end
 
   def output({:error, :mnesia_unexpectedly_running}, %{node: node_name}) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -14,7 +14,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
   def run([], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_db, :reset, [])
+    case :rabbit_misc.rpc_call(node_name, :rabbit_db, :reset, []) do
+      {:badrpc, {:EXIT, {:undef, _}}} ->
+        :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :reset, [])
+
+      ret ->
+        ret
+    end
   end
 
   def output({:error, :mnesia_unexpectedly_running}, %{node: node_name}) do


### PR DESCRIPTION
### Why

The CLI may be used against a remote node running a different version. We took that into account in several uses of the `rabbit_db*` modules on remote nodes, but not everywhere. Likewise in the
`clustering_management_SUITE` testsuite.

### How
This patch falls back to previous `rabbit_mnesia`-based calls if the initial calls throws an `undef` exception.