### PR TITLE
rabbit_db: Reset feature flags registry after a database reset

### DIFF
--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -91,8 +91,9 @@ init_using_mnesia() ->
 %% @doc Resets the database and the node.
 
 reset() ->
-    run(
-      #{mnesia => fun reset_using_mnesia/0}).
+    Ret = run(
+            #{mnesia => fun reset_using_mnesia/0}),
+    post_reset(Ret).
 
 reset_using_mnesia() ->
     ?LOG_INFO(
@@ -105,8 +106,9 @@ reset_using_mnesia() ->
 %% @doc Resets the database and the node.
 
 force_reset() ->
-    run(
-      #{mnesia => fun force_reset_using_mnesia/0}).
+    Ret = run(
+            #{mnesia => fun force_reset_using_mnesia/0}),
+    post_reset(Ret).
 
 force_reset_using_mnesia() ->
     ?LOG_DEBUG(
@@ -130,6 +132,16 @@ force_load_on_next_boot_using_mnesia() ->
       "DB: force load on next boot (using Mnesia)",
       #{domain => ?RMQLOG_DOMAIN_DB}),
     rabbit_mnesia:force_load_next_boot().
+
+post_reset(ok) ->
+    rabbit_feature_flags:reset_registry(),
+    ok;
+post_reset({error, _} = Error) ->
+    Error.
+
+%% -------------------------------------------------------------------
+%% is_virgin_node().
+%% -------------------------------------------------------------------
 
 -spec is_virgin_node() -> IsVirgin when
       IsVirgin :: boolean().

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -116,10 +116,12 @@
          running_remote_nodes/0,
          does_node_support/3,
          inject_test_feature_flags/1, inject_test_feature_flags/2,
+         clear_injected_test_feature_flags/0,
          query_supported_feature_flags/0,
          does_enabled_feature_flags_list_file_exist/0,
          read_enabled_feature_flags_list/0,
-         uses_callbacks/1]).
+         uses_callbacks/1,
+         reset_registry/0]).
 
 -ifdef(TEST).
 -export([override_nodes/1,
@@ -811,6 +813,10 @@ inject_test_feature_flags(FeatureFlags, InitReg) ->
         false -> ok
     end.
 
+clear_injected_test_feature_flags() ->
+    _ = persistent_term:erase(?PT_TESTSUITE_ATTRS),
+    ok.
+
 module_attributes_from_testsuite() ->
     persistent_term:get(?PT_TESTSUITE_ATTRS, []).
 
@@ -1293,3 +1299,12 @@ sync_feature_flags_with_cluster(Nodes, _NodeIsVirgin) ->
 
 refresh_feature_flags_after_app_load() ->
     rabbit_ff_controller:refresh_after_app_load().
+
+-spec reset_registry() -> ok.
+%% @doc Resets the feature flags registry.
+%%
+%% The registry will be automatically reloaded with the next use of it, after
+%% reading the recorded state from disc.
+
+reset_registry() ->
+    rabbit_ff_registry_factory:reset_registry().

--- a/deps/rabbit/src/rabbit_prelaunch_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_prelaunch_feature_flags.erl
@@ -24,7 +24,7 @@ setup(#{feature_flags_file := FFFile}) ->
             %% stop_app/start_app, so reset it here. This ensures that e.g.
             %% any change to the configuration file w.r.t. deprecated features
             %% are taken into account.
-            rabbit_ff_registry_factory:reset_registry(),
+            rabbit_feature_flags:reset_registry(),
 
             ?LOG_DEBUG(
                "Initializing feature flags registry", [],


### PR DESCRIPTION
### Why

A database reset removes the enabled feature flags file on disc. A reset of the registry ensures that the next time the registry is reloaded, it is also initialized from scratch.

### How

We call `rabbit_feature_flags:reset_registry/0` after both a regular reset and a forced reset.

The `reset_registry/0` is also exposed by the `rabbit_feature_flags` module now. The actual implementation in `rabbit_ff_registry_factory` should only be called by the Feature flags subsystem itself.