### PR TITLE
Improvements to feature flags and `rabbit_db*`

### DIFF
--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -89,6 +89,8 @@ join(RemoteNode, NodeType)
                       fun() -> join_using_mnesia(ClusterNodes, NodeType) end}),
             case Ret of
                 ok ->
+                    rabbit_feature_flags:copy_feature_states_after_reset(
+                      RemoteNode),
                     rabbit_node_monitor:notify_joined_cluster(),
                     ok;
                 {error, _} = Error ->

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -58,8 +58,7 @@ can_join(RemoteNode) ->
        #{domain => ?RMQLOG_DOMAIN_DB}),
     case rabbit_feature_flags:check_node_compatibility(RemoteNode) of
         ok ->
-            rabbit_db:run(
-              #{mnesia => fun() -> can_join_using_mnesia(RemoteNode) end});
+            can_join_using_mnesia(RemoteNode);
         Error ->
             Error
     end.
@@ -84,9 +83,7 @@ join(RemoteNode, NodeType)
             ?LOG_INFO(
                "DB: joining cluster using remote nodes:~n~tp", [ClusterNodes],
                #{domain => ?RMQLOG_DOMAIN_DB}),
-            Ret = rabbit_db:run(
-                    #{mnesia =>
-                      fun() -> join_using_mnesia(ClusterNodes, NodeType) end}),
+            Ret =  join_using_mnesia(ClusterNodes, NodeType),
             case Ret of
                 ok ->
                     rabbit_feature_flags:copy_feature_states_after_reset(

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -78,7 +78,7 @@ join(RemoteNode, NodeType)
   when is_atom(RemoteNode) andalso ?IS_NODE_TYPE(NodeType) ->
     case can_join(RemoteNode) of
         {ok, ClusterNodes} when is_list(ClusterNodes) ->
-            rabbit_db:reset(),
+            ok = rabbit_db:reset(),
 
             ?LOG_INFO(
                "DB: joining cluster using remote nodes:~n~tp", [ClusterNodes],


### PR DESCRIPTION
This pull request is a collection of improvements to feature flags and `rabbit_db*` modules:
* We ensure that deprecated features that must not be permitted if some enabled feature flags depend on them are actually not permitted regardless of what their configuration says.
* To speed up feature flags synchronization and to make sure that two nodes using a different database engine can form a cluster in the future, we copy the feature flags states from the cluster to the joining node. This works because the joining node is reset in the process.
* As part of `rabbit_db_cluster:join/2`, we don't want to use `rabbit_db:run/1` because we care about the remote database engine choice, not the local one.
* As part of `rabbit_db_cluster:join/2`, we assert the return value of the reset.