### PR TITLE
Tests: split parallel stream queue groups and retry if coordinator unavailable

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -801,7 +801,7 @@ rabbitmq_integration_suite(
     additional_beam = [
         ":test_quorum_queue_utils_beam",
     ],
-    shard_count = 12,
+    shard_count = 21,
     deps = [
         "@proper//:erlang_app",
     ],

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -22,14 +22,23 @@ suite() ->
 all() ->
     [
      {group, single_node},
-     {group, single_node_parallel},
+     {group, single_node_parallel_1},
+     {group, single_node_parallel_2},
+     {group, single_node_parallel_3},
+     {group, single_node_parallel_4},
      {group, cluster_size_2},
-     {group, cluster_size_2_parallel},
+     {group, cluster_size_2_parallel_1},
+     {group, cluster_size_2_parallel_2},
+     {group, cluster_size_2_parallel_3},
+     {group, cluster_size_2_parallel_4},
      {group, cluster_size_3},
      {group, cluster_size_3_1},
      {group, cluster_size_3_2},
      {group, cluster_size_3_parallel_1},
      {group, cluster_size_3_parallel_2},
+     {group, cluster_size_3_parallel_3},
+     {group, cluster_size_3_parallel_4},
+     {group, cluster_size_3_parallel_5},
      {group, unclustered_size_3_1},
      {group, unclustered_size_3_2},
      {group, unclustered_size_3_3}
@@ -38,9 +47,15 @@ all() ->
 groups() ->
     [
      {single_node, [], [restart_single_node, recover]},
-     {single_node_parallel, [parallel], all_tests()},
+     {single_node_parallel_1, [parallel], all_tests_1()},
+     {single_node_parallel_2, [parallel], all_tests_2()},
+     {single_node_parallel_3, [parallel], all_tests_3()},
+     {single_node_parallel_4, [parallel], all_tests_4()},
      {cluster_size_2, [], [recover]},
-     {cluster_size_2_parallel, [parallel], all_tests()},
+     {cluster_size_2_parallel_1, [parallel], all_tests_1()},
+     {cluster_size_2_parallel_2, [parallel], all_tests_2()},
+     {cluster_size_2_parallel_3, [parallel], all_tests_3()},
+     {cluster_size_2_parallel_4, [parallel], all_tests_4()},
      {cluster_size_3, [],
           [
            restart_coordinator_without_queues,
@@ -75,13 +90,16 @@ groups() ->
                                               leader_locator_client_local,
                                               declare_delete_same_stream
                                              ]},
-     {cluster_size_3_parallel_2, [parallel], all_tests()},
+     {cluster_size_3_parallel_2, [parallel], all_tests_1()},
+     {cluster_size_3_parallel_3, [parallel], all_tests_2()},
+     {cluster_size_3_parallel_4, [parallel], all_tests_3()},
+     {cluster_size_3_parallel_5, [parallel], all_tests_4()},
      {unclustered_size_3_1, [], [add_replica]},
      {unclustered_size_3_2, [], [consume_without_local_replica]},
      {unclustered_size_3_3, [], [grow_coordinator_cluster]}
     ].
 
-all_tests() ->
+all_tests_1() ->
     [
      declare_args,
      declare_max_age,
@@ -94,7 +112,11 @@ all_tests() ->
      delete_queue,
      publish,
      publish_confirm,
-     consume_without_qos,
+     consume_without_qos
+    ].
+
+all_tests_2() ->
+    [
      consume,
      consume_offset,
      consume_timestamp_offset,
@@ -106,7 +128,11 @@ all_tests() ->
      consume_and_reject,
      consume_from_last,
      consume_from_next,
-     consume_from_default,
+     consume_from_default
+    ].
+
+all_tests_3() ->
+    [
      consume_from_relative_time_offset,
      consume_credit,
      consume_credit_out_of_order_ack,
@@ -117,7 +143,11 @@ all_tests() ->
      max_length_bytes,
      max_age,
      invalid_policy,
-     max_age_policy,
+     max_age_policy
+    ].
+
+all_tests_4() ->
+    [
      max_segment_size_bytes_validation,
      max_segment_size_bytes_policy,
      max_segment_size_bytes_policy_validation,
@@ -158,12 +188,21 @@ init_per_group(Group, Config) ->
 init_per_group1(Group, Config) ->
     ClusterSize = case Group of
                       single_node -> 1;
-                      single_node_parallel -> 1;
+                      single_node_parallel_1 -> 1;
+                      single_node_parallel_2 -> 1;
+                      single_node_parallel_3 -> 1;
+                      single_node_parallel_4 -> 1;
                       cluster_size_2 -> 2;
-                      cluster_size_2_parallel -> 2;
+                      cluster_size_2_parallel_1 -> 2;
+                      cluster_size_2_parallel_2 -> 2;
+                      cluster_size_2_parallel_3 -> 2;
+                      cluster_size_2_parallel_4 -> 2;
                       cluster_size_3 -> 3;
                       cluster_size_3_parallel_1 -> 3;
                       cluster_size_3_parallel_2 -> 3;
+                      cluster_size_3_parallel_3 -> 3;
+                      cluster_size_3_parallel_4 -> 3;
+                      cluster_size_3_parallel_5 -> 3;
                       cluster_size_3_1 -> 3;
                       cluster_size_3_2 -> 3;
                       unclustered_size_3_1 -> 3;
@@ -269,33 +308,31 @@ end_per_testcase(Testcase, Config) ->
 declare_args(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-max-length-bytes">>, long, 2_000_000},
-                                 {<<"x-max-age">>, longstr, <<"10D">>},
-                                 {<<"x-stream-max-segment-size-bytes">>, long, 5_000_000},
-                                 {<<"x-stream-filter-size-bytes">>, long, 32}
-                                ])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-length-bytes">>, long, 2_000_000},
+                                             {<<"x-max-age">>, longstr, <<"10D">>},
+                                             {<<"x-stream-max-segment-size-bytes">>, long, 5_000_000},
+                                             {<<"x-stream-filter-size-bytes">>, long, 32}
+                                            ])),
     assert_queue_type(Server, Q, rabbit_stream_queue),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
 declare_max_age(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
 
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},
-       declare(rabbit_ct_client_helpers:open_channel(Config, Server), Q,
+       declare(Config, Server, Q,
                [{<<"x-queue-type">>, longstr, <<"stream">>},
                 {<<"x-max-age">>, longstr, <<"1A">>}])),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-max-age">>, longstr, <<"1Y">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-age">>, longstr, <<"1Y">>}])),
     assert_queue_type(Server, Q, rabbit_stream_queue),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
@@ -305,24 +342,24 @@ declare_invalid_properties(Config) ->
 
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},
-       amqp_channel:call(
-         rabbit_ct_client_helpers:open_channel(Config, Server),
+       retry_if_coordinator_unavailable(
+         Config, Server,
          #'queue.declare'{queue     = Q,
                           auto_delete = true,
                           durable   = true,
                           arguments = [{<<"x-queue-type">>, longstr, <<"stream">>}]})),
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},
-       amqp_channel:call(
-         rabbit_ct_client_helpers:open_channel(Config, Server),
+       retry_if_coordinator_unavailable(
+         Config, Server,
          #'queue.declare'{queue     = Q,
                           exclusive = true,
                           durable   = true,
                           arguments = [{<<"x-queue-type">>, longstr, <<"stream">>}]})),
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},
-       amqp_channel:call(
-         rabbit_ct_client_helpers:open_channel(Config, Server),
+       retry_if_coordinator_unavailable(
+         Config, Server,
          #'queue.declare'{queue     = Q,
                           durable   = false,
                           arguments = [{<<"x-queue-type">>, longstr, <<"stream">>}]})).
@@ -332,31 +369,29 @@ declare_server_named(Config) ->
 
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},
-       declare(rabbit_ct_client_helpers:open_channel(Config, Server),
+       declare(Config, Server,
                <<"">>, [{<<"x-queue-type">>, longstr, <<"stream">>}])).
 
 declare_invalid_arg(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
 
     ExpectedError = <<"PRECONDITION_FAILED - invalid arg 'x-overflow' for queue "
                       "'declare_invalid_arg' in vhost '/' of queue type rabbit_stream_queue">>,
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, ExpectedError}}, _},
-       declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+       declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                        {<<"x-overflow">>, longstr, <<"reject-publish">>}])).
 
 declare_invalid_filter_size(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
 
     ExpectedError = <<"PRECONDITION_FAILED - Invalid value for  x-stream-filter-size-bytes">>,
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, ExpectedError}}, _},
-       declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                       {<<"x-stream-filter-size-bytes">>, long, 256}])).
+       declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                   {<<"x-stream-filter-size-bytes">>, long, 256}])).
 
 consume_invalid_arg(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
@@ -364,7 +399,7 @@ consume_invalid_arg(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ExpectedError = <<"PRECONDITION_FAILED - invalid arg 'x-priority' for queue "
                       "'consume_invalid_arg' in vhost '/' of queue type rabbit_stream_queue">>,
@@ -380,19 +415,18 @@ consume_invalid_arg(Config) ->
 declare_queue(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     %% Test declare an existing queue
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ?assertMatch([_], find_queue_info(Config, [])),
 
     %% Test declare an existing queue with different arguments
-    ?assertExit(_, declare(Ch, Q, [])),
+    ?assertExit(_, declare(Config, Server, Q, [])),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
 find_queue_info(Config, Keys) ->
@@ -412,7 +446,7 @@ delete_queue(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     ?assertMatch(#'queue.delete_ok'{},
                  amqp_channel:call(Ch, #'queue.delete'{queue = Q})).
 
@@ -422,8 +456,8 @@ add_replicas(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 1}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-initial-cluster-size">>, long, 1}])),
 
     %% TODO: add lots of data so that replica is still out of sync when
     %% second request comes in
@@ -487,7 +521,6 @@ add_replicas(Config) ->
 add_replica(Config) ->
     [Server0, Server1, Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
 
     %% Let's also try the add replica command on other queue types, it should fail
@@ -497,11 +530,11 @@ add_replica(Config) ->
     QQuorum = <<Q/binary, "_quorum">>,
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     ?assertEqual({'queue.declare_ok', QClassic, 0, 0},
-                 declare(Ch, QClassic, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+                 declare(Config, Server0, QClassic, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
     ?assertEqual({'queue.declare_ok', QQuorum, 0, 0},
-                 declare(Ch, QQuorum, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+                 declare(Config, Server0, QQuorum, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
 
     %% Not a member of the cluster, what would happen?
     ?assertEqual({error, node_not_running},
@@ -545,10 +578,9 @@ add_replica(Config) ->
 delete_replica(Config) ->
     [Server0, Server1, Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     check_leader_and_replicas(Config, [Server0, Server1, Server2]),
     %% Not a member of the cluster, what would happen?
     ?assertEqual({error, node_not_running},
@@ -571,10 +603,9 @@ delete_replica(Config) ->
 delete_last_replica(Config) ->
     [Server0, Server1, Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     check_leader_and_replicas(Config, [Server0, Server1, Server2]),
     ?assertEqual(ok,
                  rpc:call(Server0, rabbit_stream_queue, delete_replica,
@@ -597,11 +628,10 @@ delete_last_replica(Config) ->
 grow_coordinator_cluster(Config) ->
     [Server0, Server1, _Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ok = rabbit_control_helper:command(stop_app, Server1),
     ok = rabbit_control_helper:command(join_cluster, Server1, [atom_to_list(Server0)], []),
@@ -615,9 +645,8 @@ grow_coordinator_cluster(Config) ->
                           [<<"/">>, Q, Server1])),
     %% also check we can declare a new stream when calling Server1
     Q2 = unicode:characters_to_binary([Q, <<"_2">>]),
-    ChServer1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
     ?assertEqual({'queue.declare_ok', Q2, 0, 0},
-                 declare(ChServer1, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     %% wait until the stream coordinator detects there is a new rabbit node
     %% and adds a new member on the new node
@@ -637,12 +666,11 @@ grow_coordinator_cluster(Config) ->
 shrink_coordinator_cluster(Config) ->
     [Server0, Server1, Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
 
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ok = rabbit_control_helper:command(stop_app, Server2),
     ok = rabbit_control_helper:command(forget_cluster_node, Server0, [atom_to_list(Server2)], []),
@@ -662,10 +690,9 @@ shrink_coordinator_cluster(Config) ->
 delete_classic_replica(Config) ->
     [Server0, Server1, _Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
     %% Not a member of the cluster, what would happen?
     ?assertEqual({error, classic_queue_not_supported},
                  rpc:call(Server0, rabbit_stream_queue, delete_replica,
@@ -678,10 +705,9 @@ delete_classic_replica(Config) ->
 delete_quorum_replica(Config) ->
     [Server0, Server1, _Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
     %% Not a member of the cluster, what would happen?
     ?assertEqual({error, quorum_queue_not_supported},
                  rpc:call(Server0, rabbit_stream_queue, delete_replica,
@@ -694,10 +720,9 @@ delete_quorum_replica(Config) ->
 delete_down_replica(Config) ->
     [Server0, Server1, Server2] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     check_leader_and_replicas(Config, [Server0, Server1, Server2]),
     ok = rabbit_ct_broker_helpers:stop_node(Config, Server1),
     ?assertEqual({error, node_not_running},
@@ -719,7 +744,7 @@ publish_coordinator_unavailable(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     check_leader_and_replicas(Config, [Server0, Server1, Server2]),
     ok = rabbit_ct_broker_helpers:stop_node(Config, Server1),
     ok = rabbit_ct_broker_helpers:stop_node(Config, Server2),
@@ -755,7 +780,7 @@ publish(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish(Ch, Q),
     quorum_queue_utils:wait_for_messages(Config, [[Q, <<"1">>, <<"1">>, <<"0">>]]),
@@ -767,7 +792,7 @@ publish_confirm(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
     amqp_channel:register_confirm_handler(Ch, self()),
@@ -782,7 +807,7 @@ restart_single_node(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     publish(Ch, Q),
     quorum_queue_utils:wait_for_messages(Config, [[Q, <<"1">>, <<"1">>, <<"0">>]]),
 
@@ -799,12 +824,11 @@ restart_single_node(Config) ->
 %% please never consider this a flake
 declare_with_node_down_1(Config) ->
     [Server1, Server2, Server3] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
     rabbit_ct_broker_helpers:stop_node(Config, Server2),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 3}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-initial-cluster-size">>, long, 3}])),
     check_leader_and_replicas(Config, [Server1, Server3]),
     %% Since there are not sufficient running nodes, we expect that
     %% also stopped nodes are selected as replicas.
@@ -815,13 +839,12 @@ declare_with_node_down_1(Config) ->
 
 declare_with_node_down_2(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
     rabbit_ct_broker_helpers:stop_node(Config, Server2),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 2},
-                                 {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-initial-cluster-size">>, long, 2},
+                                              {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
     check_leader_and_replicas(Config, [Server1, Server3]),
     %% Since there are sufficient running nodes, we expect that
     %% stopped nodes are not selected as replicas.
@@ -836,7 +859,7 @@ recover(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     publish(Ch, Q),
     quorum_queue_utils:wait_for_messages(Config, [[Q, <<"1">>, <<"1">>, <<"0">>]]),
 
@@ -877,16 +900,15 @@ restart_coordinator_without_queues(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     publish_confirm(Ch, Q, [<<"msg">>]),
     ?assertMatch(#'queue.delete_ok'{}, amqp_channel:call(Ch, #'queue.delete'{queue = Q})),
 
     [rabbit_ct_broker_helpers:stop_node(Config, S) || S <- Servers0],
     [rabbit_ct_broker_helpers:start_node(Config, S) || S <- lists:reverse(Servers0)],
 
-    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
 consume_without_qos(Config) ->
@@ -895,7 +917,7 @@ consume_without_qos(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
                 amqp_channel:subscribe(Ch, #'basic.consume'{queue = Q, consumer_tag = <<"ctag">>},
@@ -905,10 +927,9 @@ consume_without_qos(Config) ->
 consume_without_local_replica(Config) ->
     [Server0, Server1 | _] =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     %% Add another node to the cluster, but it won't have a replica
     ok = rabbit_control_helper:command(stop_app, Server1),
     ok = rabbit_control_helper:command(join_cluster, Server1, [atom_to_list(Server0)], []),
@@ -928,7 +949,7 @@ consume(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg">>]),
 
@@ -952,7 +973,7 @@ consume_offset(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     Payload = << <<"1">> || _ <- lists:seq(1, 500) >>,
     publish_confirm(Ch, Q, [Payload || _ <- lists:seq(1, 1000)]),
@@ -987,7 +1008,7 @@ consume_timestamp_offset(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"111">> || _ <- lists:seq(1, 100)]),
 
@@ -1019,7 +1040,7 @@ consume_timestamp_last_offset(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"111">> || _ <- lists:seq(1, 100)]),
 
@@ -1066,7 +1087,7 @@ basic_get(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
                 amqp_channel:call(Ch, #'basic.get'{queue = Q})),
@@ -1075,10 +1096,9 @@ basic_get(Config) ->
 consume_with_autoack(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
     qos(Ch1, 10, false),
@@ -1094,7 +1114,7 @@ consume_and_nack(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg">>]),
 
@@ -1110,7 +1130,10 @@ consume_and_nack(Config) ->
             %% we'll detect the conneciton/channel closure on the next call.
             %% Let's try to redeclare and see what happens
             ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
-                        declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]))
+                        amqp_channel:call(Ch1, #'queue.declare'{queue = Q,
+                                                               durable = true,
+                                                               auto_delete = false,
+                                                               arguments = [{<<"x-queue-type">>, longstr, <<"stream">>}]}))
     after 10000 ->
             exit(timeout)
     end,
@@ -1122,7 +1145,7 @@ basic_cancel(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg">>]),
 
@@ -1149,7 +1172,7 @@ receive_basic_cancel_on_queue_deletion(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     qos(Ch, 10, false),
     CTag = <<"basic_cancel_notification_on_queue_deletion">>,
@@ -1172,7 +1195,7 @@ recover_after_leader_and_coordinator_kill(Config) ->
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch1, Q, [<<"msg 1">>]),
 
@@ -1210,7 +1233,7 @@ keep_consuming_on_leader_restart(Config) ->
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch1, Q, [<<"msg 1">>]),
 
@@ -1319,7 +1342,7 @@ consume_and_reject(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg">>]),
 
@@ -1334,7 +1357,7 @@ consume_and_reject(Config) ->
             %% we'll detect the conneciton/channel closure on the next call.
             %% Let's try to redeclare and see what happens
             ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
-                        declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]))
+                        declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]))
     after 10000 ->
             exit(timeout)
     end,
@@ -1346,7 +1369,7 @@ consume_and_ack(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg">>]),
 
@@ -1362,7 +1385,7 @@ consume_and_ack(Config) ->
             %% should still be open and declare is an idempotent operation
             %%
             ?assertMatch({'queue.declare_ok', Q, _MsgCount, 0},
-                         declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                         declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
             quorum_queue_utils:wait_for_messages(Config, [[Q, <<"1">>, <<"1">>, <<"0">>]])
     after 5000 ->
             exit(timeout)
@@ -1375,7 +1398,7 @@ tracking_status(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     Vhost = ?config(rmq_vhost, Config),
     ?assertEqual([], rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_stream_queue,
@@ -1397,7 +1420,7 @@ restart_stream(Config) ->
             Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
             Q = ?config(queue_name, Config),
             ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                         declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                         declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
             publish_confirm(Ch, Q, [<<"msg">>]),
             Vhost = ?config(rmq_vhost, Config),
@@ -1427,7 +1450,7 @@ consume_from_last(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg1">> || _ <- lists:seq(1, 100)]),
 
@@ -1483,7 +1506,7 @@ consume_from_next(Config, Args) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg1">> || _ <- lists:seq(1, 100)]),
 
@@ -1528,7 +1551,7 @@ consume_from_relative_time_offset(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch, Q, [<<"msg1">> || _ <- lists:seq(1, 100)]),
 
@@ -1555,7 +1578,7 @@ consume_from_replica(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     publish_confirm(Ch1, Q, [<<"msg1">> || _ <- lists:seq(1, 100)]),
 
@@ -1584,7 +1607,7 @@ consume_credit(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     %% Let's publish a big batch, to ensure we have more than a chunk available
     NumMsgs = 100,
@@ -1642,7 +1665,7 @@ consume_credit_out_of_order_ack(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     NumMsgs = 100,
     %% Let's publish a big batch, to ensure we have more than a chunk available
@@ -1701,7 +1724,7 @@ consume_credit_multiple_ack(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     %% Let's publish a big batch, to ensure we have more than a chunk available
     NumMsgs = 100,
@@ -1736,9 +1759,9 @@ max_length_bytes(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-max-length-bytes">>, long, 10000},
-                                 {<<"x-stream-max-segment-size-bytes">>, long, 1000}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-length-bytes">>, long, 10000},
+                                             {<<"x-stream-max-segment-size-bytes">>, long, 1000}])),
 
     Payload = << <<"1">> || _ <- lists:seq(1, 100) >>,
 
@@ -1765,18 +1788,17 @@ max_length_bytes(Config) ->
 max_segment_size_bytes_validation(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-stream-max-segment-size-bytes">>, long, 10_000_000}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-stream-max-segment-size-bytes">>, long, 10_000_000}])),
 
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]),
 
     ?assertExit(
        {{shutdown, {server_initiated_close, 406, _}}, _},
-       declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                       {<<"x-stream-max-segment-size-bytes">>, long, ?MAX_STREAM_MAX_SEGMENT_SIZE + 1_000}])),
+       declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                   {<<"x-stream-max-segment-size-bytes">>, long, ?MAX_STREAM_MAX_SEGMENT_SIZE + 1_000}])),
 
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
@@ -1787,9 +1809,9 @@ max_age(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-max-age">>, longstr, <<"10s">>},
-                                 {<<"x-stream-max-segment-size-bytes">>, long, 250}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-max-age">>, longstr, <<"10s">>},
+                                             {<<"x-stream-max-segment-size-bytes">>, long, 250}])),
 
     Payload = << <<"1">> || _ <- lists:seq(1, 500) >>,
 
@@ -1814,7 +1836,7 @@ replica_recovery(Config) ->
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     publish_confirm(Ch1, Q, [<<"msg1">> || _ <- lists:seq(1, 100)]),
     amqp_channel:close(Ch1),
 
@@ -1857,7 +1879,7 @@ leader_failover(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     check_leader_and_replicas(Config, [Server1, Server2, Server3]),
     publish_confirm(Ch1, Q, [<<"msg">> || _ <- lists:seq(1, 100)]),
@@ -1884,11 +1906,10 @@ leader_failover_dedupe(Config) ->
     Nodes = lists:nth(rand:uniform(length(PermNodes)), PermNodes),
     ct:pal("~ts running with nodes ~w", [?FUNCTION_NAME, Nodes]),
     [_Server1, DownNode, PubNode] = Nodes,
-    Ch1 = rabbit_ct_client_helpers:open_channel(Config, DownNode),
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, DownNode, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     check_leader_and_replicas(Config, Nodes),
 
@@ -1955,8 +1976,8 @@ initial_cluster_size_one(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                  {<<"x-initial-cluster-size">>, long, 1}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-initial-cluster-size">>, long, 1}])),
     check_leader_and_replicas(Config, [Server1]),
 
     ?assertMatch(#'queue.delete_ok'{},
@@ -1970,8 +1991,8 @@ initial_cluster_size_two(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                  {<<"x-initial-cluster-size">>, long, 2}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-initial-cluster-size">>, long, 2}])),
 
     Info = find_queue_info(Config, [leader, members]),
 
@@ -1995,8 +2016,8 @@ initial_cluster_size_one_policy(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                  {<<"x-initial-cluster-size">>, long, 1}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-initial-cluster-size">>, long, 1}])),
     check_leader_and_replicas(Config, [Server1]),
 
     ?assertMatch(#'queue.delete_ok'{},
@@ -2012,7 +2033,7 @@ declare_delete_same_stream(Config) ->
     [begin
          Ch = rabbit_ct_client_helpers:open_channel(Config, S),
          ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                      declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                      declare(Config, S, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
          ?assertMatch(#'queue.delete_ok'{},
                       amqp_channel:call(Ch, #'queue.delete'{queue = Q})),
          rabbit_ct_client_helpers:close_channel(Ch)
@@ -2027,8 +2048,8 @@ leader_locator_client_local(Config) ->
     Q = ?config(queue_name, Config),
 
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
 
     Info = find_queue_info(Config, [leader]),
 
@@ -2040,8 +2061,8 @@ leader_locator_client_local(Config) ->
     %% Try second node
     Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server2),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch2, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+                 declare(Config, Server2, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
 
     Info2 = find_queue_info(Config, [leader]),
     ?assertEqual(Server2, proplists:get_value(leader, Info2)),
@@ -2052,8 +2073,8 @@ leader_locator_client_local(Config) ->
     %% Try third node
     Ch3 = rabbit_ct_client_helpers:open_channel(Config, Server3),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch3, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                  {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+                 declare(Config, Server3, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
 
 
     Info3 = find_queue_info(Config, [leader]),
@@ -2066,17 +2087,16 @@ leader_locator_client_local(Config) ->
 leader_locator_balanced(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     Bin = rabbit_data_coercion:to_binary(?FUNCTION_NAME),
     Q1 = <<Bin/binary, "_q1">>,
 
     ?assertEqual({'queue.declare_ok', Q1, 0, 0},
-                 declare(Ch, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                  {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+                 declare(Config, Server1, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
 
     Info = find_queue_info(Config, [leader]),
     Leader = proplists:get_value(leader, Info),
@@ -2086,21 +2106,19 @@ leader_locator_balanced(Config) ->
 
 leader_locator_balanced_maintenance(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
-    Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server2),
     Q = ?config(queue_name, Config),
     Q1 = <<"q1">>,
     Q2 = <<"q2">>,
     ?assertEqual({'queue.declare_ok', Q1, 0, 0},
-                 declare(Ch1, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                   {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+                 declare(Config, Server1, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
     ?assertEqual({'queue.declare_ok', Q2, 0, 0},
-                 declare(Ch2, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                   {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
+                 declare(Config, Server2, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
     true = rabbit_ct_broker_helpers:mark_as_being_drained(Config, Server3),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                  {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                              {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
 
     Info = find_queue_info(Config, [leader]),
     Leader = proplists:get_value(leader, Info),
@@ -2112,7 +2130,6 @@ leader_locator_balanced_maintenance(Config) ->
 select_nodes_with_least_replicas(Config) ->
     [Server1 | _ ] = Servers0 = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Servers = lists:usort(Servers0),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     Bin = rabbit_data_coercion:to_binary(?FUNCTION_NAME),
     Q1 = <<Bin/binary, "_q1">>,
@@ -2121,8 +2138,8 @@ select_nodes_with_least_replicas(Config) ->
     [Q1Members, QMembers] =
     lists:map(fun(Q0) ->
                       ?assertEqual({'queue.declare_ok', Q0, 0, 0},
-                                   declare(Ch, Q0, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                                    {<<"x-initial-cluster-size">>, long, 2}])),
+                                   declare(Config, Server1, Q0, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                                                 {<<"x-initial-cluster-size">>, long, 2}])),
                       Infos = rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, info_all,
                                                            [<<"/">>, [name, members]]),
                       Name = rabbit_misc:r(<<"/">>, queue, Q0),
@@ -2139,7 +2156,6 @@ select_nodes_with_least_replicas(Config) ->
 leader_locator_policy(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     Bin = rabbit_data_coercion:to_binary(?FUNCTION_NAME),
     Q1 = <<Bin/binary, "_q1">>,
@@ -2151,10 +2167,10 @@ leader_locator_policy(Config) ->
            [{<<"queue-leader-locator">>, <<"balanced">>}]),
 
     ?assertEqual({'queue.declare_ok', Q1, 0, 0},
-                 declare(Ch, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                 declare(Config, Server1, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                   {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     Info = find_queue_info(Config, [policy, operator_policy, effective_policy_definition, leader]),
     ?assertEqual(PolicyName, proplists:get_value(policy, Info)),
@@ -2173,24 +2189,24 @@ queue_size_on_declare(Config) ->
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server1),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     publish_confirm(Ch1, Q, [<<"msg1">> || _ <- lists:seq(1, 100)]),
 
     %% Metrics update is not synchronous, wait until metrics are updated on the leader node.
     %% Afterwards, all replicas will get the right size as they have to query the writer node
     ?awaitMatch({'queue.declare_ok', Q, 100, 0},
-                declare(Ch1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]),
+                declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]),
                 60000),
     amqp_channel:close(Ch1),
 
     Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server2),
     ?assertEqual({'queue.declare_ok', Q, 100, 0},
-                 declare(Ch2, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server2, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     amqp_channel:close(Ch2),
 
     Ch3 = rabbit_ct_client_helpers:open_channel(Config, Server3),
     ?assertEqual({'queue.declare_ok', Q, 100, 0},
-                 declare(Ch3, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server3, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     amqp_channel:close(Ch3),
 
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
@@ -2206,10 +2222,9 @@ repeat_until(Fun, N) ->
 invalid_policy(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     ok = rabbit_ct_broker_helpers:set_policy(
            Config, 0, <<"ha">>, <<"invalid_policy.*">>, <<"queues">>,
            [{<<"ha-mode">>, <<"all">>}]),
@@ -2229,10 +2244,9 @@ invalid_policy(Config) ->
 max_age_policy(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     PolicyName = atom_to_binary(?FUNCTION_NAME),
 
     ok = rabbit_ct_broker_helpers:set_policy(
@@ -2258,10 +2272,10 @@ update_retention_policy(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-stream-max-segment-size-bytes">>, long, 200},
-                                 {<<"x-stream-filter-size-bytes">>, long, 32}
-                                ])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                             {<<"x-stream-max-segment-size-bytes">>, long, 200},
+                                             {<<"x-stream-filter-size-bytes">>, long, 32}
+                                            ])),
     check_leader_and_replicas(Config, Servers),
 
     Msgs = [<<"msg">> || _ <- lists:seq(1, 10000)], %% 3 bytes * 10000 = 30000 bytes
@@ -2291,10 +2305,9 @@ update_retention_policy(Config) ->
 queue_info(Config) ->
     [Server | _] = Servers = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     rabbit_ct_helpers:await_condition(
       fun() ->
@@ -2338,10 +2351,9 @@ max_segment_size_bytes_policy(Config) ->
            [{<<"stream-max-segment-size-bytes">>, 5000}]),
 
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     Info = find_queue_info(Config, [policy, operator_policy, effective_policy_definition]),
 
     ?assertEqual(PolicyName, proplists:get_value(policy, Info)),
@@ -2357,7 +2369,7 @@ purge(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
                 amqp_channel:call(Ch, #'queue.purge'{queue = Q})),
@@ -2368,14 +2380,14 @@ dead_letter_target(Config) ->
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(Ch, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     SourceQ = <<Q/binary, "_source">>,
     ?assertEqual({'queue.declare_ok', SourceQ, 0, 0},
-                 declare(Ch, SourceQ, [{<<"x-queue-type">>, longstr, <<"classic">>},
-                                       {<<"x-dead-letter-exchange">>, longstr, <<>>},
-                                       {<<"x-dead-letter-routing-key">>, longstr, Q}
-                                      ])),
+                 declare(Config, Server, SourceQ, [{<<"x-queue-type">>, longstr, <<"classic">>},
+                                                   {<<"x-dead-letter-exchange">>, longstr, <<>>},
+                                                   {<<"x-dead-letter-routing-key">>, longstr, Q}
+                                                  ])),
 
     publish_confirm(Ch, SourceQ, [<<"msg">>]),
     Ch1 = rabbit_ct_client_helpers:open_channel(Config, Server),
@@ -2430,7 +2442,7 @@ filtering(Config) ->
     ChPublish = rabbit_ct_client_helpers:open_channel(Config, Server),
     Q = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                 declare(ChPublish, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
     #'confirm.select_ok'{} = amqp_channel:call(ChPublish, #'confirm.select'{}),
     amqp_channel:register_confirm_handler(ChPublish, self()),
@@ -2500,14 +2512,45 @@ delete_testcase_queue(Name) ->
             ok
     end.
 
-declare(Ch, Q) ->
-    declare(Ch, Q, []).
+declare(Config, Server, Q) ->
+    declare(Config, Server, Q, []).
 
-declare(Ch, Q, Args) ->
-    amqp_channel:call(Ch, #'queue.declare'{queue     = Q,
-                                           durable   = true,
-                                           auto_delete = false,
-                                           arguments = Args}).
+declare(Config, Server, Q, Args) ->
+    retry_if_coordinator_unavailable(Config, Server, #'queue.declare'{queue     = Q,
+                                                                      durable   = true,
+                                                                      auto_delete = false,
+                                                                      arguments = Args}).
+
+retry_if_coordinator_unavailable(Config, Server, Cmd) ->
+    Props = ?config(tc_group_properties, Config),
+    %% Running parallel tests the coordinator could be busy answering other
+    %% queries, on the assumption CI servers are slow, so let's allow a few
+    %% attempts.
+    Retries = case lists:member(parallel, Props) of
+                  true -> 3;
+                  false -> 1
+              end,
+    retry_if_coordinator_unavailable(Config, Server, Cmd, Retries).
+
+retry_if_coordinator_unavailable(_, _, _, 0) ->
+    exit(coordinator_unavailable);
+retry_if_coordinator_unavailable(Config, Server, Cmd, Retry) ->
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    try
+        Reply = amqp_channel:call(Ch, Cmd),
+        rabbit_ct_client_helpers:close_channel(Ch),
+        Reply
+    catch
+        exit:{{shutdown, {connection_closing, {server_initiated_close, _, Msg}}}, _} = Error ->
+            case re:run(Msg, ".*coordinator_unavailable.*", [{capture, none}]) of
+                match ->
+                    ct:pal("Attempt to execute command ~p failed, coordinator unavailable", [Cmd]),
+                    retry_if_coordinator_unavailable(Ch, Cmd, Retry - 1);
+                _ ->
+                    exit(Error)
+            end
+    end.
+
 assert_queue_type(Server, Q, Expected) ->
     Actual = get_queue_type(Server, Q),
     Expected = Actual.


### PR DESCRIPTION
This test suite times out often in CI. It is probably a real test issue as CI is slower than our dev machines.
