### PR TITLE
Only copy local listeners when FF listener_records_in_ets is enabled

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -165,7 +165,8 @@ listener_records_in_ets_enable(#{feature_name := FeatureName}) ->
                                 rabbit_listener, [{'$1',[],['$1']}]),
                   lists:foreach(
                     fun(Listener) ->
-                            ets:insert(rabbit_listener_ets, Listener)
+                            rabbit_networking:is_listener_on_this_node(Listener)
+                                andalso ets:insert(rabbit_listener_ets, Listener)
                     end, Listeners)
           end)
     catch

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -45,6 +45,8 @@
 
 -export([ensure_listener_table_for_this_node/0]).
 
+-export([is_listener_on_this_node/1]).
+
 -deprecated([{force_connection_event_refresh, 1, eventually}]).
 
 -export([
@@ -819,3 +821,7 @@ ipv6_status(TestPort) ->
 ensure_listener_table_for_this_node() ->
     _ = ets:new(?ETS_TABLE, [named_table, public, bag, {keypos, #listener.node}]),
     ok.
+
+%% Needed for migration when feature flag listener_records_in_ets is enabled
+is_listener_on_this_node(#listener{node = Node}) ->
+    Node =:= node().


### PR DESCRIPTION
## Proposed Changes

The `rabbit_listener_ets` table normally only contains listener entries for the local node. However after upgrading to 3.11.x and the `listener_records_in_ets` feature flag is enabled, all entries were copied to ETS from Mnesia, and the replicated Mnesia table contained entries for all nodes in a multi-node cluster.

In this state `rabbit_networking:listener_of_protocol_ets/1` could crash with a case clause when multiple rows match a protocol. This can happen for example when the node is put in maintenance and the web_stomp plugin is enabled which queries the ranch refs to close all client connections. (`rabbit_web_stomp_listener:close_all_client_connections/1`)

A simple restart of the node or app reinitializes the listeners and the ETS table so this "corrupt" state is cleared.

Only affects 3.11 series so opening the PR against that branch.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
