### PR TITLE
Replace remaining direct calls to `rabbit_ff_registry`

### DIFF
--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -286,7 +286,7 @@ is_permitted_nolog(FeatureName) ->
 %% features.
 
 get_phase(FeatureName) when is_atom(FeatureName) ->
-    case rabbit_ff_registry:get(FeatureName) of
+    case rabbit_ff_registry_wrapper:get(FeatureName) of
         undefined    -> undefined;
         FeatureProps -> get_phase(FeatureProps)
     end;
@@ -317,7 +317,7 @@ get_phase(FeatureProps) when is_map(FeatureProps) ->
 %% features.
 
 get_warning(FeatureName) when is_atom(FeatureName) ->
-    case rabbit_ff_registry:get(FeatureName) of
+    case rabbit_ff_registry_wrapper:get(FeatureName) of
         undefined    -> undefined;
         FeatureProps -> get_warning(FeatureProps)
     end;
@@ -328,7 +328,7 @@ get_warning(FeatureProps) when is_map(FeatureProps) ->
     get_warning(FeatureProps, Permitted).
 
 get_warning(FeatureName, Permitted) when is_atom(FeatureName) ->
-    case rabbit_ff_registry:get(FeatureName) of
+    case rabbit_ff_registry_wrapper:get(FeatureName) of
         undefined    -> undefined;
         FeatureProps -> get_warning(FeatureProps, Permitted)
     end;

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1109,11 +1109,11 @@ try_to_write_enabled_feature_flags_list(FeatureNames) ->
                         end,
     FeatureNames1 = lists:filter(
                       fun(FeatureName) ->
-                              case rabbit_ff_registry:get(FeatureName) of
-                                  undefined ->
-                                      false;
-                                  FeatureProps ->
-                                      ?IS_FEATURE_FLAG(FeatureProps)
+                              FeatureProps = rabbit_ff_registry_wrapper:get(
+                                               FeatureName),
+                              case FeatureProps of
+                                  undefined -> false;
+                                  _         -> ?IS_FEATURE_FLAG(FeatureProps)
                               end
                       end, FeatureNames),
     FeatureNames2 = lists:foldl(

--- a/deps/rabbit/src/rabbit_ff_registry.erl
+++ b/deps/rabbit/src/rabbit_ff_registry.erl
@@ -203,11 +203,10 @@ is_registry_written_to_disk() ->
       Inventory :: rabbit_feature_flags:inventory().
 
 inventory() ->
-    _ = rabbit_ff_registry_factory:initialize_registry(),
     Inventory = #{applications => [],
                   feature_flags => #{},
                   states => #{}},
-    ?convince_dialyzer(?MODULE:inventory(), Inventory, Inventory).
+    ?convince_dialyzer(?MODULE:inventory(), init_required, Inventory).
 
 always_return_true() ->
     %% This function is here to trick Dialyzer. We want some functions

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -114,8 +114,9 @@ initialize_registry(NewSupportedFeatureFlags) ->
     RegistryInitialized = rabbit_ff_registry:is_registry_initialized(),
     FeatureStates = case RegistryInitialized of
                         true ->
-                            CurrentFeatureStates = rabbit_ff_registry:states(),
-                            maps:merge(FeatureStates0, CurrentFeatureStates);
+                            maps:merge(
+                              FeatureStates0,
+                              rabbit_ff_registry_wrapper:states());
                         false ->
                             FeatureStates0
                     end,
@@ -205,7 +206,7 @@ maybe_initialize_registry(NewSupportedFeatureFlags,
     %% We take the feature flags already registered.
     RegistryInitialized = rabbit_ff_registry:is_registry_initialized(),
     KnownFeatureFlags1 = case RegistryInitialized of
-                             true  -> rabbit_ff_registry:list(all);
+                             true  -> rabbit_ff_registry_wrapper:list(all);
                              false -> #{}
                          end,
 
@@ -253,8 +254,9 @@ maybe_initialize_registry(NewSupportedFeatureFlags,
     not rabbit_feature_flags:does_enabled_feature_flags_list_file_exist(),
     FeatureStates0 = case RegistryInitialized of
                          true ->
-                             maps:merge(rabbit_ff_registry:states(),
-                                        NewFeatureStates);
+                             maps:merge(
+                               rabbit_ff_registry_wrapper:states(),
+                               NewFeatureStates);
                          false ->
                              NewFeatureStates
                      end,
@@ -374,8 +376,8 @@ does_registry_need_refresh(AllFeatureFlags,
             %% Before proceeding with the actual
             %% (re)initialization, let's see if there are any
             %% changes.
-            CurrentAllFeatureFlags = rabbit_ff_registry:list(all),
-            CurrentFeatureStates = rabbit_ff_registry:states(),
+            CurrentAllFeatureFlags = rabbit_ff_registry_wrapper:list(all),
+            CurrentFeatureStates = rabbit_ff_registry_wrapper:states(),
             CurrentWrittenToDisk =
             rabbit_ff_registry:is_registry_written_to_disk(),
 


### PR DESCRIPTION
This branch is comprised of three commits to address the remaining direct calls to the `rabbit_ff_registry` module, i.e. without going through `rabbit_ff_registry_wrapper`. Direct calls can trigger a deadlock with the Erlang Code server when the registry is reloaded; see #8155.

Here is a short description of each commit:
1. The `rabbit_ff_registry:inventory/0` stub is fixed to not initialize the registry and return `init_required`. All other functions were modified in this way (see #8155), except this one. This is an oversight from me.
2. There was one direct call to `rabbit_ff_registry` from `rabbit_feature_flags`, also an oversight probably. However, there were several direct calls in `rabbit_deprecated_features`. As this module was added in parallel (see #7390), it was not updated accordingly unfortunately.
3. Collecting remote inventories was also based on a direct call to `rabbit_ff_registry`. This last commit tries to use `rabbit_ff_registry_wrapper` first and if it is unavailable, it falls back to `rabbit_ff_registry` after logging a warning for the possible deadlock.

Commits will be backported to the 3.11.x and 3.12.x release branches except the part about deprecated features.