### PR TITLE
rabbit_stream_queue_SUITE: Fix `consume_and_reject` channel close detection

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1351,13 +1351,22 @@ consume_and_reject(Config) ->
     subscribe(Ch1, Q, false, 0),
     receive
         {#'basic.deliver'{delivery_tag = DeliveryTag}, _} ->
+            MRef = erlang:monitor(process, Ch1),
             ok = amqp_channel:cast(Ch1, #'basic.reject'{delivery_tag = DeliveryTag,
                                                       requeue      = true}),
-            %% Reject will throw a not implemented exception. As it is a cast operation,
-            %% we'll detect the conneciton/channel closure on the next call.
-            %% Let's try to redeclare and see what happens
-            ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 540, _}}}, _},
-                        declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}]))
+            %% Reject will throw a not implemented exception. As it is a cast
+            %% operation, we detect the connection error from the channel
+            %% process exit reason.
+            receive
+                {'DOWN', MRef, _, _, Reason} ->
+                    ?assertMatch(
+                       {shutdown,
+                        {connection_closing,
+                         {server_initiated_close, 540, _}}},
+                       Reason)
+            after 10000 ->
+                      exit(timeout)
+            end
     after 10000 ->
             exit(timeout)
     end,

--- a/deps/rabbitmq_ct_client_helpers/src/rabbit_ct_client_helpers.erl
+++ b/deps/rabbitmq_ct_client_helpers/src/rabbit_ct_client_helpers.erl
@@ -217,6 +217,8 @@ open_channel(Config, Node) ->
     Pid ! {open_channel, self()},
     receive
         Ch when is_pid(Ch) -> Ch
+    after 60_000 ->
+        ct:fail("Timed out waiting for connection to open")
     end.
 
 open_connection_and_channel(Config) ->


### PR DESCRIPTION
### Why

The previous detection was based on a reuse of the channel to get the error from an exit exception. The problem is that it is very dependent on the timing: if the channel process exits before it is reused, the test fails for two possible reasons:

1. The channel and connection processes exit before they are reused and the channel manager opens a new pair. The problem is that the declare suceeds but the test expected a failure.

2. The channel and connection processes exit during the reuse and `rabbit_ct_client_helpers:open_channel` in `retry_if_coordinator_unavailable()` waits a response from the channel manager forever (this is probably a weakness of the channel manager in rabbitmq_ct_client_helpers). This indefinite wait causes the testcase to timeout.

### How

A simpler solution is to monitor the exit reason of the channel process that triggers the error on the server side.