### PR TITLE
Nack rejected messages to MQTT 5.0 client

### DIFF
--- a/deps/rabbit/src/rabbit_confirms.erl
+++ b/deps/rabbit/src/rabbit_confirms.erl
@@ -144,9 +144,3 @@ next_smallest(S, U) when is_map_key(S, U) ->
 next_smallest(S, U) ->
     %% TODO: this is potentially infinitely recursive if called incorrectly
     next_smallest(S+1, U).
-
-
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.

--- a/deps/rabbit/test/rabbit_confirms_SUITE.erl
+++ b/deps/rabbit/test/rabbit_confirms_SUITE.erl
@@ -1,11 +1,6 @@
 -module(rabbit_confirms_SUITE).
 
--compile(export_all).
-
--export([
-         ]).
-
--include_lib("common_test/include/ct.hrl").
+-compile([export_all, nowarn_export_all]).
 -include_lib("eunit/include/eunit.hrl").
 
 %%%===================================================================
@@ -17,40 +12,13 @@ all() ->
      {group, tests}
     ].
 
-
-all_tests() ->
-    [
-     confirm,
-     reject,
-     remove_queue
-    ].
-
 groups() ->
     [
-     {tests, [], all_tests()}
-    ].
-
-init_per_suite(Config) ->
-    Config.
-
-end_per_suite(_Config) ->
-    ok.
-
-init_per_group(_Group, Config) ->
-    Config.
-
-end_per_group(_Group, _Config) ->
-    ok.
-
-init_per_testcase(_TestCase, Config) ->
-    Config.
-
-end_per_testcase(_TestCase, _Config) ->
-    ok.
-
-%%%===================================================================
-%%% Test cases
-%%%===================================================================
+     {tests, [shuffle],
+      [confirm,
+       reject,
+       remove_queue
+      ]}].
 
 confirm(_Config) ->
     XName = rabbit_misc:r(<<"/">>, exchange, <<"X">>),
@@ -93,7 +61,6 @@ confirm(_Config) ->
     ?assertEqual(0, rabbit_confirms:size(U7)),
     ?assertEqual(undefined, rabbit_confirms:smallest(U7)),
 
-
     U8 = rabbit_confirms:insert(2, [QName], XName, U1),
     {[{1, XName}, {2, XName}], _U9} = rabbit_confirms:confirm([1, 2], QName, U8),
     ok.
@@ -126,7 +93,6 @@ reject(_Config) ->
     {error, not_found} = rabbit_confirms:reject(2, U5),
     ?assertEqual(1, rabbit_confirms:size(U5)),
     ?assertEqual(1, rabbit_confirms:smallest(U5)),
-
     ok.
 
 remove_queue(_Config) ->
@@ -147,8 +113,4 @@ remove_queue(_Config) ->
     U5 = rabbit_confirms:insert(1, [QName], XName, U0),
     U6 = rabbit_confirms:insert(2, [QName], XName, U5),
     {[{1, XName}, {2, XName}], _U} = rabbit_confirms:remove_queue(QName, U6),
-
     ok.
-
-
-%% Utility

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -281,6 +281,14 @@ rabbitmq_suite(
     ],
 )
 
+rabbitmq_suite(
+    name = "rabbit_mqtt_confirms_SUITE",
+    size = "small",
+    deps = [
+        "//deps/rabbit_common:erlang_app",
+    ],
+)
+
 assert_suites()
 
 alias(

--- a/deps/rabbitmq_mqtt/app.bzl
+++ b/deps/rabbitmq_mqtt/app.bzl
@@ -331,3 +331,11 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp_client:erlang_app"],
     )
+    erlang_bytecode(
+        name = "rabbit_mqtt_confirms_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/rabbit_mqtt_confirms_SUITE.erl"],
+        outs = ["test/rabbit_mqtt_confirms_SUITE.beam"],
+        app_name = "rabbitmq_mqtt",
+        erlc_opts = "//:test_erlc_opts",
+    )

--- a/deps/rabbitmq_mqtt/test/rabbit_mqtt_confirms_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/rabbit_mqtt_confirms_SUITE.erl
@@ -1,0 +1,109 @@
+-module(rabbit_mqtt_confirms_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+     {group, tests}
+    ].
+
+groups() ->
+    [
+     {tests, [shuffle],
+      [confirm,
+       reject,
+       remove_queue
+      ]}].
+
+-define(MOD, rabbit_mqtt_confirms).
+
+confirm(_Config) ->
+    QName = rabbit_misc:r(<<"/">>, queue, <<"Q">>),
+    QName2 = rabbit_misc:r(<<"/">>, queue, <<"Q2">>),
+    U0 = ?MOD:init(),
+    ?assertEqual(0, ?MOD:size(U0)),
+
+    U1 = ?MOD:insert(1, [QName], U0),
+    ?assertEqual(1, ?MOD:size(U1)),
+    ?assert(?MOD:contains(1, U1)),
+
+    {[1], U2} = ?MOD:confirm([1], QName, U1),
+    ?assertEqual(0, ?MOD:size(U2)),
+    ?assertNot(?MOD:contains(1, U2)),
+
+    U3 = ?MOD:insert(2, [QName], U1),
+    ?assertEqual(2, ?MOD:size(U3)),
+    ?assert(?MOD:contains(1, U3)),
+    ?assert(?MOD:contains(2, U3)),
+
+    {[1], U4} = ?MOD:confirm([1], QName, U3),
+    ?assertEqual(1, ?MOD:size(U4)),
+    ?assertNot(?MOD:contains(1, U4)),
+    ?assert(?MOD:contains(2, U4)),
+
+    U5 = ?MOD:insert(2, [QName, QName2], U1),
+    ?assertEqual(2, ?MOD:size(U5)),
+    ?assert(?MOD:contains(1, U5)),
+    ?assert(?MOD:contains(2, U5)),
+
+    {[1], U6} = ?MOD:confirm([1, 2], QName, U5),
+    {[2], U7} = ?MOD:confirm([2], QName2, U6),
+    ?assertEqual(0, ?MOD:size(U7)),
+
+    U8 = ?MOD:insert(2, [QName], U1),
+    {Confirmed, _U9} = ?MOD:confirm([1, 2], QName, U8),
+    ?assertEqual([1, 2], lists:sort(Confirmed)),
+    ok.
+
+
+reject(_Config) ->
+    QName = rabbit_misc:r(<<"/">>, queue, <<"Q">>),
+    QName2 = rabbit_misc:r(<<"/">>, queue, <<"Q2">>),
+    U0 = ?MOD:init(),
+    ?assertEqual(0, ?MOD:size(U0)),
+
+    U1 = ?MOD:insert(1, [QName], U0),
+    ?assert(?MOD:contains(1, U1)),
+
+    {[1], U2} = ?MOD:reject([1], U1),
+    {[], U2} = ?MOD:reject([1], U2),
+    ?assertEqual(0, ?MOD:size(U2)),
+    ?assertNot(?MOD:contains(1, U2)),
+
+    U3 = ?MOD:insert(2, [QName, QName2], U1),
+
+    {[1], U4} = ?MOD:reject([1], U3),
+    {[], U4} = ?MOD:reject([1], U4),
+    ?assertEqual(1, ?MOD:size(U4)),
+
+    {[2], U5} = ?MOD:reject([2], U3),
+    {[], U5} = ?MOD:reject([2], U5),
+    ?assertEqual(1, ?MOD:size(U5)),
+    ?assert(?MOD:contains(1, U5)),
+    ok.
+
+remove_queue(_Config) ->
+    QName = rabbit_misc:r(<<"/">>, queue, <<"Q">>),
+    QName2 = rabbit_misc:r(<<"/">>, queue, <<"Q2">>),
+    U0 = ?MOD:init(),
+
+    U1 = ?MOD:insert(1, [QName, QName2], U0),
+    U2 = ?MOD:insert(2, [QName2], U1),
+    {[2], U3} = ?MOD:remove_queue(QName2, U2),
+    ?assertEqual(1, ?MOD:size(U3)),
+    ?assert(?MOD:contains(1, U3)),
+    {[1], U4} = ?MOD:remove_queue(QName, U3),
+    ?assertEqual(0, ?MOD:size(U4)),
+    ?assertNot(?MOD:contains(1, U4)),
+
+    U5 = ?MOD:insert(1, [QName], U0),
+    U6 = ?MOD:insert(2, [QName], U5),
+    {Confirmed, U7} = ?MOD:remove_queue(QName, U6),
+    ?assertEqual([1, 2], lists:sort(Confirmed)),
+    ?assertEqual(0, ?MOD:size(U7)),
+    ok.


### PR DESCRIPTION
since MQTT 5.0 supports negative acknowledgements thanks to reason codes in the PUBACK packet.

We could either choose reason code 128 or 131. The description code for
131 applies for rejected messages, hence this commit uses 131:
> The PUBLISH is valid but the receiver is not willing to accept it.