### PR TITLE
Fix crash in MQTT reader

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -249,7 +249,7 @@ handle_info({{'DOWN', _QName}, _MRef, process, _Pid, _Reason} = Evt,
         {ok, PState} ->
             maybe_process_deferred_recv(control_throttle(pstate(State, PState)));
         {error, Reason} ->
-            {stop, {shutdown, Reason, State}}
+            {stop, {shutdown, Reason}, State}
     end;
 
 handle_info({'DOWN', _MRef, process, QPid, _Reason}, State) ->


### PR DESCRIPTION
Fix the following crash:
```
crasher:
  initial call: rabbit_mqtt_reader:init/1
  pid: <0.2009.0>
  registered_name: []
  exception exit: {bad_return_value,
                   {stop,
                    {shutdown,consuming_queue_down,
                     {state,#Port<0.163>,undefined,true,undefined,4,
                      {state,
```