### PR TITLE
Bump Osiris to 1.6.2, references #8616

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -270,7 +270,7 @@ erlang_package.hex_package(
 erlang_package.git_package(
     build_file = "@rabbitmq-server//bazel:BUILD.osiris",
     repository = "rabbitmq/osiris",
-    tag = "v1.6.0",
+    tag = "v1.6.2",
 )
 
 erlang_package.hex_package(

--- a/bazel/BUILD.osiris
+++ b/bazel/BUILD.osiris
@@ -6,7 +6,7 @@ load("@rules_erlang//:ct.bzl", "assert_suites2", "ct_suite")
 
 NAME = "osiris"
 
-VERSION = "1.5.1"
+VERSION = "1.6.2"
 
 DESCRIPTION = "New project"
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -149,7 +149,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.6.1
+dep_osiris = git https://github.com/rabbitmq/osiris v1.6.2
 dep_systemd = hex 0.6.1
 dep_seshat = hex 0.4.0
 

--- a/release-notes/3.12.1.md
+++ b/release-notes/3.12.1.md
@@ -151,7 +151,6 @@ Release notes can be found on GitHub at [rabbitmq-server/release-notes](https://
 ## Dependency Upgrades
 
  * `ra` was upgraded to [`2.6.2`](https://github.com/rabbitmq/ra/releases)
- * `osiris` was upgraded [from `1.5.1` to `1.6.0`](https://github.com/rabbitmq/osiris/tags)
 
 ## Source Code Archives
 


### PR DESCRIPTION
In #8616, Osiris was bumped to 1.6.0 but
`BUILD.bazel` in the repo still reported the version as 1.5.1.

That created a fair amount of confusion.

References #8209, #9053, #9054.
