### PR TITLE
Delete MQTT usage from rabbitmq_auth_mechanism_ssl

### DIFF
--- a/deps/rabbitmq_auth_mechanism_ssl/README.md
+++ b/deps/rabbitmq_auth_mechanism_ssl/README.md
@@ -105,27 +105,6 @@ Note that the authenticated user will then be looked up in the
 the internal node database by default but could include other
 backends if so configured.
 
-
-## Usage for MQTT Clients
-
-To use this plugin with MQTT clients, set `mqtt.ssl_cert_login` to `true`:
-
-``` ini
-# It makes no sense to allow or expect anonymous client connections
-# with certificate-based authentication 
-mqtt.allow_anonymous = false
-
-# require the peer to provide a certificate, enforce certificate exchange
-ssl_options.verify = verify_peer
-ssl_options.fail_if_no_peer_cert = true
-
-# allow MQTT connections to compute their name from client certificate's CN
-# (for simplicity: CN has been deprecated in favor of SAN for a long time)
-mqtt.ssl_cert_login = true
-ssl_cert_login_from = common_name
-```
-
-
 ## Copyright & License
 
 (c) 2007-2023 VMware, Inc. or its affiliates.


### PR DESCRIPTION
The rabbitmq_auth_mechanism_ssl plugin is a RabbitMQ implementation of an SASL mechanism.

However, SASL is not supported by MQTT 3.1 and 3.1.1. Even for MQTT 5.0 where SASL is supported, the RabbitMQ MQTT plugin does not make use of SASL (as of the upcoming 3.13.0 release).

So, the rabbitmq_auth_mechanism_ssl plugin does not have any effect on the MQTT plugin.

Therefore, it's very confusing that MQTT is mentioned in this plugin.

Everything that's deleted by this commit is already available in the https://www.rabbitmq.com/mqtt.html docs.