### PR TITLE
Init dead letter counter once

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
@@ -96,16 +96,16 @@ local_connection_pids() ->
 init_global_counters() ->
     lists:foreach(fun init_global_counters/1, [?MQTT_PROTO_V3,
                                                ?MQTT_PROTO_V4,
-                                               ?MQTT_PROTO_V5]).
+                                               ?MQTT_PROTO_V5]),
+    rabbit_global_counters:init([{queue_type, ?QUEUE_TYPE_QOS_0}, {dead_letter_strategy, disabled}],
+                                [?MESSAGES_DEAD_LETTERED_MAXLEN_COUNTER]).
 
 init_global_counters(ProtoVer) ->
     Proto = {protocol, ProtoVer},
     rabbit_global_counters:init([Proto]),
     rabbit_global_counters:init([Proto, {queue_type, rabbit_classic_queue}]),
     rabbit_global_counters:init([Proto, {queue_type, rabbit_quorum_queue}]),
-    rabbit_global_counters:init([Proto, {queue_type, ?QUEUE_TYPE_QOS_0}]),
-    rabbit_global_counters:init([{queue_type, ?QUEUE_TYPE_QOS_0}, {dead_letter_strategy, disabled}],
-                                [?MESSAGES_DEAD_LETTERED_MAXLEN_COUNTER]).
+    rabbit_global_counters:init([Proto, {queue_type, ?QUEUE_TYPE_QOS_0}]).
 
 persist_static_configuration() ->
     rabbit_mqtt_util:init_sparkplug(),

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -48,7 +48,7 @@ tests() ->
     ].
 
 suite() ->
-    [{timetrap, {seconds, 60}}].
+    [{timetrap, {minutes, 3}}].
 
 %% -------------------------------------------------------------------
 %% Testsuite setup/teardown.


### PR DESCRIPTION
follow up from https://github.com/rabbitmq/rabbitmq-server/pull/9080

Call rabbit_global_counters:init/1 just once.