### PR TITLE
Bump emqtt

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -417,7 +417,7 @@ erlang_dev_package.hex_package(
 
 erlang_dev_package.git_package(
     name = "emqtt",
-    branch = "otp-26-compatibility",
+    branch = "master",
     build_file = "@rabbitmq-server//bazel:BUILD.emqtt",
     repository = "rabbitmq/emqtt",
 )

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -16,7 +16,7 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 dep_jose = git https://github.com/michaelklishin/erlang-jose mk-thoas-support
 dep_base64url = hex 1.0.1
 
-dep_emqtt = git https://github.com/rabbitmq/emqtt.git otp-26-compatibility
+dep_emqtt = git https://github.com/rabbitmq/emqtt.git master
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -44,7 +44,7 @@ DEPS = ranch rabbit_common rabbit ra
 TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_web_mqtt amqp_client
 
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_emqtt = git https://github.com/rabbitmq/emqtt.git otp-26-compatibility
+dep_emqtt = git https://github.com/rabbitmq/emqtt.git master
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/deps/rabbitmq_web_mqtt/Makefile
+++ b/deps/rabbitmq_web_mqtt/Makefile
@@ -25,7 +25,7 @@ TEST_DEPS = emqtt rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_manage
 # See rabbitmq-components.mk.
 BUILD_DEPS += ranch
 
-dep_emqtt = git https://github.com/rabbitmq/emqtt.git otp-26-compatibility
+dep_emqtt = git https://github.com/rabbitmq/emqtt.git master
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk


### PR DESCRIPTION
to latest master of rabbitmq/emqtt which corresponds to latest emqx/emqtt master + our RabbitMQ fixes on top.

RabbitMQ `main` branch already points to `master` of `rabbitmq/emqtt`.