### PR TITLE
Allow MQTT to run on Mac OS with OTP 26

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_packet.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_packet.erl
@@ -12,6 +12,13 @@
 
 -export([init_state/0, reset_state/0,
          parse/2, serialise/2]).
+
+%% This function is nowhere called externally, but must be exported
+%% to circumvent the bug in https://github.com/erlang/otp/issues/7566
+%% If not exported, this function will return garbage binary data on OTP 26
+%% on Mac OS M1 and M2.
+-export([serialise_len/1]).
+
 -export_type([state/0]).
 
 -opaque state() :: unauthenticated | authenticated | fun().


### PR DESCRIPTION
On Mac OS M1 and M2 with OTP 26, prior to this commit,
the following test failed:
```
make -C deps/rabbitmq_mqtt ct-reader t=tests:rabbit_mqtt_qos0_queue_overflow FULL=1
```
with:
```
reader_SUITE > tests > rabbit_mqtt_qos0_queue_overflow
    #1. {'EXIT',
            {function_clause,
                {emqtt_frame,parse_packet,
                    [{mqtt_packet_header,7,true,0,false},
                     <<120,120,120,120,120,120,120,120,120,120,120,120,120,120,
                       120,120,120,120,120,120,120,120,120,120,120,120,120,120,
                       120,120,120,120,48,159,31,0,31,114,97,98,98,105,116,95,
                       109,113,116,116,95,113,111,115,48,95,113,117,101,117,
                       101,95,111,118,101,114,102,108,111,119,120,120,120,120,
                       120,120,120,120,120,120,120,120,120,120,120,120,120,120,
                       120,120,120,120,120,120,120,120,120,120,120,120,120,120,
                       120,120,120,120,120,120,120,120,120,120,120,120,120,120,
                       120,120,120,120,120,120>>,
                     #{version => 4,max_size => 268435455,
                       strict_mode => false}],
                    [{file,"src/emqtt_frame.erl"},{line,182}]}}}
```

This is due to the OTP bug in https://github.com/erlang/otp/issues/7566
Simply exporting the serialise_len/1 fixes this OTP bug.