### PR TITLE
Disallow empty password in MQTT

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -645,9 +645,9 @@ check_credentials(Username, Password, SslLoginName, PeerIp) ->
             auth_attempt_failed(PeerIp, <<>>),
             ?LOG_ERROR("MQTT login failed: no username is provided"),
             {error, ?RC_BAD_USER_NAME_OR_PASSWORD};
-        {invalid_creds, {User, undefined}} when is_binary(User) ->
+        {invalid_creds, {User, _Pass}} when is_binary(User) ->
             auth_attempt_failed(PeerIp, User),
-            ?LOG_ERROR("MQTT login failed for user '~p': no password provided", [User]),
+            ?LOG_ERROR("MQTT login failed for user '~s': no password provided", [User]),
             {error, ?RC_BAD_USER_NAME_OR_PASSWORD};
         {UserBin, PassBin} ->
             {ok, {UserBin, PassBin}}
@@ -1218,7 +1218,7 @@ creds(User, Pass, SSLLoginName) ->
         is_binary(DefaultPass),
 
     CredentialsProvided = User =/= undefined orelse Pass =/= undefined,
-    CorrectCredentials = is_binary(User) andalso is_binary(Pass),
+    CorrectCredentials = is_binary(User) andalso is_binary(Pass) andalso Pass =/= <<>>,
     SSLLoginProvided = TLSAuth =:= true andalso SSLLoginName =/= none,
 
     case {CredentialsProvided, CorrectCredentials, SSLLoginProvided, HaveDefaultCreds} of


### PR DESCRIPTION
Setting a username with an empty password is allowed by the MQTT spec:
> If the Password Flag is set to 1, this is the next field in the payload. The Password field contains 0 to 65535 bytes of binary data

However, RabbitMQ's default auth backend `rabbit_auth_backend_internal` prohibits empty passwords:
https://github.com/rabbitmq/rabbitmq-server/blob/64d69f76ff294c747498368cffbd1af7482fd0ea/deps/rabbit/src/rabbit_auth_backend_internal.erl#L77-L82

Since some RabbitMQ operators were confused about other auth backends such as `rabbit_auth_backend_http`, let us prohibit empty MQTT passwords for all auth backends.