### PR TITLE
Remove unsupported overflow definition from operator policy web template

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -284,8 +284,6 @@
                 <td>
                   <span class="argument-link" field="definitionop" key="max-length" type="number">Max length</span> |
                   <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
-                  <span class="argument-link" field="definitionop" key="overflow" type="string">Overflow behaviour</span>
-                  <span class="help" id="queue-overflow"></span></br>
                   <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span>
                   <span class="help" id="queue-message-ttl"></span>
                 </td>


### PR DESCRIPTION
## Proposed Changes

Hi,
based on https://www.rabbitmq.com/parameters.html#operator-policies we can't set an `overflow` definition here.

```
# rabbitmqctl set_operator_policy limit-0 ".*" '{"max-length":0,"overflow":"reject-publish"}' --apply-to classic_queues
Setting operator policy override "limit-0" for pattern ".*" to "{"max-length":0,"overflow":"reject-publish"}" with priority "0" for vhost "/" ...
Error:
Validation failed

[{<<"overflow">>,<<"reject-publish">>}] are not recognised policy settings
```

So I would suggest to remove it from the operator policy web template in the management UI.

![rabbitmq-op-tmpl](https://github.com/rabbitmq/rabbitmq-server/assets/19973294/b3194645-63a8-4505-bcf8-fca9fb52f7c7)


## Types of Changes

- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes

