### PR TITLE
Disable add/delete/shrink/grow QQ operations via HTTP api

### DIFF
--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -521,3 +521,10 @@ end}.
     {datatype, {enum, [true, false]}},
     {include_default, false}
 ]}.
+
+%% Disables add/remove/grow/shrink over API.
+
+{mapping, "management.restrictions.quorum_queue_replica_operations.disabled", "rabbitmq_management.restrictions.quorum_queue_replica_operations.disabled", [
+    {datatype, {enum, [true, false]}},
+    {include_default, false}
+]}.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -8,7 +8,11 @@
 -module(rabbit_mgmt_features).
 
 -export([is_op_policy_updating_disabled/0,
+         is_qq_replica_operations_disabled/0,
          are_stats_enabled/0]).
+
+is_qq_replica_operations_disabled() ->
+    get_restriction([quorum_queue_replica_operations, disabled]).
 
 is_op_policy_updating_disabled() ->
     case get_restriction([operator_policy_changes, disabled]) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_add_member.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_add_member.erl
@@ -56,4 +56,9 @@ accept_content(ReqData, Context) ->
 
 
 is_authorized(ReqData, Context) ->
-  rabbit_mgmt_util:is_authorized_admin(ReqData, Context).
+    case rabbit_mgmt_features:is_qq_replica_operations_disabled() of
+        true ->
+            rabbit_mgmt_util:method_not_allowed(<<"Broker settings disallow quorum queue replica operations.">>, ReqData, Context);
+        false ->
+            rabbit_mgmt_util:is_authorized_admin(ReqData, Context)
+    end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_delete_member.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_delete_member.erl
@@ -56,5 +56,11 @@ delete_completed(ReqData, Context) ->
   %% return 202 Accepted since this is an inherently asynchronous operation
   {false, ReqData, Context}.
 
+
 is_authorized(ReqData, Context) ->
-  rabbit_mgmt_util:is_authorized_admin(ReqData, Context).
+    case rabbit_mgmt_features:is_qq_replica_operations_disabled() of
+        true ->
+            rabbit_mgmt_util:method_not_allowed(<<"Broker settings disallow quorum queue replica operations.">>, ReqData, Context);
+        false ->
+            rabbit_mgmt_util:is_authorized_admin(ReqData, Context)
+    end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_grow.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_grow.erl
@@ -48,6 +48,10 @@ accept_content(ReqData, Context) ->
     end),
   {true, ReqData, Context}.
 
-
 is_authorized(ReqData, Context) ->
-  rabbit_mgmt_util:is_authorized_admin(ReqData, Context).
+    case rabbit_mgmt_features:is_qq_replica_operations_disabled() of
+        true ->
+            rabbit_mgmt_util:method_not_allowed(<<"Broker settings disallow quorum queue replica operations.">>, ReqData, Context);
+        false ->
+            rabbit_mgmt_util:is_authorized_admin(ReqData, Context)
+    end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_shrink.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_shrink.erl
@@ -35,4 +35,9 @@ delete_completed(ReqData, Context) ->
   {false, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->
-  rabbit_mgmt_util:is_authorized_admin(ReqData, Context).
+    case rabbit_mgmt_features:is_qq_replica_operations_disabled() of
+        true ->
+            rabbit_mgmt_util:method_not_allowed(<<"Broker settings disallow quorum queue replica operations.">>, ReqData, Context);
+        false ->
+            rabbit_mgmt_util:is_authorized_admin(ReqData, Context)
+    end.


### PR DESCRIPTION
## Proposed Changes

Optionally disable add/delete/shrink/grow replica operations via HTTP api.

As a separation of Users and Operators, to have the option to disable there operations via HTTP
will make the life a an operator easier.

Similar to disabling of oper policies via http api.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
