### PR TITLE
Add new QQ members as non-voters

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -941,6 +941,11 @@ rabbitmq_integration_suite(
     size = "medium",
 )
 
+rabbitmq_suite(
+    name = "unit_quorum_queue_SUITE",
+    size = "medium",
+)
+
 rabbitmq_integration_suite(
     name = "unit_app_management_SUITE",
     size = "medium",

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -1693,6 +1693,15 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         deps = ["//deps/amqp_client:erlang_app"],
     )
     erlang_bytecode(
+        name = "unit_quorum_queue_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/unit_quorum_queue_SUITE.erl"],
+        outs = ["test/unit_quorum_queue_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+        deps = ["//deps/amqp_client:erlang_app"],
+    )
+    erlang_bytecode(
         name = "unit_app_management_SUITE_beam_files",
         testonly = True,
         srcs = ["test/unit_app_management_SUITE.erl"],

--- a/deps/rabbit/src/rabbit_observer_cli_quorum_queues.erl
+++ b/deps/rabbit/src/rabbit_observer_cli_quorum_queues.erl
@@ -137,6 +137,8 @@ sheet_body(PrevState) ->
                                          case maps:get(InternalName, RaStates, undefined) of
                                              leader -> "L";
                                              follower -> "F";
+                                             promotable -> "f";  %% temporary non-voter
+                                             non_voter -> "-";  %% permanent non-voter
                                              _ -> "?"
                                          end,
                                          format_int(proplists:get_value(memory, ProcInfo)),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -1792,7 +1792,7 @@ add_member_not_running(Config) ->
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
     ?assertEqual({error, node_not_running},
                  rpc:call(Server, rabbit_quorum_queue, add_member,
-                          [<<"/">>, QQ, 'rabbit@burrow', 5000])).
+                          [<<"/">>, QQ, 'rabbit@burrow', voter, 5000])).
 
 add_member_classic(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
@@ -1801,7 +1801,7 @@ add_member_classic(Config) ->
     ?assertEqual({'queue.declare_ok', CQ, 0, 0}, declare(Ch, CQ, [])),
     ?assertEqual({error, classic_queue_not_supported},
                  rpc:call(Server, rabbit_quorum_queue, add_member,
-                          [<<"/">>, CQ, Server, 5000])).
+                          [<<"/">>, CQ, Server, voter, 5000])).
 
 add_member_wrong_type(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
@@ -1811,7 +1811,7 @@ add_member_wrong_type(Config) ->
                  declare(Ch, SQ, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
     ?assertEqual({error, not_quorum_queue},
                  rpc:call(Server, rabbit_quorum_queue, add_member,
-                          [<<"/">>, SQ, Server, 5000])).
+                          [<<"/">>, SQ, Server, voter, 5000])).
 
 add_member_already_a_member(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
@@ -1822,14 +1822,14 @@ add_member_already_a_member(Config) ->
     %% idempotent by design
     ?assertEqual(ok,
                  rpc:call(Server, rabbit_quorum_queue, add_member,
-                          [<<"/">>, QQ, Server, 5000])).
+                          [<<"/">>, QQ, Server, voter, 5000])).
 
 add_member_not_found(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     QQ = ?config(queue_name, Config),
     ?assertEqual({error, not_found},
                  rpc:call(Server, rabbit_quorum_queue, add_member,
-                          [<<"/">>, QQ, Server, 5000])).
+                          [<<"/">>, QQ, Server, voter, 5000])).
 
 add_member(Config) ->
     [Server0, Server1] = Servers0 =
@@ -1840,12 +1840,12 @@ add_member(Config) ->
                  declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
     ?assertEqual({error, node_not_running},
                  rpc:call(Server0, rabbit_quorum_queue, add_member,
-                          [<<"/">>, QQ, Server1, 5000])),
+                          [<<"/">>, QQ, Server1, voter, 5000])),
     ok = rabbit_control_helper:command(stop_app, Server1),
     ok = rabbit_control_helper:command(join_cluster, Server1, [atom_to_list(Server0)], []),
     rabbit_control_helper:command(start_app, Server1),
     ?assertEqual(ok, rpc:call(Server1, rabbit_quorum_queue, add_member,
-                              [<<"/">>, QQ, Server1, 5000])),
+                              [<<"/">>, QQ, Server1, voter, 5000])),
     Info = rpc:call(Server0, rabbit_quorum_queue, infos,
                     [rabbit_misc:r(<<"/">>, queue, QQ)]),
     Servers = lists:sort(Servers0),

--- a/deps/rabbit/test/unit_quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/unit_quorum_queue_SUITE.erl
@@ -1,0 +1,49 @@
+-module(unit_quorum_queue_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+     all_replica_states_includes_nonvoters,
+     filter_quorum_critical_accounts_nonvoters
+    ].
+
+filter_quorum_critical_accounts_nonvoters(_Config) ->
+    Nodes = [test@leader, test@follower1, test@follower2],
+    Qs0 = [amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q1">>),
+                        {q1, test@leader},
+                        false, false, none, [], undefined, #{}),
+           amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q2">>),
+                        {q2, test@leader},
+                        false, false, none, [], undefined, #{})],
+    Qs = [Q1, Q2] = lists:map(fun (Q) ->
+                                      amqqueue:set_type_state(Q, #{nodes => Nodes})
+                              end, Qs0),
+    Ss = #{test@leader    => #{q1 => leader,   q2 => leader},
+           test@follower1 => #{q1 => promotable, q2 => follower},
+           test@follower2 => #{q1 => follower, q2 => promotable}},
+    Qs = rabbit_quorum_queue:filter_quorum_critical(Qs, Ss, test@leader),
+    [Q2] = rabbit_quorum_queue:filter_quorum_critical(Qs, Ss, test@follower1),
+    [Q1] = rabbit_quorum_queue:filter_quorum_critical(Qs, Ss, test@follower2),
+    ok.
+
+all_replica_states_includes_nonvoters(_Config) ->
+    ets:new(ra_state, [named_table, public, {write_concurrency, true}]),
+    ets:insert(ra_state, [
+                          {q1, leader, voter},
+                          {q2, follower, voter},
+                          {q3, follower, promotable},
+                          %% pre ra-2.7.0
+                          {q4, leader},
+                          {q5, follower}
+                         ]),
+    {_, #{
+          q1 := leader,
+          q2 := follower,
+          q3 := promotable,
+          q4 := leader,
+          q5 := follower
+         }} = rabbit_quorum_queue:all_replica_states(),
+
+    true = ets:delete(ra_state),
+    ok.

--- a/deps/rabbitmq_cli/test/queues/add_member_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/add_member_command_test.exs
@@ -20,6 +20,8 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommandTest do
     {:ok,
      opts: %{
        node: get_rabbit_hostname(),
+       membership: "voter",
+       vhost: "/",
        timeout: context[:test_timeout] || 30000
      }}
   end
@@ -42,17 +44,36 @@ defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommandTest do
            ) == {:validation_failure, :too_many_args}
   end
 
+  test "validate: when membership promotable is provided, returns a success" do
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node"], %{membership: "promotable"}) ==
+             :ok
+  end
+
+  test "validate: when membership voter is provided, returns a success" do
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node"], %{membership: "voter"}) == :ok
+  end
+
+  test "validate: when membership non_voter is provided, returns a success" do
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node"], %{membership: "non_voter"}) ==
+             :ok
+  end
+
+  test "validate: when wrong membership is provided, returns failure" do
+    assert @command.validate(["quorum-queue-a", "rabbit@new-node"], %{membership: "banana"}) ==
+             {:validation_failure, "voter status 'banana' is not recognised."}
+  end
+
   test "validate: treats two positional arguments and default switches as a success" do
     assert @command.validate(["quorum-queue-a", "rabbit@new-node"], %{}) == :ok
   end
 
   @tag test_timeout: 3000
-  test "run: targeting an unreachable node throws a badrpc" do
+  test "run: targeting an unreachable node throws a badrpc", context do
     assert match?(
              {:badrpc, _},
              @command.run(
                ["quorum-queue-a", "rabbit@new-node"],
-               %{node: :jake@thedog, vhost: "/", timeout: 200}
+               Map.merge(context[:opts], %{node: :jake@thedog})
              )
            )
   end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_add_member.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_add_member.erl
@@ -38,11 +38,17 @@ accept_content(ReqData, Context) ->
   QName = rabbit_mgmt_util:id(queue, ReqData),
   Res = rabbit_mgmt_util:with_decode(
     [node], ReqData, Context,
-    fun([NewReplicaNode], _Body, _ReqData) ->
+    fun([NewReplicaNode], Body, _ReqData) ->
+      Membership = maps:get(<<"membership">>, Body, promotable),
       rabbit_amqqueue:with(
         rabbit_misc:r(VHost, queue, QName),
         fun(_Q) ->
-          rabbit_quorum_queue:add_member(VHost, QName, rabbit_data_coercion:to_atom(NewReplicaNode), ?TIMEOUT)
+                rabbit_quorum_queue:add_member(
+                  VHost,
+                  QName,
+                  rabbit_data_coercion:to_atom(NewReplicaNode),
+                  rabbit_data_coercion:to_atom(Membership),
+                  ?TIMEOUT)
         end)
     end),
   case Res of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_grow.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_grow.erl
@@ -39,12 +39,14 @@ accept_content(ReqData, Context) ->
   NewReplicaNode = rabbit_mgmt_util:id(node, ReqData),
   rabbit_mgmt_util:with_decode(
     [vhost_pattern, queue_pattern, strategy], ReqData, Context,
-    fun([VHPattern, QPattern, Strategy], _Body, _ReqData) ->
+    fun([VHPattern, QPattern, Strategy], Body, _ReqData) ->
+      Membership = maps:get(<<"membership">>, Body, promotable),
       rabbit_quorum_queue:grow(
         rabbit_data_coercion:to_atom(NewReplicaNode),
         VHPattern,
         QPattern,
-        rabbit_data_coercion:to_atom(Strategy))
+        rabbit_data_coercion:to_atom(Strategy),
+        rabbit_data_coercion:to_atom(Membership))
     end),
   {true, ReqData, Context}.
 


### PR DESCRIPTION
## Proposed Changes

This makes use of rabbitmq/ra#375 to expand `rabbitmq-queues check_if_node_is_quorum_critical`.

Additionally it takes into account which node the command is being issued to. In the following example `rabbit-2` is recently added and still catching up, putting it back down will not impact quorum:

```
> rabbitmq-queues -n rabbit-0 check_if_node_is_quorum_critical
Checking if node rabbit-0@3c22fb6527ee is critical for quorum of any queues/streams ...
queue 'input' in vhost '/' will become unavailable if node rabbit-0@3c22fb6527ee stops

> rabbitmq-queues -n rabbit-2 check_if_node_is_quorum_critical
Checking if node rabbit-2@3c22fb6527ee is critical for quorum of any queues/streams ...
Node rabbit-2@3c22fb6527ee reported no queues/streams with minimum quorum
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #9519)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

The CLI and HTTP API have been extended to override the default (promotable) voter status.