### PR TITLE
Gazelle: ignore test deps fetched by make

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,7 @@ exports_files([
 # gazelle:exclude deps/cowlib
 # gazelle:exclude deps/credentials_obfuscation
 # gazelle:exclude deps/csv
+# gazelle:exclude deps/cth_styledout
 # gazelle:exclude deps/cuttlefish
 # gazelle:exclude deps/eetcd
 # gazelle:exclude deps/elvis_mk
@@ -50,11 +51,14 @@ exports_files([
 # gazelle:exclude deps/gen_batch_server
 # gazelle:exclude deps/getopt
 # gazelle:exclude deps/gun
+# gazelle:exclude deps/inet_tcp_proxy
 # gazelle:exclude deps/jose
 # gazelle:exclude deps/json
+# gazelle:exclude deps/meck
 # gazelle:exclude deps/observer_cli
 # gazelle:exclude deps/osiris
 # gazelle:exclude deps/prometheus
+# gazelle:exclude deps/proper
 # gazelle:exclude deps/quantile_estimator
 # gazelle:exclude deps/ra
 # gazelle:exclude deps/ranch


### PR DESCRIPTION
Accidentally running gazelle before `git clean -xffd deps` should produce less of a confusing diff