### PR TITLE
Refactor the code of `maybe_clear_ram_only_tables()`

### DIFF
--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -165,25 +165,7 @@ members() ->
       #{mnesia => fun members_using_mnesia/0}).
 
 members_using_mnesia() ->
-    case rabbit_mnesia:is_running() andalso rabbit_table:is_present() of
-        true ->
-            %% If Mnesia is running locally and some tables exist, we can know
-            %% the database was initialized and we can query the list of
-            %% members.
-            mnesia:system_info(db_nodes);
-        false ->
-            try
-                %% When Mnesia is not running, we fall back to reading the
-                %% cluster status files stored on disk, if they exist.
-                {Members, _, _} = rabbit_node_monitor:read_cluster_status(),
-                Members
-            catch
-                throw:{error, _Reason}:_Stacktrace ->
-                    %% If we couldn't read those files, we consider that only
-                    %% this node is part of the "cluster".
-                    [node()]
-            end
-    end.
+    rabbit_mnesia:members().
 
 -spec disc_members() -> Members when
       Members :: [node()].

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -192,11 +192,13 @@ clear_ram_only_tables() ->
       end, names()),
     ok.
 
+-spec maybe_clear_ram_only_tables() -> ok.
+
 maybe_clear_ram_only_tables() ->
-    ok = case rabbit_db_cluster:is_clustered() of
-             true  -> ok;
-             false -> clear_ram_only_tables()
-         end.
+    case rabbit_mnesia:members() of
+        [N] when N=:= node() -> clear_ram_only_tables();
+        _                    -> ok
+    end.
 
 %% The sequence in which we delete the schema and then the other
 %% tables is important: if we delete the schema first when moving to


### PR DESCRIPTION
### Why

This change comes from the Khepri integration work-in-progress. It allows to better isolate the Mnesia-specific code.