### PR TITLE
rabbit_feature_flags: Wait for in-flight operations before terminating the controller

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1031,6 +1031,10 @@ do_run_postlaunch_phase(Plugins) ->
 
 prep_stop(State) ->
     rabbit_boot_state:set(stopping),
+    %% Wait for any in-flight feature flag changes to finish. This way, we
+    %% increase the chance of letting an `enable' operation to finish if the
+    %% controller waits for anything in-flight before is actually exits.
+    ok = rabbit_ff_controller:wait_for_task_and_stop(),
     rabbit_peer_discovery:maybe_unregister(),
     State.
 


### PR DESCRIPTION
### Why

The feature flags controller ensures all nodes in a cluster are running before a feature flag can be enabled. It continues to do so whenever it wants to record a state change because it requires that all nodes get the new state otherwise the task in aborted.

However, it's difficult to verify that through out the entire process if the feature flag has an `enable` callback. But again, if we loose a node during the execution of the callback or between its execution and the time we mark the feature flag as enabled on all nodes, that's ok because the feature flag will be marked as disabled everywhere: the remaining running nodes will go back from `state_changing` to `false` and the stopped nodes will keep their initial state of `false`.

Nonetheless, we can increase the chance of letting an `enable` operation to finish if the controller waits for anything in-flight before is actually exits.

### How

The `terminate/3` function now tries to register globally, like if the controller wanted to lock the cluster and run a task. If it succeeds to register, it means nothing is running in parallel and it can exit. If it fails, it waits for the globally-registered controller to finish and tries to register again.

We expose a new `wait_for_task_and_stop/0` function to explicitly stop the feature flags controller and call it from the `rabbit` application pre-stop phase. The reason is that when the supervisor asks the controller to stop as part of the regular shutdown of a supervision tree, it has a timeout and could kill the controller if an in-flight operation takes too much time. To avoid this kill, we prefer to use `wait_for_task_and_stop/0` which has no timeout.