### PR TITLE
Adjust the node uri in //deps/rabbitmq_amqp1_0:system_SUITE

### DIFF
--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -121,7 +121,6 @@ rabbitmq_integration_suite(
     shard_count = 2,
     tags = [
         "dotnet",
-        "exclusive",
     ],
     test_env = {
         "TMPDIR": "$TEST_TMPDIR",

--- a/deps/rabbitmq_amqp1_0/test/system_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/system_SUITE.erl
@@ -277,7 +277,7 @@ run(Config, Flavors) ->
 
 run_dotnet_test(Config, Method) ->
     TestProjectDir = ?config(dotnet_test_project_dir, Config),
-    Uri = rabbit_ct_broker_helpers:node_uri(Config, 0),
+    Uri = rabbit_ct_broker_helpers:node_uri(Config, 0, [{use_ipaddr, true}]),
     Ret = rabbit_ct_helpers:exec(["dotnet", "run", "--", Method, Uri ],
       [
         {cd, TestProjectDir}


### PR DESCRIPTION
so that the tests pass when executing remotely with buildbuddy