### PR TITLE
Use the no-remote-exec instead of exclusive tag for some tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,7 +33,7 @@ build:rbe --config=buildbuddy
 
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io
 
-build:rbe --spawn_strategy=remote
+build:rbe --spawn_strategy=remote,local
 build:rbe --test_strategy=""
 build:rbe --jobs=50
 

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -42,6 +42,6 @@ jobs:
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
           --config=rbe \
-          --test_tag_filters=-mixed-version-cluster,-exclusive,-aws,-docker \
+          --test_tag_filters=-mixed-version-cluster,-no-remote-exec,-aws,-docker \
           --build_tests_only \
           --verbose_failures

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -42,6 +42,6 @@ jobs:
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
           --config=rbe \
-          --test_tag_filters=-mixed-version-cluster,-no-remote-exec,-aws,-docker \
+          --test_tag_filters=-mixed-version-cluster,-aws,-docker \
           --build_tests_only \
           --verbose_failures

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -162,69 +162,12 @@ jobs:
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
           --config=rbe-${{ matrix.otp_version_id }} \
-          --test_tag_filters=mixed-version-cluster,-no-remote-exec,-aws,-docker \
+          --test_tag_filters=mixed-version-cluster,-aws,-docker \
           --build_tests_only \
-          --verbose_failures
-  test-no-remote-exec-mixed-versions:
-    name: Test (No-Remote-Exec Tests with Mixed Version Cluster)
-    runs-on: ubuntu-20.04
-    needs: ensure-mixed-version-archive
-    strategy:
-      matrix:
-        include:
-        - erlang_version: "25.3"
-          elixir_version: 1.14.5
-    timeout-minutes: 60
-    steps:
-    - name: CHECKOUT REPOSITORY
-      uses: actions/checkout@v3
-    - name: CONFIGURE OTP & ELIXIR
-      uses: erlef/setup-beam@v1.16
-      with:
-        otp-version: ${{ matrix.erlang_version }}
-        elixir-version: ${{ matrix.elixir_version }}
-    - name: MOUNT BAZEL CACHE
-      uses: actions/cache@v3.3.1
-      with:
-        path: "/home/runner/repo-cache/"
-        key: ${{ runner.os }}-repo-cache-${{ hashFiles('MODULE.bazel','WORKSPACE','bazel/bzlmod/secondary_umbrella.bzl') }}
-        restore-keys: |
-          ${{ runner.os }}-repo-cache-
-    - name: CONFIGURE BAZEL
-      run: |
-        ERLANG_HOME="$(dirname $(dirname $(which erl)))"
-        ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
-        if [ -n "${{ secrets.BUILDBUDDY_API_KEY }}" ]; then
-        cat << EOF >> user.bazelrc
-          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
-        EOF
-        fi
-        cat << EOF >> user.bazelrc
-          build:buildbuddy --build_metadata=ROLE=CI
-          build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
-          build:buildbuddy --repository_cache=/home/runner/repo-cache/
-          build:buildbuddy --color=yes
-          build:buildbuddy --disk_cache=
-
-          build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
-          build --@rules_erlang//:erlang_home=${ERLANG_HOME}
-          build --//:elixir_home=${ELIXIR_HOME}
-        EOF
-    #! - name: Setup tmate session
-    #!   uses: mxschmitt/action-tmate@v3
-    - name: RUN NO-REMOTE-EXEC TESTS
-      run: |
-        MIXED_NO_REMOTE_EXEC_TESTS=$(bazel query 'attr(tags, "mixed-version-cluster", attr(tags, "no-remote-exec", tests(//...)))')
-        bazelisk test $MIXED_NO_REMOTE_EXEC_TESTS \
-          --config=buildbuddy \
-          --test_tag_filters=-aws,-docker \
-          --build_tests_only \
-          --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
   summary-mixed-versions:
     needs:
     - test-mixed-versions
-    - test-no-remote-exec-mixed-versions
     runs-on: ubuntu-latest
     steps:
     - name: SUMMARY

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -162,11 +162,11 @@ jobs:
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
           --config=rbe-${{ matrix.otp_version_id }} \
-          --test_tag_filters=mixed-version-cluster,-exclusive,-aws,-docker \
+          --test_tag_filters=mixed-version-cluster,-no-remote-exec,-aws,-docker \
           --build_tests_only \
           --verbose_failures
-  test-exclusive-mixed-versions:
-    name: Test (Exclusive Tests with Mixed Version Cluster)
+  test-no-remote-exec-mixed-versions:
+    name: Test (No-Remote-Exec Tests with Mixed Version Cluster)
     runs-on: ubuntu-20.04
     needs: ensure-mixed-version-archive
     strategy:
@@ -212,10 +212,10 @@ jobs:
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
-    - name: RUN EXCLUSIVE TESTS
+    - name: RUN NO-REMOTE-EXEC TESTS
       run: |
-        MIXED_EXCLUSIVE_TESTS=$(bazel query 'attr(tags, "mixed-version-cluster", attr(tags, "exclusive", tests(//...)))')
-        bazelisk test $MIXED_EXCLUSIVE_TESTS \
+        MIXED_NO_REMOTE_EXEC_TESTS=$(bazel query 'attr(tags, "mixed-version-cluster", attr(tags, "no-remote-exec", tests(//...)))')
+        bazelisk test $MIXED_NO_REMOTE_EXEC_TESTS \
           --config=buildbuddy \
           --test_tag_filters=-aws,-docker \
           --build_tests_only \
@@ -224,7 +224,7 @@ jobs:
   summary-mixed-versions:
     needs:
     - test-mixed-versions
-    - test-exclusive-mixed-versions
+    - test-no-remote-exec-mixed-versions
     runs-on: ubuntu-latest
     steps:
     - name: SUMMARY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,70 +72,12 @@ jobs:
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
           --config=rbe-${{ matrix.otp_version_id }} \
-          --test_tag_filters=-no-remote-exec,-aws,-docker,-mixed-version-cluster \
+          --test_tag_filters=-aws,-docker,-mixed-version-cluster \
           --build_tests_only \
-          --verbose_failures
-  test-no-remote-exec:
-    name: Test (No-Remote-Exec Tests)
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - erlang_version: "25.3"
-          elixir_version: 1.14.5
-        - erlang_version: "26.0"
-          elixir_version: 1.14.5
-    timeout-minutes: 60
-    steps:
-    - name: CHECKOUT REPOSITORY
-      uses: actions/checkout@v3
-    - name: CONFIGURE OTP & ELIXIR
-      uses: erlef/setup-beam@v1.16
-      with:
-        otp-version: ${{ matrix.erlang_version }}
-        elixir-version: ${{ matrix.elixir_version }}
-    - name: MOUNT BAZEL CACHE
-      uses: actions/cache@v3.3.1
-      with:
-        path: "/home/runner/repo-cache/"
-        key: ${{ runner.os }}-repo-cache-${{ hashFiles('MODULE.bazel','WORKSPACE','bazel/bzlmod/secondary_umbrella.bzl') }}
-        restore-keys: |
-          ${{ runner.os }}-repo-cache-
-    - name: CONFIGURE BAZEL
-      run: |
-        ERLANG_HOME="$(dirname $(dirname $(which erl)))"
-        ELIXIR_HOME="$(dirname $(dirname $(which iex)))"
-        if [ -n "${{ secrets.BUILDBUDDY_API_KEY }}" ]; then
-        cat << EOF >> user.bazelrc
-          build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
-        EOF
-        fi
-        cat << EOF >> user.bazelrc
-          build:buildbuddy --build_metadata=ROLE=CI
-          build:buildbuddy --build_metadata=VISIBILITY=PUBLIC
-          build:buildbuddy --repository_cache=/home/runner/repo-cache/
-          build:buildbuddy --color=yes
-          build:buildbuddy --disk_cache=
-
-          build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
-          build --@rules_erlang//:erlang_home=${ERLANG_HOME}
-          build --//:elixir_home=${ELIXIR_HOME}
-        EOF
-    #! - name: Setup tmate session
-    #!   uses: mxschmitt/action-tmate@v3
-    - name: RUN NO-REMOTE-EXEC TESTS
-      run: |
-        bazelisk test //... \
-          --config=buildbuddy \
-          --test_tag_filters=no-remote-exec,-aws,-docker,-mixed-version-cluster \
-          --build_tests_only \
-          --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
   summary-test:
     needs:
     - test
-    - test-no-remote-exec
     runs-on: ubuntu-latest
     steps:
     - name: SUMMARY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,11 +72,11 @@ jobs:
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off
         bazelisk test //... \
           --config=rbe-${{ matrix.otp_version_id }} \
-          --test_tag_filters=-exclusive,-aws,-docker,-mixed-version-cluster \
+          --test_tag_filters=-no-remote-exec,-aws,-docker,-mixed-version-cluster \
           --build_tests_only \
           --verbose_failures
-  test-exclusive:
-    name: Test (Exclusive Tests)
+  test-no-remote-exec:
+    name: Test (No-Remote-Exec Tests)
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -124,18 +124,18 @@ jobs:
         EOF
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
-    - name: RUN EXCLUSIVE TESTS
+    - name: RUN NO-REMOTE-EXEC TESTS
       run: |
         bazelisk test //... \
           --config=buildbuddy \
-          --test_tag_filters=exclusive,-aws,-docker,-mixed-version-cluster \
+          --test_tag_filters=no-remote-exec,-aws,-docker,-mixed-version-cluster \
           --build_tests_only \
           --test_env RABBITMQ_CT_HELPERS_DELETE_UNUSED_NODES=true \
           --verbose_failures
   summary-test:
     needs:
     - test
-    - test-exclusive
+    - test-no-remote-exec
     runs-on: ubuntu-latest
     steps:
     - name: SUMMARY

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -478,7 +478,7 @@ rabbitmq_integration_suite(
     shard_count = 2,
     # The enabling_* tests chmod files and then expect writes to be blocked.
     # This probably doesn't work because we are root in the remote docker image.
-    tags = ["exclusive"],
+    tags = ["no-remote-exec"],
     runtime_deps = [
         "//deps/rabbit/test/feature_flags_SUITE_data/my_plugin:erlang_app",
     ],


### PR DESCRIPTION
This allows results to be cached while still indicating that they don't pass with RBE, only locally