### PR TITLE
rabbit_feature_flags: Lower the level of some log messages

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1258,7 +1258,7 @@ does_node_support(Node, FeatureNames, Timeout) ->
           end,
     case Ret of
         {error, Reason} ->
-            ?LOG_ERROR(
+            ?LOG_WARNING(
               "Feature flags: error while querying `~tp` support on "
               "node ~ts: ~tp",
               [FeatureNames, Node, Reason],

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -1360,7 +1360,7 @@ rpc_call(Node, Module, Function, Args, Timeout) ->
         %% time, for instance, if there is a lot of data to migrate.
         error:{erpc, noconnection} = Reason
           when is_integer(Timeout) andalso Timeout > SleepBetweenRetries ->
-            ?LOG_ERROR(
+            ?LOG_WARNING(
                "Feature flags: no connection to node `~ts`; "
                "retrying in ~b milliseconds",
                [Node, SleepBetweenRetries],

--- a/deps/rabbit/src/rabbit_ff_registry_factory.erl
+++ b/deps/rabbit/src/rabbit_ff_registry_factory.erl
@@ -798,7 +798,7 @@ load_registry_mod(RegistryVsn, Mod, Bin) ->
               #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
             ok;
         {error, {restart, Expected, Current}} ->
-            ?LOG_ERROR(
+            ?LOG_DEBUG(
               "Feature flags: another registry module was loaded in the "
               "meantime (expected old vsn: ~tp, current vsn: ~tp); "
               "restarting the regen",


### PR DESCRIPTION
### Why

The log message about the restart of the registry regen is definitely not an error, just a normal situation. The level is down to debug for this one.

The other two messages are non-fatal, so they are down to warnings. If the condition is fatal, it will be handled as an error later in the code path.