### PR TITLE
CQ msg_store: Don't debug log when a cache update_counter fails

### DIFF
--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -1235,10 +1235,21 @@ contains_message(MsgId, From, State) ->
 
 update_msg_cache(CacheEts, MsgId, Msg) ->
     case ets:insert_new(CacheEts, {MsgId, Msg, 1}) of
-        true  -> ok;
-        false -> rabbit_misc:safe_ets_update_counter(
-                   CacheEts, MsgId, {3, +1}, fun (_) -> ok end,
-                   fun () -> update_msg_cache(CacheEts, MsgId, Msg) end)
+        true  ->
+            ok;
+        false ->
+            %% Note: This is basically rabbit_misc:safe_ets_update_counter/5,
+            %% but without the debug log that we don't want as the update is
+            %% more likely to fail following recent reworkings.
+            try
+                ets:update_counter(CacheEts, MsgId, {3, +1}),
+                ok
+            catch error:badarg ->
+                %% The entry must have been removed between
+                %% insert_new and update_counter, most likely
+                %% due to a file rollover or a confirm. Try again.
+                update_msg_cache(CacheEts, MsgId, Msg)
+            end
     end.
 
 adjust_valid_total_size(File, Delta, State = #msstate {


### PR DESCRIPTION
With recent reworkings of the message store this can fail more often than it did before. That's fine because in that case we will just try again. We don't need to keep the debug log.

This only applies to fan-out scenarios.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
