### PR TITLE
Set the test timeout for all tests in bazel to 2 hours

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,8 @@ build --flag_alias=erlang_version=@rules_erlang//:erlang_version
 build --flag_alias=elixir_home=//:elixir_home
 build --flag_alias=test_build=//:enable_test_build
 
+build --test_timeout=7200
+
 build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
 build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
 build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io


### PR DESCRIPTION
This should allow the common_test timeout to kick in, logs should be available as the timeout does not occur at the bazel level

https://bazel.build/reference/command-line-reference#flag--test_timeout