### PR TITLE
CQ: Fix 3.13 upgrade error in the message store

### DIFF
--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -129,7 +129,7 @@
         }).
 
 -record(file_summary,
-        {file, valid_total_size, file_size, locked}).
+        {file, valid_total_size, unused1, unused2, file_size, locked, unused3}).
 
 -record(gc_state,
         { dir,


### PR DESCRIPTION
The problem was due to a record being modified despite that record being read from disk. To avoid any potential issues the record was put back to the way it used to be, only now we have 3 'unused' fields.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
