### PR TITLE
Use our fork of BCR for erlang specific packages

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,8 @@
 build --enable_bzlmod
 
+build --registry=https://bcr.bazel.build/
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/erlang-packages/
+
 build --incompatible_strict_action_env
 build --local_test_jobs=1
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,12 +47,6 @@ bazel_dep(
     repo_name = "osiris",
 )
 
-git_override(
-    module_name = "rabbitmq_osiris",
-    commit = "910590b392be8ba9c09684203238d9606534c271",
-    remote = "https://github.com/rabbitmq/osiris.git",
-)
-
 bazel_dep(
     name = "rabbitmq_ra",
     version = "2.6.2",


### PR DESCRIPTION
This avoids waiting for the bazel team to merge PRs