### PR TITLE
Add integration test MQTT 5.0 -> Stream

### DIFF
--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -281,6 +281,7 @@ rabbitmq_integration_suite(
     runtime_deps = [
         "//deps/amqp10_client:erlang_app",
         "//deps/rabbitmq_stomp:erlang_app",
+        "//deps/rabbitmq_stream_common:erlang_app",
         "@emqtt//:erlang_app",
     ],
 )


### PR DESCRIPTION
Add an integration test that sends via MQTT 5.0,
converts the MQTT message to an AMQP 1.0 message via mc_mqtt, and consumes via the Stream protocol.