### PR TITLE
rabbitmq-run.mk: Start nodes in parallel in `start-{brokers,cluster}`

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -386,7 +386,11 @@ start-brokers start-cluster: $(DIST_TARGET)
 		  -rabbitmq_web_stomp_examples listener [{port,$$((61633 + $$n - 1))}] \
 		  -rabbitmq_prometheus tcp_config [{port,$$((15692 + $$n - 1))}] \
 		  -rabbitmq_stream tcp_listeners [$$((5552 + $$n - 1))] \
-		  "; \
+		  " & \
+	done; \
+	wait && \
+	for n in $$(seq $(NODES)); do \
+		nodename="rabbit-$$n@$(HOSTNAME)"; \
 		if test '$@' = 'start-cluster' && test "$$nodename1"; then \
 			ERL_LIBS="$(DIST_ERL_LIBS)" \
 			  $(RABBITMQCTL) -n "$$nodename" stop_app; \
@@ -403,8 +407,9 @@ stop-brokers stop-cluster:
 	@for n in $$(seq $(NODES) -1 1); do \
 		nodename="rabbit-$$n@$(HOSTNAME)"; \
 		$(MAKE) stop-node \
-		  RABBITMQ_NODENAME="$$nodename"; \
-	done
+		  RABBITMQ_NODENAME="$$nodename" & \
+	done; \
+	wait
 
 # --------------------------------------------------------------------
 # Used by testsuites.


### PR DESCRIPTION
### Why

For Mnesia, we don't really care. However, for the upcoming use of Khepri, we need that because the cluster will require at least a quorum number of nodes to start to become available.

### How

We simply rely on the shell's job management and wait for them to complete.

We do the same for `stop-{brokers,cluster}` mostly for consistency's sake.

It also makes starting nodes slightly faster.