### PR TITLE
Translate AMQP 0.9.1 CC headers to AMQP 1.0 x-cc

### DIFF
--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -441,7 +441,17 @@ essential_properties(#msg{message_annotations = MA} = Msg) ->
             lists:foldl(
               fun ({{symbol, <<"x-routing-key">>},
                     {utf8, Key}}, Acc) ->
-                      Acc#{routing_keys => [Key]};
+                      maps:update_with(routing_keys,
+                                       fun(L) -> [Key | L] end,
+                                       [Key],
+                                       Acc);
+                  ({{symbol, <<"x-cc">>},
+                    {list, CCs0}}, Acc) ->
+                      CCs = [CC || {_T, CC} <- CCs0],
+                      maps:update_with(routing_keys,
+                                       fun(L) -> L ++ CCs end,
+                                       CCs,
+                                       Acc);
                   ({{symbol, <<"x-exchange">>},
                     {utf8, Exchange}}, Acc) ->
                       Acc#{exchange => Exchange};


### PR DESCRIPTION
Translate AMQP 0.9.1 CC headers to AMQP 1.0 x-cc message annotations.

We want CC headers to be kept an AMQP legacy feature and therefore special case its conversion to AMQP 1.0.