### PR TITLE
Fix crash in rabbit_writer

### DIFF
--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -91,8 +91,11 @@ convert_from(mc_amqp, Sections) ->
                 %% TODO: This is potentially inefficient, but #content.payload_fragments_rev expects
                 %% currently a flat list of binaries. Can we make rabbit_writer work
                 %% with an iolist instead?
-                {[erlang:iolist_to_iovec(amqp10_framing:encode_bin(X))
-                  || X <- BodyRev], ?AMQP10_TYPE}
+                BinsRev = [begin
+                               IoList = amqp10_framing:encode_bin(X),
+                               erlang:iolist_to_binary(IoList)
+                           end || X <- BodyRev],
+                {BinsRev, ?AMQP10_TYPE}
         end,
     #'v1_0.properties'{message_id = MsgId,
                        user_id = UserId0,


### PR DESCRIPTION
091 payload fragements rev must be a list of binaries. Fix following crash:
```
crasher:
  initial call: rabbit_writer:enter_mainloop/2
  pid: <0.700.0>
  registered_name: []
  exception error: bad argument
    in function  size/1
       called as size([<<0,83,119,160,3,0,1,2>>])
       *** argument 1: not tuple or binary
    in call from rabbit_binary_generator:build_content_frames/7 (rabbit_binary_generator.erl, line 89)
    in call from rabbit_binary_generator:build_simple_content_frames/4 (rabbit_binary_generator.erl, line 61)
    in call from rabbit_writer:assemble_frames/5 (rabbit_writer.erl, line 334)
    in call from rabbit_writer:internal_send_command_async/3 (rabbit_writer.erl, line 365)
    in call from rabbit_writer:handle_message/3 (rabbit_writer.erl, line 232)
    in call from rabbit_writer:mainloop1/2 (rabbit_writer.erl, line 216)
    in call from rabbit_writer:mainloop/2 (rabbit_writer.erl, line 207)
```