### PR TITLE
Try to avoid running out of space in the OCI workflow in actions

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -38,6 +38,21 @@ jobs:
           - image_tag_suffix: otp-max-bazel
             otp_version_id: 26
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Sometimes the actions worker seems to run out of space