### PR TITLE
Avoid unnecessary hibernation in writer procs

### DIFF
--- a/deps/rabbit_common/src/rabbit_writer.erl
+++ b/deps/rabbit_common/src/rabbit_writer.erl
@@ -62,7 +62,7 @@
     writer_gc_threshold
 }).
 
--define(HIBERNATE_AFTER, 5000).
+-define(HIBERNATE_AFTER, 6_000).
 %% 1GB
 -define(DEFAULT_GC_THRESHOLD, 1_000_000_000).
 

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_writer.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_writer.erl
@@ -22,7 +22,7 @@
 -record(wstate, {sock, channel, frame_max, protocol, reader,
                  stats_timer, pending}).
 
--define(HIBERNATE_AFTER, 5000).
+-define(HIBERNATE_AFTER, 6_000).
 -define(AMQP_SASL_FRAME_TYPE, 1).
 
 %%---------------------------------------------------------------------------


### PR DESCRIPTION
Why:
The default rabbit.collect_statistics_interval is 5,000 ms which collides with the hibernate timeout of 5,000 ms.
It happens that the writer process hibernates and is woken up just a few microseconds thereafter to emit stats. This is wasteful as hibernation occurs costly garbage collections.

Inserting some logs before the writer emitting stats end before the writer hibernating shows the following (when consuming from a queue and sending a single message to that queue via the Management UI):
```
2023-09-12 09:46:22.820514+02:00 [info] <0.784.0> rabbit_writer:216 hibernating...
2023-09-12 09:46:22.820779+02:00 [info] <0.784.0> rabbit_writer:274 emitting stats...

2023-09-12 09:46:27.821451+02:00 [info] <0.784.0> rabbit_writer:216 hibernating...
```

How:
Change hibernate timeout from 5s to 6s.