### PR TITLE
rabbit_ct_helpers: Fix crash detection in node logs

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -793,10 +793,12 @@ query_node(Config, NodeConfig) ->
       [rabbit, plugins_dir]),
     {ok, EnabledPluginsFile} = rpc(Config, Nodename, application, get_env,
       [rabbit, enabled_plugins_file]),
+    LogLocations = rpc(Config, Nodename, rabbit, log_locations, []),
     Vars0 = [{pid_file, PidFile},
              {data_dir, DataDir},
              {plugins_dir, PluginsDir},
-             {enabled_plugins_file, EnabledPluginsFile}],
+             {enabled_plugins_file, EnabledPluginsFile},
+             {log_locations, LogLocations}],
     Vars = try
                EnabledFeatureFlagsFile = rpc(Config, Nodename,
                                              rabbit_feature_flags,
@@ -1018,11 +1020,11 @@ stop_rabbitmq_nodes(Config) ->
                           false;
                       undefined ->
                           case os:getenv("FIND_CRASHES") of
-                              undefined -> true;
-                              "1"       -> true;
-                              "yes"     -> true;
-                              "true"    -> true;
-                              _         -> false
+                              false  -> true;
+                              "1"    -> true;
+                              "yes"  -> true;
+                              "true" -> true;
+                              _      -> false
                           end
                   end,
     case FindCrashes of


### PR DESCRIPTION
... introduced in commit cb8b0bf89b340ae52788253bb7e780b76b50ba84.

### Why

Two things:
1. The change was incorrectly ported from the Khepri integration branch. Indeed, it lacked the part where it set the `log_locations` key in the `NodeConfig` variable.
2. The return value of `os:getenv/1` was incorrectly matched: this function returns `false` when an environment variable is unset, not `undefined`.

References #9290.