### PR TITLE
Use pg_local to track AMQP 1.0 connections

### DIFF
--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -65,7 +65,8 @@
 -export([error_atom/1]).
 -export([info/2, info_keys/1, info_keys/0]).
 -export([connection_name/1, update_secret/3]).
--export([socket_adapter_info/2]).
+-export([socket_adapter_info/2,
+         socket_adapter_info/3]).
 
 -define(DEFAULT_CONSUMER, {amqp_selective_consumer, []}).
 
@@ -379,7 +380,12 @@ info_keys() ->
 %% @doc Takes a socket and a protocol, returns an #amqp_adapter_info{}
 %% based on the socket for the protocol given.
 socket_adapter_info(Sock, Protocol) ->
-    amqp_direct_connection:socket_adapter_info(Sock, Protocol).
+    socket_adapter_info(Sock, Protocol, undefined).
+
+%% @doc Takes a socket and a protocol, returns an #amqp_adapter_info{}
+%% based on the socket for the protocol given.
+socket_adapter_info(Sock, Protocol, UniqueId) ->
+    amqp_direct_connection:socket_adapter_info(Sock, Protocol, UniqueId).
 
 %% @spec (ConnectionPid) -> ConnectionName
 %% where

--- a/deps/rabbit/test/rabbit_core_metrics_gc_SUITE.erl
+++ b/deps/rabbit/test/rabbit_core_metrics_gc_SUITE.erl
@@ -127,10 +127,13 @@ connection_metrics(Config) ->
 
     DeadPid = rabbit_ct_broker_helpers:rpc(Config, A, ?MODULE, dead_pid, []),
 
+    Infos = [{info0, foo}, {info1, bar}, {info2, baz},
+             {authz_backends, [rabbit_auth_backend_oauth2,rabbit_auth_backend_http]}],
+
     rabbit_ct_broker_helpers:rpc(Config, A, rabbit_core_metrics,
-                                 connection_created, [DeadPid, infos]),
+                                 connection_created, [DeadPid, Infos]),
     rabbit_ct_broker_helpers:rpc(Config, A, rabbit_core_metrics,
-                                 connection_stats, [DeadPid, infos]),
+                                 connection_stats, [DeadPid, Infos]),
     rabbit_ct_broker_helpers:rpc(Config, A, rabbit_core_metrics,
                                  connection_stats, [DeadPid, 1, 1, 1]),
 

--- a/deps/rabbit_common/src/rabbit_core_metrics.erl
+++ b/deps/rabbit_common/src/rabbit_core_metrics.erl
@@ -120,8 +120,9 @@ terminate() ->
      || {Table, _Type} <- ?CORE_TABLES ++ ?CORE_EXTRA_TABLES],
     ok.
 
-connection_created(Pid, Infos) ->
-    ets:insert(connection_created, {Pid, Infos}),
+connection_created(Pid, Infos0) ->
+    Infos1 = maybe_cleanup_infos(Infos0),
+    ets:insert(connection_created, {Pid, Infos1}),
     ets:update_counter(connection_churn_metrics, node(), {2, 1},
                        ?CONNECTION_CHURN_METRICS),
     ok.
@@ -446,3 +447,14 @@ format_auth_attempt({{RemoteAddress, Username, Protocol}, Total, Succeeded, Fail
 format_auth_attempt({Protocol, Total, Succeeded, Failed}) ->
     [{protocol, atom_to_binary(Protocol, utf8)}, {auth_attempts, Total},
      {auth_attempts_failed, Failed}, {auth_attempts_succeeded, Succeeded}].
+
+maybe_cleanup_infos(Infos0) when is_list(Infos0) ->
+    %% Note: authz_backends is added in rabbit_amqp1_0_session_sup:adapter_info/3
+    %% We delete it here, if present, because it should not be stored in the
+    %% connection_created table.
+    %%
+    %% TODO @ansd this will no longer be necessary once this PR is merged:
+    %% https://github.com/rabbitmq/rabbitmq-server/pull/9022
+    proplists:delete(authz_backends, Infos0);
+maybe_cleanup_infos(Infos) ->
+    Infos.

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_sup.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_session_sup.erl
@@ -62,7 +62,7 @@ start_link({amqp10_framing, Sock, Channel, FrameMax, ReaderPid,
                start =>
                    {rabbit_amqp1_0_session_process, start_link, [
                        {Channel, ReaderPid, WriterPid, User, VHost, FrameMax,
-                           adapter_info(User, SocketForAdapterInfo), Collector}
+                           adapter_info(User, SocketForAdapterInfo, Channel), Collector}
                    ]},
                restart => transient,
                significant => true,
@@ -98,7 +98,7 @@ init([]) ->
 %% See rabbit_direct.erl to see how `authz_bakends` is propagated from
 % amqp_adapter_info.additional_info to the rabbit_access_control module
 
-adapter_info(User, Sock) ->
-    AdapterInfo = amqp_connection:socket_adapter_info(Sock, {'AMQP', "1.0"}),
+adapter_info(User, Sock, UniqueId) ->
+    AdapterInfo = amqp_connection:socket_adapter_info(Sock, {'AMQP', "1.0"}, UniqueId),
     AdapterInfo#amqp_adapter_info{additional_info =
         AdapterInfo#amqp_adapter_info.additional_info ++ [{authz_backends, User#user.authz_backends}]}.

--- a/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/proxy_protocol_SUITE.erl
@@ -65,7 +65,7 @@ proxy_protocol_v1(Config) ->
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81 \\(\\d\\)">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -82,7 +82,7 @@ proxy_protocol_v1_tls(Config) ->
     timer:sleep(1000),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81$">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:81 \\(\\d\\)$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -100,7 +100,7 @@ proxy_protocol_v2_local(Config) ->
     {ok, _Packet} = gen_tcp:recv(Socket, 0, ?TIMEOUT),
     ConnectionName = rabbit_ct_broker_helpers:rpc(Config, 0,
         ?MODULE, connection_name, []),
-    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+$">>, [{capture, none}]),
+    match = re:run(ConnectionName, <<"^127.0.0.1:\\d+ -> 127.0.0.1:\\d+ \\(\\d\\)$">>, [{capture, none}]),
     gen_tcp:close(Socket),
     ok.
 
@@ -144,7 +144,9 @@ connection_name() ->
     end.
 
 connection_registered() ->
-    length(ets:tab2list(connection_created)) > 0.
+    I = ets:info(connection_created),
+    Size = proplists:get_value(size, I),
+    Size > 0.
 
 retry(_Function, 0) ->
     false;


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/9371

Since each AMQP 1.0 connection opens several direct AMQP connections, we
must assign each direct connection a unique name to prevent multiple
entries in the `connection_created_stats` table.

Also, use `pg_local` to track AMQP 1.0 connections instead of walking
the supervisor trees.