### PR TITLE
Match ra version between bazel and make

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rabbitmq_ra",
-    version = "2.6.2",
+    version = "2.6.3",
     repo_name = "ra",
 )
 


### PR DESCRIPTION
These fell out of sync due to a typo in 3253fe433bf42f161383eb84825fb3bdacb1892b