### PR TITLE
Forward compatibility with Erlang 27: distinguish between positive and negative 0.0

### DIFF
--- a/deps/rabbit_common/src/rabbit_numerical.erl
+++ b/deps/rabbit_common/src/rabbit_numerical.erl
@@ -30,8 +30,6 @@
 %%       human-readable output, or compact ASCII serializations for floats.
 digits(N) when is_integer(N) ->
     integer_to_list(N);
-digits(0.0) ->
-    "0.0";
 digits(Float) ->
     {Frac1, Exp1} = frexp_int(Float),
     [Place0 | Digits0] = digits1(Float, Exp1, Frac1),

--- a/deps/rabbit_common/src/rabbit_numerical.erl
+++ b/deps/rabbit_common/src/rabbit_numerical.erl
@@ -30,7 +30,7 @@
 %%       human-readable output, or compact ASCII serializations for floats.
 digits(N) when is_integer(N) ->
     integer_to_list(N);
-digits(0.0) ->
+digits(+0.0) ->
     "0.0";
 digits(-0.0) ->
     "0.0";

--- a/deps/rabbit_common/src/rabbit_numerical.erl
+++ b/deps/rabbit_common/src/rabbit_numerical.erl
@@ -30,6 +30,10 @@
 %%       human-readable output, or compact ASCII serializations for floats.
 digits(N) when is_integer(N) ->
     integer_to_list(N);
+digits(0.0) ->
+    "0.0";
+digits(-0.0) ->
+    "0.0";
 digits(Float) ->
     {Frac1, Exp1} = frexp_int(Float),
     [Place0 | Digits0] = digits1(Float, Exp1, Frac1),

--- a/deps/rabbit_common/src/rabbit_numerical.erl
+++ b/deps/rabbit_common/src/rabbit_numerical.erl
@@ -30,9 +30,7 @@
 %%       human-readable output, or compact ASCII serializations for floats.
 digits(N) when is_integer(N) ->
     integer_to_list(N);
-digits(+0.0) ->
-    "0.0";
-digits(-0.0) ->
+digits(N) when N =:= 0.0 ->
     "0.0";
 digits(Float) ->
     {Frac1, Exp1} = frexp_int(Float),


### PR DESCRIPTION
Without this change, our tests against OTP master started failing since the negative zero change was introduced, for example: https://github.com/rabbitmq/rabbitmq-server/actions/runs/6141080013/job/16660857916

The warning (treated as error) is:
```
rabbit_numerical.erl:33:8: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
```

As far as I can tell, we don't need special handling for this case in the first place - `digits(Float)` returns `"0.0"` for both `0.0` and `-0.0`.