### PR TITLE
Request more disk space for docker image jobs on RBE

### DIFF
--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -48,6 +48,7 @@ CONVENIENCE_PACKAGES = [
 FIRECRACKER_EXEC_PROPS = {
     # https://www.buildbuddy.io/docs/rbe-microvms
     "workload-isolation-type": "firecracker",
+    "EstimatedFreeDiskBytes": "16GB",
     "init-dockerd": "true",
     "recycle-runner": "true",
     # Use the default buildbuddy RBE image


### PR DESCRIPTION
On some occasions the OCI jobs fail on github actions due to lack of space