### PR TITLE
Forward compatibility with Erlang 27: negative zero fix, take 2

### DIFF
--- a/deps/rabbit_common/src/rabbit_numerical.erl
+++ b/deps/rabbit_common/src/rabbit_numerical.erl
@@ -30,7 +30,7 @@
 %%       human-readable output, or compact ASCII serializations for floats.
 digits(N) when is_integer(N) ->
     integer_to_list(N);
-digits(N) when N =:= 0.0 ->
+digits(N) when N =:= +0.0 orelse N =:= -0.0 ->
     "0.0";
 digits(Float) ->
     {Frac1, Exp1} = frexp_int(Float),


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-server/pull/9405 didn't actually solve the problem - OTP27 (git master) still complained about matching on the zero float. This does seem to make it happy.