### PR TITLE
Fix branch checkout in check-build-system-equivalence.yaml

### DIFF
--- a/.github/workflows/check-build-system-equivalence-release-branches.yaml
+++ b/.github/workflows/check-build-system-equivalence-release-branches.yaml
@@ -6,7 +6,7 @@ jobs:
   check-main:
     uses: ./.github/workflows/check-build-system-equivalence.yaml
     with:
-      ref: main
+      ref: refs/heads/main
       erlang_version: 26.0
       elixir_version: 1.15
       project_version: 3.13.0
@@ -14,7 +14,7 @@ jobs:
   check-v3_12_x:
     uses: ./.github/workflows/check-build-system-equivalence.yaml
     with:
-      ref: v3.12.x
+      ref: refs/heads/v3.12.x
       erlang_version: 26.0
       elixir_version: 1.15
       project_version: 3.12.0
@@ -22,7 +22,7 @@ jobs:
   check-v3_11_x:
     uses: ./.github/workflows/check-build-system-equivalence.yaml
     with:
-      ref: v3.11.x
+      ref: refs/heads/v3.11.x
       erlang_version: 26.0
       elixir_version: 1.15
       project_version: 3.11.0

--- a/.github/workflows/check-build-system-equivalence.yaml
+++ b/.github/workflows/check-build-system-equivalence.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.ref || github.ref }}
+        ref: ${{ inputs.ref || github.ref }}
     - name: CONFIGURE ERLANG
       uses: erlef/setup-beam@v1.16
       with:
@@ -77,7 +77,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: rabbitmq
-        ref: ${{ github.event.inputs.ref || github.ref }}
+        ref: ${{ inputs.ref || github.ref }}
     - name: CONFIGURE ERLANG
       uses: erlef/setup-beam@v1.16
       with:
@@ -115,7 +115,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: rabbitmq-server
-        ref: ${{ github.event.inputs.ref || github.ref }}
+        ref: ${{ inputs.ref || github.ref }}
     - name: CONFIGURE ERLANG
       uses: erlef/setup-beam@v1.16
       with:


### PR DESCRIPTION
The branch to be checked out was not passed correctly into the reusable github actions workflow.