### PR TITLE
forget_cluster_node: handle errors while shrinking streams and/or QQs

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1170,6 +1170,14 @@ rabbitmq_integration_suite(
     size = "large",
 )
 
+rabbitmq_integration_suite(
+    name = "cli_forget_cluster_node_SUITE",
+    size = "medium",
+    additional_beam = [
+        ":test_clustering_utils_beam",
+    ],
+)
+
 assert_suites()
 
 filegroup(

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -2040,3 +2040,12 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp_client:erlang_app"],
     )
+    erlang_bytecode(
+        name = "cli_forget_cluster_node_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/cli_forget_cluster_node_SUITE.erl"],
+        outs = ["test/cli_forget_cluster_node_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+        deps = ["//deps/amqp_client:erlang_app", "//deps/rabbitmq_ct_helpers:erlang_app"],
+    )

--- a/deps/rabbit/test/cli_forget_cluster_node_SUITE.erl
+++ b/deps/rabbit/test/cli_forget_cluster_node_SUITE.erl
@@ -1,0 +1,143 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(cli_forget_cluster_node_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+-compile(export_all).
+
+-import(clustering_utils, [
+                           assert_cluster_status/2,
+                           assert_clustered/1,
+                           assert_not_clustered/1
+                          ]).
+
+all() ->
+    [
+      {group, cluster_size_3}
+    ].
+
+groups() ->
+    [
+     {cluster_size_3, [], [
+                           forget_cluster_node_with_quorum_queues,
+                           forget_cluster_node_with_last_quorum_member
+                          ]}
+    ].
+
+suite() ->
+    [
+      %% If a testcase hangs, no need to wait for 30 minutes.
+      {timetrap, {minutes, 5}}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:merge_app_env(
+                Config, {rabbit, [
+                          {mnesia_table_loading_retry_limit, 2},
+                          {mnesia_table_loading_retry_timeout,1000}
+                         ]}),
+    rabbit_ct_helpers:run_setup_steps(Config1).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(cluster_size_3, Config) ->
+    rabbit_ct_helpers:set_config(Config, [{rmq_nodes_count, 3},
+                                          {rmq_nodes_clustered, true}]).
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    ClusterSize = ?config(rmq_nodes_count, Config),
+    TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase},
+        {tcp_ports_base, {skip_n_nodes, TestNumber * ClusterSize}},
+        {keep_pid_file_on_exit, true}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test cases
+%% -------------------------------------------------------------------
+forget_cluster_node_with_quorum_queues(Config) ->
+    [Rabbit, Hare, Bunny] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    assert_clustered([Rabbit, Hare, Bunny]),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Rabbit),
+    QQ1 = <<"quorum-queue-1">>,
+    QQ2 = <<"quorum-queue-2">>,
+    declare(Ch, QQ1, [{<<"x-queue-type">>, longstr, <<"quorum">>}]),
+    declare(Ch, QQ2, [{<<"x-queue-type">>, longstr, <<"quorum">>}]),
+    
+    ?awaitMatch(Members when length(Members) == 3, get_quorum_members(Rabbit, QQ1), 30000),
+    ?awaitMatch(Members when length(Members) == 3, get_quorum_members(Rabbit, QQ2), 30000),
+
+    ?assertEqual(ok, rabbit_control_helper:command(stop_app, Bunny)),
+    ?assertEqual(ok, forget_cluster_node(Rabbit, Bunny)),
+    assert_cluster_status({[Rabbit, Hare], [Rabbit, Hare], [Rabbit, Hare]},
+                          [Rabbit, Hare]),
+    ?awaitMatch(Members when length(Members) == 2, get_quorum_members(Rabbit, QQ1), 30000),
+    ?awaitMatch(Members when length(Members) == 2, get_quorum_members(Rabbit, QQ2), 30000).
+
+forget_cluster_node_with_last_quorum_member(Config) ->
+    [Rabbit, Hare, Bunny] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    assert_clustered([Rabbit, Hare, Bunny]),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Bunny),
+    QQ1 = <<"quorum-queue-1">>,
+    QQ2 = <<"quorum-queue-2">>,
+    declare(Ch, QQ1, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                      {<<"x-quorum-initial-group-size">>, long, 1}]),
+    declare(Ch, QQ2, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                      {<<"x-quorum-initial-group-size">>, long, 1}]),
+    
+    ?awaitMatch(Members when length(Members) == 1, get_quorum_members(Rabbit, QQ1), 30000),
+    ?awaitMatch(Members when length(Members) == 1, get_quorum_members(Rabbit, QQ2), 30000),
+
+    ?assertEqual(ok, rabbit_control_helper:command(stop_app, Bunny)),
+    ?assertMatch({error, 69, _}, forget_cluster_node(Rabbit, Bunny)),
+    assert_cluster_status({[Rabbit, Hare], [Rabbit, Hare], [Rabbit, Hare]},
+                          [Rabbit, Hare]),
+    ?awaitMatch(Members when length(Members) == 1, get_quorum_members(Rabbit, QQ1), 30000),
+    ?awaitMatch(Members when length(Members) == 1, get_quorum_members(Rabbit, QQ2), 30000).
+
+forget_cluster_node(Node, Removee) ->
+    rabbit_control_helper:command(forget_cluster_node, Node, [atom_to_list(Removee)],
+                                  []).
+
+get_quorum_members(Server, Q) ->
+    Info = rpc:call(Server, rabbit_quorum_queue, infos, [rabbit_misc:r(<<"/">>, queue, Q)]),
+    proplists:get_value(members, Info).
+
+declare(Ch, Q, Args) ->
+    amqp_channel:call(Ch, #'queue.declare'{queue     = Q,
+                                           durable   = true,
+                                           auto_delete = false,
+                                           arguments = Args}).

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -82,13 +82,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
         error
 
       :ok ->
-        case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :shrink_all, [atom_name]) do
-          {:error, _} ->
-            {:error,
-             "RabbitMQ failed to shrink some of the quorum queues on node #{node_to_remove}"}
+        qq_shrink_result =
+          :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :shrink_all, [atom_name])
 
-          _ ->
+        is_ok_fun = fn
+          {_, {:ok, _}} -> true
+          {_, {:error, _, _}} -> false
+        end
+
+        case Enum.empty?(qq_shrink_result) do
+          true ->
             :ok
+
+          false ->
+            case Enum.any?(qq_shrink_result, is_ok_fun) do
+              false ->
+                {:error,
+                 "RabbitMQ failed to shrink some of the quorum queues on node #{node_to_remove}"}
+
+              true ->
+                :ok
+            end
         end
 
       other ->


### PR DESCRIPTION
The cli command was not handling properly the errors returned by `rabbit_quorum_queue:shrink_all/1` . Any error would be ignored and returned ok instead.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

