### PR TITLE
Change log level for startup time to info

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -388,7 +388,7 @@ start_it(StartType) ->
                 ok = wait_for_ready_or_stopped(),
 
                 T1 = erlang:timestamp(),
-                ?LOG_DEBUG(
+                ?LOG_INFO(
                   "Time to start RabbitMQ: ~tp us",
                   [timer:now_diff(T1, T0)]),
                 stop_boot_marker(Marker),


### PR DESCRIPTION
## Proposed Changes

Change the log level for time to start RabbitMQ from `debug` to `info`. This info can be quite valuable in scenarios where RabbitMQ starts, runs for a short while, stops, starts again, etc. 

Currently this time can be calculated manually by looking in the log for time stamps and comparing them. Or switching log level to debug. This would make that information more widely available. 
 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it