### PR TITLE
Fix OTP 27 float match warning

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1268,7 +1268,7 @@ prioritise_cast(Msg, _Len, State) ->
 
 consumer_bias(#q{backing_queue = BQ, backing_queue_state = BQS}, Low, High) ->
     case BQ:msg_rates(BQS) of
-        {0.0,          _} -> Low;
+        {Ingress,      _} when Ingress =:= +0.0 orelse Ingress =:= -0.0 -> Low;
         {Ingress, Egress} when Egress / Ingress < ?CONSUMER_BIAS_RATIO -> High;
         {_,            _} -> Low
     end.


### PR DESCRIPTION
OTP 26.1 will warn that `matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead`