### PR TITLE
Match credentials_obfuscation version in bazel/make

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -207,8 +207,8 @@ erlang_package.hex_package(
 erlang_package.hex_package(
     name = "credentials_obfuscation",
     build_file = "@rabbitmq-server//bazel:BUILD.credentials_obfuscation",
-    sha256 = "fe8ece91a1ba6c8a08eb1063cfd5b063a723c5fe29a1fad6b7cbd76cb18d2eeb",
-    version = "3.2.0",
+    sha256 = "738ace0ed5545d2710d3f7383906fc6f6b582d019036e5269c4dbd85dbced566",
+    version = "3.4.0",
 )
 
 erlang_package.hex_package(

--- a/bazel/BUILD.credentials_obfuscation
+++ b/bazel/BUILD.credentials_obfuscation
@@ -24,16 +24,9 @@ erlang_bytecode(
         "src/credentials_obfuscation_sup.erl",
         "src/credentials_obfuscation_svc.erl",
     ],
-    outs = [
-        "ebin/credentials_obfuscation.beam",
-        "ebin/credentials_obfuscation_app.beam",
-        "ebin/credentials_obfuscation_pbe.beam",
-        "ebin/credentials_obfuscation_sup.beam",
-        "ebin/credentials_obfuscation_svc.beam",
-    ],
-    hdrs = ["include/credentials_obfuscation.hrl"],
+    hdrs = [":public_and_private_hdrs"],
     app_name = "credentials_obfuscation",
-    beam = [],
+    dest = "ebin",
     erlc_opts = "//:erlc_opts",
 )
 
@@ -54,20 +47,17 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "private_hdrs",
-    srcs = [],
-)
+filegroup(name = "private_hdrs")
 
 filegroup(
     name = "public_hdrs",
-    srcs = ["include/credentials_obfuscation.hrl"],
+    srcs = [
+        "include/credentials_obfuscation.hrl",
+        "include/otp_crypto.hrl",
+    ],
 )
 
-filegroup(
-    name = "priv",
-    srcs = [],
-)
+filegroup(name = "priv")
 
 filegroup(
     name = "licenses",
@@ -101,10 +91,21 @@ erlang_app(
     app_name = "credentials_obfuscation",
     beam_files = [":beam_files"],
     extra_apps = ["crypto"],
+    license_files = [":license_files"],
+    priv = [":priv"],
 )
 
 alias(
     name = "credentials_obfuscation",
     actual = ":erlang_app",
     visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "license_files",
+    srcs = [
+        "LICENSE",
+        "LICENSE-APACHE2",
+        "LICENSE-MPL-RabbitMQ",
+    ],
 )


### PR DESCRIPTION
8d107818bf35ba1a4ad23b68a9b2af80d05632bc accidentally bumped the credentials_obfuscation version in the erlang.mk build to 3.4.0. Since presumably we already shipped it this way, this updates the bazel build to match.