### PR TITLE
CQ: Fix a crash when CMQ master changes in mixed environment test

### DIFF
--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -1165,7 +1165,11 @@ convert_from_v2_to_v1_loop(QueueName, V1Index0, V2Index0, V2Store0,
                     V1Index1b = rabbit_queue_index:publish(MsgId, SeqId, rabbit_msg_store, Props, IsPersistent, infinity, V1Index1a),
                     rabbit_queue_index:deliver([SeqId], V1Index1b)
             end,
-            {V1Index2, V2Store1}
+            {V1Index2, V2Store1};
+        %% Ignore messages that are in memory and had an entry written in the index.
+        %% @todo Remove this clause some time after CMQs get removed as this will become dead code.
+        ({undefined, _, memory, _, _}, {V1Index1, V2Store1}) ->
+            {V1Index1, V2Store1}
     end, {V1Index0, V2Store0}, Messages),
     %% Flush to disk to avoid keeping too much in memory between segments.
     V1Index = rabbit_queue_index:flush(V1Index3),


### PR DESCRIPTION
When policies are applied to change a CMQ master, and that master moves from 3.13 to 3.12, this triggers a CQ version change (because it defaults to v2 in 3.13 but v1 in 3.12). which leads to a crash because the files on disk have an index entry for messages that are in memory only.

The index entry is only created with CMQs, normal CQs prohibit this behavior. Since we are going to remove CMQs "soon" the solution to fix the crash was to simply ignore the index entry when we know the message is already in memory.

This will need to be merged to both main and 3.12 before this fixes the mixed test that currently fails.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
