### PR TITLE
Operator policies

### DIFF
--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -1187,7 +1187,7 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         outs = ["test/policy_SUITE.beam"],
         app_name = "rabbit",
         erlc_opts = "//:test_erlc_opts",
-        deps = ["//deps/amqp_client:erlang_app"],
+        deps = ["//deps/amqp_client:erlang_app", "//deps/rabbitmq_ct_helpers:erlang_app"],
     )
     erlang_bytecode(
         name = "priority_queue_SUITE_beam_files",

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -487,7 +487,7 @@ capabilities() ->
                                <<"max-age">>, <<"stream-max-segment-size-bytes">>,
                                <<"queue-leader-locator">>, <<"initial-cluster-size">>,
                                %% Quorum policies
-                               <<"delivery-limit">>, <<"dead-letter-strategy">>],
+                               <<"delivery-limit">>, <<"dead-letter-strategy">>, <<"max-in-memory-length">>, <<"max-in-memory-bytes">>, <<"target-group-size">>],
       queue_arguments => [<<"x-expires">>, <<"x-message-ttl">>, <<"x-dead-letter-exchange">>,
                           <<"x-dead-letter-routing-key">>, <<"x-max-length">>,
                           <<"x-max-length-bytes">>, <<"x-max-priority">>,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1090,7 +1090,7 @@ capabilities() ->
                                <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
                                <<"queue-master-locator">>,
                                %% Quorum policies
-                               <<"dead-letter-strategy">>],
+                               <<"dead-letter-strategy">>, <<"target-group-size">>],
       queue_arguments => [<<"x-max-length-bytes">>, <<"x-queue-type">>,
                           <<"x-max-age">>, <<"x-stream-max-segment-size-bytes">>,
                           <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -280,30 +280,37 @@
             <div class="multifield" id="definitionop"></div>
             <table class="argument-links">
               <tr>
-                <td>Queues [All types]</td>
+                <td>Queues [Classic]</td>
                 <td>
+                  <span class="argument-link" field="definitionop" key="expires" type="number">Auto expire</span> |
+                  <span class="argument-link" field="definitionop" key="ha-mode" type="string">HA mode</span> <span class="help" id="policy-ha-mode"></span> |
+                  <span class="argument-link" field="definitionop" key="ha-params" type="number">HA params</span> <span class="help" id="policy-ha-params"></span> |
+                  <span class="argument-link" field="definitionop" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span> </br>
                   <span class="argument-link" field="definitionop" key="max-length" type="number">Max length</span> |
                   <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
-                  <span class="argument-link" field="definitionop" key="overflow" type="string">Overflow behaviour</span>
-                  <span class="help" id="queue-overflow"></span></br>
                   <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span>
                   <span class="help" id="queue-message-ttl"></span>
                 </td>
               </tr>
               <tr>
-                <td>Queues [Classic]</td>
+                <td>Queues [Quorum]</td>
                 <td>
-                  <span class="argument-link" field="definitionop" key="expires" type="number">Auto expire</span>
-                  <span class="argument-link" field="definitionop" key="ha-mode" type="string">HA mode</span> <span class="help" id="policy-ha-mode"></span> |
-                  <span class="argument-link" field="definitionop" key="ha-params" type="number">HA params</span> <span class="help" id="policy-ha-params"></span> |
-                  <span class="argument-link" field="definitionop" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span> </br>
+                  <span class="argument-link" field="definitionop" key="delivery-limit" type="number">Delivery limit</span>
+                  <span class="help" id="delivery-limit"></span> |
+                  <span class="argument-link" field="definitionop" key="expires" type="number">Auto expire</span> |
+                  <span class="argument-link" field="definitionop" key="max-in-memory-bytes" type="number">Max in-memory bytes</span> |
+                  <span class="argument-link" field="definitionop" key="max-in-memory-length" type="number">Max in-memory length</span> <br>
+                  <span class="argument-link" field="definitionop" key="max-length" type="number">Max length</span> |
+                  <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
+                  <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span>
+                  <span class="help" id="queue-message-ttl"></span> |
+                  <span class="argument-link" field="definitionop" key="target-group-size" type="number">Target group size</span>
                 </td>
               </tr>
               <tr>
-                <td>Queues [Quorum]</td>
+                <td>Queues [Streams]</td>
                 <td>
-                  <span class="argument-link" field="definitionop" key="delivery-limit" type="string">Delivery limit</span>
-                  <span class="help" id="delivery-limit"></span>
+                  <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
Management UI: List all operator policies per queue type

Add unsupported operator policies to each queue type. Just valid policies are effectively applied on each queue type, but they need to be added to 'unsupported-capabilities' to be excluded from the queue info.

Initial issue reported in  https://github.com/rabbitmq/rabbitmq-server/pull/9127
Documentation updated in https://github.com/rabbitmq/rabbitmq-website/pull/1729

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
