### PR TITLE
Support both transaction and serials on exchange callbacks

### DIFF
--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_jms_topic_exchange.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_jms_topic_exchange.erl
@@ -104,18 +104,18 @@ route(#exchange{name = XName}, Msg, _Opts) ->
 validate(_X) -> ok.
 
 % After exchange declaration and recovery
-create(none, #exchange{name = XName}) ->
+create(_Tx, #exchange{name = XName}) ->
   add_initial_record(XName).
 
 % Delete an exchange
-delete(none, #exchange{name = XName}) ->
+delete(_Tx, #exchange{name = XName}) ->
     delete_state(XName).
 
 % Before add binding
 validate_binding(_X, _B) -> ok.
 
 % A new binding has ben added or recovered
-add_binding( none
+add_binding( _Tx
            , #exchange{name = XName}
            , #binding{key = BindingKey, destination = Dest, args = Args}
            ) ->
@@ -130,7 +130,7 @@ add_binding( none
   ok.
 
 % Binding removal
-remove_bindings( none
+remove_bindings( _Tx
                , #exchange{name = XName}
                , Bindings
                ) ->

--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_exchange_type_recent_history.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_exchange_type_recent_history.erl
@@ -71,10 +71,10 @@ validate_binding(_X, _B) -> ok.
 create(_Tx, _X) -> ok.
 policy_changed(_X1, _X2) -> ok.
 
-delete(none, #exchange{ name = XName }) ->
+delete(_Tx, #exchange{ name = XName }) ->
     rabbit_db_rh_exchange:delete(XName).
 
-add_binding(none, #exchange{ name = XName },
+add_binding(_Tx, #exchange{ name = XName },
             #binding{ destination = #resource{kind = queue} = QName }) ->
     _ = case rabbit_amqqueue:lookup(QName) of
         {error, not_found} ->
@@ -84,7 +84,7 @@ add_binding(none, #exchange{ name = XName },
             deliver_messages([Q], Msgs)
     end,
     ok;
-add_binding(none, #exchange{ name = XName },
+add_binding(_Tx, #exchange{ name = XName },
             #binding{ destination = #resource{kind = exchange} = DestName }) ->
     _ = case rabbit_exchange:lookup(DestName) of
         {error, not_found} ->
@@ -102,7 +102,7 @@ add_binding(none, #exchange{ name = XName },
              end || Msg <- Msgs]
     end,
     ok;
-add_binding(none, _Exchange, _Binding) ->
+add_binding(_Tx, _Exchange, _Binding) ->
     ok.
 
 remove_bindings(_Tx, _X, _Bs) -> ok.

--- a/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
+++ b/deps/rabbitmq_sharding/src/rabbit_sharding_exchange_decorator.erl
@@ -32,7 +32,7 @@ description() ->
 
 serialise_events(_X) -> false.
 
-create(none, X) ->
+create(_Tx, X) ->
     _ = maybe_start_sharding(X),
     ok.
 
@@ -48,7 +48,7 @@ active_for(X) ->
     end.
 
 %% we have to remove the policy from ?SHARDING_TABLE
-delete(none, X) ->
+delete(_Tx, X) ->
     _ = maybe_stop_sharding(X),
     ok.
 


### PR DESCRIPTION
Exchange callbacks have been refactored to prepare for the new metadata store. These need to support being called with both a transaction or a serial number (serial or `none`). 

Issue introduced in https://github.com/rabbitmq/rabbitmq-server/commit/5b39e7e4cec8d844c2ac4ad5809065ecaa0251b2

References https://github.com/rabbitmq/rabbitmq-server/issues/9533

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

