### PR TITLE
Fix wrong queue-pattern type

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -795,6 +795,8 @@ end}.
                               _ -> V
                           end,
                     {["default_policies","operator",ID|T], NewV};
+                   ({["default_policies","operator",ID, "queue_pattern"], V}) ->
+                    {["default_policies","operator",ID,"queue_pattern"], list_to_binary(V)};
                    (E) -> E
                 end),
     case Props of

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -158,7 +158,7 @@ ssl_options.fail_if_no_peer_cert = true",
                  {<<"ha_mode">>, <<"exactly">>},
                  {<<"ha_params">>, 2},
                  {<<"ha_sync_mode">>, <<"automatic">>},
-                 {<<"queue_pattern">>, "apple"},
+                 {<<"queue_pattern">>, <<"apple">>},
                  {<<"vhost_pattern">>, "banana"}]}]}]}]}],
   []},
 


### PR DESCRIPTION
## Proposed Changes

Noticed a bug in the default operator policies for the 'queue-pattern' parameter. It was a list type, but internally expected a binary. Converts the value in the cuttlefish schema to catch it as early as possible.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
