### PR TITLE
HTTP API: document disable_stats and enable_queue_totals

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -56,6 +56,13 @@
     with the <code>columns</code> parameter. This is a comma-separated
     list of subfields separated by dots. See the example below.</p>
 
+    <p> It is possible to disable the statistics in the GET requests
+      and obtain just the basic information of every object. This reduces
+      considerably the amount of data returned and the memory and resource
+      consumption of each query in the system. For some monitoring and operation
+      purposes, these queries are more appropiate. The query string parameter
+    <code>disable_stats</code> set to <code>true</code> will achieve this.</p>
+
     <p>Most of the GET queries return many fields per
     object. The second part of this guide covers those.</p>
 
@@ -478,7 +485,10 @@ vary: accept, accept-encoding, origin</pre>
         <td></td>
         <td></td>
         <td class="path">/api/queues</td>
-        <td>A list of all queues. Use <a href="#pagination">pagination parameters</a> to filter queues.</td>
+        <td>A list of all queues. Use <a href="#pagination">pagination parameters</a> to filter queues.
+          The parameter <code>enable_queue_totals</code> can be used in combination with the
+          <code>disable_stats</code> parameter to return a reduced set of fields.
+        </td>
       </tr>
       <tr>
         <td>X</td>
@@ -2158,6 +2168,85 @@ or:
     </table>
 
     <h2>/api/queues</h2>
+
+    When using the query parameters combination of <code>disable_stats</code> and
+    <code>enable_queue_totals</code> this query returns the following fields:
+
+    <table>
+      <tr>
+        <td><code>name</code></td>
+        <td>
+          The name of the queue.
+        </td>
+      </tr>
+      <tr>
+        <td><code>vhost</code></td>
+        <td>
+          The name of the virtual host.
+        </td>
+      </tr>
+      <tr>
+        <td><code>type</code></td>
+        <td>
+          The type of the queue.
+        </td>
+      </tr>
+      <tr>
+        <td><code>node</code></td>
+        <td>
+          Depending on the type of the queue, this is the node which holds the queue or hosts the leader.
+        </td>
+      </tr>
+      <tr>
+        <td><code>state</code></td>
+        <td>
+          The status of the queue.
+        </td>
+      </tr>
+      <tr>
+        <td><code>arguments</code></td>
+        <td>
+          The arguments of the queue.
+        </td>
+      </tr>
+      <tr>
+        <td><code>auto_delete</code></td>
+        <td>
+          The value of the <code>auto_delete</code> argument.
+        </td>
+      </tr>
+      <tr>
+        <td><code>durable</code></td>
+        <td>
+          The value of the <code>durable</code> argument.
+        </td>
+      </tr>
+      <tr>
+        <td><code>exclusive</code></td>
+        <td>
+          The value of the <code>exclusive</code> argument.
+        </td>
+      </tr>
+      <tr>
+        <td><code>messages</code></td>
+        <td>
+          The total number of messages in the queue.
+        </td>
+      </tr>
+      <tr>
+        <td><code>messages_ready</code></td>
+        <td>
+          The number of messages ready to be delivered in the queue.
+        </td>
+      </tr>
+      <tr>
+        <td><code>messages_unacknowledged</code></td>
+        <td>
+          The number of messages waiting for acknowledgement in the queue.
+        </td>
+      </tr>
+    </table>
+
     <h2>/api/queues/(vhost)</h2>
 
     <p>

--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -486,8 +486,10 @@ vary: accept, accept-encoding, origin</pre>
         <td></td>
         <td class="path">/api/queues</td>
         <td>A list of all queues. Use <a href="#pagination">pagination parameters</a> to filter queues.
-          The parameter <code>enable_queue_totals</code> can be used in combination with the
-          <code>disable_stats</code> parameter to return a reduced set of fields.
+          The parameter <code>enable_queue_totals=true</code> can be used in combination with the
+          <code>disable_stats=true</code> parameter to return a reduced set of fields and significantly
+          reduce the amount of data returned by this endpoint. That in turn can significantly reduce
+          CPU and bandwidth footprint of such requests.
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
These query parameters have been present since 2019 (probably 3.8) but weren't properly documented.

Using `GET /api/queues?disable_stats=true&enable_queue_totals=true` is far more efficient than the standard `GET /api/queues` and in many cases will suffice for monitoring and operating purposes.

Related to https://github.com/rabbitmq/rabbitmq-server/issues/9437

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

