### PR TITLE
Drop an action that we no longer need

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -38,21 +38,6 @@ jobs:
           - image_tag_suffix: otp-max-bazel
             otp_version_id: 26_1
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
What was running out of disk space were BuildBuddy worker hosts, not GitHub Actions worker ones.

Plus the Action is currently broken because it tries to delete a package that was renamed.
