### PR TITLE
Monitor members to the same stream in stream connection

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -84,7 +84,7 @@
          heartbeat :: undefined | integer(),
          heartbeater :: any(),
          client_properties = #{} :: #{binary() => binary()},
-         monitors = #{} :: #{reference() => stream()},
+         monitors = #{} :: #{reference() => {pid(), stream()}},
          stats_timer :: undefined | rabbit_event:state(),
          resource_alarm :: boolean(),
          send_file_oct ::
@@ -3191,8 +3191,8 @@ clean_state_after_stream_deletion_or_failure(MemberPid, Stream,
                                                 VirtualHost, Consumer,
                                                 single_active_consumer(Consumer),
                                                 Rqsts0);
-                                          {_, #consumer{configuration =
-                                                    #consumer_configuration{member_pid = MemberPid}}} ->
+                                          {MemberPid, #consumer{configuration =
+                                                                #consumer_configuration{member_pid = MemberPid}}} ->
                                               rabbit_stream_metrics:consumer_cancelled(self(),
                                                                                        stream_r(Stream,
                                                                                                 C0),
@@ -3221,17 +3221,17 @@ clean_state_after_stream_deletion_or_failure(MemberPid, Stream,
             true ->
                 {PurgedPubs, PurgedPubToIds} =
                     maps:fold(fun(PubId,
-                                  #publisher{stream = S, reference = Ref, leader = MPid},
-                                  {Pubs, PubToIds}) when S =:= Stream andalso MPid =:= MemberPid ->
-                                         rabbit_stream_metrics:publisher_deleted(self(),
+                                  #publisher{stream = S, reference = Ref},
+                                  {Pubs, PubToIds}) when S =:= Stream andalso MemberPid =:= undefined ->
+                                      rabbit_stream_metrics:publisher_deleted(self(),
                                                                                  stream_r(Stream,
                                                                                           C1),
                                                                                  PubId),
                                          {maps:remove(PubId, Pubs),
                                           maps:remove({Stream, Ref}, PubToIds)};
                                  (PubId,
-                                  #publisher{stream = S, reference = Ref},
-                                  {Pubs, PubToIds}) when S =:= Stream andalso MemberPid =:= undefined ->
+                                  #publisher{stream = S, reference = Ref, leader = MPid},
+                                  {Pubs, PubToIds}) when S =:= Stream andalso MPid =:= MemberPid ->
                                          rabbit_stream_metrics:publisher_deleted(self(),
                                                                                  stream_r(Stream,
                                                                                           C1),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -912,10 +912,10 @@ open(info, {'DOWN', MonitorRef, process, _OsirisPid, _Reason},
          StatemData) ->
     {Connection1, State1} =
         case Monitors of
-            #{MonitorRef := Stream} ->
+            #{MonitorRef := {MemberPid, Stream}} ->
                 Monitors1 = maps:remove(MonitorRef, Monitors),
                 C = Connection#stream_connection{monitors = Monitors1},
-                case clean_state_after_stream_deletion_or_failure(Stream, C,
+                case clean_state_after_stream_deletion_or_failure(MemberPid, Stream, C,
                                                                   State)
                 of
                     {cleaned, NewConnection, NewState} ->
@@ -1893,7 +1893,7 @@ handle_frame_post_auth(Transport,
                        {request, CorrelationId,
                         {delete_publisher, PublisherId}}) ->
     case Publishers of
-        #{PublisherId := #publisher{stream = Stream, reference = Ref}} ->
+        #{PublisherId := #publisher{stream = Stream, reference = Ref, leader = LeaderPid}} ->
             Connection1 =
                 Connection0#stream_connection{publishers =
                                                   maps:remove(PublisherId,
@@ -1902,7 +1902,7 @@ handle_frame_post_auth(Transport,
                                                   maps:remove({Stream, Ref},
                                                               PubToIds)},
             Connection2 =
-                maybe_clean_connection_from_stream(Stream, Connection1),
+                maybe_clean_connection_from_stream(LeaderPid, Stream, Connection1),
             response(Transport,
                      Connection1,
                      delete_publisher,
@@ -2418,7 +2418,7 @@ handle_frame_post_auth(Transport,
                                 CorrelationId),
                     {Connection1, State1} =
                         case
-                            clean_state_after_stream_deletion_or_failure(Stream,
+                            clean_state_after_stream_deletion_or_failure(undefined, Stream,
                                                                          Connection,
                                                                          State)
                         of
@@ -3155,7 +3155,7 @@ stream_r(Stream, #stream_connection{virtual_host = VHost}) ->
               kind = queue,
               virtual_host = VHost}.
 
-clean_state_after_stream_deletion_or_failure(Stream,
+clean_state_after_stream_deletion_or_failure(MemberPid, Stream,
                                              #stream_connection{virtual_host =
                                                                     VirtualHost,
                                                                 stream_subscriptions
@@ -3180,16 +3180,30 @@ clean_state_after_stream_deletion_or_failure(Stream,
                 #{Stream := SubscriptionIds} = StreamSubscriptions,
                 Requests1 = lists:foldl(
                               fun(SubId, Rqsts0) ->
-                                      rabbit_stream_metrics:consumer_cancelled(self(),
-                                                                               stream_r(Stream,
-                                                                                        C0),
-                                                                               SubId),
                                       #{SubId := Consumer} = Consumers,
-                                      Rqsts1 = maybe_unregister_consumer(
-                                                 VirtualHost, Consumer,
-                                                 single_active_consumer(Consumer),
-                                                 Rqsts0),
-                                      Rqsts1
+                                      case {MemberPid, Consumer} of
+                                          {undefined, _C} ->
+                                              rabbit_stream_metrics:consumer_cancelled(self(),
+                                                                                       stream_r(Stream,
+                                                                                                C0),
+                                                                                       SubId),
+                                              maybe_unregister_consumer(
+                                                VirtualHost, Consumer,
+                                                single_active_consumer(Consumer),
+                                                Rqsts0);
+                                          {_, #consumer{configuration =
+                                                    #consumer_configuration{member_pid = MemberPid}}} ->
+                                              rabbit_stream_metrics:consumer_cancelled(self(),
+                                                                                       stream_r(Stream,
+                                                                                                C0),
+                                                                                       SubId),
+                                              maybe_unregister_consumer(
+                                                VirtualHost, Consumer,
+                                                single_active_consumer(Consumer),
+                                                Rqsts0);
+                                          _ ->
+                                              Rqsts0
+                                      end
                               end, Requests0, SubscriptionIds),
                 {true,
                  C0#stream_connection{stream_subscriptions =
@@ -3207,18 +3221,26 @@ clean_state_after_stream_deletion_or_failure(Stream,
             true ->
                 {PurgedPubs, PurgedPubToIds} =
                     maps:fold(fun(PubId,
-                                  #publisher{stream = S, reference = Ref},
-                                  {Pubs, PubToIds}) ->
-                                 case S of
-                                     Stream ->
+                                  #publisher{stream = S, reference = Ref, leader = MPid},
+                                  {Pubs, PubToIds}) when S =:= Stream andalso MPid =:= MemberPid ->
                                          rabbit_stream_metrics:publisher_deleted(self(),
-                                                                                 stream_r(S,
+                                                                                 stream_r(Stream,
                                                                                           C1),
                                                                                  PubId),
                                          {maps:remove(PubId, Pubs),
                                           maps:remove({Stream, Ref}, PubToIds)};
-                                     _ -> {Pubs, PubToIds}
-                                 end
+                                 (PubId,
+                                  #publisher{stream = S, reference = Ref},
+                                  {Pubs, PubToIds}) when S =:= Stream andalso MemberPid =:= undefined ->
+                                         rabbit_stream_metrics:publisher_deleted(self(),
+                                                                                 stream_r(Stream,
+                                                                                          C1),
+                                                                                 PubId),
+                                         {maps:remove(PubId, Pubs),
+                                          maps:remove({Stream, Ref}, PubToIds)};
+
+                                 (_PubId, _Publisher, {Pubs, PubToIds}) ->
+                                     {Pubs, PubToIds}
                               end,
                               {Publishers, PublisherToIds}, Publishers),
                 {true,
@@ -3240,7 +3262,7 @@ clean_state_after_stream_deletion_or_failure(Stream,
          orelse LeadersCleaned
     of
         true ->
-            C3 = demonitor_stream(Stream, C2),
+            C3 = demonitor_stream(MemberPid, Stream, C2),
             {cleaned, C3#stream_connection{stream_leaders = Leaders1}, S2};
         false ->
             {not_cleaned, C2#stream_connection{stream_leaders = Leaders1}, S2}
@@ -3279,7 +3301,7 @@ remove_subscription(SubscriptionId,
                     #stream_connection_state{consumers = Consumers} = State) ->
     #{SubscriptionId := Consumer} = Consumers,
     #consumer{log = Log,
-              configuration = #consumer_configuration{stream = Stream}} =
+              configuration = #consumer_configuration{stream = Stream, member_pid = MemberPid}} =
         Consumer,
     rabbit_log:debug("Deleting subscription ~tp (stream ~tp)",
                      [SubscriptionId, Stream]),
@@ -3299,7 +3321,7 @@ remove_subscription(SubscriptionId,
         Connection#stream_connection{stream_subscriptions =
                                          StreamSubscriptions1},
     Consumers1 = maps:remove(SubscriptionId, Consumers),
-    Connection2 = maybe_clean_connection_from_stream(Stream, Connection1),
+    Connection2 = maybe_clean_connection_from_stream(MemberPid, Stream, Connection1),
     rabbit_stream_metrics:consumer_cancelled(self(),
                                              stream_r(Stream, Connection2),
                                              SubscriptionId),
@@ -3312,7 +3334,7 @@ remove_subscription(SubscriptionId,
     {Connection2#stream_connection{outstanding_requests = Requests1},
      State#stream_connection_state{consumers = Consumers1}}.
 
-maybe_clean_connection_from_stream(Stream,
+maybe_clean_connection_from_stream(MemberPid, Stream,
                                    #stream_connection{stream_leaders =
                                                           Leaders} =
                                        Connection0) ->
@@ -3321,7 +3343,7 @@ maybe_clean_connection_from_stream(Stream,
               stream_has_subscriptions(Stream, Connection0)}
         of
             {false, false} ->
-                demonitor_stream(Stream, Connection0);
+                demonitor_stream(MemberPid, Stream, Connection0);
             _ ->
                 Connection0
         end,
@@ -3330,26 +3352,27 @@ maybe_clean_connection_from_stream(Stream,
 
 maybe_monitor_stream(Pid, Stream,
                      #stream_connection{monitors = Monitors} = Connection) ->
-    case lists:member(Stream, maps:values(Monitors)) of
+    case lists:member({Pid, Stream}, maps:values(Monitors)) of
         true ->
             Connection;
         false ->
             MonitorRef = monitor(process, Pid),
             Connection#stream_connection{monitors =
-                                             maps:put(MonitorRef, Stream,
+                                             maps:put(MonitorRef, {Pid, Stream},
                                                       Monitors)}
     end.
 
-demonitor_stream(Stream,
+demonitor_stream(MemberPid, Stream,
                  #stream_connection{monitors = Monitors0} = Connection) ->
     Monitors =
-        maps:fold(fun(MonitorRef, Strm, Acc) ->
-                     case Strm of
-                         Stream ->
-                             demonitor(MonitorRef, [flush]),
+        maps:fold(fun(MonitorRef, {MPid, Strm}, Acc) when MPid =:= MemberPid andalso Strm =:= Stream ->
+                        demonitor(MonitorRef, [flush]),
                              Acc;
-                         _ -> maps:put(MonitorRef, Strm, Acc)
-                     end
+                     (MonitorRef, {_MPid, Strm}, Acc) when MemberPid =:= undefined andalso Strm =:= Stream ->
+                        demonitor(MonitorRef, [flush]),
+                             Acc;
+                     (MonitorRef, {MPid, Strm}, Acc) ->
+                         maps:put(MonitorRef, {MPid, Strm}, Acc)
                   end,
                   #{}, Monitors0),
     Connection#stream_connection{monitors = Monitors}.

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE.erl
@@ -111,7 +111,8 @@ init_per_group(cluster = Group, Config) ->
                          {rmq_nodes_count, 3},
                          {rmq_nodename_suffix, Group},
                          {tcp_ports_base},
-                         {rabbitmq_ct_tls_verify, verify_none}
+                         {rabbitmq_ct_tls_verify, verify_none},
+                         {find_crashes, false} %% we kill stream members in some tests
                         ]),
     rabbit_ct_helpers:run_setup_steps(
       Config1,

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/src/test/java/com/rabbitmq/stream/Host.java
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/src/test/java/com/rabbitmq/stream/Host.java
@@ -101,6 +101,21 @@ public class Host {
     return System.getProperty("node2.name", "rabbit-2@" + hostname());
   }
 
+  public static Process killStreamLocalMemberProcess(String stream, String nodename) throws IOException {
+    return rabbitmqctl(
+        "eval 'case rabbit_stream_manager:lookup_local_member(<<\"/\">>, <<\""
+            + stream
+            + "\">>) of {ok, Pid} -> exit(Pid, kill); Pid -> exit(Pid, kill) end.'",
+        nodename);
+  }
+
+  public static Process killStreamLeaderProcess(String stream) throws IOException {
+    return rabbitmqctl(
+        "eval 'case rabbit_stream_manager:lookup_leader(<<\"/\">>, <<\""
+            + stream
+            + "\">>) of {ok, Pid} -> exit(Pid, kill); Pid -> exit(Pid, kill) end.'");
+  }
+
   public static String hostname() {
     try {
       return InetAddress.getLocalHost().getHostName();

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/src/test/java/com/rabbitmq/stream/TestUtils.java
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/src/test/java/com/rabbitmq/stream/TestUtils.java
@@ -44,7 +44,7 @@ public class TestUtils {
   }
 
   static int streamPortNode2() {
-    String port = System.getProperty("node2.stream.port", "5552");
+    String port = System.getProperty("node2.stream.port", "5553");
     return Integer.valueOf(port);
   }
 


### PR DESCRIPTION
This commit change makes sure that different members of the same stream are monitored in a given connection. A connection can use the stream leader for a publisher and a replica for a consumer, if the replica crashes for some reason, the connection must detect it and send a metadata notification to the client.

Note that client connections should still use different connections for publishers and consumers.