### PR TITLE
Do not log HTTP[S] listener options

### DIFF
--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_sup.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_sup.erl
@@ -30,8 +30,6 @@ ensure_listener(Listener) ->
             {Transport, TransportOpts, ProtoOpts} = preprocess_config(Listener),
             ProtoOptsMap = maps:from_list(ProtoOpts),
             StreamHandlers = stream_handlers_config(ProtoOpts),
-            rabbit_log:debug("Starting HTTP[S] listener with transport ~ts, options ~tp and protocol options ~tp, stream handlers ~tp",
-                             [Transport, TransportOpts, ProtoOptsMap, StreamHandlers]),
             CowboyOptsMap =
                 maps:merge(#{env =>
                                 #{rabbit_listener => Listener},

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_sup.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_sup.erl
@@ -30,6 +30,7 @@ ensure_listener(Listener) ->
             {Transport, TransportOpts, ProtoOpts} = preprocess_config(Listener),
             ProtoOptsMap = maps:from_list(ProtoOpts),
             StreamHandlers = stream_handlers_config(ProtoOpts),
+            rabbit_log:debug("Starting HTTP[S] listener with transport ~ts", [Transport]),
             CowboyOptsMap =
                 maps:merge(#{env =>
                                 #{rabbit_listener => Listener},


### PR DESCRIPTION
They are of little use and even though they were logged at `debug` level and only on node boot (that is, you have to explicitly opt-in to use debug logging via `rabbitmq.conf`),
technically this could lead to the [logging of a private key password](https://github.com/rabbitmq/rabbitmq-server/discussions/9569).

So we might as well not log them at all.