### PR TITLE
Core metrics: remove backing_queue_status from the core metrics

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1205,7 +1205,7 @@ emit_stats(State, Extra) ->
      {messages, M},
      {reductions, R},
      {name, Name} | Infos]
-    = [{K, V} || {K, V} <- infos(statistics_keys(), State),
+    = [{K, V} || {K, V} <- infos(statistics_keys() -- [backing_queue_status], State),
                  not lists:member(K, ExtraKs)],
     rabbit_core_metrics:queue_stats(Name, Extra ++ Infos),
     rabbit_core_metrics:queue_stats(Name, MR, MU, M, R).


### PR DESCRIPTION
They will not show in the HTTP API `GET /api/queues`, but are still available whenever the queue info is requested through the rabbit_amqqueue API.   

GET /api/queues is widely used and abused without pagination and often to retrieve just a single metric. This change will considerable reduce the size of the JSON response when querying 10s or 100s of queues, and it should not impact the operation of the system as `backing_queue_status` is an internal metric on which no monitoring tool should rely on.

References https://github.com/rabbitmq/rabbitmq-server/issues/9437

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

