### PR TITLE
Pass the message to `rabbit_backing_queue:discard` callback

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -647,7 +647,7 @@ discard(#delivery{confirm = Confirm,
                true  -> confirm_messages([MsgId], MTC, QName);
                false -> MTC
            end,
-    BQS1 = BQ:discard(MsgId, SenderPid, Flow, BQS),
+    BQS1 = BQ:discard(Msg, SenderPid, Flow, BQS),
     {BQS1, MTC1}.
 
 run_message_queue(State) -> run_message_queue(false, State).
@@ -821,7 +821,7 @@ send_reject_publish(#delivery{confirm = true,
                                              amqqueue:get_name(Q), MsgSeqNo),
 
     MTC1 = maps:remove(MsgId, MTC),
-    BQS1 = BQ:discard(MsgId, SenderPid, Flow, BQS),
+    BQS1 = BQ:discard(Msg, SenderPid, Flow, BQS),
     State#q{ backing_queue_state = BQS1, msg_id_to_channel = MTC1 };
 send_reject_publish(#delivery{confirm = false},
                       _Delivered, State) ->

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -117,7 +117,7 @@
 
 %% Called to inform the BQ about messages which have reached the
 %% queue, but are not going to be further passed to BQ.
--callback discard(rabbit_types:msg_id(), pid(), flow(), state()) -> state().
+-callback discard(rabbit_types:basic_message(), pid(), flow(), state()) -> state().
 
 %% Return ids of messages which have been confirmed since the last
 %% invocation of this function (or initialisation).

--- a/deps/rabbit/src/rabbit_mirror_queue_slave.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_slave.erl
@@ -1016,8 +1016,7 @@ process_instruction({discard, ChPid, Flow, MsgId}, State) ->
     maybe_flow_ack(ChPid, Flow),
     State1 = #state { backing_queue = BQ, backing_queue_state = BQS } =
         publish_or_discard(discarded, ChPid, MsgId, State),
-    BQS1 = BQ:discard(MsgId, ChPid, Flow, BQS),
-    {ok, State1 #state { backing_queue_state = BQS1 }};
+    {ok, State1 #state { backing_queue_state = BQS }};
 process_instruction({drop, Length, Dropped, AckRequired},
                     State = #state { backing_queue       = BQ,
                                      backing_queue_state = BQS }) ->

--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -248,22 +248,12 @@ batch_publish_delivered(Publishes, ChPid, Flow,
                         State = #passthrough{bq = BQ, bqs = BQS}) ->
     ?passthrough2(batch_publish_delivered(Publishes, ChPid, Flow, BQS)).
 
-%% TODO this is a hack. The BQ api does not give us enough information
-%% here - if we had the Msg we could look at its priority and forward
-%% to the appropriate sub-BQ. But we don't so we are stuck.
-%%
-%% But fortunately VQ ignores discard/4, so we can too, *assuming we
-%% are talking to VQ*. discard/4 is used by HA, but that's "above" us
-%% (if in use) so we don't break that either, just some hypothetical
-%% alternate BQ implementation.
-discard(_MsgId, _ChPid, _Flow, State = #state{}) ->
-    State;
-    %% We should have something a bit like this here:
-    %% pick1(fun (_P, BQSN) ->
-    %%               BQ:discard(MsgId, ChPid, Flow, BQSN)
-    %%       end, Msg, State);
-discard(MsgId, ChPid, Flow, State = #passthrough{bq = BQ, bqs = BQS}) ->
-    ?passthrough1(discard(MsgId, ChPid, Flow, BQS)).
+discard(Msg, ChPid, Flow, State = #state{bq = BQ}) ->
+    pick1(fun (_P, BQSN) ->
+                  BQ:discard(Msg, ChPid, Flow, BQSN)
+          end, Msg, State);
+discard(Msg, ChPid, Flow, State = #passthrough{bq = BQ, bqs = BQS}) ->
+    ?passthrough1(discard(Msg, ChPid, Flow, BQS)).
 
 drain_confirmed(State = #state{bq = BQ}) ->
     fold_append2(fun (_P, BQSN) -> BQ:drain_confirmed(BQSN) end, State);

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -588,7 +588,7 @@ batch_publish_delivered(Publishes, ChPid, Flow, State) ->
     State2 = ui(State1),
     {lists:reverse(SeqIds), a(maybe_update_rates(State2))}.
 
-discard(_MsgId, _ChPid, _Flow, State) -> State.
+discard(_Msg, _ChPid, _Flow, State) -> State.
 
 drain_confirmed(State = #vqstate { confirmed = C }) ->
     case sets:is_empty(C) of


### PR DESCRIPTION
## Proposed Changes

This is a re-attempt at PR https://github.com/rabbitmq/rabbitmq-server/pull/7802 which was not rolling-upgrade safe.
I ended up partly following @lhoguin suggestion: the `gm` receives the full message but forwards to the slaves only the `MsgId`.  The slaves do not call the underlying `BQ:discard` function.

Rationale behind this logic is all BQ implementations resolve to `rabbit_variable_queue:discard` which does nothing. Hence, there is no difference from slaves perspective on whether to call or not the `discard` implementation.

Therefore:
 * If the leader is a new one, it will still forward `MsgId` to old nodes which will handle it as such
 * If the leader is an old one, new nodes will still receive `MsgId` and simply do not call `BQ:discard` as un-relevant

Drawback for this implementation is we loose uniformity of implementation. Benefit is a simpler code-base as we do not need to maintain 2 callbacks for `discard`. 

Here I include the previous PR description:

The rabbit_backing_queue:discard callback is passing the message ID to the implementer. This is often not enough to carry on some necessary work as it's seen in the rabbit_priority_queue [comment](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_priority_queue.erl#L252).

In my particular case, this makes it hard to fix the following issue:
https://github.com/noxdafox/rabbitmq-message-deduplication/issues/96

In the above issue a consumer starts consuming with noAck over an empty queue. A publisher publishes a single message which gets forwarded directly to the consumer. In this case, the discard callback is invoked instead of publish_delivered and therefore it's header is not removed from the deduplication cache.

Problem is the discard callback only forwards the message ID and not the whole message not providing enough context for the implementer.

This patch adjust the rabbit_backing_queue behaviour passing the whole message to the discard callback instead of its sole ID.

This implementation has some drawback as, when using mirrored queues, more data will now be exchanged between the master node and the slaves. This will be detrimental to empty HA queue performance.

Yet the following observations should be considered:

 * This only applies when messages are consumed directly without acknowledgment from an empty queue
 * HA/mirrored queues are not the ideal choice when high performance are a need
 * The consumption without acknowledgment is a questionable pattern when combined with HA/mirrored queues
 * HA/mirrored queues do not provide much value compared to normal ones when empty

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Is there a way to run tests concurrently? It takes fairly long on my machine to run the entire `rabbit` test suite. OFC I can pin down to relevant tests but it would be nice to run the entire suite.
