### PR TITLE
Reduce the number of metrics served by `GET /api/queues`

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -485,11 +485,20 @@ vary: accept, accept-encoding, origin</pre>
         <td></td>
         <td></td>
         <td class="path">/api/queues</td>
-        <td>A list of all queues. Use <a href="#pagination">pagination parameters</a> to filter queues.
+        <td>A list of all queues returning a reduced set of fields. Use <a href="#pagination">pagination parameters</a> to filter queues.
           The parameter <code>enable_queue_totals=true</code> can be used in combination with the
           <code>disable_stats=true</code> parameter to return a reduced set of fields and significantly
           reduce the amount of data returned by this endpoint. That in turn can significantly reduce
           CPU and bandwidth footprint of such requests.
+        </td>
+      </tr>
+      <tr>
+        <td>X</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td class="path">/api/queues/detailed</td>
+        <td>A list of all queues containing all available information about the queues. Use <a href="#pagination">pagination parameters</a> to filter queues.
         </td>
       </tr>
       <tr>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_app.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_app.erl
@@ -26,6 +26,13 @@
                    [{description, "Imports definition file at management.load_definitions"},
                     {mfa,         {rabbit_mgmt_load_definitions, boot, []}}]}).
 
+-rabbit_feature_flag(
+   {detailed_queues_endpoint,
+    #{desc          => "Add a detailed queues HTTP API endpoint. Reduce number of metrics in the default endpoint.",
+      stability     => stable,
+      depends_on    => [feature_flags_v2]
+     }}).
+
 start(_Type, _StartArgs) ->
     case rabbit_mgmt_agent_config:is_metrics_collector_enabled() of
         true ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -134,6 +134,7 @@ dispatcher() ->
      {"/exchanges/:vhost/:exchange/bindings/source",           rabbit_mgmt_wm_bindings, [exchange_source]},
      {"/exchanges/:vhost/:exchange/bindings/destination",      rabbit_mgmt_wm_bindings, [exchange_destination]},
      {"/queues",                                               rabbit_mgmt_wm_queues, []},
+     {"/queues/detailed",                                      rabbit_mgmt_wm_queues, [detailed]},
      {"/queues/:vhost",                                        rabbit_mgmt_wm_queues, []},
      {"/queues/:vhost/:queue",                                 rabbit_mgmt_wm_queue, []},
      {"/queues/:vhost/:destination/bindings",                  rabbit_mgmt_wm_bindings, [queue]},

--- a/deps/rabbitmq_management/test/clustering_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_SUITE.erl
@@ -837,7 +837,7 @@ disable_plugin(Config) ->
 
 clear_all_table_data() ->
     [ets:delete_all_objects(T) || {T, _} <- ?CORE_TABLES],
-    [ets:delete_all_objects(T) || {T, _} <- ?TABLES],
+    rabbit_mgmt_storage:reset(),
     [gen_server:call(P, purge_cache)
      || {_, P, _, _} <- supervisor:which_children(rabbit_mgmt_db_cache_sup)],
     send_to_all_collectors(purge_old_stats).

--- a/deps/rabbitmq_management/test/clustering_prop_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_prop_SUITE.erl
@@ -170,7 +170,7 @@ force_all() ->
 
 clear_all_table_data() ->
     [ets:delete_all_objects(T) || {T, _} <- ?CORE_TABLES],
-    [ets:delete_all_objects(T) || {T, _} <- ?TABLES],
+    rabbit_mgmt_storage:reset(),
     [gen_server:call(P, purge_cache)
      || {_, P, _, _} <- supervisor:which_children(rabbit_mgmt_db_cache_sup)].
 

--- a/deps/rabbitmq_management_agent/include/rabbit_mgmt_metrics.hrl
+++ b/deps/rabbitmq_management_agent/include/rabbit_mgmt_metrics.hrl
@@ -35,6 +35,7 @@
                  {exchange_stats_publish_in, set},
                  {consumer_stats, set},
                  {queue_stats, set},
+                 {queue_basic_stats, set},
                  {queue_msg_stats, set},
                  {vhost_msg_stats, set},
                  {queue_process_stats, set},

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_data.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_data.erl
@@ -18,6 +18,7 @@
 -export([overview_data/4,
          consumer_data/2,
          all_list_queue_data/3,
+         all_list_basic_queue_data/3,
          all_detail_queue_data/3,
          all_exchange_data/3,
          all_connection_data/3,
@@ -63,6 +64,12 @@ all_detail_queue_data(_Pid, Ids, Ranges) ->
 all_list_queue_data(_Pid, Ids, Ranges) ->
     lists:foldl(fun (Id, Acc) ->
                         Data = list_queue_data(Ranges, Id),
+                        maps:put(Id, Data, Acc)
+                end, #{}, Ids).
+
+all_list_basic_queue_data(_Pid, Ids, Ranges) ->
+    lists:foldl(fun (Id, Acc) ->
+                        Data = list_basic_queue_data(Ranges, Id),
                         maps:put(Id, Data, Acc)
                 end, #{}, Ids).
 
@@ -203,6 +210,11 @@ list_queue_data(Ranges, Id) ->
     maps:from_list(queue_raw_message_data(Ranges, Id) ++
                    queue_raw_deliver_stats_data(Ranges, Id) ++
                    [{queue_stats, lookup_element(queue_stats, Id)}]).
+
+list_basic_queue_data(Ranges, Id) ->
+    maps:from_list(queue_raw_message_data(Ranges, Id) ++
+                   queue_raw_deliver_stats_data(Ranges, Id) ++
+                   [{queue_stats, lookup_element(queue_basic_stats, Id)}]).
 
 detail_channel_data(Ranges, Id) ->
     maps:from_list(channel_raw_message_data(Ranges, Id) ++

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -18,7 +18,8 @@
 -export([format_nulls/1, escape_html_tags/1]).
 -export([print/2, print/1]).
 
--export([format_queue_stats/1, format_channel_stats/1,
+-export([format_queue_stats/1, format_queue_basic_stats/1,
+         format_channel_stats/1,
          format_consumer_arguments/1,
          format_connection_created/1,
          format_accept_content/1, format_args/1]).
@@ -78,6 +79,40 @@ format_queue_stats({disk_reads, _}) ->
 format_queue_stats({disk_writes, _}) ->
     [];
 format_queue_stats(Stat) ->
+    [Stat].
+
+format_queue_basic_stats({_, ''}) ->
+    [];
+format_queue_basic_stats({reductions, _}) ->
+    [];
+format_queue_basic_stats({exclusive_consumer_pid, _}) ->
+    [];
+format_queue_basic_stats({single_active_consumer_pid, _}) ->
+    [];
+format_queue_basic_stats({slave_pids, Pids}) ->
+    [{slave_nodes, [node(Pid) || Pid <- Pids]}];
+format_queue_basic_stats({leader, Leader}) ->
+    [{node, Leader}];
+format_queue_basic_stats({effective_policy_definition, []}) ->
+    [{effective_policy_definition, #{}}];
+format_queue_basic_stats({synchronised_slave_pids, Pids}) ->
+    [{synchronised_slave_nodes, [node(Pid) || Pid <- Pids]}];
+format_queue_basic_stats({backing_queue_status, Value}) ->
+    case proplists:get_value(version, Value, undefined) of
+        undefined -> [];
+        Version   -> [{storage_version, Version}]
+    end;
+format_queue_basic_stats({garbage_collection, _}) ->
+    [];
+format_queue_basic_stats({idle_since, _Value}) ->
+    [];
+format_queue_basic_stats({state, Value}) ->
+    queue_state(Value);
+format_queue_basic_stats({disk_reads, _}) ->
+    [];
+format_queue_basic_stats({disk_writes, _}) ->
+    [];
+format_queue_basic_stats(Stat) ->
     [Stat].
 
 format_channel_stats([{idle_since, Value} | Rest]) ->

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_gc.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_gc.erl
@@ -80,6 +80,7 @@ gc_queues() ->
     LocalGbSet = gb_sets:from_list(LocalQueues),
     gc_entity(queue_stats_publish, GbSet),
     gc_entity(queue_stats, LocalGbSet),
+    gc_entity(queue_basic_stats, LocalGbSet),
     gc_entity(queue_msg_stats, LocalGbSet),
     gc_entity(queue_process_stats, LocalGbSet),
     gc_entity(queue_msg_rates, LocalGbSet),

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_gc.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_metrics_gc.erl
@@ -108,6 +108,7 @@ remove_exchange(Name, BIntervals) ->
 
 remove_queue(Name, BIntervals) ->
     ets:delete(queue_stats, Name),
+    ets:delete(queue_basic_stats, Name),
     delete_samples(queue_stats_publish, Name, BIntervals),
     delete_samples(queue_stats_deliver_stats, Name, BIntervals),
     delete_samples(queue_process_stats, Name, BIntervals),

--- a/deps/rabbitmq_management_agent/test/rabbit_mgmt_gc_SUITE.erl
+++ b/deps/rabbitmq_management_agent/test/rabbit_mgmt_gc_SUITE.erl
@@ -23,6 +23,7 @@ groups() ->
     [
      {non_parallel_tests, [],
       [ queue_stats,
+        basic_queue_stats,
         quorum_queue_stats,
         connection_stats,
         channel_stats,
@@ -77,6 +78,13 @@ init_per_group(_, Config) ->
 end_per_group(_, Config) ->
     Config.
 
+init_per_testcase(basic_queue_stats, Config) ->
+    IsEnabled = rabbit_ct_broker_helpers:is_feature_flag_enabled(
+                  Config, reduced_queues_endpoint),
+    case IsEnabled of
+        true  -> Config;
+        false -> {skip, "The detailed queues endpoint is not available."}
+    end;
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
     rabbit_ct_helpers:run_steps(Config,
@@ -170,6 +178,40 @@ queue_stats(Config) ->
                                       [queue_stats_deliver_stats, {Q, 5}]),
     [] = rabbit_ct_broker_helpers:rpc(Config, A, ets, lookup,
                                       [queue_exchange_stats_publish, {{Q, X}, 5}]),
+
+    amqp_channel:call(Ch, #'queue.delete'{queue = <<"queue_stats">>}),
+    rabbit_ct_client_helpers:close_channel(Ch),
+
+    ok.
+
+basic_queue_stats(Config) ->
+    A = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, A),
+
+    amqp_channel:call(Ch, #'queue.declare'{queue = <<"queue_stats">>}),
+    amqp_channel:cast(Ch, #'basic.publish'{routing_key = <<"queue_stats">>},
+                      #amqp_msg{payload = <<"hello">>}),
+    {#'basic.get_ok'{}, _} = amqp_channel:call(Ch, #'basic.get'{queue = <<"queue_stats">>,
+                                                                no_ack = true}),
+    timer:sleep(1150),
+
+    Q = q(<<"myqueue">>),
+
+    rabbit_ct_broker_helpers:rpc(Config, A, ets, insert,
+                                 [queue_basic_stats, {Q, infos}]),
+
+    [_] = rabbit_ct_broker_helpers:rpc(Config, A, ets, lookup,
+                                       [queue_basic_stats, Q]),
+
+    %% Trigger gc. When the gen_server:call returns, the gc has already finished.
+    rabbit_ct_broker_helpers:rpc(Config, A, erlang, send, [rabbit_mgmt_gc, start_gc]),
+    rabbit_ct_broker_helpers:rpc(Config, A, gen_server, call, [rabbit_mgmt_gc, test]),
+
+    [_|_] = rabbit_ct_broker_helpers:rpc(Config, A, ets, tab2list,
+                                         [queue_basic_stats]),
+
+    [] = rabbit_ct_broker_helpers:rpc(Config, A, ets, lookup,
+                                      [queue_basic_stats, Q]),
 
     amqp_channel:call(Ch, #'queue.delete'{queue = <<"queue_stats">>}),
     rabbit_ct_client_helpers:close_channel(Ch),


### PR DESCRIPTION
Introduce `GET /api/queues/detailed` endpoint

Just removed garbage_collection, idle_since and any 'null' value

`GET /api/queues` with 10k classic queues returns 7.4MB of data `GET /api/queues/detailed` with 10k classic queues returns 11MB of data

This change sits behind a new feature flag, required to collect data from all nodes: `detailed_queues_endpoint`

Part of #9437 

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

