### PR TITLE
Stream queue: treat discard and return like settle

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -555,9 +555,10 @@ recover(_VHost, Queues) ->
               {[Q | R0], F0}
       end, {[], []}, Queues).
 
-settle(QName, complete, CTag, MsgIds, #stream_client{readers = Readers0,
+settle(QName, _, CTag, MsgIds, #stream_client{readers = Readers0,
                                                      local_pid = LocalPid,
                                                      name = Name} = State) ->
+    %% all settle reasons will "give credit" to the stream queue
     Credit = length(MsgIds),
     {Readers, Msgs} = case Readers0 of
                           #{CTag := #stream{credit = Credit0} = Str0} ->
@@ -567,11 +568,7 @@ settle(QName, complete, CTag, MsgIds, #stream_client{readers = Readers0,
                           _ ->
                               {Readers0, []}
                       end,
-    {State#stream_client{readers = Readers}, [{deliver, CTag, true, Msgs}]};
-settle(_, _, _, _, #stream_client{name = Name}) ->
-    {protocol_error, not_implemented,
-     "basic.nack and basic.reject not supported by stream queues ~ts",
-     [rabbit_misc:rs(Name)]}.
+    {State#stream_client{readers = Readers}, [{deliver, CTag, true, Msgs}]}.
 
 info(Q, all_keys) ->
     info(Q, ?INFO_KEYS);


### PR DESCRIPTION
Currently these are not allowed for use with stream queues which is a bit too strict. Some client impl will automatically nack or reject messages that are pending when an application requests to stop consuming. Treating all message outcomes the same makes as much sense as not to.
