### PR TITLE
CLI: support for pre-hashed passwords

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/doc_guide.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/doc_guide.ex
@@ -54,6 +54,7 @@ defmodule RabbitMQ.CLI.Core.DocGuide do
   Macros.defguide("monitoring")
   Macros.defguide("networking")
   Macros.defguide("parameters")
+  Macros.defguide("passwords")
   Macros.defguide("plugins")
   Macros.defguide("prometheus")
   Macros.defguide("publishers")

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -18,17 +18,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
   def validate(args, _) when length(args) < 1, do: {:validation_failure, :not_enough_args}
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
-  def validate([_], _), do: :ok
+  # Password will be provided via standard input
+  def validate([_username], _), do: :ok
 
   def validate(["", _], _) do
     {:validation_failure, {:bad_argument, "user cannot be an empty string"}}
+  end
+
+  def validate([_, base64_encoded_password_hash], %{pre_hashed_password: true}) do
+    case Base.decode64(base64_encoded_password_hash) do
+      {:ok, _password_hash} ->
+        :ok
+      _ ->
+        {:validation_failure, {:bad_argument, "Could not Base64 decode provided password hash value"}}
+    end
   end
 
   def validate([_, _], _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([username], %{node: node_name} = opts) do
+  def run([username], %{node: node_name, pre_hashed_password: false} = opts) do
     # note: blank passwords are currently allowed, they make sense
     # e.g. when a user only authenticates using X.509 certificates.
     # Credential validators can be used to require passwords of a certain length
@@ -47,13 +57,38 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
     end
   end
 
-  def run([username, password_hash], %{node: node_name, pre_hashed_password: true}) do
-    :rabbit_misc.rpc_call(
-      node_name,
-      :rabbit_auth_backend_internal,
-      :add_user_sans_validation,
-      [username, password, Helpers.cli_acting_user(), :undefined, []]
-    )
+  def run([username], %{node: node_name, pre_hashed_password: true} = opts) do
+    case Input.infer_password("Hashed and salted password: ", opts) do
+      :eof ->
+        {:error, :not_enough_args}
+
+      base64_encoded_password_hash ->
+        case Base.decode64(base64_encoded_password_hash) do
+          {:ok, password_hash} ->
+            :rabbit_misc.rpc_call(
+              node_name,
+              :rabbit_auth_backend_internal,
+              :add_user_with_pre_hashed_password_sans_validation,
+              [username, password_hash, Helpers.cli_acting_user()]
+            )
+          _ ->
+            {:error, ExitCodes.exit_dataerr(), "Could not Base64 decode provided password hash value"}
+        end
+    end
+  end
+
+  def run([username, base64_encoded_password_hash], %{node: node_name, pre_hashed_password: true} = opts) do
+    case Base.decode64(base64_encoded_password_hash) do
+      {:ok, password_hash} ->
+        :rabbit_misc.rpc_call(
+          node_name,
+          :rabbit_auth_backend_internal,
+          :add_user_with_pre_hashed_password_sans_validation,
+          [username, password_hash, Helpers.cli_acting_user()]
+        )
+      _ ->
+        {:error, ExitCodes.exit_dataerr(), "Could not Base64 decode provided password hash value"}
+    end
   end
 
   def run([username, password], %{node: node_name}) do
@@ -102,21 +137,30 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
-  def usage, do: "add_user <username> <password>"
+  def usage, do: "add_user <username> [<password>] [<password_hash> --pre-hashed-password]"
 
   def usage_additional() do
     [
       ["<username>", "Self-explanatory"],
       [
         "<password>",
-        "Password this user will authenticate with. Use a blank string to disable password-based authentication."
+        "Password this user will authenticate with. Use a blank string to disable password-based authentication. Mutually exclusive with <password_hash>"
+      ],
+      [
+        "<password_hash>",
+        "A Base64-encoded password hash produced by the 'hash_password' command or a different method as described in the Passwords guide. Must be used in combination with --pre-hashed-password. Mutually exclusive with <password>"
+      ],
+      [
+        "--pre-hashed-password",
+        "Use to pass in a password hash instead of a clear text password. Disabled by default"
       ]
     ]
   end
 
   def usage_doc_guides() do
     [
-      DocGuide.access_control()
+      DocGuide.access_control(),
+      DocGuide.passwords()
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -29,8 +29,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
     case Base.decode64(base64_encoded_password_hash) do
       {:ok, _password_hash} ->
         :ok
+
       _ ->
-        {:validation_failure, {:bad_argument, "Could not Base64 decode provided password hash value"}}
+        {:validation_failure,
+         {:bad_argument, "Could not Base64 decode provided password hash value"}}
     end
   end
 
@@ -71,13 +73,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
               :add_user_with_pre_hashed_password_sans_validation,
               [username, password_hash, Helpers.cli_acting_user()]
             )
+
           _ ->
-            {:error, ExitCodes.exit_dataerr(), "Could not Base64 decode provided password hash value"}
+            {:error, ExitCodes.exit_dataerr(),
+             "Could not Base64 decode provided password hash value"}
         end
     end
   end
 
-  def run([username, base64_encoded_password_hash], %{node: node_name, pre_hashed_password: true} = opts) do
+  def run(
+        [username, base64_encoded_password_hash],
+        %{node: node_name, pre_hashed_password: true} = opts
+      ) do
     case Base.decode64(base64_encoded_password_hash) do
       {:ok, password_hash} ->
         :rabbit_misc.rpc_call(
@@ -86,6 +93,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
           :add_user_with_pre_hashed_password_sans_validation,
           [username, password_hash, Helpers.cli_acting_user()]
         )
+
       _ ->
         {:error, ExitCodes.exit_dataerr(), "Could not Base64 decode provided password hash value"}
     end

--- a/deps/rabbitmq_cli/test/ctl/add_user_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_user_command_test.exs
@@ -9,6 +9,8 @@ defmodule AddUserCommandTest do
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.AddUserCommand
+  @hash_password_command RabbitMQ.CLI.Ctl.Commands.HashPasswordCommand
+  @authenticate_user_command RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -18,7 +20,7 @@ defmodule AddUserCommandTest do
 
   setup context do
     on_exit(context, fn -> delete_user(context[:user]) end)
-    {:ok, opts: %{node: get_rabbit_hostname()}}
+    {:ok, opts: %{node: get_rabbit_hostname(), pre_hashed_password: false}}
   end
 
   test "validate: no positional arguments fails" do
@@ -55,6 +57,17 @@ defmodule AddUserCommandTest do
     assert @command.validate([context[:user], context[:password]], context[:opts]) == :ok
   end
 
+  @tag user: "someone"
+  test "validate: pre-hashed with a non-Base64-encoded value returns an error", context do
+    hashed = "this is not a Base64-encoded value"
+    opts = Map.merge(context[:opts], %{pre_hashed_password: true})
+
+    assert match?(
+         {:validation_failure, {:bad_argument, _}},
+         @command.validate([context[:user], hashed], opts)
+       )
+  end
+
   @tag user: "someone", password: "password"
   test "run: request to a non-existent node returns a badrpc", context do
     opts = %{node: :jake@thedog, timeout: 200}
@@ -62,9 +75,30 @@ defmodule AddUserCommandTest do
   end
 
   @tag user: "someone", password: "password"
-  test "run: default case completes successfully", context do
+  test "run: happy path completes successfully", context do
     assert @command.run([context[:user], context[:password]], context[:opts]) == :ok
     assert list_users() |> Enum.count(fn record -> record[:user] == context[:user] end) == 1
+
+    assert @authenticate_user_command.run([context[:user], context[:password]], context[:opts])
+  end
+
+  @tag user: "someone"
+  test "run: a pre-hashed request to a non-existent node returns a badrpc", context do
+    opts = %{node: :jake@thedog, timeout: 200}
+    hashed = "BMT6cj/MsI+4UOBtsPPQWpQfk7ViRLj4VqpMTxu54FU3qa1G"
+    assert match?({:badrpc, _}, @command.run([context[:user], hashed], opts))
+  end
+
+  @tag user: "someone"
+  test "run: pre-hashed happy path completes successfully", context do
+    pwd = "guest10"
+    hashed = @hash_password_command.hash_password(pwd)
+    opts = Map.merge(%{pre_hashed_password: true}, context[:opts])
+
+    assert @command.run([context[:user], hashed], opts) == :ok
+    assert list_users() |> Enum.count(fn record -> record[:user] == context[:user] end) == 1
+
+    assert @authenticate_user_command.run([context[:user], pwd], opts)
   end
 
   @tag user: "someone", password: "password"

--- a/deps/rabbitmq_cli/test/ctl/add_user_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/add_user_command_test.exs
@@ -63,9 +63,9 @@ defmodule AddUserCommandTest do
     opts = Map.merge(context[:opts], %{pre_hashed_password: true})
 
     assert match?(
-         {:validation_failure, {:bad_argument, _}},
-         @command.validate([context[:user], hashed], opts)
-       )
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate([context[:user], hashed], opts)
+           )
   end
 
   @tag user: "someone", password: "password"


### PR DESCRIPTION
Providing a pre-hashed and salted password is
not significantly more secure but satisfies those
who cannot pass clear text passwords on the command
line for regulatory reasons.

Note that the optimal way of seeding users is still
definition import on node boot, not scripting with
CLI tools.

Closes #9166