### PR TITLE
Fix list_stream_consumer_groups validation

### DIFF
--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumerGroupsCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumerGroupsCommand.erl
@@ -54,7 +54,7 @@ help_section() ->
     {plugin, stream}.
 
 validate(Args, _) ->
-    ValidKeys = lists:map(fun atom_to_list/1, ?CONSUMER_INFO_ITEMS),
+    ValidKeys = lists:map(fun atom_to_list/1, ?CONSUMER_GROUP_INFO_ITEMS),
     case 'Elixir.RabbitMQ.CLI.Ctl.InfoKeys':validate_info_keys(Args,
                                                                ValidKeys)
     of

--- a/deps/rabbitmq_stream/test/commands_SUITE.erl
+++ b/deps/rabbitmq_stream/test/commands_SUITE.erl
@@ -52,7 +52,8 @@ groups() ->
      {list_publishers, [],
       [list_publishers_merge_defaults, list_publishers_run]},
      {list_consumer_groups, [],
-      [list_consumer_groups_merge_defaults, list_consumer_groups_run]},
+      [list_consumer_groups_validate, list_consumer_groups_merge_defaults,
+       list_consumer_groups_run]},
      {list_group_consumers, [],
       [list_group_consumers_validate, list_group_consumers_merge_defaults,
        list_group_consumers_run]},
@@ -337,6 +338,18 @@ list_publishers_run(Config) ->
     close(S2, C2_2),
     ?awaitMatch(0, publisher_count(Config), ?WAIT),
     ok.
+
+list_consumer_groups_validate(_) ->
+    ValidOpts = #{vhost => <<"/">>},
+    ?assertMatch({validation_failure, {bad_info_key, [foo]}},
+                 ?COMMAND_LIST_CONSUMER_GROUPS:validate([<<"foo">>],
+                                                        ValidOpts)),
+    ?assertMatch(ok,
+                 ?COMMAND_LIST_CONSUMER_GROUPS:validate([<<"reference">>],
+                                                        ValidOpts)),
+    ?assertMatch(ok,
+                 ?COMMAND_LIST_CONSUMER_GROUPS:validate([], ValidOpts)).
+
 
 list_consumer_groups_merge_defaults(_Config) ->
     DefaultItems =


### PR DESCRIPTION
It had been broken in a refactoring to squash dialyzer warnings.