### PR TITLE
Osiris v1.6.8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,7 +43,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rabbitmq_osiris",
-    version = "1.6.7",
+    version = "1.6.8",
     repo_name = "osiris",
 )
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.6.7
+dep_osiris = git https://github.com/rabbitmq/osiris v1.6.8
 dep_systemd = hex 0.6.1
 
 dep_seshat = git https://github.com/rabbitmq/seshat v0.6.1

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -251,6 +251,8 @@ consume(Q, Spec,
               args := Args,
               ok_msg := OkMsg} = Spec,
             QName = amqqueue:get_name(Q),
+            rabbit_log:debug("~s:~s Local pid resolved ~0p",
+                             [?MODULE, ?FUNCTION_NAME, LocalPid]),
             case parse_offset_arg(
                    rabbit_misc:table_lookup(Args, <<"x-stream-offset">>)) of
                 {error, _} = Err ->


### PR DESCRIPTION
This osiris release contains optimisations and bug fixes:

* Various index scanning operations have been substantially improved resulting in up to 10x improvement for certain cases.
* A bug which meant stream replication listener would fail if the TLS version was limited to `tlsv1.3` has been fixed.
* A bug where the log may be incorrectly truncated when filters are used has been fixed. (only relevant for RabbitMQ 3.13 and above).
* Startup handles one more case where a file has been corrupted after an unclean shutdown.
