### PR TITLE
rabbit_feature_flags: Write one feature name per line in `feature_flags`

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1129,7 +1129,7 @@ do_write_enabled_feature_flags_list(EnabledFeatureNames) ->
     EnabledFeatureNames1 = lists:sort(EnabledFeatureNames),
 
     File = enabled_feature_flags_list_file(),
-    Content = io_lib:format("~tp.~n", [EnabledFeatureNames1]),
+    Content = io_lib:format("~1tp.~n", [EnabledFeatureNames1]),
     %% TODO: If we fail to write the the file, we should spawn a process
     %% to retry the operation.
     case file:write_file(File, Content) of


### PR DESCRIPTION
## Why

The `feature_flags` file is used to record the states of feature flags. The content is a formatted sorted Erlang list.

This works just fine, but reading it for a human (a developer) is more difficult than if we had a single feature name per line. It is also more difficult to use diff(1) on the file.

This patch ensures that the Erlang list is formatted with an item per text line.

## How

The format string enforces an line width of 1 column. The terms are not truncated obviously, but the lines are wrapped immediately after an item.