### PR TITLE
rabbit_db: Copy feature states early when joining a cluster

### DIFF
--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -173,6 +173,17 @@ force_load_on_next_boot_using_mnesia() ->
 
 post_reset() ->
     rabbit_feature_flags:reset_registry(),
+
+    %% The cluster status files that RabbitMQ uses when Mnesia is the database
+    %% are initially created from rabbit_prelaunch_cluster. However, it will
+    %% only be done once the `rabbit` app is restarted. Meanwhile, they are
+    %% missing and the CLI or the testsuite may rely on them. Indeed, after
+    %% the reset, Mnesia is assumed to be the database and the cluster status
+    %% files should have been created the first time the application was
+    %% started already.
+    ThisNode = node(),
+    rabbit_node_monitor:write_cluster_status({[ThisNode], [ThisNode], []}),
+
     ok.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -172,7 +172,7 @@ force_load_on_next_boot_using_mnesia() ->
     rabbit_mnesia:force_load_next_boot().
 
 post_reset() ->
-    rabbit_feature_flags:reset_registry(),
+    rabbit_feature_flags:reset(),
 
     %% The cluster status files that RabbitMQ uses when Mnesia is the database
     %% are initially created from rabbit_prelaunch_cluster. However, it will

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -73,6 +73,10 @@ can_join(RemoteNode) ->
     end.
 
 can_join_using_mnesia(RemoteNode) ->
+    case rabbit_khepri:is_enabled() of
+        true  -> rabbit_node_monitor:prepare_cluster_status_files();
+        false -> ok
+    end,
     rabbit_mnesia:can_join_cluster(RemoteNode).
 
 can_join_using_khepri(RemoteNode) ->
@@ -86,6 +90,8 @@ can_join_using_khepri(RemoteNode) ->
       Error :: {error, {inconsistent_cluster, string()}}.
 %% @doc Adds this node to a cluster using `RemoteNode' to reach it.
 
+join(ThisNode, _NodeType) when ThisNode =:= node() ->
+    {error, cannot_cluster_node_with_itself};
 join(RemoteNode, NodeType)
   when is_atom(RemoteNode) andalso ?IS_NODE_TYPE(NodeType) ->
     case can_join(RemoteNode) of

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -122,6 +122,7 @@
          read_enabled_feature_flags_list/0,
          copy_feature_states_after_reset/1,
          uses_callbacks/1,
+         reset/0,
          reset_registry/0]).
 
 -ifdef(TEST).
@@ -1334,6 +1335,14 @@ sync_feature_flags_with_cluster(Nodes, _NodeIsVirgin) ->
 refresh_feature_flags_after_app_load() ->
     rabbit_ff_controller:refresh_after_app_load().
 
+-spec reset() -> ok.
+%% @doc Resets the feature flags registry and recorded states on disk.
+
+reset() ->
+    ok = reset_registry(),
+    ok = delete_enabled_feature_flags_list_file(),
+    ok.
+
 -spec reset_registry() -> ok.
 %% @doc Resets the feature flags registry.
 %%
@@ -1341,6 +1350,4 @@ refresh_feature_flags_after_app_load() ->
 %% reading the recorded state from disc.
 
 reset_registry() ->
-    ok = rabbit_ff_registry_factory:reset_registry(),
-    ok = delete_enabled_feature_flags_list_file(),
-    ok.
+    rabbit_ff_registry_factory:reset_registry().

--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1144,6 +1144,18 @@ do_write_enabled_feature_flags_list(EnabledFeatureNames) ->
             Error
     end.
 
+-spec delete_enabled_feature_flags_list_file() -> Ret when
+      Ret :: ok | {error, file:posix() | badarg}.
+%% @private
+
+delete_enabled_feature_flags_list_file() ->
+    File = enabled_feature_flags_list_file(),
+    case file:delete(File) of
+        ok              -> ok;
+        {error, enoent} -> ok;
+        Error           -> Error
+    end.
+
 -spec enabled_feature_flags_list_file() -> file:filename().
 %% @doc
 %% Returns the path to the file where the state of feature flags is stored.
@@ -1329,4 +1341,6 @@ refresh_feature_flags_after_app_load() ->
 %% reading the recorded state from disc.
 
 reset_registry() ->
-    rabbit_ff_registry_factory:reset_registry().
+    ok = rabbit_ff_registry_factory:reset_registry(),
+    ok = delete_enabled_feature_flags_list_file(),
+    ok.

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1352,6 +1352,22 @@ khepri_db_migration_post_enable(
        [FeatureName],
        #{domain => ?RMQLOG_DOMAIN_DB}),
     _ = mnesia_to_khepri:cleanup_after_table_copy(?STORE_ID, ?MIGRATION_ID),
+
+    rabbit_mnesia:stop_mnesia(),
+
+    %% We delete all Mnesia-related files in the data directory. This is in
+    %% case this node joins a Mnesia-based cluster: it will be reset and switch
+    %% back from Khepri to Mnesia. If there were Mnesia files left, Mnesia
+    %% would restart with stale/incorrect data.
+    MsgStoreDir = filename:dirname(rabbit_vhost:msg_store_dir_base()),
+    DataDir = rabbit:data_dir(),
+    MnesiaAndMsgStoreFiles = rabbit_mnesia:mnesia_and_msg_store_files(),
+    MnesiaFiles0 = MnesiaAndMsgStoreFiles -- [filename:basename(MsgStoreDir)],
+    MnesiaFiles = [filename:join(DataDir, File) || File <- MnesiaFiles0],
+    NodeMonitorFiles = [rabbit_node_monitor:cluster_status_filename(),
+                        rabbit_node_monitor:running_nodes_filename()],
+    _ = rabbit_file:recursive_delete(MnesiaFiles ++ NodeMonitorFiles),
+
     ok;
 khepri_db_migration_post_enable(
   #{feature_name := FeatureName, enabled := false}) ->

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1347,7 +1347,7 @@ khepri_db_migration_enable(#{feature_name := FeatureName}) ->
 
 khepri_db_migration_post_enable(
   #{feature_name := FeatureName, enabled := true}) ->
-    ?LOG_ERROR(
+    ?LOG_DEBUG(
        "Feature flag `~s`: cleaning up after finished migration",
        [FeatureName],
        #{domain => ?RMQLOG_DOMAIN_DB}),
@@ -1355,8 +1355,8 @@ khepri_db_migration_post_enable(
     ok;
 khepri_db_migration_post_enable(
   #{feature_name := FeatureName, enabled := false}) ->
-    ?LOG_ERROR(
-       "Feature flag `~s`: cleaning up after finished migration",
+    ?LOG_DEBUG(
+       "Feature flag `~s`: cleaning up after aborted migration",
        [FeatureName],
        #{domain => ?RMQLOG_DOMAIN_DB}),
     _ = mnesia_to_khepri:rollback_table_copy(?STORE_ID, ?MIGRATION_ID),

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -77,6 +77,9 @@
 %% Used internally in `rabbit_db_cluster'.
 -export([members/0]).
 
+%% Used internally in `rabbit_khepri'.
+-export([mnesia_and_msg_store_files/0]).
+
 -export([check_reset_gracefully/0]).
 
 -deprecated({on_running_node, 1,
@@ -1062,11 +1065,14 @@ with_running_or_clean_mnesia(Fun) ->
 %% exception of certain files and directories, which can be there very early
 %% on node boot.
 is_virgin_node() ->
+    mnesia_and_msg_store_files() =:= [].
+
+mnesia_and_msg_store_files() ->
     case rabbit_file:list_dir(dir()) of
         {error, enoent} ->
-            true;
+            [];
         {ok, []} ->
-            true;
+            [];
         {ok, List0} ->
             IgnoredFiles0 =
             [rabbit_node_monitor:cluster_status_filename(),
@@ -1082,7 +1088,7 @@ is_virgin_node() ->
                             [string:join(lists:usort(List0), ", "), string:join(lists:usort(IgnoredFiles), ", ")]),
             List = List0 -- IgnoredFiles,
             rabbit_log:debug("Files and directories found in node's data directory sans ignored ones: ~ts", [string:join(lists:usort(List), ", ")]),
-            List =:= []
+            List
     end.
 
 is_only_clustered_disc_node() ->

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -19,7 +19,7 @@
 -export([update_metadata/3]).
 -export([lookup/1, default_name/0]).
 -export([info/1, info/2, info_all/0, info_all/1, info_all/2, info_all/3]).
--export([dir/1, msg_store_dir_path/1, msg_store_dir_wildcard/0, config_file_path/1, ensure_config_file/1]).
+-export([dir/1, msg_store_dir_path/1, msg_store_dir_wildcard/0, msg_store_dir_base/0, config_file_path/1, ensure_config_file/1]).
 -export([delete_storage/1]).
 -export([vhost_down/1]).
 -export([put_vhost/5,

--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -606,12 +606,6 @@ forget_unavailable_node_in_minority(Config) ->
     %% Stop other two nodes
     ok = rabbit_ct_broker_helpers:stop_node(Config, Rabbit),
     ok = rabbit_ct_broker_helpers:stop_node(Config, Bunny),
-    %% Wait until Mnesia has detected both nodes down
-    ?awaitMatch(
-       [Hare],
-       rabbit_ct_broker_helpers:rpc(Config, Hare,
-                                    rabbit_mnesia, cluster_nodes, [running]),
-       30000),
 
     %% If Hare was the leader, it is able to forget one of the nodes. Change takes place as soon as it is written on the log. The other membership change will be rejected until the last change has consensus.
     ct:pal("Initial Raft status: ~p", [RaftStatus]),

--- a/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
+++ b/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
@@ -358,14 +358,26 @@ join_when_ram_node_type_is_not_permitted_from_conf_khepri(Config) ->
     ?assertEqual([NodeB], get_disc_nodes(Config, NodeB)).
 
 get_all_nodes(Config, Node) ->
-    lists:sort(
-      rabbit_ct_broker_helpers:rpc(
-        Config, Node, rabbit_mnesia, cluster_nodes, [all])).
+    Nodes = case rabbit_khepri:is_enabled(Node) of
+                true ->
+                    rabbit_ct_broker_helpers:rpc(
+                      Config, Node, rabbit_khepri, locally_known_nodes, []);
+                false ->
+                    rabbit_ct_broker_helpers:rpc(
+                      Config, Node, rabbit_mnesia, cluster_nodes, [all])
+            end,
+    lists:sort(Nodes).
 
 get_disc_nodes(Config, Node) ->
-    lists:sort(
-      rabbit_ct_broker_helpers:rpc(
-        Config, Node, rabbit_mnesia, cluster_nodes, [disc])).
+    Nodes = case rabbit_khepri:is_enabled(Node) of
+                true ->
+                    rabbit_ct_broker_helpers:rpc(
+                      Config, Node, rabbit_khepri, locally_known_nodes, []);
+                false ->
+                    rabbit_ct_broker_helpers:rpc(
+                      Config, Node, rabbit_mnesia, cluster_nodes, [disc])
+            end,
+    lists:sort(Nodes).
 
 %% -------------------------------------------------------------------
 %% Classic queue mirroring.

--- a/deps/rabbitmq_cli/test/ctl/join_cluster_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/join_cluster_command_test.exs
@@ -67,14 +67,6 @@ defmodule JoinClusterCommandTest do
     start_rabbitmq_app()
   end
 
-  # TODO
-  test "run: request to an active node fails", context do
-    assert match?(
-             {:error, :mnesia_unexpectedly_running},
-             @command.run([context[:opts][:node]], context[:opts])
-           )
-  end
-
   test "run: request to a non-existent node returns a badrpc", context do
     opts = %{
       node: :jake@thedog,


### PR DESCRIPTION
## Why

So far, the feature states were copied from the cluster after the actual join. However, the join may have reloaded the feature flags registry, using the previous on-disk record, defeating the purpose of copying the cluster's states.

This was done in this order to have a simpler error handling.

## How
This time, we copy the remote cluster's feature states just after the reset.

If the join fails, we reset the feature flags again, including the on-disk states.