### PR TITLE
Properly list Web-MQTT connections in CLI list_mqtt_connections

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
@@ -69,7 +69,13 @@ emit_connection_info(Items, Ref, AggregatorPid, Pids) ->
     rabbit_control_misc:emitting_map_with_exit_handler(
       AggregatorPid, Ref,
       fun(Pid) ->
-              rabbit_mqtt_reader:info(Pid, Items)
+              case rabbit_mqtt_reader:info(Pid, Items) of
+                  {error, not_found} ->
+                      %% a Web-MQTT connection
+                      rabbit_web_mqtt_handler:info(Pid, Items);
+                  Result ->
+                      Result
+              end
       end, Pids).
 
 -spec close_local_client_connections(atom()) -> {'ok', non_neg_integer()}.


### PR DESCRIPTION
## Proposed Changes

Before this change only `:not_found` was printed for each Web-MQTT connection.

See https://github.com/rabbitmq/rabbitmq-server/discussions/9302 for details

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
