### PR TITLE
Osiris v1.6.9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,7 +43,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rabbitmq_osiris",
-    version = "1.6.8",
+    version = "1.6.9",
     repo_name = "osiris",
 )
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -148,7 +148,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.6.8
+dep_osiris = git https://github.com/rabbitmq/osiris v1.6.9
 dep_systemd = hex 0.6.1
 
 dep_seshat = git https://github.com/rabbitmq/seshat v0.6.1


### PR DESCRIPTION
This contains a fix for a situation where a replica may not discover the current commit offset until the next entry is written to the stream.

Should help with a frequent flake in rabbit_stream_queue_SUITE:add_replicas
