### PR TITLE
Add WORKSPACE.bzlmod

### DIFF
--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -124,6 +124,12 @@ jobs:
 
         echo "WORKSPACE updated"
 
+        echo "$(cat WORKSPACE.bzlmod | buildozer 'set downloaded_file_path "OTP-${{ steps.fetch-version.outputs.VERSION }}.tar.gz"' -:otp_src_${{ matrix.name }})" > WORKSPACE.bzlmod
+        echo "$(cat WORKSPACE.bzlmod | buildozer 'set urls ["https://github.com/erlang/otp/archive/OTP-${{ steps.fetch-version.outputs.VERSION }}.tar.gz"]' -:otp_src_${{ matrix.name }})" > WORKSPACE.bzlmod
+        echo "$(cat WORKSPACE.bzlmod | buildozer 'set sha256 "${{ steps.fetch-version.outputs.SHA2 }}"' -:otp_src_${{ matrix.name }})" > WORKSPACE.bzlmod
+
+        echo "WORKSPACE.bzlmod updated"
+
         set -x
         git diff
     - name: CREATE PULL REQUEST

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,92 @@
+workspace(name = "rabbitmq-server")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
+
+container_pull(
+    name = "ubuntu2004",
+    registry = "index.docker.io",
+    repository = "pivotalrabbitmq/ubuntu",
+    tag = "20.04",
+)
+
+http_file(
+    name = "openssl-3.1.1",
+    downloaded_file_path = "openssl-3.1.1.tar.gz",
+    sha256 = "b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674",
+    urls = ["https://github.com/openssl/openssl/releases/download/openssl-3.1.1/openssl-3.1.1.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_24",
+    downloaded_file_path = "OTP-24.3.4.6.tar.gz",
+    sha256 = "dc3d2c54eeb093e0dc9a0fe493bc69d6dfac0affbe77c9e3c935aa86c0f63cd5",
+    urls = ["https://github.com/erlang/otp/archive/OTP-24.3.4.6.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_25_0",
+    downloaded_file_path = "OTP-25.0.4.tar.gz",
+    sha256 = "05878cb51a64b33c86836b12a21903075c300409b609ad5e941ddb0feb8c2120",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.0.4.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_25_1",
+    downloaded_file_path = "OTP-25.1.2.1.tar.gz",
+    sha256 = "79f8e31bb9ff7d43a920f207ef104d1106b2332fdbadf11241d714eacb6d8d1a",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.1.2.1.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_25_2",
+    downloaded_file_path = "OTP-25.2.3.tar.gz",
+    sha256 = "637bc5cf68dd229fd3c3fe889a6f84dd32c4a827488550a0a98123b00c2d78b5",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.2.3.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_25_3",
+    downloaded_file_path = "OTP-25.3.2.7.tar.gz",
+    sha256 = "e8023bc61a7613a9beb0b60db166ae5eeb97de928924d1d1031e4aae8fb1e669",
+    urls = ["https://github.com/erlang/otp/archive/OTP-25.3.2.7.tar.gz"],
+)
+
+http_file(
+    name = "otp_src_26_1",
+    downloaded_file_path = "OTP-26.1.2.tar.gz",
+    sha256 = "56042d53b30863d4e720ebf463d777f0502f8c986957fc3a9e63dae870bbafe0",
+    urls = ["https://github.com/erlang/otp/archive/OTP-26.1.2.tar.gz"],
+)
+
+new_git_repository(
+    name = "bats",
+    build_file = "@//:BUILD.bats",
+    remote = "https://github.com/sstephenson/bats",
+    tag = "v0.4.0",
+)
+
+load("//deps/amqp10_client:activemq.bzl", "activemq_archive")
+
+activemq_archive()


### PR DESCRIPTION
This file shadows the WORKSPACE file when bzlmod is used, and reduces the fetching of unused dependencies