### PR TITLE
Add missing dep for //deps/rabbitmq_aws:eunit

### DIFF
--- a/deps/rabbitmq_aws/BUILD.bazel
+++ b/deps/rabbitmq_aws/BUILD.bazel
@@ -58,6 +58,7 @@ eunit(
     ],
     runtime_deps = [
         "//deps/rabbit_common:erlang_app",
+        "@jsx//:erlang_app",
         "@meck//:erlang_app",
     ],
 )


### PR DESCRIPTION
It may have been that the rules_erlang upgrade no longer automatically includes this dep on the code path