### PR TITLE
rabbit_deprecated_features: Improve reliability of the `classic_queue_mirroring` callback

### DIFF
--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -962,8 +962,16 @@ are_cmqs_used(_) ->
             RuntimeParamsReady = lists:member(
                                    rabbit_runtime_parameters, AllTables),
             case RuntimeParamsReady of
-                true  -> are_cmqs_used1();
-                false -> false
+                true ->
+                    %% We also wait for the table because it could exist but
+                    %% may be unavailable. For instance, Mnesia needs another
+                    %% replica on another node before it considers it to be
+                    %% available.
+                    rabbit_table:wait(
+                      [rabbit_runtime_parameters], _Retry = true),
+                    are_cmqs_used1();
+                false ->
+                    false
             end
     end.
 

--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -951,7 +951,7 @@ are_cmqs_permitted() ->
 are_cmqs_used(_) ->
     case rabbit_khepri:get_feature_state() of
         enabled ->
-            are_cmqs_used1();
+            false;
         _ ->
             %% If we are using Mnesia, we want to check manually if the table
             %% exists first. Otherwise it can conflict with the way


### PR DESCRIPTION
## Why

The callback wants to query the `rabbit_runtime_parameters` Mnesia table to see if there HA policies configured. However this table may exist but may be unavailable. This is the case in a cluster if the node running the callback has to wait for another cluster member before Mnesia tables can be queried or updated.

## How

Once we verified the `rabbit_runtime_parameters` Mnesia table exists, we wait for its availability before we query it. `rabbit_table:wait/2` will throw an exception if the wait times out.

In particular this avoids an infinite loop in   `mnesia_to_khepri:handle_fallback()` because it relies on the availability of the table too to determine if the table is being migrated or not.