### PR TITLE
Reduce memory with many SSL connections

### DIFF
--- a/deps/rabbit_common/src/rabbit_ssl_options.erl
+++ b/deps/rabbit_common/src/rabbit_ssl_options.erl
@@ -18,7 +18,9 @@
 -spec fix(rabbit_types:infos()) -> rabbit_types:infos().
 
 fix(Config) ->
-    fix_verify_fun(fix_ssl_protocol_versions(Config)).
+    fix_verify_fun(
+      fix_ssl_protocol_versions(
+        hibernate_after(Config))).
 
 fix_verify_fun(SslOptsConfig) ->
     %% Starting with ssl 4.0.1 in Erlang R14B, the verify_fun function
@@ -83,4 +85,13 @@ fix_ssl_protocol_versions(Config) ->
                              Vs        -> Vs
                          end,
             rabbit_misc:pset(versions, Configured -- ?BAD_SSL_PROTOCOL_VERSIONS, Config)
+    end.
+
+hibernate_after(Config) ->
+    Key = hibernate_after,
+    case proplists:is_defined(Key, Config) of
+        true ->
+            Config;
+        false ->
+            [{Key, 6_000} | Config]
     end.


### PR DESCRIPTION
By default, hibernate the SSL connection after 6 seconds, reducing its memory footprint. This reduces memory usage of RabbitMQ by multiple GBs with thousands of idle SSL connections.

This commit chooses a default value of 6 seconds because that hibernate_after value is currently hard coded for rabbit_writer.
rabbit_mqtt_reader uses 1 second, rabbit_channel uses 1 - 10 seconds.

This value can be overriden by advanced.config, similar to:
```
[{rabbit, [
    {ssl_options, [
        {hibernate_after, 30000},
        {keyfile, "/etc/.../server_key.pem"},
        {certfile, "/etc/.../server_certificate.pem"},
        {cacertfile, "/etc/.../ca_certificate.pem"},
        {verify,verify_none}
    ]}
]}].
```

See https://www.erlang.org/doc/man/ssl.html#type-hibernate_after
```
When an integer-value is specified, TLS/DTLS-connection goes into
hibernation after the specified number of milliseconds of inactivity,
thus reducing its memory footprint. When undefined is specified
(this is the default), the process never goes into hibernation.
```

Relates
https://github.com/rabbitmq/rabbitmq-server/discussions/5346
https://groups.google.com/g/rabbitmq-users/c/be8qtkkpg5s/m/dHUa-Lh2DwAJ

Thanks to @mkuratczyk for suggesting that setting! 