### PR TITLE
AMQP 1.0 client connection: implement format_status/1

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -48,7 +48,7 @@
          opened/3,
          close_sent/3]).
 
--export([format_status/1, obfuscate_state_config_sasl/1, obfuscate_state_config_tls_opts/1, obfuscate_state/1]).
+-export([format_status/1]).
 
 -type amqp10_socket() :: {tcp, gen_tcp:socket()} | {ssl, ssl:sslsocket()}.
 


### PR DESCRIPTION
Note that this callback is used/respect by some tools (via 'sys:get_status/1') but that won't be enough in all cases (namely a process crash logger **in practice** would still log the original state as it is, contrary to the documentation, based on my testing).
