### PR TITLE
AMQP 1.0 Erlang client: integrate credentials_obfuscation

### DIFF
--- a/deps/amqp10_client/BUILD.bazel
+++ b/deps/amqp10_client/BUILD.bazel
@@ -74,7 +74,10 @@ rabbitmq_app(
     ],
     license_files = [":license_files"],
     priv = [":priv"],
-    deps = ["//deps/amqp10_common:erlang_app"],
+    deps = [
+        "//deps/amqp10_common:erlang_app",
+        "@credentials_obfuscation//:erlang_app",
+    ],
 )
 
 xref(

--- a/deps/amqp10_client/Makefile
+++ b/deps/amqp10_client/Makefile
@@ -29,7 +29,7 @@ endef
 PACKAGES_DIR ?= $(abspath PACKAGES)
 
 BUILD_DEPS = rabbit_common elvis_mk
-DEPS = amqp10_common
+DEPS = amqp10_common credentials_obfuscation
 TEST_DEPS = rabbit rabbitmq_amqp1_0 rabbitmq_ct_helpers
 LOCAL_DEPS = ssl inets crypto public_key
 

--- a/deps/amqp10_client/src/amqp10_client.erl
+++ b/deps/amqp10_client/src/amqp10_client.erl
@@ -87,6 +87,7 @@
 -spec open_connection(inet:socket_address() | inet:hostname(),
                       inet:port_number()) -> supervisor:startchild_ret().
 open_connection(Addr, Port) ->
+    _ = ensure_started(),
     open_connection(#{address => Addr, port => Port, notify => self(),
                       sasl => anon}).
 
@@ -97,14 +98,19 @@ open_connection(Addr, Port) ->
 -spec open_connection(connection_config()) ->
     supervisor:startchild_ret().
 open_connection(ConnectionConfig0) ->
+    _ = ensure_started(),
+
     Notify = maps:get(notify, ConnectionConfig0, self()),
     NotifyWhenOpened = maps:get(notify_when_opened, ConnectionConfig0, self()),
     NotifyWhenClosed = maps:get(notify_when_closed, ConnectionConfig0, self()),
-    amqp10_client_connection:open(ConnectionConfig0#{
+    ConnectionConfig1 = ConnectionConfig0#{
         notify => Notify,
         notify_when_opened => NotifyWhenOpened,
         notify_when_closed => NotifyWhenClosed
-    }).
+    },
+    Sasl = maps:get(sasl, ConnectionConfig1),
+    ConnectionConfig2 = ConnectionConfig1#{sasl => amqp10_client_connection:encrypt_sasl(Sasl)},
+    amqp10_client_connection:open(ConnectionConfig2).
 
 %% @doc Opens a connection using a connection_config map
 %% This is asynchronous and will notify completion to the caller using
@@ -497,6 +503,8 @@ try_to_existing_atom(L) when is_list(L) ->
             throw({non_existent_atom, L})
     end.
 
+ensure_started() ->
+    _ = application:ensure_all_started([credentials_obfuscation]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/deps/amqp10_client/src/amqp10_client.erl
+++ b/deps/amqp10_client/src/amqp10_client.erl
@@ -504,7 +504,7 @@ try_to_existing_atom(L) when is_list(L) ->
     end.
 
 ensure_started() ->
-    _ = application:ensure_all_started([credentials_obfuscation]).
+    _ = application:ensure_all_started(credentials_obfuscation).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
`gen_statem:format_status/1` did not make any difference for logged crash reports, so we reach for the solution we already use in multiple places.

References #9763.
