### PR TITLE
Handle `{error, not_found}` case when recovering a binding

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -109,7 +109,11 @@ recover_semi_durable_route(Gatherer, Binding, Src, Dst, ToRecover, Fun) ->
                                    Fun(Binding, X),
                                    gatherer:finish(Gatherer)
                            end);
-                {error, not_found} -> ok
+                {error, not_found}=Error ->
+                    rabbit_log:warning(
+                      "expected exchange ~tp to exist during recovery, "
+                      "error: ~tp", [Src, Error]),
+                    ok
             end;
         false -> ok
     end.

--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -100,13 +100,17 @@ recover(XNames, QNames) ->
 
 recover_semi_durable_route(Gatherer, Binding, Src, Dst, ToRecover, Fun) ->
     case sets:is_element(Dst, ToRecover) of
-        true  -> {ok, X} = rabbit_exchange:lookup(Src),
-                 ok = gatherer:fork(Gatherer),
-                 ok = worker_pool:submit_async(
-                        fun () ->
-                                Fun(Binding, X),
-                                gatherer:finish(Gatherer)
-                        end);
+        true  ->
+            case rabbit_exchange:lookup(Src) of
+                {ok, X} ->
+                    ok = gatherer:fork(Gatherer),
+                    ok = worker_pool:submit_async(
+                           fun () ->
+                                   Fun(Binding, X),
+                                   gatherer:finish(Gatherer)
+                           end);
+                {error, not_found} -> ok
+            end;
         false -> ok
     end.
 


### PR DESCRIPTION
A customer could not recover a vhost due to the following error:

```
[error] <0.32570.2> Unable to recover vhost <<"/">> data. Reason {badmatch,{error,not_found}}
[error] <0.32570.2>  Stacktrace [{rabbit_binding,recover_semi_durable_route,3,
[error] <0.32570.2>                              [{file,"rabbit_binding.erl"},{line,113}]},
[error] <0.32570.2>              {rabbit_binding,'-recover/2-lc$^1/1-1-',3,
[error] <0.32570.2>                              [{file,"rabbit_binding.erl"},{line,103}]},
[error] <0.32570.2>              {rabbit_binding,recover,2,
[error] <0.32570.2>                              [{file,"rabbit_binding.erl"},{line,104}]},
```

Reference: https://vmware.slack.com/archives/C0RDGG81Z/p1698140367947859