### PR TITLE
Speed up shovel start

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -84,7 +84,8 @@ stop_child({VHost, ShovelName} = Name) ->
 
 cleanup_specs() ->
     SpecsSet = sets:from_list([element(2, element(1, S)) || S <- mirrored_supervisor:which_children(?SUPERVISOR)]),
-    ParamsSet = sets:from_list(rabbit_runtime_parameters:list_component(<<"shovel">>)),
+    ParamsSet = sets:from_list([ {proplists:get_value(vhost, S), proplists:get_value(name, S)}
+                                 || S <- rabbit_runtime_parameters:list_component(<<"shovel">>) ]),
     F = fun(Name, ok) ->
             _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name)),
             ok


### PR DESCRIPTION
Previously whenever a shovel was declared, a full cleanup of all shovels was performed. Since some users have a lot of shovels, that would slow things down - especially import and node startup when we performed a cleanup of all shovels for each new shovel.

In a test with 1000 shovels, this change speeds up a definition import from a few minutes to a few seconds.

Fixes https://github.com/rabbitmq/rabbitmq-server/discussions/9714
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/8364