### PR TITLE
Require Erlang/OTP 26.0 (ERTS 14.0)

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         include:
           - image_tag_suffix: otp-min-bazel
-            otp_version_id: 25_3
+            otp_version_id: 26_1
           - image_tag_suffix: otp-max-bazel
             otp_version_id: 26_1
     steps:

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "25"
+        - "26"
         include:
-        - erlang_version: "25"
+        - erlang_version: "26"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:
@@ -48,9 +48,9 @@ jobs:
     strategy:
       matrix:
         erlang_version:
-        - "25"
+        - "26"
         include:
-        - erlang_version: "25"
+        - erlang_version: "26"
           cache_name: ci-bazel-cache-analysis
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -130,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         otp_version_id:
-        - "25_3"
+        - "26_1"
         metadata_store:
           - mnesia
           - khepri

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,6 @@ on:
       - v3.12.x
       - v3.11.x
       - v3.10.x
-      - v3.9.x
-      - v3.8.x
       - bump-otp-for-oci
       - bump-rbe-*
       - bump-rules_erlang
@@ -35,7 +33,6 @@ jobs:
       fail-fast: false
       matrix:
         otp_version_id:
-        - 25_3
         - 26
         metadata_store:
           - mnesia

--- a/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
+++ b/deps/rabbit/apps/rabbitmq_prelaunch/src/rabbit_prelaunch_erlang_compat.erl
@@ -6,8 +6,10 @@
 
 -export([check/1]).
 
--define(OTP_MINIMUM, "25.0").
--define(ERTS_MINIMUM, "13.0").
+%% minimum Erlang/OTP version supported
+-define(OTP_MINIMUM, "26.0").
+%% the ERTS version provided by the minimum Erlang/OTP version supported
+-define(ERTS_MINIMUM, "14.0").
 
 check(_Context) ->
     ?LOG_DEBUG(


### PR DESCRIPTION
for RabbitMQ 3.13 only, 3.12.x and earlier releases will continue to support 25.3 until Erlang 27 comes out and a transitional period of 1-3 months passes.