### PR TITLE
Fix quorum queue open files info

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1615,8 +1615,13 @@ open_files(Name) ->
     case whereis(Name) of
         undefined ->
             {node(), 0};
-        Pid ->
-            {node(), ets_lookup_element(ra_open_file_metrics, Pid, 2, 0)}
+        _ ->
+            case ra_counters:counters({Name, node()}, [open_segments]) of
+                #{open_segments := Num} ->
+                    {node(), Num};
+                _ ->
+                    {node(), 0}
+            end
     end.
 
 leader(Q) when ?is_amqqueue(Q) ->


### PR DESCRIPTION
At some point Ra stopped updating the ra_open_files_metrics table in favour of using counters. This change updates the rabbit_quorum_queue:open_files/1 function to use ra counters instead of querying the deprecated ETS table.
