### PR TITLE
Skip test maintenance in mixed version mode

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -1276,29 +1276,38 @@ cli_list_queues(Config) ->
     ok = emqtt:disconnect(C).
 
 maintenance(Config) ->
-    C0 = connect(<<"client-0">>, Config, 0, []),
-    C1a = connect(<<"client-1a">>, Config, 1, []),
-    C1b = connect(<<"client-1b">>, Config, 1, []),
-    ClientsNode1 = [C1a, C1b],
+    case is_feature_flag_enabled(Config, delete_ra_cluster_mqtt_node) of
+        false ->
+            %% When either file rabbit_mqtt_collector changes or different OTP versions
+            %% are used for compilation, the rabbit_mqtt_collector module version will
+            %% change and cause a bad fun error when executing ra:leader_query/2 remotely.
+            {skip, "Anonymous fun as used in ra:leader_query/2 errors when executing "
+             "remotely with a different module version"};
+        true ->
+            C0 = connect(<<"client-0">>, Config, 0, []),
+            C1a = connect(<<"client-1a">>, Config, 1, []),
+            C1b = connect(<<"client-1b">>, Config, 1, []),
+            ClientsNode1 = [C1a, C1b],
 
-    timer:sleep(500),
+            timer:sleep(500),
 
-    ok = drain_node(Config, 2),
-    ok = revive_node(Config, 2),
-    timer:sleep(500),
-    [?assert(erlang:is_process_alive(C)) || C <- [C0, C1a, C1b]],
+            ok = drain_node(Config, 2),
+            ok = revive_node(Config, 2),
+            timer:sleep(500),
+            [?assert(erlang:is_process_alive(C)) || C <- [C0, C1a, C1b]],
 
-    process_flag(trap_exit, true),
-    ok = drain_node(Config, 1),
-    [await_exit(Pid) || Pid <- ClientsNode1],
-    [assert_v5_disconnect_reason_code(Config, ?RC_SERVER_SHUTTING_DOWN) || _ <- ClientsNode1],
-    ok = revive_node(Config, 1),
-    ?assert(erlang:is_process_alive(C0)),
+            process_flag(trap_exit, true),
+            ok = drain_node(Config, 1),
+            [await_exit(Pid) || Pid <- ClientsNode1],
+            [assert_v5_disconnect_reason_code(Config, ?RC_SERVER_SHUTTING_DOWN) || _ <- ClientsNode1],
+            ok = revive_node(Config, 1),
+            ?assert(erlang:is_process_alive(C0)),
 
-    ok = drain_node(Config, 0),
-    await_exit(C0),
-    assert_v5_disconnect_reason_code(Config, ?RC_SERVER_SHUTTING_DOWN),
-    ok = revive_node(Config, 0).
+            ok = drain_node(Config, 0),
+            await_exit(C0),
+            assert_v5_disconnect_reason_code(Config, ?RC_SERVER_SHUTTING_DOWN),
+            ok = revive_node(Config, 0)
+    end.
 
 keepalive(Config) ->
     KeepaliveSecs = 1,


### PR DESCRIPTION
`main` branch is currently broken due to https://github.com/rabbitmq/rabbitmq-server/pull/9787

`maintenance` test fails when MQTT client ID tracking is performed in Ra, and the higher version node gets compiled with a different OTP version (26) than the lower version node (25).

The reason is described in https://github.com/rabbitmq/rabbitmq-server/commit/83eede7ef2babffd1e8ae658c91c9e696fde64fa

> An interesting side note learned here is that the compiled file
> rabbit_mqtt_collector must not be changed. This commit only modifies
> function specs. However as soon as the compiled code is changed, this
> module becomes a new version. The new version causes the anonymous ra query
> function to fail in mixed clusters: When the old node does a
> ra:leader_query where the leader is on the new node, the query function
> fails on the new node with `badfun` because the new node does not have
> the same module version. For more context, read:
> https://web.archive.org/web/20181017104411/http://www.javalimit.com/2010/05/passing-funs-to-other-erlang-nodes.html


We shouldn’t use an anonymous function for ra:leader_query or ra:consistent_query. Instead we should use the {M,F,A} form.
https://github.com/rabbitmq/ra/blob/9e5d437a0a76cc126f396be93645a290e758ac75/src/ra.erl#L102-L103

In MQTT the anonymous function is used in https://github.com/rabbitmq/rabbitmq-server/blob/bcb95c949d8622fb7ba6d3c1b4a12fdb73b0fa66/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl#L50 This causes the query to return a bad fun error (silently ignored in https://github.com/rabbitmq/rabbitmq-server/blob/bcb95c949d8622fb7ba6d3c1b4a12fdb73b0fa66/deps/rabbitmq_mqtt/src/rabbit_mqtt_collector.erl#L70-L71 ) when executed on a different node and either:
1.) Any code in file rabbit_mqtt_collector.erl changed, or 2.) The code gets compiled with a different OTP version.

2.) is the reason for a failing mixed version test in https://github.com/rabbitmq/rabbitmq-server/pull/8553 because both higher and lower versions run OTP 26, but the higher version node got compiled with 26 while the lower version node got compiled with 25.

The same file
compiled with OTP 26.0.1
```
1> rabbit_mqtt_collector:module_info(attributes).
[{vsn,[30045739264236496640687548892374951597]}]
```

compiled with OTP 25.3.2
```
1> rabbit_mqtt_collector:module_info(attributes).
[{vsn,[168144385419873449889532520247510637232]}]
```

Due to the very low impact that maintenance mode will not close all MQTT client connections with feature flag delete_ra_cluster_mqtt_node being disabled, we skip this test.