### PR TITLE
Use new OTP 26 fun ets:lookup_element/4

### DIFF
--- a/deps/rabbit/src/rabbit_exchange_type_direct.erl
+++ b/deps/rabbit/src/rabbit_exchange_type_direct.erl
@@ -36,12 +36,7 @@ route(#exchange{name = Name, type = Type}, Msg) ->
 
 route(#exchange{name = Name, type = Type}, Msg, _Opts) ->
     Routes = mc:get_annotation(routing_keys, Msg),
-    case Type of
-        direct ->
-            rabbit_db_binding:match_routing_key(Name, Routes, true);
-        _ ->
-            rabbit_db_binding:match_routing_key(Name, Routes, false)
-        end.
+    rabbit_db_binding:match_routing_key(Name, Routes, Type =:= direct).
 
 validate(_X) -> ok.
 validate_binding(_X, _B) -> ok.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1049,7 +1049,7 @@ cluster_state(Name) ->
     case whereis(Name) of
         undefined -> down;
         _ ->
-            case ets_lookup_element(ra_state, Name, 2, undefined) of
+            case ets:lookup_element(ra_state, Name, 2, undefined) of
                 recover ->
                     recovering;
                 _ ->
@@ -1496,10 +1496,10 @@ i(messages, Q) when ?is_amqqueue(Q) ->
     quorum_messages(QName);
 i(messages_ready, Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    ets_lookup_element(queue_coarse_metrics, QName, 2, 0);
+    ets:lookup_element(queue_coarse_metrics, QName, 2, 0);
 i(messages_unacknowledged, Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    ets_lookup_element(queue_coarse_metrics, QName, 3, 0);
+    ets:lookup_element(queue_coarse_metrics, QName, 3, 0);
 i(policy, Q) ->
     case rabbit_policy:name(Q) of
         none   -> '';
@@ -1517,7 +1517,7 @@ i(effective_policy_definition, Q) ->
     end;
 i(consumers, Q) when ?is_amqqueue(Q) ->
     QName = amqqueue:get_name(Q),
-    Consumers = ets_lookup_element(queue_metrics, QName, 2, []),
+    Consumers = ets:lookup_element(queue_metrics, QName, 2, []),
     proplists:get_value(consumers, Consumers, 0);
 i(memory, Q) when ?is_amqqueue(Q) ->
     {Name, _} = amqqueue:get_pid(Q),
@@ -1539,7 +1539,7 @@ i(state, Q) when ?is_amqqueue(Q) ->
     end;
 i(local_state, Q) when ?is_amqqueue(Q) ->
     {Name, _} = amqqueue:get_pid(Q),
-    ets_lookup_element(ra_state, Name, 2, not_member);
+    ets:lookup_element(ra_state, Name, 2, not_member);
 i(garbage_collection, Q) when ?is_amqqueue(Q) ->
     {Name, _} = amqqueue:get_pid(Q),
     try
@@ -1683,7 +1683,7 @@ is_process_alive(Name, Node) ->
 -spec quorum_messages(rabbit_amqqueue:name()) -> non_neg_integer().
 
 quorum_messages(QName) ->
-    ets_lookup_element(queue_coarse_metrics, QName, 4, 0).
+    ets:lookup_element(queue_coarse_metrics, QName, 4, 0).
 
 quorum_ctag(Int) when is_integer(Int) ->
     integer_to_binary(Int);
@@ -1794,14 +1794,6 @@ notify_decorators(QName, F, A) ->
             ok;
         {error, not_found} ->
             ok
-    end.
-
-ets_lookup_element(Tbl, Key, Pos, Default) ->
-    try ets:lookup_element(Tbl, Key, Pos) of
-        V -> V
-    catch
-        _:badarg ->
-            Default
     end.
 
 erpc_call(Node, M, F, A, _Timeout)

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_data.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_data.erl
@@ -379,12 +379,11 @@ match_consumer_spec(Id) ->
 match_queue_consumer_spec(Id) ->
     [{{{'$1', '_', '_'}, '_'}, [{'==', {Id}, '$1'}], ['$_']}].
 
-lookup_element(Table, Key) -> lookup_element(Table, Key, 2).
+lookup_element(Table, Key) ->
+    lookup_element(Table, Key, 2).
 
 lookup_element(Table, Key, Pos) ->
-    try ets:lookup_element(Table, Key, Pos)
-    catch error:badarg -> []
-    end.
+    ets:lookup_element(Table, Key, Pos, []).
 
 -spec lookup_smaller_sample(atom(), any()) -> maybe_slide().
 lookup_smaller_sample(Table, Id) ->


### PR DESCRIPTION
Routing to nowhere with the direct exchange is now a bit faster 🙃
```
java -jar target/perf-test.jar -x 2 -y 0 -k route-nowhere -z 60
```