### PR TITLE
Skip some assertions in mixed version tests

### DIFF
--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -154,7 +154,7 @@ rabbitmq_integration_suite(
         ":test_util_beam",
     ],
     flaky = True,
-    shard_count = 6,
+    shard_count = 4,
     sharding_method = "case",
     runtime_deps = [
         "@emqtt//:erlang_app",


### PR DESCRIPTION
follow up of https://github.com/rabbitmq/rabbitmq-server/pull/9805

See commit message 00c77e0a1a67645337ab32916d9fbe931153cad7 for details.

In a multi node mixed version cluster where the lower version is compiled with a different OTP version, anonymous Ra leader queries will fail with a badfun error if initiated on the higher version and executed on the leader on the lower version node.

