### PR TITLE
Message container conversion improvements

### DIFF
--- a/deps/rabbit/include/mc.hrl
+++ b/deps/rabbit/include/mc.hrl
@@ -17,8 +17,6 @@
 %% good enough for most use cases
 -define(IS_MC(Msg), element(1, Msg) == mc andalso tuple_size(Msg) == 5).
 
-%% "Field names MUST start with a letter, '$' or '#' and may continue with letters, '$' or '#', digits, or
-%% underlines, to a maximum length of 128 characters." [AMQP 0.9.1 4.2.5.5 Field Tables]
-%% Given that the valid chars are ASCII chars, 1 char is encoded as 1 byte.
--define(AMQP_LEGACY_FIELD_NAME_MAX_LEN, 128).
+%% "Short strings can carry up to 255 octets of UTF-8 data, but
+%% may not contain binary zero octets." [AMQP 0.9.1 $4.2.5.3]
 -define(IS_SHORTSTR_LEN(B), byte_size(B) < 256).

--- a/deps/rabbit/include/mc.hrl
+++ b/deps/rabbit/include/mc.hrl
@@ -21,3 +21,4 @@
 %% underlines, to a maximum length of 128 characters." [AMQP 0.9.1 4.2.5.5 Field Tables]
 %% Given that the valid chars are ASCII chars, 1 char is encoded as 1 byte.
 -define(AMQP_LEGACY_FIELD_NAME_MAX_LEN, 128).
+-define(IS_SHORTSTR_LEN(B), byte_size(B) < 256).

--- a/deps/rabbit/src/mc.erl
+++ b/deps/rabbit/src/mc.erl
@@ -2,6 +2,7 @@
 
 -export([
          init/3,
+         init/4,
          size/1,
          is/1,
          get_annotation/2,
@@ -19,6 +20,7 @@
          routing_headers/2,
          %%
          convert/2,
+         convert/3,
          protocol_state/1,
          prepare/2,
          record_death/3,
@@ -36,6 +38,7 @@
 -type protocol() :: module().
 -type annotations() :: #{internal_ann_key() => term(),
                          x_ann_key() => x_ann_value()}.
+-type environment() :: #{atom() => term()}.
 -type ann_key() :: internal_ann_key() | x_ann_key().
 -type ann_value() :: term().
 
@@ -107,12 +110,14 @@
 
 %% Convert state to another protocol
 %% all protocols must be able to convert to mc_amqp (AMQP 1.0)
--callback convert_to(Target :: protocol(), proto_state()) ->
+-callback convert_to(Target :: protocol(), proto_state(),
+                     Env :: #{atom() => term()}) ->
     proto_state() | not_implemented.
 
 %% Convert from another protocol
 %% all protocols must be able to convert from mc_amqp (AMQP 1.0)
--callback convert_from(Source :: protocol(), proto_state()) ->
+-callback convert_from(Source :: protocol(), proto_state(),
+                       Env :: #{atom() => term()}) ->
     proto_state() | not_implemented.
 
 %% emit a protocol specific state package
@@ -128,10 +133,22 @@
 %%% API
 
 -spec init(protocol(), term(), annotations()) -> state().
-init(Proto, Data, Anns)
+init(Proto, Data, Anns) ->
+    init(Proto, Data, Anns, #{}).
+
+-spec init(protocol(), term(), annotations(),
+           environment()) -> state().
+init(Proto, Data, Anns0, Env)
   when is_atom(Proto)
-       andalso is_map(Anns) ->
+       andalso is_map(Anns0)
+       andalso is_map(Env) ->
     {ProtoData, ProtoAnns} = Proto:init(Data),
+    Anns = case maps:size(Env) == 0 of
+               true ->
+                   Anns0;
+               false ->
+                   Anns0#{env => Env}
+           end,
     #?MODULE{protocol = Proto,
              data = ProtoData,
              annotations = maps:merge(ProtoAnns, Anns)}.
@@ -265,18 +282,26 @@ set_ttl(Value, BasicMsg) ->
     mc_compat:set_ttl(Value, BasicMsg).
 
 -spec convert(protocol(), state()) -> state().
-convert(Proto, #?MODULE{protocol = Proto} = State) ->
+convert(Proto, State) ->
+    convert(Proto, State, #{}).
+
+-spec convert(protocol(), state(), Env :: #{atom() => term()}) -> state().
+convert(Proto, #?MODULE{protocol = Proto} = State, _Env) ->
     State;
 convert(TargetProto, #?MODULE{protocol = SourceProto,
-                              data = Data0} = State) ->
+                              annotations = Anns,
+                              data = Data0} = State,
+        TargetEnv) ->
     Data = SourceProto:prepare(read, Data0),
+    SourceEnv = maps:get(env, Anns, #{}),
+    Env = maps:merge(SourceEnv, TargetEnv),
     TargetState =
-        case SourceProto:convert_to(TargetProto, Data) of
+        case SourceProto:convert_to(TargetProto, Data, Env) of
             not_implemented ->
-                case TargetProto:convert_from(SourceProto, Data) of
+                case TargetProto:convert_from(SourceProto, Data, Env) of
                     not_implemented ->
-                        AmqpData = SourceProto:convert_to(mc_amqp, Data),
-                        mc_amqp:convert_to(TargetProto, AmqpData);
+                        AmqpData = SourceProto:convert_to(mc_amqp, Data, Env),
+                        mc_amqp:convert_to(TargetProto, AmqpData, Env);
                     TargetState0 ->
                         TargetState0
                 end;
@@ -285,7 +310,7 @@ convert(TargetProto, #?MODULE{protocol = SourceProto,
         end,
     State#?MODULE{protocol = TargetProto,
                   data = TargetState};
-convert(Proto, BasicMsg) ->
+convert(Proto, BasicMsg, _Env) ->
     mc_compat:convert_to(Proto, BasicMsg).
 
 -spec protocol_state(state()) -> term().

--- a/deps/rabbit/src/mc.erl
+++ b/deps/rabbit/src/mc.erl
@@ -110,14 +110,12 @@
 
 %% Convert state to another protocol
 %% all protocols must be able to convert to mc_amqp (AMQP 1.0)
--callback convert_to(Target :: protocol(), proto_state(),
-                     Env :: #{atom() => term()}) ->
+-callback convert_to(Target :: protocol(), proto_state(), environment()) ->
     proto_state() | not_implemented.
 
 %% Convert from another protocol
 %% all protocols must be able to convert from mc_amqp (AMQP 1.0)
--callback convert_from(Source :: protocol(), proto_state(),
-                       Env :: #{atom() => term()}) ->
+-callback convert_from(Source :: protocol(), proto_state(), environment()) ->
     proto_state() | not_implemented.
 
 %% emit a protocol specific state package
@@ -136,8 +134,7 @@
 init(Proto, Data, Anns) ->
     init(Proto, Data, Anns, #{}).
 
--spec init(protocol(), term(), annotations(),
-           environment()) -> state().
+-spec init(protocol(), term(), annotations(), environment()) -> state().
 init(Proto, Data, Anns0, Env)
   when is_atom(Proto)
        andalso is_map(Anns0)
@@ -285,7 +282,7 @@ set_ttl(Value, BasicMsg) ->
 convert(Proto, State) ->
     convert(Proto, State, #{}).
 
--spec convert(protocol(), state(), Env :: #{atom() => term()}) -> state().
+-spec convert(protocol(), state(), environment()) -> state().
 convert(Proto, #?MODULE{protocol = Proto} = State, _Env) ->
     State;
 convert(TargetProto, #?MODULE{protocol = SourceProto,

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -11,8 +11,8 @@
          property/2,
          routing_headers/2,
          get_property/2,
-         convert_to/2,
-         convert_from/2,
+         convert_to/3,
+         convert_from/3,
          protocol_state/2,
          serialize/1,
          prepare/2
@@ -70,9 +70,9 @@ init(#msg{} = Msg) ->
     Anns = essential_properties(Msg),
     {Msg, Anns}.
 
-convert_from(?MODULE, Sections) ->
+convert_from(?MODULE, Sections, _Env) ->
     element(1, init(Sections));
-convert_from(_SourceProto, _) ->
+convert_from(_SourceProto, _, _Env) ->
     not_implemented.
 
 size(#msg{data = Body}) ->
@@ -177,10 +177,12 @@ get_property(priority, Msg) ->
 get_property(_P, _Msg) ->
     undefined.
 
-convert_to(?MODULE, Msg) ->
+convert_to(?MODULE, Msg, _Env) ->
     Msg;
-convert_to(TargetProto, Msg) ->
-    TargetProto:convert_from(?MODULE, msg_to_sections(Msg, fun (X) -> X end)).
+convert_to(TargetProto, Msg, Env) ->
+    TargetProto:convert_from(?MODULE,
+                             msg_to_sections(Msg, fun (X) -> X end),
+                             Env).
 
 serialize(Sections) ->
     encode_bin(Sections).

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -12,8 +12,8 @@
          size/1,
          x_header/2,
          routing_headers/2,
-         convert_to/2,
-         convert_from/2,
+         convert_to/3,
+         convert_from/3,
          protocol_state/2,
          property/2,
          set_property/3,
@@ -54,7 +54,7 @@ init(#content{} = Content0) ->
     Anns = essential_properties(Content),
     {strip_header(Content, ?DELETED_HEADER), Anns}.
 
-convert_from(mc_amqp, Sections) ->
+convert_from(mc_amqp, Sections, _Env) ->
     {H, MAnn, Prop, AProp, BodyRev} =
         lists:foldl(
           fun
@@ -144,14 +144,15 @@ convert_from(mc_amqp, Sections) ->
            end,
 
     Headers0 = [to_091(K, V) || {{utf8, K}, V} <- AP,
-                                byte_size(K) =< ?AMQP_LEGACY_FIELD_NAME_MAX_LEN],
+                                ?IS_SHORTSTR_LEN(K)],
     %% Add remaining message annotations as headers?
     XHeaders = lists:filtermap(fun({{symbol, <<"x-cc">>}, V}) ->
                                        {true, to_091(<<"CC">>, V)};
-                                  ({{symbol, K}, V})
-                                    when byte_size(K) =< ?AMQP_LEGACY_FIELD_NAME_MAX_LEN ->
+                                  ({{symbol, <<"x-", _/binary>> = K}, V})
+                                    when ?IS_SHORTSTR_LEN(K) ->
                                        case is_internal_header(K) of
-                                           false -> {true, to_091(K, V)};
+                                           false ->
+                                               {true, to_091(K, V)};
                                            true -> false
                                        end;
                                   (_) ->
@@ -161,6 +162,8 @@ convert_from(mc_amqp, Sections) ->
     {Headers, CorrId091} = message_id(CorrId, <<"x-correlation-id">>, Headers1),
 
     UserId1 = unwrap(UserId0),
+    %% user-id is a binary type so we need to validate
+    %% if we can use it as is
     UserId = case mc_util:is_valid_shortstr(UserId1) of
                  true ->
                      UserId1;
@@ -177,9 +180,9 @@ convert_from(mc_amqp, Sections) ->
                                   [] -> undefined;
                                   AllHeaders -> AllHeaders
                               end,
-                    reply_to = unwrap(ReplyTo0),
+                    reply_to = unwrap_shortstr(ReplyTo0),
                     type = Type,
-                    app_id = unwrap(GroupId),
+                    app_id = unwrap_shortstr(GroupId),
                     priority = Priority,
                     correlation_id = CorrId091,
                     content_type = unwrap(ContentType),
@@ -190,7 +193,7 @@ convert_from(mc_amqp, Sections) ->
              properties = BP,
              properties_bin = none,
              payload_fragments_rev = PayloadRev};
-convert_from(_SourceProto, _) ->
+convert_from(_SourceProto, _, _) ->
     not_implemented.
 
 size(#content{properties_bin = PropsBin,
@@ -263,11 +266,11 @@ prepare(store, Content) ->
     rabbit_binary_parser:clear_decoded_content(
       rabbit_binary_generator:ensure_content_encoded(Content, ?PROTOMOD)).
 
-convert_to(?MODULE, Content) ->
+convert_to(?MODULE, Content, _Env) ->
     Content;
-convert_to(mc_amqp, #content{payload_fragments_rev = Payload} = Content) ->
+convert_to(mc_amqp, #content{payload_fragments_rev = Payload} = Content, Env) ->
     #content{properties = Props} = prepare(read, Content),
-    #'P_basic'{message_id = MsgId,
+    #'P_basic'{message_id = MsgId0,
                expiration = Expiration,
                delivery_mode = DelMode,
                headers = Headers0,
@@ -276,7 +279,7 @@ convert_to(mc_amqp, #content{payload_fragments_rev = Payload} = Content) ->
                type = Type,
                priority = Priority,
                app_id = AppId,
-               correlation_id = CorrId,
+               correlation_id = CorrId0,
                content_type = ContentType,
                content_encoding = ContentEncoding,
                timestamp = Timestamp} = Props,
@@ -297,6 +300,8 @@ convert_to(mc_amqp, #content{payload_fragments_rev = Payload} = Content) ->
               undefined ->
                   undefined;
               _ ->
+                  %% TODO: do we need to validate this doesn't fail?
+                  %% Some validation is done in then channel already
                   binary_to_integer(Expiration)
           end,
 
@@ -304,14 +309,26 @@ convert_to(mc_amqp, #content{payload_fragments_rev = Payload} = Content) ->
                        ttl = wrap(uint, Ttl),
                        %% TODO: check Priority is a ubyte?
                        priority = wrap(ubyte, Priority)},
+    CorrId = case mc_util:urn_string_to_uuid(CorrId0) of
+                 {ok, CorrUUID} ->
+                     {uuid, CorrUUID};
+                 _ ->
+                     wrap(utf8, CorrId0)
+             end,
+    MsgId = case mc_util:urn_string_to_uuid(MsgId0) of
+                 {ok, MsgUUID} ->
+                     {uuid, MsgUUID};
+                 _ ->
+                     wrap(utf8, MsgId0)
+             end,
     P = case amqp10_section_header(?AMQP10_PROPERTIES_HEADER, Headers) of
             undefined ->
-                #'v1_0.properties'{message_id = wrap(utf8, MsgId),
+                #'v1_0.properties'{message_id = MsgId,
                                    user_id = wrap(binary, UserId),
                                    to = undefined,
                                    % subject = wrap(utf8, RKey),
                                    reply_to = wrap(utf8, ReplyTo),
-                                   correlation_id = wrap(utf8, CorrId),
+                                   correlation_id = CorrId,
                                    content_type = wrap(symbol, ContentType),
                                    content_encoding = wrap(symbol, ContentEncoding),
                                    creation_time = wrap(timestamp, ConvertedTs),
@@ -367,8 +384,8 @@ convert_to(mc_amqp, #content{payload_fragments_rev = Payload} = Content) ->
                    end,
 
     Sections = [H, MA, P, AP | BodySections],
-    mc_amqp:convert_from(mc_amqp, Sections);
-convert_to(_TargetProto, _Content) ->
+    mc_amqp:convert_from(mc_amqp, Sections, Env);
+convert_to(_TargetProto, _Content, _Env) ->
     not_implemented.
 
 protocol_state(#content{properties = #'P_basic'{headers = H00} = B0} = C,
@@ -606,7 +623,15 @@ unwrap({timestamp, V}) ->
 unwrap({_Type, V}) ->
     V.
 
-to_091(Key, {utf8, V}) when is_binary(V) -> {Key, longstr, V};
+unwrap_shortstr({utf8, V})
+  when is_binary(V) andalso
+       byte_size(V) < 256 ->
+    V;
+unwrap_shortstr(_) ->
+    undefined.
+
+to_091(Key, {utf8, V}) -> {Key, longstr, V};
+to_091(Key, {symbol, V}) -> {Key, longstr, V};
 to_091(Key, {long, V}) -> {Key, long, V};
 to_091(Key, {ulong, V}) -> {Key, long, V}; %% TODO: we could try to constrain this
 to_091(Key, {byte, V}) -> {Key, byte, V};
@@ -630,6 +655,7 @@ to_091(Key, {map, M}) ->
     {Key, table, [to_091(unwrap(K), V) || {K, V} <- M]}.
 
 to_091({utf8, V}) -> {longstr, V};
+to_091({symbol, V}) -> {longstr, V};
 to_091({long, V}) -> {long, V};
 to_091({byte, V}) -> {byte, V};
 to_091({ubyte, V}) -> {unsignedbyte, V};
@@ -652,17 +678,17 @@ to_091({map, M}) ->
     {table, [to_091(unwrap(K), V) || {K, V} <- M]}.
 
 message_id({uuid, UUID}, _HKey, H0) ->
-    {H0, mc_util:uuid_to_string(UUID)};
+    {H0, mc_util:uuid_to_urn_string(UUID)};
 message_id({ulong, N}, _HKey, H0) ->
     {H0, erlang:integer_to_binary(N)};
 message_id({binary, B}, HKey, H0) ->
-    {[{HKey, longstr, B} | H0], undefined};
+    {[{HKey, binary, B} | H0], undefined};
 message_id({utf8, S}, HKey, H0) ->
-    case byte_size(S) > 255 of
+    case byte_size(S) < 256 of
         true ->
-            {[{HKey, longstr, S} | H0], undefined};
+            {H0, S};
         false ->
-            {H0, S}
+            {[{HKey, longstr, S} | H0], undefined}
     end;
 message_id(undefined, _HKey, H) ->
     {H, undefined}.

--- a/deps/rabbit/src/mc_util.erl
+++ b/deps/rabbit/src/mc_util.erl
@@ -2,7 +2,8 @@
 
 -export([is_valid_shortstr/1,
          is_utf8_no_null/1,
-         uuid_to_string/1,
+         uuid_to_urn_string/1,
+         urn_string_to_uuid/1,
          infer_type/1,
          utf8_string_is_ascii/1,
          amqp_map_get/3,
@@ -11,7 +12,7 @@
 
 -spec is_valid_shortstr(term()) -> boolean().
 is_valid_shortstr(Bin) when byte_size(Bin) < 256 ->
-    is_utf8_no_null(Bin);
+    utf8_scan(Bin, fun (C) -> C > 0 end);
 is_valid_shortstr(_) ->
     false.
 
@@ -24,11 +25,26 @@ is_utf8_no_null(<<_/utf8, Rem/binary>>) ->
 is_utf8_no_null(_) ->
     false.
 
--spec uuid_to_string(binary()) -> binary().
-uuid_to_string(<<TL:32, TM:16, THV:16, CSR:8, CSL:8, N:48>>) ->
-    list_to_binary(
-      io_lib:format(<<"urn:uuid:~8.16.0b-~4.16.0b-~4.16.0b-~2.16.0b~2.16.0b-~12.16.0b">>,
-                    [TL, TM, THV, CSR, CSL, N])).
+-spec uuid_to_urn_string(binary()) -> binary().
+uuid_to_urn_string(<<TL:4/binary, TM:2/binary, THV:2/binary,
+                     CSR:1/binary, CSL:1/binary, N:6/binary>>) ->
+    Delim = <<"-">>,
+    iolist_to_binary(
+      [<<"urn:uuid:">>,
+       binary:encode_hex(TL, lowercase), Delim,
+       binary:encode_hex(TM, lowercase), Delim,
+       binary:encode_hex(THV, lowercase), Delim,
+       binary:encode_hex(CSR, lowercase),
+       binary:encode_hex(CSL, lowercase), Delim,
+       binary:encode_hex(N, lowercase)]).
+
+-spec urn_string_to_uuid(binary()) ->
+    {ok, binary()} | {error, not_urn_string}.
+urn_string_to_uuid(<<"urn:uuid:", UuidStr:36/binary>>) ->
+    Parts = binary:split(UuidStr, <<"-">>, [global]),
+    {ok, iolist_to_binary([binary:decode_hex(Part) || Part <- Parts])};
+urn_string_to_uuid(_) ->
+    {error, not_urn_string}.
 
 
 infer_type(undefined) ->
@@ -43,13 +59,8 @@ infer_type({T, _} = V) when is_atom(T) ->
     %% looks like a pre-tagged type
     V.
 
-utf8_string_is_ascii(UTF8String)
-  when is_binary(UTF8String) ->
-    List = unicode:characters_to_list(UTF8String),
-    lists:all(fun(Char) ->
-                      Char >= 0 andalso
-                      Char < 128
-              end, List).
+utf8_string_is_ascii(UTF8String) ->
+    utf8_scan(UTF8String, fun(Char) -> Char >= 0 andalso Char < 128 end).
 
 amqp_map_get(Key, {map, List}, Default) ->
     amqp_map_get(Key, List, Default);
@@ -67,4 +78,18 @@ amqp_map_get(_, _, Default) ->
 is_x_header(<<"x-", _/binary>>) ->
     true;
 is_x_header(_) ->
+    false.
+
+%% INTERNAL
+
+utf8_scan(<<>>, _Pred) ->
+    true;
+utf8_scan(<<C/utf8, Rem/binary>>, Pred) ->
+    case Pred(C) of
+        true ->
+            utf8_scan(Rem, Pred);
+        false ->
+            false
+    end;
+utf8_scan(_, _Pred) ->
     false.

--- a/deps/rabbit/src/mc_util.erl
+++ b/deps/rabbit/src/mc_util.erl
@@ -1,5 +1,7 @@
 -module(mc_util).
 
+-include("mc.hrl").
+
 -export([is_valid_shortstr/1,
          is_utf8_no_null/1,
          uuid_to_urn_string/1,
@@ -11,19 +13,14 @@
         ]).
 
 -spec is_valid_shortstr(term()) -> boolean().
-is_valid_shortstr(Bin) when byte_size(Bin) < 256 ->
-    utf8_scan(Bin, fun (C) -> C > 0 end);
+is_valid_shortstr(Bin) when ?IS_SHORTSTR_LEN(Bin) ->
+    is_utf8_no_null(Bin);
 is_valid_shortstr(_) ->
     false.
 
-is_utf8_no_null(<<>>) ->
-    true;
-is_utf8_no_null(<<0, _/binary>>) ->
-    false;
-is_utf8_no_null(<<_/utf8, Rem/binary>>) ->
-    is_utf8_no_null(Rem);
-is_utf8_no_null(_) ->
-    false.
+-spec is_utf8_no_null(term()) -> boolean().
+is_utf8_no_null(Term) ->
+    utf8_scan(Term, fun (C) -> C > 0 end).
 
 -spec uuid_to_urn_string(binary()) -> binary().
 uuid_to_urn_string(<<TL:4/binary, TM:2/binary, THV:2/binary,

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -241,10 +241,6 @@ amqpl_death_records(_Config) ->
     {_, array, [{table, T2a}, {table, T2b}]} = header(<<"x-death">>, H2),
     ?assertMatch({_, longstr, <<"dl">>}, header(<<"queue">>, T2a)),
     ?assertMatch({_, longstr, <<"q1">>}, header(<<"queue">>, T2b)),
-
-    ct:pal("H2 ~p", [T2a]),
-    ct:pal("routing headers ~p", [mc:routing_headers(Msg2, [x_headers])]),
-
     ok.
 
 header(K, H) ->
@@ -320,7 +316,6 @@ amqpl_amqp_bin_amqpl(_Config) ->
     %% at this point the type is now present as a message annotation
     ?assertEqual({utf8, <<"45">>}, mc:x_header(<<"x-basic-type">>, Msg10)),
     ?assertEqual(RoutingHeaders, mc:routing_headers(Msg10, [])),
-    % ct:pal("Sections ~p", [mc:protocol_state(Msg10Pre)]),
 
     [
      #'v1_0.header'{} = Hdr10,
@@ -345,22 +340,22 @@ amqpl_amqp_bin_amqpl(_Config) ->
     Get = fun(K, AP) -> amqp_map_get(utf8(K), AP) end,
 
 
-    ?assertMatch({long, 99}, Get(<<"a-stream-offset">>, AP10)),
-    ?assertMatch({utf8, <<"a string">>}, Get(<<"a-string">>, AP10)),
-    ?assertMatch({boolean, false}, Get(<<"a-bool">>, AP10)),
-    ?assertMatch({ubyte, 1}, Get(<<"a-unsignedbyte">>, AP10)),
-    ?assertMatch({ushort, 1}, Get(<<"a-unsignedshort">>, AP10)),
-    ?assertMatch({uint, 1}, Get(<<"a-unsignedint">>, AP10)),
-    ?assertMatch({int, 1}, Get(<<"a-signedint">>, AP10)),
-    ?assertMatch({timestamp, 1000}, Get(<<"a-timestamp">>, AP10)),
-    ?assertMatch({double, 1.0}, Get(<<"a-double">>, AP10)),
-    ?assertMatch({float, 1.0}, Get(<<"a-float">>, AP10)),
-    ?assertMatch(undefined, Get(<<"a-void">>, AP10)),
-    ?assertMatch({binary, <<"data">>}, Get(<<"a-binary">>, AP10)),
+    ?assertEqual({long, 99}, Get(<<"a-stream-offset">>, AP10)),
+    ?assertEqual({utf8, <<"a string">>}, Get(<<"a-string">>, AP10)),
+    ?assertEqual({boolean, false}, Get(<<"a-bool">>, AP10)),
+    ?assertEqual({ubyte, 1}, Get(<<"a-unsignedbyte">>, AP10)),
+    ?assertEqual({ushort, 1}, Get(<<"a-unsignedshort">>, AP10)),
+    ?assertEqual({uint, 1}, Get(<<"a-unsignedint">>, AP10)),
+    ?assertEqual({int, 1}, Get(<<"a-signedint">>, AP10)),
+    ?assertEqual({timestamp, 1000}, Get(<<"a-timestamp">>, AP10)),
+    ?assertEqual({double, 1.0}, Get(<<"a-double">>, AP10)),
+    ?assertEqual({float, 1.0}, Get(<<"a-float">>, AP10)),
+    ?assertEqual(undefined, Get(<<"a-void">>, AP10)),
+    ?assertEqual({binary, <<"data">>}, Get(<<"a-binary">>, AP10)),
     %% x-headers do not go into app props
-    ?assertMatch(undefined, Get(<<"x-stream-filter">>, AP10)),
+    ?assertEqual(undefined, Get(<<"x-stream-filter">>, AP10)),
     %% arrays are not converted
-    ?assertMatch(undefined, Get(<<"a-array">>, AP10)),
+    ?assertEqual(undefined, Get(<<"a-array">>, AP10)),
     %% assert properties
 
     MsgL2 = mc:convert(mc_amqpl, Msg10),
@@ -374,7 +369,6 @@ amqpl_amqp_bin_amqpl(_Config) ->
     ?assertEqual({utf8, <<"msg-id">>}, mc:message_id(MsgL2)),
     ?assertEqual(1, mc:ttl(MsgL2)),
     ?assertEqual({utf8, <<"apple">>}, mc:x_header(<<"x-stream-filter">>, MsgL2)),
-    ct:pal("MSGL2 ~p", [MsgL2]),
     ?assertEqual(RoutingHeaders, mc:routing_headers(MsgL2, [])),
     ok.
 
@@ -415,7 +409,7 @@ mc_util_uuid_to_urn_roundtrip(_Config) ->
     UUID = <<88,184,103,176,129,81,31,86,27,212,115,34,152,7,253,96>>,
     S = mc_util:uuid_to_urn_string(UUID),
     ?assertEqual(<<"urn:uuid:58b867b0-8151-1f56-1bd4-73229807fd60">>, S),
-    ?assertMatch({ok, UUID}, mc_util:urn_string_to_uuid(S)),
+    ?assertEqual({ok, UUID}, mc_util:urn_string_to_uuid(S)),
     ok.
 
 do_n(0, _) ->
@@ -467,8 +461,8 @@ amqp_amqpl_amqp_uuid_correlation_id(_Config) ->
     MsgL = mc:convert(mc_amqpl, Msg),
     MsgOut = mc:convert(mc_amqp, MsgL),
 
-    ?assertMatch({uuid, UUID}, mc:correlation_id(MsgOut)),
-    ?assertMatch({uuid, UUID}, mc:message_id(MsgOut)),
+    ?assertEqual({uuid, UUID}, mc:correlation_id(MsgOut)),
+    ?assertEqual({uuid, UUID}, mc:message_id(MsgOut)),
 
     ok.
 
@@ -485,7 +479,6 @@ amqp_amqpl(_Config) ->
            thead2('x-list', list, [utf8(<<"l">>)]),
            thead2('x-map', map, [{utf8(<<"k">>), utf8(<<"v">>)}])
           ],
-    ct:pal("MAC ~p", [MAC]),
     M =  #'v1_0.message_annotations'{content = MAC},
     P = #'v1_0.properties'{content_type = {symbol, <<"ctype">>},
                            content_encoding = {symbol, <<"cenc">>},
@@ -550,8 +543,8 @@ amqp_amqpl(_Config) ->
 
     ?assertMatch({_, longstr, <<"apple">>}, header(<<"x-stream-filter">>, HL)),
     %% these are not coverted as not x- headers
-    ?assertMatch(undefined, header(<<"list">>, HL)),
-    ?assertMatch(undefined, header(<<"map">>, HL)),
+    ?assertEqual(undefined, header(<<"list">>, HL)),
+    ?assertEqual(undefined, header(<<"map">>, HL)),
     ?assertMatch({_ ,array, [{longstr,<<"l">>}]}, header(<<"x-list">>, HL)),
     ?assertMatch({_, table, [{<<"k">>,longstr,<<"v">>}]}, header(<<"x-map">>, HL)),
 
@@ -708,7 +701,6 @@ amqp_amqpl_amqp_bodies(_Config) ->
                           false ->
                               [Payload]
                       end,
-         % ct:pal("ProtoState ~p", [BodySections]),
          ?assertEqual(AssertBody, BodySections)
      end || Payload <- Bodies],
     ok.

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -24,6 +24,7 @@ groups() ->
 
 all_tests() ->
     [
+     mc_util_uuid_to_urn_roundtrip,
      amqpl_defaults,
      amqpl_compat,
      amqpl_table_x_header,
@@ -31,7 +32,13 @@ all_tests() ->
      amqpl_death_records,
      amqpl_amqp_bin_amqpl,
      amqpl_cc_amqp_bin_amqpl,
+     amqp_amqpl_amqp_uuid_correlation_id,
      amqp_amqpl,
+     amqp_amqpl_message_id_ulong,
+     amqp_amqpl_amqp_message_id_uuid,
+     amqp_amqpl_message_id_large,
+     amqp_amqpl_message_id_binary,
+     amqp_amqpl_unsupported_values_not_converted,
      amqp_to_amqpl_data_body,
      amqp_amqpl_amqp_bodies
     ].
@@ -104,7 +111,6 @@ amqpl_compat(_Config) ->
     ?assertEqual({utf8, <<"apple">>}, mc:x_header(<<"x-stream-filter">>, Msg)),
 
     RoutingHeaders = mc:routing_headers(Msg, []),
-    ct:pal("routing headers ~p", [RoutingHeaders]),
     ?assertMatch(#{<<"a-binary">> := <<"data">>,
                    <<"a-bool">> := false,
                    <<"a-double">> := 1.0,
@@ -239,9 +245,6 @@ amqpl_death_records(_Config) ->
     ct:pal("H2 ~p", [T2a]),
     ct:pal("routing headers ~p", [mc:routing_headers(Msg2, [x_headers])]),
 
-
-
-
     ok.
 
 header(K, H) ->
@@ -265,6 +268,7 @@ amqpl_amqp_bin_amqpl(_Config) ->
                                   {<<"a-float">>, float, 1.0},
                                   {<<"a-void">>, void, undefined},
                                   {<<"a-binary">>, binary, <<"data">>},
+                                  {<<"a-array">>, array, [{long, 1}, {long, 2}]},
                                   {<<"x-stream-filter">>, longstr, <<"apple">>}
                                  ],
                        delivery_mode = 2,
@@ -295,7 +299,9 @@ amqpl_amqp_bin_amqpl(_Config) ->
     ?assertEqual(1, mc:ttl(Msg)),
     ?assertEqual({utf8, <<"apple">>}, mc:x_header(<<"x-stream-filter">>, Msg)),
 
-    RoutingHeaders = mc:routing_headers(Msg, []),
+
+    %% array type non x-headers cannot be converted into amqp
+    RoutingHeaders = maps:remove(<<"a-array">>, mc:routing_headers(Msg, [])),
 
     %% roundtrip to binary
     Msg10Pre = mc:convert(mc_amqp, Msg),
@@ -311,7 +317,51 @@ amqpl_amqp_bin_amqpl(_Config) ->
     ?assertEqual({utf8, <<"msg-id">>}, mc:message_id(Msg10)),
     ?assertEqual(1, mc:ttl(Msg10)),
     ?assertEqual({utf8, <<"apple">>}, mc:x_header(<<"x-stream-filter">>, Msg10)),
+    %% at this point the type is now present as a message annotation
+    ?assertEqual({utf8, <<"45">>}, mc:x_header(<<"x-basic-type">>, Msg10)),
     ?assertEqual(RoutingHeaders, mc:routing_headers(Msg10, [])),
+    % ct:pal("Sections ~p", [mc:protocol_state(Msg10Pre)]),
+
+    [
+     #'v1_0.header'{} = Hdr10,
+     #'v1_0.message_annotations'{},
+     #'v1_0.properties'{} = Props10,
+     #'v1_0.application_properties'{content = AP10}
+     | _] = Sections,
+
+    ?assertMatch(#'v1_0.header'{durable = true,
+                                ttl = {uint, 1},
+                                priority = {ubyte, 98}},
+                 Hdr10),
+    ?assertMatch(#'v1_0.properties'{content_encoding = {symbol, <<"gzip">>},
+                                    content_type = {symbol, <<"text/plain">>},
+                                    reply_to = {utf8, <<"reply-to">>},
+                                    creation_time = {timestamp, 99000},
+                                    user_id = {binary, <<"banana">>},
+                                    group_id = {utf8, <<"rmq">>}
+                                   },
+                 Props10),
+
+    Get = fun(K, AP) -> amqp_map_get(utf8(K), AP) end,
+
+
+    ?assertMatch({long, 99}, Get(<<"a-stream-offset">>, AP10)),
+    ?assertMatch({utf8, <<"a string">>}, Get(<<"a-string">>, AP10)),
+    ?assertMatch({boolean, false}, Get(<<"a-bool">>, AP10)),
+    ?assertMatch({ubyte, 1}, Get(<<"a-unsignedbyte">>, AP10)),
+    ?assertMatch({ushort, 1}, Get(<<"a-unsignedshort">>, AP10)),
+    ?assertMatch({uint, 1}, Get(<<"a-unsignedint">>, AP10)),
+    ?assertMatch({int, 1}, Get(<<"a-signedint">>, AP10)),
+    ?assertMatch({timestamp, 1000}, Get(<<"a-timestamp">>, AP10)),
+    ?assertMatch({double, 1.0}, Get(<<"a-double">>, AP10)),
+    ?assertMatch({float, 1.0}, Get(<<"a-float">>, AP10)),
+    ?assertMatch(undefined, Get(<<"a-void">>, AP10)),
+    ?assertMatch({binary, <<"data">>}, Get(<<"a-binary">>, AP10)),
+    %% x-headers do not go into app props
+    ?assertMatch(undefined, Get(<<"x-stream-filter">>, AP10)),
+    %% arrays are not converted
+    ?assertMatch(undefined, Get(<<"a-array">>, AP10)),
+    %% assert properties
 
     MsgL2 = mc:convert(mc_amqpl, Msg10),
 
@@ -324,6 +374,7 @@ amqpl_amqp_bin_amqpl(_Config) ->
     ?assertEqual({utf8, <<"msg-id">>}, mc:message_id(MsgL2)),
     ?assertEqual(1, mc:ttl(MsgL2)),
     ?assertEqual({utf8, <<"apple">>}, mc:x_header(<<"x-stream-filter">>, MsgL2)),
+    ct:pal("MSGL2 ~p", [MsgL2]),
     ?assertEqual(RoutingHeaders, mc:routing_headers(MsgL2, [])),
     ok.
 
@@ -353,8 +404,75 @@ amqpl_cc_amqp_bin_amqpl(_Config) ->
 thead2(T, Value) ->
     {symbol(atom_to_binary(T)), {T, Value}}.
 
+thead2(K, T, Value) ->
+    {symbol(atom_to_binary(K)), {T, Value}}.
+
 thead(T, Value) ->
     {utf8(atom_to_binary(T)), {T, Value}}.
+
+mc_util_uuid_to_urn_roundtrip(_Config) ->
+    %% roundtrip uuid test
+    UUID = <<88,184,103,176,129,81,31,86,27,212,115,34,152,7,253,96>>,
+    S = mc_util:uuid_to_urn_string(UUID),
+    ?assertEqual(<<"urn:uuid:58b867b0-8151-1f56-1bd4-73229807fd60">>, S),
+    ?assertMatch({ok, UUID}, mc_util:urn_string_to_uuid(S)),
+    ok.
+
+do_n(0, _) ->
+    ok;
+do_n(N, Fun) ->
+    Fun(),
+    do_n(N -1, Fun).
+
+amqp_amqpl_unsupported_values_not_converted(_Config) ->
+    LongKey = binary:copy(<<"a">>, 256),
+    UTF8Key = <<"I am a 🐰"/utf8>>,
+    APC = [
+           {{utf8, <<"area">>}, {utf8, <<"East Sussex">>}},
+           {{utf8, LongKey}, {utf8, <<"apple">>}},
+           {{utf8, UTF8Key}, {utf8, <<"dog">>}}
+          ],
+    AP =  #'v1_0.application_properties'{content = APC},
+
+    %% invalid utf8
+    UserId = <<0, "banana"/utf8>>,
+    ?assertEqual(false, mc_util:is_valid_shortstr(UserId)),
+
+    P = #'v1_0.properties'{user_id = {binary, UserId}},
+    D =  #'v1_0.data'{content = <<"data">>},
+
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    Msg = mc:init(mc_amqp, [P, AP, D], Anns),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    #content{properties = #'P_basic'{user_id = undefined,
+                                     headers = HL}} = mc:protocol_state(MsgL),
+    ?assertMatch({_, longstr, <<"East Sussex">>}, header(<<"area">>, HL)),
+    ?assertMatch(undefined, header(LongKey, HL)),
+    %% RabbitMQ does not validate that keys are ascii as per spec
+    %% that's ok after all who really cares?
+    ok.
+
+amqp_amqpl_amqp_uuid_correlation_id(_Config) ->
+    %% ensure uuid correlation ids are correctly roundtripped via urn formatting
+    UUID = crypto:strong_rand_bytes(16),
+
+    P = #'v1_0.properties'{correlation_id = {uuid, UUID},
+                           message_id = {uuid, UUID}},
+    D =  #'v1_0.data'{content = <<"data">>},
+
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    Msg = mc:init(mc_amqp, [P, D], Anns),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    MsgOut = mc:convert(mc_amqp, MsgL),
+
+    ?assertMatch({uuid, UUID}, mc:correlation_id(MsgOut)),
+    ?assertMatch({uuid, UUID}, mc:message_id(MsgOut)),
+
+    ok.
+
+
 
 amqp_amqpl(_Config) ->
     H = #'v1_0.header'{priority = {ubyte, 3},
@@ -362,9 +480,12 @@ amqp_amqpl(_Config) ->
                        durable = true},
     MAC = [
            {{symbol, <<"x-stream-filter">>}, {utf8, <<"apple">>}},
-          thead2(list, [utf8(<<"1">>)]),
-          thead2(map, [{utf8(<<"k">>), utf8(<<"v">>)}])
+           thead2(list, [utf8(<<"l">>)]),
+           thead2(map, [{utf8(<<"k">>), utf8(<<"v">>)}]),
+           thead2('x-list', list, [utf8(<<"l">>)]),
+           thead2('x-map', map, [{utf8(<<"k">>), utf8(<<"v">>)}])
           ],
+    ct:pal("MAC ~p", [MAC]),
     M =  #'v1_0.message_annotations'{content = MAC},
     P = #'v1_0.properties'{content_type = {symbol, <<"ctype">>},
                            content_encoding = {symbol, <<"cenc">>},
@@ -380,6 +501,7 @@ amqp_amqpl(_Config) ->
           thead(ulong, 5),
           thead(utf8, <<"a-string">>),
           thead(binary, <<"data">>),
+          thead(symbol, <<"symbol">>),
           thead(ubyte, 1),
           thead(short, 2),
           thead(ushort, 3),
@@ -390,6 +512,7 @@ amqp_amqpl(_Config) ->
           thead(timestamp, 7000),
           thead(byte, 128),
           thead(boolean, true),
+          {{utf8, <<"boolean2">>}, false},
           {utf8(<<"null">>), null}
          ],
     A =  #'v1_0.application_properties'{content = AC},
@@ -411,8 +534,10 @@ amqp_amqpl(_Config) ->
     ?assertEqual(3, mc:priority(MsgL)),
     ?assertEqual(true, mc:is_persistent(MsgL)),
     ?assertEqual({utf8, <<"msg-id">>}, mc:message_id(MsgL)),
-    #content{properties = #'P_basic'{headers = HL} = Props} = Content = mc:protocol_state(MsgL),
+    #content{properties = #'P_basic'{headers = HL} = Props} = Content =
+        mc:protocol_state(MsgL),
 
+    %% the user id is valid utf8 shortstr
     ?assertMatch(#'P_basic'{user_id = <<"user-id">>}, Props),
     ?assertMatch(#'P_basic'{reply_to = <<"reply-to">>}, Props),
     ?assertMatch(#'P_basic'{content_type = <<"ctype">>}, Props),
@@ -424,11 +549,17 @@ amqp_amqpl(_Config) ->
     ?assertMatch(#'P_basic'{expiration = <<"20000">>}, Props),
 
     ?assertMatch({_, longstr, <<"apple">>}, header(<<"x-stream-filter">>, HL)),
+    %% these are not coverted as not x- headers
+    ?assertMatch(undefined, header(<<"list">>, HL)),
+    ?assertMatch(undefined, header(<<"map">>, HL)),
+    ?assertMatch({_ ,array, [{longstr,<<"l">>}]}, header(<<"x-list">>, HL)),
+    ?assertMatch({_, table, [{<<"k">>,longstr,<<"v">>}]}, header(<<"x-map">>, HL)),
 
     ?assertMatch({_, long, 5}, header(<<"long">>, HL)),
     ?assertMatch({_, long, 5}, header(<<"ulong">>, HL)),
     ?assertMatch({_, longstr, <<"a-string">>}, header(<<"utf8">>, HL)),
     ?assertMatch({_, binary, <<"data">>}, header(<<"binary">>, HL)),
+    ?assertMatch({_, longstr, <<"symbol">>}, header(<<"symbol">>, HL)),
     ?assertMatch({_, unsignedbyte, 1}, header(<<"ubyte">>, HL)),
     ?assertMatch({_, short, 2}, header(<<"short">>, HL)),
     ?assertMatch({_, unsignedshort, 3}, header(<<"ushort">>, HL)),
@@ -439,6 +570,7 @@ amqp_amqpl(_Config) ->
     ?assertMatch({_, timestamp, 7}, header(<<"timestamp">>, HL)),
     ?assertMatch({_, byte, 128}, header(<<"byte">>, HL)),
     ?assertMatch({_, bool, true}, header(<<"boolean">>, HL)),
+    ?assertMatch({_, bool, false}, header(<<"boolean2">>, HL)),
     ?assertMatch({_, void, undefined}, header(<<"null">>, HL)),
 
     %% validate content is serialisable
@@ -446,6 +578,79 @@ amqp_amqpl(_Config) ->
                                                             1000000,
                                                             rabbit_framing_amqp_0_9_1),
 
+    ok.
+
+amqp_amqpl_message_id_ulong(_Config) ->
+    Num = 9876789,
+    ULong = erlang:integer_to_binary(Num),
+    P = #'v1_0.properties'{message_id = {ulong, Num},
+                           correlation_id = {ulong, Num}},
+    D =  #'v1_0.data'{content = <<"data">>},
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    Msg = mc:init(mc_amqp, [P, D], Anns),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    ?assertEqual({utf8, ULong}, mc:message_id(MsgL)),
+    ?assertEqual({utf8, ULong}, mc:correlation_id(MsgL)),
+    #content{properties = #'P_basic'{} = Props} = mc:protocol_state(MsgL),
+    ?assertMatch(#'P_basic'{message_id = ULong,
+                            correlation_id = ULong}, Props),
+    %% NB we can't practically roundtrip ulong correlation ids
+    ok.
+
+amqp_amqpl_amqp_message_id_uuid(_Config) ->
+    %% uuid message-ids are roundtripped using a urn uuid format
+    UUId = crypto:strong_rand_bytes(16),
+    Urn = mc_util:uuid_to_urn_string(UUId),
+    P = #'v1_0.properties'{message_id = {uuid, UUId},
+                           correlation_id = {uuid, UUId}},
+    D =  #'v1_0.data'{content = <<"data">>},
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    Msg = mc:init(mc_amqp, [P, D], Anns),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    ?assertEqual({utf8, Urn}, mc:message_id(MsgL)),
+    ?assertEqual({utf8, Urn}, mc:correlation_id(MsgL)),
+    #content{properties = #'P_basic'{} = Props} = mc:protocol_state(MsgL),
+    ?assertMatch(#'P_basic'{message_id = Urn,
+                            correlation_id = Urn}, Props),
+    %% check roundtrip back
+    Msg2 = mc:convert(mc_amqp, MsgL),
+    ?assertEqual({uuid, UUId}, mc:message_id(Msg2)),
+    ?assertEqual({uuid, UUId}, mc:correlation_id(Msg2)),
+    ok.
+
+
+amqp_amqpl_message_id_large(_Config) ->
+    Orig = binary:copy(<<"hi">>, 256),
+    P = #'v1_0.properties'{message_id = {utf8, Orig},
+                           correlation_id = {utf8, Orig}},
+    D =  #'v1_0.data'{content = <<"data">>},
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    Msg = mc:init(mc_amqp, [P, D], Anns),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    ?assertEqual(undefined, mc:message_id(MsgL)),
+    ?assertEqual(undefined, mc:correlation_id(MsgL)),
+    #content{properties = #'P_basic'{headers = Hdrs}} = mc:protocol_state(MsgL),
+    ?assertMatch({_, longstr, Orig}, header(<<"x-message-id">>, Hdrs)),
+    ?assertMatch({_, longstr, Orig}, header(<<"x-correlation-id">>, Hdrs)),
+    ok.
+
+amqp_amqpl_message_id_binary(_Config) ->
+    Orig = crypto:strong_rand_bytes(128),
+    P = #'v1_0.properties'{message_id = {binary, Orig},
+                           correlation_id = {binary, Orig}},
+    D =  #'v1_0.data'{content = <<"data">>},
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    Msg = mc:init(mc_amqp, [P, D], Anns),
+    MsgL = mc:convert(mc_amqpl, Msg),
+    ?assertEqual(undefined, mc:message_id(MsgL)),
+    ?assertEqual(undefined, mc:correlation_id(MsgL)),
+    #content{properties = #'P_basic'{headers = Hdrs}} = mc:protocol_state(MsgL),
+    ?assertMatch({_, binary, Orig}, header(<<"x-message-id">>, Hdrs)),
+    ?assertMatch({_, binary, Orig}, header(<<"x-correlation-id">>, Hdrs)),
     ok.
 
 amqp_to_amqpl_data_body(_Config) ->
@@ -508,172 +713,12 @@ amqp_amqpl_amqp_bodies(_Config) ->
      end || Payload <- Bodies],
     ok.
 
-unsupported_091_header_is_dropped(_Config) ->
-    Props = #'P_basic'{
-                       headers = [
-                                  {<<"x-received-from">>, array, []}
-                                 ]
-                      },
-    MsgRecord0 = rabbit_msg_record:from_amqp091(Props, <<"payload">>),
-    MsgRecord = rabbit_msg_record:init(
-                  iolist_to_binary(rabbit_msg_record:to_iodata(MsgRecord0))),
-    % meck:unload(),
-    {PropsOut, <<"payload">>} = rabbit_msg_record:to_amqp091(MsgRecord),
-
-    ?assertMatch(#'P_basic'{headers = undefined}, PropsOut),
-
-    ok.
-
-message_id_ulong(_Config) ->
-    Num = 9876789,
-    ULong = erlang:integer_to_binary(Num),
-    P = #'v1_0.properties'{message_id = {ulong, Num},
-                           correlation_id = {ulong, Num}},
-    D =  #'v1_0.data'{content = <<"data">>},
-    Bin = [amqp10_framing:encode_bin(P),
-           amqp10_framing:encode_bin(D)],
-    R = rabbit_msg_record:init(iolist_to_binary(Bin)),
-    {Props, _} = rabbit_msg_record:to_amqp091(R),
-    ?assertMatch(#'P_basic'{message_id = ULong,
-                            correlation_id = ULong,
-                            headers =
-                            [
-                             %% ordering shouldn't matter
-                             {<<"x-correlation-id-type">>, longstr, <<"ulong">>},
-                             {<<"x-message-id-type">>, longstr, <<"ulong">>}
-                            ]},
-                 Props),
-    ok.
-
-message_id_uuid(_Config) ->
-    %% fake a uuid
-    UUId = erlang:md5(term_to_binary(make_ref())),
-    TextUUId = rabbit_data_coercion:to_binary(rabbit_guid:to_string(UUId)),
-    P = #'v1_0.properties'{message_id = {uuid, UUId},
-                           correlation_id = {uuid, UUId}},
-    D =  #'v1_0.data'{content = <<"data">>},
-    Bin = [amqp10_framing:encode_bin(P),
-           amqp10_framing:encode_bin(D)],
-    R = rabbit_msg_record:init(iolist_to_binary(Bin)),
-    {Props, _} = rabbit_msg_record:to_amqp091(R),
-    ?assertMatch(#'P_basic'{message_id = TextUUId,
-                            correlation_id = TextUUId,
-                            headers =
-                            [
-                             %% ordering shouldn't matter
-                             {<<"x-correlation-id-type">>, longstr, <<"uuid">>},
-                             {<<"x-message-id-type">>, longstr, <<"uuid">>}
-                            ]},
-                 Props),
-    ok.
-
-message_id_binary(_Config) ->
-    %% fake a uuid
-    Orig = <<"asdfasdf">>,
-    Text = base64:encode(Orig),
-    P = #'v1_0.properties'{message_id = {binary, Orig},
-                           correlation_id = {binary, Orig}},
-    D =  #'v1_0.data'{content = <<"data">>},
-    Bin = [amqp10_framing:encode_bin(P),
-           amqp10_framing:encode_bin(D)],
-    R = rabbit_msg_record:init(iolist_to_binary(Bin)),
-    {Props, _} = rabbit_msg_record:to_amqp091(R),
-    ?assertMatch(#'P_basic'{message_id = Text,
-                            correlation_id = Text,
-                            headers =
-                            [
-                             %% ordering shouldn't matter
-                             {<<"x-correlation-id-type">>, longstr, <<"binary">>},
-                             {<<"x-message-id-type">>, longstr, <<"binary">>}
-                            ]},
-                 Props),
-    ok.
-
-message_id_large_binary(_Config) ->
-    %% cannot fit in a shortstr
-    Orig = crypto:strong_rand_bytes(500),
-    P = #'v1_0.properties'{message_id = {binary, Orig},
-                           correlation_id = {binary, Orig}},
-    D =  #'v1_0.data'{content = <<"data">>},
-    Bin = [amqp10_framing:encode_bin(P),
-           amqp10_framing:encode_bin(D)],
-    R = rabbit_msg_record:init(iolist_to_binary(Bin)),
-    {Props, _} = rabbit_msg_record:to_amqp091(R),
-    ?assertMatch(#'P_basic'{message_id = undefined,
-                            correlation_id = undefined,
-                            headers =
-                            [
-                             %% ordering shouldn't matter
-                             {<<"x-correlation-id">>, longstr, Orig},
-                             {<<"x-message-id">>, longstr, Orig}
-                            ]},
-                 Props),
-    ok.
-
-message_id_large_string(_Config) ->
-    %% cannot fit in a shortstr
-    Orig = base64:encode(crypto:strong_rand_bytes(500)),
-    P = #'v1_0.properties'{message_id = {utf8, Orig},
-                           correlation_id = {utf8, Orig}},
-    D =  #'v1_0.data'{content = <<"data">>},
-    Bin = [amqp10_framing:encode_bin(P),
-           amqp10_framing:encode_bin(D)],
-    R = rabbit_msg_record:init(iolist_to_binary(Bin)),
-    {Props, _} = rabbit_msg_record:to_amqp091(R),
-    ?assertMatch(#'P_basic'{message_id = undefined,
-                            correlation_id = undefined,
-                            headers =
-                            [
-                             %% ordering shouldn't matter
-                             {<<"x-correlation-id">>, longstr, Orig},
-                             {<<"x-message-id">>, longstr, Orig}
-                            ]},
-                 Props),
-    ok.
-
-reuse_amqp10_binary_chunks(_Config) ->
-    Amqp10MsgAnnotations = #'v1_0.message_annotations'{content =
-                                                       [{{symbol, <<"x-route">>}, {utf8, <<"dummy">>}}]},
-    Amqp10MsgAnnotationsBin = amqp10_encode_bin(Amqp10MsgAnnotations),
-    Amqp10Props = #'v1_0.properties'{group_id = {utf8, <<"my-group">>},
-                                     group_sequence = {uint, 42}},
-    Amqp10PropsBin = amqp10_encode_bin(Amqp10Props),
-    Amqp10AppProps = #'v1_0.application_properties'{content = [{{utf8, <<"foo">>}, {utf8, <<"bar">>}}]},
-    Amqp10AppPropsBin = amqp10_encode_bin(Amqp10AppProps),
-    Amqp091Headers = [{<<"x-amqp-1.0-message-annotations">>, longstr, Amqp10MsgAnnotationsBin},
-                      {<<"x-amqp-1.0-properties">>, longstr, Amqp10PropsBin},
-                      {<<"x-amqp-1.0-app-properties">>, longstr, Amqp10AppPropsBin}],
-    Amqp091Props = #'P_basic'{type= <<"amqp-1.0">>, headers = Amqp091Headers},
-    Body = #'v1_0.amqp_value'{content = {utf8, <<"hello world">>}},
-    EncodedBody = amqp10_encode_bin(Body),
-    R = rabbit_msg_record:from_amqp091(Amqp091Props, EncodedBody),
-    RBin = rabbit_msg_record:to_iodata(R),
-    Amqp10DecodedMsg = amqp10_framing:decode_bin(iolist_to_binary(RBin)),
-    [Amqp10DecodedMsgAnnotations, Amqp10DecodedProps,
-     Amqp10DecodedAppProps, DecodedBody] = Amqp10DecodedMsg,
-    ?assertEqual(Amqp10MsgAnnotations, Amqp10DecodedMsgAnnotations),
-    ?assertEqual(Amqp10Props, Amqp10DecodedProps),
-    ?assertEqual(Amqp10AppProps, Amqp10DecodedAppProps),
-    ?assertEqual(Body, DecodedBody),
-    ok.
-
 amqp10_encode_bin(L) when is_list(L) ->
     [iolist_to_binary(amqp10_framing:encode_bin(X)) || X <- L];
 amqp10_encode_bin(X) ->
     [iolist_to_binary(amqp10_framing:encode_bin(X))].
 
 %% Utility
-
-test_amqp091_roundtrip(Props, Payload) ->
-    MsgRecord0 = rabbit_msg_record:from_amqp091(Props, Payload),
-    MsgRecord = rabbit_msg_record:init(
-                  iolist_to_binary(rabbit_msg_record:to_iodata(MsgRecord0))),
-    % meck:unload(),
-    {PropsOut, PayloadOut} = rabbit_msg_record:to_amqp091(MsgRecord),
-    ?assertEqual(Props, PropsOut),
-    ?assertEqual(iolist_to_binary(Payload),
-                 iolist_to_binary(PayloadOut)),
-    ok.
 
 utf8(V) ->
     {utf8, V}.
@@ -682,3 +727,13 @@ symbol(V) ->
 
 amqp_serialize(Msg) ->
     mc_amqp:serialize(mc:protocol_state(Msg)).
+
+amqp_map_get(_K, []) ->
+    undefined;
+amqp_map_get(K, Tuples) ->
+    case lists:keyfind(K, 1, Tuples) of
+        false ->
+            undefined;
+        {_, V}  ->
+            V
+    end.

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2081,9 +2081,8 @@ leader_locator_client_local(Config) ->
                  declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                               {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
 
-    Info = find_queue_info(Config, [leader]),
-
-    ?assertEqual(Server1, proplists:get_value(leader, Info)),
+    ?assertMatch(Server1, proplists:get_value(leader,
+                                              find_queue_info(Config, [leader]))),
 
     ?assertMatch(#'queue.delete_ok'{},
                  delete(Config, Server1, Q)),
@@ -2093,8 +2092,8 @@ leader_locator_client_local(Config) ->
                  declare(Config, Server2, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                               {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
 
-    Info2 = find_queue_info(Config, [leader]),
-    ?assertEqual(Server2, proplists:get_value(leader, Info2)),
+    ?assertMatch(Server2, proplists:get_value(leader,
+                                              find_queue_info(Config, [leader]))),
 
     ?assertMatch(#'queue.delete_ok'{}, delete(Config, Server2, Q)),
 
@@ -2104,8 +2103,8 @@ leader_locator_client_local(Config) ->
                                               {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
 
 
-    Info3 = find_queue_info(Config, [leader]),
-    ?assertEqual(Server3, proplists:get_value(leader, Info3)),
+    ?assertEqual(Server3, proplists:get_value(leader,
+                                              find_queue_info(Config, [leader]))),
 
     ?assertMatch(#'queue.delete_ok'{}, delete(Config, Server3, Q)),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -82,7 +82,6 @@
 -export([safe_ets_update_counter/3, safe_ets_update_counter/4, safe_ets_update_counter/5,
          safe_ets_update_element/3, safe_ets_update_element/4, safe_ets_update_element/5]).
 -export([is_even/1, is_odd/1]).
--export([is_valid_shortstr/1]).
 
 -export([maps_any/2,
          maps_put_truthy/3,
@@ -1596,21 +1595,6 @@ is_even(N) ->
 -spec is_odd(integer()) -> boolean().
 is_odd(N) ->
     (N band 1) =:= 1.
-
--spec is_valid_shortstr(term()) -> boolean().
-is_valid_shortstr(Bin) when byte_size(Bin) < 256 ->
-    is_utf8_no_null(Bin);
-is_valid_shortstr(_) ->
-    false.
-
-is_utf8_no_null(<<>>) ->
-    true;
-is_utf8_no_null(<<0, _/binary>>) ->
-    false;
-is_utf8_no_null(<<_/utf8, Rem/binary>>) ->
-    is_utf8_no_null(Rem);
-is_utf8_no_null(_) ->
-    false.
 
 -spec maps_put_truthy(Key, Value, Map) -> Map when
       Map :: #{Key => Value}.

--- a/deps/rabbitmq_mqtt/app.bzl
+++ b/deps/rabbitmq_mqtt/app.bzl
@@ -351,7 +351,7 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         hdrs = ["include/rabbit_mqtt_packet.hrl"],
         app_name = "rabbitmq_mqtt",
         erlc_opts = "//:test_erlc_opts",
-        deps = ["//deps/amqp10_common:erlang_app"],
+        deps = ["//deps/amqp10_common:erlang_app", "//deps/rabbit_common:erlang_app"],
     )
     erlang_bytecode(
         name = "protocol_interop_SUITE_beam_files",

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -10,6 +10,7 @@
 -define(QUEUE_TYPE_QOS_0, rabbit_mqtt_qos0_queue).
 -define(PERSISTENT_TERM_MAILBOX_SOFT_LIMIT, mqtt_mailbox_soft_limit).
 -define(PERSISTENT_TERM_EXCHANGE, mqtt_exchange).
+-define(DEFAULT_MQTT_EXCHANGE, <<"amq.topic">>).
 -define(MQTT_GUIDE_URL, <<"https://rabbitmq.com/mqtt.html">>).
 
 -define(MQTT_PROTO_V3, mqtt310).

--- a/deps/rabbitmq_mqtt/src/mc_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/mc_mqtt.erl
@@ -397,7 +397,12 @@ x_header(_Key, #mqtt_msg{}) ->
     undefined.
 
 property(correlation_id, #mqtt_msg{props = #{'Correlation-Data' := Corr}}) ->
-    {binary, Corr};
+    case mc_util:urn_string_to_uuid(Corr) of
+        {ok, UUId} ->
+            {uuid, UUId};
+        _ ->
+            {binary, Corr}
+    end;
 property(_Key, #mqtt_msg{}) ->
     undefined.
 

--- a/deps/rabbitmq_mqtt/src/mc_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/mc_mqtt.erl
@@ -1,15 +1,14 @@
 -module(mc_mqtt).
 -behaviour(mc).
 
--include("rabbit_mqtt_packet.hrl").
 -include("rabbit_mqtt.hrl").
+-include("rabbit_mqtt_packet.hrl").
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit/include/mc.hrl").
 
 -define(CONTENT_TYPE_AMQP, <<"message/vnd.rabbitmq.amqp">>).
--define(DEFAULT_MQTT_EXCHANGE, <<"amq.topic">>).
 
 -export([
          init/1,
@@ -17,8 +16,8 @@
          x_header/2,
          property/2,
          routing_headers/2,
-         convert_to/2,
-         convert_from/2,
+         convert_to/3,
+         convert_from/3,
          protocol_state/2,
          prepare/2
         ]).
@@ -52,7 +51,7 @@ init(Msg = #mqtt_msg{qos = Qos,
            end,
     {Msg, Anns}.
 
-convert_from(mc_amqp, Sections) ->
+convert_from(mc_amqp, Sections, Env) ->
     {Header, MsgAnns, AmqpProps, AppProps, PayloadRev,
      PayloadFormatIndicator, ContentType} =
     lists:foldl(
@@ -93,12 +92,15 @@ convert_from(mc_amqp, Sections) ->
              end,
     Props1 = case AmqpProps of
                  #'v1_0.properties'{reply_to = {utf8, Address}} ->
-                     MqttX = persistent_term:get(?PERSISTENT_TERM_EXCHANGE),
+                     % MqttX = persistent_term:get(?PERSISTENT_TERM_EXCHANGE),
+                     MqttX = maps:get(mqtt_exchange, Env, ?DEFAULT_MQTT_EXCHANGE),
                      case Address of
-                         <<"/topic/", Topic/binary>>
-                           when MqttX =:= ?DEFAULT_MQTT_EXCHANGE ->
-                             add_response_topic(Topic, Props0);
-                         <<"/exchange/", MqttX:(byte_size(MqttX))/binary, "/", RoutingKey/binary>> ->
+                         % <<"/topic/", Topic/binary>>
+                         %   when MqttX =:= ?DEFAULT_MQTT_EXCHANGE ->
+                         %     add_response_topic(Topic, Props0);
+                         <<"/exchange/",
+                           MqttX:(byte_size(MqttX))/binary, "/",
+                           RoutingKey/binary>> ->
                              add_response_topic(RoutingKey, Props0);
                          _ ->
                              Props0
@@ -143,7 +145,8 @@ convert_from(mc_amqp, Sections) ->
               props = Props,
               payload = Payload};
 convert_from(mc_amqpl, #content{properties = PBasic,
-                                payload_fragments_rev = Payload}) ->
+                                payload_fragments_rev = Payload},
+            _Env) ->
     #'P_basic'{expiration = Expiration,
                delivery_mode = DelMode,
                headers = H0,
@@ -196,14 +199,14 @@ convert_from(mc_amqpl, #content{properties = PBasic,
               dup = false,
               payload = lists:reverse(Payload),
               props = P};
-convert_from(_SourceProto, _) ->
+convert_from(_SourceProto, _, _) ->
     not_implemented.
 
-convert_to(?MODULE, Msg) ->
+convert_to(?MODULE, Msg, _Env) ->
     Msg;
 convert_to(mc_amqp, #mqtt_msg{qos = Qos,
                               props = Props,
-                              payload = Payload}) ->
+                              payload = Payload}, Env) ->
     Body = case Props of
                #{'Payload-Format-Indicator' := 1}
                  when is_binary(Payload) ->
@@ -233,7 +236,8 @@ convert_to(mc_amqp, #mqtt_msg{qos = Qos,
                                         Acc
                                 end;
                            ({Name, Val}, {MAnns, AProps, M}) ->
-                                {MAnns, [{{utf8, Name}, {utf8, Val}} | AProps], M#{Name => true}}
+                                {MAnns, [{{utf8, Name}, {utf8, Val}} | AProps],
+                                 M#{Name => true}}
                         end, {[], [], #{}}, UserProps),
             {lists:reverse(MsgAnnsRev), lists:reverse(AppPropsRev)};
         _ ->
@@ -257,19 +261,20 @@ convert_to(mc_amqp, #mqtt_msg{qos = Qos,
                   end,
     CorrId = case Props of
                  #{'Correlation-Data' := Corr} ->
-                     {binary, Corr};
+                     case mc_util:urn_string_to_uuid(Corr) of
+                         {ok, MsgUUID} ->
+                             {uuid, MsgUUID};
+                         _ ->
+                             {binary, Corr}
+                     end;
                  _ ->
                      undefined
              end,
     ReplyTo = case Props of
                   #{'Response-Topic' := MqttTopic} ->
+                      Exchange = maps:get(mqtt_exchange, Env, ?DEFAULT_MQTT_EXCHANGE),
                       Topic = rabbit_mqtt_util:mqtt_to_amqp(MqttTopic),
-                      Address = case persistent_term:get(?PERSISTENT_TERM_EXCHANGE) of
-                                    ?DEFAULT_MQTT_EXCHANGE ->
-                                        <<"/topic/", Topic/binary>>;
-                                    Exchange ->
-                                        <<"/exchange/", Exchange/binary, "/", Topic/binary>>
-                                end,
+                      Address = <<"/exchange/", Exchange/binary, "/", Topic/binary>>,
                       {utf8, Address};
                   _ ->
                       undefined
@@ -288,23 +293,31 @@ convert_to(mc_amqp, #mqtt_msg{qos = Qos,
              _ -> [#'v1_0.message_annotations'{content = MsgAnns} | S2]
          end,
     S = [#'v1_0.header'{durable = Qos > 0} | S3],
-    mc_amqp:convert_from(mc_amqp, S);
+    mc_amqp:convert_from(mc_amqp, S, Env);
 convert_to(mc_amqpl, #mqtt_msg{qos = Qos,
                                props = Props,
-                               payload = Payload}) ->
+                               payload = Payload}, _Env) ->
     DelMode = case Qos of
                   ?QOS_0 -> 1;
                   ?QOS_1 -> 2
               end,
     ContentType = case Props of
-                      #{'Content-Type' := ContType} -> ContType;
-                      _ -> undefined
+                      #{'Content-Type' := ContType}
+                        when ?IS_SHORTSTR_LEN(ContType)->
+                          case mc_util:utf8_string_is_ascii(ContType) of
+                              true ->
+                                  ContType;
+                              false ->
+                                  undefined
+                          end;
+                      _ ->
+                          undefined
                   end,
     Hs0 = case Props of
               #{'User-Property' := UserProperty} ->
                   lists:filtermap(
                     fun({Name, Value})
-                          when byte_size(Name) =< ?AMQP_LEGACY_FIELD_NAME_MAX_LEN ->
+                          when ?IS_SHORTSTR_LEN(Name) ->
                             {true, {Name, longstr, Value}};
                        (_) ->
                             false
@@ -356,7 +369,7 @@ convert_to(mc_amqpl, #mqtt_msg{qos = Qos,
              properties = BP,
              properties_bin = none,
              payload_fragments_rev = PFR};
-convert_to(_TargetProto, #mqtt_msg{}) ->
+convert_to(_TargetProto, #mqtt_msg{}, _Env) ->
     not_implemented.
 
 size(#mqtt_msg{payload = Payload,
@@ -421,17 +434,21 @@ protocol_state(Msg = #mqtt_msg{props = Props0,
                             Props2;
                         Timestamp ->
                             SourceProtocolIsMqtt = Topic =/= undefined,
-                            %% Only if source protocol is MQTT we know that timestamp was set by the server.
+                            %% Only if source protocol is MQTT we know that
+                            %% timestamp was set by the server.
                             case SourceProtocolIsMqtt of
                                 false ->
                                     Props2;
                                 true ->
-                                    %% "The PUBLISH packet sent to a Client by the Server MUST contain a
-                                    %% Message Expiry Interval set to the received value minus the time that
-                                    %% the Application Message has been waiting in the Server" [MQTT-3.3.2-6]
+                                    %% "The PUBLISH packet sent to a Client by
+                                    %% the Server MUST contain a
+                                    %% Message Expiry Interval set to the received
+                                    %% value minus the time that
+                                    %% the Application Message has been waiting
+                                    %% in the Server" [MQTT-3.3.2-6]
                                     WaitingMillis0 = os:system_time(millisecond) - Timestamp,
-                                    %% For a delayed Will Message, the waiting time starts
-                                    %% when the Will Message was published.
+                                    %% For a delayed Will Message, the waiting
+                                    %% time starts when the Will Message was published.
                                     WaitingMillis = WaitingMillis0 - WillDelay * 1000,
                                     MEIMillis = max(0, Ttl - WaitingMillis),
                                     Props2#{'Message-Expiry-Interval' => MEIMillis div 1000}
@@ -446,7 +463,7 @@ prepare(_For, #mqtt_msg{} = Msg) ->
     Msg.
 
 correlation_id({uuid, UUID}) ->
-    mc_util:uuid_to_string(UUID);
+    mc_util:uuid_to_urn_string(UUID);
 correlation_id({_T, Corr}) ->
     rabbit_data_coercion:to_binary(Corr).
 
@@ -496,6 +513,9 @@ filter_map_amqp_to_utf8_string(Key, TypeVal) ->
     end.
 
 amqp_to_utf8_string({utf8, Val})
+  when is_binary(Val) ->
+    Val;
+amqp_to_utf8_string({symbol, Val})
   when is_binary(Val) ->
     Val;
 amqp_to_utf8_string(Val)

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1550,9 +1550,16 @@ publish_to_queues(
                     trace_state = TraceState},
          auth_state = #auth_state{user = #user{username = Username}}} = State) ->
 
+    Env = case persistent_term:get(?PERSISTENT_TERM_EXCHANGE) of
+              ?DEFAULT_MQTT_EXCHANGE ->
+                  #{};
+              MqttX ->
+                  #{mqtt_exchange => MqttX}
+          end,
+
     Anns = #{exchange => ExchangeNameBin,
              routing_keys => [mqtt_to_amqp(Topic)]},
-    Msg0 = mc:init(mc_mqtt, MqttMsg, Anns),
+    Msg0 = mc:init(mc_mqtt, MqttMsg, Anns, Env),
     Msg = rabbit_message_interceptor:intercept(Msg0),
     case rabbit_exchange:lookup(ExchangeName) of
         {ok, Exchange} ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1549,17 +1549,9 @@ publish_to_queues(
                     conn_name = ConnName,
                     trace_state = TraceState},
          auth_state = #auth_state{user = #user{username = Username}}} = State) ->
-
-    Env = case persistent_term:get(?PERSISTENT_TERM_EXCHANGE) of
-              ?DEFAULT_MQTT_EXCHANGE ->
-                  #{};
-              MqttX ->
-                  #{mqtt_exchange => MqttX}
-          end,
-
     Anns = #{exchange => ExchangeNameBin,
              routing_keys => [mqtt_to_amqp(Topic)]},
-    Msg0 = mc:init(mc_mqtt, MqttMsg, Anns, Env),
+    Msg0 = mc:init(mc_mqtt, MqttMsg, Anns, mc_env()),
     Msg = rabbit_message_interceptor:intercept(Msg0),
     case rabbit_exchange:lookup(ExchangeName) of
         {ok, Exchange} ->
@@ -1788,7 +1780,7 @@ maybe_send_will(
                        _ ->
                            Anns0
                    end,
-            Msg = mc:init(mc_mqtt, MqttMsg, Anns),
+            Msg = mc:init(mc_mqtt, MqttMsg, Anns, mc_env()),
             case check_publish_permitted(DefaultX, Topic, State) of
                 ok ->
                     ok = rabbit_queue_type:publish_at_most_once(DefaultX, Msg),
@@ -2040,7 +2032,7 @@ deliver_one_to_client({QNameOrType, QPid, QMsgId, _Redelivered, Mc} = Delivery,
                         true -> ?QOS_1;
                         false -> ?QOS_0
                     end,
-    McMqtt = mc:convert(mc_mqtt, Mc),
+    McMqtt = mc:convert(mc_mqtt, Mc, mc_env()),
     MqttMsg = #mqtt_msg{qos = PublisherQos} = mc:protocol_state(McMqtt),
     QoS = effective_qos(PublisherQos, SubscriberQoS),
     {SettleOp, State1} = maybe_publish_to_client(MqttMsg, Delivery, QoS, State0),
@@ -2543,6 +2535,14 @@ format_status(
       ra_register_state => RaRegisterState,
       queues_soft_limit_exceeded => QSLE,
       qos0_messages_dropped => Qos0MsgsDropped}.
+
+mc_env() ->
+    case persistent_term:get(?PERSISTENT_TERM_EXCHANGE) of
+        ?DEFAULT_MQTT_EXCHANGE ->
+            #{};
+        MqttX ->
+            #{mqtt_x => MqttX}
+    end.
 
 -spec compat(mc:state(), state()) -> mc:state().
 compat(McMqtt, #state{cfg = #cfg{exchange = XName}}) ->

--- a/deps/rabbitmq_mqtt/test/mc_mqtt_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mc_mqtt_SUITE.erl
@@ -11,13 +11,12 @@
 
 all() ->
     [
-     {group, lossless},
-     {group, lossy}
+     {group, tests}
     ].
 
 groups() ->
     [
-     {lossless, [shuffle],
+     {tests, [shuffle],
       [roundtrip_amqp,
        roundtrip_amqp_payload_format_indicator,
        roundtrip_amqp_response_topic,
@@ -27,11 +26,8 @@ groups() ->
        amqp_to_mqtt_amqp_value_section_list,
        amqp_to_mqtt_amqp_value_section_null,
        amqp_to_mqtt_amqp_value_section_int,
-       amqp_to_mqtt_amqp_value_section_boolean
-      ]
-     },
-     {lossy, [shuffle],
-      [roundtrip_amqp_user_property,
+       amqp_to_mqtt_amqp_value_section_boolean,
+       roundtrip_amqp_user_property,
        roundtrip_amqpl_user_property,
        roundtrip_amqp_content_type,
        amqp_to_mqtt_reply_to,
@@ -41,8 +37,7 @@ groups() ->
        mqtt_amqp,
        mqtt_amqp_alt,
        amqp_mqtt
-      ]
-     }
+      ]}
     ].
 
 roundtrip_amqp(_Config) ->
@@ -126,7 +121,7 @@ roundtrip_amqp_payload_format_indicator(_Config) ->
 roundtrip_amqp_response_topic(_Config) ->
     Topic = <<"/rabbit/🐇"/utf8>>,
     Msg0 = mqtt_msg(),
-    Key = mqtt_exchange,
+    Key = mqtt_x,
     MqttExchanges = [<<"amq.topic">>,
                      <<"some-other-topic-exchange">>],
     [begin
@@ -275,7 +270,7 @@ roundtrip_amqp_content_type(_Config) ->
 
 amqp_to_mqtt_reply_to(_Config) ->
     Val = amqp_value({utf8, <<"hey">>}),
-    Key = mqtt_exchange,
+    Key = mqtt_x,
     Env = #{Key => <<"mqtt-topic-exchange">>},
     AmqpProps1 = #'v1_0.properties'{reply_to = {utf8, <<"/exchange/mqtt-topic-exchange/my.routing.key">>}},
     #mqtt_msg{props = Props1} = amqp_to_mqtt([AmqpProps1, Val], Env),
@@ -350,7 +345,7 @@ mqtt_amqpl_alt(_Config) ->
     ok.
 
 mqtt_amqp(_Config) ->
-    Key = mqtt_exchange,
+    Key = mqtt_x,
     Ex = <<"mqtt-topic-exchange">>,
     Env =  #{Key => <<"mqtt-topic-exchange">>},
     Mqtt0 = mqtt_msg(),
@@ -390,7 +385,7 @@ mqtt_amqp(_Config) ->
     ok.
 
 mqtt_amqp_alt(_Config) ->
-    Key = mqtt_exchange,
+    Key = mqtt_x,
     Ex = <<"mqtt-topic-exchange">>,
     Env = #{Key => <<"mqtt-topic-exchange">>},
     CorrId = <<"urn:uuid:550e8400-e29b-41d4-a716-446655440000">>,
@@ -432,7 +427,7 @@ mqtt_amqp_alt(_Config) ->
     ok.
 
 amqp_mqtt(_Config) ->
-    Env = #{mqtt_exchange => <<"mqtt-topic-exchange">>},
+    Env = #{mqtt_x => <<"mqtt-topic-exchange">>},
     H = #'v1_0.header'{priority = {ubyte, 3},
                        ttl = {uint, 20000},
                        durable = true},

--- a/deps/rabbitmq_mqtt/test/mc_mqtt_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mc_mqtt_SUITE.erl
@@ -4,6 +4,8 @@
           nowarn_export_all]).
 
 -include_lib("rabbitmq_mqtt/include/rabbit_mqtt_packet.hrl").
+-include_lib("rabbit_common/include/rabbit_framing.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("amqp10_common/include/amqp10_framing.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -33,7 +35,12 @@ groups() ->
        roundtrip_amqpl_user_property,
        roundtrip_amqp_content_type,
        amqp_to_mqtt_reply_to,
-       amqp_to_mqtt_footer
+       amqp_to_mqtt_footer,
+       mqtt_amqpl,
+       mqtt_amqpl_alt,
+       mqtt_amqp,
+       mqtt_amqp_alt,
+       amqp_mqtt
       ]
      }
     ].
@@ -63,8 +70,9 @@ roundtrip_amqp(_Config) ->
     ExpectedSize = {MetaDataSize, PayloadSize},
     ?assertEqual(ExpectedSize, mc:size(Mc0)),
 
-    ?assertEqual(Msg, mc_mqtt:convert_to(mc_mqtt, Msg)),
-    ?assertEqual(not_implemented, mc_mqtt:convert_to(mc_stomp, Msg)),
+    Env = #{},
+    ?assertEqual(Msg, mc_mqtt:convert_to(mc_mqtt, Msg, Env)),
+    ?assertEqual(not_implemented, mc_mqtt:convert_to(mc_stomp, Msg, Env)),
     ?assertEqual(Mc0, mc:convert(mc_mqtt, Mc0)),
 
     %% roundtrip
@@ -122,11 +130,11 @@ roundtrip_amqp_response_topic(_Config) ->
     MqttExchanges = [<<"amq.topic">>,
                      <<"some-other-topic-exchange">>],
     [begin
-         ok = persistent_term:put(Key, X),
+         Env = #{Key => X},
          Msg = Msg0#mqtt_msg{props = #{'Response-Topic' => Topic}},
          ?assertMatch(#mqtt_msg{props = #{'Response-Topic' := Topic}},
-                      roundtrip(mc_amqp, Msg)),
-         true = persistent_term:erase(Key)
+                      roundtrip(mc_amqp, Msg, Env)),
+         ok
      end || X <- MqttExchanges].
 
 roundtrip_amqpl(_Config) ->
@@ -248,7 +256,7 @@ roundtrip_amqpl_user_property(_Config) ->
     Msg = Msg0#mqtt_msg{
             props = #{'User-Property' => [{<<"key-2">>, <<"val-2">>},
                                           {<<"key-1">>, <<"val-1">>},
-                                          {binary:copy(<<"k">>, 129), <<"val-2">>},
+                                          {binary:copy(<<"k">>, 256), <<"val-2">>},
                                           {<<"key-1">>, <<"val-1">>}
                                          ]}},
     ?assertMatch(#mqtt_msg{props = #{'User-Property' := [{<<"key-1">>, <<"val-1">>},
@@ -268,10 +276,9 @@ roundtrip_amqp_content_type(_Config) ->
 amqp_to_mqtt_reply_to(_Config) ->
     Val = amqp_value({utf8, <<"hey">>}),
     Key = mqtt_exchange,
-    ok = persistent_term:put(Key, <<"mqtt-topic-exchange">>),
-
+    Env = #{Key => <<"mqtt-topic-exchange">>},
     AmqpProps1 = #'v1_0.properties'{reply_to = {utf8, <<"/exchange/mqtt-topic-exchange/my.routing.key">>}},
-    #mqtt_msg{props = Props1} = amqp_to_mqtt([AmqpProps1, Val]),
+    #mqtt_msg{props = Props1} = amqp_to_mqtt([AmqpProps1, Val], Env),
     ?assertEqual({ok, <<"my/routing/key">>},
                  maps:find('Response-Topic', Props1)),
 
@@ -279,8 +286,8 @@ amqp_to_mqtt_reply_to(_Config) ->
     #mqtt_msg{props = Props2} = amqp_to_mqtt([AmqpProps2, Val]),
     ?assertEqual(error,
                  maps:find('Response-Topic', Props2)),
+    ok.
 
-    true = persistent_term:erase(Key).
 
 amqp_to_mqtt_footer(_Config) ->
     Val = amqp_value({utf8, <<"hey">>}),
@@ -289,23 +296,266 @@ amqp_to_mqtt_footer(_Config) ->
     #mqtt_msg{payload = Payload} = amqp_to_mqtt([Val, Footer]),
     ?assertEqual(<<"hey">>, iolist_to_binary(Payload)).
 
+mqtt_amqpl(_Config) ->
+    Msg0 = mqtt_msg(),
+    Msg = Msg0#mqtt_msg{qos = 1,
+                        props = #{'Content-Type' => <<"text/plain">>,
+                                  'User-Property' => [{<<"key-2">>, <<"val-2">>},
+                                                      {<<"key-1">>, <<"val-1">>}],
+                                  'Correlation-Data' => <<"banana">>,
+                                  'Message-Expiry-Interval' => 1001,
+                                  'Response-Topic' => <<"tmp/blah/responses">>
+                                 }
+                       },
+    Anns = #{routing_keys => [rabbit_mqtt_util:mqtt_to_amqp(Msg#mqtt_msg.topic)]},
+    Mc = mc:init(mc_mqtt, Msg, Anns),
+    MsgL = mc:convert(mc_amqpl, Mc),
+
+    #content{properties = #'P_basic'{headers = HL} = Props} =
+        mc:protocol_state(MsgL),
+
+    ?assertMatch(#'P_basic'{delivery_mode = 2,
+                            correlation_id = <<"banana">>,
+                            expiration = <<"1001000">>,
+                            content_type = <<"text/plain">>}, Props),
+    ?assertMatch({_, longstr, <<"val-2">>}, amqpl_header(<<"key-2">>, HL)),
+    ?assertMatch({_, longstr, <<"val-1">>}, amqpl_header(<<"key-1">>, HL)),
+    ?assertMatch({_, longstr, <<"tmp.blah.responses">>},
+                 amqpl_header(<<"x-reply-to-topic">>, HL)),
+    ok.
+
+mqtt_amqpl_alt(_Config) ->
+    InvalidUtf8 = <<14,23,97,23,144,149,12,108,140,66,151,2>>,
+    Msg0 = mqtt_msg(),
+    Msg = Msg0#mqtt_msg{qos = 0,
+                        props = #{'Content-Type' => <<"no-ascii🐇"/utf8>>,
+                                  % 'User-Property' => [{<<"key-2">>, <<"val-2">>},
+                                  %                     {<<"key-1">>, <<"val-1">>}],
+                                  'Correlation-Data' => InvalidUtf8
+                                 }
+                       },
+    Anns = #{routing_keys => [rabbit_mqtt_util:mqtt_to_amqp(Msg#mqtt_msg.topic)]},
+    Mc = mc:init(mc_mqtt, Msg, Anns),
+    MsgL = mc:convert(mc_amqpl, Mc),
+
+    #content{properties = #'P_basic'{headers = HL} = Props} =
+        mc:protocol_state(MsgL),
+
+    ?assertMatch(#'P_basic'{delivery_mode = 1,
+                            correlation_id = undefined,
+                            content_type = undefined}, Props),
+
+    ?assertMatch({_, longstr, InvalidUtf8},
+                 amqpl_header(<<"x-correlation-id">>, HL)),
+    ok.
+
+mqtt_amqp(_Config) ->
+    Key = mqtt_exchange,
+    Ex = <<"mqtt-topic-exchange">>,
+    Env =  #{Key => <<"mqtt-topic-exchange">>},
+    Mqtt0 = mqtt_msg(),
+    Mqtt = Mqtt0#mqtt_msg{qos = 1,
+                          props = #{'Content-Type' => <<"text/plain">>,
+                                    'User-Property' =>
+                                        [{<<"key-2">>, <<"val-2">>},
+                                         {<<"key-1">>, <<"val-1">>},
+                                         {<<"x-stream-filter">>, <<"apple">>}],
+                                    'Correlation-Data' => <<"banana">>,
+                                    'Message-Expiry-Interval' => 1001,
+                                    'Response-Topic' => <<"tmp/blah/responses">>
+                                   }
+                         },
+    Anns = #{exchange => Ex,
+             routing_keys => [rabbit_mqtt_util:mqtt_to_amqp(Mqtt#mqtt_msg.topic)]},
+    Mc = mc:init(mc_mqtt, Mqtt, Anns, Env),
+    %% no target env
+    Msg = mc:convert(mc_amqp, Mc),
+
+    [H,
+     #'v1_0.message_annotations'{content = MA},
+     P,
+     #'v1_0.application_properties'{content = AP},
+     D] =
+        mc:protocol_state(Msg),
+
+    ?assertMatch(#'v1_0.data'{content = _}, D),
+    ?assertMatch(#'v1_0.header'{durable = true}, H),
+    ?assertMatch(#'v1_0.properties'{content_type = {symbol, <<"text/plain">>},
+                                    correlation_id = {binary, <<"banana">>}}, P),
+
+    ?assertEqual({utf8, <<"apple">>}, amqp_map_get(symbol(<<"x-stream-filter">>), MA)),
+    ?assertEqual({utf8, <<"val-1">>}, amqp_map_get(utf8(<<"key-1">>), AP)),
+    ?assertEqual({utf8, <<"val-2">>}, amqp_map_get(utf8(<<"key-2">>), AP)),
+
+    ok.
+
+mqtt_amqp_alt(_Config) ->
+    Key = mqtt_exchange,
+    Ex = <<"mqtt-topic-exchange">>,
+    Env = #{Key => <<"mqtt-topic-exchange">>},
+    CorrId = <<"urn:uuid:550e8400-e29b-41d4-a716-446655440000">>,
+    Mqtt0 = mqtt_msg(),
+    Mqtt = Mqtt0#mqtt_msg{qos = 0,
+                          props = #{'Content-Type' => <<"text/plain">>,
+                                    'Payload-Format-Indicator' => 1,
+                                    'User-Property' =>
+                                        [{<<"key-2">>, <<"val-2">>},
+                                         {<<"key-1">>, <<"val-1">>},
+                                         {<<"x-stream-filter">>, <<"apple">>}],
+                                        %% TODO uuid
+                                    'Correlation-Data' => CorrId,
+                                    'Message-Expiry-Interval' => 1001,
+                                    'Response-Topic' => <<"tmp/blah/responses">>
+                                   }
+                         },
+    Anns = #{exchange => Ex,
+             routing_keys => [rabbit_mqtt_util:mqtt_to_amqp(Mqtt#mqtt_msg.topic)]},
+    Mc = mc:init(mc_mqtt, Mqtt, Anns, Env),
+    Msg = mc:convert(mc_amqp, Mc),
+
+    [H,
+     #'v1_0.message_annotations'{content = MA},
+     P,
+     #'v1_0.application_properties'{content = AP},
+     D] = mc:protocol_state(Msg),
+
+    ?assertMatch(#'v1_0.amqp_value'{content = {utf8, _}}, D),
+
+    ?assertMatch(#'v1_0.header'{durable = false}, H),
+    ?assertMatch(#'v1_0.properties'{content_type = {symbol, <<"text/plain">>},
+                                    correlation_id = {uuid, _}}, P),
+
+    ?assertEqual({utf8, <<"apple">>}, amqp_map_get(symbol(<<"x-stream-filter">>), MA)),
+    ?assertEqual({utf8, <<"val-1">>}, amqp_map_get(utf8(<<"key-1">>), AP)),
+    ?assertEqual({utf8, <<"val-2">>}, amqp_map_get(utf8(<<"key-2">>), AP)),
+
+    ok.
+
+amqp_mqtt(_Config) ->
+    Env = #{mqtt_exchange => <<"mqtt-topic-exchange">>},
+    H = #'v1_0.header'{priority = {ubyte, 3},
+                       ttl = {uint, 20000},
+                       durable = true},
+    MAC = [
+           {{symbol, <<"x-stream-filter">>}, {utf8, <<"apple">>}},
+           thead2(list, [utf8(<<"l">>)]),
+           thead2(map, [{utf8(<<"k">>), utf8(<<"v">>)}]),
+           thead2('x-list', list, [utf8(<<"l">>)]),
+           thead2('x-map', map, [{utf8(<<"k">>), utf8(<<"v">>)}])
+          ],
+    M =  #'v1_0.message_annotations'{content = MAC},
+    P = #'v1_0.properties'{content_type = {symbol, <<"text/plain">>},
+                           correlation_id = {utf8, <<"corr-id">>},
+                           creation_time = {timestamp, 10000}
+                          },
+    AC = [
+          thead(long, 5),
+          thead(ulong, 5),
+          thead(utf8, <<"a-string">>),
+          thead(binary, <<"data">>),
+          thead(symbol, <<"symbol">>),
+          thead(ubyte, 1),
+          thead(short, 2),
+          thead(ushort, 3),
+          thead(uint, 4),
+          thead(int, 4),
+          thead(double, 5.0),
+          thead(float, 6.0),
+          thead(timestamp, 7000),
+          thead(byte, 128),
+          thead(boolean, true),
+          {{utf8, <<"boolean2">>}, false},
+          {utf8(<<"null">>), null}
+         ],
+    A =  #'v1_0.application_properties'{content = AC},
+    D =  #'v1_0.data'{content = <<"data">>},
+
+    Anns = #{exchange => <<"exch">>,
+             routing_keys => [<<"apple">>]},
+    AMsg = mc:init(mc_amqp, [H, M, P, A, D], Anns),
+    Msg = mc:convert(mc_mqtt, AMsg, Env),
+    Mqtt = mc:protocol_state(Msg),
+    ?assertMatch(
+       #mqtt_msg{qos = 1,
+                 props = #{'Content-Type' := <<"text/plain">>,
+                           'User-Property' :=
+                               [{<<"x-stream-filter">>,<<"apple">>},
+                                {<<"long">>,<<"5">>},
+                                {<<"ulong">>,<<"5">>},
+                                {<<"utf8">>,<<"a-string">>},
+                                {<<"symbol">>,<<"symbol">>},
+                                {<<"ubyte">>,<<"1">>},
+                                {<<"short">>,<<"2">>},
+                                {<<"ushort">>,<<"3">>},
+                                {<<"uint">>,<<"4">>},
+                                {<<"int">>,<<"4">>},
+                                {<<"double">>,
+                                 <<"5.00000000000000000000e+00">>},
+                                {<<"float">>,
+                                 <<"6.00000000000000000000e+00">>},
+                                {<<"timestamp">>,<<"7">>},
+                                {<<"byte">>,<<"128">>},
+                                {<<"boolean">>,<<"true">>},
+                                {<<"boolean2">>,<<"false">>},
+                                {<<"null">>,<<>>}],
+                           'Correlation-Data' := <<"corr-id">>
+                           % 'Message-Expiry-Interval' := 20000
+                          }
+                }, Mqtt),
+
+    ok.
+
 mqtt_msg() ->
     #mqtt_msg{qos = 0,
               topic = <<"my/topic">>,
               payload = <<>>}.
 
 roundtrip(Mod, MqttMsg) ->
+    roundtrip(Mod, MqttMsg, #{}).
+
+roundtrip(Mod, MqttMsg, SrcEnv) ->
     Anns = #{routing_keys => [rabbit_mqtt_util:mqtt_to_amqp(MqttMsg#mqtt_msg.topic)]},
-    Mc0 = mc:init(mc_mqtt, MqttMsg, Anns),
+    Mc0 = mc:init(mc_mqtt, MqttMsg, Anns, SrcEnv),
     Mc1 = mc:convert(Mod, Mc0),
     Mc = mc:convert(mc_mqtt, Mc1),
     mc:protocol_state(Mc).
 
 amqp_to_mqtt(Sections) ->
+    amqp_to_mqtt(Sections, #{}).
+
+amqp_to_mqtt(Sections, Env) ->
     Anns = #{routing_keys => [<<"apple">>]},
     Mc0 = mc:init(mc_amqp, Sections, Anns),
-    Mc = mc:convert(mc_mqtt, Mc0),
+    Mc = mc:convert(mc_mqtt, Mc0, Env),
     mc:protocol_state(Mc).
 
 amqp_value(Content) ->
     #'v1_0.amqp_value'{content = Content}.
+
+amqpl_header(K, H) ->
+    rabbit_basic:header(K, H).
+
+amqp_map_get(_K, []) ->
+    undefined;
+amqp_map_get(K, Tuples) ->
+    case lists:keyfind(K, 1, Tuples) of
+        false ->
+            undefined;
+        {_, V}  ->
+            V
+    end.
+
+symbol(X) ->
+    {symbol, X}.
+
+utf8(X) ->
+    {utf8, X}.
+
+thead(T, Value) ->
+    {utf8(atom_to_binary(T)), {T, Value}}.
+
+thead2(T, Value) ->
+    {symbol(atom_to_binary(T)), {T, Value}}.
+
+thead2(K, T, Value) ->
+    {symbol(atom_to_binary(K)), {T, Value}}.

--- a/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
@@ -430,7 +430,7 @@ stream(Config) ->
                    content_type => ContentType,
                    %% We expect that reply_to contains a valid address,
                    %% and that the topic format got translated from MQTT to AMQP 0.9.1.
-                   reply_to => <<"/topic/response.topic">>},
+                   reply_to => <<"/exchange/amq.topic/response.topic">>},
                  amqp10_msg:properties(Msg)),
     ?assertEqual(#{<<"rabbit🐇"/utf8>> => <<"carrot🥕"/utf8>>,
                    <<"key">> => <<"val">>},

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -251,7 +251,9 @@ client_set_max_packet_size_publish(Config) ->
     assert_nothing_received(),
     NumRejected = dead_letter_metric(messages_dead_lettered_rejected_total, Config) - NumRejectedBefore,
     ?assertEqual(1, NumRejected),
-    ok = emqtt:disconnect(C).
+    ok = emqtt:disconnect(C),
+    ok.
+
 
 client_set_max_packet_size_connack(Config) ->
     {C, Connect} = start_client(?FUNCTION_NAME, Config, 0,


### PR DESCRIPTION
To refine conversion behaviour add additional tests
and ensure it matches the [documentation](https://github.com/rabbitmq/rabbitmq-website/pull/1747).

mc: optionally capture source environment

And pass target environment to mc:convert

This allows environmental data and configuration to be captured and
used to modify and complete conversion logic whilst allowing conversion
code to remain pure and portable.