### PR TITLE
Update RabbitMQ-Overview.json

### DIFF
--- a/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json
+++ b/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json
@@ -306,7 +306,7 @@
       "pluginVersion": "8.3.4",
       "targets": [
         {
-          "expr": "sum(rabbitmq_channels * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\"}) - sum(rabbitmq_channel_consumers * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\"})",
+          "expr": "sum(rabbitmq_global_publishers * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,


### PR DESCRIPTION
Global counters for producers added in https://github.com/rabbitmq/rabbitmq-server/pull/3127 but never made it to this dashboard

Before
![neg_pub](https://github.com/rabbitmq/rabbitmq-server/assets/460369/905c5dfd-535f-42e8-ad6a-9e5a03d2122c)
After
![pos_pub](https://github.com/rabbitmq/rabbitmq-server/assets/460369/9c0bc0b7-c446-47a7-bd71-7b030799872d)
