### PR TITLE
Use rules_erlang 3.14.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,12 +15,12 @@ bazel_dep(
 
 bazel_dep(
     name = "platforms",
-    version = "0.0.6",
+    version = "0.0.7",
 )
 
 bazel_dep(
     name = "rules_cc",
-    version = "0.0.2",
+    version = "0.0.9",
 )
 
 bazel_dep(
@@ -31,7 +31,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rules_erlang",
-    version = "3.13.1",
+    version = "3.14.0",
 )
 
 bazel_dep(


### PR DESCRIPTION
This version detects major version mismatches in transient dependencies

In this case, it will notice if, for instance, ra and osiris ask for different major versions of seshat