### PR TITLE
CLI commands for mirroring deprecation

### DIFF
--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -32,6 +32,9 @@
 -export([are_cmqs_permitted/0,
          are_cmqs_used/1]).
 
+-export([list_policies_with_classic_queue_mirroring_for_cli/0,
+         list_operator_policies_with_classic_queue_mirroring_for_cli/0]).
+
 %% for testing only
 -export([module/1]).
 
@@ -997,6 +1000,22 @@ has_ha_policies(Policies) ->
 
 does_policy_configure_cmq(KeyList) ->
     lists:keymember(<<"ha-mode">>, 1, KeyList).
+
+list_policies_with_classic_queue_mirroring_for_cli() ->
+    Policies = rabbit_policy:list(),
+    lists:filter(
+      fun(Policy) ->
+              KeyList = proplists:get_value(definition, Policy),
+              does_policy_configure_cmq(KeyList)
+      end, Policies).
+
+list_operator_policies_with_classic_queue_mirroring_for_cli() ->
+    Policies = rabbit_policy:list_op(),
+    lists:filter(
+      fun(Policy) ->
+              KeyList = proplists:get_value(definition, Policy),
+              does_policy_configure_cmq(KeyList)
+      end, Policies).
 
 validate_policy(KeyList) ->
     Mode = proplists:get_value(<<"ha-mode">>, KeyList, none),

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
@@ -39,5 +39,5 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesComma
     do: "Removes all classic queue mirroring policies and operator policies"
 
   def banner([], %{}),
-    do: "Will remove all classic queue mirroring policies and operator policies"
+    do: "Will remove all regular policies and operator policies that enable classic queue mirroring"
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
@@ -1,0 +1,38 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    :rabbit_misc.rpc_call(node_name, :rabbit_mirror_queue_misc, :remove_classic_queue_mirroring_from_policies_for_cli, [], timeout)
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "remove_classic_queue_mirroring_from_policies"
+
+  def usage_doc_guides() do
+    [
+      DocGuide.mirroring()
+    ]
+  end
+
+  def help_section(), do: :operations
+
+  def description,
+    do:
+      "Removes all classic queue mirroring policies and operator policies"
+
+  def banner([], %{}),
+    do: "Will remove all classic queue mirroring policies and operator policies"
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
@@ -14,7 +14,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesComma
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
   def run([], %{node: node_name, timeout: timeout}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_mirror_queue_misc, :remove_classic_queue_mirroring_from_policies_for_cli, [], timeout)
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_mirror_queue_misc,
+      :remove_classic_queue_mirroring_from_policies_for_cli,
+      [],
+      timeout
+    )
   end
 
   use RabbitMQ.CLI.DefaultOutput
@@ -30,8 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesComma
   def help_section(), do: :operations
 
   def description,
-    do:
-      "Removes all classic queue mirroring policies and operator policies"
+    do: "Removes all classic queue mirroring policies and operator policies"
 
   def banner([], %{}),
     do: "Will remove all classic queue mirroring policies and operator policies"

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
@@ -39,5 +39,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesComma
     do: "Removes keys that enable classic queue mirroring from all regular and operator policies"
 
   def banner([], %{}),
-    do: "Will remove keys that enable classic queue mirroring from all regular and operator policies"
+    do:
+      "Will remove keys that enable classic queue mirroring from all regular and operator policies"
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/remove_classic_queue_mirroring_from_policies_command.ex
@@ -36,8 +36,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesComma
   def help_section(), do: :operations
 
   def description,
-    do: "Removes all classic queue mirroring policies and operator policies"
+    do: "Removes keys that enable classic queue mirroring from all regular and operator policies"
 
   def banner([], %{}),
-    do: "Will remove all regular policies and operator policies that enable classic queue mirroring"
+    do: "Will remove keys that enable classic queue mirroring from all regular and operator policies"
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_any_deprecated_features_are_used_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_any_deprecated_features_are_used_command.ex
@@ -25,24 +25,29 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedC
       :classic_queue_mirroring => is_used_classic_queue_mirroring(opts)
     }
 
-    deprecated_features_list = Enum.reduce(are_deprecated_features_used,
-      [],
-      fn({_feat, _result}, {:badrpc, _} = acc) ->
-          acc
-        ({feat, result}, acc) ->
-          case result do
-            {:badrpc, _} = err -> err
-            {:error, _} = err -> err
-            true  -> [feat | acc]
-            false -> acc
-          end
-      end)
+    deprecated_features_list =
+      Enum.reduce(
+        are_deprecated_features_used,
+        [],
+        fn
+          {_feat, _result}, {:badrpc, _} = acc ->
+            acc
+
+          {feat, result}, acc ->
+            case result do
+              {:badrpc, _} = err -> err
+              {:error, _} = err -> err
+              true -> [feat | acc]
+              false -> acc
+            end
+        end
+      )
 
     # health checks return true if they pass
     case deprecated_features_list do
-      {:badrpc, _} = err  -> err
-      {:error, _}  = err  -> err
-      []                  -> true
+      {:badrpc, _} = err -> err
+      {:error, _} = err -> err
+      [] -> true
       xs when is_list(xs) -> {false, deprecated_features_list}
     end
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_any_deprecated_features_are_used_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_any_deprecated_features_are_used_command.ex
@@ -1,0 +1,65 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+
+  alias RabbitMQ.CLI.Diagnostics.Commands.{
+    CheckIfClusterHasClassicQueueMirroringPolicyCommand
+  }
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:ctl, :diagnostics]
+
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+
+  def validate([_ | _] = args, _) when length(args) != 0,
+    do: {:validation_failure, :too_many_args}
+
+  def validate([], %{formatter: formatter}) do
+    case formatter do
+      "report" -> :ok
+      _other -> {:validation_failure, "Only report formatter is supported"}
+    end
+  end
+
+  def validate([], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name} = opts) do
+        [
+          run_command(CheckIfClusterHasClassicQueueMirroringPolicyCommand, [], opts)
+        ]
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Report
+
+  def usage, do: "check_if_any_deprecated_features_are_used"
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(),
+    do:
+      "Generate a report listing all deprecated features in use"
+
+  def banner(_, %{node: node_name}), do: "Checking if any deprecated features are used ..."
+
+  #
+  # Implementation
+  #
+
+  defp run_command(command, args, opts) do
+    {args, opts} = command.merge_defaults(args, opts)
+    banner = command.banner(args, opts)
+    command_result = command.run(args, opts) |> command.output(opts)
+    {command, banner, command_result}
+  end
+
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_cluster_has_classic_queue_mirroring_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_cluster_has_classic_queue_mirroring_policy_command.ex
@@ -4,13 +4,12 @@
 ##
 ## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Queues.Commands.CheckIfClusterHasClassicQueueMirroringPolicyCommand do
+defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfClusterHasClassicQueueMirroringPolicyCommand do
   @moduledoc """
-  Exits with a non-zero code if there are classic mirrored queues that don't
-  have any in sync mirrors online and would potentially lose data
-  if the target node is shut down.
+  Exits with a non-zero code if there are policies enabling classic queue mirroring.
 
-  This command is meant to be used as a pre-upgrade (pre-shutdown) check.
+  This command is meant to be used as a pre-upgrade (pre-shutdown) check before classic queue
+  mirroring is removed.
   """
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_cluster_has_classic_queue_mirroring_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_cluster_has_classic_queue_mirroring_policy_command.ex
@@ -93,6 +93,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfClusterHasClassicQueueMirrori
 
     {:error, :check_failed, Enum.join(Enum.concat(lines, op_lines), line_separator())}
   end
+
   use RabbitMQ.CLI.DefaultOutput
 
   def help_section(), do: :observability_and_health_checks

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_cluster_has_classic_queue_mirroring_policy_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_cluster_has_classic_queue_mirroring_policy_command.ex
@@ -1,0 +1,121 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.CheckIfClusterHasClassicQueueMirroringPolicyCommand do
+  @moduledoc """
+  Exits with a non-zero code if there are classic mirrored queues that don't
+  have any in sync mirrors online and would potentially lose data
+  if the target node is shut down.
+
+  This command is meant to be used as a pre-upgrade (pre-shutdown) check.
+  """
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
+
+  def scopes(), do: [:diagnostics, :queues]
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    policies =
+      :rabbit_misc.rpc_call(
+        node_name,
+        :rabbit_mirror_queue_misc,
+        :list_policies_with_classic_queue_mirroring_for_cli,
+        [],
+        timeout
+      )
+
+    op_policies =
+      :rabbit_misc.rpc_call(
+        node_name,
+        :rabbit_mirror_queue_misc,
+        :list_operator_policies_with_classic_queue_mirroring_for_cli,
+        [],
+        timeout
+      )
+
+    case {policies, op_policies} do
+      {[], []} ->
+        :ok
+
+      {_, _} when is_list(policies) and is_list(op_policies) ->
+        {:ok, policies, op_policies}
+
+      other ->
+        other
+    end
+  end
+
+  def output(:ok, %{formatter: "json"}) do
+    {:ok, %{"result" => "ok"}}
+  end
+
+  def output(:ok, %{silent: true}) do
+    {:ok, :check_passed}
+  end
+
+  def output(:ok, %{}) do
+    {:ok, "Cluster reported no policies enabling classic queue mirroring"}
+  end
+
+  def output({:ok, ps, op_ps}, %{formatter: "json"})
+      when is_list(ps) and is_list(op_ps) do
+    {:error, :check_failed,
+     %{
+       "result" => "error",
+       "policies" => ps,
+       "operator_policies" => op_ps,
+       "message" => "Cluster reported policies enabling classic queue mirroring"
+     }}
+  end
+
+  def output({:ok, ps, op_ps}, %{silent: true}) when is_list(ps) and is_list(op_ps) do
+    {:error, :check_failed}
+  end
+
+  def output({:ok, ps, op_ps}, _) when is_list(ps) and is_list(op_ps) do
+    lines = policy_lines(ps)
+    op_lines = op_policy_lines(op_ps)
+
+    {:error, :check_failed, Enum.join(Enum.concat(lines, op_lines), line_separator())}
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description() do
+    "Health check that exits with a non-zero code if there are policies that enable classic queue mirroring"
+  end
+
+  def usage, do: "check_if_cluster_has_classic_queue_mirroring_policy"
+
+  def banner([], _) do
+    "Checking if cluster has any classic queue mirroring policy ..."
+  end
+
+  #
+  # Implementation
+  #
+
+  def policy_lines(ps) do
+    for p <- ps do
+      "Policy #{p[:name]} enables classic queue mirroring"
+    end
+  end
+
+  def op_policy_lines(ps) do
+    for p <- ps do
+      "Operator policy #{p[:name]} enables classic queue mirroring"
+    end
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/list_operator_policies_with_classic_queue_mirroring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/list_operator_policies_with_classic_queue_mirroring_command.ex
@@ -1,0 +1,39 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.ListOperatorPoliciesWithClassicQueueMirroringCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:diagnostics, :queues]
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_mirror_queue_misc,
+      :list_operator_policies_with_classic_queue_mirroring_for_cli,
+      [],
+      timeout
+    )
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Table
+
+  def usage, do: "list_operator_policies_with_classic_queue_mirroring [--no-table-headers]"
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description() do
+    "List all operator policies that enable classic queue mirroring"
+  end
+
+  def banner(_, _), do: "Listing operator policies with classic queue mirroring ..."
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/list_policies_with_classic_queue_mirroring_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/list_policies_with_classic_queue_mirroring_command.ex
@@ -1,0 +1,39 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.ListPoliciesWithClassicQueueMirroringCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:diagnostics, :queues]
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_mirror_queue_misc,
+      :list_policies_with_classic_queue_mirroring_for_cli,
+      [],
+      timeout
+    )
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Table
+
+  def usage, do: "list_policies_with_classic_queue_mirroring [--no-table-headers]"
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description() do
+    "List all policies that enable classic queue mirroring"
+  end
+
+  def banner(_, _), do: "Listing policies with classic queue mirroring ..."
+end

--- a/deps/rabbitmq_cli/test/ctl/remove_classic_queue_mirroring_from_policies_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/remove_classic_queue_mirroring_from_policies_command_test.exs
@@ -1,0 +1,59 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2016-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RemoveClassicQueueMirroringFromPoliciesCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.RemoveClassicQueueMirroringFromPoliciesCommand
+
+  @vhost "/"
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       vhost: @vhost
+     }}
+  end
+
+  test "validate: specifying no arguments succeeds", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  test "validate: specifying a position argument is reported as an error", context do
+    assert @command.validate(["q1"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
+  end
+
+  test "validate: specifying three queue names is reported as an error", context do
+    assert @command.validate(["q1", "q2", "q3"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
+  end
+
+  test "run: request to a non-existent RabbitMQ node returns a nodedown" do
+    opts = %{node: :jake@thedog, vhost: @vhost, timeout: 200}
+    assert match?({:badrpc, _}, @command.run([], opts))
+  end
+
+  test "banner", context do
+    s = @command.banner([], context[:opts])
+
+    assert s =~ ~r/Will remove/
+  end
+end

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_any_deprecated_features_are_used_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_any_deprecated_features_are_used_command_test.exs
@@ -1,0 +1,69 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule CheckIfAnyDeprecatedFeaturesAreUsedCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedCommand
+  @policy_name "cmq-policy-8373"
+  @policy_value "{\"ha-mode\":\"all\"}"
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+      clear_policy("/", @policy_name)
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
+  end
+
+  test "run: when there are no policies that enable CMQ mirroring, reports success", context do
+    clear_policy("/", @policy_name)
+    assert @command.run([], context[:opts])
+  end
+
+  test "output: when the result is true, returns successfully", context do
+    assert match?({:ok, _}, @command.output(true, context[:opts]))
+  end
+
+  # this is a check command
+  test "output: when the result is false, returns an error", context do
+    assert match?({:error, _}, @command.output(false, context[:opts]))
+  end
+end

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_cluster_has_classic_queue_mirroring_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_cluster_has_classic_queue_mirroring_policy_command_test.exs
@@ -1,0 +1,69 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule CheckIfClusterHasClassicQueueMirroringPolicyCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfClusterHasClassicQueueMirroringPolicyCommand
+  @policy_name "cmq-policy-8373"
+  @policy_value "{\"ha-mode\":\"all\"}"
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+      clear_policy("/", @policy_name)
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
+  end
+
+  test "run: when there are no policies that enable CMQ mirroring, reports success", context do
+    clear_policy("/", @policy_name)
+    assert @command.run([], context[:opts])
+  end
+
+  test "output: when the result is true, returns successfully", context do
+    assert match?({:ok, _}, @command.output(true, context[:opts]))
+  end
+
+  # this is a check command
+  test "output: when the result is false, returns an error", context do
+    assert match?({:error, _}, @command.output(false, context[:opts]))
+  end
+end

--- a/deps/rabbitmq_cli/test/queues/list_operator_policies_with_classic_queue_mirroring_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/list_operator_policies_with_classic_queue_mirroring_command_test.exs
@@ -1,0 +1,53 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.ListOperatorPoliciesWithClassicQueueMirroringCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Queues.Commands.ListOperatorPoliciesWithClassicQueueMirroringCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "validate: treats no arguments as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  test "validate: accepts no positional arguments" do
+    assert @command.validate(["arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: when two or more arguments are provided, returns a failure" do
+    assert @command.validate(["arg1", "arg2"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["arg1", "arg2", "arg3"], %{}) ==
+             {:validation_failure, :too_many_args}
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc" do
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               [],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
+  end
+end

--- a/deps/rabbitmq_cli/test/queues/list_policies_with_classic_queue_mirroring_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/list_policies_with_classic_queue_mirroring_command_test.exs
@@ -1,0 +1,53 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.ListPoliciesWithClassicQueueMirroringCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Queues.Commands.ListPoliciesWithClassicQueueMirroringCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "validate: treats no arguments as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  test "validate: accepts no positional arguments" do
+    assert @command.validate(["arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: when two or more arguments are provided, returns a failure" do
+    assert @command.validate(["arg1", "arg2"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["arg1", "arg2", "arg3"], %{}) ==
+             {:validation_failure, :too_many_args}
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc" do
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               [],
+               %{node: :jake@thedog, vhost: "/", timeout: 200}
+             )
+           )
+  end
+end


### PR DESCRIPTION
This PR contains four commands to facilitate mirroring deprecation. The CMQ feature is going to be completely removed in 4.0.

`rabbitmq-diagnostics check_if_cluster_has_classic_queue_mirroring_policy`
`rabbitmq-queues list_policies_with_classic_queue_mirroring`
`rabbitmq-queues list_operator_policies_with_classic_queue_mirroring`
`rabbitmqctl remove_classic_queue_mirroring_from_policies`

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

