### PR TITLE
Optimise HTTP API /queues endpoint

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1812,6 +1812,7 @@ handle_pre_hibernate(State = #q{backing_queue = BQ,
 
 format_message_queue(Opt, MQ) -> rabbit_misc:format_message_queue(Opt, MQ).
 
+%% TODO: this can be removed after 3.13
 format(Q) when ?is_amqqueue(Q) ->
     case rabbit_mirror_queue_misc:is_mirrored(Q) of
         false ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -27,6 +27,7 @@
          purge/1,
          policy_changed/1,
          stat/1,
+         format/2,
          remove/2,
          info/2,
          state_info/1,
@@ -228,6 +229,9 @@
 -callback stat(amqqueue:amqqueue()) ->
     {'ok', non_neg_integer(), non_neg_integer()}.
 
+-callback format(amqqueue:amqqueue(), Context :: map()) ->
+    [{atom(), term()}].
+
 -callback capabilities() ->
     #{atom() := term()}.
 
@@ -303,6 +307,12 @@ policy_changed(Q) ->
 stat(Q) ->
     Mod = amqqueue:get_type(Q),
     Mod:stat(Q).
+
+-spec format(amqqueue:amqqueue(), map()) ->
+    [{atom(), term()}].
+format(Q, Context) ->
+    Mod = amqqueue:get_type(Q),
+    Mod:format(Q, Context).
 
 -spec remove(queue_name(), state()) -> state().
 remove(QRef, #?STATE{ctxs = Ctxs0} = State) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -23,7 +23,7 @@
          stop_server/1,
          delete/4,
          delete_immediately/1]).
--export([state_info/1, info/2, stat/1, infos/1]).
+-export([state_info/1, info/2, stat/1, infos/1, infos/2]).
 -export([settle/5, dequeue/5, consume/3, cancel/5]).
 -export([credit/5]).
 -export([purge/1]).

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1670,8 +1670,8 @@ peek(_Pos, Q) when ?is_amqqueue(Q) ->
 online(Q) when ?is_amqqueue(Q) ->
     Nodes = get_connected_nodes(Q),
     {Name, _} = amqqueue:get_pid(Q),
-    [node(Pid) || {ok, Pid} <- 
-                  erpc:multicall(Nodes, fun () -> whereis(Name) end),
+    [node(Pid) || {ok, Pid} <-
+                  erpc:multicall(Nodes, erlang, whereis, [Name]),
                   is_pid(Pid)].
 
 format(Q, Ctx) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -35,7 +35,7 @@
 -export([become_leader/2, handle_tick/3, spawn_deleter/1]).
 -export([rpc_delete_metrics/1,
          key_metrics_rpc/1]).
--export([format/1]).
+-export([format/2]).
 -export([open_files/1]).
 -export([peek/2, peek/3]).
 -export([add_member/2,
@@ -432,7 +432,7 @@ filter_quorum_critical(Queues) ->
 
 filter_quorum_critical(Queues, ReplicaStates, Self) ->
     lists:filter(fun (Q) ->
-                    MemberNodes = rabbit_amqqueue:get_quorum_nodes(Q),
+                    MemberNodes = get_nodes(Q),
                     {Name, _Node} = amqqueue:get_pid(Q),
                     AllUp = lists:filter(fun (N) ->
                                             case maps:get(N, ReplicaStates, undefined) of
@@ -510,7 +510,8 @@ handle_tick(QName,
                              0 -> 0;
                              _ -> rabbit_fifo:usage(Name)
                          end,
-                  Keys = ?STATISTICS_KEYS -- [consumers,
+                  Keys = ?STATISTICS_KEYS -- [leader,
+                                              consumers,
                                               messages_dlx,
                                               message_bytes_dlx,
                                               single_active_consumer_pid,
@@ -531,7 +532,8 @@ handle_tick(QName,
                            {messages_dlx, NumDiscarded + NumDiscardedCheckedOut},
                            {message_bytes_dlx, MsgBytesDiscarded},
                            {single_active_consumer_tag, SacTag},
-                           {single_active_consumer_pid, SacPid}
+                           {single_active_consumer_pid, SacPid},
+                           {leader, node()}
                            | infos(QName, Keys)],
                   rabbit_core_metrics:queue_stats(QName, Infos),
                   ok = repair_leader_record(QName, Self),
@@ -971,7 +973,7 @@ info(Q, Items) ->
     lists:foldr(fun(totals, Acc) ->
                         i_totals(Q) ++ Acc;
                    (type_specific, Acc) ->
-                        format(Q) ++ Acc;
+                        format(Q, #{}) ++ Acc;
                    (Item, Acc) ->
                         [{Item, i(Item, Q)} | Acc]
                 end, [], Items).
@@ -1668,11 +1670,41 @@ peek(_Pos, Q) when ?is_amqqueue(Q) ->
 online(Q) when ?is_amqqueue(Q) ->
     Nodes = get_connected_nodes(Q),
     {Name, _} = amqqueue:get_pid(Q),
-    [Node || Node <- Nodes, is_process_alive(Name, Node)].
+    [node(Pid) || {ok, Pid} <- 
+                  erpc:multicall(Nodes, fun () -> whereis(Name) end),
+                  is_pid(Pid)].
 
-format(Q) when ?is_amqqueue(Q) ->
+format(Q, Ctx) when ?is_amqqueue(Q) ->
+    %% TODO: this should really just be voters
     Nodes = get_nodes(Q),
-    [{members, Nodes}, {online, online(Q)}, {leader, leader(Q)}].
+    Running = case Ctx of
+                  #{running_nodes := Running0} ->
+                      Running0;
+                  _ ->
+                      %% WARN: slow
+                      rabbit_nodes:list_running()
+              end,
+    Online = [N || N <- Nodes, lists:member(N, Running)],
+    {_, LeaderNode} = amqqueue:get_pid(Q),
+    State = case is_minority(Nodes, Online) of
+                true when length(Online) == 0 ->
+                    down;
+                true ->
+                    minority;
+                false ->
+                    case lists:member(LeaderNode, Online) of
+                        true ->
+                            running;
+                        false ->
+                            down
+                    end
+            end,
+    [{type, quorum},
+     {state, State},
+     {node, LeaderNode},
+     {members, Nodes},
+     {leader, LeaderNode},
+     {online, Online}].
 
 is_process_alive(Name, Node) ->
     %% don't attempt rpc if node is not already connected
@@ -1860,3 +1892,7 @@ force_all_queues_shrink_member_to_current_member() ->
          end || Q <- rabbit_amqqueue:list(), amqqueue:get_type(Q) == ?MODULE],
     rabbit_log:warning("Disaster recovery procedure: shrinking finished"),
     ok.
+
+is_minority(All, Up) ->
+    MinQuorum = length(All) div 2 + 1,
+    length(Up) < MinQuorum.

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -3421,7 +3421,7 @@ get_queue_type(Server, VHost, Q0) ->
 
 count_online_nodes(Server, VHost, Q0) ->
     QNameRes = rabbit_misc:r(VHost, queue, Q0),
-    Info = rpc:call(Server, rabbit_quorum_queue, infos, [QNameRes]),
+    Info = rpc:call(Server, rabbit_quorum_queue, infos, [QNameRes, [online]]),
     length(proplists:get_value(online, Info, [])).
 
 publish_many(Ch, Queue, Count) ->

--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -621,6 +621,11 @@ function fmt_object_state(obj) {
         colour = 'red';
         explanation = 'The queue process was stopped by the vhost supervisor.';
     }
+    else if (obj.state == 'minority') {
+        colour = 'yellow';
+        explanation = 'The queue does not have sufficient online members to ' +
+            'make progress'
+    }
 
     return fmt_state(colour, text, explanation);
 }

--- a/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
@@ -667,9 +667,12 @@ node_stats(Ranges, Objs, Interval) ->
 combine(New, Old) ->
     case pget(state, Old) of
         unknown -> New ++ Old;
-        live    -> New ++ lists:keydelete(state, 1, Old);
+        live    -> New ++ delete_keys([state, online], Old);
         _       -> lists:keydelete(state, 1, New) ++ Old
     end.
+
+delete_keys(Keys, List) ->
+    [I || I <- List, not lists:member(element(1, I), Keys)].
 
 revert({'_', _}, {Id, _}) ->
     Id;

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
@@ -45,7 +45,8 @@ content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 resource_exists(ReqData, {Mode, Context}) ->
-    {case queues0(ReqData) of
+    %% just checking that the vhost requested exists
+    {case rabbit_mgmt_util:all_or_one_vhost(ReqData, fun (_) -> ok end) of
          vhost_not_found -> false;
          _               -> true
      end, ReqData, {Mode, Context}}.
@@ -155,9 +156,6 @@ basic_vhost_filtered(ReqData, Context) ->
 
 all_queues(ReqData) ->
     rabbit_mgmt_util:all_or_one_vhost(ReqData, fun rabbit_amqqueue:list_all/1).
-
-queues0(ReqData) ->
-    rabbit_mgmt_util:all_or_one_vhost(ReqData, fun rabbit_amqqueue:list/1).
 
 queues_with_totals(ReqData) ->
     rabbit_mgmt_util:all_or_one_vhost(ReqData, fun collect_info_all/1).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
@@ -13,11 +13,19 @@
          augmented/2]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
--include_lib("rabbit_common/include/rabbit.hrl").
--include_lib("rabbit/include/amqqueue.hrl").
 
--define(BASIC_COLUMNS, ["vhost", "name", "durable", "auto_delete", "exclusive",
-                       "owner_pid", "arguments", "pid", "state"]).
+-define(BASIC_COLUMNS,
+        ["vhost",
+         "name",
+         "node",
+         "durable",
+         "auto_delete",
+         "exclusive",
+         "owner_pid",
+         "arguments",
+         "type",
+         "pid",
+         "state"]).
 
 -define(DEFAULT_SORT, ["vhost", "name"]).
 
@@ -63,23 +71,52 @@ is_authorized(ReqData, {Mode, Context}) ->
 %% Exported functions
 
 basic(ReqData) ->
+    %% rabbit_nodes:list_running/1 is a potentially slow function that performs
+    %% a cluster wide query with a reasonably long (10s) timeout.
+    %% TODO: replace with faster approximate function
+    Running = rabbit_nodes:list_running(),
+    Ctx = #{running_nodes => Running},
+    FmtQ = fun (Q) -> rabbit_mgmt_format:queue(Q, Ctx) end,
     case rabbit_mgmt_util:disable_stats(ReqData) of
         false ->
-            [rabbit_mgmt_format:queue(Q) || Q <- queues0(ReqData)] ++
-                [rabbit_mgmt_format:queue(amqqueue:set_state(Q, down)) ||
-                    Q <- down_queues(ReqData)];
+            list_queues(ReqData, Running, FmtQ, FmtQ);
         true ->
             case rabbit_mgmt_util:enable_queue_totals(ReqData) of
                 false ->
-                    [rabbit_mgmt_format:queue(Q) ++ policy(Q) || Q <- queues0(ReqData)] ++
-                        [rabbit_mgmt_format:queue(amqqueue:set_state(Q, down)) ||
-                            Q <- down_queues(ReqData)];
+                    list_queues(ReqData, Running,
+                                fun(Q) ->
+                                        FmtQ(Q) ++
+                                        %% TODO: just add policy name in
+                                        %% rabbit_mgmt_format:queue/1?
+                                        policy(Q)
+                                end,
+                                FmtQ);
                 true ->
-                    [rabbit_mgmt_format:queue_info(Q) || Q <- queues_with_totals(ReqData)] ++
-                        [rabbit_mgmt_format:queue(amqqueue:set_state(Q, down)) ||
-                            Q <- down_queues(ReqData)]
+                    %% TODO: this is not optimised like the other code paths
+                    %% most likely we can avoid the collector pattern by
+                    %% simply querying the queue_metrics table for infos
+                    [rabbit_mgmt_format:queue_info(Q)
+                     || Q <- queues_with_totals(ReqData)] ++
+                        [FmtQ(amqqueue:set_state(Q, down)) ||
+                            Q <- down_queues(ReqData, Running)]
             end
     end.
+
+list_queues(ReqData, Running, FormatRunningFun, FormatDownFun) ->
+    [begin
+         Pid = amqqueue:get_pid(Q),
+         %% only queues whose leader pid is a on a non running node
+         %% are considered "down", all other states should be passed
+         %% as they are and the queue type impl will decide how to
+         %% emit them.
+         case not rabbit_amqqueue:is_local_to_node_set(Pid, Running) of
+             false ->
+                 FormatRunningFun(Q);
+             true ->
+                 FormatDownFun(amqqueue:set_state(Q, down))
+         end
+     end || Q <- all_queues(ReqData)].
+
 
 augmented(ReqData, Context) ->
     Fun = augment(basic),
@@ -92,8 +129,12 @@ augment(Mode) ->
     fun(Basic, ReqData) ->
             case rabbit_mgmt_util:disable_stats(ReqData) of
                 false ->
-                    %% The reduced endpoint needs to sit behind a feature flag, as it calls a different data aggregation function that is used against all cluster nodes.
-                    %% Data can be collected locally even if other nodes in the cluster do not, it's just a local ETS table. But it can't be queried until all nodes enable the FF.
+                    %% The reduced endpoint needs to sit behind a feature flag,
+                    %% as it calls a different data aggregation function
+                    %% that is used against all cluster nodes.
+                    %% Data can be collected locally even if other nodes in the
+                    %% cluster do not, it's just a local ETS table.
+                    %% But it can't be queried until all nodes enable the FF.
                     IsEnabled = rabbit_feature_flags:is_enabled(detailed_queues_endpoint),
                     Stats = case {IsEnabled, Mode, rabbit_mgmt_util:columns(ReqData)} of
                                 {false, _, _} -> detailed;
@@ -101,8 +142,8 @@ augment(Mode) ->
                                 {_, _, all} -> basic;
                                 _ -> detailed
                             end,
-                    rabbit_log:warning("AUGMENT QUEUES is_enabled ~p stats ~p", [IsEnabled, Stats]),
-                    rabbit_mgmt_db:augment_queues(Basic, rabbit_mgmt_util:range_ceil(ReqData),
+                    rabbit_mgmt_db:augment_queues(Basic,
+                                                  rabbit_mgmt_util:range_ceil(ReqData),
                                                   Stats);
                 true ->
                     Basic
@@ -112,6 +153,9 @@ augment(Mode) ->
 basic_vhost_filtered(ReqData, Context) ->
     rabbit_mgmt_util:filter_vhost(basic(ReqData), ReqData, Context).
 
+all_queues(ReqData) ->
+    rabbit_mgmt_util:all_or_one_vhost(ReqData, fun rabbit_amqqueue:list_all/1).
+
 queues0(ReqData) ->
     rabbit_mgmt_util:all_or_one_vhost(ReqData, fun rabbit_amqqueue:list/1).
 
@@ -119,10 +163,14 @@ queues_with_totals(ReqData) ->
     rabbit_mgmt_util:all_or_one_vhost(ReqData, fun collect_info_all/1).
 
 collect_info_all(VHostPath) ->
-    rabbit_amqqueue:collect_info_all(VHostPath, [name, durable, auto_delete, exclusive, owner_pid, arguments, type, state, policy, totals, type_specific]).
+    rabbit_amqqueue:collect_info_all(VHostPath,
+                                     [name, durable, auto_delete, exclusive,
+                                      owner_pid, arguments, type, state,
+                                      policy, totals, online, type_specific]).
 
-down_queues(ReqData) ->
-    rabbit_mgmt_util:all_or_one_vhost(ReqData, fun rabbit_amqqueue:list_down/1).
+down_queues(ReqData, Running) ->
+    Fun = fun(VhostPath) -> rabbit_amqqueue:list_down(VhostPath, Running) end,
+    rabbit_mgmt_util:all_or_one_vhost(ReqData, Fun).
 
 policy(Q) ->
     case rabbit_policy:name(Q) of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queues.erl
@@ -46,7 +46,7 @@ content_types_provided(ReqData, Context) ->
 
 resource_exists(ReqData, {Mode, Context}) ->
     %% just checking that the vhost requested exists
-    {case rabbit_mgmt_util:all_or_one_vhost(ReqData, fun (_) -> ok end) of
+    {case rabbit_mgmt_util:all_or_one_vhost(ReqData, fun (_) -> [] end) of
          vhost_not_found -> false;
          _               -> true
      end, ReqData, {Mode, Context}}.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -36,6 +36,7 @@
          policy_changed/1,
          info/2,
          stat/1,
+         format/2,
          capabilities/0,
          notify_decorators/1
         ]).
@@ -201,6 +202,12 @@ notify_decorators(_) ->
     {'ok', non_neg_integer(), non_neg_integer()}.
 stat(_Q) ->
     {ok, 0, 0}.
+
+-spec format(amqqueue:amqqueue(), map()) ->
+    [{atom(), term()}].
+format(Q, _Ctx) ->
+    [{type, ?MODULE},
+     {state, amqqueue:get_state(Q)}].
 
 -spec capabilities() ->
     #{atom() := term()}.

--- a/deps/rabbitmq_stream_management/src/rabbit_stream_publishers_mgmt.erl
+++ b/deps/rabbitmq_stream_management/src/rabbit_stream_publishers_mgmt.erl
@@ -86,8 +86,9 @@ to_json(ReqData, Context = #context{user = User}) ->
                                         ReqData,
                                         Context);
         true ->
-            rabbit_mgmt_util:bad_request(<<"Stats in management UI are disabled on this node">>,
-                                         ReqData, Context)
+            %% if we don't return a 200 it is not possible to view the queue page
+            %% for a queue if the stream mgmt is enabled
+            rabbit_mgmt_util:reply_list([], [], ReqData, Context)
     end.
 
 is_authorized(ReqData, Context) ->


### PR DESCRIPTION
Listing queues with the HTTP API when there are many (1000s) of
quorum queues could be excessively slow compared to the same scenario
with classic queues.

This optimises various aspects of HTTP API queue listings.
For QQs it removes the expensive cluster wide rpcs used to get the
"online" status of each quorum queue. This was previously done _before_
paging and thus would perform a cluster-wide query for _each_ quorum queue in
the vhost/system. This accounted for most of the slowness compared to
classic queues.

Secondly the query to separate the running from the down queues
consisted of two separate queries that later were combined when a single
query would have sufficed.

This commit also includes a variety of other improvements and minor
fixes discovered during testing and optimisation.

MINOR BREAKING CHANGE: quorum queues would previously only display one
of two states: running or down. Now there is a new state called minority
which is emitted when the queue has at least one member running but
cannot commit entries due to lack of quorum.

Also the quorum queue may transiently enter the down state when a node
goes down and before its elected a new leader.