### PR TITLE
Logger exchange: fix race condition during initialisation

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1079,6 +1079,7 @@ stop(State) ->
         [] -> rabbit_prelaunch:set_stop_reason(normal);
         _  -> rabbit_prelaunch:set_stop_reason(State)
     end,
+    rabbit_db:clear_init_finished(),
     rabbit_boot_state:set(stopped),
     ok.
 


### PR DESCRIPTION
The logger exchange needs to declare the exchange during initialisation, which requires the metadata store to be ready.
Metadata store initalisation happens in a rabbit boot step after logger initialisation in the second phase of the prelaunch. The spawned process that declares the exchange, should also wait for the store to be ready. Otherwise it enters a loop trying to decide which store to use which generates a huge log and delays initialisation:

```
Mnesia->Khepri fallback handling: Mnesia function failed because table
 'rabbit_vhost' is missing or read-only. Migration could be in progress;
 waiting for migration to progress and trying again... 
```


This commit gives it 60 seconds for the metadata store to boot, and only afterwards tries (and retries if needed) to declare the exchange.

Detected by frequent CI flakes in `logging_SUITE:logging_to_exchange_works` 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

