### PR TITLE
Adjust strategy flags for bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,8 +38,7 @@ build:rbe --config=buildbuddy
 
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io
 
-build:rbe --spawn_strategy=remote,local
-build:rbe --test_strategy=""
+build:rbe --strategy=TestRunner=remote,worker,sandboxed,local
 build:rbe --jobs=50
 
 build:rbe --crosstool_top=@rbe//cc:toolchain

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -1,7 +1,7 @@
 # rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS
 # sandbox (https://github.com/bazelbuild/bazel/issues/7448)
-# adding "--spawn_strategy=local" to the invocation is a workaround
-build --spawn_strategy=local
+# adding "--strategy=TestRunner=local" to the invocation is a workaround
+build --strategy=TestRunner=local
 
 # --experimental_strict_action_env breaks memory size detection on macOS,
 # so turn it off for local runs


### PR DESCRIPTION
With this adjustment, more actions will use the sandbox, which may help with an error relating to a missing `rabbit.hrl` that could occur when building the cli or running its tests

Since this adjusts the user-template.bazelrc, everyone should likely update their own user.bazelrc accordingly