### PR TITLE
Avoid warning of unhandled message

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_internal_event_handler.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_internal_event_handler.erl
@@ -9,7 +9,7 @@
 
 -behaviour(gen_event).
 
--export([init/1, handle_event/2, handle_call/2]).
+-export([init/1, handle_event/2, handle_call/2, handle_info/2]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -35,3 +35,6 @@ handle_event(_Event, ?STATE) ->
 
 handle_call(_Request, ?STATE) ->
     {ok, ok, ?STATE}.
+
+handle_info(_Info, State) ->
+    {ok, State}.


### PR DESCRIPTION
Prior to this commit:
1. Start RabbitMQ with MQTT plugin enabled. 2.
```
rabbitmq-diagnostics consume_event_stream
^C
```
3. The logs will print the following warning:
```
[warning] <0.570.0> ** Undefined handle_info in rabbit_mqtt_internal_event_handler
[warning] <0.570.0> ** Unhandled message: {'DOWN',#Ref<0.2410135134.1846280193.145044>,process,
[warning] <0.570.0>                               <52723.100.0>,noconnection}
[warning] <0.570.0>
```

This is because rabbit_event_consumer:init/1 monitors the CLI process.

Any rabbit_event handler should therefore implement handle_info/2.

It's similar to what's described in the gen_event docs about add_sup_handler/3:
> Any event handler attached to an event manager which in turn has a
> supervised handler should expect callbacks of the shape
> Module:handle_info({'EXIT', Pid, Reason}, State).

Thanks @mkuratczyk for spotting this!