### PR TITLE
Bump AMQP 1.0 .NET dependencies

### DIFF
--- a/deps/rabbitmq_amqp1_0/test/system_SUITE_data/fsharp-tests/fsharp-tests.fsproj
+++ b/deps/rabbitmq_amqp1_0/test/system_SUITE_data/fsharp-tests/fsharp-tests.fsproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="6.*" />
-    <PackageReference Include="AmqpNetLite" Version="2.4.1" />
-    <PackageReference Include="AmqpNetLite.Serialization" Version="2.4.1" />
+    <PackageReference Include="AmqpNetLite" Version="2.4.7" />
+    <PackageReference Include="AmqpNetLite.Serialization" Version="2.4.7" />
   </ItemGroup>
 </Project>

--- a/deps/rabbitmq_amqp1_0/test/system_SUITE_data/fsharp-tests/global.json
+++ b/deps/rabbitmq_amqp1_0/test/system_SUITE_data/fsharp-tests/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "3.1"
+    "version": "7.0"
   }
 }


### PR DESCRIPTION
The latest .NET version is .NET 7:
https://learn.microsoft.com/en-us/dotnet/standard/frameworks#latest-versions