### PR TITLE
Dynamic Shovels: support old (pre-3.13.0, 3.12.8) and new supervisor child ID formats

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -58,7 +58,10 @@ obfuscated_uris_parameters(Def) when is_list(Def) ->
     rabbit_shovel_parameters:obfuscate_uris_in_definition(Def).
 
 child_exists(Name) ->
-    lists:any(fun ({{_, N}, _, _, _}) -> N =:= Name end,
+    lists:any(fun ({{_, N}, _, _, _}) -> N =:= Name;
+                  %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894.
+                  ({N, _, _, _})      -> N =:= Name
+              end,
               mirrored_supervisor:which_children(?SUPERVISOR)).
 
 stop_child({VHost, ShovelName} = Name) ->
@@ -83,14 +86,21 @@ stop_child({VHost, ShovelName} = Name) ->
 %% See rabbit_shovel_worker:terminate/2
 
 cleanup_specs() ->
-    SpecsSet = sets:from_list([element(2, element(1, S)) || S <- mirrored_supervisor:which_children(?SUPERVISOR)]),
+    Children = mirrored_supervisor:which_children(?SUPERVISOR),
+
+    %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
+    OldStyleSpecsSet = sets:from_list([element(1, S) || S <- Children]),
+    NewStyleSpecsSet = sets:from_list([element(2, element(1, S)) || S <- Children]),
     ParamsSet = sets:from_list([ {proplists:get_value(vhost, S), proplists:get_value(name, S)}
                                  || S <- rabbit_runtime_parameters:list_component(<<"shovel">>) ]),
     F = fun(Name, ok) ->
             _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name)),
             ok
         end,
-    ok = sets:fold(F, ok, sets:subtract(SpecsSet, ParamsSet)).
+    AllSpecs = sets:union(NewStyleSpecsSet, OldStyleSpecsSet),
+    %% Delete any supervisor children that do not have their respective runtime parameters in the database.
+    SetToCleanUp = sets:subtract(AllSpecs, ParamsSet),
+    ok = sets:fold(F, ok, SetToCleanUp).
 
 %%----------------------------------------------------------------------------
 
@@ -98,4 +108,7 @@ init([]) ->
     {ok, {{one_for_one, 3, 10}, []}}.
 
 id({V, S} = Name) ->
-    {[V, S], Name}.
+    {[V, S], Name};
+%% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
+id(Other) ->
+    Other.


### PR DESCRIPTION
During a rolling upgrade, all cluster nodes collectively may (and usually will, due to Shovel migration during node restarts) contain mirrored_supervisor children with IDs that use two different parameters (see referenced commits below).

The old format should not trip up node startup, so new nodes must accept it in a few places, and try to use these older values during dynamic Shovel spec cleanup.

References ccc22cb86b01ea, 5f0981c5a3b, #9785.

See #9894.
