### PR TITLE
Add --binding-keys to add_super_stream command

### DIFF
--- a/deps/rabbit/docs/rabbitmq-streams.8
+++ b/deps/rabbit/docs/rabbitmq-streams.8
@@ -307,7 +307,7 @@ for each producer:
 .sp
 .Dl rabbitmq-streams list_stream_publishers connection_pid publisher_id stream
 .\" ------------------------------------------------------------------
-.It Cm add_super_stream Ar super-stream Oo Fl -vhost Ar vhost Oc Oo Fl -partitions Ar partitions Oc Oo Fl -routing-keys Ar routing-keys Oc Oo Fl -max-length-bytes Ar max-length-bytes Oc Oo Fl -max-age Ar max-age Oc Oo Fl -stream-max-segment-size-bytes Ar stream-max-segment-size-bytes Oc Oo Fl -leader-locator Ar leader-locator Oc Oo Fl -initial-cluster-size Ar initial-cluster-size Oc
+.It Cm add_super_stream Ar super-stream Oo Fl -vhost Ar vhost Oc Oo Fl -partitions Ar partitions Oc Oo Fl -binding-keys Ar binding-keys Oc Oo Fl -max-length-bytes Ar max-length-bytes Oc Oo Fl -max-age Ar max-age Oc Oo Fl -stream-max-segment-size-bytes Ar stream-max-segment-size-bytes Oc Oo Fl -leader-locator Ar leader-locator Oc Oo Fl -initial-cluster-size Ar initial-cluster-size Oc
 .Bl -tag -width Ds
 .It Ar super-stream
 The name of the super stream to create.
@@ -315,8 +315,8 @@ The name of the super stream to create.
 The name of the virtual host to create the super stream into.
 .It Ar partitions
 The number of partitions the super stream will have.
-.It Ar routing-keys
-Comma-separated list of routing keys.
+.It Ar binding-keys
+Comma-separated list of binding keys.
 .It Ar max-length-bytes
 The maximum size of partition streams, example values: 20gb, 500mb.
 .It Ar max-age

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
@@ -40,6 +40,7 @@ description() ->
 
 switches() ->
     [{partitions, integer},
+     {binding_keys, string},
      {routing_keys, string},
      {max_length_bytes, string},
      {max_age, string},
@@ -52,9 +53,15 @@ help_section() ->
 
 validate([], _Opts) ->
     {validation_failure, not_enough_args};
+validate([_Name], #{routing_keys := _, binding_keys := _}) ->
+    {validation_failure,
+     "Specify --binding-keys only."};
+validate([_Name], #{partitions := _, binding_keys := _}) ->
+    {validation_failure,
+     "Specify --partitions or --binding-keys, not both."};
 validate([_Name], #{partitions := _, routing_keys := _}) ->
     {validation_failure,
-     "Specify --partitions or routing-keys, not both."};
+     "Specify --partitions or --binding-keys, not both."};
 validate([_Name], #{partitions := Partitions}) when Partitions < 1 ->
     {validation_failure, "The partition number must be greater than 0"};
 validate([_Name], Opts) ->
@@ -128,14 +135,17 @@ validate_stream_arguments(#{initial_cluster_size := Value} = Opts) ->
 validate_stream_arguments(_) ->
     ok.
 
-merge_defaults(_Args, #{routing_keys := _V} = Opts) ->
+merge_defaults(_Args, #{binding_keys := _V} = Opts) ->
     {_Args, maps:merge(#{vhost => <<"/">>}, Opts)};
+merge_defaults(_Args, #{routing_keys := RKs} = Opts) ->
+    {_Args, maps:merge(#{vhost => <<"/">>, binding_keys => RKs},
+                       maps:remove(routing_keys, Opts))};
 merge_defaults(_Args, Opts) ->
     {_Args, maps:merge(#{partitions => 3, vhost => <<"/">>}, Opts)}.
 
 usage() ->
     <<"add_super_stream <name> [--vhost <vhost>] [--partition"
-      "s <partitions>] [--routing-keys <routing-keys>]">>.
+      "s <partitions>] [--binding-keys <binding-keys>]">>.
 
 usage_additional() ->
     [[<<"<name>">>,
@@ -144,8 +154,8 @@ usage_additional() ->
       <<"The virtual host the super stream is added to.">>],
      [<<"--partitions <partitions>">>,
       <<"The number of partitions, default is 3. Mutually exclusive with --routing-keys.">>],
-     [<<"--routing-keys <routing-keys>">>,
-      <<"Comma-separated list of routing keys. Mutually exclusive with --partitions.">>],
+     [<<"--binding-keys <binding-keys>">>,
+      <<"Comma-separated list of binding keys. Mutually exclusive with --partitions.">>],
      [<<"--max-length-bytes <max-length-bytes>">>,
       <<"The maximum size of partition streams, example values: 20gb, 500mb.">>],
      [<<"--max-age <max-age>">>,
@@ -184,26 +194,26 @@ run([SuperStream],
     #{node := NodeName,
       vhost := VHost,
       timeout := Timeout,
-      routing_keys := RoutingKeysStr} =
+      binding_keys := BindingKeysStr} =
         Opts) ->
-    RoutingKeys =
+    BindingKeys =
         [rabbit_data_coercion:to_binary(
              string:strip(K))
          || K
                 <- string:tokens(
-                       rabbit_data_coercion:to_list(RoutingKeysStr), ",")],
+                       rabbit_data_coercion:to_list(BindingKeysStr), ",")],
     Streams =
         [list_to_binary(binary_to_list(SuperStream)
                         ++ "-"
                         ++ binary_to_list(K))
-         || K <- RoutingKeys],
+         || K <- BindingKeys],
     create_super_stream(NodeName,
                         Timeout,
                         VHost,
                         SuperStream,
                         Streams,
                         stream_arguments(Opts),
-                        RoutingKeys).
+                        BindingKeys).
 
 stream_arguments(Opts) ->
     stream_arguments(#{}, Opts).


### PR DESCRIPTION
It is meant to replace --routing-keys, which
is still available but not documented anymore.

This is to be consistent with AMQP 0.9.1 terminology.