### PR TITLE
Handle different queue states on queue deletion from the management API more robustly

### DIFF
--- a/deps/rabbit/src/amqqueue.erl
+++ b/deps/rabbit/src/amqqueue.erl
@@ -73,6 +73,7 @@
          is_amqqueue/1,
          is_auto_delete/1,
          is_durable/1,
+         is_exclusive/1,
          is_classic/1,
          is_quorum/1,
          pattern_match_all/0,
@@ -556,6 +557,11 @@ is_auto_delete(#amqqueue{auto_delete = AutoDelete}) ->
 -spec is_durable(amqqueue()) -> boolean().
 
 is_durable(#amqqueue{durable = Durable}) -> Durable.
+
+-spec is_exclusive(amqqueue()) -> boolean().
+
+is_exclusive(Queue) ->
+    is_pid(get_exclusive_owner(Queue)).
 
 -spec is_classic(amqqueue()) -> boolean().
 


### PR DESCRIPTION
## Proposed Changes

We'd like to have queue deletion behaviour from the management API to also more robustly handle different queue states, similar to changes introduced to the cli here: https://github.com/rabbitmq/rabbitmq-server/pull/9324 (after prior issues faced in prod). This is an extension/update to https://github.com/rabbitmq/rabbitmq-server/pull/9550

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
