### PR TITLE
Use rabbit_json in the CLI

### DIFF
--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -1,12 +1,11 @@
 PROJECT = rabbitmq_cli
 
 BUILD_DEPS = rabbit_common
-DEPS = csv json observer_cli stdout_formatter
+DEPS = csv observer_cli stdout_formatter
 TEST_DEPS = amqp amqp_client temp x509 rabbit
 
 dep_amqp = hex 3.3.0
 dep_csv = hex 3.2.0
-dep_json = hex 1.4.1
 dep_temp = hex 0.4.7
 dep_x509 = hex 0.8.8
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -159,7 +159,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
         end)
       end)
 
-    {:ok, json} = JSON.encode(map)
+    {:ok, json} = :rabbit_json.try_encode(map)
     json
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
@@ -166,7 +166,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
   #
 
   defp deserialise(bin, "json") do
-    JSON.decode(bin)
+    :rabbit_json.try_decode(bin)
   end
 
   defp deserialise(bin, "erlang") do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_user_limits_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_user_limits_command.ex
@@ -36,7 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserLimitsCommand do
 
       val ->
         Enum.map(val, fn {user, val} ->
-          {:ok, val_encoded} = JSON.encode(Map.new(val))
+          {:ok, val_encoded} = :rabbit_json.try_encode(Map.new(val))
           [user: user, limits: val_encoded]
         end)
     end
@@ -56,7 +56,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserLimitsCommand do
         {:badrpc, node}
 
       val when is_list(val) or is_map(val) ->
-        {:ok, val_encoded} = JSON.encode(Map.new(val))
+        {:ok, val_encoded} = :rabbit_json.try_encode(Map.new(val))
         val_encoded
     end
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
@@ -36,7 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostLimitsCommand do
 
       val ->
         Enum.map(val, fn {vhost, val} ->
-          {:ok, val_encoded} = JSON.encode(Map.new(val))
+          {:ok, val_encoded} = :rabbit_json.try_encode(Map.new(val))
           [vhost: vhost, limits: val_encoded]
         end)
     end
@@ -54,7 +54,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostLimitsCommand do
         {:badrpc, node}
 
       val when is_list(val) or is_map(val) ->
-        JSON.encode(Map.new(val))
+        :rabbit_json.try_encode(Map.new(val))
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
@@ -18,7 +18,7 @@ defmodule RabbitMQ.CLI.Formatters.Json do
   end
 
   def format_output(output, _opts) do
-    {:ok, json} = JSON.encode(keys_to_atoms(output))
+    {:ok, json} = :rabbit_json.try_encode(keys_to_atoms(output))
     json
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json_stream.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json_stream.ex
@@ -31,7 +31,7 @@ defmodule RabbitMQ.CLI.Formatters.JsonStream do
   end
 
   def format_output(output, _opts) do
-    {:ok, json} = JSON.encode(keys_to_atoms(output))
+    {:ok, json} = :rabbit_json.try_encode(output)
     json
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -558,7 +558,7 @@ defmodule RabbitMQCtl do
   end
 
   defp format_error({:error, :check_failed, err}, %{formatter: "json"}, _) when is_map(err) do
-    {:ok, res} = JSON.encode(err)
+    {:ok, res} = :rabbit_json.try_encode(err)
     {:error, ExitCodes.exit_unavailable(), res}
   end
 
@@ -578,12 +578,12 @@ defmodule RabbitMQCtl do
 
   # Catch all clauses
   defp format_error({:error, err}, %{formatter: "json"}, _) when is_map(err) do
-    {:ok, res} = JSON.encode(err)
+    {:ok, res} = :rabbit_json.try_encode(err)
     {:error, ExitCodes.exit_unavailable(), res}
   end
 
   defp format_error({:error, exit_code, err}, %{formatter: "json"}, _) when is_map(err) do
-    {:ok, res} = JSON.encode(err)
+    {:ok, res} = :rabbit_json.try_encode(err)
     {:error, exit_code, res}
   end
 

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -15,6 +15,7 @@ defmodule RabbitMQCtl.MixfileBase do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       escript: [main_module: RabbitMQCtl, emu_args: "-hidden", path: "escript/rabbitmqctl"],
+      prune_code_paths: false,
       deps: deps(Mix.env()),
       aliases: aliases(),
       xref: [
@@ -140,10 +141,6 @@ defmodule RabbitMQCtl.MixfileBase do
     is_bazel = System.get_env("IS_BAZEL") != nil
 
     [
-      {
-        :json,
-        path: Path.join(deps_dir, "json")
-      },
       {
         :csv,
         path: Path.join(deps_dir, "csv")

--- a/deps/rabbitmq_cli/test/ctl/export_definitions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/export_definitions_command_test.exs
@@ -111,7 +111,7 @@ defmodule ExportDefinitionsCommandTest do
     {:ok, nil} = @command.run([valid_file_path()], context[:opts])
 
     {:ok, bin} = File.read(valid_file_path())
-    {:ok, map} = JSON.decode(bin)
+    {:ok, map} = :rabbit_json.try_decode(bin)
     assert Map.has_key?(map, "rabbitmq_version")
   end
 
@@ -128,7 +128,7 @@ defmodule ExportDefinitionsCommandTest do
     clear_parameter("/", "federation-upstream", "up-1")
 
     {:ok, bin} = File.read(valid_file_path())
-    {:ok, map} = JSON.decode(bin)
+    {:ok, map} = :rabbit_json.try_decode(bin)
     assert Map.has_key?(map, "rabbitmq_version")
     params = map["parameters"]
     assert is_map(hd(params)["value"])

--- a/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
@@ -131,6 +131,6 @@ defmodule SetUserLimitsCommandTest do
 
   defp assert_limits(context, definition) do
     limits = get_user_limits(context[:user])
-    assert {:ok, limits} == JSON.decode(definition)
+    assert {:ok, limits} == :rabbit_json.try_decode(definition)
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
@@ -138,6 +138,6 @@ defmodule SetVhostLimitsCommandTest do
 
   defp assert_limits(context) do
     limits = get_vhost_limits(context[:vhost])
-    assert {:ok, limits} == JSON.decode(context[:definition])
+    assert {:ok, limits} == :rabbit_json.try_decode(context[:definition])
   end
 end

--- a/deps/rabbitmq_cli/test/json_formatting.exs
+++ b/deps/rabbitmq_cli/test/json_formatting.exs
@@ -29,7 +29,7 @@ defmodule JSONFormattingTest do
         error_check(command, exit_ok())
       end)
 
-    {:ok, doc} = JSON.decode(output)
+    {:ok, doc} = :rabbit_json.try_decode(output)
 
     assert Map.has_key?(doc, "memory")
     assert Map.has_key?(doc, "file_descriptors")
@@ -53,7 +53,7 @@ defmodule JSONFormattingTest do
         error_check(command, exit_ok())
       end)
 
-    {:ok, doc} = JSON.decode(output)
+    {:ok, doc} = :rabbit_json.try_decode(output)
 
     assert Enum.member?(doc["disk_nodes"], node)
     assert Map.has_key?(doc["listeners"], node)

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -19,7 +19,6 @@ true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit_common", 
 true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit", "ebin"]))
 
 true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "amqp", "ebin"]))
-true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "json", "ebin"]))
 true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "x509", "ebin"]))
 
 if function_exported?(Mix, :ensure_application!, 1) do


### PR DESCRIPTION
dep_json doesn't seem to be maintained
and it's unnecessary anyway, since we can
use rabbit_json, which uses thoas underneath