### PR TITLE
Revert elixir json switch

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,6 +53,7 @@ exports_files([
 # gazelle:exclude deps/gun
 # gazelle:exclude deps/inet_tcp_proxy
 # gazelle:exclude deps/jose
+# gazelle:exclude deps/json
 # gazelle:exclude deps/meck
 # gazelle:exclude deps/observer_cli
 # gazelle:exclude deps/osiris

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -277,6 +277,13 @@ erlang_package.git_package(
     repository = "michaelklishin/erlang-jose",
 )
 
+erlang_package.hex_package(
+    name = "json",
+    build_file = "@rabbitmq-server//bazel:BUILD.json",
+    sha256 = "9abf218dbe4ea4fcb875e087d5f904ef263d012ee5ed21d46e9dbca63f053d16",
+    version = "1.4.1",
+)
+
 erlang_package.git_package(
     name = "khepri",
     build_file = "@rabbitmq-server//bazel:BUILD.khepri",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -408,6 +408,7 @@ use_repo(
     "gun",
     "horus",
     "jose",
+    "json",
     "khepri",
     "khepri_mnesia_migration",
     "observer_cli",

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ XREF_EXTRA_APP_DIRS = $(filter-out deps/rabbitmq_cli/_build/dev/lib/rabbit_commo
 # protocols directly.
 XREF_IGNORE = [ \
     {'Elixir.CSV.Encode',impl_for,1}, \
+    {'Elixir.JSON.Decoder',impl_for,1}, \
+    {'Elixir.JSON.Encoder',impl_for,1}, \
     {'Elixir.RabbitMQ.CLI.Core.DataCoercion',impl_for,1}]
 
 # Include Elixir libraries in the Xref checks.

--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -17,6 +17,13 @@ mix_archive_build(
     archives = ["@hex//:archive"],
 )
 
+mix_archive_build(
+    name = "json_ez",
+    srcs = ["@json//:sources"],
+    out = "json.ez",
+    archives = ["@hex//:archive"],
+)
+
 # Note: All the various rabbitmq-* scripts are just copies of rabbitmqctl
 rabbitmqctl(
     name = "rabbitmqctl",
@@ -32,6 +39,7 @@ rabbitmqctl(
     license_files = glob(["LICENSE*"]),
     source_deps = {
         "@csv//:sources": "csv",
+        "@json//:sources": "json",
     },
     visibility = ["//visibility:public"],
     deps = [
@@ -101,6 +109,7 @@ plt(
     ],
     ez_deps = [
         ":csv_ez",
+        ":json_ez",
     ],
     ignore_warnings = True,
     libs = [":elixir"],
@@ -142,6 +151,7 @@ rabbitmqctl_test(
     source_deps = {
         "@amqp//:sources": "amqp",
         "@csv//:sources": "csv",
+        "@json//:sources": "json",
         "@temp//:sources": "temp",
         "@x509//:sources": "x509",
     },

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -1,11 +1,12 @@
 PROJECT = rabbitmq_cli
 
 BUILD_DEPS = rabbit_common
-DEPS = csv observer_cli stdout_formatter
+DEPS = csv json observer_cli stdout_formatter
 TEST_DEPS = amqp amqp_client temp x509 rabbit
 
 dep_amqp = hex 3.3.0
 dep_csv = hex 3.2.0
+dep_json = hex 1.4.1
 dep_temp = hex 0.4.7
 dep_x509 = hex 0.8.8
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -159,7 +159,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
         end)
       end)
 
-    {:ok, json} = :rabbit_json.try_encode(map)
+    {:ok, json} = JSON.encode(map)
     json
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
@@ -166,7 +166,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
   #
 
   defp deserialise(bin, "json") do
-    :rabbit_json.try_decode(bin)
+    JSON.decode(bin)
   end
 
   defp deserialise(bin, "erlang") do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_user_limits_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_user_limits_command.ex
@@ -36,7 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserLimitsCommand do
 
       val ->
         Enum.map(val, fn {user, val} ->
-          {:ok, val_encoded} = :rabbit_json.try_encode(Map.new(val))
+          {:ok, val_encoded} = JSON.encode(Map.new(val))
           [user: user, limits: val_encoded]
         end)
     end
@@ -56,7 +56,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserLimitsCommand do
         {:badrpc, node}
 
       val when is_list(val) or is_map(val) ->
-        {:ok, val_encoded} = :rabbit_json.try_encode(Map.new(val))
+        {:ok, val_encoded} = JSON.encode(Map.new(val))
         val_encoded
     end
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
@@ -36,7 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostLimitsCommand do
 
       val ->
         Enum.map(val, fn {vhost, val} ->
-          {:ok, val_encoded} = :rabbit_json.try_encode(Map.new(val))
+          {:ok, val_encoded} = JSON.encode(Map.new(val))
           [vhost: vhost, limits: val_encoded]
         end)
     end
@@ -54,7 +54,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostLimitsCommand do
         {:badrpc, node}
 
       val when is_list(val) or is_map(val) ->
-        :rabbit_json.try_encode(Map.new(val))
+        JSON.encode(Map.new(val))
     end
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
@@ -18,7 +18,7 @@ defmodule RabbitMQ.CLI.Formatters.Json do
   end
 
   def format_output(output, _opts) do
-    {:ok, json} = :rabbit_json.try_encode(keys_to_atoms(output))
+    {:ok, json} = JSON.encode(keys_to_atoms(output))
     json
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json_stream.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json_stream.ex
@@ -31,7 +31,7 @@ defmodule RabbitMQ.CLI.Formatters.JsonStream do
   end
 
   def format_output(output, _opts) do
-    {:ok, json} = :rabbit_json.try_encode(output)
+    {:ok, json} = JSON.encode(keys_to_atoms(output))
     json
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmqctl.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmqctl.ex
@@ -558,7 +558,7 @@ defmodule RabbitMQCtl do
   end
 
   defp format_error({:error, :check_failed, err}, %{formatter: "json"}, _) when is_map(err) do
-    {:ok, res} = :rabbit_json.try_encode(err)
+    {:ok, res} = JSON.encode(err)
     {:error, ExitCodes.exit_unavailable(), res}
   end
 
@@ -578,12 +578,12 @@ defmodule RabbitMQCtl do
 
   # Catch all clauses
   defp format_error({:error, err}, %{formatter: "json"}, _) when is_map(err) do
-    {:ok, res} = :rabbit_json.try_encode(err)
+    {:ok, res} = JSON.encode(err)
     {:error, ExitCodes.exit_unavailable(), res}
   end
 
   defp format_error({:error, exit_code, err}, %{formatter: "json"}, _) when is_map(err) do
-    {:ok, res} = :rabbit_json.try_encode(err)
+    {:ok, res} = JSON.encode(err)
     {:error, exit_code, res}
   end
 

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -15,6 +15,7 @@ defmodule RabbitMQCtl.MixfileBase do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       escript: [main_module: RabbitMQCtl, emu_args: "-hidden", path: "escript/rabbitmqctl"],
+      prune_code_paths: false,
       deps: deps(Mix.env()),
       aliases: aliases(),
       xref: [

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -15,7 +15,6 @@ defmodule RabbitMQCtl.MixfileBase do
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       escript: [main_module: RabbitMQCtl, emu_args: "-hidden", path: "escript/rabbitmqctl"],
-      prune_code_paths: false,
       deps: deps(Mix.env()),
       aliases: aliases(),
       xref: [
@@ -140,6 +139,10 @@ defmodule RabbitMQCtl.MixfileBase do
     is_bazel = System.get_env("IS_BAZEL") != nil
 
     [
+      {
+        :json,
+        path: Path.join(deps_dir, "json")
+      },
       {
         :csv,
         path: Path.join(deps_dir, "csv")

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -21,6 +21,7 @@ defmodule RabbitMQCtl.MixfileBase do
         exclude: [
           CSV,
           CSV.Encode,
+          JSON,
           :mnesia,
           :msacc,
           :observer_cli,

--- a/deps/rabbitmq_cli/test/ctl/export_definitions_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/export_definitions_command_test.exs
@@ -111,7 +111,7 @@ defmodule ExportDefinitionsCommandTest do
     {:ok, nil} = @command.run([valid_file_path()], context[:opts])
 
     {:ok, bin} = File.read(valid_file_path())
-    {:ok, map} = :rabbit_json.try_decode(bin)
+    {:ok, map} = JSON.decode(bin)
     assert Map.has_key?(map, "rabbitmq_version")
   end
 
@@ -128,7 +128,7 @@ defmodule ExportDefinitionsCommandTest do
     clear_parameter("/", "federation-upstream", "up-1")
 
     {:ok, bin} = File.read(valid_file_path())
-    {:ok, map} = :rabbit_json.try_decode(bin)
+    {:ok, map} = JSON.decode(bin)
     assert Map.has_key?(map, "rabbitmq_version")
     params = map["parameters"]
     assert is_map(hd(params)["value"])

--- a/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_user_limits_command_test.exs
@@ -131,6 +131,6 @@ defmodule SetUserLimitsCommandTest do
 
   defp assert_limits(context, definition) do
     limits = get_user_limits(context[:user])
-    assert {:ok, limits} == :rabbit_json.try_decode(definition)
+    assert {:ok, limits} == JSON.decode(definition)
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_vhost_limits_command_test.exs
@@ -138,6 +138,6 @@ defmodule SetVhostLimitsCommandTest do
 
   defp assert_limits(context) do
     limits = get_vhost_limits(context[:vhost])
-    assert {:ok, limits} == :rabbit_json.try_decode(context[:definition])
+    assert {:ok, limits} == JSON.decode(context[:definition])
   end
 end

--- a/deps/rabbitmq_cli/test/json_formatting.exs
+++ b/deps/rabbitmq_cli/test/json_formatting.exs
@@ -29,7 +29,7 @@ defmodule JSONFormattingTest do
         error_check(command, exit_ok())
       end)
 
-    {:ok, doc} = :rabbit_json.try_decode(output)
+    {:ok, doc} = JSON.decode(output)
 
     assert Map.has_key?(doc, "memory")
     assert Map.has_key?(doc, "file_descriptors")
@@ -53,7 +53,7 @@ defmodule JSONFormattingTest do
         error_check(command, exit_ok())
       end)
 
-    {:ok, doc} = :rabbit_json.try_decode(output)
+    {:ok, doc} = JSON.decode(output)
 
     assert Enum.member?(doc["disk_nodes"], node)
     assert Map.has_key?(doc["listeners"], node)

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -19,6 +19,7 @@ true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit_common", 
 true = Code.append_path(Path.join([System.get_env("DEPS_DIR"), "rabbit", "ebin"]))
 
 true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "amqp", "ebin"]))
+true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "json", "ebin"]))
 true = Code.append_path(Path.join(["_build", Atom.to_string(Mix.env()), "lib", "x509", "ebin"]))
 
 if function_exported?(Mix, :ensure_application!, 1) do

--- a/dist.bzl
+++ b/dist.bzl
@@ -336,6 +336,15 @@ def source_archive(
     )
 
     pkg_files(
+        name = "json-files",
+        srcs = [
+            "@json//:sources",
+        ],
+        strip_prefix = "",
+        prefix = "deps/json",
+    )
+
+    pkg_files(
         name = "csv-files",
         srcs = [
             "@csv//:sources",
@@ -349,6 +358,7 @@ def source_archive(
         extension = extension,
         srcs = [
             ":deps-files",
+            ":json-files",
             ":csv-files",
             Label("@rabbitmq-server//:root-licenses"),
         ],


### PR DESCRIPTION
Unfortunately the switch to `rabbit_json`/`thoas` led to some commands failing:
```
> rabbitmqctl list_stream_connections --formatter json conn_name
[
{"conn_name":"127.0.0.1:60556 -> 127.0.0.1:5552"}
,{"conn_name":"127.0.0.1:60552 -> 127.0.0.1:5552"}
,{"conn_name":"127.0.0.1:60555 -> 127.0.0.1:5552"}
]

> rabbitmqctl list_stream_connections --formatter json conn_name,client_properties
[
{:badmatch, {:error, :function_clause}}
```

We'll look into this at some point. For now, let's revert.

References #9926 #9932.