### PR TITLE
Fix handling shovels with old supervisor id format

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -72,8 +72,18 @@ stop_child({VHost, ShovelName} = Name) ->
     case get({shovel_worker_autodelete, Name}) of
         true -> ok; %% [1]
         _ ->
-            ok = mirrored_supervisor:terminate_child(?SUPERVISOR, id(Name)),
-            ok = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name)),
+            case mirrored_supervisor:terminate_child(?SUPERVISOR, id(Name)) of
+                ok ->
+                    ok = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name));
+                {error, not_found} ->
+                    %% try older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894.
+                    case mirrored_supervisor:terminate_child(?SUPERVISOR, old_id(Name)) of
+                        ok ->
+                            ok = mirrored_supervisor:delete_child(?SUPERVISOR, old_id(Name));
+                        {error, not_found} ->
+                            ok
+                    end
+            end,
             rabbit_shovel_status:remove(Name)
     end,
     rabbit_shovel_locks:unlock(LockId),
@@ -90,23 +100,26 @@ stop_child({VHost, ShovelName} = Name) ->
 cleanup_specs() ->
     Children = mirrored_supervisor:which_children(?SUPERVISOR),
 
-    %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
-    OldStyleSpecsSet = sets:from_list([element(1, S) || S <- Children]),
-    NewStyleSpecsSet = sets:from_list([element(2, element(1, S)) || S <- Children]),
-    ParamsSet = sets:from_list([ {proplists:get_value(vhost, S), proplists:get_value(name, S)}
-                                 || S <- rabbit_runtime_parameters:list_component(<<"shovel">>) ]),
-    F = fun(Name, ok) ->
+    SupIdSet = sets:from_list([element(1, S) || S <- Children]),
+    ParamsSet = sets:from_list(
+                  lists:flatmap(
+                    fun(S) ->
+                            Name = {proplists:get_value(vhost, S), proplists:get_value(name, S)},
+                            %% Supervisor Id format was different pre 3.13.0 and 3.12.8.
+                            %% Try both formats to cover the transitionary mixed version cluster period.
+                            [id(Name), old_id(Name)]
+                    end,
+                    rabbit_runtime_parameters:list_component(<<"shovel">>))),
+    F = fun(SupId, ok) ->
             try
-                _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name))
+                _ = mirrored_supervisor:delete_child(?SUPERVISOR, SupId)
             catch _:_:_Stacktrace ->
                 ok
             end,
             ok
         end,
-    %% Try both formats to cover the transitionary mixed version cluster period.
-    AllSpecs = sets:union(NewStyleSpecsSet, OldStyleSpecsSet),
     %% Delete any supervisor children that do not have their respective runtime parameters in the database.
-    SetToCleanUp = sets:subtract(AllSpecs, ParamsSet),
+    SetToCleanUp = sets:subtract(SupIdSet, ParamsSet),
     ok = sets:fold(F, ok, SetToCleanUp).
 
 %%----------------------------------------------------------------------------
@@ -115,7 +128,8 @@ init([]) ->
     {ok, {{one_for_one, 3, 10}, []}}.
 
 id({V, S} = Name) ->
-    {[V, S], Name};
+    {[V, S], Name}.
+
 %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
-id(Other) ->
-    Other.
+old_id({_V, _S} = Name) ->
+    Name.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -41,16 +41,18 @@ start_child({VHost, ShovelName} = Name, Def) ->
     LockId = rabbit_shovel_locks:lock(Name),
     cleanup_specs(),
     rabbit_log_shovel:debug("Starting a mirrored supervisor named '~ts' in virtual host '~ts'", [ShovelName, VHost]),
-    Result = case mirrored_supervisor:start_child(
+    case child_exists(Name)
+        orelse mirrored_supervisor:start_child(
            ?SUPERVISOR,
            {id(Name), {rabbit_shovel_dyn_worker_sup, start_link, [Name, obfuscated_uris_parameters(Def)]},
             transient, ?WORKER_WAIT, worker, [rabbit_shovel_dyn_worker_sup]}) of
+        true                             -> ok;
         {ok,                      _Pid}  -> ok;
         {error, {already_started, _Pid}} -> ok
     end,
     %% release the lock if we managed to acquire one
     rabbit_shovel_locks:unlock(LockId),
-    Result.
+    ok.
 
 obfuscated_uris_parameters(Def) when is_map(Def) ->
     to_map(rabbit_shovel_parameters:obfuscate_uris_in_definition(to_list(Def)));


### PR DESCRIPTION
## Proposed Changes

- Don't create shovel if already exists with old sup id

  Before 3.13.0 and 3.12.8 supervisor id format was different. Don't
  start a shovel with the new id format if one exists with the old id
  format.

- Fix deleting and cleanup of shovels with old ids

Fixes #9964 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
