### PR TITLE
rabbitmq-dist.mk: Install CLI scripts as part of the build instead of the `dist` target

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-dist.mk
+++ b/deps/rabbit_common/mk/rabbitmq-dist.mk
@@ -215,7 +215,7 @@ CLI_SCRIPTS_LOCK = $(CLI_SCRIPTS_DIR).lock
 CLI_ESCRIPTS_LOCK = $(CLI_ESCRIPTS_DIR).lock
 
 ifneq ($(filter-out rabbit_common amqp10_common rabbitmq_stream_common,$(PROJECT)),)
-dist:: install-cli
+app:: install-cli
 test-build:: install-cli
 endif
 


### PR DESCRIPTION
## Why

We already do that when building tests. Thus it is more consistent to do the same.

Also, it makes sense to ensure everything is ready before the `dist` step. For instance, an Erlang release would not depend on the `dist` target, just the build and it would still need the CLI to be ready.