### PR TITLE
Make 'ctl node_health_check' a no-op

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -9,54 +9,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  @default_timeout 70_000
-
   def scopes(), do: [:ctl, :diagnostics]
   use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
 
   def merge_defaults(args, opts) do
-    timeout =
-      case opts[:timeout] do
-        nil -> @default_timeout
-        :infinity -> @default_timeout
-        other -> other
-      end
-
-    {args, Map.merge(opts, %{timeout: timeout})}
+    {args, opts}
   end
 
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([], %{node: node_name, timeout: timeout}) do
-    case :rabbit_misc.rpc_call(node_name, :rabbit_health_check, :node, [node_name, timeout]) do
-      :ok ->
-        :ok
-
-      true ->
-        :ok
-
-      {:badrpc, _} = err ->
-        err
-
-      {:error_string, error_message} ->
-        {:healthcheck_failed, error_message}
-
-      {:node_is_ko, error_message, _exit_code} ->
-        {:healthcheck_failed, error_message}
-
-      other ->
-        other
-    end
-  end
-
-  def output(:ok, _) do
-    {:ok, "Health check passed"}
-  end
-
-  def output({:healthcheck_failed, message}, _) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software(),
-     "Error: health check failed. Message: #{message}"}
+  def run([], _opts) do
+    :ok
   end
 
   use RabbitMQ.CLI.DefaultOutput
@@ -72,17 +36,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
   def help_section(), do: :deprecated
 
   def description() do
-    "DEPRECATED. Performs intrusive, opinionated health checks on a fully booted node. " <>
-      "See https://www.rabbitmq.com/monitoring.html#health-checks instead"
+    "DEPRECATED. This command is a no-op. " <>
+      "See https://www.rabbitmq.com/monitoring.html#health-checks"
   end
 
-  def banner(_, %{node: node_name, timeout: timeout}) do
+  def banner(_, _opts) do
     [
-      "This command is DEPRECATED and will be removed in a future version.",
-      "It performs intrusive, opinionated health checks and requires a fully booted node.",
-      "Use one of the options covered in https://www.rabbitmq.com/monitoring.html#health-checks instead.",
-      "Timeout: #{trunc(timeout / 1000)} seconds ...",
-      "Checking health of node #{node_name} ..."
+      "This command is DEPRECATED and is a no-op. It will be removed in a future version. ",
+      "Use one of the options covered in https://www.rabbitmq.com/monitoring.html#health-checks instead."
     ]
   end
 end

--- a/deps/rabbitmq_cli/test/ctl/node_health_check_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/node_health_check_command_test.exs
@@ -38,27 +38,11 @@ defmodule NodeHealthCheckCommandTest do
     assert @command.validate([], context[:opts]) == :ok
   end
 
-  test "run: request to a named, active node succeeds", context do
+  test "run: is a no-op", context do
     assert @command.run([], context[:opts])
   end
 
-  test "run: request to a named, active node with an alarm in effect fails", context do
-    set_vm_memory_high_watermark(0.0000000000001)
-    # give VM memory monitor check some time to kick in
-    :timer.sleep(1500)
-    {:healthcheck_failed, _message} = @command.run([], context[:opts])
-
-    reset_vm_memory_high_watermark()
-    :timer.sleep(1500)
-    assert @command.run([], context[:opts]) == :ok
-  end
-
-  test "run: request to a non-existent node returns a badrpc" do
-    assert match?({:badrpc, _}, @command.run([], %{node: :jake@thedog, timeout: 200}))
-  end
-
   test "banner", context do
-    assert @command.banner([], context[:opts]) |> Enum.join("\n") =~ ~r/Checking health/
-    assert @command.banner([], context[:opts]) |> Enum.join("\n") =~ ~r/#{get_rabbit_hostname()}/
+    assert @command.banner([], context[:opts]) |> Enum.join("\n") =~ ~r/DEPRECATED/
   end
 end


### PR DESCRIPTION
It's been deprecated over three years ago [1]
(before RabbitMQ 3.9).

This version for `3.13` intentionally does not remove the command or make it always fail.
Making it fail will make it easy to notice the deprecation but at the same time, seriously
annoy a lot of operators. Consider scenarios where the health check is used by external tools outside of operator's control.

So this seems to be the most natural deprecation progression for 3.13.

1. https://github.com/rabbitmq/rabbitmq-server/commit/e01753ed7adb4ae2d3fa217bfee2598736ca035f
