### PR TITLE
rabbit_writer: ignore unknown messages

### DIFF
--- a/deps/rabbit_common/src/rabbit_writer.erl
+++ b/deps/rabbit_common/src/rabbit_writer.erl
@@ -271,6 +271,14 @@ handle_message({'DOWN', _MRef, process, QPid, _Reason}, State) ->
 handle_message(emit_stats, State = #wstate{reader = ReaderPid}) ->
     ReaderPid ! ensure_stats,
     rabbit_event:reset_stats_timer(State, #wstate.stats_timer);
+handle_message(ok, State) ->
+    State;
+handle_message({_Ref, ok} = Msg, State) ->
+    rabbit_log:warning("AMQP 0-9-1 channel writer has received a message it does not support: ~p", [Msg]),
+    State;
+handle_message({ok, _Ref} = Msg, State) ->
+    rabbit_log:warning("AMQP 0-9-1 channel writer has received a message it does not support: ~p", [Msg]),
+    State;
 handle_message(Message, _State) ->
     exit({writer, message_not_understood, Message}).
 


### PR DESCRIPTION
of a certain structure reported in #9803.

Closes #9991.

The goal at this point is to avoid connection termination. Those who would like to investigate
these messages further now have a place to add extra logging or tracing.