### PR TITLE
sync otp_version_id across oci.yaml and rabbitmq_peer_discovery_aws.yaml

### DIFF
--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - image_tag_suffix: otp-max-bazel
-            otp_version_id: 26
+            otp_version_id: 26_1
     timeout-minutes: 45
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -1,6 +1,14 @@
 name: Peer Discovery AWS Integration Test
 on:
+  push:
+    paths-ignore:
+      - '.github/workflows/secondary-umbrella.yaml'
+      - '.github/workflows/update-elixir-patches.yaml'
+      - '.github/workflows/update-otp-patches.yaml'
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 jobs:
   peer-discovery-aws-integration-test:
     name: Integration Test


### PR DESCRIPTION
The need to match as the aws workflow waits for the oci from the oci workflow