### PR TITLE
rabbit_runtime: Improve get_erl_path/0

### DIFF
--- a/deps/rabbit_common/src/rabbit_runtime.erl
+++ b/deps/rabbit_common/src/rabbit_runtime.erl
@@ -56,11 +56,10 @@ msacc_stats(TimeInMs) ->
 % get the full path to the erl executable used to start this VM
 -spec get_erl_path() -> file:filename_all().
 get_erl_path() ->
-    ERTSDir = rabbit_misc:format("erts-~ts", [erlang:system_info(version)]),
-    Bin = filename:join([code:root_dir(), ERTSDir, "bin"]),
+    {ok, [[BinDir]]} = init:get_argument(bindir),
     case os:type() of
         {win32, _} ->
-            filename:join(Bin, "erl.exe");
+            filename:join(BinDir, "erl.exe");
         _ ->
-            filename:join(Bin, "erl")
+            filename:join(BinDir, "erl")
     end.


### PR DESCRIPTION
## Why

The previous implementation assumed that ERTS was in the Erlang root dir. This is true for a standard Erlang install. However, it's not the case of an Erlang release that does not include the runtime.

## How

The bin directory (`bindir`) is already available as an argument to init. We can simply query it and use the value as is.