### PR TITLE
Shovel: convert AMQP 1.0 props and app props to AMQP 0.9.1 props and headers

### DIFF
--- a/deps/amqp10_client/src/amqp10_msg.erl
+++ b/deps/amqp10_client/src/amqp10_msg.erl
@@ -28,6 +28,7 @@
          new/3,
          set_handle/2,
          set_settled/2,
+         set_delivery_tag/2,
          set_message_format/2,
          set_headers/2,
          set_properties/2,
@@ -297,6 +298,10 @@ set_handle(Handle, #amqp10_msg{transfer = T} = Msg) ->
 -spec set_settled(boolean(), amqp10_msg()) -> amqp10_msg().
 set_settled(Settled, #amqp10_msg{transfer = T} = Msg) ->
     Msg#amqp10_msg{transfer = T#'v1_0.transfer'{settled = Settled}}.
+
+-spec set_delivery_tag(binary(), amqp10_msg()) -> amqp10_msg().
+set_delivery_tag(Tag, #amqp10_msg{transfer = T} = Msg) when is_binary(Tag) ->
+    Msg#amqp10_msg{transfer = T#'v1_0.transfer'{delivery_tag = {binary, Tag}}}.
 
 %% @doc Set amqp message headers.
 -spec set_headers(#{atom() => any()}, amqp10_msg()) -> amqp10_msg().

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -63,6 +63,10 @@
 init(Sections) when is_list(Sections) ->
     Msg = decode(Sections, #msg{}),
     init(Msg);
+init(Amqp10Msg) when element(1, Amqp10Msg) =:= amqp10_msg ->
+    [#'v1_0.transfer'{}| AmqpRecords] = amqp10_msg:to_amqp_records(Amqp10Msg),
+    Msg = decode(AmqpRecords, #msg{}),
+    init(Msg);
 init(#msg{} = Msg) ->
     %% TODO: as the essential annotations, durable, priority, ttl and delivery_count
     %% is all we are interested in it isn't necessary to keep hold of the

--- a/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl
@@ -12,6 +12,7 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include("rabbit_shovel.hrl").
 
+
 -export([
          parse/2,
          source_uri/1,
@@ -31,7 +32,7 @@
          ack/3,
          nack/3,
          status/1,
-         forward/4
+         forward/3
         ]).
 
 %% Function references should not be stored on the metadata store.
@@ -167,8 +168,8 @@ forward_pending(State) ->
     case pop_pending(State) of
         empty ->
             State;
-        {{Tag, Props, Payload}, S} ->
-            S2 = do_forward(Tag, Props, Payload, S),
+        {{Tag, Msg}, S} ->
+            S2 = do_forward(Tag, Msg, S),
             S3 = control_throttle(S2),
             case is_blocked(S3) of
                 true ->
@@ -181,80 +182,40 @@ forward_pending(State) ->
             end
     end.
 
-forward(IncomingTag, Props, Payload, State) ->
+forward(IncomingTag, Msg, State) ->
     case is_blocked(State) of
         true ->
             %% We are blocked by client-side flow-control and/or
             %% `connection.blocked` message from the destination
             %% broker. Simply cache the forward.
-            PendingEntry = {IncomingTag, Props, Payload},
+            PendingEntry = {IncomingTag, Msg},
             add_pending(PendingEntry, State);
         false ->
-            State1 = do_forward(IncomingTag, Props, Payload, State),
+            State1 = do_forward(IncomingTag, Msg, State),
             control_throttle(State1)
     end.
 
-do_forward(IncomingTag, Props, Payload,
+do_forward(IncomingTag, InMsg,
            State0 = #{dest := #{props_fun := {M, F, Args},
                                 current := {_, _, DstUri},
                                 fields_fun := {Mf, Ff, Argsf}}}) ->
     SrcUri = rabbit_shovel_behaviour:source_uri(State0),
-    % do publish
-    Exchange = maps:get(exchange, Props, undefined),
-    RoutingKey = maps:get(routing_key, Props, undefined),
-    Method = #'basic.publish'{exchange = Exchange, routing_key = RoutingKey},
+
+    Mc = mc:convert(mc_amqpl, InMsg),
+
+    Exchange = mc:get_annotation(exchange, Mc),
+    RoutingKey = case mc:get_annotation(routing_keys, Mc) of
+                    [Rk | _] -> Rk;
+                    _ -> undefined
+                 end,
+    {Props, Payload} = rabbit_basic:from_content(mc:protocol_state(Mc)),
+
+    Method = #'basic.publish'{exchange = Exchange,
+                              routing_key = RoutingKey},
     Method1 = apply(Mf, Ff, Argsf ++ [SrcUri, DstUri, Method]),
-    Msg1 = #amqp_msg{props = apply(M, F, Args ++ [SrcUri, DstUri, props_from_map(Props)]),
+    Msg1 = #amqp_msg{props = apply(M, F, Args ++ [SrcUri, DstUri, Props]),
                      payload = Payload},
     publish(IncomingTag, Method1, Msg1, State0).
-
-props_from_map(Map) ->
-    #'P_basic'{content_type = maps:get(content_type, Map, undefined),
-               content_encoding = maps:get(content_encoding, Map, undefined),
-               headers = maps:get(headers, Map, undefined),
-               delivery_mode = maps:get(delivery_mode, Map, undefined),
-               priority = maps:get(priority, Map, undefined),
-               correlation_id = maps:get(correlation_id, Map, undefined),
-               reply_to = maps:get(reply_to, Map, undefined),
-               expiration = maps:get(expiration, Map, undefined),
-               message_id = maps:get(message_id, Map, undefined),
-               timestamp = maps:get(timestamp, Map, undefined),
-               type = maps:get(type, Map, undefined),
-               user_id = maps:get(user_id, Map, undefined),
-               app_id = maps:get(app_id, Map, undefined),
-               cluster_id = maps:get(cluster_id, Map, undefined)}.
-
-map_from_props(#'P_basic'{content_type = Content_type,
-                          content_encoding = Content_encoding,
-                          headers = Headers,
-                          delivery_mode = Delivery_mode,
-                          priority = Priority,
-                          correlation_id = Correlation_id,
-                          reply_to = Reply_to,
-                          expiration = Expiration,
-                          message_id = Message_id,
-                          timestamp = Timestamp,
-                          type = Type,
-                          user_id = User_id,
-                          app_id = App_id,
-                          cluster_id = Cluster_id}) ->
-    lists:foldl(fun({_K, undefined}, Acc) -> Acc;
-                   ({K, V}, Acc) -> Acc#{K => V}
-                end, #{}, [{content_type, Content_type},
-                           {content_encoding, Content_encoding},
-                           {headers, Headers},
-                           {delivery_mode, Delivery_mode},
-                           {priority, Priority},
-                           {correlation_id, Correlation_id},
-                           {reply_to, Reply_to},
-                           {expiration, Expiration},
-                           {message_id, Message_id},
-                           {timestamp, Timestamp},
-                           {type, Type},
-                           {user_id, User_id},
-                           {app_id, App_id},
-                           {cluster_id, Cluster_id}
-                          ]).
 
 handle_source(#'basic.consume_ok'{}, State) ->
     State;
@@ -262,10 +223,10 @@ handle_source({#'basic.deliver'{delivery_tag = Tag,
                                 exchange = Exchange,
                                 routing_key = RoutingKey},
               #amqp_msg{props = Props0, payload = Payload}}, State) ->
-    Props = (map_from_props(Props0))#{exchange => Exchange,
-                                      routing_key => RoutingKey},
-    % forward to destination
-    rabbit_shovel_behaviour:forward(Tag, Props, Payload, State);
+    Anns = #{exchange => Exchange, routing_keys => [RoutingKey]},
+    Content = rabbit_basic:build_content(Props0, [Payload]),
+    Mc = mc:init(mc_amqpl, Content, Anns),
+    rabbit_shovel_behaviour:forward(Tag, Mc, State);
 
 handle_source({'EXIT', Conn, Reason},
               #{source := #{current := {Conn, _, _}}}) ->

--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -178,7 +178,8 @@ dest_endpoint(#{shovel_type := dynamic,
 handle_source({amqp10_msg, _LinkRef, Msg}, State) ->
     Tag = amqp10_msg:delivery_id(Msg),
     Payload = amqp10_msg:body_bin(Msg),
-    rabbit_shovel_behaviour:forward(Tag, #{}, Payload, State);
+    Props = props_to_map(Msg),
+    rabbit_shovel_behaviour:forward(Tag, Props, Payload, State);
 handle_source({amqp10_event, {connection, Conn, opened}},
               State = #{source := #{current := #{conn := Conn}}}) ->
     State;
@@ -382,7 +383,9 @@ add_forward_headers(_, Msg) -> Msg.
 set_message_properties(Props, Msg) ->
     %% this is effectively special handling properties from amqp 0.9.1
     maps:fold(
-      fun(content_type, Ct, M) ->
+      fun(_Key, undefined, M) ->
+              M;
+         (content_type, Ct, M) ->
               amqp10_msg:set_properties(
                 #{content_type => to_binary(Ct)}, M);
          (content_encoding, Ct, M) ->
@@ -390,6 +393,8 @@ set_message_properties(Props, Msg) ->
                 #{content_encoding => to_binary(Ct)}, M);
          (delivery_mode, 2, M) ->
               amqp10_msg:set_headers(#{durable => true}, M);
+         (priority, P, M) when is_integer(P) ->
+                amqp10_msg:set_headers(#{priority => P}, M);
          (correlation_id, Ct, M) ->
               amqp10_msg:set_properties(#{correlation_id => to_binary(Ct)}, M);
          (reply_to, Ct, M) ->
@@ -397,8 +402,8 @@ set_message_properties(Props, Msg) ->
          (message_id, Ct, M) ->
               amqp10_msg:set_properties(#{message_id => to_binary(Ct)}, M);
          (timestamp, Ct, M) ->
-              amqp10_msg:set_properties(#{creation_time => Ct}, M);
-         (user_id, Ct, M) ->
+              amqp10_msg:set_properties(#{creation_time => timestamp_091_to_10(Ct)}, M);
+         (user_id, Ct, M) when Ct =/= undefined ->
               amqp10_msg:set_properties(#{user_id => Ct}, M);
          (headers, Headers0, M) when is_list(Headers0) ->
               %% AMPQ 0.9.1 are added as applicatin properties
@@ -440,3 +445,63 @@ is_amqp10_compat(T) ->
     %% TODO: not all lists are compatible
     is_list(T) orelse
     is_boolean(T).
+
+to_amqp091_compatible_value(Key, Value) when is_binary(Value) ->
+    {Key, longstr, Value};
+to_amqp091_compatible_value(Key, Value) when is_integer(Value) ->
+    {Key, long, Value};
+to_amqp091_compatible_value(Key, Value) when is_float(Value) ->
+    {Key, double, Value};
+to_amqp091_compatible_value(Key, true) ->
+    {Key, bool, true};
+to_amqp091_compatible_value(Key, false) ->
+    {Key, bool, false};
+to_amqp091_compatible_value(_Key, _Value) ->
+    undefined.
+
+delivery_mode(Headers) ->
+    case maps:get(durable, Headers, undefined) of
+        undefined -> undefined;
+        true -> 2;
+        false -> 1
+    end.
+
+timestamp_10_to_091(T) when is_integer(T) ->
+    trunc(T / 1000);
+timestamp_10_to_091(_) ->
+    undefined.
+
+timestamp_091_to_10(T) when is_integer(T) ->
+    T * 1000;
+timestamp_091_to_10(_Value) ->
+    undefined.
+
+ttl(T) when is_integer(T) ->
+    erlang:integer_to_binary(T);
+ttl(_T)  -> undefined.
+
+props_to_map(Msg) ->
+    AppProps = amqp10_msg:application_properties(Msg),
+    AppProps091Headers = lists:filtermap(fun({K, V}) ->
+                                        case to_amqp091_compatible_value(K, V) of
+                                            undefined ->
+                                                false;
+                                            Value ->
+                                                {true, Value}
+                                        end
+                                end, maps:to_list(AppProps)),
+    InProps = amqp10_msg:properties(Msg),
+    Headers = amqp10_msg:headers(Msg),
+    #{
+        headers => AppProps091Headers,
+        content_type => maps:get(content_type, InProps, undefined),
+        content_encoding => maps:get(content_encoding, InProps, undefined),
+        delivery_mode => delivery_mode(Headers),
+        priority => maps:get(priority, Headers, undefined),
+        correlation_id => maps:get(correlation_id, InProps, undefined),
+        reply_to => maps:get(reply_to, InProps, undefined),
+        expiration => ttl(maps:get(ttl, Headers, undefined)),
+        message_id => maps:get(message_id, InProps, undefined),
+        timestamp => timestamp_10_to_091(maps:get(creation_time, InProps, undefined)),
+        user_id => maps:get(user_id, InProps, undefined)
+    }.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_behaviour.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_behaviour.erl
@@ -24,7 +24,7 @@
          dest_protocol/1,
          source_endpoint/1,
          dest_endpoint/1,
-         forward/4,
+         forward/3,
          ack/3,
          nack/3,
          status/1,
@@ -79,8 +79,7 @@
 
 -callback ack(Tag :: tag(), Multi :: boolean(), state()) -> state().
 -callback nack(Tag :: tag(), Multi :: boolean(), state()) -> state().
--callback forward(Tag :: tag(), Props :: #{atom() => any()},
-                  Payload :: binary(), state()) ->
+-callback forward(Tag :: tag(), mc:state(), state()) ->
     state() | {stop, any()}.
 -callback status(state()) -> rabbit_shovel_status:blocked_status() | ignore.
 
@@ -141,10 +140,10 @@ source_endpoint(#{source := #{module := Mod}} = State) ->
 dest_endpoint(#{dest := #{module := Mod}} = State) ->
     Mod:dest_endpoint(State).
 
--spec forward(tag(), #{atom() => any()}, binary(), state()) ->
+-spec forward(tag(), mc:state(), state()) ->
     state() | {stop, any()}.
-forward(Tag, Props, Payload, #{dest := #{module := Mod}} = State) ->
-    Mod:forward(Tag, Props, Payload, State).
+forward(Tag, Message, #{dest := #{module := Mod}} = State) ->
+    Mod:forward(Tag, Message, State).
 
 -spec ack(tag(), boolean(), state()) -> state().
 ack(Tag, Multi, #{source := #{module := Mod}} = State) ->

--- a/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
@@ -29,7 +29,9 @@ groups() ->
           autodelete_amqp091_dest_on_confirm,
           autodelete_amqp091_dest_on_publish,
           simple_amqp10_dest,
-          simple_amqp10_src
+          simple_amqp10_src,
+          message_prop_conversion,
+          message_prop_conversion_no_props
         ]},
       {with_map_config, [], [
           simple,
@@ -167,6 +169,168 @@ simple_amqp10_src(Config) ->
               % This isn't due to the shovel though.
               ok
       end).
+
+message_prop_conversion(Config) ->
+    MapConfig = ?config(map_config, Config),
+    Src = ?config(srcq, Config),
+    Dest = ?config(destq, Config),
+    with_session(Config,
+        fun (Sess) ->
+                shovel_test_utils:set_param(
+                Config,
+                <<"test">>, [{<<"src-protocol">>, <<"amqp10">>},
+                                {<<"src-address">>,  Src},
+                                {<<"dest-protocol">>, <<"amqp091">>},
+                                {<<"dest-queue">>, Dest},
+                                {<<"add-forward-headers">>, true},
+                                {<<"dest-add-timestamp-header">>, true},
+                                {<<"publish-properties">>,
+                                case MapConfig of
+                                    true -> #{<<"cluster_id">> => <<"x">>};
+                                    _    -> [{<<"cluster_id">>, <<"x">>}]
+                                end}
+                            ]),
+                LinkName = <<"dynamic-sender-", Dest/binary>>,
+                Tag = <<"tag1">>,
+                Payload = <<"payload">>,
+                {ok, Sender} = amqp10_client:attach_sender_link(Sess, LinkName, Src,
+                                                                unsettled, unsettled_state),
+                ok = await_amqp10_event(link, Sender, attached),
+                Headers = #{durable => true, priority => 3, ttl => 180000},
+                Msg = amqp10_msg:set_headers(Headers,
+                                                amqp10_msg:new(Tag, Payload, false)),
+                Msg2 = amqp10_msg:set_properties(#{
+                    message_id => <<"message-id">>,
+                    user_id => <<"guest">>,
+                    to => <<"to">>,
+                    subject => <<"subject">>,
+                    reply_to => <<"reply-to">>,
+                    correlation_id => <<"correlation-id">>,
+                    content_type => <<"content-type">>,
+                    content_encoding => <<"content-encoding">>,
+                    %absolute_expiry_time => 123456789,
+                    creation_time => 123456789,
+                    group_id => <<"group-id">>,
+                    group_sequence => 123,
+                    reply_to_group_id => <<"reply-to-group-id">>
+                    }, Msg),
+                Msg3 = amqp10_msg:set_application_properties(#{
+                    <<"x-binary">> => <<"binary">>,
+                    <<"x-int">> => 33,
+                    <<"x-negative-int">> => -33,
+                    <<"x-float">> => 1.3,
+                    <<"x-true">> => true,
+                    <<"x-false">> => false
+                }, Msg2),
+                ok = amqp10_client:send_msg(Sender, Msg3),
+                receive
+                    {amqp10_disposition, {accepted, Tag}} -> ok
+                after 3000 ->
+                            exit(publish_disposition_not_received)
+                end,
+                amqp10_client:detach_link(Sender),
+                Channel = rabbit_ct_client_helpers:open_channel(Config),
+                {#'basic.get_ok'{}, #amqp_msg{payload = Payload, props = #'P_basic'{
+                    content_type = ReceivedContentType,
+                    content_encoding = ReceivedContentEncoding,
+                    headers = Headers2,
+                    delivery_mode = ReceivedDeliveryMode,
+                    priority = ReceivedPriority,
+                    correlation_id = ReceivedCorrelationId,
+                    reply_to = ReceivedReplyTo,
+                    expiration = ReceivedExpiration,
+                    message_id = ReceivedMessageId,
+                    timestamp = ReceivedTimestamp,
+                    type = _ReceivedType,
+                    user_id = ReceivedUserId,
+                    app_id = _ReceivedAppId,
+                    cluster_id = _ReceivedClusterId
+                }}} = amqp_channel:call(Channel, #'basic.get'{queue = Dest, no_ack = true}),
+
+                ?assertEqual(<<"payload">>, Payload),
+                ?assertEqual(2, ReceivedDeliveryMode),
+                ?assertEqual({longstr, <<"binary">>}, rabbit_misc:table_lookup(Headers2, <<"x-binary">>)),
+                ?assertEqual({long, 33}, rabbit_misc:table_lookup(Headers2, <<"x-int">>)),
+                ?assertEqual({long, -33}, rabbit_misc:table_lookup(Headers2, <<"x-negative-int">>)),
+                ?assertEqual({double, 1.3}, rabbit_misc:table_lookup(Headers2, <<"x-float">>)),
+                ?assertEqual({bool, true}, rabbit_misc:table_lookup(Headers2, <<"x-true">>)),
+                ?assertEqual({bool, false}, rabbit_misc:table_lookup(Headers2, <<"x-false">>)),
+
+                ?assertEqual(<<"content-type">>, ReceivedContentType),
+                ?assertEqual(<<"content-encoding">>, ReceivedContentEncoding),
+
+                ?assertEqual(3, ReceivedPriority),
+                ?assertEqual(<<"correlation-id">>, ReceivedCorrelationId),
+                ?assertEqual(<<"reply-to">>, ReceivedReplyTo),
+                ?assertEqual(<<"180000">>, ReceivedExpiration),
+                ?assertEqual(<<"message-id">>, ReceivedMessageId),
+                ?assertEqual(123456, ReceivedTimestamp), % timestamp is divided by 1 000
+                ?assertEqual(<<"guest">>, ReceivedUserId),
+                ok
+      end).
+
+message_prop_conversion_no_props(Config) ->
+    MapConfig = ?config(map_config, Config),
+    Src = ?config(srcq, Config),
+    Dest = ?config(destq, Config),
+    with_session(Config,
+        fun (Sess) ->
+                shovel_test_utils:set_param(
+                Config,
+                <<"test">>, [{<<"src-protocol">>, <<"amqp10">>},
+                                {<<"src-address">>,  Src},
+                                {<<"dest-protocol">>, <<"amqp091">>},
+                                {<<"dest-queue">>, Dest},
+                                {<<"add-forward-headers">>, true},
+                                {<<"dest-add-timestamp-header">>, true},
+                                {<<"publish-properties">>,
+                                case MapConfig of
+                                    true -> #{<<"cluster_id">> => <<"x">>};
+                                    _    -> [{<<"cluster_id">>, <<"x">>}]
+                                end}
+                            ]),
+                LinkName = <<"dynamic-sender-", Dest/binary>>,
+                Tag = <<"tag1">>,
+                Payload = <<"payload">>,
+                {ok, Sender} = amqp10_client:attach_sender_link(Sess, LinkName, Src,
+                                                                unsettled, unsettled_state),
+                ok = await_amqp10_event(link, Sender, attached),
+                Msg = amqp10_msg:new(Tag, Payload, false),
+                ok = amqp10_client:send_msg(Sender, Msg),
+                receive
+                    {amqp10_disposition, {accepted, Tag}} -> ok
+                after 3000 ->
+                            exit(publish_disposition_not_received)
+                end,
+                amqp10_client:detach_link(Sender),
+                Channel = rabbit_ct_client_helpers:open_channel(Config),
+                {#'basic.get_ok'{}, #amqp_msg{payload = ReceivedPayload, props = #'P_basic'{
+                    content_type = undefined,
+                    content_encoding = undefined,
+                    headers = ReceivedHeaders,
+                    delivery_mode = ReceivedDeliveryMode,
+                    priority = ReceivedPriority,
+                    correlation_id = undefined,
+                    reply_to = undefined,
+                    expiration = undefined,
+                    message_id = undefined,
+                    timestamp = undefined,
+                    type = undefined,
+                    user_id = undefined,
+                    app_id = undefined,
+                    cluster_id = ReceivedClusterId
+                }}} = amqp_channel:call(Channel, #'basic.get'{queue = Dest, no_ack = true}),
+
+                ?assertEqual(<<"payload">>, ReceivedPayload),
+                ?assertEqual(1, ReceivedDeliveryMode),
+                ?assertEqual(<<"x">>, ReceivedClusterId),
+                ?assertEqual(4, ReceivedPriority),
+
+                ?assertNotEqual(undefined, rabbit_misc:table_lookup(ReceivedHeaders, <<"x-shovelled">>)),
+
+                ok
+    end).
+
 
 change_definition(Config) ->
     Src = ?config(srcq, Config),

--- a/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
@@ -250,8 +250,8 @@ message_prop_conversion(Config) ->
                 ?assertEqual(<<"payload">>, Payload),
                 ?assertEqual(2, ReceivedDeliveryMode),
                 ?assertEqual({longstr, <<"binary">>}, rabbit_misc:table_lookup(Headers2, <<"x-binary">>)),
-                ?assertEqual({long, 33}, rabbit_misc:table_lookup(Headers2, <<"x-int">>)),
-                ?assertEqual({long, -33}, rabbit_misc:table_lookup(Headers2, <<"x-negative-int">>)),
+                ?assertEqual({unsignedint, 33}, rabbit_misc:table_lookup(Headers2, <<"x-int">>)),
+                ?assertEqual({signedint, -33}, rabbit_misc:table_lookup(Headers2, <<"x-negative-int">>)),
                 ?assertEqual({double, 1.3}, rabbit_misc:table_lookup(Headers2, <<"x-float">>)),
                 ?assertEqual({bool, true}, rabbit_misc:table_lookup(Headers2, <<"x-true">>)),
                 ?assertEqual({bool, false}, rabbit_misc:table_lookup(Headers2, <<"x-false">>)),
@@ -324,7 +324,8 @@ message_prop_conversion_no_props(Config) ->
                 ?assertEqual(<<"payload">>, ReceivedPayload),
                 ?assertEqual(1, ReceivedDeliveryMode),
                 ?assertEqual(<<"x">>, ReceivedClusterId),
-                ?assertEqual(4, ReceivedPriority),
+                % AMQP 1.0 default priority is 4 but I don't think it's a protocol error to not fill it
+                ?assertEqual(undefined, ReceivedPriority),
 
                 ?assertNotEqual(undefined, rabbit_misc:table_lookup(ReceivedHeaders, <<"x-shovelled">>)),
 


### PR DESCRIPTION
Hi, 

We've implemented Application Property conversion to AMQP 0.9.1 headers for shovel. We wanted this to work on 3.12 and we were not sure if this is appropriate for these message container changes. 

Let us know what you think.

- Timestamps are milliseconds in AMQP 1.0, but in AMQP 0.9.1 it is seconds. Fixed by multiplying the timestamp by 1 000.
- Shovel crashed if user_id was set in the message because the encoding was as utf8 while it should be a byte array.
- Negative integers were encoded as integers - therefore leading to incorrect positive values.
- Float values were not supported by the client.
- Fixed priority header encoding in AMQP 1.0. It was set as uint but it should be ubyte.
- Priority of the message is now in the Headers instead of Application Properties. This is potentially a breaking change.

GitHub issue: https://github.com/rabbitmq/rabbitmq-server/issues/7508.

A `v3.12.x` version of this PR: https://github.com/rabbitmq/rabbitmq-server/pull/10037.

## Proposed Changes

Implement conversion of Application Properties to Headers. 

Configurable by using the following key: 

```
shovel.convert_amqp10_props_to_amqp091 = true
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

