### PR TITLE
GitHub Actions: Convert '_' to '-' in `$AWS_ECS_CLUSTER_NAME`

### DIFF
--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -62,5 +62,5 @@ jobs:
           --test_env AWS_ACCESS_KEY_ID=${{ secrets.CONCOURSE_AWS_ACCESS_KEY_ID }} \
           --test_env AWS_SECRET_ACCESS_KEY=${{ secrets.CONCOURSE_AWS_SECRET_ACCESS_KEY }} \
           --test_env RABBITMQ_IMAGE="pivotalrabbitmq/rabbitmq:${{ github.sha }}-otp-max-bazel" \
-          --test_env AWS_ECS_CLUSTER_NAME="rabbitmq-peer-discovery-aws-actions-${branch_or_tag//./-}" \
+          --test_env AWS_ECS_CLUSTER_NAME="rabbitmq-peer-discovery-aws-actions-${branch_or_tag//[._]/-}" \
           --verbose_failures


### PR DESCRIPTION
## Why

The AWS ECS cluster name must match the regex `[a-zA-Z][-a-zA-Z0-9]*`. Underscores are forbidden.

## How

Like '.' was converted, we convert '_' to '.' using Bash parameter expansion.