### PR TITLE
Handle undefined virtual host when importing runtime parameters

### DIFF
--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -175,6 +175,8 @@ get_all_in_mnesia() ->
 %%
 %% @private
 
+get_all(undefined = _VHostName, Comp) ->
+      get_all('_', Comp);
 get_all(VHostName, Comp)
   when (is_binary(VHostName) orelse VHostName =:= '_') andalso
        (is_binary(Comp) orelse Comp =:= '_') ->


### PR DESCRIPTION
A suggested fix for ##10068 (note: this is submitted against `v3.12.x` for now).