### PR TITLE
Dynamic Shovels: support old and new supervisor child ID formats on 3.11.x

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -61,7 +61,7 @@ obfuscated_uris_parameters(Def) when is_list(Def) ->
 
 child_exists(Name) ->
     Id = id(Name),
-    %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894.
+    %% older format, pre 3.13.0, 3.12.8 and 3.11.25. See rabbitmq/rabbitmq-server#9894.
     OldId = old_id(Name),
     lists:any(fun ({ChildId, _, _, _}) ->
                       ChildId =:= Id orelse ChildId =:= OldId
@@ -78,7 +78,7 @@ stop_child({VHost, ShovelName} = Name) ->
                 ok ->
                     ok = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name));
                 {error, not_found} ->
-                    %% try older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894.
+                    %% try older format, pre 3.13.0, 3.12.8 and 3.11.25. See rabbitmq/rabbitmq-server#9894.
                     case mirrored_supervisor:terminate_child(?SUPERVISOR, old_id(Name)) of
                         ok ->
                             ok = mirrored_supervisor:delete_child(?SUPERVISOR, old_id(Name));
@@ -107,7 +107,7 @@ cleanup_specs() ->
                   lists:flatmap(
                     fun(S) ->
                             Name = {proplists:get_value(vhost, S), proplists:get_value(name, S)},
-                            %% Supervisor Id format was different pre 3.13.0 and 3.12.8.
+                            %% Supervisor Id format was different pre 3.13.0, 3.12.8 and 3.11.25.
                             %% Try both formats to cover the transitionary mixed version cluster period.
                             [id(Name), old_id(Name)]
                     end,
@@ -132,6 +132,6 @@ init([]) ->
 id({V, S} = Name) ->
     {[V, S], Name}.
 
-%% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
+%% older format, pre 3.13.0, 3.12.8 and 3.11.25. See rabbitmq/rabbitmq-server#9894
 old_id({_V, _S} = Name) ->
     Name.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -72,8 +72,18 @@ stop_child({VHost, ShovelName} = Name) ->
     case get({shovel_worker_autodelete, Name}) of
         true -> ok; %% [1]
         _ ->
-            ok = mirrored_supervisor:terminate_child(?SUPERVISOR, id(Name)),
-            ok = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name)),
+            case mirrored_supervisor:terminate_child(?SUPERVISOR, id(Name)) of
+                ok ->
+                    ok = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name));
+                {error, not_found} ->
+                    %% try older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894.
+                    case mirrored_supervisor:terminate_child(?SUPERVISOR, old_id(Name)) of
+                        ok ->
+                            ok = mirrored_supervisor:delete_child(?SUPERVISOR, old_id(Name));
+                        {error, not_found} ->
+                            ok
+                    end
+            end,
             rabbit_shovel_status:remove(Name)
     end,
     rabbit_shovel_locks:unlock(LockId),
@@ -90,23 +100,26 @@ stop_child({VHost, ShovelName} = Name) ->
 cleanup_specs() ->
     Children = mirrored_supervisor:which_children(?SUPERVISOR),
 
-    %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
-    OldStyleSpecsSet = sets:from_list([element(1, S) || S <- Children]),
-    NewStyleSpecsSet = sets:from_list([element(2, element(1, S)) || S <- Children]),
-    ParamsSet = sets:from_list([ {proplists:get_value(vhost, S), proplists:get_value(name, S)}
-                                 || S <- rabbit_runtime_parameters:list_component(<<"shovel">>) ]),
-    F = fun(Name, ok) ->
+    SupIdSet = sets:from_list([element(1, S) || S <- Children]),
+    ParamsSet = sets:from_list(
+                  lists:flatmap(
+                    fun(S) ->
+                            Name = {proplists:get_value(vhost, S), proplists:get_value(name, S)},
+                            %% Supervisor Id format was different pre 3.13.0 and 3.12.8.
+                            %% Try both formats to cover the transitionary mixed version cluster period.
+                            [id(Name), old_id(Name)]
+                    end,
+                    rabbit_runtime_parameters:list_component(<<"shovel">>))),
+    F = fun(SupId, ok) ->
             try
-                _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name))
+                _ = mirrored_supervisor:delete_child(?SUPERVISOR, SupId)
             catch _:_:_Stacktrace ->
                 ok
             end,
             ok
         end,
-    %% Try both formats to cover the transitionary mixed version cluster period.
-    AllSpecs = sets:union(NewStyleSpecsSet, OldStyleSpecsSet),
     %% Delete any supervisor children that do not have their respective runtime parameters in the database.
-    SetToCleanUp = sets:subtract(AllSpecs, ParamsSet),
+    SetToCleanUp = sets:subtract(SupIdSet, ParamsSet),
     ok = sets:fold(F, ok, SetToCleanUp).
 
 %%----------------------------------------------------------------------------
@@ -115,7 +128,8 @@ init([]) ->
     {ok, {{one_for_one, 3, 10}, []}}.
 
 id({V, S} = Name) ->
-    {[V, S], Name};
+    {[V, S], Name}.
+
 %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
-id(Other) ->
-    Other.
+old_id({_V, _S} = Name) ->
+    Name.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -58,7 +58,10 @@ obfuscated_uris_parameters(Def) when is_list(Def) ->
     rabbit_shovel_parameters:obfuscate_uris_in_definition(Def).
 
 child_exists(Name) ->
-    lists:any(fun ({{_, N}, _, _, _}) -> N =:= Name end,
+    lists:any(fun ({{_, N}, _, _, _}) -> N =:= Name;
+                  %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894.
+                  ({N, _, _, _})      -> N =:= Name
+              end,
               mirrored_supervisor:which_children(?SUPERVISOR)).
 
 stop_child({VHost, ShovelName} = Name) ->
@@ -83,14 +86,21 @@ stop_child({VHost, ShovelName} = Name) ->
 %% See rabbit_shovel_worker:terminate/2
 
 cleanup_specs() ->
-    SpecsSet = sets:from_list([element(2, element(1, S)) || S <- mirrored_supervisor:which_children(?SUPERVISOR)]),
+    Children = mirrored_supervisor:which_children(?SUPERVISOR),
+
+    %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
+    OldStyleSpecsSet = sets:from_list([element(1, S) || S <- Children]),
+    NewStyleSpecsSet = sets:from_list([element(2, element(1, S)) || S <- Children]),
     ParamsSet = sets:from_list([ {proplists:get_value(vhost, S), proplists:get_value(name, S)}
                                  || S <- rabbit_runtime_parameters:list_component(<<"shovel">>) ]),
     F = fun(Name, ok) ->
             _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name)),
             ok
         end,
-    ok = sets:fold(F, ok, sets:subtract(SpecsSet, ParamsSet)).
+    AllSpecs = sets:union(NewStyleSpecsSet, OldStyleSpecsSet),
+    %% Delete any supervisor children that do not have their respective runtime parameters in the database.
+    SetToCleanUp = sets:subtract(AllSpecs, ParamsSet),
+    ok = sets:fold(F, ok, SetToCleanUp).
 
 %%----------------------------------------------------------------------------
 
@@ -98,4 +108,11 @@ init([]) ->
     {ok, {{one_for_one, 3, 10}, []}}.
 
 id({V, S} = Name) ->
+<<<<<<< HEAD
     {[V, S], Name}.
+=======
+    {[V, S], Name};
+%% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
+id(Other) ->
+    Other.
+>>>>>>> 2ce0307641 (Dynamic Shovels: support old and new supervisor child ID formats)

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -95,23 +95,14 @@ cleanup_specs() ->
                                  || S <- rabbit_runtime_parameters:list_component(<<"shovel">>) ]),
     F = fun(Name, ok) ->
             try
-                %% The supervisor operation is very unlikely to fail, it's the schema
-                %% data stores that can make a fuss about a non-existent or non-standard value passed in.
-                %% For example, an old style Shovel name is an invalid Khepri query path element. MK.
                 _ = mirrored_supervisor:delete_child(?SUPERVISOR, id(Name))
             catch _:_:_Stacktrace ->
                 ok
             end,
             ok
         end,
-    %% Khepri won't handle values in OldStyleSpecsSet in its path well. At the same time,
-    %% those older elements simply cannot exist in Khepri because having Khepri enabled
-    %% means a cluster-wide move to 3.13+, so we can conditionally compute what specs we care about. MK.
-    AllSpecs =
-        case rabbit_khepri:is_enabled() of
-            true  -> NewStyleSpecsSet;
-            false -> sets:union(NewStyleSpecsSet, OldStyleSpecsSet)
-        end,
+    %% Try both formats to cover the transitionary mixed version cluster period.
+    AllSpecs = sets:union(NewStyleSpecsSet, OldStyleSpecsSet),
     %% Delete any supervisor children that do not have their respective runtime parameters in the database.
     SetToCleanUp = sets:subtract(AllSpecs, ParamsSet),
     ok = sets:fold(F, ok, SetToCleanUp).
@@ -122,11 +113,7 @@ init([]) ->
     {ok, {{one_for_one, 3, 10}, []}}.
 
 id({V, S} = Name) ->
-<<<<<<< HEAD
-    {[V, S], Name}.
-=======
     {[V, S], Name};
 %% older format, pre 3.13.0 and 3.12.8. See rabbitmq/rabbitmq-server#9894
 id(Other) ->
     Other.
->>>>>>> 2ce0307641 (Dynamic Shovels: support old and new supervisor child ID formats)


### PR DESCRIPTION
## Proposed Changes

v3.11.25 contains a backport of a change that modified the supervisor child ids of dynamic shovel workers.

This is a backport of #9919, #9965 and #9968 to v3.11.x from 3.12.x that together fixed the situation.

An alternative would be to just revert the id format to the old one and somehow "withdraw" versions 3.11.25 and 3.11.26 (or say that it is not possible to upgrade to 3.12.0..3.12.7 from those versions)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
