### PR TITLE
rabbitmq_management_agent: Use `rabbit_plugins:enabled_plugins/0`

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
@@ -245,7 +245,7 @@ i(net_ticktime, State) ->
 i(persister_stats, State) ->
     {State, persister_stats(State)};
 i(enabled_plugins, State) ->
-    {ok, Dir} = application:get_env(rabbit, enabled_plugins_file),
+    Dir = rabbit_plugins:enabled_plugins_file(),
     {State, rabbit_plugins:read_enabled(Dir)};
 i(auth_mechanisms, State) ->
     {ok, Mechanisms} = application:get_env(rabbit, auth_mechanisms),


### PR DESCRIPTION
… instead of reading an application environment variable directly.

## Why

There is an API to abstract this already, let's use it.