### PR TITLE
rabbit_writer: Convert to a regular gen_server

### DIFF
--- a/deps/amqp_client/src/amqp_channel.erl
+++ b/deps/amqp_client/src/amqp_channel.erl
@@ -839,7 +839,11 @@ handle_channel_exit(Reason = #amqp_error{name = ErrorName, explanation = Expl},
     handle_shutdown({connection_closing, ReportedReason}, State);
 handle_channel_exit(Reason, State) ->
     %% Unexpected death of a channel infrastructure process
-    {stop, {infrastructure_died, Reason}, State}.
+    Reason1 = case Reason of
+                  {shutdown, R} -> R;
+                  _             -> Reason
+              end,
+    {stop, {infrastructure_died, Reason1}, State}.
 
 handle_shutdown({_, 200, _}, State) ->
     {stop, normal, State};

--- a/deps/amqp_client/src/amqp_channel.erl
+++ b/deps/amqp_client/src/amqp_channel.erl
@@ -876,11 +876,8 @@ do(Method, Content, Flow, #state{driver = direct, writer = W}) ->
 
 
 flush_writer(#state{driver = network, writer = Writer}) ->
-    try
-        rabbit_writer:flush(Writer)
-    catch
-        exit:noproc -> ok
-    end;
+    _ = catch rabbit_writer:flush(Writer),
+    ok;
 flush_writer(#state{driver = direct}) ->
     ok.
 amqp_msg(none) ->

--- a/deps/amqp_client/test/system_SUITE.erl
+++ b/deps/amqp_client/test/system_SUITE.erl
@@ -1347,7 +1347,13 @@ channel_writer_death(Config) ->
           when ConnType =:= direct -> ok;
 
         exit:{{infrastructure_died, {unknown_properties_record, <<>>}}, _}
-        when ConnType =:= network -> ok
+        when ConnType =:= network -> ok;
+
+        %% The writer process exited before the call and the amqp_channel_sup
+        %% supervisor shut the supervision tree down because the channel is
+        %% significant. The call happened at that shutdown time or just after.
+        exit:{shutdown, {gen_server, call, _}} -> ok;
+        exit:{noproc, {gen_server, call, _}} -> ok
     end,
     wait_for_death(Channel),
     wait_for_death(Connection).
@@ -1435,7 +1441,12 @@ shortstr_overflow_property(Config) ->
         Ret = amqp_channel:call(Channel, QoS),
         throw({unexpected_success, Ret})
     catch
-        exit:{{infrastructure_died, content_properties_shortstr_overflow}, _} -> ok
+        exit:{{infrastructure_died, content_properties_shortstr_overflow}, _} -> ok;
+        %% The writer process exited before the call and the amqp_channel_sup
+        %% supervisor shut the supervision tree down because the channel is
+        %% significant. The call happened at that shutdown time or just after.
+        exit:{shutdown, {gen_server, call, _}} -> ok;
+        exit:{noproc, {gen_server, call, _}} -> ok
     end,
     wait_for_death(Channel),
     wait_for_death(Connection).
@@ -1457,7 +1468,12 @@ shortstr_overflow_field(Config) ->
                                           consumer_tag = SentString}),
         throw({unexpected_success, Ret})
     catch
-        exit:{{infrastructure_died, method_field_shortstr_overflow}, _} -> ok
+        exit:{{infrastructure_died, method_field_shortstr_overflow}, _} -> ok;
+        %% The writer process exited before the call and the amqp_channel_sup
+        %% supervisor shut the supervision tree down because the channel is
+        %% significant. The call happened at that shutdown time or just after.
+        exit:{shutdown, {gen_server, call, _}} -> ok;
+        exit:{noproc, {gen_server, call, _}} -> ok
     end,
     wait_for_death(Channel),
     wait_for_death(Connection).


### PR DESCRIPTION
## Why

This process failed to implement properly the OTP principles. For instance, the mainloop always kept a reference on the module because it was not tail-recursive.

This prevents the module from being reloaded at runtime: because the process always keep that reference on the module, it is killed by the Code server as part of the code reloading.