### PR TITLE
Allow to override hostname path within EC2 discovery response, AWS

### DIFF
--- a/deps/rabbitmq_peer_discovery_aws/priv/schema/rabbitmq_peer_discovery_aws.schema
+++ b/deps/rabbitmq_peer_discovery_aws/priv/schema/rabbitmq_peer_discovery_aws.schema
@@ -94,3 +94,17 @@ fun(Conf) ->
             [ {lists:last(K), V} || {K, V} <- Settings ]
     end
 end}.
+
+%% hostname_path
+
+{mapping, "cluster_formation.aws.hostname_path", "rabbit.cluster_formation.peer_discovery_aws.aws_hostname_path", [
+    {datatype, string,
+    {default, ["privateDnsName"]}}
+]}.
+{translation, "rabbit.cluster_formation.peer_discovery_aws.aws_hostname_path",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.aws.hostname_path", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> rabbit_peer_discovery_util:as_list(Value)
+    end
+end}.

--- a/deps/rabbitmq_peer_discovery_aws/test/config_schema_SUITE_data/rabbitmq_peer_discovery_aws.snippets
+++ b/deps/rabbitmq_peer_discovery_aws/test/config_schema_SUITE_data/rabbitmq_peer_discovery_aws.snippets
@@ -91,5 +91,17 @@
                 ]}
             ]}
         ], [rabbitmq_peer_discovery_aws]
+    },
+    {aws_hostname_path,
+        "cluster_formation.aws.hostname_path = banana, 1, apple",
+        [
+            {rabbit, [
+                {cluster_formation, [
+                    {peer_discovery_aws, [
+                        {aws_hostname_path, ["banana", 1, "apple"]}
+                    ]}
+                ]}
+            ]}
+        ], [rabbitmq_peer_discovery_aws]
     }
 ].

--- a/deps/rabbitmq_peer_discovery_common/include/rabbit_peer_discovery.hrl
+++ b/deps/rabbitmq_peer_discovery_common/include/rabbit_peer_discovery.hrl
@@ -16,7 +16,14 @@
 % by `httpc`
 -define(DEFAULT_HTTP_TIMEOUT, 2250).
 
--type peer_discovery_config_value() :: atom() | integer() | string() | list() | map() | any() | undefined.
+-type peer_discovery_config_value() :: port()
+                                     | atom()
+                                     | integer()
+                                     | string()
+                                     | proplists:proplist()
+                                     | map()
+                                     | list()
+                                     | undefined.
 
 -record(peer_discovery_config_entry_meta,
         {env_variable  :: string(),

--- a/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_config.erl
+++ b/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_config.erl
@@ -127,7 +127,7 @@ normalize(Type, Value) when Type =:= port ->
 normalize(Type, Value) when Type =:= atom ->
   rabbit_peer_discovery_util:as_atom(Value);
 normalize(Type, Value) when Type =:= list ->
-  rabbit_data_coercion:to_list(Value);
+  rabbit_peer_discovery_util:as_list(Value);
 normalize(Type, Value) when Type =:= integer ->
   rabbit_peer_discovery_util:as_integer(Value);
 normalize(Type, Value) when Type =:= string ->

--- a/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_config.erl
+++ b/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_config.erl
@@ -119,8 +119,8 @@ get_integer_from_env_variable_or_map(Map, OSKey, AppKey, Default) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec normalize(Type  :: atom(),
-                Value :: atom() | boolean() | integer() | string() | list()) ->
-  atom() | integer() | string().
+                Value :: term()) ->
+  peer_discovery_config_value().
 %% TODO: switch these to use delegate to rabbit_data_coercion:*
 normalize(Type, Value) when Type =:= port ->
   rabbit_peer_discovery_util:parse_port(Value);

--- a/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_util.erl
+++ b/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_util.erl
@@ -410,14 +410,18 @@ as_list([]) -> [];
 as_list(Value) when is_atom(Value) ; is_integer(Value) ; is_binary(Value) ->
   [Value];
 as_list(Value) when is_list(Value) ->
+  Parse = fun(T) -> 
+    S = string:strip(T),
+    case string:to_float(S) of
+      {Float, []} -> Float;
+      _ -> case string:to_integer(S) of
+             {Integer, []} -> Integer;
+             _ -> S
+           end
+    end
+  end,
   case io_lib:printable_list(Value) or io_lib:printable_unicode_list(Value) of
-    true -> [case string:to_float(S) of
-               {Float, []} -> Float;
-               _ -> case string:to_integer(S) of
-                      {Integer, []} -> Integer;
-                      _ -> string:strip(S)
-                    end
-             end || S <- string:tokens(Value, ",")];
+    true -> [Parse(T) || T <- string:tokens(Value, ",")];
     false -> Value
   end;
 as_list(Value) ->


### PR DESCRIPTION
## Proposed Changes

Add config to override location of the hostname within EC2 instance description. It is targeting cases where user has multiple interfaces on the instance, but is generic by design.

This also fixes list coercion withing common discovery code and some unit tests that were ignored previously.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

