### PR TITLE
Optimise cluster_status cli command when not all nodes are online and responding.

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -699,10 +699,9 @@ info(Options) when is_map(Options) ->
 
 get_state(FeatureName) when is_atom(FeatureName) ->
     IsEnabled = is_enabled(FeatureName),
-    IsSupported = is_supported(FeatureName),
     case IsEnabled of
         true  -> enabled;
-        false -> case IsSupported of
+        false -> case is_supported(FeatureName) of
                      true  -> disabled;
                      false -> unavailable
                  end

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -415,6 +415,8 @@ active_listeners() ->
 
 -spec node_listeners(node()) -> [rabbit_types:listener()].
 
+node_listeners(Node) when node() == Node ->
+    ets:tab2list(?ETS_TABLE);
 node_listeners(Node) ->
     case rabbit_misc:rpc_call(Node, ets, tab2list, [?ETS_TABLE]) of
         {badrpc, _} ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -285,23 +285,21 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
   end
 
   defp listeners_of(node, timeout) do
-    # This may seem inefficient since this call returns all known listeners
-    # in the cluster, so why do we run it on every node? See the badrpc clause,
-    # some nodes may be inavailable or partitioned from other nodes. This way we
-    # gather as complete a picture as possible. MK.
+    node = to_atom(node)
+
     listeners =
       case :rabbit_misc.rpc_call(
-             to_atom(node),
+             node,
              :rabbit_networking,
-             :active_listeners,
-             [],
+             :node_listeners,
+             [node],
              timeout
            ) do
         {:badrpc, _} -> []
         xs -> xs
       end
 
-    {node, listeners_on(listeners, node)}
+    {node, listeners}
   end
 
   defp versions_by_node(node, timeout) do


### PR DESCRIPTION
If rabbitmqctl cluster_status was called when a node had just been force terminated such that the TCP connection was left dangling it could take several minutes to complete. This was mostly due to various uses of `rabbit_nodes:list_running/0` when retrieving listeners and feature flags and these have now been optimised to mostly avoid calls to this function.