### PR TITLE
CI: Use 'bazel cquery' to find OCI tests

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Test
         run: |
-          OCI_TESTS=$(bazel query 'tests(//packaging/docker-image/...)')
+          OCI_TESTS=$(bazel cquery 'tests(//packaging/docker-image/...)' | awk '{ print $1 }')
           bazelisk test ${OCI_TESTS} \
             --config=rbe-${{ matrix.otp_version_id }}
 


### PR DESCRIPTION
Bazel 7 can't seem to resolve Osiris 1.7.1 when running this query using 'bazel query':

    ERROR: Error computing the main repository mapping: in module dependency chain <root> -> rabbitmq_osiris@1.7.1: module not found in registries: rabbitmq_osiris@1.7.1

Switching to cquery resolves the tests correctly. It also prints the configuration hashes per case which we need to cut off with awk.
