### PR TITLE
v3.12.x: Ensure that elixir escript does not read from stdin

### DIFF
--- a/deps/rabbit/scripts/rabbitmq-diagnostics
+++ b/deps/rabbit/scripts/rabbitmq-diagnostics
@@ -20,4 +20,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-diagnostics "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-diagnostics "$@"

--- a/deps/rabbit/scripts/rabbitmq-env
+++ b/deps/rabbit/scripts/rabbitmq-env
@@ -178,25 +178,13 @@ _rmq_env_set_erl_libs()
 
 run_escript()
 {
-    escript_main="${1:?escript_main must be defined}"
-    shift
     escript="${1:?escript must be defined}"
     shift
 
     _rmq_env_set_erl_libs
 
-    # Important: do not quote RABBITMQ_CTL_ERL_ARGS as they must be
-    # word-split
     # shellcheck disable=SC2086
-    exec erl +B \
-        -boot "$CLEAN_BOOT_FILE" \
-        -noinput -noshell -hidden -smp enable \
-        $RABBITMQ_CTL_ERL_ARGS \
-        -kernel inet_dist_listen_min "$RABBITMQ_CTL_DIST_PORT_MIN" \
-        -kernel inet_dist_listen_max "$RABBITMQ_CTL_DIST_PORT_MAX" \
-        -run escript start \
-        -escript main "$escript_main" \
-        -extra "$escript" "$@"
+    ERL_FLAGS="-boot $CLEAN_BOOT_FILE $RABBITMQ_CTL_ERL_ARGS -kernel inet_dist_listen_min $RABBITMQ_CTL_DIST_PORT_MIN -kernel inet_dist_listen_max $RABBITMQ_CTL_DIST_PORT_MAX" "$escript" "$@"
 }
 
 RABBITMQ_ENV_LOADED=1

--- a/deps/rabbit/scripts/rabbitmq-plugins
+++ b/deps/rabbit/scripts/rabbitmq-plugins
@@ -20,4 +20,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-plugins "$@"

--- a/deps/rabbit/scripts/rabbitmq-queues
+++ b/deps/rabbit/scripts/rabbitmq-queues
@@ -20,4 +20,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-queues "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-queues "$@"

--- a/deps/rabbit/scripts/rabbitmq-streams
+++ b/deps/rabbit/scripts/rabbitmq-streams
@@ -21,4 +21,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-streams "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-streams "$@"

--- a/deps/rabbit/scripts/rabbitmq-upgrade
+++ b/deps/rabbit/scripts/rabbitmq-upgrade
@@ -20,4 +20,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-upgrade "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmq-upgrade "$@"

--- a/deps/rabbit/scripts/rabbitmqctl
+++ b/deps/rabbit/scripts/rabbitmqctl
@@ -20,4 +20,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmqctl "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/rabbitmqctl "$@"

--- a/deps/rabbit/scripts/vmware-rabbitmq
+++ b/deps/rabbit/scripts/vmware-rabbitmq
@@ -20,4 +20,4 @@ set -a
 # shellcheck source=./rabbitmq-env
 . "${0%/*}"/rabbitmq-env
 
-run_escript rabbitmqctl_escript "${ESCRIPT_DIR:?must be defined}"/vmware-rabbitmq "$@"
+run_escript "${ESCRIPT_DIR:?must be defined}"/vmware-rabbitmq "$@"

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -14,7 +14,11 @@ defmodule RabbitMQCtl.MixfileBase do
       elixir: ">= 1.13.4 and < 1.16.0",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      escript: [main_module: RabbitMQCtl, emu_args: "-hidden", path: "escript/rabbitmqctl"],
+      escript: [
+        main_module: RabbitMQCtl,
+        emu_args: "-noinput -hidden",
+        path: "escript/rabbitmqctl"
+      ],
       prune_code_paths: false,
       deps: deps(Mix.env()),
       aliases: aliases(),


### PR DESCRIPTION
This change ensures that you do not have to redirect `stdin` from `/dev/null` to use `rabbitmqctl` and related utilities in a `while` / `read` shell loop.

References:
* https://github.com/lukebakken/vesc-1073/blob/main/delete.bash#L24-L32
* https://github.com/rabbitmq/support-tools/pull/38

(cherry picked from commit 761d5928ac033eaa215e0d9144f45f7713c80ff7)