### PR TITLE
Ensure `peer:start/1` takes long names into account

### DIFF
--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_dist.erl
@@ -12,7 +12,7 @@ setup(#{nodename := Node, nodename_type := NameType} = Context) ->
        "~n== Erlang distribution ==", [],
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     ?LOG_DEBUG(
-       "Rqeuested node name: ~ts (type: ~ts)",
+       "Requested node name: ~ts (type: ~ts)",
        [Node, NameType],
        #{domain => ?RMQLOG_DOMAIN_PRELAUNCH}),
     case node() of
@@ -149,5 +149,3 @@ set_credentials_obfuscation_secret() ->
                                    credentials_obfuscation_fallback_secret, 
                                    <<"nocookie">>),
     ok = credentials_obfuscation:set_fallback_secret(Fallback).
-
-    


### PR DESCRIPTION
Discovered while testing
https://github.com/rabbitmq/rabbitmq-server/pull/10108 by using the [lukebakken/docker-rabbitmq-cluster](https://github.com/lukebakken/docker-rabbitmq-cluster) project.

That project, by default, uses longnames for node names. When testing classic peer discovery, starting a peer node would time out every time.