### PR TITLE
Fix crash when closing connection

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection_user_name.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection_user_name.erl
@@ -85,7 +85,8 @@ force_close_connection(ReqData, Conn, Pid) ->
         network ->
             rabbit_networking:close_connection(Pid, Reason);
         _ ->
-            % best effort, this will work for connections to the stream plugin
-            gen_server:cast(Pid, {shutdown, Reason})
-    end,
-    ok.
+            %% Best effort will work for following plugins:
+            %% rabbitmq_stream, rabbitmq_mqtt, rabbitmq_web_mqtt
+            _ = Pid ! {shutdown, Reason},
+            ok
+    end.


### PR DESCRIPTION
Avoid the following crash
```
** Reason for termination ==
** {mqtt_unexpected_cast,{shutdown,"Closed via management plugin"}}

  crasher:
    initial call: rabbit_mqtt_reader:init/1
    pid: <0.1096.0>
    registered_name: []
    exception exit: {mqtt_unexpected_cast,
                        {shutdown,"Closed via management plugin"}}
      in function  gen_server:handle_common_reply/8 (gen_server.erl, line 1208)
```
when closing MQTT or Stream connections via HTTP API endpoint
```
/connections/username/:username
```