### PR TITLE
Fix test expectation

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -614,7 +614,7 @@ events(Config) ->
                                            {exclusive, false},
                                            {arguments, []}],
                                           ConsumerCreated),
-                        classic
+                        rabbit_classic_queue
                 end,
     assert_event_type(queue_created, E2),
     assert_event_prop([{name, QueueName},


### PR DESCRIPTION
as `main` and `v3.12.x` branches are currently red due to https://github.com/rabbitmq/rabbitmq-server/pull/10139