### PR TITLE
Add log on queue expiry

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1720,7 +1720,7 @@ handle_info({maybe_expire, Vsn}, State = #q{q = Q, expires = Expiry, args_policy
     case is_unused(State) of
         true  ->
             QResource = rabbit_misc:rs(amqqueue:get_name(Q)),
-            rabbit_log_queue:debug("Deleting '~ts' on expiry after ~tp milliseconds", [QResource, Expiry]),
+            rabbit_log_queue:debug("Deleting 'classic ~ts' on expiry after ~tp milliseconds", [QResource, Expiry]),
             stop(State);
         false -> noreply(State#q{expiry_timer_ref = undefined})
     end;


### PR DESCRIPTION
## Proposed Changes

Add debug log when expired queue is dropped. We want a bit more exposure from the broker on when expired queues are dropped when investigating some client app related amqp issues we're noticing.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
