### PR TITLE
Revert "HTTP API: DELETE /api/queues/{vhost}/{name} use internal API call

### DIFF
--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -2050,7 +2050,9 @@ queue_purge_test(Config) ->
     http_delete(Config, "/queues/%2F/myqueue/contents", {group, '2xx'}),
     http_delete(Config, "/queues/%2F/badqueue/contents", ?NOT_FOUND),
     http_delete(Config, "/queues/%2F/exclusive/contents", ?BAD_REQUEST),
-    http_delete(Config, "/queues/%2F/exclusive", {group, '2xx'}),
+    http_delete(Config, "/queues/%2F/exclusive", ?BAD_REQUEST),
+    #'basic.get_empty'{} =
+        amqp_channel:call(Ch, #'basic.get'{queue = <<"myqueue">>}),
     close_channel(Ch),
     close_connection(Conn),
     http_delete(Config, "/queues/%2F/myqueue", {group, '2xx'}),


### PR DESCRIPTION
This reverts commit 78f901a224796a52f660d6ed6e2815690ce836af (#9550).
