### PR TITLE
Fix plugin bug in test suites

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -756,7 +756,7 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
                     NodeConfig1 = rabbit_ct_helpers:set_config(
                                     NodeConfig,
                                     [{effective_srcdir, SrcDir},
-                                    {make_vars_for_node_startup, MakeVars}]),
+                                     {make_vars_for_node_startup, MakeVars}]),
                     query_node(Config, NodeConfig1);
                 _ ->
                     AbortCmd = ["stop-node" | MakeVars],
@@ -766,19 +766,24 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
         RunCmd ->
             UseSecondary = CanUseSecondary andalso
                 rabbit_ct_helpers:get_config(Config, rabbitmq_run_secondary_cmd) =/= undefined,
-            EnabledPluginsMakeVars = case {UseSecondary, WithPlugins} of
-                {_, false} ->
-                    ["RABBITMQ_ENABLED_PLUGINS=rabbit"];
-                {true, _} ->
-                    [{"RABBITMQ_ENABLED_PLUGINS=~ts", [filename:basename(SrcDir)]}];
-                _ ->
-                    []
-            end,
+            PluginsMakeVars = case {UseSecondary, WithPlugins} of
+                                  {_, false} ->
+                                      ["LEAVE_PLUGINS_DISABLED=1"];
+                                  {true, _} ->
+                                      case filename:basename(SrcDir) of
+                                          "rabbit" ->
+                                              ["LEAVE_PLUGINS_DISABLED=1"];
+                                          Plugin ->
+                                              [{"RABBITMQ_ENABLED_PLUGINS=~ts", [Plugin]}]
+                                      end;
+                                  _ ->
+                                      []
+                              end,
             RmqRun = case CanUseSecondary of
-                false -> RunCmd;
-                _ -> rabbit_ct_helpers:get_config(Config, rabbitmq_run_secondary_cmd, RunCmd)
-            end,
-            case rabbit_ct_helpers:exec([RmqRun, "-C", SrcDir] ++ EnabledPluginsMakeVars ++ Cmd) of
+                         false -> RunCmd;
+                         _ -> rabbit_ct_helpers:get_config(Config, rabbitmq_run_secondary_cmd, RunCmd)
+                     end,
+            case rabbit_ct_helpers:exec([RmqRun, "-C", SrcDir] ++ PluginsMakeVars ++ Cmd) of
                 {ok, _} ->
                     NodeConfig1 = rabbit_ct_helpers:set_config(
                                     NodeConfig,


### PR DESCRIPTION
`rabbit` is not a plugin.

```
make run-broker RABBITMQ_ENABLED_PLUGINS=rabbit

rabbitmq-plugins enable rabbitmq_amqp1_0
Enabling plugins on node rabbit@nuc:
rabbitmq_amqp1_0
Error:
{:plugins_not_found, [:rabbit]}
```

Instead, we want:
```
make run-broker LEAVE_PLUGINS_DISABLED=1

rabbitmq-plugins enable rabbitmq_amqp1_0
Enabling plugins on node rabbit@nuc:
rabbitmq_amqp1_0
The following plugins have been configured:
  rabbitmq_amqp1_0
Applying plugin configuration to rabbit@nuc...
The following plugins have been enabled:
  rabbitmq_amqp1_0

started 1 plugins.
```

This commit allows enabling plugins on the old node in mixed version tests from tests in app `rabbit`.
Previously this failed with above error:
```
{:plugins_not_found, [:rabbit]}
```
This feature will be needed for branch `native-amqp` which needs to enable the AMQP 1.0 plugin on the old node in tests of app `rabbit` (since the plugin on the new node moved to `rabbit`).