### PR TITLE
QQ: Avoid secondary process when repairing leader record.

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -381,7 +381,8 @@ become_leader0(QName, Name) ->
             Nodes = get_nodes(Q0),
             [_ = erpc_call(Node, ?MODULE, rpc_delete_metrics,
                            [QName], ?RPC_TIMEOUT)
-             || Node <- Nodes, Node =/= node()];
+             || Node <- Nodes, Node =/= node()],
+            ok;
         _ ->
             ok
     end.
@@ -572,7 +573,7 @@ repair_leader_record(QName, Self) ->
             rabbit_log:debug("~ts: repairing leader record",
                              [rabbit_misc:rs(QName)]),
             {_, Name} = erlang:process_info(Self, registered_name),
-            become_leader0(QName, Name),
+            ok = become_leader0(QName, Name),
             ok
     end,
     ok.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -230,18 +230,23 @@ start_cluster(Q) ->
                  {error, {too_long, N}} ->
                      rabbit_data_coercion:to_atom(ra:new_uid(N))
              end,
-    {Leader, Followers} = rabbit_queue_location:select_leader_and_followers(Q, QuorumSize),
-    LeaderId = {RaName, Leader},
+    {LeaderNode, FollowerNodes} =
+        rabbit_queue_location:select_leader_and_followers(Q, QuorumSize),
+    LeaderId = {RaName, LeaderNode},
     NewQ0 = amqqueue:set_pid(Q, LeaderId),
-    NewQ1 = amqqueue:set_type_state(NewQ0, #{nodes => [Leader | Followers]}),
+    NewQ1 = amqqueue:set_type_state(NewQ0,
+                                    #{nodes => [LeaderNode | FollowerNodes]}),
 
     rabbit_log:debug("Will start up to ~w replicas for quorum ~ts with leader on node '~ts'",
-                     [QuorumSize, rabbit_misc:rs(QName), Leader]),
+                     [QuorumSize, rabbit_misc:rs(QName), LeaderNode]),
     case rabbit_amqqueue:internal_declare(NewQ1, false) of
         {created, NewQ} ->
             RaConfs = [make_ra_conf(NewQ, ServerId)
                        || ServerId <- members(NewQ)],
-            try erpc_call(Leader, ra, start_cluster,
+
+            %% khepri projections on remote nodes are eventually consistent
+            wait_for_projections(LeaderNode, QName),
+            try erpc_call(LeaderNode, ra, start_cluster,
                           [?RA_SYSTEM, RaConfs, ?START_CLUSTER_TIMEOUT],
                           ?START_CLUSTER_RPC_TIMEOUT) of
                 {ok, _, _} ->
@@ -266,10 +271,10 @@ start_cluster(Q) ->
                                           ActingUser}]),
                     {new, NewQ};
                 {error, Error} ->
-                    declare_queue_error(Error, NewQ, Leader, ActingUser)
+                    declare_queue_error(Error, NewQ, LeaderNode, ActingUser)
             catch
                 error:Error ->
-                    declare_queue_error(Error, NewQ, Leader, ActingUser)
+                    declare_queue_error(Error, NewQ, LeaderNode, ActingUser)
             end;
         {existing, _} = Ex ->
             Ex
@@ -634,7 +639,7 @@ recover(_Vhost, Queues) ->
                           Err1 == name_not_registered ->
                        rabbit_log:warning("Quorum queue recovery: configured member of ~ts was not found on this node. Starting member as a new one. "
                                           "Context: ~s",
-                                       [rabbit_misc:rs(QName), Err1]),
+                                          [rabbit_misc:rs(QName), Err1]),
                        % queue was never started on this node
                        % so needs to be started from scratch.
                        case start_server(make_ra_conf(Q0, ServerId)) of
@@ -1902,3 +1907,23 @@ force_all_queues_shrink_member_to_current_member() ->
 is_minority(All, Up) ->
     MinQuorum = length(All) div 2 + 1,
     length(Up) < MinQuorum.
+
+wait_for_projections(Node, QName) ->
+    case rabbit_feature_flags:is_enabled(khepri_db) andalso
+         Node =/= node() of
+        true ->
+            wait_for_projections(Node, QName, 256);
+        false ->
+            ok
+    end.
+
+wait_for_projections(Node, QName, 0) ->
+    exit({wait_for_projections_timed_out, Node, QName});
+wait_for_projections(Node, QName, N) ->
+    case erpc_call(Node, rabbit_amqqueue, lookup, [QName], 100) of
+        {ok, _} ->
+            ok;
+        _ ->
+            timer:sleep(100),
+            wait_for_projections(Node, QName, N - 1)
+    end.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -379,9 +379,9 @@ become_leader0(QName, Name) ->
     case rabbit_amqqueue:lookup(QName) of
         {ok, Q0} when ?is_amqqueue(Q0) ->
             Nodes = get_nodes(Q0),
-            [_ = erpc_call(Node, ?MODULE, rpc_delete_metrics,
-                           [QName], ?RPC_TIMEOUT)
-             || Node <- Nodes, Node =/= node()],
+            _ = [_ = erpc_call(Node, ?MODULE, rpc_delete_metrics,
+                               [QName], ?RPC_TIMEOUT)
+                 || Node <- Nodes, Node =/= node()],
             ok;
         _ ->
             ok


### PR DESCRIPTION
## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

If English isn't your first language, don't worry about it and try to communicate the problem you are trying to solve to the best of your abilities.
As long as we can understand the intent, it's all good.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
