### PR TITLE
Skip rabbit_mqtt_qos0_queue_kill_node in mixed version mode

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -102,6 +102,7 @@ subgroups() ->
       ]},
      {cluster_size_3, [],
       [
+       rabbit_mqtt_qos0_queue_kill_node,
        queue_down_qos1,
        consuming_classic_mirrored_queue_down,
        consuming_classic_queue_down,
@@ -109,7 +110,6 @@ subgroups() ->
        flow_quorum_queue,
        flow_stream,
        rabbit_mqtt_qos0_queue,
-       rabbit_mqtt_qos0_queue_kill_node,
        cli_list_queues,
        maintenance,
        delete_create_queue,

--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -174,6 +174,11 @@ end_per_group(_, Config) ->
       rabbit_ct_client_helpers:teardown_steps() ++
       rabbit_ct_broker_helpers:teardown_steps()).
 
+init_per_testcase(rabbit_mqtt_qos0_queue_kill_node = T, Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, rabbit_mqtt_qos0_queue) of
+        ok -> init_per_testcase0(T, Config);
+        {skip, _} = Skip -> Skip
+    end;
 init_per_testcase(T, Config)
   when T =:= management_plugin_connection;
        T =:= management_plugin_enable ->


### PR DESCRIPTION
Follow up of #10205

Branch v3.12.x is currently red because test
```
bazel test //deps/rabbitmq_mqtt:shared_SUITE-mixed -t- --test_sharding_strategy=disabled --test_env FOCUS="-group [mqtt,cluster_size_3] -case rabbit_mqtt_qos0_queue_kill_node"
```

fails because the old node will error out with:
```
[info] <0.1962.0> accepting MQTT connection <0.1962.0> (127.0.0.1:61899 -> 127.0.0.1:21059, client id: subscriber)
[debug] <0.1962.0> Received a SUBSCRIBE for topic(s) [{mqtt_topic,
[debug] <0.1962.0>                                        "rabbit_mqtt_qos0_queue_kill_node",0}]
[error] <0.1977.0> Channel error on connection <0.1965.0> (127.0.0.1:61899 -> 127.0.0.1:21059, vhost: '/', user: 'guest'), channel 1:
[error] <0.1977.0> operation queue.declare caused a channel exception resource_locked: cannot obtain exclusive access to locked queue 'mqtt-subscription-subscriberqos0' in vhost '/'. It could be originally declared on another connection or the exclusive property value does not match that of the original declaration.
```

Classic mirrored queue could be used instead as descibed in https://groups.google.com/g/rabbitmq-users/c/pxgy0QiwilM/m/LkJQ-3DyBgAJ

PR #10205 specifically allows for clients to re-subscribe to a live node for queue type rabbit_mqtt_qos0_queue.

So, it's okay to skip the test when run with feature flag rabbit_mqtt_qos0_queue being disabled causing a classic queue to be created.