### PR TITLE
[#8557/CLI] Removed ANSI escape codes from JSON output

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -32,7 +32,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([], %{node: node_name, timeout: timeout}) do
+  def run([], %{node: node_name, timeout: timeout} = opts) do
     status =
       case :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :cli_cluster_status, []) do
         {:badrpc, {:EXIT, {:undef, _}}} ->
@@ -72,7 +72,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
             maintenance_status_by_node =
               Enum.map(
                 nodes,
-                fn n -> maintenance_status_by_node(n, per_node_timeout(timeout, count)) end
+                fn n -> maintenance_status_by_node(n, per_node_timeout(timeout, count), opts) end
               )
 
             cpu_cores_by_node =
@@ -340,26 +340,26 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
      }}
   end
 
-  defp maintenance_status_by_node(node, timeout) do
+  defp maintenance_status_by_node(node, timeout, opts) do
     target = to_atom(node)
+    formatter = Map.get(opts, :formatter)
+
+    rpc_result =
+      :rabbit_misc.rpc_call(target, :rabbit_maintenance, :status_local_read, [target], timeout)
 
     result =
-      case :rabbit_misc.rpc_call(
-             target,
-             :rabbit_maintenance,
-             :status_local_read,
-             [target],
-             timeout
-           ) do
-        {:badrpc, _} -> "unknown"
-        :regular -> "not under maintenance"
-        :draining -> magenta("marked for maintenance")
+      case {rpc_result, formatter} do
+        {{:badrpc, _}, _} -> "unknown"
+        {:regular, _} -> "not under maintenance"
+        {:draining, "json"} -> "marked for maintenance"
+        {:draining, _} -> magenta("marked for maintenance")
         # forward compatibility: should we figure out a way to know when
         # draining completes (it involves inherently asynchronous cluster
         # operations such as quorum queue leader re-election), we'd introduce
         # a new state
-        :drained -> magenta("marked for maintenance")
-        value -> to_string(value)
+        {:drained, "json"} -> "marked for maintenance"
+        {:drained, _} -> magenta("marked for maintenance")
+        {value, _} -> to_string(value)
       end
 
     {node, result}

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
@@ -8,6 +8,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   import RabbitMQ.CLI.Core.ANSI
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
 
   use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
   use RabbitMQ.CLI.Core.MergesNoDefaults
@@ -67,7 +68,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
 
   def output(result, _opts) do
     cookie_file_lines = [
-      "#{bright("Cookie File")}\n",
+      "#{bright("Cookie File")}",
       "Effective user: #{result[:effective_user] || "(none)"}",
       "Effective home directory: #{result[:home_dir] || "(none)"}",
       "Cookie file path: #{result[:cookie_file_path]}",
@@ -78,20 +79,20 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
     ]
 
     switch_lines = [
-      "\n#{bright("Cookie CLI Switch")}\n",
+      "#{line_separator()}#{bright("Cookie CLI Switch")}",
       "--erlang-cookie value set? #{result[:switch_cookie_set]}",
       "--erlang-cookie value length: #{result[:switch_cookie_value_length] || 0}"
     ]
 
     os_env_lines = [
-      "\n#{bright("Env variable ")} #{bright_red("(Deprecated)")}\n",
+      "#{line_separator()}#{bright("Env variable ")} #{bright_red("(Deprecated)")}",
       "RABBITMQ_ERLANG_COOKIE value set? #{result[:os_env_cookie_set]}",
       "RABBITMQ_ERLANG_COOKIE value length: #{result[:os_env_cookie_value_length] || 0}"
     ]
 
     lines = cookie_file_lines ++ switch_lines ++ os_env_lines
 
-    {:ok, lines}
+    {:ok, Enum.join(lines, line_separator())}
   end
 
   def help_section(), do: :configuration
@@ -102,7 +103,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
 
   def usage, do: "erlang_cookie_sources"
 
-  def formatter(), do: RabbitMQ.CLI.Formatters.StringPerLine
+  def formatter(), do: RabbitMQ.CLI.Formatters.String
 
   #
   # Implementation


### PR DESCRIPTION
Fixes #8557 

## Proposed Changes

Removed ANSI escape codes in JSON output.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #8557)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

- highlighting not more applied by `maintenance_status_by_node/2`
- done from `maintenance_lines/1`, only in console output.