### PR TITLE
[deps/amqp_client] client_properties could be set as maps

### DIFF
--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -88,8 +88,10 @@
 %% <li>node :: atom() - The node the broker runs on (direct only)</li>
 %% <li>adapter_info :: amqp_adapter_info() - Extra management information for if
 %%     this connection represents a non-AMQP network connection.</li>
-%% <li>client_properties :: [{binary(), atom(), binary()}] - A list of extra
-%%     client properties to be sent to the server, defaults to []</li>
+%% <li>client_properties :: [{binary(), atom(), binary()}] 
+%%                          | [#{key=>binary(), type=>atom(), val=>binary()}] 
+%%     - A list of extra client properties to be sent to the server, defaults to []
+%% </li>
 %% </ul>
 %%
 %% @type amqp_params_network() = #amqp_params_network{}.
@@ -116,8 +118,10 @@
 %%     defaults to 30000 (network only)</li>
 %% <li>ssl_options :: term() - The second parameter to be used with the
 %%     ssl:connect/2 function, defaults to 'none' (network only)</li>
-%% <li>client_properties :: [{binary(), atom(), binary()}] - A list of extra
-%%     client properties to be sent to the server, defaults to []</li>
+%% <li>client_properties :: [{binary(), atom(), binary()}] 
+%%                          | [#{key=>binary(), type=>atom(), val=>binary()}] 
+%%     - A list of extra client properties to be sent to the server, defaults to []
+%% </li>
 %% <li>socket_options :: [any()] - Extra socket options.  These are
 %%     appended to the default options.  See
 %%     <a href="https://www.erlang.org/doc/man/inet.html#setopts-2">inet:setopts/2</a>


### PR DESCRIPTION
## Proposed Changes

- added a check in `start/2`: if `client_properties` come as a list of maps, turn it into a list of tuples
- accepted map: `#{key => binary(), type => atom(), val => binary()}`

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2640)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

None.
