### PR TITLE
rabbit_db: Restart Ra systems after reset during join

### DIFF
--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -67,9 +67,13 @@ is_ra_system_running(Children, RaSystem) ->
 -spec ensure_started() -> ok | no_return().
 
 ensure_started() ->
-    ?LOG_DEBUG("Starting Ra systems"),
+    ?LOG_DEBUG(
+       "Starting Ra systems",
+       #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
     lists:foreach(fun ensure_ra_system_started/1, all_ra_systems()),
-    ?LOG_DEBUG("Ra systems started"),
+    ?LOG_DEBUG(
+       "Ra systems started",
+       #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
     ok.
 
 -spec ensure_ra_system_started(ra_system_name()) -> ok | no_return().
@@ -134,9 +138,13 @@ get_default_config() ->
 -spec ensure_stopped() -> ok | no_return().
 
 ensure_stopped() ->
-    ?LOG_DEBUG("Stopping Ra systems"),
+    ?LOG_DEBUG(
+       "Stopping Ra systems",
+       #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
     lists:foreach(fun ensure_ra_system_stopped/1, all_ra_systems()),
-    ?LOG_DEBUG("Ra systems stopped"),
+    ?LOG_DEBUG(
+       "Ra systems stopped",
+       #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
     ok.
 
 -spec ensure_ra_system_stopped(ra_system_name()) -> ok | no_return().

--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -29,9 +29,7 @@ setup() ->
 -spec setup(Context :: map()) -> ok | no_return().
 
 setup(_) ->
-    ?LOG_DEBUG("Starting Ra systems"),
-    lists:foreach(fun ensure_ra_system_started/1, all_ra_systems()),
-    ?LOG_DEBUG("Ra systems started"),
+    ensure_started(),
     ok.
 
 -spec all_ra_systems() -> [ra_system_name()].
@@ -39,6 +37,14 @@ setup(_) ->
 all_ra_systems() ->
     [quorum_queues,
      coordination].
+
+-spec ensure_started() -> ok | no_return().
+
+ensure_started() ->
+    ?LOG_DEBUG("Starting Ra systems"),
+    lists:foreach(fun ensure_ra_system_started/1, all_ra_systems()),
+    ?LOG_DEBUG("Ra systems started"),
+    ok.
 
 -spec ensure_ra_system_started(ra_system_name()) -> ok | no_return().
 

--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -14,7 +14,9 @@
 -export([setup/0,
          setup/1,
          all_ra_systems/0,
-         ensure_ra_system_started/1]).
+         ensure_ra_system_started/1,
+         ensure_started/0,
+         ensure_stopped/0]).
 
 -type ra_system_name() :: atom().
 
@@ -104,3 +106,25 @@ get_config(coordination = RaSystem) ->
 
 get_default_config() ->
     ra_system:default_config().
+
+-spec ensure_stopped() -> ok | no_return().
+
+ensure_stopped() ->
+    ?LOG_DEBUG("Stopping Ra systems"),
+    lists:foreach(fun ensure_ra_system_stopped/1, all_ra_systems()),
+    ?LOG_DEBUG("Ra systems stopped"),
+    ok.
+
+-spec ensure_ra_system_stopped(ra_system_name()) -> ok | no_return().
+
+ensure_ra_system_stopped(RaSystem) ->
+    case ra_system:stop(RaSystem) of
+        ok ->
+            ok;
+        {error, _} = Error ->
+            ?LOG_ERROR(
+               "Failed to stop Ra system \"~ts\": ~tp",
+               [RaSystem, Error],
+               #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
+            throw(Error)
+    end.


### PR DESCRIPTION
## Why

When the local node joins a remote node, it resets its own data first. This includes the files of the Ra systems (`quorum` and `coordination`).

When the CLI is used, that's fine because the `rabbit` app is stopped and thus the Ra systems.

However, when this is done as part of peer discovery, the node is booting: the Ra systems were started earlier because they are required to run Khepri. Therefore, the reset deletes files being used. This breaks the Ra systems.

## How

The Ra systems are stopped just before the reset (if the join is performed as part of peer discovery) and they are restarted after.