### PR TITLE
[2640] client_properties accepted as either a proplists, or a map

### DIFF
--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -157,19 +157,19 @@ start(AmqpParams) ->
 %% user specified connection name.
 start(AmqpParams, ConnName) when ConnName == undefined; is_binary(ConnName) ->
     ensure_started(),
-    Obfuscate   = fun(Password) -> credentials_obfuscation:encrypt(Password) end,
-    ToPropLists = fun(Props)    -> rabbit_data_coercion:to_proplist(Props) end,
+    ObfuscateFn = fun credentials_obfuscation:encrypt/1,
+    ToPropList  = fun rabbit_data_coercion:to_proplist/1,
     AmqpParams0 =
         case AmqpParams of
             #amqp_params_direct{password = Password, client_properties = Props} ->
                 AmqpParams#amqp_params_direct{
-		  password          = Obfuscate(Password),
-		  client_properties = ToPropLists(Props)
+		  password          = ObfuscateFn(Password),
+		  client_properties = ToPropList(Props)
 		 };
             #amqp_params_network{password = Password, client_properties = Props} ->
                 AmqpParams#amqp_params_network{
-		  password          = Obfuscate(Password),
-		  client_properties = ToPropLists(Props)
+		  password          = ObfuscateFn(Password),
+		  client_properties = ToPropList(Props)
 		 }
         end,
     AmqpParams1 =

--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -88,8 +88,10 @@
 %% <li>node :: atom() - The node the broker runs on (direct only)</li>
 %% <li>adapter_info :: amqp_adapter_info() - Extra management information for if
 %%     this connection represents a non-AMQP network connection.</li>
-%% <li>client_properties :: [{binary(), atom(), binary()}] - A list of extra
-%%     client properties to be sent to the server, defaults to []</li>
+%% <li>client_properties :: [{binary(), atom(), binary()}]
+%%                          | #{binary() => binary()}
+%%     - A list (or a map) of extra client properties to be sent to the server,
+%%      defaults to []</li>
 %% </ul>
 %%
 %% @type amqp_params_network() = #amqp_params_network{}.
@@ -116,8 +118,10 @@
 %%     defaults to 30000 (network only)</li>
 %% <li>ssl_options :: term() - The second parameter to be used with the
 %%     ssl:connect/2 function, defaults to 'none' (network only)</li>
-%% <li>client_properties :: [{binary(), atom(), binary()}] - A list of extra
-%%     client properties to be sent to the server, defaults to []</li>
+%% <li>client_properties :: [{binary(), atom(), binary()}]
+%%                          | #{binary() => binary()}
+%%     - A list (or a map) of extra client properties to be sent to the server,
+%%      defaults to []</li>
 %% <li>socket_options :: [any()] - Extra socket options.  These are
 %%     appended to the default options.  See
 %%     <a href="https://www.erlang.org/doc/man/inet.html#setopts-2">inet:setopts/2</a>

--- a/deps/amqp_client/src/amqp_connection.erl
+++ b/deps/amqp_client/src/amqp_connection.erl
@@ -157,20 +157,14 @@ start(AmqpParams) ->
 %% user specified connection name.
 start(AmqpParams, ConnName) when ConnName == undefined; is_binary(ConnName) ->
     ensure_started(),
-    ObfuscateFn = fun credentials_obfuscation:encrypt/1,
-    ToPropList  = fun rabbit_data_coercion:to_proplist/1,
     AmqpParams0 =
         case AmqpParams of
             #amqp_params_direct{password = Password, client_properties = Props} ->
-                AmqpParams#amqp_params_direct{
-		  password          = ObfuscateFn(Password),
-		  client_properties = ToPropList(Props)
-		 };
+                AmqpParams#amqp_params_direct{password          = credentials_obfuscation:encrypt(Password),
+                                              client_properties = rabbit_data_coercion:to_proplist(Props)};
             #amqp_params_network{password = Password, client_properties = Props} ->
-                AmqpParams#amqp_params_network{
-		  password          = ObfuscateFn(Password),
-		  client_properties = ToPropList(Props)
-		 }
+                AmqpParams#amqp_params_network{password          = credentials_obfuscation:encrypt(Password),
+                                               client_properties = rabbit_data_coercion:to_proplist(Props)}
         end,
     AmqpParams1 =
         case AmqpParams0 of


### PR DESCRIPTION
## Proposed Changes

- followed definition of `deps/rabbitmq_stream/src/rabbit_stream_reader.erl`
- did not introduce new variable: so the API stay the same.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2640)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

```erlang
% awk '/prop/ && /binary/' deps/rabbitmq_stream/src/rabbit_stream_reader.erl
         client_properties = #{} :: #{binary() => binary()},
```
