### PR TITLE
Return error atom according to specification

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -418,8 +418,10 @@ handle_call({topology, VirtualHost, Stream}, _From, State) ->
                                      #{leader_node => undefined,
                                        replica_nodes => []},
                                      Members)};
-                      _ ->
-                          {error, not_available}
+                      Err ->
+                          rabbit_log:info("Error locating ~tp stream members: ~tp",
+                                          [StreamName, Err]),
+                          {error, stream_not_available}
                   end;
               {error, not_found} ->
                   {error, stream_not_found};


### PR DESCRIPTION
In stream topology function call. This would
trigger an exception in the frame creation
when the stream was not available because the atom was unexpected.