### PR TITLE
rabbit_feature_flags: Trap `exit` signal in the controller

### DIFF
--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -186,6 +186,7 @@ init(_Args) ->
     ?LOG_DEBUG(
        "Feature flags: controller standing by",
        #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
+    process_flag(trap_exit, true),
     {ok, standing_by, none}.
 
 standing_by(


### PR DESCRIPTION
## Why

We need to do this for the `terminate/3` to be called. Without this, the process exits without calling it.