### PR TITLE
Asynchronous resource alarm tracker registration for protocol connections

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1217,6 +1217,11 @@ rabbitmq_integration_suite(
 )
 
 rabbitmq_integration_suite(
+    name = "reader_SUITE",
+    size = "medium",
+)
+
+rabbitmq_integration_suite(
     name = "cli_forget_cluster_node_SUITE",
     size = "medium",
     additional_beam = [

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -2153,3 +2153,11 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp_client:erlang_app"],
     )
+    erlang_bytecode(
+        name = "reader_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/reader_SUITE.erl"],
+        outs = ["test/reader_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+    )

--- a/deps/rabbit/test/reader_SUITE.erl
+++ b/deps/rabbit/test/reader_SUITE.erl
@@ -1,0 +1,193 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+%%
+
+-module(reader_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-compile([nowarn_export_all, export_all]).
+-compile(export_all).
+
+-import(rabbit_ct_client_helpers, [open_connection/2
+                                   ]).
+
+all() ->
+    [
+     {group, cluster_size_1}
+    ].
+
+suite() ->
+    [{timetrap, {minutes, 5}}].
+
+groups() ->
+    [
+     {cluster_size_1, [], all_tests()}
+    ].
+
+all_tests() ->
+    [
+     successful_connection_and_alarm_registration,
+     successful_connection_and_alarm_registration_after_scheduled_check,
+     successful_connection_and_failed_alarm_registration_before_check,
+     unsuccessful_connection_and_failed_alarm_registration_after_check
+    ].
+
+%% -------------------------------------------------------------------
+%% Test suite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(Group, Config) ->
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Group},
+        {rmq_nodes_count, 1}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+init_per_group_common(Group, Config, Size) ->
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Group},
+        {rmq_nodes_count, Size}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% ---------------------------------------------------------------------------
+%% Test Cases
+%% ---------------------------------------------------------------------------
+
+successful_connection_and_alarm_registration(Config) ->
+    [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    _Conn1 = open_connection(Config, A),
+    [ReaderPid] = get_reader_pid(Config),
+    ?assert(is_connection_registered_to_resource_alarms(Config, ReaderPid)),
+    passed.
+
+successful_connection_and_alarm_registration_after_scheduled_check(Config) ->
+    [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    _Conn1 = open_connection(Config, A),
+
+    set_alarms_registration_check_timeout(Config, 500),
+    timer:sleep(1_000),
+
+    [ReaderPid] = get_reader_pid(Config),
+    ?assert(is_connection_registered_to_resource_alarms(Config, ReaderPid)),
+    passed.
+
+successful_connection_and_failed_alarm_registration_before_check(Config) ->
+    [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [_ = terminate_rabbit_alarm(Config) || _ <- lists:seq(0, 10)],
+
+    set_alarms_registration_check_timeout(Config, 10_000),
+
+    _Conn1 = open_connection(Config, A),
+    [ReaderPid] = get_reader_pid(Config),
+
+    try
+        ?assert(is_connection_registered_to_resource_alarms(Config, ReaderPid))
+    catch
+        _:{_,{noproc,{_,_,[rabbit_alarm,_,_,_]}}} ->
+            ok
+    end,
+
+    ?assert(is_remote_process_alive(Config, ReaderPid)),
+    passed.
+
+unsuccessful_connection_and_failed_alarm_registration_after_check(Config) ->
+    ok = restart_rabbit_app(Config),
+    [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [_ = terminate_rabbit_alarm(Config) || _ <- lists:seq(0, 10)],
+
+    set_alarms_registration_check_timeout(Config, 500),
+
+    _Conn1 = open_connection(Config, A),
+    [ReaderPid] = get_reader_pid(Config),
+
+    %% delay and let connection fail with {noproc, rabbit_alarm} after scheduled
+    timer:sleep(1_000),
+
+    try
+        ?assert(is_connection_registered_to_resource_alarms(Config, ReaderPid))
+    catch
+        _:{_,{noproc,{_,_,[rabbit_alarm,_,_,_]}}} ->
+            ok
+    end,
+
+    ?assertNot(is_remote_process_alive(Config, ReaderPid)),
+    passed.
+
+is_connection_registered_to_resource_alarms(Config, Conn) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, is_connection_registered_to_resource_alarms1, [Conn]).
+
+is_connection_registered_to_resource_alarms1(Conn) ->
+    rabbit_alarm:is_registered(Conn).
+
+get_reader_pid(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, get_reader_pid1, []).
+
+get_reader_pid1() ->
+    rabbit_networking:local_connections().
+
+get_reader_state(Config, ReaderPid) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, get_reader_state1, [ReaderPid]).
+
+get_reader_state1(ReaderPid) ->
+    sys:get_state(ReaderPid).
+
+set_alarms_registration_check_timeout(Config, Timeout) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, set_alarms_registration_check_timeout1, [Timeout]).
+
+is_remote_process_alive(Config, ReaderPid) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, is_remote_process_alive1, [ReaderPid]).
+
+is_remote_process_alive1(ReaderPid) ->
+    is_process_alive(ReaderPid).
+
+set_alarms_registration_check_timeout1(Timeout) ->
+    application:set_env(rabbit, alarms_registration_check_timeout, Timeout).
+
+restart_rabbit_app(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, restart_rabbit_app1, []).
+
+restart_rabbit_app1() ->
+    rabbit:stop(),
+    rabbit:start(),
+    true = is_process_alive(whereis(rabbit_alarm)),
+    ok.
+
+terminate_rabbit_alarm(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, terminate_rabbit_alarm1, []).
+
+terminate_rabbit_alarm1() ->
+    case whereis(rabbit_alarm) of
+        undefined -> ok;
+        Pid when is_pid(Pid) ->
+            exit(Pid, kill),
+            ?assertNot(is_process_alive(Pid)),
+            ok
+    end.

--- a/deps/rabbit/test/reader_SUITE.erl
+++ b/deps/rabbit/test/reader_SUITE.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 %%
 
 -module(reader_SUITE).

--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -116,6 +116,11 @@ rabbitmq_integration_suite(
 )
 
 rabbitmq_integration_suite(
+    name = "reader_SUITE",
+    size = "medium",
+)
+
+rabbitmq_integration_suite(
     name = "system_SUITE",
     flaky = True,
     shard_count = 2,

--- a/deps/rabbitmq_amqp1_0/app.bzl
+++ b/deps/rabbitmq_amqp1_0/app.bzl
@@ -176,3 +176,11 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp10_common:erlang_app"],
     )
+    erlang_bytecode(
+        name = "reader_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/reader_SUITE.erl"],
+        outs = ["test/reader_SUITE.beam"],
+        app_name = "rabbitmq_amqp1_0",
+        erlc_opts = "//:test_erlc_opts",
+    )

--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_reader.erl
@@ -455,6 +455,7 @@ handle_1_0_connection_frame(#'v1_0.open'{ max_frame_size = ClientFrameMax,
                         container_id   = {utf8, rabbit_nodes:cluster_name()},
                         properties     = server_properties()}),
     _ = rabbit_alarm:register_async(self(), make_ref(), {?MODULE, conserve_resources, []}),
+    _ = rabbit_alarm:schedule_alarms_registration_check(),
     rabbit_amqp1_0:register_connection(self()),
     State1;
 

--- a/deps/rabbitmq_amqp1_0/test/reader_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/reader_SUITE.erl
@@ -1,0 +1,154 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(reader_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+all() ->
+    [
+      {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+     {non_parallel_tests, [], [
+        alarm_registration,
+        alarm_registration_after_scheduled_check,
+        failed_alarm_registration_before_check,
+        failed_connection_and_failed_alarm_registration_after_check
+                 ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    application:ensure_all_started(amqp10_client),
+    rabbit_ct_helpers:log_environment(),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(Group, Config) ->
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [
+                         {rmq_nodename_suffix, Suffix},
+                         {amqp10_client_library, Group}
+                        ]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testsuite cases
+%% -------------------------------------------------------------------
+
+alarm_registration(Config) ->
+    Connection = open_connection(Config, ?FUNCTION_NAME),
+    Amqp10ReaderPid = get_amqp10_reader_pid(Config),
+    ?assert(rabbit_ct_broker_helpers:is_pid_registered_to_resource_alarms(Config, 0, Amqp10ReaderPid)),
+    ok = amqp10_client:close_connection(Connection).
+
+alarm_registration_after_scheduled_check(Config) ->
+    Connection = open_connection(Config, ?FUNCTION_NAME),
+
+    Timeout = 500,
+    rabbit_ct_broker_helpers:set_alarms_registration_check_timeout(Config, 0, Timeout),
+    timer:sleep(Timeout + 500),
+
+    Amqp10ReaderPid = get_amqp10_reader_pid(Config),
+    ?assert(rabbit_ct_broker_helpers:is_pid_registered_to_resource_alarms(Config, 0, Amqp10ReaderPid)),
+
+    ok = amqp10_client:close_connection(Connection).
+
+failed_alarm_registration_before_check(Config) ->
+    rabbit_ct_broker_helpers:terminate_rabbit_alarm(Config),
+
+    Timeout = 10_000,
+    rabbit_ct_broker_helpers:set_alarms_registration_check_timeout(Config, 0, Timeout),
+
+    Connection = open_connection(Config, ?FUNCTION_NAME),
+    Amqp10ReaderPid = get_amqp10_reader_pid(Config),
+
+    try
+        ?assert(rabbit_ct_broker_helpers:is_pid_registered_to_resource_alarms(Config, 0, Amqp10ReaderPid))
+    catch
+        _:{_,{noproc,{_,_,[rabbit_alarm,_,_,_]}}} ->
+            ok
+    end,
+
+    ?assert(rabbit_ct_broker_helpers:is_process_alive(Config, Amqp10ReaderPid)),
+
+    ok = amqp10_client:close_connection(Connection).
+
+failed_connection_and_failed_alarm_registration_after_check(Config) ->
+    ok = rabbit_ct_broker_helpers:restart_broker(Config),
+    ?assert(rabbit_ct_broker_helpers:is_process_alive(Config, rabbit_alarm)),
+    rabbit_ct_broker_helpers:terminate_rabbit_alarm(Config),
+
+    Timeout = 500,
+    rabbit_ct_broker_helpers:set_alarms_registration_check_timeout(Config, 0, Timeout),
+
+    Connection = open_connection(Config, ?FUNCTION_NAME),
+    Amqp10ReaderPid = get_amqp10_reader_pid(Config),
+
+    %% delay > timeout, and let connection fail with {noproc, rabbit_alarm}
+    timer:sleep(Timeout + 500),
+
+    try
+        ?assert(rabbit_ct_broker_helpers:is_pid_registered_to_resource_alarms(Config, 0, Amqp10ReaderPid))
+    catch
+        _:{_,{noproc,{_,_,[rabbit_alarm,_,_,_]}}} ->
+            ok
+    end,
+
+    ?assertNot(rabbit_ct_broker_helpers:is_process_alive(Config, Amqp10ReaderPid)),
+    ok = amqp10_client:close_connection(Connection).
+
+%% -------------------------------------------------------------------
+
+get_amqp10_reader_pid(Config) ->
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, get_amqp10_reader_pid1, []).
+
+get_amqp10_reader_pid1() ->
+    lists:last(rabbit_amqp1_0:list()).
+
+open_connection(Config, Name) ->
+    Container = atom_to_binary(Name, utf8),
+    Host = ?config(rmq_hostname, Config),
+    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    
+    OpnConf = #{address => Host,
+                port => Port,
+                container_id => Container,
+                sasl => {plain, <<"guest">>, <<"guest">>}},
+    {ok, Connection} = amqp10_client:open_connection(OpnConf),
+    {ok, _Session} = amqp10_client:begin_session(Connection),
+    Connection.
+
+


### PR DESCRIPTION
## Proposed Changes

When connections start, they all register/subscribe to the rabbit-alarm manager and listen for resource alarms and respond accordingly, e.g. throttle connections. All along this has been carried out via the synchronous `rabbit_alarm:register/2` [call](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_reader.erl#L1232), which in-turn calls `gen_event:call/4` with a timeout `infinity`. This path is OK when only a few connections are in use and reconnect near concurrently. However, as connection counts increase to the order of thousands and millions (as seen with common MQTT/IoT use cases), the `rabbit_alarm` gen_server process becomes a bottleneck, queueing up thousands of connection registration requests in its message queue.  This in-turn blocks the socket reader process from proceeding with processing incoming protocol frames from the client, until successful registration in the rabbit-alarm manager. 

This PR changes the the way different protocol connections register/subscribe to resource alarms. This is now done in a non-blocking async manner, where registration request spawns a process and allows the socket reader process to proceed processing with resource alarm registration confirmation following after, allowing socket reader processes to complete initialization fast to start processing ingress frames immediately (this should be OK and should not have any reason to be blocked or interfered by alarm registration). Effects of the existing blocking effects of rabbit_alarm manager can be observed by inserting code to log: `{message_queue_len, L} = erlang:process_info(whereis(rabbit_alarm), message_queue_len).` after the existing `rabbit_alarm:register/2` calls in the different protocol reader processes. The message queue can be observed growing, and thus slowing down the socket reader/connection initialisation. 

Asynchronous rabbit-alarm registration support in this PR is currently added for:
- AMQP-0.9.1
- AMQP-1.0
- MQTT (v4 and v5)
- STOMP

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
