### PR TITLE
#2634 - if ASCII disabled, remove escape codes

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/ansi.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/ansi.ex
@@ -6,30 +6,36 @@
 
 defmodule RabbitMQ.CLI.Core.ANSI do
   def bright(string) do
-    "#{IO.ANSI.bright()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:bright, string])
   end
 
   def red(string) do
-    "#{IO.ANSI.red()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:red, string])
   end
 
   def yellow(string) do
-    "#{IO.ANSI.yellow()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:yellow, string])
   end
 
   def magenta(string) do
-    "#{IO.ANSI.magenta()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:magenta, string])
   end
 
   def bright_red(string) do
-    "#{IO.ANSI.bright()}#{IO.ANSI.red()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:bright, :red, string])
   end
 
   def bright_yellow(string) do
-    "#{IO.ANSI.bright()}#{IO.ANSI.yellow()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:bright, :yellow, string])
   end
 
   def bright_magenta(string) do
-    "#{IO.ANSI.bright()}#{IO.ANSI.magenta()}#{string}#{IO.ANSI.reset()}"
+    maybe_colorize([:bright, :magenta, string])
+  end
+
+  defp maybe_colorize(ascii_esc_and_string) do
+    ascii_esc_and_string
+    |> IO.ANSI.format()
+    |> IO.chardata_to_string()
   end
 end


### PR DESCRIPTION
## Proposed Changes

String piped through [`IO.ANSI.format/2`](https://hexdocs.pm/elixir/IO.ANSI.html#format/2): in console other than _stdout_ and _stderr,_ no escape code is printed.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #2634)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

None.