### PR TITLE
New upgrade time QQ health check: add check_if_new_quorum_queue_replicas_have_finished_initial_sync

### DIFF
--- a/deps/rabbit/src/amqqueue.erl
+++ b/deps/rabbit/src/amqqueue.erl
@@ -84,6 +84,7 @@
          reset_mirroring_and_decorators/1,
          set_immutable/1,
          qnode/1,
+         to_printable/1,
          macros/0]).
 
 -define(record_version, amqqueue_v2).
@@ -640,6 +641,14 @@ qnode(none) ->
     undefined;
 qnode({_, Node}) ->
     Node.
+
+-spec to_printable(amqqueue()) -> #{binary() => any()}.
+to_printable(#amqqueue{name = QName = #resource{name = Name},
+                       vhost = VHost, type = Type}) ->
+     #{<<"readable_name">> => rabbit_data_coercion:to_binary(rabbit_misc:rs(QName)),
+       <<"name">> => Name,
+       <<"virtual_host">> => VHost,
+       <<"type">> => Type}.
 
 % private
 

--- a/deps/rabbit/src/rabbit_upgrade_preparation.erl
+++ b/deps/rabbit/src/rabbit_upgrade_preparation.erl
@@ -85,15 +85,7 @@ list_with_minimum_quorum_for_cli() ->
     EndangeredQueues = lists:append(
                          rabbit_quorum_queue:list_with_minimum_quorum(),
                          rabbit_stream_queue:list_with_minimum_quorum()),
-    [begin
-         #resource{name = Name} = QName = amqqueue:get_name(Q),
-         #{
-           <<"readable_name">> => rabbit_data_coercion:to_binary(rabbit_misc:rs(QName)),
-           <<"name">> => Name,
-           <<"virtual_host">> => amqqueue:get_vhost(Q),
-           <<"type">> => amqqueue:get_type(Q)
-          }
-     end || Q <- EndangeredQueues] ++
+    [amqqueue:to_printable(Q) || Q <- EndangeredQueues] ++
     [#{
            <<"readable_name">> => C,
            <<"name">> => C,

--- a/deps/rabbit/test/unit_quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/unit_quorum_queue_SUITE.erl
@@ -5,6 +5,7 @@
 all() ->
     [
      all_replica_states_includes_nonvoters,
+     filter_nonvoters,
      filter_quorum_critical_accounts_nonvoters
     ].
 
@@ -25,6 +26,24 @@ filter_quorum_critical_accounts_nonvoters(_Config) ->
     Qs = rabbit_quorum_queue:filter_quorum_critical(Qs, Ss, test@leader),
     [Q2] = rabbit_quorum_queue:filter_quorum_critical(Qs, Ss, test@follower1),
     [Q1] = rabbit_quorum_queue:filter_quorum_critical(Qs, Ss, test@follower2),
+    ok.
+
+filter_nonvoters(_Config) ->
+    Qs = [_, _, _, Q4] =
+           [amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q1">>),
+                        {q1, test@leader},
+                        false, false, none, [], undefined, #{}),
+            amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q2">>),
+                        {q2, test@leader},
+                        false, false, none, [], undefined, #{}),
+            amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q3">>),
+                        {q3, test@leader},
+                        false, false, none, [], undefined, #{}),
+            amqqueue:new(rabbit_misc:r(<<"/">>, queue, <<"q4">>),
+                        {q4, test@leader},
+                        false, false, none, [], undefined, #{})],
+    Ss = #{q1 => leader, q2 => follower, q3 => non_voter, q4 => promotable},
+    [Q4] = rabbit_quorum_queue:filter_promotable(Qs, Ss),
     ok.
 
 all_replica_states_includes_nonvoters(_Config) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/check_if_new_quorum_queue_replicas_have_finished_initial_sync.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/check_if_new_quorum_queue_replicas_have_finished_initial_sync.ex
@@ -1,0 +1,93 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNewQuorumQueueReplicasHaveFinishedInitialSyncCommand do
+  @moduledoc """
+  Exits with a non-zero code if there are quorum queues
+  that run promotable replicas on the current node.
+
+  This command is used to verify if a new cluster member has synchronized.
+  """
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
+
+  def scopes(), do: [:diagnostics, :queues]
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(
+           node_name,
+           :rabbit_quorum_queue,
+           :list_with_local_promotable_for_cli,
+           [],
+           timeout
+         ) do
+      [] -> {:ok, []}
+      qs when is_list(qs) -> {:ok, qs}
+      other -> other
+    end
+  end
+
+  def output({:ok, []}, %{formatter: "json"}) do
+    {:ok, %{"result" => "ok"}}
+  end
+
+  def output({:ok, []}, %{silent: true}) do
+    {:ok, :check_passed}
+  end
+
+  def output({:ok, []}, %{node: node_name}) do
+    {:ok, "Node #{node_name} reported no queues with promotable replicas"}
+  end
+
+  def output({:ok, qs}, %{node: node_name, formatter: "json"}) when is_list(qs) do
+    {:error, :check_failed,
+     %{
+       "result" => "error",
+       "queues" => qs,
+       "message" => "Node #{node_name} reported local queues promotable replicas"
+     }}
+  end
+
+  def output({:ok, qs}, %{silent: true}) when is_list(qs) do
+    {:error, :check_failed}
+  end
+
+  def output({:ok, qs}, %{node: node_name}) when is_list(qs) do
+    lines = queue_lines(qs, node_name)
+
+    {:error, :check_failed, Enum.join(lines, line_separator())}
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description() do
+    "Health check that exits with a non-zero code if there are queues " <>
+      "that run promotable replicas on the current node."
+  end
+
+  def usage, do: "check_if_new_quorum_queue_replicas_have_finished_initial_sync"
+
+  def banner([], %{node: node_name}) do
+    "Checking if node #{node_name} runs promotable replicas of any queues ..."
+  end
+
+  #
+  # Implementation
+  #
+
+  def queue_lines(qs, node_name) do
+    for q <- qs, do: "#{q["readable_name"]} hasn't finished synchronization with #{node_name}."
+  end
+end


### PR DESCRIPTION
## Proposed Changes

In our infrastructure the tool that decides which node to replace is abstracted and has no notion of what runs within an instance, nor can run any commands. It spawns a deploy worker and that is what will check_if_node_is_quorum_critical. This means the same worker also has to ensure all newly spawned replicas are synchronized before signaling process complete back. It is an unfortunate limitation, but for cases that require this level of isolation and security, a separate CLI tool is needed.

This PR adds internal API and a diagnostics/queues command to check if the node has no promotable QQ replicas.

Some notable observations:
- I took liberty to add amqqueue:to_printable. The code it runs is now used in two places, but will happily revert.
- The command is check_if_node_has_promotable_replicas. It's the clearest I could come up with, suggestions welcome.
- There a fair bit of new user-facing text in the new command, would appreciate feedback regarding its clarity, etc.
- Unlike check_if_node_is_quorum_critical, this test doesn't handle streams at all, hope it is acceptable and streams can be added later.
- Nor does it have an equivalent HTTP API. Don't want to blow up the diff, but can add it as well.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
