### PR TITLE
Fix undef internal call in supervisor2

### DIFF
--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -878,17 +878,13 @@ do_restart_delay(Reason,
 
 maybe_restart(Strategy, Child, State) ->
     case restart(Strategy, Child, State) of
-        {{try_again, Reason}, NState2} ->
+        {{try_again, TryAgainId}, NState2} ->
             %% Leaving control back to gen_server before
             %% trying again. This way other incoming requests
             %% for the supervisor can be handled - e.g. a
             %% shutdown request for the supervisor or the
             %% child.
-            Id = if ?is_simple(State) -> Child#child.pid;
-                    true -> Child#child.id
-                 end,
-            Args = [self(), Id, Reason],
-            {ok, _TRef} = timer:apply_after(0, ?MODULE, try_again_restart, Args),
+            try_again_restart(TryAgainId),
             {ok, NState2};
         Other ->
             Other


### PR DESCRIPTION
## Proposed Changes

Must be a leftover from the refactoring in commit 0a87aea

This should prevent the below crash that was seen with an exchange federation link

```
{undef,
    [{supervisor2,try_again_restart,
         [<0.105395.0>,
          {upstream,
              [{encrypted,
                   <<"...">>}],
              <some mirrored supervisor data>},
          {upstream,
              [{encrypted,
                   <<"...">>}],
              <some mirrored supervisor data>}],
         []}]}
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments