### PR TITLE
Avoid repeat vhost existance checks and extend vhost deletion logging

### DIFF
--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -127,7 +127,7 @@ handle_cast({user_deleted, Details}) ->
     %% Schedule user entry deletion, allowing time for connections to close
     _ = timer:apply_after(?TRACKING_EXECUTION_TIMEOUT, ?MODULE,
             delete_tracked_connection_user_entry, [Username]),
-    rabbit_log_connection:info("Closing all connections from user '~ts' because it's being deleted", [Username]),
+    rabbit_log_connection:info("Closing all connections for user '~ts' because the user is being deleted", [Username]),
     shutdown_tracked_items(
         rabbit_connection_tracking:list_of_user(Username),
         rabbit_misc:format("user '~ts' is deleted", [Username])).

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -336,7 +336,7 @@ put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
                                         Metadata0#{default_queue_type =>
                                                        DefaultQueueType}
                                 end,
-                     case add(Name, Metadata, Username) of
+                     case catch do_add(Name, Metadata, Username) of
                          ok ->
                              %% wait for up to 45 seconds for the vhost to initialise
                              %% on all nodes

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -271,18 +271,23 @@ delete(VHost, ActingUser) ->
     %% modules, like `rabbit_amqqueue:delete_all_for_vhost(VHost)'. These new
     %% calls would be responsible for the atomicity, not this code.
     %% Clear the permissions first to prohibit new incoming connections when deleting a vhost
+    rabbit_log:info("Clearing permissions in vhost '~ts' because it's being deleted", [VHost]),
     _ = rabbit_auth_backend_internal:clear_permissions_for_vhost(VHost, ActingUser),
     _ = rabbit_auth_backend_internal:clear_topic_permissions_for_vhost(VHost, ActingUser),
+    rabbit_log:info("Deleting queues in vhost '~ts' because it's being deleted", [VHost]),
     QDelFun = fun (Q) -> rabbit_amqqueue:delete(Q, false, false, ActingUser) end,
     [begin
          Name = amqqueue:get_name(Q),
          assert_benign(rabbit_amqqueue:with(Name, QDelFun), ActingUser)
      end || Q <- rabbit_amqqueue:list(VHost)],
+    rabbit_log:info("Deleting exchanges in vhost '~ts' because it's being deleted", [VHost]),
     [assert_benign(rabbit_exchange:delete(Name, false, ActingUser), ActingUser) ||
         #exchange{name = Name} <- rabbit_exchange:list(VHost)],
+    rabbit_log:info("Clearing policies and runtime parameters in vhost '~ts' because it's being deleted", [VHost]),
     _ = rabbit_runtime_parameters:clear_vhost(VHost, ActingUser),
     _ = [rabbit_policy:delete(VHost, proplists:get_value(name, Info), ActingUser)
          || Info <- rabbit_policy:list(VHost)],
+    rabbit_log:debug("Removing vhost '~ts' from the metadata storage because it's being deleted", [VHost]),
     case rabbit_db_vhost:delete(VHost) of
         true ->
             ok = rabbit_event:notify(

--- a/deps/rabbit/src/rabbit_vhost_sup_sup.erl
+++ b/deps/rabbit/src/rabbit_vhost_sup_sup.erl
@@ -75,11 +75,17 @@ delete_on_all_nodes(VHost) ->
 
 stop_and_delete_vhost(VHost) ->
     StopResult = case lookup_vhost_sup_record(VHost) of
-        not_found -> ok;
+        not_found ->
+            rabbit_log:warning("Supervisor for vhost '~ts' not found during deletion procedure",
+                            [VHost]),
+            ok;
         #vhost_sup{wrapper_pid = WrapperPid,
                    vhost_sup_pid = VHostSupPid} ->
             case is_process_alive(WrapperPid) of
-                false -> ok;
+                false ->
+                    rabbit_log:info("Supervisor ~tp for vhost '~ts' already stopped",
+                                    [VHostSupPid, VHost]),
+                    ok;
                 true  ->
                     rabbit_log:info("Stopping vhost supervisor ~tp"
                                     " for vhost '~ts'",

--- a/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
+++ b/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
@@ -107,10 +107,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 %%----------------------------------------------------------------------------
 
 ensure_vhost_exists(VHost) ->
-    case rabbit_vhost:exists(VHost) of
-        false -> rabbit_vhost:add(VHost, ?INTERNAL_USER);
-        _     -> ok
-    end.
+    rabbit_vhost:add(VHost, ?INTERNAL_USER).
 
 %% pattern matching is way more efficient that the string operations,
 %% let's use all the keys we're aware of to speed up the handler.


### PR DESCRIPTION
## Proposed Changes

Hi Rabbit folks. This PR avoids repeat vhost existence checks (during definition imports and on event exchange), and also improves logging on vhost deletion procedures. We need bit more verbose info in the logs to see what elements are being deleted/have been deleted, when vhosts are undergoing deletion (this follows an ongoing issue where default exchange is lost following some migrations & restarts in 3.12.x, but no sign of any underlying issues).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
