### PR TITLE
Stream coordinator: fixes to automatic membership changes.

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -829,7 +829,7 @@ rabbitmq_integration_suite(
     additional_beam = [
         ":test_queue_utils_beam",
     ],
-    shard_count = 21,
+    shard_count = 22,
     deps = [
         "@proper//:erlang_app",
     ],

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -540,6 +540,9 @@ rabbitmq_integration_suite(
 rabbitmq_integration_suite(
     name = "message_containers_SUITE",
     size = "medium",
+    additional_beam = [
+        ":test_queue_utils_beam",
+    ],
 )
 
 rabbitmq_integration_suite(
@@ -675,6 +678,9 @@ rabbitmq_integration_suite(
 rabbitmq_integration_suite(
     name = "queue_type_SUITE",
     size = "medium",
+    additional_beam = [
+        ":test_queue_utils_beam",
+    ],
 )
 
 rabbitmq_integration_suite(

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -40,7 +40,8 @@
 -export([emit_unresponsive/6, emit_unresponsive_local/5, is_unresponsive/2]).
 -export([has_synchronised_mirrors_online/1, is_match/2, is_in_virtual_host/2]).
 -export([is_replicated/1, is_exclusive/1, is_not_exclusive/1, is_dead_exclusive/1]).
--export([list_local_quorum_queues/0, list_local_quorum_queue_names/0, list_local_stream_queues/0,
+-export([list_local_quorum_queues/0, list_local_quorum_queue_names/0,
+         list_local_stream_queues/0, list_stream_queues_on/1,
          list_local_mirrored_classic_queues/0, list_local_mirrored_classic_names/0,
          list_local_leaders/0, list_local_followers/0, get_quorum_nodes/1,
          list_local_mirrored_classic_without_synchronised_mirrors/0,
@@ -1220,9 +1221,12 @@ list_local_quorum_queues() ->
 
 -spec list_local_stream_queues() -> [amqqueue:amqqueue()].
 list_local_stream_queues() ->
-    [ Q || Q <- list_by_type(stream),
-      amqqueue:get_state(Q) =/= crashed,
-      lists:member(node(), get_quorum_nodes(Q))].
+    list_stream_queues_on(node()).
+
+-spec list_stream_queues_on(node()) -> [amqqueue:amqqueue()].
+list_stream_queues_on(Node) when is_atom(Node) ->
+     [Q || Q <- list_by_type(rabbit_stream_queue),
+           lists:member(Node, get_quorum_nodes(Q))].
 
 -spec list_local_leaders() -> [amqqueue:amqqueue()].
 list_local_leaders() ->

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -295,6 +295,15 @@ members_using_mnesia() ->
     rabbit_mnesia:members().
 
 members_using_khepri() ->
+    %% This function returns the empty list when it encounters an error
+    %% trying to query khepri for it's members. As this function does not
+    %% return ok | error this is the only way for callers to detect this.
+    %% rabbit_mnesia:members/0 however _will_ still return at least the
+    %% current node making it impossible to detect the situation where
+    %% the current cluster members may not be correct. It is unlikely we
+    %% ever reach that as the mnesia cluster file probably always exists.
+    %% For khepri however it is a lot more likely to encounter an error
+    %% so we need to allow callers to be more defensive in this case.
     rabbit_khepri:locally_known_nodes().
 
 -spec disc_members() -> Members when

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -295,10 +295,7 @@ members_using_mnesia() ->
     rabbit_mnesia:members().
 
 members_using_khepri() ->
-    case rabbit_khepri:locally_known_nodes() of
-        []      -> [node()];
-        Members -> Members
-    end.
+    rabbit_khepri:locally_known_nodes().
 
 -spec disc_members() -> Members when
       Members :: [node()].

--- a/deps/rabbit/src/rabbit_queue_type_util.erl
+++ b/deps/rabbit/src/rabbit_queue_type_util.erl
@@ -12,7 +12,8 @@
          check_auto_delete/1,
          check_exclusive/1,
          check_non_durable/1,
-         run_checks/2]).
+         run_checks/2,
+         erpc_call/5]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("amqqueue.hrl").
@@ -69,4 +70,31 @@ run_checks([C | Checks], Q) ->
             run_checks(Checks, Q);
         Err ->
             Err
+    end.
+
+-spec erpc_call(node(), module(), atom(), list(), non_neg_integer()) ->
+    term() | {error, term()}.
+erpc_call(Node, M, F, A, _Timeout)
+  when Node =:= node()  ->
+    %% Only timeout 'infinity' optimises the local call in OTP 23-25 avoiding a new process being spawned:
+    %% https://github.com/erlang/otp/blob/47f121af8ee55a0dbe2a8c9ab85031ba052bad6b/lib/kernel/src/erpc.erl#L121
+    try erpc:call(Node, M, F, A, infinity) of
+        Result ->
+            Result
+    catch
+        error:Err ->
+            {error, Err}
+    end;
+erpc_call(Node, M, F, A, Timeout) ->
+    case lists:member(Node, nodes()) of
+        true ->
+            try erpc:call(Node, M, F, A, Timeout) of
+                Result ->
+                    Result
+            catch
+                error:Err ->
+                    {error, Err}
+            end;
+        false ->
+            {error, noconnection}
     end.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -539,7 +539,7 @@ handle_tick(QName,
                            {single_active_consumer_tag, SacTag},
                            {single_active_consumer_pid, SacPid},
                            {leader, node()}
-                           | infos(QName, Keys)],
+                           | info(Q, Keys)],
                   rabbit_core_metrics:queue_stats(QName, Infos),
                   ok = repair_leader_record(Q, Self),
                   ExpectedNodes = rabbit_nodes:list_members(),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -78,7 +78,8 @@
          force_all_queues_shrink_member_to_current_member/0]).
 
 -import(rabbit_queue_type_util, [args_policy_lookup/3,
-                                 qname_to_internal_name/1]).
+                                 qname_to_internal_name/1,
+                                 erpc_call/5]).
 
 -include_lib("stdlib/include/qlc.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
@@ -1840,31 +1841,6 @@ notify_decorators(QName, F, A) ->
             ok;
         {error, not_found} ->
             ok
-    end.
-
-erpc_call(Node, M, F, A, _Timeout)
-  when Node =:= node()  ->
-    %% Only timeout 'infinity' optimises the local call in OTP 23-25 avoiding a new process being spawned:
-    %% https://github.com/erlang/otp/blob/47f121af8ee55a0dbe2a8c9ab85031ba052bad6b/lib/kernel/src/erpc.erl#L121
-    try erpc:call(Node, M, F, A, infinity) of
-        Result ->
-            Result
-    catch
-        error:Err ->
-            {error, Err}
-    end;
-erpc_call(Node, M, F, A, Timeout) ->
-    case lists:member(Node, nodes()) of
-        true ->
-            try erpc:call(Node, M, F, A, Timeout) of
-                Result ->
-                    Result
-            catch
-                error:Err ->
-                    {error, Err}
-            end;
-        false ->
-            {error, noconnection}
     end.
 
 is_stateful() -> true.

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -11,6 +11,7 @@
 
 -export([format_ra_event/2]).
 
+%% machine callbacks
 -export([init/1,
          apply/3,
          state_enter/2,
@@ -19,43 +20,57 @@
          tick/2,
          version/0,
          which_module/1,
-         overview/1]).
+         overview/1,
+         policy_changed/1]).
 
--export([recover/0,
+%% coordinator API
+-export([process_command/1,
+         recover/0,
          stop/0,
-         add_replica/2,
-         delete_replica/2,
-         register_listener/1,
-         register_local_member_listener/1]).
+         transfer_leadership/1,
+         forget_node/1,
+         status/0,
+         member_overview/0
+        ]).
 
+%% stream API
 -export([new_stream/2,
          restart_stream/1,
          restart_stream/2,
          delete_stream/2,
-         transfer_leadership/1]).
-
--export([policy_changed/1]).
+         add_replica/2,
+         delete_replica/2,
+         register_listener/1,
+         register_local_member_listener/1
+        ]).
 
 -export([local_pid/1,
          writer_pid/1,
          members/1,
          stream_overview/1]).
+
+%% machine queries
 -export([query_local_pid/3,
          query_writer_pid/2,
          query_members/2,
          query_stream_overview/2]).
 
 
--export([log_overview/1]).
--export([replay/1]).
+-export([log_overview/1,
+         key_metrics_rpc/1
+         ]).
 
 %% for SAC coordinator
--export([process_command/1,
-         sac_state/1]).
+-export([sac_state/1]).
 
 %% for testing and debugging
 -export([eval_listeners/3,
+         replay/1,
          state/0]).
+
+-import(rabbit_queue_type_util, [
+                                 erpc_call/5
+                                ]).
 
 -rabbit_boot_step({?MODULE,
                    [{description, "Restart stream coordinator"},
@@ -390,23 +405,32 @@ process_command([Server | Servers], Cmd) ->
             process_command(Servers, Cmd);
         {error, noproc} ->
             process_command(Servers, Cmd);
+        {error, nodedown} ->
+            process_command(Servers, Cmd);
         Reply ->
             Reply
     end.
 
 ensure_coordinator_started() ->
     Local = {?MODULE, node()},
-    AllNodes = all_coord_members(),
+    ExpectedMembers = expected_coord_members(),
     case whereis(?MODULE) of
         undefined ->
             global:set_lock(?STREAM_COORDINATOR_STARTUP),
             Nodes = case ra:restart_server(?RA_SYSTEM, Local) of
                         {error, Reason} when Reason == not_started orelse
                                              Reason == name_not_registered ->
-                            OtherNodes = all_coord_members() -- [Local],
+                            OtherNodes = ExpectedMembers -- [Local],
+                            %% this could potentially be slow if some expected
+                            %% members are on nodes that have recently terminated
+                            %% and have left a dangling TCP connection
+                            %% I suspect this very rarely happens as the local coordinator
+                            %% server is started in recover/0
                             case lists:filter(
                                    fun({_, N}) ->
-                                           erpc:call(N, erlang, whereis, [?MODULE]) =/= undefined
+                                           is_pid(erpc_call(N, erlang,
+                                                            whereis, [?MODULE],
+                                                            1000))
                                    end, OtherNodes) of
                                 [] ->
                                     start_coordinator_cluster();
@@ -414,16 +438,28 @@ ensure_coordinator_started() ->
                                     OtherNodes
                             end;
                         ok ->
-                            AllNodes;
+                            %% TODO: it may be better to do a leader call
+                            %% here as the local member may not have caught up
+                            %% yet
+                            locally_known_members();
                         {error, {already_started, _}} ->
-                            AllNodes;
+                            locally_known_members();
                         _ ->
-                            AllNodes
+                            locally_known_members()
                     end,
             global:del_lock(?STREAM_COORDINATOR_STARTUP),
             Nodes;
         _ ->
-            AllNodes
+            locally_known_members()
+    end.
+
+locally_known_members() ->
+    %% TODO: use ra_leaderboard and fallback if leaderboard not populated
+    case ra:members({local, {?MODULE, node()}}) of
+        {_, Members, _} ->
+            Members;
+        Err ->
+            exit({error_fetching_locally_known_coordinator_members, Err})
     end.
 
 start_coordinator_cluster() ->
@@ -440,9 +476,13 @@ start_coordinator_cluster() ->
             []
     end.
 
-all_coord_members() ->
-    Nodes = rabbit_nodes:list_running() -- [node()],
-    [{?MODULE, Node} || Node <- [node() | Nodes]].
+expected_coord_members() ->
+    Nodes = rabbit_nodes:list_members(),
+    [{?MODULE, Node} || Node <- Nodes].
+
+reachable_coord_members() ->
+    Nodes = rabbit_nodes:list_reachable(),
+    [{?MODULE, Node} || Node <- Nodes].
 
 version() -> 4.
 
@@ -681,69 +721,127 @@ all_member_nodes(Streams) ->
 tick(_Ts, _State) ->
     [{aux, maybe_resize_coordinator_cluster}].
 
+members() ->
+    %% TODO: this can be replaced with a ra_leaderboard
+    %% lookup after Ra 2.7.3_
+    LocalServerId = {?MODULE, node()},
+    case whereis(?MODULE) of
+        undefined ->
+            %% no local member running, we need to try the cluster
+            OtherMembers = lists:delete(LocalServerId, reachable_coord_members()),
+            case ra:members(OtherMembers) of
+                {_, Members, Leader} ->
+                    {ok, Members, Leader};
+                Err ->
+                    Err
+            end;
+        _Pid ->
+            case ra:members({local, LocalServerId}) of
+                {_, Members, Leader} ->
+                    {ok, Members, Leader};
+                Err ->
+                    Err
+            end
+    end.
+
 maybe_resize_coordinator_cluster() ->
     spawn(fun() ->
                   RabbitIsRunning = rabbit:is_running(),
-                  case rabbit_nodes:list_members() of
-                      All when RabbitIsRunning andalso length(All) > 0 ->
-                          %% the members need to be the non-empty list _and_
-                          %% rabbit needs to be running for it to be safe
-                          %% to do any of the below
-                          case ra:members({?MODULE, node()}) of
-                              {_, Members, _} ->
-                                  MemberNodes = [Node || {_, Node} <- Members],
-                                  Running = rabbit_nodes:list_running(),
-                                  case Running -- MemberNodes of
-                                      [] ->
-                                          ok;
-                                      New ->
-                                          rabbit_log:info("~ts: New rabbit node(s) detected, "
-                                                          "adding : ~w",
-                                                          [?MODULE, New]),
-                                          add_members(Members, New)
-                                  end,
-                                  case MemberNodes -- All of
-                                      [] ->
-                                          ok;
-                                      Old ->
-                                          rabbit_log:info("~ts: Rabbit node(s) removed from the cluster, "
-                                                          "deleting: ~w", [?MODULE, Old]),
-                                          remove_members(Members, Old)
-                                  end;
-                              _ ->
-                                  ok
+                  case members() of
+                      {ok, Members, Leader} when RabbitIsRunning ->
+                          MemberNodes = [Node || {_, Node} <- Members],
+                          %% TODO: in the future replace with
+                          %% rabbit_presence:list_present/0
+                          Present = rabbit_nodes:list_running(),
+                          RabbitNodes = rabbit_nodes:list_members(),
+                          AddableNodes = [N || N <- RabbitNodes,
+                                               lists:member(N, Present)],
+                          case AddableNodes -- MemberNodes of
+                              [] ->
+                                  ok;
+                              [New | _] ->
+                                  %% any remaining members will be added
+                                  %% next tick
+                                  rabbit_log:info("~ts: New rabbit node(s) detected, "
+                                                  "adding : ~w",
+                                                  [?MODULE, New]),
+                                  add_member(Members, New)
+                          end,
+                          case MemberNodes -- RabbitNodes of
+                              [] ->
+                                  ok;
+                              [Old | _]  ->
+                                  %% this ought to be rather rare as the stream
+                                  %% coordinator member is now removed as part
+                                  %% of the forget_cluster_node command
+                                  rabbit_log:info("~ts: Rabbit node(s) removed from the cluster, "
+                                                  "deleting: ~w", [?MODULE, Old]),
+                                  remove_member(Leader, Members, Old)
                           end;
                       _ ->
                           ok
                   end
           end).
 
-add_members(_, []) ->
-    ok;
-add_members(Members, [Node | Nodes]) ->
+add_member(Members, Node) ->
     Conf = make_ra_conf(Node, [N || {_, N} <- Members]),
+    ServerId = {?MODULE, Node},
     case ra:start_server(?RA_SYSTEM, Conf) of
         ok ->
-            case ra:add_member(Members, {?MODULE, Node}) of
-                {ok, NewMembers, _} ->
-                    add_members(NewMembers, Nodes);
-                _ ->
-                    add_members(Members, Nodes)
+            case ra:add_member(Members, ServerId) of
+                {ok, _, _} ->
+                    ok;
+                {error, Err} ->
+                    rabbit_log:warning("~ts: Failed to add member, reason ~w"
+                                       "deleting started server on ~w",
+                                       [?MODULE, Err, Node]),
+                    case ra:force_delete_server(?RA_SYSTEM, ServerId) of
+                        ok ->
+                            ok;
+                        Err ->
+                            rabbit_log:warning("~ts: Failed to delete server "
+                                               "on ~w, reason ~w",
+                                               [?MODULE, Node, Err]),
+                            ok
+                    end
+            end;
+        {error, {already_started, _}} ->
+            case lists:member(ServerId, Members) of
+                true ->
+                    %% this feels like an unlikely scenario but best to handle
+                    %% it just in case
+                    ok;
+                false ->
+                    %% there is a server running but is not a member of the
+                    %% stream coordinator cluster
+                    %% In this case it needs to be deleted
+                    rabbit_log:warning("~ts: server already running on ~w but not
+                                       part of cluster, "
+                                       "deleting started server",
+                                       [?MODULE, Node]),
+                    case ra:force_delete_server(?RA_SYSTEM, ServerId) of
+                        ok ->
+                            ok;
+                        Err ->
+                            rabbit_log:warning("~ts: Failed to delete server "
+                                               "on ~w, reason ~w",
+                                               [?MODULE, Node, Err]),
+                            ok
+                    end
             end;
         Error ->
-            rabbit_log:warning("Stream coordinator failed to start on node ~ts : ~W",
+            rabbit_log:warning("Stream coordinator server failed to start on node ~ts : ~W",
                                [Node, Error, 10]),
-            add_members(Members, Nodes)
+            ok
     end.
 
-remove_members(_, []) ->
-    ok;
-remove_members(Members, [Node | Nodes]) ->
-    case ra:remove_member(Members, {?MODULE, Node}) of
-        {ok, NewMembers, _} ->
-            remove_members(NewMembers, Nodes);
-        _ ->
-            remove_members(Members, Nodes)
+remove_member(Leader, Members, Node) ->
+    ToRemove = {?MODULE, Node},
+    case lists:member(ToRemove, Members) of
+        true ->
+            ra:leave_and_delete_server(?RA_SYSTEM, Leader, ToRemove);
+        false ->
+            ok
     end.
 
 -record(aux, {actions = #{} ::
@@ -2109,6 +2207,107 @@ transfer_leadership([Destination | _] = _TransferCandidates) ->
         undefined ->
             {ok, undefined}
     end.
+
+-spec forget_node(node()) -> ok | {error, term()}.
+forget_node(Node) when is_atom(Node) ->
+    case ra_directory:uid_of(?RA_SYSTEM, ?MODULE) of
+        undefined ->
+            %% if there is no local stream coordinator registered it is likely that the
+            %% system does not use streams at all and we just return ok
+            %% here. The alternative would be to do a cluster wide rpc here
+            %% to check but given there is a fallback
+            ok;
+        _ ->
+            IsRunning = rabbit_nodes:is_running(Node),
+            ExpectedMembers = expected_coord_members(),
+            ToRemove = {?MODULE, Node},
+            case ra:members(ExpectedMembers) of
+                {ok, Members, Leader} ->
+                    case lists:member(ToRemove, Members) of
+                        true ->
+                            case ra:remove_member(Leader, ToRemove) of
+                                {ok, _, _} when IsRunning ->
+                                    _ = ra:force_delete_server(?RA_SYSTEM, ToRemove),
+                                    ok;
+                                {ok, _, _} ->
+                                    ok;
+                                {error, _} = Err ->
+                                    Err
+                            end;
+                        false ->
+                            ok
+                    end;
+                Err ->
+                    Err
+            end
+    end.
+
+
+-spec member_overview() ->
+    {ok, map()} | {error, term()}.
+member_overview() ->
+    case whereis(?MODULE) of
+        undefined ->
+            {error, local_stream_coordinator_not_running};
+        _ ->
+            case ra:member_overview({?MODULE, node()}) of
+                {ok, Result, _} ->
+                    {ok, maps:remove(system_config, Result)};
+                Err ->
+                    Err
+            end
+    end.
+
+-spec status() ->
+    [[{binary(), term()}]] | {error, term()}.
+status() ->
+    case members() of
+        {ok, Members, _} ->
+            [begin
+                 case erpc_call(N, ?MODULE, key_metrics_rpc, [ServerId], ?RPC_TIMEOUT) of
+                     #{state := RaftState,
+                       membership := Membership,
+                       commit_index := Commit,
+                       term := Term,
+                       last_index := Last,
+                       last_applied := LastApplied,
+                       last_written_index := LastWritten,
+                       snapshot_index := SnapIdx,
+                       machine_version := MacVer} ->
+                         [{<<"Node Name">>, N},
+                          {<<"Raft State">>, RaftState},
+                          {<<"Membership">>, Membership},
+                          {<<"Last Log Index">>, Last},
+                          {<<"Last Written">>, LastWritten},
+                          {<<"Last Applied">>, LastApplied},
+                          {<<"Commit Index">>, Commit},
+                          {<<"Snapshot Index">>, SnapIdx},
+                          {<<"Term">>, Term},
+                          {<<"Machine Version">>, MacVer}
+                         ];
+                     {error, Err} ->
+                         [{<<"Node Name">>, N},
+                          {<<"Raft State">>, Err},
+                          {<<"Membership">>, <<>>},
+                          {<<"LastLog Index">>, <<>>},
+                          {<<"Last Written">>, <<>>},
+                          {<<"Last Applied">>, <<>>},
+                          {<<"Commit Index">>, <<>>},
+                          {<<"Snapshot Index">>, <<>>},
+                          {<<"Term">>, <<>>},
+                          {<<"Machine Version">>, <<>>}
+                         ]
+                 end
+             end || {_, N} = ServerId <- Members];
+        {error, {no_more_servers_to_try, _}} ->
+            {error, coordinator_not_started_or_available};
+        Err ->
+            Err
+    end.
+
+key_metrics_rpc(ServerId) ->
+    Metrics = ra:key_metrics(ServerId),
+    Metrics#{machine_version => rabbit_fifo:version()}.
 
 maps_to_list(M) ->
     lists:sort(maps:to_list(M)).

--- a/deps/rabbit/src/rabbit_stream_coordinator.hrl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.hrl
@@ -5,6 +5,7 @@
 -define(PHASE_RETRY_TIMEOUT, 10000).
 -define(CMD_TIMEOUT, 30000).
 -define(RA_SYSTEM, coordination).
+-define(RPC_TIMEOUT, 1000).
 
 -type stream_id() :: string().
 -type stream() :: #{conf := osiris:config(),

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -983,7 +983,7 @@ delete_replica(VHost, Name, Node) ->
 
 delete_all_replicas(Node) ->
     rabbit_log:info("Asked to remove all stream replicas from node ~ts", [Node]),
-    Streams = rabbit_amqqueue:list_by_type(stream),
+    Streams = rabbit_amqqueue:list_stream_queues_on(Node),
     lists:map(fun(Q) ->
                       QName = amqqueue:get_name(Q),
                       rabbit_log:info("~ts: removing replica on node ~w",

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -447,30 +447,30 @@ cancel(_Q, ConsumerTag, OkMsg, ActingUser, #stream_client{readers = Readers0,
 credit(QName, CTag, Credit, Drain, #stream_client{readers = Readers0,
                                                   name = Name,
                                                   local_pid = LocalPid} = State) ->
-    {Readers1, Msgs} = case Readers0 of
-                          #{CTag := #stream{credit = Credit0} = Str0} ->
-                              Str1 = Str0#stream{credit = Credit0 + Credit},
-                              {Str, Msgs0} = stream_entries(QName, Name, LocalPid, Str1),
-                              {Readers0#{CTag => Str}, Msgs0};
+    case Readers0 of
+        #{CTag := #stream{credit = Credit0} = Str0} ->
+            Str1 = Str0#stream{credit = Credit0 + Credit},
+            {Str, Msgs} = stream_entries(QName, Name, LocalPid, Str1),
+            Actions = case Msgs of
+                          [] ->
+                              [{send_credit_reply, 0}];
                           _ ->
-                              {Readers0, []}
+                              [{send_credit_reply, length(Msgs)},
+                               {deliver, CTag, true, Msgs}]
                       end,
-    {Readers, Actions} =
-        case Drain of
-            true ->
-                case Readers1 of
-                    #{CTag := #stream{credit = Credit1} = Str2} ->
-                        {Readers0#{CTag => Str2#stream{credit = 0}},
-                         [{send_drained, {CTag, Credit1}}]};
-                    _ ->
-                        {Readers1, []}
-                end;
-            false ->
-                {Readers1, []}
-        end,
-    {State#stream_client{readers = Readers},
-     [{send_credit_reply, length(Msgs)},
-      {deliver, CTag, true, Msgs}] ++ Actions}.
+            case Drain of
+                true ->
+                    Readers = Readers0#{CTag => Str#stream{credit = 0}},
+                    {State#stream_client{readers = Readers},
+                     %% send_drained needs to come after deliver
+                     Actions ++ [{send_drained, {CTag, Str#stream.credit}}]};
+                false ->
+                    Readers = Readers0#{CTag => Str},
+                    {State#stream_client{readers = Readers}, Actions}
+            end;
+        _ ->
+            {State, []}
+    end.
 
 deliver(QSs, Msg, Options) ->
     lists:foldl(
@@ -552,16 +552,20 @@ handle_event(QName, {osiris_offset, _From, _Offs},
              State = #stream_client{local_pid = LocalPid,
                                     readers = Readers0,
                                     name = Name}) ->
+    Ack = true,
     %% offset isn't actually needed as we use the atomic to read the
     %% current committed
-    {Readers, TagMsgs} = maps:fold(
-                           fun (Tag, Str0, {Acc, TM}) ->
-                                   {Str, Msgs} = stream_entries(QName, Name, LocalPid, Str0),
-                                   {Acc#{Tag => Str}, [{Tag, LocalPid, Msgs} | TM]}
-                           end, {#{}, []}, Readers0),
-    Ack = true,
-    Deliveries = [{deliver, Tag, Ack, OffsetMsg}
-                  || {Tag, _LeaderPid, OffsetMsg} <- TagMsgs],
+    {Readers, Deliveries} =
+        maps:fold(
+          fun (Tag, Str0, {Acc, TM}) ->
+                  case stream_entries(QName, Name, LocalPid, Str0) of
+                      {Str, []} ->
+                          {Acc#{Tag => Str}, TM};
+                      {Str, Msgs} ->
+                          {Acc#{Tag => Str},
+                           [{deliver, Tag, Ack, Msgs} | TM]}
+                  end
+          end, {#{}, []}, Readers0),
     {ok, State#stream_client{readers = Readers}, Deliveries};
 handle_event(_QName, {stream_leader_change, Pid}, State) ->
     {ok, update_leader_pid(Pid, State), []};

--- a/deps/rabbit/test/queue_type_SUITE.erl
+++ b/deps/rabbit/test/queue_type_SUITE.erl
@@ -261,6 +261,12 @@ stream(Config) ->
 
     SubCh = rabbit_ct_client_helpers:open_channel(Config, 2),
     qos(SubCh, 10, false),
+    %% wait for local replica
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+              queue_utils:has_local_stream_member(Config, 2, QName, <<"/">>)
+      end, 60000),
+
     try
         amqp_channel:subscribe(
           SubCh, #'basic.consume'{queue = QName,

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -462,10 +462,16 @@ find_queue_info(Config, Node, Keys) ->
 
 find_queue_info(Name, Config, Node, Keys) ->
     QName = rabbit_misc:r(<<"/">>, queue, Name),
-    Infos = rabbit_ct_broker_helpers:rpc(Config, Node, rabbit_amqqueue, info_all,
-                                             [<<"/">>, [name] ++ Keys]),
-    [Info] = [Props || Props <- Infos, lists:member({name, QName}, Props)],
-    Info.
+    rabbit_ct_broker_helpers:rpc(Config, Node, ?MODULE, find_queue_info_rpc,
+                                 [QName, [name | Keys]]).
+
+find_queue_info_rpc(QName, Infos) ->
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            rabbit_amqqueue:info(Q, Infos);
+        _ ->
+            []
+    end.
 
 delete_queue(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -190,13 +190,6 @@ init_per_group(cluster_size_3_parallel = Group, Config) ->
         _ ->
             init_per_group1(Group, Config)
     end;
-init_per_group(unclustered_size_3_4 = Group, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "not mixed versions compatible"};
-        _ ->
-            init_per_group1(Group, Config)
-    end;
 init_per_group(Group, Config) ->
     init_per_group1(Group, Config).
 
@@ -665,8 +658,12 @@ grow_then_shrink_coordinator_cluster(Config) ->
     ?assertEqual({'queue.declare_ok', Q, 0, 0},
                  declare(Config, Server0, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
+    ok = rabbit_control_helper:command(stop_app, Server1),
     ok = rabbit_control_helper:command(join_cluster, Server1, [atom_to_list(Server0)], []),
+    ok = rabbit_control_helper:command(start_app, Server1),
+    ok = rabbit_control_helper:command(stop_app, Server2),
     ok = rabbit_control_helper:command(join_cluster, Server2, [atom_to_list(Server0)], []),
+    ok = rabbit_control_helper:command(start_app, Server2),
 
     rabbit_ct_helpers:await_condition(
       fun() ->

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -190,6 +190,13 @@ init_per_group(cluster_size_3_parallel = Group, Config) ->
         _ ->
             init_per_group1(Group, Config)
     end;
+init_per_group(unclustered_size_3_4 = Group, Config) ->
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            {skip, "not mixed versions compatible"};
+        _ ->
+            init_per_group1(Group, Config)
+    end;
 init_per_group(Group, Config) ->
     init_per_group1(Group, Config).
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -97,6 +97,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
               any
           end
 
+        stream_coord_result =
+          :rabbit_misc.rpc_call(node_name, :rabbit_stream_coordinator, :forget_node, [atom_name])
+
         is_error_fun = fn
           {_, {:ok, _}} ->
             false
@@ -117,20 +120,22 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
         has_stream_error =
           not Enum.empty?(stream_shrink_result) and Enum.any?(stream_shrink_result, is_error_fun)
 
-        case {has_qq_error, has_stream_error} do
-          {false, false} ->
+        errors =
+          append_err(stream_coord_result != :ok, "Stream coordinator", [])
+
+        errors =
+          append_err(has_qq_error, "Quorum queues", errors)
+
+        errors =
+          append_err(has_stream_error, "Streams", errors)
+
+        case errors do
+          [] ->
             :ok
 
-          {true, false} ->
+          _ ->
             {:error,
-             "RabbitMQ failed to shrink some of the quorum queues on node #{node_to_remove}"}
-
-          {false, true} ->
-            {:error, "RabbitMQ failed to shrink some of the streams on node #{node_to_remove}"}
-
-          {true, true} ->
-            {:error,
-             "RabbitMQ failed to shrink some of the quorum queues and streams on node #{node_to_remove}"}
+             "RabbitMQ failed to shrink some entities on node #{node_to_remove} : #{errors}"}
         end
 
       other ->
@@ -175,6 +180,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
   #
   # Implementation
   #
+
+  defp append_err(false, _err, errs) do
+    errs
+  end
+
+  defp append_err(true, err, []) do
+    [err]
+  end
+
+  defp append_err(true, err, errs) do
+    [err, ", " | errs]
+  end
 
   defp become(node_name, opts) do
     :error_logger.tty(false)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/coordinator_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/coordinator_status_command.ex
@@ -34,8 +34,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.CoordinatorStatusCommand do
   end
 
   def usage_additional do
-    [
-    ]
+    []
   end
 
   def usage_doc_guides() do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/coordinator_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/coordinator_status_command.ex
@@ -1,0 +1,53 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.CoordinatorStatusCommand do
+  alias RabbitMQ.CLI.Core.DocGuide
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  def scopes(), do: [:diagnostics, :streams]
+
+  def merge_defaults(args, opts), do: {args, opts}
+
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([] = _args, %{node: node_name}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_stream_coordinator, :status, []) do
+      {:error, :coordinator_not_started_or_available} ->
+        {:error, "Cannot get coordinator status as coordinator not started or unavailable"}
+
+      other ->
+        other
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.PrettyTable
+
+  def usage() do
+    "coordinator_status"
+  end
+
+  def usage_additional do
+    [
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.streams()
+    ]
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays raft status of the stream coordinator"
+
+  def banner([], %{node: node_name}),
+    do: "Status of stream coordinator ..."
+end


### PR DESCRIPTION
Various bug fixes to make stream coordinator membership changes more reliable. Previously various errors could happen as well as partially successful attempts where the membership change command may fail but it leaves the new server running.

Also ensure that stream coordinator members are removed as part of the `forget_cluster_node` command.

Also added `rabbitmq-streams coordinator_status` command so that we can get a view of replication and other information in a nice tabular format, same as `rabbitmq-queues quorum_status`

This PR also contains a change to allow `rabbit_nodes:list_member/0` to return `[]` (rather than `[node()]`) when the query to fetch the current members fails. This allows us to detect this scenario in the code and avoid, e.g. shrinking the coordinator cluster incorrectly.

Also adding back a missing clause in the quorum queue tick handler that was accidentally removed in #10364
