### PR TITLE
Remove FF warning as soon as all features are enabled

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -668,6 +668,10 @@ function postprocess() {
                            "after deletion.");
         });
 
+    $('form.enable-feature-flag').on('submit', function() {
+                    full_refresh();
+    });
+
     $('label').map(function() {
             if ($(this).attr('for') == '') {
                 var id = 'auto-label-' + Math.floor(Math.random()*1000000000);

--- a/deps/rabbitmq_management/priv/www/js/tmpl/feature-flags.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/feature-flags.ejs
@@ -48,7 +48,7 @@
               <p><span>&#9888;</span>Disabled!</p>
            <% } %>
            <% if (feature_flag.state == "disabled") { %>
-           <form action="#/feature-flags-enable" method="put" style="display: inline-block">
+           <form action="#/feature-flags-enable" method="put" style="display: inline-block" class="enable-feature-flag">
            <input type="hidden" name="name" value="<%= fmt_string(feature_flag.name) %>"/>
            <input type="submit" value="Enable" class="c"/>
            </form>


### PR DESCRIPTION
Updating the page content doesn't clear the warning in the header, which requires a full refresh.

It could become annoying/confusing for users after enabling feature flags which wouldn't see the banner gone until re-opening the page or manually refreshing it. Reported by @mkuratczyk 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

