### PR TITLE
Logger exchange should take message_containers feature flag into account

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1264,7 +1264,7 @@ handle_method(#'basic.publish'{exchange    = ExchangeNameBin,
                 Opts = maps_put_truthy(flow, Flow, #{correlation => SeqNo, mandatory => Mandatory}),
                 {Opts, State0#ch{publish_seqno = SeqNo + 1}}
         end,
-    % rabbit_feature_flags:is_enabled(message_containers),
+
     case mc_amqpl:message(ExchangeName,
                           RoutingKey,
                           DecodedContent) of

--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -54,12 +54,16 @@ do_log(LogEvent, #{config := #{exchange := Exchange}} = Config) ->
     PBasic = log_event_to_amqp_msg(LogEvent, Config),
     Body = try_format_body(LogEvent, Config),
     Content = rabbit_basic:build_content(PBasic, Body),
-    Anns = #{exchange => Exchange#resource.name,
-             routing_keys => [RoutingKey]},
-    Msg = mc:init(mc_amqpl, Content, Anns),
-    case rabbit_queue_type:publish_at_most_once(Exchange, Msg) of
-        ok -> ok;
-        {error, not_found} -> ok
+
+    case mc_amqpl:message(Exchange, RoutingKey, Content) of
+        {ok, Msg} ->
+            case rabbit_queue_type:publish_at_most_once(Exchange, Msg) of
+                ok -> ok;
+                {error, not_found} -> ok
+            end;
+        {error, _Reason} ->
+            %% it would be good to log this error but can we?
+            ok
     end.
 
 removing_handler(Config) ->


### PR DESCRIPTION
To avoid creating mc wrapped messages before the feature flag has been enabled.

Fixes #10346 