### PR TITLE
Ensure blank member state is always returned when there are no member states to avoid crashing the gm process

### DIFF
--- a/deps/rabbit/src/gm.erl
+++ b/deps/rabbit/src/gm.erl
@@ -1373,12 +1373,12 @@ with_member_acc(Fun, Id, {MembersState, Acc}) ->
     {MemberState, Acc1} = Fun(find_member_or_blank(Id, MembersState), Acc),
     {store_member(Id, MemberState, MembersState), Acc1}.
 
+find_member_or_blank(_Id, undefined) -> blank_member();
 find_member_or_blank(Id, MembersState) when is_map(MembersState) ->
     case maps:find(Id, MembersState) of
         {ok, Result} -> Result;
         error        -> blank_member()
-    end;
-find_member_or_blank(_Id, _MembersState) -> blank_member().
+    end.
 
 erase_member(Id, MembersState) -> maps:remove(Id, MembersState).
 

--- a/deps/rabbit/src/gm.erl
+++ b/deps/rabbit/src/gm.erl
@@ -1373,12 +1373,20 @@ with_member_acc(Fun, Id, {MembersState, Acc}) ->
     {MemberState, Acc1} = Fun(find_member_or_blank(Id, MembersState), Acc),
     {store_member(Id, MemberState, MembersState), Acc1}.
 
-find_member_or_blank(_Id, undefined) -> blank_member();
+find_member_or_blank(Id, MembersState = undefined) ->
+    log_member_not_found_warning(Id, MembersState),
+    blank_member();
 find_member_or_blank(Id, MembersState) when is_map(MembersState) ->
     case maps:find(Id, MembersState) of
         {ok, Result} -> Result;
-        error        -> blank_member()
+        error        ->
+            log_member_not_found_warning(Id, MembersState),
+            blank_member()
     end.
+
+log_member_not_found_warning(Id, MembersState) ->
+    rabbit_log:warning(
+        "gm member ~tp not found when members state is '~tp'", [Id, MembersState]).
 
 erase_member(Id, MembersState) -> maps:remove(Id, MembersState).
 

--- a/deps/rabbit/src/gm.erl
+++ b/deps/rabbit/src/gm.erl
@@ -1373,11 +1373,12 @@ with_member_acc(Fun, Id, {MembersState, Acc}) ->
     {MemberState, Acc1} = Fun(find_member_or_blank(Id, MembersState), Acc),
     {store_member(Id, MemberState, MembersState), Acc1}.
 
-find_member_or_blank(Id, MembersState) ->
+find_member_or_blank(Id, MembersState) when is_map(MembersState) ->
     case maps:find(Id, MembersState) of
         {ok, Result} -> Result;
         error        -> blank_member()
-    end.
+    end;
+find_member_or_blank(_Id, _MembersState) -> blank_member().
 
 erase_member(Id, MembersState) -> maps:remove(Id, MembersState).
 


### PR DESCRIPTION
## Proposed Changes

Hi Rabbit Team. We are still heavily using CMQs and there are couple crashes we want to iron out while 3.12.x series is still active (QQ adoption slowly underway). This PR is a fix to GM's `find_member_or_blank/2` when there isn't existing members state defined (rare case, but often manifests), which causes a ton of crashes illustrated below. We want to guarantee that blank member state is always returned in such cases, to avoid leaving queues in a very bad state.

```
2024-01-13 17:35:33.614 [error] <0.8801.670> ** Generic server <0.8801.670> terminating
** Last message in was {'$gen_cast',{'$gm',4029,{catchup,{4026,<5817.3973.1732>},[{{4008,<5819.16632.0>},{member,{[],[]},17,17}},{{4025,<5818.5272.6>},{member,{[],[]},0,0}},{{4026,<0.8801.670>},{member,{[],[]},-1,-1}},{{4026,<5817.3973.1732>},{member,{[],[]},-1,-1}}]}}}
** When Server state == {state,{4026,<0.8801.670>},{{4025,<5818.5272.6>},#Ref<0.1395141190.206569492.44498>},{{4025,<5818.5272.6>},#Ref<0.1395141190.206569492.44499>},{resource,<<"xxxxxxx">>,queue,<<"xxxxxxx">>},rabbit_mirror_queue_slave,{4028,#{{4025,<5818.5272.6>} => {view_member,{4025,<5818.5272.6>},[],{4026,<0.8801.670>},{4026,<0.8801.670>}},{4026,<0.8801.670>} => {view_member,{4026,<0.8801.670>},[{4008,<5819.16632.0>}],{4025,<5818.5272.6>},{4025,<5818.5272.6>}}}},-1,undefined,[<0.1904.670>],{[],[]},[],0,undefined,#Ref<0.1395141190.206569492.44500>,fun rabbit_misc:execute_mnesia_transaction/1,false}
** Reason for termination ==
** {{badmap,undefined},[{maps,find,[{4026,<5817.3973.1732>},undefined],[]},{gm,find_member_or_blank,2,[{file,"src/gm.erl"},{line,1379}]},{gm,'-remove_erased_members/2-fun-0-',3,[{file,"src/gm.erl"},{line,1406}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{gm,handle_cast,2,[{file,"src/gm.erl"},{line,639}]},{gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1050}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
2024-01-13 17:35:33.614 [error] <0.19147.667> Supervisor {<0.19147.667>,rabbit_amqqueue_sup} had child rabbit_amqqueue started with rabbit_prequeue:start_link({amqqueue,{resource,<<"xxxxx">>,queue,<<"xxxxx">>},true,false,none,...}, slave, <0.19127.667>) at <0.8628.670> exit with reason {{badmap,undefined},[{maps,find,[{26,<5817.9014.1732>},undefined],[]},{gm,find_member_or_blank,2,[{file,"src/gm.erl"},{line,1379}]},{gm,'-remove_erased_members/2-fun-0-',3,[{file,"src/gm.erl"},{line,1406}]},{lists,foldl,3,[{file,"lists.erl"},{line,1263}]},{gm,handle_cast,2,[{file,"src/gm.erl"},{line,639}]},{gen_server2,handle_msg,2,[{file,"src/gen_server2.erl"},{line,1050}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]} in context child_terminated

```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
