### PR TITLE
Reduce flakiness of certain Common Test suites

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -312,7 +312,6 @@ handle_event(QName, {reject_publish, SeqNo, _QPid},
 handle_event(QName, {down, Pid, Info}, #?STATE{monitored = Monitored,
                                                pid = MasterPid,
                                                unconfirmed = U0} = State0) ->
-    rabbit_log:info("~s: down queue ~w with ~p", [?MODULE, QName, Info]),
     State = State0#?STATE{monitored = maps:remove(Pid, Monitored)},
     Actions0 = case Pid =:= MasterPid of
                    true ->

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -312,6 +312,7 @@ handle_event(QName, {reject_publish, SeqNo, _QPid},
 handle_event(QName, {down, Pid, Info}, #?STATE{monitored = Monitored,
                                                pid = MasterPid,
                                                unconfirmed = U0} = State0) ->
+    rabbit_log:info("~s: down queue ~w with ~p", [?MODULE, QName, Info]),
     State = State0#?STATE{monitored = maps:remove(Pid, Monitored)},
     Actions0 = case Pid =:= MasterPid of
                    true ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -542,9 +542,9 @@ handle_tick(QName,
                   ok = repair_leader_record(QName, Self),
                   ExpectedNodes = rabbit_nodes:list_members(),
                   case Nodes -- ExpectedNodes of
-                      [] ->
-                          ok;
-                      Stale ->
+                      Stale when length(ExpectedNodes) > 0 ->
+                          %% rabbit_nodes:list_members/0 returns [] when there
+                          %% is an error so we need to handle that case
                           rabbit_log:debug("~ts: stale nodes detected. Purging ~w",
                                            [rabbit_misc:rs(QName), Stale]),
                           %% pipeline purge command
@@ -552,6 +552,8 @@ handle_tick(QName,
                           ok = ra:pipeline_command(amqqueue:get_pid(Q),
                                                    rabbit_fifo:make_purge_nodes(Stale)),
 
+                          ok;
+                      _ ->
                           ok
                   end
               catch

--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -131,6 +131,11 @@ reconciliate_quorum_queue_membership(State) ->
     Running = rabbit_nodes:list_running(),
     reconciliate_quorum_members(ExpectedNodes, Running, LocalLeaders, State, noop).
 
+reconciliate_quorum_members([], _Running, _, _State, Result) ->
+    %% if there are no expected nodes rabbit_nodes:list_running/0 encountered
+    %% an error during query and returned the empty list which is case we need
+    %% to handle
+    Result;
 reconciliate_quorum_members(_ExpectedNodes, _Running, [], _State, Result) ->
     Result;
 reconciliate_quorum_members(ExpectedNodes, Running, [Q | LocalLeaders],

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -564,11 +564,13 @@ handle_event(QName, {osiris_offset, _From, _Offs},
     {ok, State#stream_client{readers = Readers}, Deliveries};
 handle_event(_QName, {stream_leader_change, Pid}, State) ->
     {ok, update_leader_pid(Pid, State), []};
-handle_event(_QName, {stream_local_member_change, Pid}, #stream_client{local_pid = P} = State)
+handle_event(_QName, {stream_local_member_change, Pid},
+             #stream_client{local_pid = P} = State)
   when P == Pid ->
     {ok, State, []};
-handle_event(_QName, {stream_local_member_change, Pid}, State = #stream_client{name = QName,
-                                                                       readers = Readers0}) ->
+handle_event(_QName, {stream_local_member_change, Pid},
+             #stream_client{name = QName,
+                            readers = Readers0} = State) ->
     rabbit_log:debug("Local member change event for ~tp", [QName]),
     Readers1 = maps:fold(fun(T, #stream{log = Log0, reader_options = Options} = S0, Acc) ->
                                  Offset = osiris_log:next_offset(Log0),

--- a/deps/rabbit/test/message_containers_SUITE.erl
+++ b/deps/rabbit/test/message_containers_SUITE.erl
@@ -131,14 +131,30 @@ end_per_testcase(Testcase, Config) ->
 enable_ff(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QueueType = ?config(queue_type, Config),
     QName = ?config(queue_name, Config),
     ?assertEqual({'queue.declare_ok', QName, 0, 0},
-                 declare(Ch, QName, [{<<"x-queue-type">>, longstr,
-                                      ?config(queue_type, Config)}])),
+                 declare(Ch, QName,
+                         [{<<"x-queue-type">>, longstr, QueueType}])),
     #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
     amqp_channel:register_confirm_handler(Ch, self()),
 
-    timer:sleep(100),
+    case QueueType of
+        <<"stream">> ->
+            %% if it is a stream we need to wait until there is a local member
+            %% on the node we want to subscibe from before proceeding
+            rabbit_ct_helpers:await_condition(
+              fun() ->
+                      rabbit_ct_broker_helpers:rpc(Config, 2, ?MODULE,
+                                                   has_local_member,
+                                                   [#resource{kind = queue,
+                                                              virtual_host = <<"/">>,
+                                                              name = QName}])
+              end, 60000),
+            ok;
+        _ ->
+            ok
+    end,
 
     ConsumerTag1 = <<"ctag1">>,
     Ch2 = rabbit_ct_client_helpers:open_channel(Config, 2),
@@ -243,3 +259,17 @@ get_global_counters(Config) ->
 qos(Ch, Prefetch) ->
     ?assertMatch(#'basic.qos_ok'{},
                  amqp_channel:call(Ch, #'basic.qos'{prefetch_count = Prefetch})).
+
+has_local_member(QName) ->
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            #{name := StreamId} = amqqueue:get_type_state(Q),
+            case rabbit_stream_coordinator:local_pid(StreamId) of
+                {ok, Pid} ->
+                    is_process_alive(Pid);
+                _ ->
+                    false
+            end;
+        _Err ->
+            false
+    end.

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2145,9 +2145,12 @@ leader_locator_balanced_maintenance(Config) ->
                  declare(Config, Server1, Q, [{<<"x-queue-type">>, longstr, <<"stream">>},
                                               {<<"x-queue-leader-locator">>, longstr, <<"balanced">>}])),
 
-    Info = find_queue_info(Config, [leader]),
-    Leader = proplists:get_value(leader, Info),
-    ?assert(lists:member(Leader, [Server1, Server2])),
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+              Info = find_queue_info(Config, [leader]),
+              Leader = proplists:get_value(leader, Info),
+              lists:member(Leader, [Server1, Server2])
+      end, 60000),
 
     true = rabbit_ct_broker_helpers:unmark_as_being_drained(Config, Server3),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2107,7 +2107,7 @@ leader_locator_client_local(Config) ->
                                               find_queue_info(Config, [leader]))),
 
     ?assertMatch(#'queue.delete_ok'{}, delete(Config, Server3, Q)),
-    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
+    ok.
 
 leader_locator_balanced(Config) ->
     [Server1, Server2, Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -891,12 +891,13 @@ recover(Config) ->
     %% Such a slow test, let's select a single random permutation and trust that over enough
     %% ci rounds any failure will eventually show up
 
+    flush(),
     ct:pal("recover: running stop start for permutation ~w", [Servers]),
     [rabbit_ct_broker_helpers:stop_node(Config, S) || S <- Servers],
     [rabbit_ct_broker_helpers:async_start_node(Config, S) || S <- lists:reverse(Servers)],
     [ok = rabbit_ct_broker_helpers:wait_for_async_start_node(S) || S <- lists:reverse(Servers)],
 
-    ct:pal("recover: running stop waiting for messages ~w", [Servers]),
+    ct:pal("recover: post stop / start, waiting for messages ~w", [Servers]),
     check_leader_and_replicas(Config, Servers0),
     queue_utils:wait_for_messages(Config, [[Q, <<"1">>, <<"1">>, <<"0">>]], 60),
 

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2594,10 +2594,15 @@ check_leader_and_replicas(Config, Members) ->
 check_leader_and_replicas(Config, Members, Tag) ->
     rabbit_ct_helpers:await_condition(
       fun() ->
-              Info = find_queue_info(Config, [leader, Tag]),
-              ct:pal("~ts members ~w ~tp", [?FUNCTION_NAME, Members, Info]),
-              lists:member(proplists:get_value(leader, Info), Members)
-                  andalso (lists:sort(Members) == lists:sort(proplists:get_value(Tag, Info)))
+              case find_queue_info(Config, [leader, Tag]) of
+                  [] ->
+                      false;
+                  Info ->
+                      ct:pal("~ts members ~w ~tp", [?FUNCTION_NAME, Members, Info]),
+                      lists:member(proplists:get_value(leader, Info), Members)
+                          andalso (lists:sort(Members) ==
+                                   lists:sort(proplists:get_value(Tag, Info)))
+              end
       end, 60_000).
 
 check_members(Config, ExpectedMembers) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -245,10 +245,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
       timeout,
       fn ->
         case :file.read_file(pid_file) do
+          {:ok, <<>>} ->
+            {:error, :loop}
+
           {:ok, bin} ->
             case Integer.parse(bin) do
               :error ->
-                {:error, {:garbage_in_pid_file, {bin, pid_file}}}
+                {:error, {:garbage_in_pid_file, pid_file}}
 
               {pid, _} ->
                 case check_distribution(pid, node_name) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -248,7 +248,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
           {:ok, bin} ->
             case Integer.parse(bin) do
               :error ->
-                {:error, {:garbage_in_pid_file, pid_file}}
+                {:error, {:garbage_in_pid_file, {bin, pid_file}}}
 
               {pid, _} ->
                 case check_distribution(pid, node_name) do

--- a/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
@@ -160,7 +160,8 @@ amqp(Config) ->
     {ok, Session1} = amqp10_client:begin_session(Connection1),
     ReceiverLinkName = <<"test-receiver">>,
     {ok, Receiver} = amqp10_client:attach_receiver_link(
-                       Session1, ReceiverLinkName, <<"/topic/topic.1">>, unsettled),
+                       Session1, ReceiverLinkName, <<"/topic/topic.1">>, unsettled,
+                       configuration),
 
     %% MQTT 5.0 to AMQP 1.0
     C = connect(ClientId, Config),
@@ -183,10 +184,6 @@ amqp(Config) ->
                               'User-Property' => UserProperty},
                             RequestPayload, [{qos, 1}]),
 
-    %% this test sometimes flakes, and the call to amqp10_client:get_msg/1
-    %% times out, I can't quite work it out but there is a chance waiting a
-    %% little bit could help, [Karl]
-    timer:sleep(500),
 
     %% As of 3.13, AMQP 1.0 is proxied via AMQP 0.9.1 and therefore the conversion from
     %% mc_mqtt to mc_amqpl takes place. We therefore lose MQTT User Property and Response Topic

--- a/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
@@ -183,6 +183,11 @@ amqp(Config) ->
                               'User-Property' => UserProperty},
                             RequestPayload, [{qos, 1}]),
 
+    %% this test sometimes flakes, and the call to amqp10_client:get_msg/1
+    %% times out, I can't quite work it out but there is a chance waiting a
+    %% little bit could help, [Karl]
+    timer:sleep(500),
+
     %% As of 3.13, AMQP 1.0 is proxied via AMQP 0.9.1 and therefore the conversion from
     %% mc_mqtt to mc_amqpl takes place. We therefore lose MQTT User Property and Response Topic
     %% which gets converted to AMQP 0.9.1 headers. In the future, Native AMQP 1.0 will convert


### PR DESCRIPTION
A variety of flaky test improvement and smaller bug fixes:

Bug fixes:

* Check that the rabbit app is running on the current node before modifying the stream coordinator cluster. This stops unwanted changes being triggered during shutdown
* `rabbit_nodes:list_running/0` returns `[]` whenever there is a failure so this PR also handles a few cases where that could cause unwanted side effects. This will be changed in a future version of the API.
* The wait command now keeps trying if it reads the empty binary from the file (race condition)