### PR TITLE
Catch ETS exception when system is still starting

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream.erl
@@ -87,15 +87,19 @@ port() ->
     end.
 
 port_from_listener() ->
-    Listeners = rabbit_networking:node_listeners(node()),
-    Port =
+    try
+        Listeners = rabbit_networking:node_listeners(node()),
         lists:foldl(fun (#listener{port = Port, protocol = stream}, _Acc) ->
                             Port;
                         (_, Acc) ->
                             Acc
                     end,
-                    undefined, Listeners),
-    Port.
+                    undefined, Listeners)
+    catch error:Reason ->
+              %% can happen if a remote node calls and the current has not fully started yet
+              rabbit_log:info("Error while retrieving stream plugin port: ~tp", [Reason]),
+              {error, Reason}
+    end.
 
 tls_port() ->
     case application:get_env(rabbitmq_stream, advertised_tls_port,
@@ -108,16 +112,20 @@ tls_port() ->
     end.
 
 tls_port_from_listener() ->
-    Listeners = rabbit_networking:node_listeners(node()),
-    Port =
+    try
+        Listeners = rabbit_networking:node_listeners(node()),
         lists:foldl(fun (#listener{port = Port, protocol = 'stream/ssl'},
                          _Acc) ->
                             Port;
                         (_, Acc) ->
                             Acc
                     end,
-                    undefined, Listeners),
-    Port.
+                    undefined, Listeners)
+        catch error:Reason ->
+        %% can happen if a remote node calls and the current has not fully started yet
+        rabbit_log:info("Error while retrieving stream plugin port: ~tp", [Reason]),
+        {error, Reason}
+    end.
 
 stop(_State) ->
     ok.


### PR DESCRIPTION
Because the ETS table may be not created yet.
A stream connection can call another node to
get the port of the stream plugin on this node.
The stream plugin uses the rabbit_networking module, which relies on an ETS table to store listener information. The table may be not created yet when the node starts up, so the calling node ends up logging a large stack trace.

This commit catches the exception and logs a simple message. This reduces unnecessary noise in the logs.