### PR TITLE
#140 - Bound delivery tags to longlong

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1991,7 +1991,11 @@ record_sent(Type, QueueType, Tag, AckRequired,
                 false ->
                     UAMQ
             end,
-    State#ch{unacked_message_q = UAMQ1, next_tag = DeliveryTag + 1}.
+    NextTag = case DeliveryTag=<math:pow(2,63)-1 of
+		  true  -> Tag + 1;
+		  false -> 1
+	      end,
+    State#ch{unacked_message_q = UAMQ1, next_tag = NextTag}.
 
 %% Records a client-sent acknowledgement. Handles both single delivery acks
 %% and multi-acks.


### PR DESCRIPTION
## Proposed Changes

In [Section 1.1 of AMQP 0.9.1](https://www.rabbitmq.com/resources/specs/amqp-xml-doc0-9-1.pdf
) delivery tags defined as longlong.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #140)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

None.
