### PR TITLE
Use read permission for store_offset

### DIFF
--- a/deps/rabbitmq_stream/test/rabbit_stream_reader_SUITE.erl
+++ b/deps/rabbitmq_stream/test/rabbit_stream_reader_SUITE.erl
@@ -83,7 +83,7 @@ ensure_token_expiry_timer_test(_) ->
     DummyTRef = erlang:send_after(1_000 * 1_000, self(), dummy),
     meck:expect(rabbit_access_control, permission_cache_can_expire, fun (_) -> false end),
     {Cancel5, #stream_connection{token_expiry_timer = TR5}} = ensure_token_expiry_timer(#user{},
-                                                                                       #stream_connection{token_expiry_timer = DummyTRef}),
+                                                                                        #stream_connection{token_expiry_timer = DummyTRef}),
     ?assertEqual(undefined, TR5),
     ?assert(is_integer(Cancel5)),
 


### PR DESCRIPTION
Instead of write permission. Storing an offset in a stream is not like adding messages to the stream, so we consider the write permission to be too hard for this case. Read permission, like for consuming, is more appropriate.

The implementation checks there is a subscription for the target stream and falls back to an actual read permission call if there is not (e.g. when the subscription state goes away before store_offset is sent when closing a consumer).

Fixes #10383
