### PR TITLE
HTTP auth example dotnetcore: Update to .NET 8

### DIFF
--- a/deps/rabbitmq_auth_backend_http/examples/README.md
+++ b/deps/rabbitmq_auth_backend_http/examples/README.md
@@ -9,7 +9,7 @@ different platforms and frameworks:
  * Java and Spring Boot
  * Kotlin and Spring Boot
  * C# and ASP.NET Web API
- * C# and ASP.NET Core 7
+ * C# and ASP.NET Core 8.0
  * PHP
 
 ## Python Example
@@ -124,15 +124,15 @@ Port number may vary but will likely be `62190`.
 
 When the example is hosted on IIS, port 80 will be used by default.
 
-## ASP.NET Core 7 Example
+## ASP.NET Core 8.0 Example
 
 `rabbitmq_auth_backend_webapi_dotnetcore` is a modification of the `rabbitmq_auth_backend_webapi_dotnet` example
-designed for ASP.NET Core 7. It's very similar to the original version but it also adds some static typing
+designed for ASP.NET Core 8.0. It's very similar to the original version but it also adds some static typing
 for requests and responses.
 
 ### Running the Example
 
-Open the solution file, `RabbitMqAuthBackendHttp.sln` in Visual Studio 2022 version 17.4 or later.
+Open the solution file, `RabbitMqAuthBackendHttp.sln` in Visual Studio 2022 version 17.8 or later.
 
 As with other examples, RabbitMQ [authentication and authorization backends](http://www.rabbitmq.com/access-control.html) must be configured
 to use this plugin and the endpoints provided by this example app.
@@ -151,8 +151,8 @@ Have a look at `AuthController`.
 
 This example was developed using
 
- * .NET SDK 7.0
- * Visual Studio 2022 version 17.4 or Visual Studio Code
+ * .NET SDK 8.0
+ * Visual Studio 2022 version 17.8 or Visual Studio Code
  * Windows 10
 
 It is possible to build and run service from Visual Studio using IIS or from Visual Studio or Visual Studio Code using cross-platform server Kestrel.

--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/RabbitMqAuthBackendHttp.csproj
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/RabbitMqAuthBackendHttp.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
-
 </Project>

--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/ResourceAuthRequest.cs
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/ResourceAuthRequest.cs
@@ -2,13 +2,13 @@
 {
     public class ResourceAuthRequest
     {
-        public string UserName { get; set; }
+        public required string UserName { get; set; }
 
-        public string Vhost { get; set; }
+        public required string Vhost { get; set; }
 
         public Resource Resource { get; set; }
 
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
         public ResourcePermission Permission { get; set; }
     }

--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/TopicAuthRequest.cs
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/TopicAuthRequest.cs
@@ -4,18 +4,18 @@ namespace RabbitMqAuthBackendHttp.Requests
 {
     public class TopicAuthRequest
     {
-        public string UserName { get; set; }
+        public required string UserName { get; set; }
 
-        public string Vhost { get; set; }
+        public required string Vhost { get; set; }
 
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
         public Resource Resource { get; set; }
 
         public TopicPermission Permission { get; set; }
 
         [ModelBinder(Name = "routing_key")]
-        public string RoutingKey { get; set; }
+        public required string RoutingKey { get; set; }
     }
 
     public enum TopicPermission

--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/UserAuthRequest.cs
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/UserAuthRequest.cs
@@ -2,8 +2,8 @@
 {
     public class UserAuthRequest
     {
-        public string UserName { get; set; }
+        public required string UserName { get; set; }
 
-        public string Password { get; set; }
+        public required string Password { get; set; }
     }
 }

--- a/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/VhostAuthRequest.cs
+++ b/deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore/Requests/VhostAuthRequest.cs
@@ -2,10 +2,10 @@
 {
     public class VhostAuthRequest
     {
-        public string UserName { get; set; }
+        public required string UserName { get; set; }
 
-        public string Vhost { get; set; }
+        public required string Vhost { get; set; }
 
-        public string Ip { get; set; }
+        public required string Ip { get; set; }
     }
 }


### PR DESCRIPTION
## Proposed Changes

I updated `deps/rabbitmq_auth_backend_http/examples/rabbitmq_auth_backend_webapi_dotnetcore` to .NET 8 LTS.
The old dotnetcore example .NET 7 will be out of support in May 2024.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

