### PR TITLE
Removed extra clause in platform.os_name/1

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/platform.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/platform.ex
@@ -19,10 +19,6 @@ defmodule RabbitMQ.CLI.Core.Platform do
     end
   end
 
-  def os_name({:unix, :linux}) do
-    "Linux"
-  end
-
   def os_name({:unix, :darwin}) do
     "macOS"
   end


### PR DESCRIPTION
## Proposed Changes

* `platform.os_name/1` parses output of `:rabbit.status/1`
* `:rabbit.status/1` get its `os` key from `:os.type/0`
* `:linux` already matched by `platform.os_name({:unix, name})`.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

None.
