### PR TITLE
Remove rabbit_authz_backend:state_can_expire/0

### DIFF
--- a/deps/rabbit/src/rabbit_auth_backend_internal.erl
+++ b/deps/rabbit/src/rabbit_auth_backend_internal.erl
@@ -41,7 +41,7 @@
          list_user_vhost_permissions/2,
          list_user_topic_permissions/1, list_vhost_topic_permissions/1, list_user_vhost_topic_permissions/2]).
 
--export([state_can_expire/0, expiry_timestamp/1]).
+-export([expiry_timestamp/1]).
 
 -export([hashing_module_for_user/1, expand_topic_permission/2]).
 
@@ -108,8 +108,6 @@ user_login_authentication(Username, AuthProps) ->
                 _ -> internal_check_user_login(Username, fun(_) -> true end)
             end
     end.
-
-state_can_expire() -> false.
 
 expiry_timestamp(_) -> never.
 

--- a/deps/rabbit/test/rabbit_auth_backend_context_propagation_mock.erl
+++ b/deps/rabbit/test/rabbit_auth_backend_context_propagation_mock.erl
@@ -15,7 +15,7 @@
 
 -export([user_login_authentication/2, user_login_authorization/2,
   check_vhost_access/3, check_resource_access/4, check_topic_access/4,
-  state_can_expire/0, expiry_timestamp/1,
+  expiry_timestamp/1,
   get/1, init/0]).
 
 init() ->
@@ -39,8 +39,6 @@ check_resource_access(#auth_user{}, #resource{}, _Permission, AuthzContext) ->
 check_topic_access(#auth_user{}, #resource{}, _Permission, TopicContext) ->
   ets:insert(?MODULE, {topic_access, TopicContext}),
   true.
-
-state_can_expire() -> false.
 
 expiry_timestamp(_) ->
     never.

--- a/deps/rabbit_common/src/rabbit_auth_backend_dummy.erl
+++ b/deps/rabbit_common/src/rabbit_auth_backend_dummy.erl
@@ -14,7 +14,7 @@
 -export([user/0]).
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4]).
--export([state_can_expire/0, expiry_timestamp/1]).
+-export([expiry_timestamp/1]).
 
 -spec user() -> rabbit_types:user().
 
@@ -36,5 +36,4 @@ check_vhost_access(#auth_user{}, _VHostPath, _AuthzData) -> true.
 check_resource_access(#auth_user{}, #resource{}, _Permission, _Context) -> true.
 check_topic_access(#auth_user{}, #resource{}, _Permission, _Context) -> true.
 
-state_can_expire() -> false.
 expiry_timestamp(_) -> never.

--- a/deps/rabbit_common/src/rabbit_authz_backend.erl
+++ b/deps/rabbit_common/src/rabbit_authz_backend.erl
@@ -67,10 +67,6 @@
     rabbit_types:topic_access_context()) ->
     boolean() | {'error', any()}.
 
-%% Returns true for backends that support state or credential expiration (e.g. use JWTs).
-%% @deprecated Please use {@link expiry_timestamp/1} instead.
--callback state_can_expire() -> boolean().
-
 %% Updates backend state that has expired.
 %%
 %% Possible responses:

--- a/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
+++ b/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
@@ -13,7 +13,7 @@
 
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
-         state_can_expire/0, expiry_timestamp/1]).
+         expiry_timestamp/1]).
 
 %% API
 
@@ -59,8 +59,6 @@ check_topic_access(#auth_user{} = AuthUser,
             ({error, _} = Err) -> Err;
             (_)                -> unknown
         end).
-
-state_can_expire() -> false.
 
 expiry_timestamp(_) -> never.
 

--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -15,7 +15,7 @@
 -export([description/0, p/1, q/1, join_tags/1]).
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
-         state_can_expire/0, expiry_timestamp/1]).
+         expiry_timestamp/1]).
 
 %% If keepalive connection is closed, retry N times before failing.
 -define(RETRY_ON_KEEPALIVE_CLOSED, 3).
@@ -128,8 +128,6 @@ check_topic_access(#auth_user{username = Username, tags = Tags},
         {name,       Name},
         {permission, Permission},
         {tags, join_tags(Tags)}] ++ OptionsParameters).
-
-state_can_expire() -> false.
 
 expiry_timestamp(_) -> never.
 

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -17,7 +17,7 @@
 
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
-         state_can_expire/0, expiry_timestamp/1,
+         expiry_timestamp/1,
          format_multi_attr/1, format_multi_attr/2]).
 
 -export([get_connections/0]).
@@ -167,8 +167,6 @@ check_topic_access(User = #auth_user{username = Username,
         [log_resource(Args), log_user(User),
          log_result(R0), log_result(R1)]),
     R1.
-
-state_can_expire() -> false.
 
 expiry_timestamp(_) -> never.
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -14,7 +14,7 @@
 -export([description/0]).
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4,
-         check_topic_access/4, check_token/1, state_can_expire/0, update_state/2,
+         check_topic_access/4, check_token/1, update_state/2,
          expiry_timestamp/1]).
 
 % for testing
@@ -103,8 +103,6 @@ check_topic_access(#auth_user{impl = DecodedTokenFun},
             Scopes = get_expanded_scopes(Token, Resource),
             rabbit_oauth2_scope:topic_access(Resource, Permission, Context, Scopes)
         end).
-
-state_can_expire() -> true.
 
 update_state(AuthUser, NewToken) ->
   case check_token(NewToken) of

--- a/deps/rabbitmq_mqtt/test/rabbit_auth_backend_mqtt_mock.erl
+++ b/deps/rabbitmq_mqtt/test/rabbit_auth_backend_mqtt_mock.erl
@@ -16,7 +16,7 @@
 -export([setup/1,
          user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
-         state_can_expire/0,
+         expiry_timestamp/1,
          get/1]).
 
 setup(CallerPid) ->
@@ -47,7 +47,8 @@ check_topic_access(#auth_user{}, #resource{}, _Permission, TopicContext) ->
     ets:insert(?MODULE, {topic_access, TopicContext}),
     true.
 
-state_can_expire() -> false.
+expiry_timestamp(_) ->
+    never.
 
 get(K) ->
     ets:lookup(?MODULE, K).


### PR DESCRIPTION
Use expiry_timestamp/1 instead, which returns 'never' if the credentials do not expire.

Fixes #10382
