### PR TITLE
Handle old child id format in federation_exchange_link_sup_sup

### DIFF
--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -66,42 +66,98 @@ start_link() ->
 %% Note that the next supervisor down, rabbit_federation_link_sup, is common
 %% between exchanges and queues.
 start_child(X) ->
-    case mirrored_supervisor:start_child(
-           ?SUPERVISOR,
-           {id(X), {rabbit_federation_link_sup, start_link, [X]},
-            transient, ?SUPERVISOR_WAIT, supervisor,
-            [rabbit_federation_link_sup]}) of
-        {ok, _Pid}               -> ok;
-        {error, {already_started, _Pid}} ->
-          #exchange{name = ExchangeName} = X,
-          rabbit_log_federation:debug("Federation link for exchange ~tp was already started",
-                                      [rabbit_misc:rs(ExchangeName)]),
-          ok;
-        %% A link returned {stop, gone}, the link_sup shut down, that's OK.
-        {error, {shutdown, _}} -> ok
+    Result =
+        case child_exists(X) orelse
+            mirrored_supervisor:start_child(
+              ?SUPERVISOR,
+              {id(X), {rabbit_federation_link_sup, start_link, [X]},
+               transient, ?SUPERVISOR_WAIT, supervisor,
+               [rabbit_federation_link_sup]}) of
+            true ->
+                already_started;
+            {ok, _Pid} ->
+                ok;
+            {error, {already_started, _Pid}} ->
+                already_started;
+            %% A link returned {stop, gone}, the link_sup shut down, that's OK.
+            {error, {shutdown, _}} ->
+                ok
+        end,
+    case Result of
+        ok ->
+            ok;
+        already_started ->
+            #exchange{name = ExchangeName} = X,
+            rabbit_log_federation:debug("Federation link for exchange ~tp was already started",
+                                        [rabbit_misc:rs(ExchangeName)]),
+            ok
     end.
+
+
+child_exists(Name) ->
+    Id = id(Name),
+    %% older format, pre 3.13.0
+    OldId = old_id(Name),
+    lists:any(fun ({ChildId, _, _, _}) ->
+                      ChildId =:= Id orelse ChildId =:= OldId
+              end,
+              mirrored_supervisor:which_children(?SUPERVISOR)).
 
 adjust({clear_upstream, VHost, UpstreamName}) ->
     _ = [rabbit_federation_link_sup:adjust(Pid, X, {clear_upstream, UpstreamName}) ||
-            {{_, #exchange{name = Name} = X}, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
-            Name#resource.virtual_host == VHost],
+            {Id, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR),
+            case Id of
+                {_, #exchange{name = Name} = X} ->
+                    Name#resource.virtual_host == VHost;
+                #exchange{name = Name} = X ->
+                    %% Old child id format, pre 3.13.0
+                    Name#resource.virtual_host == VHost
+            end
+                ],
     ok;
 adjust(Reason) ->
-    _ = [rabbit_federation_link_sup:adjust(Pid, X, Reason) ||
-            {{_, X}, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],
+    _ = [case Id of
+             {_, #exchange{} = X} ->
+                 rabbit_federation_link_sup:adjust(Pid, X, Reason);
+             #exchange{} = X ->
+                 %% Old child id format, pre 3.13.0
+                 rabbit_federation_link_sup:adjust(Pid, X, Reason)
+         end
+         || {Id, Pid, _, _} <- mirrored_supervisor:which_children(?SUPERVISOR)],
     ok.
 
 stop_child(X) ->
-    case mirrored_supervisor:terminate_child(?SUPERVISOR, id(X)) of
-      ok -> ok;
-      {error, Err} ->
-        #exchange{name = ExchangeName} = X,
-        rabbit_log_federation:warning(
-          "Attempt to stop a federation link for exchange ~tp failed: ~tp",
-          [rabbit_misc:rs(ExchangeName), Err]),
-        ok
-    end,
-    ok = mirrored_supervisor:delete_child(?SUPERVISOR, id(X)).
+    Result =
+        case stop_and_delete_child(id(X)) of
+            ok -> ok;
+            {error, not_found} = Error ->
+                case rabbit_khepri:is_enabled() of
+                    true ->
+                    %% Old id format is not supported by and cannot exist in Khepri
+                        Error;
+                    false ->
+                        %% try old format, pre 3.13.0
+                        stop_and_delete_child(old_id(X))
+                end
+        end,
+    case Result of
+        ok ->
+            ok;
+        {error, Err} ->
+            #exchange{name = ExchangeName} = X,
+            rabbit_log_federation:warning(
+              "Attempt to stop a federation link for exchange ~tp failed: ~tp",
+              [rabbit_misc:rs(ExchangeName), Err]),
+            ok
+    end.
+
+stop_and_delete_child(Id) ->
+    case mirrored_supervisor:terminate_child(?SUPERVISOR, Id) of
+        ok ->
+            ok = mirrored_supervisor:delete_child(?SUPERVISOR, Id);
+        {error, not_found} = Error ->
+            Error
+    end.
 
 %%----------------------------------------------------------------------------
 
@@ -115,3 +171,8 @@ id(X = #exchange{policy = Policy}) ->
 
 simple_id(#exchange{name = #resource{virtual_host = VHost, name = Name}}) ->
     [exchange, VHost, Name].
+
+%% Old child id format, pre 3.13.0
+old_id(X = #exchange{policy = Policy}) ->
+    X1 = rabbit_exchange:immutable(X),
+    X1#exchange{policy = Policy}.


### PR DESCRIPTION
## Proposed Changes

After an upgrade (multi-node cluster with rolling restart) from pre 3.13.0 with already existing exchange federation links, old child ids are preserved in the mirrored supervisor.

Fixes #10306 

Tested manually to cover affected functions:
- Create a 3 node cluster with 1 federation upstream, 1 policy and 3 federated exchanges on 3.12.12
- Rolling upgrade to 3.13.0+this branch
- add a new upstream (calls `rabbit_federation_exchange_link_sup_sup:adjust({upstream,<<"upstream2">>})`)
- delete unused upstream (calls `rabbit_federation_exchange_link_sup_sup:adjust({clear_upstream,<<"vhost">>,<<"upstream2">>})`)
- delete one of the pre-existing federated exchanges (calls `stop_child(<exchange>)`)
- change priority of policy (calls `stop_child(<exchange>) + start_child(<exchange>)`)
- create new federated exchange (calls `start_child(<exchange>)`)
- stop_app on node 01 to trigger mirrored supervisor takeover

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
