### PR TITLE
Minor: Fix error handling in rabbit_quorum_queue:status/2

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1096,7 +1096,7 @@ status(Vhost, QueueName) ->
                           {<<"Term">>, Term},
                           {<<"Machine Version">>, MacVer}
                          ];
-                     {error, Err} ->
+                     {error, _} ->
                          %% try the old method
                          case get_sys_status(ServerId) of
                              {ok, Sys} ->


### PR DESCRIPTION
## Proposed Changes

The `Err` variable was accidentally bound twice resulting in the below error when `erpc_call` and `get_sys_status` returned two different errors.

An example when 1 follower of a quorum queue is not alive
```
% rabbitmq-queues quorum_status qq1
Status of quorum queue qq1 on node rabbit-1@localhost ...
Error:
{{:case_clause, {:error, :noproc}}, [{:rabbit_quorum_queue, :"-status/2-lc$^0/1-0-", 2, [file: 'rabbit_quorum_queue.erl', line: 1094]}, {:rabbit_quorum_queue, :status, 2, []}]}
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
