### PR TITLE
Allow management users to query feature flags and deprecated features

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -389,30 +389,30 @@ function update_navigation() {
 
 function update_warnings() {
     feature_flags = JSON.parse(sync_get('/feature-flags'));
-    var needs_enable = false;
+    var needs_enabling = false;
     for (var i = 0; i < feature_flags.length; i++) {
          var feature_flag = feature_flags[i];
          if (feature_flag.state == "disabled" && feature_flag.stability != "experimental") {
-             needs_enable = true;
+             needs_enabling = true;
          }
     }
     deprecated_features = JSON.parse(sync_get('/deprecated-features/used'));
-    var needs_deprecate = false;
+    var needs_deprecating = false;
     if (deprecated_features.length > 0) {
-        needs_deprecate = true;
+        needs_deprecating = true;
     }
     var l1 = '<p class="warning">';
-    if (needs_enable) {
+    if (needs_enabling) {
         l1 += '<span>&#9888;</span> All stable feature flags must be enabled after completing an upgrade. <a href="https://www.rabbitmq.com/feature-flags.html">[Learn more]</a>';
     }
-    if (needs_deprecate) {
-        if (needs_enable) {
+    if (needs_deprecating) {
+        if (needs_enabling) {
             l1 += '<br/>'
         }
         l1 += '<span>&#9888;</span> Deprecated features are being used. <a href="https://www.rabbitmq.com/feature-flags.html">[Learn more]</a>'
     }
     l1 += '</p>';
-    if (needs_enable || needs_deprecate) {
+    if (needs_enabling || needs_deprecating) {
       $('#main').addClass('with-warnings');
       $('#rhs').addClass('with-warnings');
       replace_content('warnings', l1);

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -403,13 +403,13 @@ function update_warnings() {
     }
     var l1 = '<p class="warning">';
     if (needs_enable) {
-        l1 += '<span>&#9888;</span> All stable feature flags must be enabled after completing an upgrade. <a href="#/feature-flags">[Learn more]</a>';
+        l1 += '<span>&#9888;</span> All stable feature flags must be enabled after completing an upgrade. <a href="https://www.rabbitmq.com/feature-flags.html">[Learn more]</a>';
     }
     if (needs_deprecate) {
         if (needs_enable) {
             l1 += '<br/>'
         }
-        l1 += '<span>&#9888;</span> Deprecated features are being used. <a href="#/feature-flags">[Learn more]</a>'
+        l1 += '<span>&#9888;</span> Deprecated features are being used. <a href="https://www.rabbitmq.com/feature-flags.html">[Learn more]</a>'
     }
     l1 += '</p>';
     if (needs_enable || needs_deprecate) {

--- a/deps/rabbitmq_management/priv/www/js/tmpl/deprecated-features.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/deprecated-features.ejs
@@ -3,12 +3,12 @@
   var used_deprecated_features_names = [];
   for (var i = 0; i < used_deprecated_features.length; i++) {
       used_deprecated_features_names.push(used_deprecated_features[i].name);
-  var needs_deprecate = false;
+  var needs_deprecating = false;
   if (used_deprecated_features.length > 0) {
-      needs_deprecate = true;
+      needs_deprecating = true;
   }
   }
-  if (needs_deprecate) { %>
+  if (needs_deprecating) { %>
      <p class="warning">
         Deprecated features are being used. While using deprecated features, upgrading to future minor or major versions of RabbitMQ may not be possible. <a href="https://www.rabbitmq.com/feature-flags.html">[Learn more]</a>
      </p>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/feature-flags.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/feature-flags.ejs
@@ -1,13 +1,13 @@
 <h1>Feature Flags</h1>
   <%
-       var needs_enable = false;
+       var needs_enabling = false;
        for (var i = 0; i < feature_flags.length; i++) {
          var feature_flag = feature_flags[i];
          if (feature_flag.state == "disabled" && feature_flag.stability != "experimental") {
-           needs_enable = true;
+           needs_enabling = true;
          }
        }
-  if (needs_enable) { %>
+  if (needs_enabling) { %>
      <p class="warning">
         All stable feature flags must be enabled after completing an upgrade. Without enabling all flags, upgrading to future minor or major versions of RabbitMQ may not be possible. <a href="https://www.rabbitmq.com/feature-flags.html">[Learn more]</a>
      </p>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_deprecated_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_deprecated_features.erl
@@ -40,7 +40,7 @@ to_json(ReqData, {Mode, Context}) ->
     rabbit_mgmt_util:reply_list(deprecated_features(Mode), ReqData, Context).
 
 is_authorized(ReqData, {Mode, Context}) ->
-    {Res, Req2, Context2} = rabbit_mgmt_util:is_authorized_admin(ReqData, Context),
+    {Res, Req2, Context2} = rabbit_mgmt_util:is_authorized(ReqData, Context),
     {Res, Req2, {Mode, Context2}}.
 
 %%--------------------------------------------------------------------

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_feature_flags.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_feature_flags.erl
@@ -36,8 +36,7 @@ to_json(ReqData, Context) ->
     rabbit_mgmt_util:reply_list(feature_flags(), ReqData, Context).
 
 is_authorized(ReqData, Context) ->
-    {Res, Req2, Context2} = rabbit_mgmt_util:is_authorized_admin(ReqData, Context),
-    {Res, Req2, Context2}.
+    rabbit_mgmt_util:is_authorized(ReqData, Context).
 
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
The new banner to warn about not-enabled feature flags requires access to this endpoint, and it must be visible for all users.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
