### PR TITLE
add consumer tag and queue name in the ack timeout warning message

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2780,13 +2780,15 @@ evaluate_consumer_timeout1(PA = #pending_ack{delivered_at = Time},
             {noreply, State}
     end.
 
-handle_consumer_timed_out(Timeout,#pending_ack{delivery_tag = DeliveryTag},
+handle_consumer_timed_out(Timeout,#pending_ack{delivery_tag = DeliveryTag, tag = ConsumerTag, queue = QName},
 			  State = #ch{cfg = #conf{channel = Channel}}) ->
-    rabbit_log_channel:warning("Consumer ~ts on channel ~w has timed out "
-			       "waiting for delivery acknowledgement. Timeout used: ~tp ms. "
+    rabbit_log_channel:warning("Consumer '~ts' on channel ~w and ~ts has timed out "
+			       "waiting for ~ts delivery acknowledgement. Timeout used: ~tp ms. "
 			       "This timeout value can be configured, see consumers doc guide to learn more",
-			       [rabbit_data_coercion:to_binary(DeliveryTag),
-				Channel, Timeout]),
+			       [ConsumerTag,
+                    Channel,
+                    rabbit_misc:rs(QName),
+                rabbit_data_coercion:to_binary(DeliveryTag), Timeout]),
     Ex = rabbit_misc:amqp_error(precondition_failed,
 				"delivery acknowledgement on channel ~w timed out. "
 				"Timeout value used: ~tp ms. "


### PR DESCRIPTION
## Proposed Changes

In my company we sometimes have the `Consumer has timed out ...` warning, the problem is that we don't know which consumer or queue that had it which makes it really hard to debug, so adding more info to the message for better debugging

The message will look like this:
`2024-01-30 18:40:52.582519+02:00 [warning] <0.691.0> Consumer 'rule-service-<my-pod-name>' on channel 1 and queue 'rule-service-action-execution' in vhost '/' has timed out waiting for 1 delivery acknowledgement. Timeout used: 3000 ms. This timeout value can be configured, see consumers doc guide to learn more`

instead of:
`2024-01-30 19:02:39.321032+02:00 [warning] <0.690.0> Consumer 1 on channel 1 has timed out waiting for delivery acknowledgement. Timeout used: 3000 ms. This timeout value can be configured, see consumers doc guide to learn more`



## Types of Changes

What types of changes does your code introduce to this project?
(I don't know what this change category)

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I have no idea how to format the code 😅 
