### PR TITLE
rabbit_stream_queue_SUITE: Wait for `ra_leaderboard` to return the leader

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1381,6 +1381,13 @@ recover_coordinator(Config, Node) ->
 
 get_stream_coordinator_leader(Config) ->
     Node = hd(rabbit_ct_broker_helpers:get_node_configs(Config, nodename)),
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+              Ret = rabbit_ct_broker_helpers:rpc(
+                      Config, Node, ra_leaderboard, lookup_leader,
+                      [rabbit_stream_coordinator]),
+              is_tuple(Ret)
+      end),
     rabbit_ct_broker_helpers:rpc(Config, Node, ra_leaderboard,
                                  lookup_leader, [rabbit_stream_coordinator]).
 


### PR DESCRIPTION
## Why

Sometimes, `ra_leaderboard:lookup_leader/1` will return `undefined` because it doesn't know the leader yet. This leads to a failure of the testcase with a `badmatch` exception.

## How

We wait for the function to return a valid leader ID, then try again and return the result.