### PR TITLE
Check whether EPMD is running before starting it

### DIFF
--- a/deps/rabbit_common/src/rabbit_nodes_common.erl
+++ b/deps/rabbit_common/src/rabbit_nodes_common.erl
@@ -107,6 +107,14 @@ epmd_port() ->
     end.
 
 ensure_epmd() ->
+    case net_adm:names() of
+        {ok, _Names} ->
+            ok;
+        _ ->
+            start_epmd()
+    end.
+
+start_epmd() ->
     Exe = rabbit_runtime:get_erl_path(),
     ID = rabbit_misc:random(1000000000),
     Port = open_port(


### PR DESCRIPTION
`rabbit_nodes_common:ensure_epmd/0` unconditionally starts EPMD by spawning `erl` with nodename options. Spawning `erl` can be quite slow though (around 250ms for me locally), so we should try to avoid it when we detect that EPMD is already running.

We can relatively cheaply check whether EPMD is already running with [`net_adm:names/0`](https://www.erlang.org/doc/man/net_adm#names-0), a function that asks the daemon on localhost to list any registered names, the same as `epmd -names` on the comand line. If we can successfully get the list of names from the daemon then we don't need to start EPMD. `net_adm:names/0` is relatively cheap compared to running `erl`, costing around 8ms when EPMD is running and less than a millisecond when it is not.

This improves the CLI's total run time for commands that read the `enabled_plugins_file` and `plugins_dir` config options. Those options try to consult a running node and so they start distribution and ensure that EPMD is running. `rabbitmqctl --help` saves nearly 500ms when EPMD is already running as it reads both options, since previously it spawned and blocked on `erl` when reading each option.