### PR TITLE
Resolve CLI elixirc warnings

### DIFF
--- a/deps/rabbitmq_cli/BUILD.bazel
+++ b/deps/rabbitmq_cli/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(":rabbitmqctl.bzl", "rabbitmqctl")
 load(":rabbitmqctl_check_formatted.bzl", "rabbitmqctl_check_formatted_test")
+load(":rabbitmqctl_compile_warnings_as_errors.bzl", "rabbitmqctl_compile_warnings_as_errors_test")
 load(":rabbitmqctl_test.bzl", "rabbitmqctl_test")
 load("//:rabbitmq_home.bzl", "rabbitmq_home")
 load("//:rabbitmq_run.bzl", "rabbitmq_run")
@@ -95,6 +96,52 @@ rabbitmqctl_check_formatted_test(
 test_suite(
     name = "rabbitmqctl_check_formatted",
     tests = ["check_formatted"],
+)
+
+rabbitmqctl_compile_warnings_as_errors_test(
+    name = "compile_warnings_as_errors",
+    size = "small",
+    srcs = [
+        ".formatter.exs",
+        "config/config.exs",
+        "mix.exs",
+    ] + glob([
+        "lib/**/*.ex",
+        "test/**/*.exs",
+    ]),
+    data = glob(["test/fixtures/**/*"]),
+    archives = [
+        "@hex//:archive",
+    ],
+    source_deps = {
+        "@amqp//:sources": "amqp",
+        "@csv//:sources": "csv",
+        "@json//:sources": "json",
+        "@temp//:sources": "temp",
+        "@x509//:sources": "x509",
+    },
+    deps = [
+        "//deps/amqp_client:erlang_app",
+        "//deps/rabbit:erlang_app",
+        "//deps/rabbit_common:erlang_app",
+        "@observer_cli//:erlang_app",
+        "@stdout_formatter//:erlang_app",
+    ],
+    target_compatible_with = select({
+        "@platforms//os:macos": [
+            "@platforms//os:macos",
+            "@elixir_config//:elixir_1_15",
+        ],
+        "//conditions:default": [
+            "@platforms//os:linux",
+            "@elixir_config//:elixir_1_15",
+        ],
+    }),
+)
+
+test_suite(
+    name = "rabbitmqctl_compile_warnings_as_errors",
+    tests = ["compile_warnings_as_errors"],
 )
 
 plt(

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
@@ -69,7 +69,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
           {:ok, enabled_plugins_file} = PluginsHelpers.enabled_plugins_file(opts)
           require Logger
 
-          Logger.warn(
+          Logger.warning(
             "Unable to read the enabled plugins file.\n" <>
               "  Reason: #{inspect(err)}\n" <>
               "  Commands provided by plugins will not be available.\n" <>

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -83,7 +83,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
   def run(
         [username, base64_encoded_password_hash],
-        %{node: node_name, pre_hashed_password: true} = opts
+        %{node: node_name, pre_hashed_password: true}
       ) do
     case Base.decode64(base64_encoded_password_hash) do
       {:ok, password_hash} ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_standalone_khepri_boot.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_standalone_khepri_boot.ex
@@ -5,14 +5,14 @@
 ## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ForceStandaloneKhepriBootCommand do
-  alias RabbitMQ.CLI.Core.{Config, DocGuide}
+  alias RabbitMQ.CLI.Core.DocGuide
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   use RabbitMQ.CLI.Core.MergesNoDefaults
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
-  def run([], %{node: node_name} = opts) do
+  def run([], %{node: node_name}) do
     ret =
       :rabbit_misc.rpc_call(node_name, :rabbit_khepri, :force_shrink_member_to_current_member, [])
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -72,7 +72,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
         {:error,
          "RabbitMQ on node #{node_to_remove} must be stopped with 'rabbitmqctl -n #{node_to_remove} stop_app' before it can be removed"}
 
-      {:error, {:failed_to_remove_node, ^atom_name, unavailable}} ->
+      {:error, {:failed_to_remove_node, ^atom_name, :unavailable}} ->
         {:error, "Node #{node_to_remove} must be running before it can be removed"}
 
       {:error, _} = error ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -76,7 +76,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
      "Error: cannot cluster node with itself: #{node_name}"}
   end
 
-  def output({:error, {:node_type_unsupported, db, node_type}}, %{node: node_name}) do
+  def output({:error, {:node_type_unsupported, db, node_type}}, %{node: _node_name}) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software(),
      "Error: `#{node_type}` node type is unsupported by the #{db} by database engine"}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -6,8 +6,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
   require Integer
-  alias RabbitMQ.CLI.Core.{DocGuide, Validators}
-  import RabbitMQ.CLI.Core.DataCoercion
+  alias RabbitMQ.CLI.Core.DocGuide
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -21,7 +20,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
     :ok
   end
 
-  def run(nodes, %{node: node_name}) do
+  def run(_nodes, %{node: _node_name}) do
     :ok
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -5,7 +5,7 @@
 ## Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
-  alias RabbitMQ.CLI.Core.{Config, DocGuide, Helpers}
+  alias RabbitMQ.CLI.Core.DocGuide
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_any_deprecated_features_are_used_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_any_deprecated_features_are_used_command.ex
@@ -5,12 +5,6 @@
 ## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedCommand do
-  alias RabbitMQ.CLI.Core.DocGuide
-
-  alias RabbitMQ.CLI.Diagnostics.Commands.{
-    CheckIfClusterHasClassicQueueMirroringPolicyCommand
-  }
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   def scopes(), do: [:ctl, :diagnostics]
@@ -100,16 +94,5 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedC
   def description(),
     do: "Generate a report listing all deprecated features in use"
 
-  def banner(_, %{node: node_name}), do: "Checking if any deprecated features are used ..."
-
-  #
-  # Implementation
-  #
-
-  defp run_command(command, args, opts) do
-    {args, opts} = command.merge_defaults(args, opts)
-    banner = command.banner(args, opts)
-    command_result = command.run(args, opts) |> command.output(opts)
-    {command, banner, command_result}
-  end
+  def banner(_, %{node: _node_name}), do: "Checking if any deprecated features are used ..."
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/list_policies_that_match.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/list_policies_that_match.ex
@@ -56,16 +56,16 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ListPoliciesThatMatchCommand do
     end
   end
 
-  def output([], %{node: node_name, formatter: "json"}) do
+  def output([], %{node: _node_name, formatter: "json"}) do
     {:ok, %{"result" => "ok", "policies" => []}}
   end
 
-  def output({:error, :not_found}, %{node: node_name, formatter: "json"}) do
+  def output({:error, :not_found}, %{node: _node_name, formatter: "json"}) do
     {:ok,
      %{"result" => "error", "message" => "object (queue, exchange) not found", "policies" => []}}
   end
 
-  def output(value, %{node: node_name, formatter: "json"}) when is_list(value) do
+  def output(value, %{node: _node_name, formatter: "json"}) when is_list(value) do
     {:ok, %{"result" => "ok", "policies" => value}}
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/metadata_store_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/metadata_store_status_command.ex
@@ -5,8 +5,6 @@
 ## Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Diagnostics.Commands.MetadataStoreStatusCommand do
-  alias RabbitMQ.CLI.Core.DocGuide
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   def scopes(), do: [:diagnostics]
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/remote_shell_command.ex
@@ -38,7 +38,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.RemoteShellCommand do
     case :shell.start_interactive({node_name, {:shell, :start, []}}) do
       :ok -> :ok
       {:error, :already_started} -> :ok
-      {error, _} -> {:error, {:badrpc, :nodedown}}
+      {:error, _} -> {:error, {:badrpc, :nodedown}}
     end
 
     :timer.sleep(:infinity)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/coordinator_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/streams/commands/coordinator_status_command.ex
@@ -47,6 +47,6 @@ defmodule RabbitMQ.CLI.Queues.Commands.CoordinatorStatusCommand do
 
   def description(), do: "Displays raft status of the stream coordinator"
 
-  def banner([], %{node: node_name}),
+  def banner([], %{node: _node_name}),
     do: "Status of stream coordinator ..."
 end

--- a/deps/rabbitmq_cli/rabbitmqctl_compile_warnings_as_errors.bzl
+++ b/deps/rabbitmq_cli/rabbitmqctl_compile_warnings_as_errors.bzl
@@ -1,0 +1,202 @@
+load("@bazel_skylib//lib:shell.bzl", "shell")
+load(
+    "@rules_erlang//:erlang_app_info.bzl",
+    "ErlangAppInfo",
+)
+load(
+    "@rules_erlang//:util.bzl",
+    "path_join",
+    "windows_path",
+)
+load(
+    "@rules_erlang//private:util.bzl",
+    "additional_file_dest_relative_path",
+)
+load(
+    "//bazel/elixir:elixir_toolchain.bzl",
+    "elixir_dirs",
+    "erlang_dirs",
+    "maybe_install_erlang",
+)
+load(
+    ":rabbitmqctl.bzl",
+    "deps_dir_contents",
+)
+
+def _impl(ctx):
+    (erlang_home, _, erlang_runfiles) = erlang_dirs(ctx)
+    (elixir_home, elixir_runfiles) = elixir_dirs(ctx, short_path = True)
+
+    deps_dir = ctx.label.name + "_deps"
+
+    deps_dir_files = deps_dir_contents(
+        ctx,
+        ctx.attr.deps,
+        deps_dir,
+    )
+
+    for dep, app_name in ctx.attr.source_deps.items():
+        for src in dep.files.to_list():
+            if not src.is_directory:
+                rp = additional_file_dest_relative_path(dep.label, src)
+                f = ctx.actions.declare_file(path_join(
+                    deps_dir,
+                    app_name,
+                    rp,
+                ))
+                ctx.actions.symlink(
+                    output = f,
+                    target_file = src,
+                )
+                deps_dir_files.append(f)
+
+    package_dir = path_join(
+        ctx.label.workspace_root,
+        ctx.label.package,
+    )
+
+    precompiled_deps = " ".join([
+        dep[ErlangAppInfo].app_name
+        for dep in ctx.attr.deps
+    ])
+
+    if not ctx.attr.is_windows:
+        output = ctx.actions.declare_file(ctx.label.name)
+        script = """set -euo pipefail
+
+{maybe_install_erlang}
+
+if [[ "{elixir_home}" == /* ]]; then
+    ABS_ELIXIR_HOME="{elixir_home}"
+else
+    ABS_ELIXIR_HOME=$PWD/{elixir_home}
+fi
+
+export PATH="$ABS_ELIXIR_HOME"/bin:"{erlang_home}"/bin:${{PATH}}
+
+export LANG="en_US.UTF-8"
+export LC_ALL="en_US.UTF-8"
+
+INITIAL_DIR="$(pwd)"
+
+if [ ! -f ${{INITIAL_DIR}}/{package_dir}/test/test_helper.exs ]; then
+    echo "test_helper.exs cannot be found. 'bazel clean' might fix this."
+    exit 1
+fi
+
+cp -r ${{INITIAL_DIR}}/{package_dir}/config ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp -r ${{INITIAL_DIR}}/{package_dir}/lib ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp -r ${{INITIAL_DIR}}/{package_dir}/test ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp    ${{INITIAL_DIR}}/{package_dir}/mix.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+cp    ${{INITIAL_DIR}}/{package_dir}/.formatter.exs ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+
+cd ${{TEST_UNDECLARED_OUTPUTS_DIR}}
+
+export IS_BAZEL=true
+export HOME=${{PWD}}
+export DEPS_DIR=$TEST_SRCDIR/$TEST_WORKSPACE/{package_dir}/{deps_dir}
+export MIX_ENV=test
+export ERL_COMPILER_OPTIONS=deterministic
+for archive in {archives}; do
+    "${{ABS_ELIXIR_HOME}}"/bin/mix archive.install --force $INITIAL_DIR/$archive
+done
+set -x
+"${{ABS_ELIXIR_HOME}}"/bin/mix deps.compile
+"${{ABS_ELIXIR_HOME}}"/bin/mix compile --warnings-as-errors
+""".format(
+            maybe_install_erlang = maybe_install_erlang(ctx, short_path = True),
+            erlang_home = erlang_home,
+            elixir_home = elixir_home,
+            package_dir = package_dir,
+            deps_dir = deps_dir,
+            archives = " ".join([shell.quote(a.short_path) for a in ctx.files.archives]),
+            precompiled_deps = precompiled_deps,
+        )
+    else:
+        output = ctx.actions.declare_file(ctx.label.name + ".bat")
+        script = """@echo off
+:: set LANG="en_US.UTF-8"
+:: set LC_ALL="en_US.UTF-8"
+
+set PATH="{elixir_home}\\bin";"{erlang_home}\\bin";%PATH%
+
+set OUTPUTS_DIR=%TEST_UNDECLARED_OUTPUTS_DIR:/=\\%
+
+:: robocopy exits non-zero when files are copied successfully
+:: https://social.msdn.microsoft.com/Forums/en-US/d599833c-dcea-46f5-85e9-b1f028a0fefe/robocopy-exits-with-error-code-1?forum=tfsbuild
+robocopy {package_dir}\\config %OUTPUTS_DIR%\\config /E /NFL /NDL /NJH /NJS /nc /ns /np
+robocopy {package_dir}\\lib %OUTPUTS_DIR%\\lib /E /NFL /NDL /NJH /NJS /nc /ns /np
+robocopy {package_dir}\\test %OUTPUTS_DIR%\\test /E /NFL /NDL /NJH /NJS /nc /ns /np
+copy {package_dir}\\mix.exs %OUTPUTS_DIR%\\mix.exs || goto :error
+copy {package_dir}\\.formatter.exs %OUTPUTS_DIR%\\.formatter.exs || goto :error
+
+cd %OUTPUTS_DIR% || goto :error
+
+set DEPS_DIR=%TEST_SRCDIR%/%TEST_WORKSPACE%/{package_dir}/{deps_dir}
+set DEPS_DIR=%DEPS_DIR:/=\\%
+set ERL_COMPILER_OPTIONS=deterministic
+set MIX_ENV=test
+for %%a in ({archives}) do (
+    set ARCH=%TEST_SRCDIR%/%TEST_WORKSPACE%/%%a
+    set ARCH=%ARCH:/=\\%
+    "{elixir_home}\\bin\\mix" archive.install --force %ARCH% || goto :error
+)
+"{elixir_home}\\bin\\mix" deps.compile || goto :error
+"{elixir_home}\\bin\\mix" compile --warnings-as-errors || goto :error
+goto :EOF
+:error
+exit /b 1
+""".format(
+            erlang_home = windows_path(erlang_home),
+            elixir_home = windows_path(elixir_home),
+            package_dir = windows_path(ctx.label.package),
+            deps_dir = deps_dir,
+            archives = " ".join([shell.quote(a.short_path) for a in ctx.files.archives]),
+            precompiled_deps = precompiled_deps,
+        )
+
+    ctx.actions.write(
+        output = output,
+        content = script,
+    )
+
+    runfiles = ctx.runfiles(
+        files = ctx.files.srcs + ctx.files.data + ctx.files.archives,
+        transitive_files = depset(deps_dir_files),
+    ).merge_all([
+        erlang_runfiles,
+        elixir_runfiles,
+    ])
+
+    return [DefaultInfo(
+        runfiles = runfiles,
+        executable = output,
+    )]
+
+rabbitmqctl_compile_warnings_as_errors_private_test = rule(
+    implementation = _impl,
+    attrs = {
+        "is_windows": attr.bool(mandatory = True),
+        "srcs": attr.label_list(allow_files = [".ex", ".exs"]),
+        "data": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [ErlangAppInfo]),
+        "archives": attr.label_list(
+            allow_files = [".ez"],
+        ),
+        "source_deps": attr.label_keyed_string_dict(),
+    },
+    toolchains = [
+        "//bazel/elixir:toolchain_type",
+    ],
+    test = True,
+)
+
+def rabbitmqctl_compile_warnings_as_errors_test(**kwargs):
+    rabbitmqctl_compile_warnings_as_errors_private_test(
+        is_windows = select({
+            "@bazel_tools//src/conditions:host_windows": True,
+            "//conditions:default": False,
+        }),
+        **kwargs
+    )
+


### PR DESCRIPTION
Most of the elixirc warnings in the CLI are benign. There are a few cases where I believe a variable was meant to be an atom instead though, which should change some error-handling behavior slightly.

I've also added a bazel test for running `mix compile --warnings-as-errors` so these can be caught by the CI in the future.