### PR TITLE
rabbitmq_federation: Handle `shutdown` from upstream

### DIFF
--- a/deps/rabbitmq_federation/src/rabbit_federation_link_util.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_link_util.erl
@@ -262,6 +262,9 @@ handle_downstream_down(Reason, _Args, State) ->
 
 %% If the upstream channel goes down for an intelligible reason, just
 %% log it and die quietly.
+handle_upstream_down(shutdown, {Upstream, UParams, XName}, State) ->
+    rabbit_federation_link_util:connection_error(
+      remote, {upstream_channel_down, shutdown}, Upstream, UParams, XName, State);
 handle_upstream_down({shutdown, Reason}, {Upstream, UParams, XName}, State) ->
     rabbit_federation_link_util:connection_error(
       remote, {upstream_channel_down, Reason}, Upstream, UParams, XName, State);


### PR DESCRIPTION
## Why

The downstream process was already handling a `{shutdown, Term}` termination reason from upstream gracefully: it would log a message an close the connection.

However it didn't handle the more common `shutdown` reason, which happens with a regular stop of the upstream node. It led to the log of a giant scary crash message.

## How

We handle `shutdown` the same as `{shutdown, Term}`.