### PR TITLE
Streams: Soft remove policy configuration of max_segment_size_bytes

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -148,3 +148,11 @@
                          post_enable =>
                          {rabbit_khepri, khepri_db_migration_post_enable}}
      }}).
+
+-rabbit_feature_flag(
+   {stream_update_config_command,
+    #{desc          => "A new internal command that is used to update streams as "
+                        "part of a policy.",
+      stability     => stable,
+      depends_on    => [stream_queue]
+     }}).

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -249,6 +249,12 @@ init_per_group1(Group, Config) ->
                          Config2, stream_queue),
             case EnableFF of
                 ok ->
+                    if Clustered ->
+                           rabbit_ct_broker_helpers:enable_feature_flag(
+                             Config2, stream_update_config_command);
+                       true ->
+                           ok
+                    end,
                     ok = rabbit_ct_broker_helpers:rpc(
                            Config2, 0, application, set_env,
                            [rabbit, channel_tick_interval, 100]),

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -207,9 +207,6 @@ var HELP = {
     'queue-max-age':
       'How long a message published to a stream queue can live before it is discarded.',
 
-    'queue-stream-max-segment-size-bytes':
-      'Total segment size for stream segments on disk.<br/>(Sets the x-stream-max-segment-size-bytes argument.)',
-
     'queue-stream-filter-size-bytes':
       'Size of the filter data attached to each stream chunk.<br/>(Sets the x-stream-filter-size-bytes argument.)',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -139,8 +139,6 @@
                 <td>
                   <span class="argument-link" field="definition" key="max-age" type="string">Max age</span>
                   <span class="help" id="queue-max-age"></span> |
-                  <span class="argument-link" field="definition" key="stream-max-segment-size-bytes" type="number">Max segment size in bytes</span>
-                  <span class="help" id="queue-stream-max-segment-size-bytes"></span> |
                   <span class="argument-link" field="definition" key="stream-filter-size-bytes" type="number">Filter size in bytes. Valid range: 16-255</span>
                   <span class="help" id="queue-stream-filter-size-bytes"></span> |
                   <span class="argument-link" field="definition" key="queue-leader-locator" type="string">Leader locator</span>


### PR DESCRIPTION
This configuration is not guaranteed to be safe to change after a stream has been declared and thus we'll remove the ability to change it after the initial declaration. Users should favour the x- queue arg for this config but it will still be possible to configure it as a policy but it will only be evaluated at declaration time.

This means that if a policy is set for a stream that re-configures the `stream-max-segment-size-bytes` key it will show in the UI as updated but the pre-existing stream will not use the updated configuration.

The key has been removed from the UI but for backwards compatibility it is still settable.

NB: this PR adds a new command `update_config` to the stream coordinator state machine. Strictly speaking this should require a new machine version but we're bypassing that by relying on the feature flag instead which avoids this command being committed before all nodes have the new code version. A new machine version can lower the availability properties during a rolling cluster upgrade so in this case it is preferable to avoid that given the simplicity of the change.
