### PR TITLE
Remove delivery_mode header from amqp 1.0 shovel.

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -390,6 +390,11 @@ set_message_properties(Props, Msg) ->
                 #{content_encoding => to_binary(Ct)}, M);
          (delivery_mode, 2, M) ->
               amqp10_msg:set_headers(#{durable => true}, M);
+         (delivery_mode, 1, M) ->
+              % by default the durable flag is false
+              M;
+         (priority, P, M) when is_integer(P) ->
+                amqp10_msg:set_headers(#{priority => P}, M);
          (correlation_id, Ct, M) ->
               amqp10_msg:set_properties(#{correlation_id => to_binary(Ct)}, M);
          (reply_to, Ct, M) ->

--- a/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
@@ -131,12 +131,15 @@ test_amqp10_destination(Config, Src, Dest, Sess, Protocol, ProtocolSrc) ->
                                            <<"message-ann-value">>}]
                                   end}]),
     Msg = publish_expect(Sess, Src, Dest, <<"tag1">>, <<"hello">>),
+    AppProps = amqp10_msg:application_properties(Msg),
+
     ?assertMatch((#{user_id := <<"guest">>, creation_time := _}),
                  (amqp10_msg:properties(Msg))),
     ?assertMatch((#{<<"shovel-name">> := <<"test">>,
                     <<"shovel-type">> := <<"dynamic">>, <<"shovelled-by">> := _,
                     <<"app-prop-key">> := <<"app-prop-value">>}),
-                 (amqp10_msg:application_properties(Msg))),
+                 (AppProps)),
+    ?assertEqual(undefined, maps:get(<<"delivery_mode">>, AppProps, undefined)),
     ?assertMatch((#{<<"message-ann-key">> := <<"message-ann-value">>}),
                  (amqp10_msg:message_annotations(Msg))).
 


### PR DESCRIPTION
This header is not present if delivery_mode = 2, it does not really makes sense to leave it when delivery_mode = 1.
The durability of the message is reflected in the durable flag of the amqp 1.0 message.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
