### PR TITLE
Log message in case of stream publisher declaration failure

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1747,7 +1747,12 @@ handle_frame_post_auth(Transport,
                                internal_sequence = InternalSequence + 1},
                              State}
                     end;
-                {_, _} ->
+                {PublisherIdTaken, ReferenceTaken} ->
+                    rabbit_log:warning("Error while declaring publisher ~tp for stream '~ts', "
+                                       "with reference '~ts'. ID already taken: ~tp. "
+                                       "Reference already taken: ~tp.",
+                                       [PublisherId, Stream, WriterRef,
+                                        PublisherIdTaken, ReferenceTaken]),
                     response(Transport,
                              Connection0,
                              declare_publisher,


### PR DESCRIPTION
The "precondition failed" error code is good enough for an application, but it may be useful when working on a client library to have more information about the reason of the failure of the publisher declaration.

This commit adds a warning log message that gives the reason(s) of the failure (publisher ID already taken and/or existing publisher with the same reference for the same stream in the connection).