### PR TITLE
Fix consumer offset and offset lag calculation

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -3908,16 +3908,21 @@ consumer_i(messages_consumed,
                          #consumer_configuration{counters = Counters}}) ->
     messages_consumed(Counters);
 consumer_i(offset,
-           #consumer{configuration =
-                         #consumer_configuration{counters = Counters}}) ->
-    consumer_offset(Counters);
+           #consumer{configuration = #consumer_configuration{counters = Counters},
+                     last_listener_offset = LLO}) ->
+    rabbit_stream_utils:consumer_offset(consumer_offset(Counters),
+                                        messages_consumed(Counters),
+                                        LLO);
 consumer_i(offset_lag, #consumer{log = undefined}) ->
     0;
 consumer_i(offset_lag,
-           #consumer{configuration =
-                         #consumer_configuration{counters = Counters},
+           #consumer{configuration = #consumer_configuration{counters = Counters},
+                     last_listener_offset = LLO,
                      log = Log}) ->
-    stream_stored_offset(Log) - consumer_offset(Counters);
+    rabbit_stream_utils:offset_lag(stream_stored_offset(Log),
+                                   consumer_offset(Counters),
+                                   messages_consumed(Counters),
+                                   LLO);
 consumer_i(connection_pid, _) ->
     self();
 consumer_i(node, _) ->


### PR DESCRIPTION
The offset lag for a consumer is the difference between the last committed offset (offset of the first message in the last chunk confirmed by a quorum of stream members) and the current offset of the consumer (offset of the first message in the last chunk dispatched to the consumer).

The calculation is simple for most cases, but it needs to be refined by using more context for edge cases (subscription to a stream that has not messages yet, subscription at the very end of a quiet stream).

Example: subscription at "next" (waiting for new messages) in a quiet stream (no messages published). The previous implementation would return consumer offset = 0 and offset lag = last committed offset, where we would expect to get consumer offset = next offset and offset lag = 0.

This commit fixes the calculation for these edge cases.