### PR TITLE
Fix AMQP 1.0 -> AMQP 0.9.1 durability conversion

### DIFF
--- a/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_message.erl
+++ b/deps/rabbitmq_amqp1_0/src/rabbit_amqp1_0_message.erl
@@ -154,7 +154,8 @@ translate_header(Header10, Props) ->
     Props#'P_basic'{
       delivery_mode = case Header10#'v1_0.header'.durable of
                           true -> 2;
-                          _    -> 1
+                          {boolean, true} -> 2;
+                          _ -> 1
                       end,
       priority = unwrap(Header10#'v1_0.header'.priority),
       expiration = to_expiration(Header10#'v1_0.header'.ttl),

--- a/deps/rabbitmq_amqp1_0/test/amqp10_client_SUITE.erl
+++ b/deps/rabbitmq_amqp1_0/test/amqp10_client_SUITE.erl
@@ -127,7 +127,10 @@ reliable_send_receive(Config, Outcome) ->
     %% create an unsettled message,
     %% link will be in "mixed" mode by default
     Msg1 = amqp10_msg:new(DTag1, <<"body-1">>, false),
-    ok = amqp10_client:send_msg(Sender, Msg1),
+    %% Use the 2 byte AMQP boolean encoding, see AMQP §1.6.2
+    True = {boolean, true},
+    Msg2 = amqp10_msg:set_headers(#{durable => True}, Msg1),
+    ok = amqp10_client:send_msg(Sender, Msg2),
     ok = wait_for_settlement(DTag1),
 
     ok = amqp10_client:detach_link(Sender),
@@ -142,8 +145,8 @@ reliable_send_receive(Config, Outcome) ->
                                                         Address,
                                                         unsettled),
     {ok, Msg} = amqp10_client:get_msg(Receiver),
-
     ct:pal("got ~p", [amqp10_msg:body(Msg)]),
+    ?assertEqual(true, amqp10_msg:header(durable, Msg)),
 
     ok = amqp10_client:settle_msg(Receiver, Msg, Outcome),
 


### PR DESCRIPTION
This is the https://github.com/rabbitmq/rabbitmq-server/pull/10567 fix for RabbitMQ 3.12 and 3.11