### PR TITLE
Configurable writer module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,7 +43,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rabbitmq_osiris",
-    version = "1.7.2",
+    version = "1.8.0",
     repo_name = "osiris",
 )
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -139,7 +139,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.7.2
+dep_osiris = git https://github.com/rabbitmq/osiris v1.8.0
 dep_systemd = hex 0.6.1
 
 dep_seshat = git https://github.com/rabbitmq/seshat v0.6.1

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1049,7 +1049,7 @@ phase_delete_member(StreamId, #{node := Node} = Arg, Conf) ->
     fun() ->
             case rabbit_nodes:is_member(Node) of
                 true ->
-                    try osiris_server_sup:delete_child(Node, Conf) of
+                    try osiris:delete_member(Node, Conf) of
                         ok ->
                             rabbit_log:info("~ts: Member deleted for ~ts : on node ~ts",
                                             [?MODULE, StreamId, Node]),
@@ -1071,10 +1071,9 @@ phase_delete_member(StreamId, #{node := Node} = Arg, Conf) ->
             end
     end.
 
-phase_stop_member(StreamId, #{node := Node,
-                              epoch := Epoch} = Arg0, Conf) ->
+phase_stop_member(StreamId, #{node := Node, epoch := Epoch} = Arg0, Conf) ->
     fun() ->
-            try osiris_server_sup:stop_child(Node, StreamId) of
+            try osiris:stop_member(Node, Conf) of
                 ok ->
                     %% get tail
                     try get_replica_tail(Node, Conf) of
@@ -1108,10 +1107,9 @@ phase_stop_member(StreamId, #{node := Node,
             end
     end.
 
-phase_start_writer(StreamId, #{epoch := Epoch,
-                               node := Node} = Args0, Conf) ->
+phase_start_writer(StreamId, #{epoch := Epoch, node := Node} = Args0, Conf) ->
     fun() ->
-            try osiris_writer:start(Conf) of
+            try osiris:start_writer(Conf) of
                 {ok, Pid} ->
                     Args = Args0#{epoch => Epoch, pid => Pid},
                     rabbit_log:info("~ts: started writer ~ts on ~w in ~b",
@@ -2018,7 +2016,6 @@ make_writer_conf(Node, #stream{epoch = Epoch,
           nodes => Nodes,
           replica_nodes => lists:delete(Node, Nodes),
           epoch => Epoch}.
-
 
 find_leader(Members) ->
     case lists:partition(

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1121,9 +1121,10 @@ phase_start_writer(StreamId, #{epoch := Epoch, node := Node} = Args0, Conf) ->
                     rabbit_log:warning("~ts: failed to start writer ~ts on ~ts in ~b Error: ~w",
                                        [?MODULE, StreamId, Node, Epoch, Err]),
                     send_action_failed(StreamId, starting, Args0)
-            catch _:Err ->
-                    rabbit_log:warning("~ts: failed to start writer ~ts on ~ts in ~b Error: ~w",
-                                       [?MODULE, StreamId, Node, Epoch, Err]),
+            catch _:Err:Stack ->
+                    rabbit_log:warning("~ts: failed to start writer ~ts on ~ts
+    in ~b Error: ~w ~n~p",
+                                       [?MODULE, StreamId, Node, Epoch, Err, Stack]),
                     send_action_failed(StreamId, starting, Args0)
             end
     end.

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1139,9 +1139,9 @@ phase_start_writer(StreamId, #{epoch := Epoch, node := Node} = Args0, Conf) ->
                     rabbit_log:warning("~ts: failed to start writer ~ts on ~ts in ~b Error: ~w",
                                        [?MODULE, StreamId, Node, Epoch, Err]),
                     send_action_failed(StreamId, starting, Args0)
-            catch _:Err:Stack ->
-                    rabbit_log:warning("~ts: failed to start writer ~ts on ~ts in ~b Error: ~w ~n~p",
-                                       [?MODULE, StreamId, Node, Epoch, Err, Stack]),
+            catch _:Err ->
+                    rabbit_log:warning("~ts: failed to start writer ~ts on ~ts in ~b Error: ~w",
+                                       [?MODULE, StreamId, Node, Epoch, Err]),
                     send_action_failed(StreamId, starting, Args0)
             end
     end.

--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1122,8 +1122,7 @@ phase_start_writer(StreamId, #{epoch := Epoch, node := Node} = Args0, Conf) ->
                                        [?MODULE, StreamId, Node, Epoch, Err]),
                     send_action_failed(StreamId, starting, Args0)
             catch _:Err:Stack ->
-                    rabbit_log:warning("~ts: failed to start writer ~ts on ~ts
-    in ~b Error: ~w ~n~p",
+                    rabbit_log:warning("~ts: failed to start writer ~ts on ~ts in ~b Error: ~w ~n~p",
                                        [?MODULE, StreamId, Node, Epoch, Err, Stack]),
                     send_action_failed(StreamId, starting, Args0)
             end

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -160,11 +160,9 @@ create_stream(Q0) ->
                            args_policy_lookup(<<"initial-cluster-size">>,
                                               fun policy_precedence/2, Q0)),
     {Leader, Followers} = rabbit_queue_location:select_leader_and_followers(Q0, InitialClusterSize),
-    WriterMod = application:get_env(rabbit, stream_writer_module, osiris_writer),
     Conf = maps:merge(Conf0, #{nodes => [Leader | Followers],
                                leader_node => Leader,
-                               replica_nodes => Followers,
-                               writer_mod => WriterMod}),
+                               replica_nodes => Followers}),
     Q1 = amqqueue:set_type_state(Q0, Conf),
     case rabbit_amqqueue:internal_declare(Q1, false) of
         {created, Q} ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -160,9 +160,11 @@ create_stream(Q0) ->
                            args_policy_lookup(<<"initial-cluster-size">>,
                                               fun policy_precedence/2, Q0)),
     {Leader, Followers} = rabbit_queue_location:select_leader_and_followers(Q0, InitialClusterSize),
+    WriterMod = application:get_env(rabbit, stream_writer_module, osiris_writer),
     Conf = maps:merge(Conf0, #{nodes => [Leader | Followers],
                                leader_node => Leader,
-                               replica_nodes => Followers}),
+                               replica_nodes => Followers,
+                               writer_mod => WriterMod}),
     Q1 = amqqueue:set_type_state(Q0, Conf),
     case rabbit_amqqueue:internal_declare(Q1, false) of
         {created, Q} ->


### PR DESCRIPTION
Make posible to configure the writer module used by the stream coordinator

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
