### PR TITLE
Add gazelle directive to stabilize bazel run gazelle

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
+++ b/deps/rabbitmq_auth_backend_oauth2/BUILD.bazel
@@ -50,7 +50,7 @@ rabbitmq_app(
         "//deps/rabbit:erlang_app",
         "@base64url//:erlang_app",
         "@cowlib//:erlang_app",
-        "@jose//:erlang_app"
+        "@jose//:erlang_app",
     ],
 )
 

--- a/deps/rabbitmq_stream/app.bzl
+++ b/deps/rabbitmq_stream/app.bzl
@@ -184,5 +184,8 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         hdrs = ["src/rabbit_stream_reader.hrl"],
         app_name = "rabbitmq_stream",
         erlc_opts = "//:test_erlc_opts",
-        deps = ["//deps/rabbit_common:erlang_app", "//deps/rabbitmq_stream_common:erlang_app"],
+        deps = [
+            "//deps/rabbit_common:erlang_app",  #keep
+            "//deps/rabbitmq_stream_common:erlang_app",
+        ],
     )


### PR DESCRIPTION
rabbit_common is indirectly included via rabbit_stream_reader.hrl, and the rules_erlang gazelle extension does not yet know how to detect this, therefore the directive manually declares it

Follow up to bc2a11d1bd15ad423df25afe93bf95b4cbf0d08c