### PR TITLE
Clean up some incorrect references to rabbitmq_oauth2_client

### DIFF
--- a/deps/oauth2_client/BUILD.bazel
+++ b/deps/oauth2_client/BUILD.bazel
@@ -107,7 +107,7 @@ all_test_beam_files(name = "all_test_beam_files")
 test_suite_beam_files(name = "test_suite_beam_files")
 
 alias(
-    name = "rabbitmq_oauth2_client",
+    name = "oauth2_client",
     actual = ":erlang_app",
     visibility = ["//visibility:public"],
 )
@@ -126,9 +126,3 @@ rabbitmq_integration_suite(
 )
 
 assert_suites()
-
-alias(
-    name = "oauth2_client",
-    actual = ":erlang_app",
-    visibility = ["//visibility:public"],
-)

--- a/moduleindex.yaml
+++ b/moduleindex.yaml
@@ -1170,9 +1170,6 @@ rabbitmq_mqtt:
 - rabbit_mqtt_retainer_sup
 - rabbit_mqtt_sup
 - rabbit_mqtt_util
-rabbitmq_oauth2_client:
-- oauth2_client
-- oauth2_client_app
 rabbitmq_peer_discovery_aws:
 - rabbit_peer_discovery_aws
 - rabbitmq_peer_discovery_aws


### PR DESCRIPTION
which may have been called that at one time, but is now just oauth2_client