### PR TITLE
Osiris 1.8.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,7 +43,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rabbitmq_osiris",
-    version = "1.7.2",
+    version = "1.8.0",
     repo_name = "osiris",
 )
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -139,7 +139,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client meck prop
 PLT_APPS += mnesia
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.7.2
+dep_osiris = git https://github.com/rabbitmq/osiris v1.8.0
 dep_systemd = hex 0.6.1
 
 dep_seshat = git https://github.com/rabbitmq/seshat v0.6.1


### PR DESCRIPTION
Contains a fix to be more defensive when evaluating retention as well as some new APIs for starting, stopping and deleting osiris members.
