### PR TITLE
Use `MaxInterval` when free space is `NaN`

### DIFF
--- a/deps/rabbit/src/rabbit_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_disk_monitor.erl
@@ -421,6 +421,9 @@ start_timer(State) ->
 interval(#state{alarmed      = true,
                 max_interval = MaxInterval}) ->
     MaxInterval;
+interval(#state{actual       = 'NaN',
+                max_interval = MaxInterval}) ->
+    MaxInterval;
 interval(#state{limit        = Limit,
                 actual       = Actual,
                 min_interval = MinInterval,


### PR DESCRIPTION
Fixes #10597