### PR TITLE
Use default sorting when `?sort=` in MGMT API

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -276,6 +276,8 @@ get_sorts_param(ReqData, Def) ->
     case get_value_param(<<"sort">>, ReqData) of
         undefined ->
             Def;
+        [] ->
+            Def;
         S ->
             [S]
     end.


### PR DESCRIPTION
Affects the old (3rd party) Prometheus plugin, see https://github.com/rabbitmq/rabbitmq-server/issues/10609