### PR TITLE
Fix AMQP 0.9.1 headers regression

### DIFF
--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -412,7 +412,7 @@ protocol_state(#content{properties = #'P_basic'{headers = H00} = B0} = C,
                  end, Headers0, Anns),
     Headers = case Headers1 of
                   [] ->
-                      undefined;
+                      H00;
                   _ ->
                       %% Dedup
                       lists:usort(fun({Key1, _, _}, {Key2, _, _}) ->


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/discussions/10620

Up to RabbitMQ 3.12:
* When an AMQP 0.9.1 publisher sends a message with P_basic.headers unset, RabbitMQ will deliver an AMQP 0.9.1 message with P_basic.headers unset.
* When an AMQP 0.9.1 publisher sends a message with P_basic.headers being an empty list ([]), RabbitMQ will deliver an AMQP 0.9.1 message with P_basic.headers being an empty list ([]).

In 3.13 including message containers, the 1st behaviour stayed the same while the 2nd behaviour changed to:
* When an AMQP 0.9.1 publisher sends a message with P_basic.headers being an empty list ([]), RabbitMQ will deliver an AMQP 0.9.1 message with P_basic.headers unset.

This commit fixes this regression by using the same behaviour as in 3.12.