### PR TITLE
Use binary concatenation for classic queue segment filenames

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -196,9 +196,10 @@ init_for_conversion(#resource{ virtual_host = VHost } = Name, OnSyncFun, OnSyncM
 
 init1(Name, Dir, OnSyncFun, OnSyncMsgFun) ->
     ensure_queue_name_stub_file(Name, Dir),
+    DirBin = rabbit_file:filename_to_binary(Dir),
     #qi{
         queue_name = Name,
-        dir = rabbit_file:filename_to_binary(Dir),
+        dir = << DirBin/binary, "/" >>,
         on_sync = OnSyncFun,
         on_sync_msg = OnSyncMsgFun
     }.
@@ -1277,8 +1278,8 @@ queue_name_to_dir_name(#resource { kind = queue,
     rabbit_misc:format("~.36B", [Num]).
 
 segment_file(Segment, #qi{ dir = Dir }) ->
-    filename:join(rabbit_file:binary_to_filename(Dir),
-                  integer_to_list(Segment) ++ ?SEGMENT_EXTENSION).
+    N = integer_to_binary(Segment),
+    <<Dir/binary, N/binary, ?SEGMENT_EXTENSION>>.
 
 highest_continuous_seq_id([SeqId|Tail], EndSeqId)
         when (1 + SeqId) =:= EndSeqId ->

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -118,7 +118,8 @@ init(#resource{ virtual_host = VHost } = Name) ->
     ?DEBUG("~0p", [Name]),
     VHostDir = rabbit_vhost:msg_store_dir_path(VHost),
     Dir = rabbit_classic_queue_index_v2:queue_dir(VHostDir, Name),
-    #qs{dir = rabbit_file:filename_to_binary(Dir)}.
+    DirBin = rabbit_file:filename_to_binary(Dir),
+    #qs{dir = << DirBin/binary, "/" >>}.
 
 -spec terminate(State) -> State when State::state().
 
@@ -570,6 +571,6 @@ check_crc32() ->
 
 %% Same implementation as rabbit_classic_queue_index_v2:segment_file/2,
 %% but with a different state record.
-segment_file(Segment, #qs{ dir = Dir }) ->
-    filename:join(rabbit_file:binary_to_filename(Dir),
-                  integer_to_list(Segment) ++ ?SEGMENT_EXTENSION).
+segment_file(Segment, #qs{dir = Dir}) ->
+    N = integer_to_binary(Segment),
+    <<Dir/binary, N/binary, ?SEGMENT_EXTENSION>>.


### PR DESCRIPTION
I noticed that in some scenarios with intense CQ workloads, we spend a few percent of the CPU time in `filename:join`. This PR simplifies how classic queues generate the file paths. I was unable to see measurable performance improvement because of this change (actual disk operations probably overshadow any CPU work here), but it reduces unnecessary CPU work and the amount of garbage generated, so it's still a reasonable change.

not to be backported