### PR TITLE
Cosmetic: Fix operator policy separators

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -288,9 +288,8 @@
                   <span class="argument-link" field="definitionop" key="ha-sync-mode" type="string">HA sync mode</span> <span class="help" id="policy-ha-sync-mode"></span> </br>
                   <span class="argument-link" field="definitionop" key="max-length" type="number">Max length</span> |
                   <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
-                  <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span> |
-                  <span class="help" id="queue-message-ttl"></span> |
-                  <span class="argument-link" field="definitionop" key="queue-version" type="number">Version</span> <span class="help" id="queue-version"></span> </br> |
+                  <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span> <span class="help" id="queue-message-ttl"></span> |
+                  <span class="argument-link" field="definitionop" key="queue-version" type="number">Version</span> <span class="help" id="queue-version"></span> </br>
                   <span class="argument-link" field="definitionop" key="overflow" type="string">Length limit overflow behavior</span> <span class="help" id="overflow"></span> </br>
                 </td>
               </tr>


### PR DESCRIPTION
## Proposed Changes

The formatting of the operator policies had the separators (`|`) in the wrong place 
<img width="1056" alt="Screenshot 2024-02-28 at 15 50 29" src="https://github.com/rabbitmq/rabbitmq-server/assets/460369/a9704539-7ce2-4a5b-a6b8-34c2f69593bd">

## Types of Changes

- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
