### PR TITLE
QQ: add feature flag to control adding non-voting members.

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -160,6 +160,14 @@
      }}).
 
 -rabbit_feature_flag(
+   {quorum_queue_non_voters,
+    #{desc =>
+          "Allows new quorum queue members to be added as non voters initially.",
+      stability => stable,
+      depends_on => [quorum_queue]
+     }}).
+
+-rabbit_feature_flag(
    {credit_api_v2,
     #{desc          => "Credit API v2 between queue clients and queue processes",
       stability     => stable


### PR DESCRIPTION
Without a feature flag it is possible to add a member on a newer node with a Ra command format that the other nodes do not yet understand resulting in crashed nodes.
