### PR TITLE
Optionally block enabling certain feature flags via Management UI/API

### DIFF
--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -646,3 +646,10 @@ end}.
     {datatype, {enum, [true, false]}},
     {include_default, false}
 ]}.
+
+%% Block enabling certain feature flags over API
+
+{mapping, "management.restrictions.feature_flag_blocked.$name", "rabbitmq_management.restrictions.feature_flag_blocked", [
+    {datatype, [string, {enum, [false]}]},
+    {include_default, false}
+]}.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_features.erl
@@ -9,6 +9,7 @@
 
 -export([is_op_policy_updating_disabled/0,
          is_qq_replica_operations_disabled/0,
+         is_feature_flag_blocked/1,
          are_stats_enabled/0]).
 
 is_qq_replica_operations_disabled() ->
@@ -17,6 +18,13 @@ is_qq_replica_operations_disabled() ->
 is_op_policy_updating_disabled() ->
     case get_restriction([operator_policy_changes, disabled]) of
         true -> true;
+        _ -> false
+    end.
+
+-spec is_feature_flag_blocked(rabbit_feature_flags:feature_name()) -> {true, string()} | false.
+is_feature_flag_blocked(FeatureFlag) ->
+    case get_restriction([feature_flag_blocked, FeatureFlag]) of
+        Msg when is_list(Msg) -> {true, Msg};
         _ -> false
     end.
 


### PR DESCRIPTION
## Proposed Changes

Useful to avoid accidentally enabling for example experimental feature flags from the Management UI on sensitive clusters,
even for users who have administrator access to the Mgmt UI/API, but still don't have server access. After testing an experimental feature flag in a test/staging env, the feature flag can be unblocked by operators on the sensitive production clusters.

I intentionally kept this configuration outside of the core feature flags framework, and only a management plugin feature.

I am open to suggestions if this should be configured or implemented differently.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
