### PR TITLE
feature_flags_SUITE: Kill dangling spammer process in registry_concurrent_reloads()

### DIFF
--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -548,8 +548,10 @@ registry_concurrent_reloads(_Config) ->
     %% all added feature flags.
     timer:sleep(1000),
 
+    MRef = erlang:monitor(process, Spammer),
     unlink(Spammer),
-    exit(Spammer, normal).
+    exit(Spammer, kill),
+    receive {'DOWN', MRef, process, Spammer, _} -> ok end.
 
 registry_spammer(CurrentFeatureNames, FinalFeatureNames) ->
     %% Infinite loop.


### PR DESCRIPTION
## Why

It looks like `exit(Spammer, normal)` doesn't terminate the process. This leaves a dangling process around and seems to cause transient failures in the `try_to_deadlock_in_registry_reload_1` testcase that follows it.

## How

We use `exit(Spammer, kill)` and a monitor to wait for the process to actually terminate.