### PR TITLE
Prevent not_found on list web mqtt connections

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -34,7 +34,8 @@
          force_connection_event_refresh/1, force_non_amqp_connection_event_refresh/1,
          handshake/2, tcp_host/1,
          ranch_ref/1, ranch_ref/2, ranch_ref_of_protocol/1,
-         listener_of_protocol/1, stop_ranch_listener_of_protocol/1]).
+         listener_of_protocol/1, stop_ranch_listener_of_protocol/1,
+         list_local_connections_of_protocol/1]).
 
 %% Used by TCP-based transports, e.g. STOMP adapter
 -export([tcp_listener_addresses/1,
@@ -250,6 +251,13 @@ stop_ranch_listener_of_protocol(Protocol) ->
         Ref       ->
             rabbit_log:debug("Stopping Ranch listener for protocol ~ts", [Protocol]),
             ranch:stop_listener(Ref)
+    end.
+
+-spec list_local_connections_of_protocol(atom()) -> [pid()].
+list_local_connections_of_protocol(Protocol) ->
+    case ranch_ref_of_protocol(Protocol) of
+        undefined   -> [];
+        AcceptorRef -> ranch:procs(AcceptorRef, connections)
     end.
 
 -spec start_tcp_listener(

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -12,7 +12,10 @@
 -define(PERSISTENT_TERM_EXCHANGE, mqtt_exchange).
 -define(DEFAULT_MQTT_EXCHANGE, <<"amq.topic">>).
 -define(MQTT_GUIDE_URL, <<"https://rabbitmq.com/docs/mqtt/">>).
+-define(WEB_MQTT_GUIDE_URL, <<"https://rabbitmq.com/docs/web-mqtt/">>).
 
+-define(MQTT_TCP_PROTOCOL, 'mqtt').
+-define(MQTT_TLS_PROTOCOL, 'mqtt/ssl').
 -define(MQTT_PROTO_V3, mqtt310).
 -define(MQTT_PROTO_V4, mqtt311).
 -define(MQTT_PROTO_V5, mqtt50).

--- a/deps/rabbitmq_mqtt/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListMqttConnectionsCommand.erl
+++ b/deps/rabbitmq_mqtt/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListMqttConnectionsCommand.erl
@@ -80,7 +80,6 @@ run(Args, #{node := NodeName,
         InfoKeys,
         length(Nodes)).
 
-
 banner(_, _) -> <<"Listing MQTT connections ...">>.
 
 output(Result, _Opts) ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
@@ -62,7 +62,7 @@ emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
 
 -spec emit_connection_info_local(rabbit_types:info_keys(), reference(), pid()) -> ok.
 emit_connection_info_local(Items, Ref, AggregatorPid) ->
-    LocalPids = local_connection_pids(),
+    LocalPids = list_local_mqtt_connections(),
     emit_connection_info(Items, Ref, AggregatorPid, LocalPids).
 
 emit_connection_info(Items, Ref, AggregatorPid, Pids) ->
@@ -92,6 +92,13 @@ local_connection_pids() ->
                                   pg:get_local_members(PgScope, Group)
                           end, pg:which_groups(PgScope))
     end.
+
+%% This function excludes Web MQTT connections
+list_local_mqtt_connections() ->
+    PlainPids = rabbit_networking:list_local_connections_of_protocol(?MQTT_TCP_PROTOCOL),
+    TLSPids   = rabbit_networking:list_local_connections_of_protocol(?MQTT_TLS_PROTOCOL),
+    PlainPids ++ TLSPids.
+
 
 init_global_counters() ->
     lists:foreach(fun init_global_counters/1, [?MQTT_PROTO_V3,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
@@ -13,9 +13,6 @@
 
 -export([start_link/2, init/1, stop_listeners/0]).
 
--define(TCP_PROTOCOL, 'mqtt').
--define(TLS_PROTOCOL, 'mqtt/ssl').
-
 start_link(Listeners, []) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, [Listeners]).
 
@@ -66,8 +63,8 @@ init([{Listeners, SslListeners0}]) ->
 
 -spec stop_listeners() -> ok.
 stop_listeners() ->
-    _ = rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
-    _ = rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
+    _ = rabbit_networking:stop_ranch_listener_of_protocol(?MQTT_TCP_PROTOCOL),
+    _ = rabbit_networking:stop_ranch_listener_of_protocol(?MQTT_TLS_PROTOCOL),
     ok.
 
 %%
@@ -86,7 +83,7 @@ tcp_listener_spec([Address, SocketOpts, NumAcceptors, ConcurrentConnsSups]) ->
       rabbit_mqtt_listener_sup,
       Address,
       SocketOpts,
-      transport(?TCP_PROTOCOL),
+      transport(?MQTT_TCP_PROTOCOL),
       rabbit_mqtt_reader,
       [],
       mqtt,
@@ -101,7 +98,7 @@ ssl_listener_spec([Address, SocketOpts, SslOpts, NumAcceptors, ConcurrentConnsSu
       rabbit_mqtt_listener_sup,
       Address,
       SocketOpts ++ SslOpts,
-      transport(?TLS_PROTOCOL),
+      transport(?MQTT_TLS_PROTOCOL),
       rabbit_mqtt_reader,
       [],
       'mqtt/ssl',
@@ -111,7 +108,7 @@ ssl_listener_spec([Address, SocketOpts, SslOpts, NumAcceptors, ConcurrentConnsSu
       "MQTT TLS listener"
      ).
 
-transport(?TCP_PROTOCOL) ->
+transport(?MQTT_TCP_PROTOCOL) ->
     ranch_tcp;
-transport(?TLS_PROTOCOL) ->
+transport(?MQTT_TLS_PROTOCOL) ->
     ranch_ssl.

--- a/deps/rabbitmq_web_mqtt/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListWebMqttConnectionsCommand.erl
+++ b/deps/rabbitmq_web_mqtt/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListWebMqttConnectionsCommand.erl
@@ -4,9 +4,9 @@
 %%
 %% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 
--module('Elixir.RabbitMQ.CLI.Ctl.Commands.ListMqttConnectionsCommand').
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.ListWebMqttConnectionsCommand').
 
--include("rabbit_mqtt.hrl").
+-include_lib("rabbitmq_mqtt/include/rabbit_mqtt.hrl").
 
 -behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
 
@@ -30,10 +30,10 @@ scopes() -> [ctl, diagnostics].
 switches() -> [{verbose, boolean}].
 aliases() -> [{'V', verbose}].
 
-description() -> <<"Lists all MQTT connections">>.
+description() -> <<"Lists all Web MQTT connections">>.
 
 help_section() ->
-    {plugin, mqtt}.
+    {plugin, web_mqtt}.
 
 validate(Args, _) ->
     InfoItems = lists:map(fun atom_to_list/1, ?INFO_ITEMS),
@@ -49,7 +49,7 @@ merge_defaults(Args, Opts) ->
     {Args, maps:merge(#{verbose => false}, Opts)}.
 
 usage() ->
-    <<"list_mqtt_connections [<column> ...]">>.
+    <<"list_web_mqtt_connections [<column> ...]">>.
 
 usage_additional() ->
     Prefix = <<" must be one of ">>,
@@ -59,7 +59,7 @@ usage_additional() ->
     ].
 
 usage_doc_guides() ->
-    [?MQTT_GUIDE_URL].
+    [?WEB_MQTT_GUIDE_URL].
 
 run(Args, #{node := NodeName,
             timeout := Timeout,
@@ -73,15 +73,14 @@ run(Args, #{node := NodeName,
 
     'Elixir.RabbitMQ.CLI.Ctl.RpcStream':receive_list_items(
         NodeName,
-        rabbit_mqtt,
+        rabbit_web_mqtt_app,
         emit_connection_info_all,
         [Nodes, InfoKeys],
         Timeout,
         InfoKeys,
         length(Nodes)).
 
-
-banner(_, _) -> <<"Listing MQTT connections ...">>.
+banner(_, _) -> <<"Listing Web MQTT connections ...">>.
 
 output(Result, _Opts) ->
     'Elixir.RabbitMQ.CLI.DefaultOutput':output(Result).

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_app.erl
@@ -12,7 +12,9 @@
     start/2,
     prep_stop/1,
     stop/1,
-    list_connections/0
+    list_connections/0,
+    emit_connection_info_all/4,
+    emit_connection_info_local/3
 ]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
@@ -48,26 +50,32 @@ init([]) -> {ok, {{one_for_one, 1, 5}, []}}.
 
 -spec list_connections() -> [pid()].
 list_connections() ->
-    PlainPids = connection_pids_of_protocol(?TCP_PROTOCOL),
-    TLSPids   = connection_pids_of_protocol(?TLS_PROTOCOL),
+    PlainPids = rabbit_networking:list_local_connections_of_protocol(?TCP_PROTOCOL),
+    TLSPids   = rabbit_networking:list_local_connections_of_protocol(?TLS_PROTOCOL),
     PlainPids ++ TLSPids.
 
+-spec emit_connection_info_all([node()], rabbit_types:info_keys(), reference(), pid()) -> term().
+emit_connection_info_all(Nodes, Items, Ref, AggregatorPid) ->
+    Pids = [spawn_link(Node, ?MODULE, emit_connection_info_local,
+                       [Items, Ref, AggregatorPid])
+            || Node <- Nodes],
+
+    rabbit_control_misc:await_emitters_termination(Pids).
+
+-spec emit_connection_info_local(rabbit_types:info_keys(), reference(), pid()) -> ok.
+emit_connection_info_local(Items, Ref, AggregatorPid) ->
+    LocalPids = list_connections(),
+    emit_connection_info(Items, Ref, AggregatorPid, LocalPids).
+
+emit_connection_info(Items, Ref, AggregatorPid, Pids) ->
+    rabbit_control_misc:emitting_map_with_exit_handler(
+      AggregatorPid, Ref,
+      fun(Pid) ->
+              rabbit_web_mqtt_handler:info(Pid, Items)
+      end, Pids).
 %%
 %% Implementation
 %%
-
-connection_pids_of_protocol(Protocol) ->
-    case rabbit_networking:ranch_ref_of_protocol(Protocol) of
-        undefined   -> [];
-        AcceptorRef ->
-            lists:map(fun cowboy_ws_connection_pid/1, ranch:procs(AcceptorRef, connections))
-    end.
-
--spec cowboy_ws_connection_pid(pid()) -> pid().
-cowboy_ws_connection_pid(RanchConnPid) ->
-    Children = supervisor:which_children(RanchConnPid),
-    {cowboy_clear, Pid, _, _} = lists:keyfind(cowboy_clear, 1, Children),
-    Pid.
 
 mqtt_init() ->
     CowboyOpts0  = maps:from_list(get_env(cowboy_opts, [])),

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -23,6 +23,7 @@
 ]).
 
 -export([conserve_resources/3]).
+-export([info/2]).
 
 %% cowboy_sub_protocol
 -export([upgrade/4,
@@ -94,6 +95,19 @@ init(Req, Opts) ->
             end
     end.
 
+%% We cannot use a gen_server call, because the handler process is a
+%% special cowboy_websocket process (not a gen_server) which assumes
+%% all gen_server calls are supervisor calls, and does not pass on the
+%% request to this callback module. (see cowboy_websocket:loop/3 and
+%% cowboy_children:handle_supervisor_call/4) However using a generic
+%% gen:call with a special label ?MODULE works fine.
+-spec info(pid(), rabbit_types:info_keys()) ->
+    rabbit_types:infos().
+info(Pid, all) ->
+    info(Pid, ?INFO_ITEMS);
+info(Pid, Items) ->
+    {ok, Res} = gen:call(Pid, ?MODULE, {info, Items}),
+    Res.
 -spec websocket_init(state()) ->
     {cowboy_websocket:commands(), state()} |
     {cowboy_websocket:commands(), state(), hibernate}.
@@ -243,6 +257,10 @@ websocket_info(connection_created, State) ->
     Infos = infos(?EVENT_KEYS, State),
     rabbit_core_metrics:connection_created(self(), Infos),
     rabbit_event:notify(connection_created, Infos),
+    {[], State, hibernate};
+websocket_info({?MODULE, From, {info, Items}}, State) ->
+    Infos = infos(Items, State),
+    gen:reply(From, Infos),
     {[], State, hibernate};
 websocket_info(Msg, State) ->
     ?LOG_WARNING("Web MQTT: unexpected message ~tp", [Msg]),

--- a/deps/rabbitmq_web_mqtt/test/rabbit_web_mqtt_test_util.erl
+++ b/deps/rabbitmq_web_mqtt/test/rabbit_web_mqtt_test_util.erl
@@ -1,0 +1,39 @@
+-module(rabbit_web_mqtt_test_util).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([connect/3,
+         connect/4
+        ]).
+
+connect(ClientId, Config, AdditionalOpts) ->
+    connect(ClientId, Config, 0, AdditionalOpts).
+
+connect(ClientId, Config, Node, AdditionalOpts) ->
+    {C, Connect} = start_client(ClientId, Config, Node, AdditionalOpts),
+    {ok, _Properties} = Connect(C),
+    C.
+
+start_client(ClientId, Config, Node, AdditionalOpts) ->
+    {Port, WsOpts, Connect} =
+    case rabbit_ct_helpers:get_config(Config, websocket, false) of
+        false ->
+            {rabbit_ct_broker_helpers:get_node_config(Config, Node, tcp_port_mqtt),
+             [],
+             fun emqtt:connect/1};
+        true ->
+            {rabbit_ct_broker_helpers:get_node_config(Config, Node, tcp_port_web_mqtt),
+             [{ws_path, "/ws"}],
+             fun emqtt:ws_connect/1}
+    end,
+    ProtoVer = proplists:get_value(
+                 proto_ver,
+                 AdditionalOpts,
+                 rabbit_ct_helpers:get_config(Config, mqtt_version, v4)),
+    Options = [{host, "localhost"},
+               {port, Port},
+               {proto_ver, ProtoVer},
+               {clientid, rabbit_data_coercion:to_binary(ClientId)}
+              ] ++ WsOpts ++ AdditionalOpts,
+    {ok, C} = emqtt:start_link(Options),
+    {C, Connect}.


### PR DESCRIPTION
## Proposed Changes

Fixes #9302

As described in the discussion list MQTT connection gives a `:not_found` when listing Web MQTT connections so we've provided a separated command for listing web MQTT connections.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Regarding tests for this feature, we were not sure whether to provide them under the `rabbitmq_mqtt` plugin or under `rabbitmq_web_mqtt` since there are some tests/utilities for testing Web MQTT connections under `deps/rabbitmq_mqtt`. Any hints on where said tests should get placed?
