### PR TITLE
CLI: update guide URLs to use the website new path structure

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/doc_guide.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/doc_guide.ex
@@ -18,7 +18,7 @@ defmodule RabbitMQ.CLI.Core.DocGuide.Macros do
 
     quote do
       def unquote(fn_name)() do
-        unquote("https://#{domain}/#{path_segment}.html")
+        unquote("https://#{domain}/docs/#{path_segment}/")
       end
     end
   end

--- a/deps/rabbitmq_federation/include/rabbit_federation.hrl
+++ b/deps/rabbitmq_federation/include/rabbit_federation.hrl
@@ -43,6 +43,6 @@
 -define(DOWNSTREAM_VHOST_ARG, <<"x-downstream-vhost">>).
 -define(DEF_PREFETCH, 1000).
 
--define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/federation.html">>).
+-define(FEDERATION_GUIDE_URL, <<"https://rabbitmq.com/docs/federation/">>).
 
 -define(FEDERATION_PG_SCOPE, rabbitmq_federation_pg_scope).

--- a/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
+++ b/deps/rabbitmq_mqtt/include/rabbit_mqtt.hrl
@@ -11,7 +11,7 @@
 -define(PERSISTENT_TERM_MAILBOX_SOFT_LIMIT, mqtt_mailbox_soft_limit).
 -define(PERSISTENT_TERM_EXCHANGE, mqtt_exchange).
 -define(DEFAULT_MQTT_EXCHANGE, <<"amq.topic">>).
--define(MQTT_GUIDE_URL, <<"https://rabbitmq.com/mqtt.html">>).
+-define(MQTT_GUIDE_URL, <<"https://rabbitmq.com/docs/mqtt/">>).
 
 -define(MQTT_PROTO_V3, mqtt310).
 -define(MQTT_PROTO_V4, mqtt311).

--- a/deps/rabbitmq_shovel/include/rabbit_shovel.hrl
+++ b/deps/rabbitmq_shovel/include/rabbit_shovel.hrl
@@ -28,4 +28,4 @@
 -define(DEFAULT_ACK_MODE, on_confirm).
 -define(DEFAULT_RECONNECT_DELAY, 5).
 
--define(SHOVEL_GUIDE_URL, <<"https://rabbitmq.com/shovel.html">>).
+-define(SHOVEL_GUIDE_URL, <<"https://rabbitmq.com/docs/shovel">>).

--- a/deps/rabbitmq_stomp/include/rabbit_stomp.hrl
+++ b/deps/rabbitmq_stomp/include/rabbit_stomp.hrl
@@ -39,6 +39,6 @@
          ssl_cipher,
          ssl_hash]).
 
--define(STOMP_GUIDE_URL, <<"https://rabbitmq.com/stomp.html">>).
+-define(STOMP_GUIDE_URL, <<"https://rabbitmq.com/docs/stomp">>).
 
 -define(DEFAULT_MAX_FRAME_SIZE, 4 * 1024 * 1024).

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddSuperStreamCommand.erl
@@ -168,7 +168,7 @@ usage_additional() ->
       <<"The initial cluster size of partition streams.">>]].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run([SuperStream],
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DeleteSuperStreamCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DeleteSuperStreamCommand.erl
@@ -58,7 +58,7 @@ usage_additional() ->
      [<<"--vhost <vhost>">>, <<"The virtual host of the super stream.">>]].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run([SuperStream],
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConnectionsCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConnectionsCommand.erl
@@ -79,7 +79,7 @@ usage_additional() ->
     [{<<"<column>">>, <<Prefix/binary, InfoItems/binary>>}].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run(Args,
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumerGroupsCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumerGroupsCommand.erl
@@ -83,7 +83,7 @@ usage_additional() ->
     [{<<"<column>">>, <<Prefix/binary, InfoItems/binary>>}].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run(Args,
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumersCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamConsumersCommand.erl
@@ -82,7 +82,7 @@ usage_additional() ->
     [{<<"<column>">>, <<Prefix/binary, InfoItems/binary>>}].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run(Args,
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamGroupConsumersCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamGroupConsumersCommand.erl
@@ -86,7 +86,7 @@ usage_additional() ->
     [{<<"<column>">>, <<Prefix/binary, InfoItems/binary>>}].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run(Args,
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamPublishersCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamPublishersCommand.erl
@@ -82,7 +82,7 @@ usage_additional() ->
     [{<<"<column>">>, <<Prefix/binary, InfoItems/binary>>}].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run(Args,
     #{node := NodeName,

--- a/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamTrackingCommand.erl
+++ b/deps/rabbitmq_stream/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListStreamTrackingCommand.erl
@@ -91,7 +91,7 @@ usage_additional() ->
       <<"The virtual host of the stream.">>]].
 
 usage_doc_guides() ->
-    [?STREAM_GUIDE_URL].
+    [?STREAMS_GUIDE_URL].
 
 run([Stream],
     #{node := NodeName,

--- a/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
+++ b/deps/rabbitmq_stream_common/include/rabbit_stream.hrl
@@ -152,4 +152,4 @@
   state
 ]).
 
--define(STREAM_GUIDE_URL, <<"https://rabbitmq.com/stream.html">>).
+-define(STREAMS_GUIDE_URL, <<"https://rabbitmq.com/docs/streams">>).


### PR DESCRIPTION
the original paths, e.g. /streams.html, do have redirects in place but it turned out to be a surprisingly fragile Cloudflare feature when there are hundreds of them, so we better switch now.
