### PR TITLE
rabbit_env: Correctly pass `TakeFromRemoteNode` argument to `update_context/3`

### DIFF
--- a/deps/rabbit_common/src/rabbit_env.erl
+++ b/deps/rabbit_common/src/rabbit_env.erl
@@ -194,7 +194,7 @@ context_base(TakeFromRemoteNode) ->
                Timeout >= 0 ->
             update_context(Context,
                            from_remote_node,
-                           {TakeFromRemoteNode, Timeout})
+                           TakeFromRemoteNode)
     end.
 
 -ifdef(TEST).
@@ -2146,7 +2146,8 @@ maybe_stop_dist_for_remote_query(
 maybe_stop_dist_for_remote_query(Context) ->
     Context.
 
-query_remote({RemoteNode, Timeout}, Mod, Func, Args) ->
+query_remote({RemoteNode, Timeout}, Mod, Func, Args)
+  when is_atom(RemoteNode) ->
     Ret = rpc:call(RemoteNode, Mod, Func, Args, Timeout),
     case Ret of
         {badrpc, nodedown} = Error -> Error;

--- a/deps/rabbit_common/test/rabbit_env_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_env_SUITE.erl
@@ -383,7 +383,8 @@ check_values_from_reachable_remote_node(Config) ->
 
     try
         persistent_term:put({rabbit_env, os_type}, {unix, undefined}),
-        UnixContext = rabbit_env:get_context(Node),
+        TakeFromRemoteNode = {Node, 120000},
+        UnixContext = rabbit_env:get_context(TakeFromRemoteNode),
 
         persistent_term:erase({rabbit_env, os_type}),
 
@@ -447,7 +448,7 @@ check_values_from_reachable_remote_node(Config) ->
              erlang_dist_tcp_port => 25672,
              feature_flags_file => FeatureFlagsFile,
              forced_feature_flags_on_init => RFFValue,
-             from_remote_node => {Node, 10000},
+             from_remote_node => TakeFromRemoteNode,
              interactive_shell => false,
              keep_pid_file_on_exit => false,
              log_base_dir => "/var/log/rabbitmq",


### PR DESCRIPTION
## Why

The given `TakeFromRemoteNode` argument was unpacked and another tuple
was created to pass to `update_context/3`. However, the constructed
tuple would be:  

```
{{Node, Timeout}, Timeout}
```

… which is incorrect.