### PR TITLE
Dedupe ?awaitMatch/4 in rabbit_assert.hrl

### DIFF
--- a/deps/rabbitmq_ct_helpers/include/rabbit_assert.hrl
+++ b/deps/rabbitmq_ct_helpers/include/rabbit_assert.hrl
@@ -25,25 +25,4 @@
         end).
 
 -define(awaitMatch(Guard, Expr, Timeout),
-        begin
-            ((fun AwaitMatchFilter(AwaitMatchHorizon) ->
-                      AwaitMatchResult = Expr,
-                      case (AwaitMatchResult) of
-                          Guard -> AwaitMatchResult;
-                          __V -> case erlang:system_time(millisecond) of
-                                     AwaitMatchNow when AwaitMatchNow < AwaitMatchHorizon ->
-                                         timer:sleep(
-                                           min(?AWAIT_MATCH_DEFAULT_POLLING_INTERVAL,
-                                               AwaitMatchHorizon - AwaitMatchNow)),
-                                         AwaitMatchFilter(AwaitMatchHorizon);
-                                     _ ->
-                                         erlang:error({awaitMatch,
-                                                       [{module, ?MODULE},
-                                                        {line, ?LINE},
-                                                        {expression, (??Expr)},
-                                                        {pattern, (??Guard)},
-                                                        {value, __V}]})
-                                 end
-                      end
-              end)(erlang:system_time(millisecond) + Timeout))
-        end).
+        ?awaitMatch(Guard, Expr, Timeout, ?AWAIT_MATCH_DEFAULT_POLLING_INTERVAL)).


### PR DESCRIPTION
when originally written, I didn't know macros would get recursively expanded