### PR TITLE
Store management UI OIDC tokens in localStorage instead of sessionStorage

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -88,7 +88,7 @@ function auth_settings_apply_defaults(authSettings) {
 
 function oauth_initialize_user_manager(resource_server) {
     oidcSettings = {
-        //userStore: new WebStorageStateStore({ store: window.localStorage }),
+        userStore: new oidc.WebStorageStateStore({ store: window.localStorage }),
         authority: resource_server.oauth_provider_url,
         client_id: resource_server.oauth_client_id,
         response_type: resource_server.oauth_response_type,


### PR DESCRIPTION
## Proposed Changes

The main goal of this PR is to improve user experience when using OpenID Connect SSO in management UI. New behavior matches what users expect when using any web app.

Use of `sessionStorage` to keep tokens makes user experience extremely hostile, as separate tabs in a browser do not share the session. In addition to that, opening a new tab happens to initiate complete IdP signout if another signed in tab is open. None of these problems appear if `localStorage` is used.

Original author clearly had an idea to implement this, but for whatever reason kept this line commented out. Maybe because `WebStorageStateStore` type needs to be qualified with `oidc.`?


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes unexpected sign-outs)
- [x] New feature (non-breaking change which allows using management UI in multiple browser tabs)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

None
