### PR TITLE
rabbit_peer_discovery: Add pre/post discovery steps

### DIFF
--- a/deps/rabbit/test/unit_cluster_formation_locking_mocks_SUITE.erl
+++ b/deps/rabbit/test/unit_cluster_formation_locking_mocks_SUITE.erl
@@ -49,7 +49,7 @@ init_with_lock_exits_after_errors(_Config) ->
     meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> {error, "test error"} end),
     ?assertEqual(
        {error, "test error"},
-       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, missing@localhost, disc)),
+       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, undefined, missing@localhost, disc)),
     ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
     passed.
 
@@ -61,7 +61,7 @@ init_with_lock_ignore_after_errors(_Config) ->
     meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> {error, "test error"} end),
     ?assertEqual(
        {error, {aborted_feature_flags_compat_check, {error, feature_flags_file_not_set}}},
-       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, missing@localhost, disc)),
+       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, undefined, missing@localhost, disc)),
     ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
     passed.
 
@@ -69,7 +69,7 @@ init_with_lock_not_supported(_Config) ->
     meck:expect(rabbit_peer_discovery_classic_config, lock, fun(_) -> not_supported end),
     ?assertEqual(
        {error, {aborted_feature_flags_compat_check, {error, feature_flags_file_not_set}}},
-       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, missing@localhost, disc)),
+       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, undefined, missing@localhost, disc)),
     ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
     passed.
 
@@ -78,6 +78,6 @@ init_with_lock_supported(_Config) ->
     meck:expect(rabbit_peer_discovery_classic_config, unlock, fun(data) -> ok end),
     ?assertEqual(
        {error, {aborted_feature_flags_compat_check, {error, feature_flags_file_not_set}}},
-       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, missing@localhost, disc)),
+       rabbit_peer_discovery:join_selected_node(rabbit_peer_discovery_classic_config, undefined, missing@localhost, disc)),
     ?assert(meck:validate(rabbit_peer_discovery_classic_config)),
     passed.

--- a/deps/rabbit_common/src/rabbit_peer_discovery_backend.erl
+++ b/deps/rabbit_common/src/rabbit_peer_discovery_backend.erl
@@ -52,8 +52,38 @@
 
 -callback post_registration()   -> ok | {error, Reason :: string()}.
 
--callback lock(Nodes :: [node()]) -> {ok, Data :: term()} | not_supported | {error, Reason :: string()}.
+-callback pre_discovery() ->
+    {ok, BackendPriv :: backend_priv()} | {error, Reason :: string()}.
 
--callback unlock(Data :: term()) -> ok.
+-callback post_discovery(BackendPriv :: backend_priv()) ->
+    ok.
 
--optional_callbacks([init/0]).
+-callback lock(Nodes :: [node()]) ->
+    {ok, LockData :: lock_data()} |
+    not_supported |
+    {error, Reason :: string()}.
+
+-callback lock(Nodes :: [node()], BackendPriv :: term()) ->
+    {ok, LockData :: lock_data()} |
+    not_supported |
+    {error, Reason :: string()}.
+
+-callback unlock(LockData :: lock_data()) ->
+    ok.
+
+-callback unlock(LockData :: lock_data(), BackendPriv :: backend_priv()) ->
+    ok.
+
+-type backend_priv() :: any().
+-type lock_data() :: any().
+
+-optional_callbacks([init/0,
+                     pre_discovery/0,
+                     post_discovery/1,
+                     lock/1,
+                     lock/2,
+                     unlock/1,
+                     unlock/2]).
+
+-export_type([backend_priv/0,
+              lock_data/0]).

--- a/deps/rabbitmq_peer_discovery_consul/src/rabbitmq_peer_discovery_consul.erl
+++ b/deps/rabbitmq_peer_discovery_consul/src/rabbitmq_peer_discovery_consul.erl
@@ -9,7 +9,8 @@
 -behaviour(rabbit_peer_discovery_backend).
 
 -export([init/0, list_nodes/0, supports_registration/0, register/0, unregister/0,
-         post_registration/0, lock/1, unlock/1]).
+         post_registration/0, lock/2, unlock/2,
+         pre_discovery/0, post_discovery/1]).
 -export([send_health_check_pass/0]).
 -export([session_ttl_update_callback/1]).
 
@@ -42,13 +43,31 @@ unregister() ->
 post_registration() ->
     ?DELEGATE:post_registration().
 
--spec lock(Nodes :: [node()]) -> {ok, Data :: term()} | {error, Reason :: string()}.
-lock(Node) ->
-    ?DELEGATE:lock(Node).
+-spec pre_discovery() ->
+    {ok, BackendPriv :: rabbit_peer_discovery_backend:backend_priv()} |
+    {error, Reason :: string()}.
 
--spec unlock({SessionId :: string(), TRef :: timer:tref()}) -> ok.
-unlock(Data) ->
-    ?DELEGATE:unlock(Data).
+pre_discovery() ->
+    ?DELEGATE:pre_discovery().
+
+-spec post_discovery(BackendPriv :: rabbit_peer_discovery_backend:backend_priv()) ->
+    ok.
+
+post_discovery(BackendPriv) ->
+    ?DELEGATE:post_discovery(BackendPriv).
+
+-spec lock(Nodes :: [node()],
+           BackendPriv :: rabbit_peer_discovery_backend:backend_priv()) ->
+    {ok, ok} | {error, Reason :: string()}.
+
+lock(Node, BackendPriv) ->
+    ?DELEGATE:lock(Node, BackendPriv).
+
+-spec unlock(LockData :: rabbit_peer_discovery_backend:lock_data(),
+            BackendPriv :: rabbit_peer_discovery_backend:backend_priv()) ->
+    ok.
+unlock(LockData, BackendPriv) ->
+    ?DELEGATE:unlock(LockData, BackendPriv).
 
 -spec send_health_check_pass() -> ok.
 send_health_check_pass() ->


### PR DESCRIPTION
## Why

The Consul peer discovery backend needs to create a session before it can acquire a lock. This session is also required for nodes to discover each other.

This session was created as part of the lock callback. However, after pull request #9797, the lock was only acquired if and when a node had ot join another one. Thus, after the actual discovery phase. This broke Consul peer discovery because the discovery was performed before that Consul session was created.

## How

We introduce two new callbacks, `pre_discovery/0` and `post_discovery/1` to allow a backend to perform actions before and after the whole discover/lock/join process. The new callbacks are used by the Consul peer discovery backend to create and delete that session.

To remain compatible with other peer discovery backend, the new callbacks are optional.

Fixes #10760.