### PR TITLE
rabbit_env_SUITE: Wait for application env. to be ready

### DIFF
--- a/deps/rabbit_common/test/rabbit_env_SUITE.erl
+++ b/deps/rabbit_common/test/rabbit_env_SUITE.erl
@@ -493,9 +493,19 @@ consume_stdout(Port, Nodename) ->
 
 wait_for_remote_node(Nodename) ->
     case net_adm:ping(Nodename) of
-        pong -> ok;
-        pang -> timer:sleep(200),
-                wait_for_remote_node(Nodename)
+        pong ->
+            Ret = erpc:call(
+                    Nodename, application, get_env, [rabbit, plugins_dir]),
+            case Ret of
+                {ok, Val} when is_list(Val) ->
+                    ok;
+                _ ->
+                    timer:sleep(200),
+                    wait_for_remote_node(Nodename)
+            end;
+        pang ->
+            timer:sleep(200),
+            wait_for_remote_node(Nodename)
     end.
 
 check_values_from_offline_remote_node(_) ->


### PR DESCRIPTION
## Why

If the testcase run between the time the node is started and the time the `rabbit` application environment is loaded, it will fail.

## How

Instead of waiting for the node to be reachable only, we also wait for the `rabbit` application environment to be filled.