### PR TITLE
Revert Maven bump

### DIFF
--- a/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
+++ b/deps/rabbitmq_mqtt/test/java_SUITE_data/pom.xml
@@ -22,7 +22,7 @@
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <groovy-maven-plugin.version>2.1.1</groovy-maven-plugin.version>
     <groovy.version>2.4.21</groovy.version>
-    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <spotless.version>2.43.0</spotless.version>
     <google-java-format.version>1.17.0</google-java-format.version>
     <test-keystore.ca>${project.build.directory}/ca.keystore</test-keystore.ca>

--- a/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream/test/rabbit_stream_SUITE_data/pom.xml
@@ -30,7 +30,7 @@
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <assertj.version>3.25.3</assertj.version>
         <logback.version>1.2.13</logback.version>
-        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <spotless.version>2.43.0</spotless.version>
         <google-java-format.version>1.17.0</google-java-format.version>

--- a/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
+++ b/deps/rabbitmq_stream_management/test/http_SUITE_data/pom.xml
@@ -30,7 +30,7 @@
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <assertj.version>3.25.3</assertj.version>
         <logback.version>1.2.13</logback.version>
-        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <spotless.version>2.43.0</spotless.version>
         <google-java-format.version>1.18.1</google-java-format.version>


### PR DESCRIPTION
Revert the following pull requests that bumped the version of Maven:
* #10772
* #10773
* #10774

As seen in the CI reports on each of these pull requests, they break the Java-based tests because we only have Maven 3.6.3 available. They should not have been merged in the first place.