### PR TITLE
rabbitmq-server: Propagate exit code

### DIFF
--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -83,7 +83,7 @@ start_rabbitmq_server() {
 stop_rabbitmq_server() {
     if test "$rabbitmq_server_pid"; then
         kill -TERM "$rabbitmq_server_pid"
-        wait "$rabbitmq_server_pid" || true
+        wait "$rabbitmq_server_pid" || (exit $?)
     fi
 }
 
@@ -147,5 +147,5 @@ else
     # force that statement to succeed and the signal handler to properly
     # execute. Because the statement below has an exit code of 0, the
     # signal handler has to restate the expected exit code.
-    wait "$rabbitmq_server_pid" || true
+    wait "$rabbitmq_server_pid" || (exit $?)
 fi

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -83,7 +83,7 @@ start_rabbitmq_server() {
 stop_rabbitmq_server() {
     if test "$rabbitmq_server_pid"; then
         kill -TERM "$rabbitmq_server_pid"
-        wait "$rabbitmq_server_pid" || (exit $?)
+        wait "$rabbitmq_server_pid" || exit "$?"
     fi
 }
 

--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -147,5 +147,5 @@ else
     # force that statement to succeed and the signal handler to properly
     # execute. Because the statement below has an exit code of 0, the
     # signal handler has to restate the expected exit code.
-    wait "$rabbitmq_server_pid" || (exit $?)
+    wait "$rabbitmq_server_pid" || exit "$?"
 fi


### PR DESCRIPTION
## Proposed Changes

Exit code is useful for monitoring and process supervisors when it comes to deciding on what to do when the process exits, for example we may want to restart it or send a report. The current implementation of `rabbitmq-server` script does not propagate the exit code in a general case which makes it impossible to know whether the exit was clean and, for example, use restart policy `on-failure` in docker.

This change makes the exit code to be propagated.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
