### PR TITLE
Add v3.13.x to the bazel/make equivalence check

### DIFF
--- a/.github/workflows/check-build-system-equivalence-release-branches.yaml
+++ b/.github/workflows/check-build-system-equivalence-release-branches.yaml
@@ -8,7 +8,15 @@ jobs:
     uses: ./.github/workflows/check-build-system-equivalence.yaml
     with:
       ref: refs/heads/main
-      erlang_version: 26.1
+      erlang_version: 26.2
+      elixir_version: 1.15
+      project_version: 4.0.0
+
+  check-v3_13_x:
+    uses: ./.github/workflows/check-build-system-equivalence.yaml
+    with:
+      ref: refs/heads/v3.13.x
+      erlang_version: 26.2
       elixir_version: 1.15
       project_version: 3.13.0
 
@@ -19,11 +27,3 @@ jobs:
       erlang_version: 26.1
       elixir_version: 1.15
       project_version: 3.12.0
-
-  check-v3_11_x:
-    uses: ./.github/workflows/check-build-system-equivalence.yaml
-    with:
-      ref: refs/heads/v3.11.x
-      erlang_version: 26.1
-      elixir_version: 1.15
-      project_version: 3.11.0

--- a/.github/workflows/check-build-system-equivalence.yaml
+++ b/.github/workflows/check-build-system-equivalence.yaml
@@ -19,7 +19,7 @@ on:
       erlang_version:
         description: 'OTP version to build with'
         required: true
-        default: "26.1"
+        default: "26.2"
       elixir_version:
         description: 'Elixir version to build with'
         required: true
@@ -27,7 +27,7 @@ on:
       project_version:
         description: 'PROJECT_VERSION used for make'
         required: true
-        default: "3.13.0"
+        default: "4.0.0"
 env:
   erlang_version: ${{ inputs.erlang_version || github.event.inputs.erlang_version }}
   elixir_version: ${{ inputs.elixir_version || github.event.inputs.elixir_version }}


### PR DESCRIPTION
Also drop 3.11.x