### PR TITLE
rabbitmq-plugins list: allow warnings to be suppressed

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -25,10 +25,11 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
       minimal: :boolean,
       enabled: :boolean,
       implicitly_enabled: :boolean,
-      no_warn: :boolean
+      ignore_warnings: :boolean
     ]
 
-  def aliases(), do: [v: :verbose, m: :minimal, E: :enabled, e: :implicitly_enabled, o: :no_warn]
+  def aliases(),
+    do: [v: :verbose, m: :minimal, E: :enabled, e: :implicitly_enabled, o: :ignore_warnings]
 
   def validate(args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
@@ -59,7 +60,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
       minimal: minimal,
       enabled: only_enabled,
       implicitly_enabled: all_enabled,
-      no_warn: no_warn
+      ignore_warnings: ignore_warnings
     } =
       opts
 
@@ -68,7 +69,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
 
     missing = MapSet.difference(MapSet.new(enabled), MapSet.new(PluginHelpers.plugin_names(all)))
 
-    case Enum.empty?(missing) or no_warn do
+    case Enum.empty?(missing) or ignore_warnings do
       true ->
         :ok
 
@@ -121,7 +122,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   def banner([pattern], _), do: "Listing plugins with pattern \"#{pattern}\" ..."
 
   def usage,
-    do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled] [--no-warn]"
+    do:
+      "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled] [--ignore-warnings]"
 
   def usage_additional() do
     [
@@ -133,7 +135,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
       ],
       ["--enabled", "only list enabled plugins"],
       ["--implicitly-enabled", "include plugins enabled as dependencies of other plugins"],
-      ["--no-warn", "do not print warnings e.g. for plugins missing"]
+      ["--ignore-warnings", "do not print warnings e.g. for plugins missing"]
     ]
   end
 
@@ -200,6 +202,12 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   end
 
   defp default_opts() do
-    %{minimal: false, verbose: false, enabled: false, implicitly_enabled: false, no_warn: false}
+    %{
+      minimal: false,
+      verbose: false,
+      enabled: false,
+      implicitly_enabled: false,
+      ignore_warnings: false
+    }
   end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -20,7 +20,13 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   def merge_defaults(args, opts), do: {args, Map.merge(default_opts(), opts)}
 
   def switches(),
-    do: [verbose: :boolean, minimal: :boolean, enabled: :boolean, implicitly_enabled: :boolean, no_warn: :boolean]
+    do: [
+      verbose: :boolean,
+      minimal: :boolean,
+      enabled: :boolean,
+      implicitly_enabled: :boolean,
+      no_warn: :boolean
+    ]
 
   def aliases(), do: [v: :verbose, m: :minimal, E: :enabled, e: :implicitly_enabled, o: :no_warn]
 
@@ -48,7 +54,13 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   end
 
   def run([pattern], %{node: node_name} = opts) do
-    %{verbose: verbose, minimal: minimal, enabled: only_enabled, implicitly_enabled: all_enabled, no_warn: no_warn} =
+    %{
+      verbose: verbose,
+      minimal: minimal,
+      enabled: only_enabled,
+      implicitly_enabled: all_enabled,
+      no_warn: no_warn
+    } =
       opts
 
     all = PluginHelpers.list(opts)
@@ -56,7 +68,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
 
     missing = MapSet.difference(MapSet.new(enabled), MapSet.new(PluginHelpers.plugin_names(all)))
 
-    case (Enum.empty?(missing) or no_warn) do
+    case Enum.empty?(missing) or no_warn do
       true ->
         :ok
 
@@ -108,7 +120,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
 
   def banner([pattern], _), do: "Listing plugins with pattern \"#{pattern}\" ..."
 
-  def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled] [--no-warn]"
+  def usage,
+    do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled] [--no-warn]"
 
   def usage_additional() do
     [

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -116,11 +116,11 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
       ["--verbose", "output more information"],
       [
         "--minimal",
-        "only print plugin names. Most useful in compbination with --silent and --enabled."
+        "only print plugin names. Most useful in combination with --silent and --enabled."
       ],
       ["--enabled", "only list enabled plugins"],
       ["--implicitly-enabled", "include plugins enabled as dependencies of other plugins"],
-      ["--no-warn", "do not print warnings e.g. for plugins missings"]
+      ["--no-warn", "do not print warnings e.g. for plugins missing"]
     ]
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -197,7 +197,7 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
 
     no_warn = Map.get(opts, :no_warn, false)
 
-    case (Enum.empty?(missing) or no_warn) do
+    case Enum.empty?(missing) or no_warn do
       true ->
         case :rabbit_file.write_term_file(to_charlist(plugins_file), [plugins]) do
           :ok ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -195,9 +195,9 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     all_plugin_names = Enum.map(all, &plugin_name/1)
     missing = MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
 
-    no_warn = Map.get(opts, :no_warn, false)
+    ignore_warnings = Map.get(opts, :ignore_warnings, false)
 
-    case Enum.empty?(missing) or no_warn do
+    case Enum.empty?(missing) or ignore_warnings do
       true ->
         case :rabbit_file.write_term_file(to_charlist(plugins_file), [plugins]) do
           :ok ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -195,7 +195,9 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     all_plugin_names = Enum.map(all, &plugin_name/1)
     missing = MapSet.difference(MapSet.new(plugins), MapSet.new(all_plugin_names))
 
-    case Enum.empty?(missing) do
+    no_warn = Map.get(opts, :no_warn, false)
+
+    case (Enum.empty?(missing) or no_warn) do
       true ->
         case :rabbit_file.write_term_file(to_charlist(plugins_file), [plugins]) do
           :ok ->

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -454,7 +454,13 @@ defmodule ListPluginsCommandTest do
     missing_plugin = :rabbitmq_non_existent
 
     reset_enabled_plugins_to_preconfigured_defaults(context)
-    set_enabled_plugins([:rabbitmq_federation, missing_plugin], :online, context[:opts][:node], context[:opts])
+
+    set_enabled_plugins(
+      [:rabbitmq_federation, missing_plugin],
+      :online,
+      context[:opts][:node],
+      context[:opts]
+    )
 
     on_exit(fn ->
       set_enabled_plugins(
@@ -473,24 +479,21 @@ defmodule ListPluginsCommandTest do
     opts = context[:opts]
 
     assert capture_io(fn ->
-      %{
-        plugins: actual_plugins
-      } = @command.run([".*"], opts)
+             %{
+               plugins: actual_plugins
+             } = @command.run([".*"], opts)
 
-      assert_plugin_states(actual_plugins, expected_plugins)
-
-    end) =~ ~s//
+             assert_plugin_states(actual_plugins, expected_plugins)
+           end) =~ ~s//
 
     opts = Map.replace(opts, :no_warn, false)
 
     assert capture_io(fn ->
-      %{
-        plugins: actual_plugins
-      } = @command.run([".*"], opts)
+             %{
+               plugins: actual_plugins
+             } = @command.run([".*"], opts)
 
-      assert_plugin_states(actual_plugins, expected_plugins)
-
-    end) =~ ~s/WARNING - plugins currently enabled but missing: #{missing_plugin}\n/
-
+             assert_plugin_states(actual_plugins, expected_plugins)
+           end) =~ ~s/WARNING - plugins currently enabled but missing: #{missing_plugin}\n/
   end
 end

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -39,7 +39,7 @@ defmodule ListPluginsCommandTest do
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
 
     IO.puts(
-      "plugins list tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
+      "plugins list tests will assume that #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
     )
 
     opts = %{

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -50,7 +50,7 @@ defmodule ListPluginsCommandTest do
       verbose: false,
       enabled: false,
       implicitly_enabled: false,
-      no_warn: false
+      ignore_warnings: false
     }
 
     on_exit(fn ->
@@ -448,7 +448,7 @@ defmodule ListPluginsCommandTest do
   end
 
   test "run: lists all plugins with missing plugins warning control", context do
-    opts = Map.replace(context[:opts], :no_warn, true)
+    opts = Map.replace(context[:opts], :ignore_warnings, true)
     context = Map.replace(context, :opts, opts)
 
     missing_plugin = :rabbitmq_non_existent
@@ -486,7 +486,7 @@ defmodule ListPluginsCommandTest do
              assert_plugin_states(actual_plugins, expected_plugins)
            end) =~ ~s//
 
-    opts = Map.replace(opts, :no_warn, false)
+    opts = Map.replace(opts, :ignore_warnings, false)
 
     assert capture_io(fn ->
              %{


### PR DESCRIPTION
## Proposed Changes

Some tools list plugins e.g. in `json` format, and can fail to decode output from missing plugins warning banner. We want to be able to optionally list plugins with no warning banner - avoiding any extra work on calling tools (e.g. in the case of sharing config files across new and legacy brokers). Example, with `rabbitmq_unknown` in enabled_plugins file:

#### with warning
```
ayanda@host$ rabbitmq-plugins list --formatter json
WARNING - plugins currently enabled but missing: rabbitmq_unknown

{"status":"running","format":"normal","plugins":[{"enabled":"not_enabled","name":"rabbitmq_amqp1_0","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_cache","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_http","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_ldap","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_oauth2","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_mechanism_ssl","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_consistent_hash_exchange","running":false,"version":[51,46,49
```

#### with no warning

```
ayanda@host$ rabbitmq-plugins list --formatter json --ignore-warnings
{"status":"running","format":"normal","plugins":[{"enabled":"not_enabled","name":"rabbitmq_amqp1_0","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_cache","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_http","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_ldap","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_backend_oauth2","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_auth_mechanism_ssl","running":false,"version":[51,46,49,50,46,56],"running_version":null},{"enabled":"not_enabled","name":"rabbitmq_consistent_hash_exchange","running":false,"version":[51,46,49
```

**NOTE**: --silent and --quiet options more for generic CommandBehaviour messages

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
