### PR TITLE
Bump Khepri to v0.13.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -293,11 +293,13 @@ erlang_package.hex_package(
     version = "1.4.1",
 )
 
-erlang_package.hex_package(
+erlang_package.git_package(
     name = "khepri",
     build_file = "@rabbitmq-server//bazel:BUILD.khepri",
-    sha256 = "0b6ff09fabf27cb1e8df0f976149305ad936abd17233263b36ccc7becbf31cb3",
-    version = "0.12.1",
+    commit = "e3b7b7bc7df0545d829b371fbefc052114fc0e2e",
+    repository = "rabbitmq/khepri",
+    # sha256 = "0b6ff09fabf27cb1e8df0f976149305ad936abd17233263b36ccc7becbf31cb3",
+    # version = "0.12.1",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1015,9 +1015,17 @@ register_projections() ->
                     fun register_rabbit_index_route_projection/0,
                     fun register_rabbit_topic_graph_projection/0],
     [case RegisterFun() of
-         ok              -> ok;
-         {error, exists} -> ok;
-         {error, Error}  -> throw(Error)
+         ok ->
+             ok;
+         %% Before Khepri v0.13.0, `khepri:register_projection/1,2,3` would
+         %% return `{error, exists}` for projections which already exist.
+         {error, exists} ->
+             ok;
+         %% In v0.13.0+, Khepri returns a `?khepri_error(..)` instead.
+         {error, {khepri, projection_already_exists, _Info}} ->
+             ok;
+         {error, Error} ->
+             throw(Error)
      end || RegisterFun <- RegisterFuns],
     ok.
 


### PR DESCRIPTION
Khepri v0.13.0 contains a fix for how projections are handled during registration and recovery. The error returned from `khepri:register_projection/1,2,3` has also been updated to use the `?khepri_error(..)` helper macro.