### PR TITLE
rabbitmq-plugins list: respect --silent and --quiet

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -7,7 +7,7 @@
 defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   import RabbitCommon.Records
 
-  alias RabbitMQ.CLI.Core.{DocGuide, Validators}
+  alias RabbitMQ.CLI.Core.{Config, DocGuide, Validators}
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   import RabbitMQ.CLI.Core.{CodePath, Paths}
 
@@ -61,8 +61,14 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
         :ok
 
       false ->
-        names = Enum.join(Enum.to_list(missing), ", ")
-        IO.puts("WARNING - plugins currently enabled but missing: #{names}\n")
+        case Config.output_less?(opts) do
+          false ->
+            names = Enum.join(Enum.to_list(missing), ", ")
+            IO.puts("WARNING - plugins currently enabled but missing: #{names}\n")
+
+          true ->
+            :ok
+        end
     end
 
     implicit = :rabbit_plugins.dependencies(false, enabled, all)
@@ -172,8 +178,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
 
     %{
       name: name,
-      version: version,
-      running_version: running[name],
+      version: to_string(version),
+      running_version: to_string(running[name]),
       enabled: enabled_mode,
       running: Keyword.has_key?(running, name)
     }

--- a/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/list_plugins_command_test.exs
@@ -38,7 +38,7 @@ defmodule ListPluginsCommandTest do
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
 
     IO.puts(
-      "plugins list tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
+      "plugins list tests will assume that #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to"
     )
 
     opts = %{


### PR DESCRIPTION
When emitting warnings.

Originally suggested in #10865 by @Ayanda-D.

The test in #10865 that enables a non-existent plugin is incompatible with Make-based builds,
so it's not worth adding given the very narrow scope of this PR.

Perhaps an event better, but also much larger in scope, approach to this, would be to make the decision based on the `--formatter` used. However, machine-readable `--formatter`s should be used with `-s`, `--silent` virtually all the time, and other commands suppress their additional output based on `-s` or `-q`.