### PR TITLE
Remove deprecated queue_explicit_gc_run_operation_threshold config

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -116,9 +116,6 @@ _APP_ENV = """[
 	    {cluster_nodes, {[], disc}},
 
 	    {config_entry_decoder, [{passphrase, undefined}]},
-
-	    %% rabbitmq-server#973
-	    {queue_explicit_gc_run_operation_threshold, 1000},
 	    {background_gc_enabled, false},
 	    {background_gc_target_interval, 60000},
 	    %% rabbitmq-server#589

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -99,9 +99,6 @@ define PROJECT_ENV
 	    {cluster_nodes, {[], disc}},
 
 	    {config_entry_decoder, [{passphrase, undefined}]},
-
-	    %% rabbitmq-server#973
-	    {queue_explicit_gc_run_operation_threshold, 1000},
 	    {background_gc_enabled, false},
 	    {background_gc_target_interval, 60000},
 	    %% rabbitmq-server#589

--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -193,18 +193,12 @@ end_per_group1(_, Config) ->
 
 init_per_testcase(Testcase, Config) when Testcase == variable_queue_requeue;
                                          Testcase == variable_queue_fold ->
-    ok = rabbit_ct_broker_helpers:rpc(
-           Config, 0, application, set_env,
-           [rabbit, queue_explicit_gc_run_operation_threshold, 0]),
     rabbit_ct_helpers:testcase_started(Config, Testcase);
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) when Testcase == variable_queue_requeue;
                                         Testcase == variable_queue_fold ->
-    ok = rabbit_ct_broker_helpers:rpc(
-           Config, 0, application, set_env,
-           [rabbit, queue_explicit_gc_run_operation_threshold, 1000]),
     rabbit_ct_helpers:testcase_finished(Config, Testcase);
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).


### PR DESCRIPTION
## Proposed Changes

Removing `queue_explicit_gc_run_operation_threshold` config which seems to have been deprecated in https://github.com/rabbitmq/rabbitmq-server/pull/4522 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
