### PR TITLE
Be more defensive when importing definitions where some virtual hosts do not have a default queue type

### DIFF
--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -318,7 +318,7 @@ put_vhost(Name, Description, Tags0, Trace, Username) ->
     boolean(),
     rabbit_types:username()) ->
     'ok' | {'error', any()} | {'EXIT', any()}.
-put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
+put_vhost(Name, Description, Tags0, DefaultQueueType0, Trace, Username) ->
     Tags = case Tags0 of
       undefined   -> <<"">>;
       null        -> <<"">>;
@@ -326,6 +326,10 @@ put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
       "null"      -> <<"">>;
       Other       -> Other
     end,
+    DefaultQueueType = case DefaultQueueType0 of
+        <<"undefined">> -> undefined;
+        _ -> DefaultQueueType0
+    end,     
     ParsedTags = parse_tags(Tags),
     rabbit_log:debug("Parsed tags ~tp to ~tp", [Tags, ParsedTags]),
     Result = case exists(Name) of


### PR DESCRIPTION

the version of erlang is erlang-25.3.2.6-1.el8.x86_64. 
the version of rabbitmq-server is rabbitmq-server-3.12.10-1.

To reproduce the exception as follows:
1. rabbitmqctl export_definitions def.json
2. rabbitmqctl import_definitions def.json
3. The result of ''rabbit_definitions:list_vhosts()' is: [root@c1 ssl]#  rabbitmqctl eval 'rabbit_definitions:list_vhosts().' [#{<<"limits">> => [],
   <<"metadata">> =>
       #{default_queue_type => undefined,
         description => <<"Default virtual host">>,tags => []},
   <<"name">> => <<"/">>}

4. rabbitmqctl export_definitions def.json
5. rabbitmqctl import_definitions def.json
6. The result of ''rabbit_definitions:list_vhosts()' is: [root@c1 ssl]#  rabbitmqctl eval 'rabbit_definitions:list_vhosts().' [#{<<"limits">> => [],
   <<"metadata">> =>
       #{default_queue_type => <<"undefined">>,
         description => <<"Default virtual host">>,tags => []},
   <<"name">> => <<"/">>}
7. Declare a queue and an exception will appear, as shown below: 2024-03-29 17:38:09.696 [error] <0.1441.0> ** Generic server <0.1441.0> terminating, ** Last message in was {'$gen_cast', {method, {'queue.declare',0,<<"q12">>,false,false, false,false,false,[]}, none,noflow}}, ** When Server state == {ch, {conf,running,rabbit_framing_amqp_0_9_1,1, <0.1432.0>,<0.1439.0>,<0.1432.0>, <<"10.225.80.5:40388 -> 10.225.80.5:5673">>, undefined, {user,<<"guest">>, [administrator], [{rabbit_auth_backend_internal, #Fun<rabbit_auth_backend_internal.3.2577553>}]}, <<"/">>,<<>>,<0.1433.0>, [{<<"authentication_failure_close">>,bool,true}, {<<"basic.nack">>,bool,true}, {<<"connection.blocked">>,bool,true}, {<<"consumer_cancel_notify">>,bool,true}, {<<"publisher_confirms">>,bool,true}], none,0,134217728,1800000,#{},1000000000,false}, {lstate,<0.1440.0>,false}, none,1, {0,[],[]}, {state,#{},erlang}, #{},#{}, {state,fine,30000, #Ref<0.3663679405.4218945538.136240>}, true,1, {rabbit_confirms,undefined,#{}}, [],[],none,flow,[], {rabbit_queue_type,#{}}, #Ref<0.3663679405.4218945537.194739>,false, {erlang,#Ref<0.3663679405.4218945537.194740>}, "none",false}, ** Reason for termination == , ** {function_clause, [{rabbit_queue_type,discover, [<<"undefined">>], [{file,"rabbit_queue_type.erl"},{line,225}]}, {rabbit_amqqueue,augment_declare_args,5, [{file,"rabbit_amqqueue.erl"},{line,804}]}, {rabbit_channel,handle_method,6, [{file,"rabbit_channel.erl"},{line,2762}]}, {rabbit_channel,handle_method,3, [{file,"rabbit_channel.erl"},{line,1828}]}, {rabbit_channel,handle_cast,2, [{file,"rabbit_channel.erl"},{line,728}]}, {gen_server2,handle_msg,2,[{file,"gen_server2.erl"},{line,1056}]}, {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]},


