### PR TITLE
Be more defensive when importing definitions where some virtual hosts do not have a default queue type

### DIFF
--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -329,7 +329,7 @@ put_vhost(Name, Description, Tags0, DefaultQueueType0, Trace, Username) ->
     DefaultQueueType = case DefaultQueueType0 of
         <<"undefined">> -> undefined;
         _ -> DefaultQueueType0
-    end,     
+    end,
     ParsedTags = parse_tags(Tags),
     rabbit_log:debug("Parsed tags ~tp to ~tp", [Tags, ParsedTags]),
     Result = case exists(Name) of

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -318,7 +318,7 @@ put_vhost(Name, Description, Tags0, Trace, Username) ->
     boolean(),
     rabbit_types:username()) ->
     'ok' | {'error', any()} | {'EXIT', any()}.
-put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
+put_vhost(Name, Description, Tags0, DefaultQueueType0, Trace, Username) ->
     Tags = case Tags0 of
       undefined   -> <<"">>;
       null        -> <<"">>;
@@ -326,6 +326,10 @@ put_vhost(Name, Description, Tags0, DefaultQueueType, Trace, Username) ->
       "null"      -> <<"">>;
       Other       -> Other
     end,
+    DefaultQueueType = case DefaultQueueType0 of
+        <<"undefined">> -> undefined;
+        _ -> DefaultQueueType0
+    end,     
     ParsedTags = parse_tags(Tags),
     rabbit_log:debug("Parsed tags ~tp to ~tp", [Tags, ParsedTags]),
     Result = case exists(Name) of


### PR DESCRIPTION
This is #10891 by @tomyouyou with a cosmetic change from me.