### PR TITLE
Skip flaky mixed version test

### DIFF
--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -2230,11 +2230,13 @@ async_notify_settled_stream(Config) ->
     async_notify(settled, <<"stream">>, Config).
 
 async_notify_unsettled_classic_queue(Config) ->
-    %% TODO Bump old version in mixed version tests to 3.13.x,
-    %% require ff message_containers and always run this test case.
-    case rabbit_ct_broker_helpers:enable_feature_flag(Config, message_containers) of
-        ok -> async_notify(unsettled, <<"classic">>, Config);
-        {skip, _} = Skip -> Skip
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, credit_api_v2) of
+        ok ->
+            async_notify(unsettled, <<"classic">>, Config);
+        {skip, _} ->
+            {skip, "Skipping as this test will flake. Link flow control in classic "
+             "queues with credit API v1 is known to be broken: "
+             "https://github.com/rabbitmq/rabbitmq-server/issues/2597"}
     end.
 
 async_notify_unsettled_quorum_queue(Config) ->


### PR DESCRIPTION
Follow up of https://github.com/rabbitmq/rabbitmq-server/pull/10632:

```
bazel test //deps/rabbit:amqp_client_SUITE-mixed -t- --test_sharding_strategy=disabled --test_env FOCUS="-group [cluster_size_3] -case async_notify_unsettled_classic_queue" --config=rbe-26 --runs_per_test=40
```
was failing 8 out of 40 times.

Skip this test as we know that link flow control with classic queues is broken in 3.13:
https://github.com/rabbitmq/rabbitmq-server/issues/2597

Credit API v2 in RabbitMQ 4.0 fixes this bug.