### PR TITLE
Handle database timeouts from Khepri minority

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -207,11 +207,11 @@ erlang_package.hex_package(
     version = "1.4.1",
 )
 
-erlang_package.hex_package(
+erlang_package.git_package(
     name = "khepri",
     build_file = "@rabbitmq-server//bazel:BUILD.khepri",
-    sha256 = "1157d963eb5c002e040bbc86348669818d1da86d259a3705008655fefbd7f1c2",
-    version = "0.13.0",
+    commit = "e65e3b38d772b76ef3974feec5697fb9f995f0d7",
+    repository = "rabbitmq/khepri",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -331,12 +331,10 @@ is_server_named_allowed(Args) ->
     Type = get_queue_type(Args),
     rabbit_queue_type:is_server_named_allowed(Type).
 
--spec lookup
-        (name()) ->
-            rabbit_types:ok(amqqueue:amqqueue()) |
-            rabbit_types:error('not_found');
-        ([name()]) ->
-            [amqqueue:amqqueue()].
+-spec lookup(QueueName) -> Ret when
+      QueueName :: name(),
+      Ret :: rabbit_types:ok(amqqueue:amqqueue())
+             | rabbit_types:error('not_found').
 
 lookup(Name) when is_record(Name, resource) ->
     rabbit_db_queue:get(Name).

--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -41,7 +41,8 @@
 -type bind_ok_or_error() :: 'ok' | bind_errors() |
                             rabbit_types:error({'binding_invalid', string(), [any()]}) |
                             %% inner_fun() result
-                            rabbit_types:error(rabbit_types:amqp_error()).
+                            rabbit_types:error(rabbit_types:amqp_error()) |
+                            rabbit_khepri:timeout_error().
 -type bind_res() :: bind_ok_or_error() | rabbit_misc:thunk(bind_ok_or_error()).
 -type inner_fun() ::
         fun((rabbit_types:exchange(),

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1822,6 +1822,9 @@ binding_action(Action, Binding, Username, ConnPid) ->
             rabbit_misc:protocol_error(precondition_failed, Fmt, Args);
         {error, #amqp_error{} = Error} ->
             rabbit_misc:protocol_error(Error);
+        {error, timeout} ->
+            rabbit_misc:protocol_error(
+              internal_error, "Could not ~s binding due to timeout", [Action]);
         ok ->
             ok
     end.

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2471,7 +2471,12 @@ handle_method(#'queue.declare'{queue       = QueueNameBin,
                 {error, queue_limit_exceeded, Reason, ReasonArgs} ->
                     rabbit_misc:precondition_failed(Reason, ReasonArgs);
                 {protocol_error, ErrorType, Reason, ReasonArgs} ->
-                    rabbit_misc:protocol_error(ErrorType, Reason, ReasonArgs)
+                    rabbit_misc:protocol_error(ErrorType, Reason, ReasonArgs);
+                {error, timeout} ->
+                    rabbit_misc:protocol_error(
+                      internal_error,
+                      "Could not declare queue '~ts' due to timeout",
+                      [rabbit_misc:rs(QueueName)])
             end;
         {error, {absent, Q, Reason}} ->
             rabbit_amqqueue:absent(Q, Reason)

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2522,6 +2522,11 @@ handle_method(#'exchange.delete'{exchange  = ExchangeNameBin,
             ok;
         {error, in_use} ->
             rabbit_misc:precondition_failed("~ts in use", [rabbit_misc:rs(ExchangeName)]);
+        {error, timeout} ->
+            rabbit_misc:protocol_error(
+              internal_error,
+              "Could not delete exchange '~ts' due to timeout",
+              [rabbit_misc:rs(ExchangeName)]);
         ok ->
             ok
     end;

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -637,11 +637,12 @@ delete_in_khepri(X = #exchange{name = XName}, OnlyDurable, RemoveBindingsForSour
 %% delete_serial().
 %% -------------------------------------------------------------------
 
--spec delete_serial(ExchangeName) -> ok when
-      ExchangeName :: rabbit_exchange:name().
+-spec delete_serial(ExchangeName) -> Ret when
+      ExchangeName :: rabbit_exchange:name(),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Deletes an exchange serial record from the database.
 %%
-%% @returns ok
+%% @returns ok if the deletion succeeds or an error tuple otherwise.
 %%
 %% @private
 
@@ -659,7 +660,7 @@ delete_serial_in_mnesia(XName) ->
 
 delete_serial_in_khepri(XName) ->
     Path = khepri_exchange_serial_path(XName),
-    ok = rabbit_khepri:delete(Path).
+    rabbit_khepri:delete(Path).
 
 %% -------------------------------------------------------------------
 %% recover().

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -480,8 +480,9 @@ peek_serial_in_khepri(XName) ->
 %% next_serial().
 %% -------------------------------------------------------------------
 
--spec next_serial(ExchangeName) -> Serial when
+-spec next_serial(ExchangeName) -> Ret when
       ExchangeName :: rabbit_exchange:name(),
+      Ret :: Serial | no_return(),
       Serial :: integer().
 %% @doc Returns the next serial number and increases it.
 %%
@@ -511,39 +512,30 @@ next_serial_in_mnesia_tx(XName) ->
     Serial.
 
 next_serial_in_khepri(XName) ->
-    %% Just storing the serial number is enough, no need to keep #exchange_serial{}
-    Path = khepri_exchange_serial_path(XName),
-    Ret1 = rabbit_khepri:adv_get(Path),
-    case Ret1 of
-        {ok, #{data := Serial,
-               payload_version := Vsn}} ->
-            UpdatePath =
-                khepri_path:combine_with_conditions(
-                  Path, [#if_payload_version{version = Vsn}]),
-            case rabbit_khepri:put(UpdatePath, Serial + 1) of
-                ok ->
-                    Serial;
-                {error, {khepri, mismatching_node, _}} ->
-                    next_serial_in_khepri(XName);
-                Err ->
-                    Err
-            end;
-        _ ->
-            Serial = 1,
-            ok = rabbit_khepri:put(Path, Serial + 1),
+    Ret = rabbit_khepri:transaction(
+            fun() ->
+                    next_serial_in_khepri_tx(XName)
+            end, rw),
+    case Ret of
+        {error, Reason} ->
+            erlang:error(Reason);
+        Serial ->
             Serial
     end.
 
 -spec next_serial_in_khepri_tx(Exchange) -> Serial when
-      Exchange :: rabbit_types:exchange(),
+      Exchange :: rabbit_types:exchange() | rabbit_exchange:name(),
       Serial :: integer().
 
 next_serial_in_khepri_tx(#exchange{name = XName}) ->
+    next_serial_in_khepri_tx(XName);
+next_serial_in_khepri_tx(#resource{} = XName) ->
     Path = khepri_exchange_serial_path(XName),
     Serial = case khepri_tx:get(Path) of
                  {ok, Serial0} -> Serial0;
                  _ -> 1
              end,
+    %% Just storing the serial number is enough, no need to keep #exchange_serial{}
     ok = khepri_tx:put(Path, Serial + 1),
     Serial.
 

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -256,9 +256,10 @@ count_in_khepri() ->
 %% update().
 %% -------------------------------------------------------------------
 
--spec update(ExchangeName, UpdateFun) -> ok when
+-spec update(ExchangeName, UpdateFun) -> Ret when
       ExchangeName :: rabbit_exchange:name(),
-      UpdateFun :: fun((Exchange) -> Exchange).
+      UpdateFun :: fun((Exchange) -> Exchange),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Updates an existing exchange record using the result of
 %% `UpdateFun'.
 %%

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -781,7 +781,7 @@ exists_in_khepri(Name) ->
 %% clear().
 %% -------------------------------------------------------------------
 
--spec clear() -> ok.
+-spec clear() -> ok | no_return().
 %% @doc Deletes all exchanges.
 %%
 %% @private
@@ -805,7 +805,7 @@ clear_in_khepri() ->
 khepri_delete(Path) ->
     case rabbit_khepri:delete(Path) of
         ok -> ok;
-        Error -> throw(Error)
+        {error, _} = Error -> erlang:error(Error)
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -358,7 +358,9 @@ update_in_khepri_tx(Name, Fun) ->
 
 -spec create_or_get(Exchange) -> Ret when
       Exchange :: rabbit_types:exchange(),
-      Ret :: {new, Exchange} | {existing, Exchange}.
+      Ret :: {new, Exchange} |
+             {existing, Exchange} |
+             rabbit_khepri:timeout_error().
 %% @doc Writes an exchange record if it doesn't exist already or returns
 %% the existing one.
 %%
@@ -390,7 +392,9 @@ create_or_get_in_khepri(#exchange{name = XName} = X) ->
         ok ->
             {new, X};
         {error, {khepri, mismatching_node, #{node_props := #{data := ExistingX}}}} ->
-            {existing, ExistingX}
+            {existing, ExistingX};
+        {error, _} = Error ->
+            Error
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -555,7 +555,10 @@ next_serial_in_khepri_tx(#exchange{name = XName}) ->
       Exchange :: rabbit_types:exchange(),
       Binding :: rabbit_types:binding(),
       Deletions :: dict:dict(),
-      Ret :: {error, not_found} | {error, in_use} | {deleted, Exchange, [Binding], Deletions}.
+      Ret :: {error, not_found}
+             | {error, in_use}
+             | {deleted, Exchange, [Binding], Deletions}
+             | rabbit_khepri:timeout_error().
 %% @doc Deletes an exchange record from the database. If `IfUnused' is set
 %% to `true', it is only deleted when there are no bindings present on the
 %% exchange.

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -402,8 +402,9 @@ create_or_get_in_khepri(#exchange{name = XName} = X) ->
 %% set().
 %% -------------------------------------------------------------------
 
--spec set([Exchange]) -> ok when
-      Exchange :: rabbit_types:exchange().
+-spec set([Exchange]) -> Ret when
+      Exchange :: rabbit_types:exchange(),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Writes the exchange records.
 %%
 %% @returns ok.
@@ -419,16 +420,16 @@ set(Xs) ->
 set_in_mnesia(Xs) when is_list(Xs) ->
     rabbit_mnesia:execute_mnesia_transaction(
       fun () ->
-              [mnesia:write(rabbit_durable_exchange, X, write) || X <- Xs]
-      end),
-    ok.
+              _ = [mnesia:write(rabbit_durable_exchange, X, write) || X <- Xs],
+              ok
+      end).
 
 set_in_khepri(Xs) when is_list(Xs) ->
     rabbit_khepri:transaction(
       fun() ->
-              [set_in_khepri_tx(X) || X <- Xs]
-      end, rw),
-    ok.
+              _ = [set_in_khepri_tx(X) || X <- Xs],
+              ok
+      end, rw).
 
 set_in_khepri_tx(X) ->
     Path = khepri_exchange_path(X#exchange.name),

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -914,8 +914,9 @@ set_in_khepri(Q) ->
 %% set_many().
 %% -------------------------------------------------------------------
 
--spec set_many([Queue]) -> ok when
-      Queue :: amqqueue:amqqueue().
+-spec set_many([Queue]) -> Ret when
+      Queue :: amqqueue:amqqueue(),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Writes a list of durable queue records.
 %%
 %% It is responsibility of the calling function to ensure all records are
@@ -952,9 +953,9 @@ set_many_in_khepri(Qs) ->
                        ok      -> ok;
                        Error   -> khepri_tx:abort(Error)
                    end
-               end || Q <- Qs]
-      end),
-    ok.
+               end || Q <- Qs],
+               ok
+      end).
 
 %% -------------------------------------------------------------------
 %% delete_transient().

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -964,7 +964,8 @@ set_many_in_khepri(Qs) ->
       Queue :: amqqueue:amqqueue(),
       FilterFun :: fun((Queue) -> boolean()),
       QName :: rabbit_amqqueue:name(),
-      Ret :: {[QName], [Deletions :: rabbit_binding:deletions()]}.
+      Ret :: {[QName], [Deletions :: rabbit_binding:deletions()]}
+             | rabbit_khepri:timeout_error().
 %% @doc Deletes all transient queues that match `FilterFun'.
 %%
 %% @private
@@ -1025,29 +1026,76 @@ delete_transient_in_khepri(FilterFun) ->
     %% process might call itself. Instead we can fetch all of the transient
     %% queues with `get_many' and then filter and fold the results outside of
     %% Khepri's Ra server process.
-    case rabbit_khepri:get_many(PathPattern) of
-        {ok, Qs} ->
-            Items = maps:fold(
-                     fun(Path, Queue, Acc) when ?is_amqqueue(Queue) ->
-                             case FilterFun(Queue) of
-                                 true ->
-                                     QueueName = khepri_queue_path_to_name(
-                                                   Path),
-                                     case delete_in_khepri(QueueName, false) of
-                                         ok ->
-                                             Acc;
-                                         Deletions ->
-                                             [{QueueName, Deletions} | Acc]
-                                     end;
-                                 false ->
-                                     Acc
-                             end
-                     end, [], Qs),
-            {QueueNames, Deletions} = lists:unzip(Items),
-            {QueueNames, lists:flatten(Deletions)};
+    case rabbit_khepri:adv_get_many(PathPattern) of
+        {ok, Props} ->
+            Qs = maps:fold(
+                   fun(Path0, #{data := Q, payload_version := Vsn}, Acc)
+                       when ?is_amqqueue(Q) ->
+                           case FilterFun(Q) of
+                               true ->
+                                   Path = khepri_path:combine_with_conditions(
+                                            Path0,
+                                            [#if_payload_version{version = Vsn}]),
+                                   QName = amqqueue:get_name(Q),
+                                   [{Path, QName} | Acc];
+                               false ->
+                                   Acc
+                           end
+                   end, [], Props),
+            case Qs of
+                [] ->
+                    %% If there are no changes to make, avoid performing a
+                    %% transaction. When Khepri is in a minority this avoids
+                    %% a long timeout waiting for the transaction command to
+                    %% be processed. Otherwise it avoids appending a somewhat
+                    %% large transaction command to Khepri's log.
+                    {[], []};
+                _ ->
+                    do_delete_transient_queues_in_khepri(Qs, FilterFun)
+            end;
         {error, _} = Error ->
             Error
     end.
+
+do_delete_transient_queues_in_khepri(Qs, FilterFun) ->
+    Res = rabbit_khepri:transaction(
+            fun() ->
+                    fold_while_ok(
+                      fun({Path, QName}, Acc) ->
+                              %% Also see `delete_in_khepri/2'.
+                              case khepri_tx_adv:delete(Path) of
+                                  {ok, #{data := _}} ->
+                                      Deletions = rabbit_db_binding:delete_for_destination_in_khepri(
+                                                    QName, false),
+                                      {ok, [{QName, Deletions} | Acc]};
+                                  {ok, _} ->
+                                      {ok, Acc};
+                                  {error, _} = Error ->
+                                      Error
+                              end
+                      end, [], Qs)
+            end),
+    case Res of
+        {ok, Items} ->
+            {QNames, Deletions} = lists:unzip(Items),
+            {QNames, lists:flatten(Deletions)};
+        {error, {khepri, mismatching_node, _}} ->
+            %% One of the queues changed while attempting to update all
+            %% queues. Retry the operation.
+            delete_transient_in_khepri(FilterFun);
+        {error, _} = Error ->
+            Error
+    end.
+
+fold_while_ok(Fun, Acc0, [Elem | Rest]) ->
+    case Fun(Elem, Acc0) of
+        {ok, Acc} ->
+            fold_while_ok(Fun, Acc, Rest);
+        {error, _} = Error ->
+            Error
+    end;
+fold_while_ok(_Fun, Acc, []) ->
+    {ok, Acc}.
 
 %% -------------------------------------------------------------------
 %% foreach_transient().
@@ -1318,6 +1366,3 @@ khepri_queues_path() ->
 
 khepri_queue_path(#resource{virtual_host = VHost, name = Name}) ->
     [?MODULE, queues, VHost, Name].
-
-khepri_queue_path_to_name([?MODULE, queues, VHost, Name]) ->
-    rabbit_misc:r(VHost, queue, Name).

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -823,7 +823,10 @@ get_all_by_type_and_node_in_khepri(VHostName, Type, Node) ->
 
 -spec create_or_get(Queue) -> Ret when
       Queue :: amqqueue:amqqueue(),
-      Ret :: {created, Queue} | {existing, Queue} | {absent, Queue, nodedown}.
+      Ret :: {created, Queue}
+             | {existing, Queue}
+             | {absent, Queue, nodedown}
+             | rabbit_khepri:timeout_error().
 %% @doc Writes a queue record if it doesn't exist already or returns the existing one
 %%
 %% @returns the existing record if there is one in the database already, or the newly
@@ -872,8 +875,9 @@ create_or_get_in_khepri(Q) ->
 %% set().
 %% -------------------------------------------------------------------
 
--spec set(Queue) -> ok when
-      Queue :: amqqueue:amqqueue().
+-spec set(Queue) -> Ret when
+      Queue :: amqqueue:amqqueue(),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Writes a queue record. If the queue is durable, it writes both instances:
 %% durable and transient. For the durable one, it resets decorators.
 %% The transient one is left as it is.

--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -224,8 +224,9 @@ get_all_in_khepri(VHostName, Comp) ->
 %% delete().
 %% -------------------------------------------------------------------
 
--spec delete(Key) -> ok when
-      Key :: atom().
+-spec delete(Key) -> Ret when
+      Key :: atom(),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Deletes the global runtime parameter named `Key'.
 %%
 %% @private
@@ -235,10 +236,11 @@ delete(Key) when is_atom(Key) ->
       #{mnesia => fun() -> delete_in_mnesia(Key) end,
         khepri => fun() -> delete_in_khepri(Key) end}).
 
--spec delete(VHostName, Comp, Name) -> ok when
+-spec delete(VHostName, Comp, Name) -> Ret when
       VHostName :: vhost:name() | '_',
       Comp :: binary() | '_',
-      Name :: binary() | atom() | '_'.
+      Name :: binary() | atom() | '_',
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Deletes the non-global runtime parameter named `Name' for the given
 %% virtual host and component.
 %%
@@ -281,7 +283,7 @@ delete_matching_in_mnesia_tx(VHostName, Comp, Name) ->
 
 delete_in_khepri(Key) ->
     Path = khepri_rp_path(Key),
-    ok = rabbit_khepri:delete(Path).
+    rabbit_khepri:delete(Path).
 
 delete_matching_in_khepri(VHostName, Comp, Name) ->
     Key = {?any(VHostName), ?any(Comp), ?any(Name)},

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -470,9 +470,10 @@ set_user_permissions_in_khepri_tx(Username, VHostName, UserPermission) ->
 %% clear_user_permissions().
 %% -------------------------------------------------------------------
 
--spec clear_user_permissions(Username, VHostName) -> ok when
+-spec clear_user_permissions(Username, VHostName) -> Ret when
       Username :: internal_user:username(),
-      VHostName :: vhost:name().
+      VHostName :: vhost:name(),
+      Ret :: ok | no_return().
 %% @doc Clears the user permissions of the given user in the given virtual
 %% host.
 %%
@@ -499,8 +500,8 @@ clear_user_permissions_in_mnesia_tx(Username, VHostName) ->
 clear_user_permissions_in_khepri(Username, VHostName) ->
     Path = khepri_user_permission_path(Username, VHostName),
     case rabbit_khepri:delete(Path) of
-        ok      -> ok;
-        Error   -> khepri_tx:abort(Error)
+        ok -> ok;
+        {error, _} = Error -> erlang:error(Error)
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -61,7 +61,7 @@
       VHostName :: vhost:name(),
       Limits :: vhost:limits(),
       Metadata :: vhost:metadata(),
-      Ret :: {existing | new, VHost},
+      Ret :: {existing | new, VHost} | no_return(),
       VHost :: vhost:vhost().
 %% @doc Writes a virtual host record if it doesn't exist already or returns
 %% the existing one.

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -456,7 +456,7 @@ delete_in_khepri(VHostName) ->
 %% clear().
 %% -------------------------------------------------------------------
 
--spec clear() -> ok.
+-spec clear() -> ok | rabbit_khepri:timeout_error().
 %% @doc Deletes all vhosts.
 %%
 %% @private
@@ -472,10 +472,7 @@ clear_in_mnesia() ->
 
 clear_in_khepri() ->
     Path = khepri_vhosts_path(),
-    case rabbit_khepri:delete(Path) of
-        ok    -> ok;
-        Error -> throw(Error)
-    end.
+    rabbit_khepri:delete(Path).
 
 %% --------------------------------------------------------------
 %% Paths

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -419,8 +419,9 @@ with_fun_in_khepri_tx(VHostName, Thunk) ->
 %% delete().
 %% -------------------------------------------------------------------
 
--spec delete(VHostName) -> Existed when
+-spec delete(VHostName) -> Ret when
       VHostName :: vhost:name(),
+      Ret :: Existed | rabbit_khepri:timeout_error(),
       Existed :: boolean().
 %% @doc Deletes a virtual host record from the database.
 %%
@@ -448,7 +449,7 @@ delete_in_khepri(VHostName) ->
     case rabbit_khepri:delete_or_fail(Path) of
         ok -> true;
         {error, {node_not_found, _}} -> false;
-        _ -> false
+        {error, _} = Err -> Err
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -705,6 +705,8 @@ format({no_such_vhost, VHost}) ->
                          [VHost]));
 format({vhost_limit_exceeded, ErrMsg}) ->
     rabbit_data_coercion:to_binary(ErrMsg);
+format({timeout, ErrMsg}) ->
+    rabbit_data_coercion:to_binary(ErrMsg);
 format({shutdown, _} = Error) ->
     rabbit_log:debug("Metadata store is unavailable: ~p", [Error]),
     rabbit_data_coercion:to_binary(
@@ -863,13 +865,21 @@ add_exchange_int(Exchange, Name, ActingUser) ->
                            undefined -> false; %% =< 2.2.0
                            I         -> I
                        end,
-            rabbit_exchange:declare(Name,
-                                    rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
-                                    maps:get(durable,                         Exchange, undefined),
-                                    maps:get(auto_delete,                     Exchange, undefined),
-                                    Internal,
-                                    args(maps:get(arguments, Exchange, undefined)),
-                                    ActingUser)
+            case rabbit_exchange:declare(Name,
+                                         rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
+                                         maps:get(durable,                         Exchange, undefined),
+                                         maps:get(auto_delete,                     Exchange, undefined),
+                                         Internal,
+                                         args(maps:get(arguments, Exchange, undefined)),
+                                         ActingUser) of
+                {ok, _} ->
+                    ok;
+                {error, timeout} ->
+                    ErrMsg = rabbit_misc:format(
+                               "Failed to declare exchange '~ts' due to a "
+                               "timeout", [Name]),
+                    exit({timeout, ErrMsg})
+            end
     end.
 
 add_binding(Binding, ActingUser) ->

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -741,7 +741,7 @@ add_parameter(VHost, Param, Username) ->
 add_global_parameter(Param, Username) ->
     Key   = maps:get(name,      Param, undefined),
     Term  = maps:get(value,     Param, undefined),
-    case is_map(Term) of
+    Result = case is_map(Term) of
         true ->
             %% coerce maps to proplists for backwards compatibility.
             %% See rabbitmq-management#528.
@@ -749,6 +749,13 @@ add_global_parameter(Param, Username) ->
             rabbit_runtime_parameters:set_global(Key, TermProplist, Username);
         _ ->
             rabbit_runtime_parameters:set_global(Key, Term, Username)
+    end,
+    case Result of
+        ok               -> ok;
+        {error, timeout} ->
+            exit(rabbit_misc:format(
+                   "Could not set global parameter '~ts' because the "
+                   "operation timed out", [Key]))
     end.
 
 add_policy(Param, Username) ->

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -48,7 +48,7 @@ recover(VHost) ->
 
 callback(X = #exchange{decorators = Decorators, name = XName}, Fun, Serial, Args) ->
     case Fun of
-        delete -> rabbit_db_exchange:delete_serial(XName);
+        delete -> ok = rabbit_db_exchange:delete_serial(XName);
         _ -> ok
     end,
     Modules = rabbit_exchange_decorator:select(all, Decorators),

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -91,10 +91,17 @@ serial(X) ->
         true -> rabbit_db_exchange:next_serial(X#exchange.name)
     end.
 
--spec declare
-        (name(), type(), boolean(), boolean(), boolean(),
-         rabbit_framing:amqp_table(), rabbit_types:username())
-        -> rabbit_types:exchange().
+-spec declare(Name, Type, Durable, AutoDelete, Internal, Args, Username) -> Ret
+    when
+      Name :: name(),
+      Type :: type(),
+      Durable :: boolean(),
+      AutoDelete :: boolean(),
+      Internal :: boolean(),
+      Args :: rabbit_framing:amqp_table(),
+      Username :: rabbit_types:username(),
+      Ret :: {ok, Exchange} | {error, timeout},
+      Exchange :: rabbit_types:exchange().
 
 declare(XName, Type, Durable, AutoDelete, Internal, Args, Username) ->
     X = rabbit_exchange_decorator:set(
@@ -121,14 +128,16 @@ declare(XName, Type, Durable, AutoDelete, Internal, Args, Username) ->
                     Serial = serial(Exchange),
                     ok = callback(X, create, Serial, [Exchange]),
                     rabbit_event:notify(exchange_created, info(Exchange)),
-                    Exchange;
+                    {ok, Exchange};
                 {existing, Exchange} ->
-                    Exchange
+                    {ok, Exchange};
+                {error, _} = Error ->
+                    Error
             end;
         _ ->
             rabbit_log:warning("ignoring exchange.declare for exchange ~tp,
                                 exchange.delete in progress~n.", [XName]),
-            X
+            {ok, X}
     end.
 
 %% Used with binaries sent over the wire; the type may not exist.

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -453,9 +453,13 @@ cons_if_present(XName, L) ->
 
 -spec delete
         (name(),  'true', rabbit_types:username()) ->
-                    'ok'| rabbit_types:error('not_found' | 'in_use');
+                    'ok'
+                    | rabbit_types:error('not_found' | 'in_use')
+                    | rabbit_khepri:timeout_error();
         (name(), 'false', rabbit_types:username()) ->
-                    'ok' | rabbit_types:error('not_found').
+                    'ok'
+                    | rabbit_types:error('not_found')
+                    | rabbit_khepri:timeout_error().
 
 delete(XName, IfUnused, Username) ->
     try

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -287,7 +287,7 @@ wait_for_leader(Timeout, Retries) ->
         Exists when is_boolean(Exists) ->
             rabbit_log:info("Khepri leader elected"),
             ok;
-        {error, {timeout, _ServerId}} ->
+        {error, timeout} ->
             wait_for_leader(Timeout, Retries -1);
         {error, Reason} ->
             throw(Reason)
@@ -491,13 +491,13 @@ remove_down_member(NodeToRemove) ->
                [NodeToRemove, ?RA_CLUSTER_NAME, Reason],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
             Error;
-        {timeout, _} = Reason ->
+        {timeout, _LeaderId} ->
             ?LOG_ERROR(
                "Failed to remove remote down node ~s from Khepri "
-               "cluster \"~s\": ~p",
-               [NodeToRemove, ?RA_CLUSTER_NAME, Reason],
+               "cluster \"~s\" due to timeout",
+               [NodeToRemove, ?RA_CLUSTER_NAME],
                #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
-            {error, Reason}
+            {error, timeout}
     end.
 
 %% @private

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -180,6 +180,10 @@
          clear_forced_metadata_store/0]).
 -endif.
 
+-type timeout_error() :: khepri:error(timeout).
+
+-export_type([timeout_error/0]).
+
 -compile({no_auto_import, [get/1, get/2, nodes/0]}).
 
 -define(RA_SYSTEM, coordination).

--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -173,14 +173,20 @@ declare_exchange(
                                       virtual_host = VHost} = Exchange}}) ->
     try
         %% Durable.
-        #exchange{} = rabbit_exchange:declare(
-                        Exchange, topic, true, false, true, [],
-                        ?INTERNAL_USER),
-        ?LOG_DEBUG(
-           "Declared exchange '~ts' in vhost '~ts'",
-           [Name, VHost],
-           #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
-        ok
+        case rabbit_exchange:declare(
+               Exchange, topic, true, false, true, [], ?INTERNAL_USER) of
+            {ok, #exchange{}} ->
+                ?LOG_DEBUG(
+                   "Declared exchange '~ts' in vhost '~ts'",
+                   [Name, VHost],
+                   #{domain => ?RMQLOG_DOMAIN_GLOBAL});
+            {error, timeout} ->
+                ?LOG_DEBUG(
+                   "Could not create exchange '~ts' in vhost '~ts' due to "
+                   "timeout",
+                   [Name, VHost],
+                   #{domain => ?RMQLOG_DOMAIN_GLOBAL})
+        end
     catch
         Class:Reason ->
             ?LOG_DEBUG(

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -44,10 +44,10 @@
 
 -export([parse_set/5, set/5, set_any/5, clear/4, clear_any/4, list/0, list/1,
          list_component/1, list/2, list_formatted/1, list_formatted/3,
-         lookup/3, value/3, value/4, info_keys/0, clear_vhost/2,
+         lookup/3, value/3, info_keys/0, clear_vhost/2,
          clear_component/2]).
 
--export([parse_set_global/3, set_global/3, value_global/1, value_global/2,
+-export([parse_set_global/3, set_global/3, value_global/1,
          list_global/0, list_global_formatted/0, list_global_formatted/2,
          lookup_global/1, global_info_keys/0, clear_global/2]).
 
@@ -368,19 +368,10 @@ lookup_global(Name)  ->
 
 value(VHost, Comp, Name) -> value0({VHost, Comp, Name}).
 
--spec value(rabbit_types:vhost(), binary(), binary(), term()) -> term().
-
-value(VHost, Comp, Name, Def) -> value0({VHost, Comp, Name}, Def).
-
 -spec value_global(atom()) -> term() | 'not_found'.
 
 value_global(Key) ->
     value0(Key).
-
--spec value_global(atom(), term()) -> term().
-
-value_global(Key, Default) ->
-    value0(Key, Default).
 
 value0(Key) ->
     case lookup0(Key, rabbit_misc:const(not_found)) of
@@ -388,18 +379,11 @@ value0(Key) ->
         Params    -> Params#runtime_parameters.value
     end.
 
-value0(Key, Default) ->
-    Params = lookup0(Key, fun () -> lookup_missing(Key, Default) end),
-    Params#runtime_parameters.value.
-
 lookup0(Key, DefaultFun) ->
     case rabbit_db_rtparams:get(Key) of
         undefined -> DefaultFun();
         Record    -> Record
     end.
-
-lookup_missing(Key, Default) ->
-    rabbit_db_rtparams:get_or_set(Key, Default).
 
 p(#runtime_parameters{key = {VHost, Component, Name}, value = Value}) ->
     [{vhost,     VHost},

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -287,7 +287,9 @@ delete(VHost, ActingUser) ->
                         [{name, VHost},
                          {user_who_performed_action, ActingUser}]);
              false ->
-                 {error, {no_such_vhost, VHost}}
+                 {error, {no_such_vhost, VHost}};
+             {error, _} = Err ->
+                 Err
          end,
     %% After vhost was deleted from the database, we try to stop vhost
     %% supervisors on all the nodes.

--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -180,11 +180,11 @@ consume_from_queue(Config) ->
                  amqp_channel:call(Ch, #'basic.consume'{queue = <<"test-queue">>})).
 
 add_vhost(Config) ->
-    ?assertMatch({error, {timeout, _}},
+    ?assertMatch({error, timeout},
                  rabbit_ct_broker_helpers:add_vhost(Config, <<"vhost1">>)).
 
 update_vhost(Config) ->
-    ?assertThrow({error, {timeout, _}},
+    ?assertThrow({error, timeout},
                  rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_vhost, update_tags,
                                               [<<"/">>, [carrots], <<"user">>])).
 
@@ -192,15 +192,15 @@ delete_vhost(Config) ->
     ?assertMatch({'EXIT', _}, rabbit_ct_broker_helpers:delete_vhost(Config, <<"vhost1">>)).
 
 add_user(Config) ->
-    ?assertMatch({error, {timeout, _}},
+    ?assertMatch({error, timeout},
                  rabbit_ct_broker_helpers:add_user(Config, <<"user1">>)).
 
 update_user(Config) ->
-    ?assertMatch({error, {timeout, _}},
+    ?assertMatch({error, timeout},
                  rabbit_ct_broker_helpers:set_user_tags(Config, 0, <<"user1">>, [<<"admin">>])).
 
 delete_user(Config) ->
-    ?assertMatch({error, {timeout, _}},
+    ?assertMatch({error, timeout},
                  rabbit_ct_broker_helpers:delete_user(Config, <<"user1">>)).
 
 set_policy(Config) ->

--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -25,6 +25,7 @@ groups() ->
                               open_channel,
                               declare_exchange,
                               declare_binding,
+                              delete_binding,
                               declare_queue,
                               publish_to_exchange,
                               publish_and_consume_to_local_classic_queue,
@@ -78,7 +79,7 @@ init_per_group(Group, Config0) when Group == client_operations;
         {skip, _} ->
             Config1;
         _ ->
-            %% Before partitioning the cluster, create a policy and queue that can be used in
+            %% Before partitioning the cluster, create resources that can be used in
             %% the test cases. They're needed for delete and consume operations, which can list
             %% them but fail to operate anything else.
             %%
@@ -88,6 +89,10 @@ init_per_group(Group, Config0) when Group == client_operations;
             %% To be used in consume_from_queue
             #'queue.declare_ok'{} = amqp_channel:call(Ch, #'queue.declare'{queue = <<"test-queue">>,
                                                                            arguments = [{<<"x-queue-type">>, longstr, <<"classic">>}]}),
+            %% To be used in delete_binding
+            #'exchange.bind_ok'{} = amqp_channel:call(Ch, #'exchange.bind'{destination = <<"amq.fanout">>,
+                                                                           source = <<"amq.direct">>,
+                                                                           routing_key = <<"binding-to-be-deleted">>}),
 
             %% Lower the default Khepri command timeout. By default this is set
             %% to 30s in `rabbit_khepri:setup/1' which makes the cases in this
@@ -152,6 +157,14 @@ declare_binding(Config) ->
                 amqp_channel:call(Ch, #'exchange.bind'{destination = <<"amq.fanout">>,
                                                        source = <<"amq.direct">>,
                                                        routing_key = <<"key">>})).
+
+delete_binding(Config) ->
+    [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, A),
+    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+                amqp_channel:call(Ch, #'exchange.unbind'{destination = <<"amq.fanout">>,
+                                                         source = <<"amq.direct">>,
+                                                         routing_key = <<"binding-to-be-deleted">>})).
 
 declare_queue(Config) ->
     [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbit/test/routing_SUITE.erl
+++ b/deps/rabbit/test/routing_SUITE.erl
@@ -84,9 +84,9 @@ topic(Config) ->
 
 topic1(_Config) ->
     XName = rabbit_misc:r(?VHOST, exchange, <<"topic_matching-exchange">>),
-    X = rabbit_exchange:declare(
-          XName, topic, _Durable = true, _AutoDelete = false,
-          _Internal = false, _Args = [], ?USER),
+    {ok, X} = rabbit_exchange:declare(
+                XName, topic, _Durable = true, _AutoDelete = false,
+                _Internal = false, _Args = [], ?USER),
 
     %% add some bindings
     Bindings = [#binding{source = XName,

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/default_output.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/default_output.ex
@@ -68,7 +68,7 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output({unknown, _} = input, _opts) when is_atom(unknown), do: {:error, input}
   defp normalize_output(result, _opts) when not is_atom(result), do: {:ok, result}
 
-  defp format_khepri_output({:error, {:timeout, {:rabbitmq_metadata, _}}}, %{node: node_name}) do
+  defp format_khepri_output({:error, :timeout}, %{node: node_name}) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_tempfail(), khepri_timeout_error(node_name)}
   end
 

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -2079,8 +2079,8 @@ clear_policy(Config, Node, Name) ->
     clear_policy(Config, Node, Name, <<"acting-user">>).
 
 clear_policy(Config, Node, Name, Username) ->
-    rpc(Config, Node,
-        rabbit_policy, delete, [<<"/">>, Name, Username]).
+    ok = rpc(Config, Node,
+             rabbit_policy, delete, [<<"/">>, Name, Username]).
 
 set_operator_policy(Config, Node, Name, Pattern, ApplyTo, Definition) ->
     ok = rpc(Config, Node,

--- a/deps/rabbitmq_federation/test/unit_inbroker_SUITE.erl
+++ b/deps/rabbitmq_federation/test/unit_inbroker_SUITE.erl
@@ -202,8 +202,8 @@ upstream_validation(_Config) ->
 with_exchanges(Fun) ->
     rabbit_exchange:declare(r(?US_NAME), fanout, false, false, false, [],
                             <<"acting-user">>),
-    X = rabbit_exchange:declare(r(?DS_NAME), fanout, false, false, false, [],
-                                <<"acting-user">>),
+    {ok, X} = rabbit_exchange:declare(r(?DS_NAME), fanout, false, false, false,
+                                      [], <<"acting-user">>),
     Fun(X),
     %% Delete downstream first or it will recreate the upstream
     rabbit_exchange:delete(r(?DS_NAME), false, <<"acting-user">>),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_cluster_name.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_cluster_name.erl
@@ -42,8 +42,8 @@ to_json(ReqData, Context) ->
 accept_content(ReqData0, Context = #context{user = #user{username = Username}}) ->
     rabbit_mgmt_util:with_decode(
       [name], ReqData0, Context, fun([Name], _, ReqData) ->
-                                        rabbit_nodes:set_cluster_name(
-                                          as_binary(Name), Username),
+                                        ok = rabbit_nodes:set_cluster_name(
+                                               as_binary(Name), Username),
                                         {true, ReqData, Context}
                                 end).
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_global_parameter.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_global_parameter.erl
@@ -52,7 +52,7 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
           Val = if is_map(Value) -> maps:to_list(Value);
                     true         -> Value
                 end,
-          rabbit_runtime_parameters:set_global(name(ReqData), Val, Username),
+          ok = rabbit_runtime_parameters:set_global(name(ReqData), Val, Username),
           {true, ReqData, Context}
       end).
 


### PR DESCRIPTION
Operations like declaring/deleting queues fail when sent against a node that's part of a minority. We need to let the database failures (`{error, timeout}`) bubble up to the callers - usually the channel - so that these operations don't cause needless crash reports.

Closes https://github.com/rabbitmq/rabbitmq-server/issues/10753
This depends on a change upstream in Khepri: https://github.com/rabbitmq/khepri/pull/256