### PR TITLE
Make more TLS client options configurable for Kubernetes peer discovery

### DIFF
--- a/deps/rabbitmq_peer_discovery_k8s/priv/schema/rabbitmq_peer_discovery_k8s.schema
+++ b/deps/rabbitmq_peer_discovery_k8s/priv/schema/rabbitmq_peer_discovery_k8s.schema
@@ -51,7 +51,7 @@ end}.
 %% (ACL) Token path
 
 {mapping, "cluster_formation.k8s.token_path", "rabbit.cluster_formation.peer_discovery_k8s.k8s_token_path", [
-    {datatype, string}
+    {datatype, string}, {validators, ["file_accessible"]}
 ]}.
 
 {translation, "rabbit.cluster_formation.peer_discovery_k8s.k8s_token_path",
@@ -62,10 +62,14 @@ fun(Conf) ->
     end
 end}.
 
-%% Certificate path
+%%
+%% TLS
+%%
+
+%% deprecated
 
 {mapping, "cluster_formation.k8s.cert_path", "rabbit.cluster_formation.peer_discovery_k8s.k8s_cert_path", [
-    {datatype, string}
+    {datatype, string}, {validators, ["file_accessible"]}
 ]}.
 
 {translation, "rabbit.cluster_formation.peer_discovery_k8s.k8s_cert_path",
@@ -76,10 +80,73 @@ fun(Conf) ->
     end
 end}.
 
+%% modern keys
+
+{mapping, "cluster_formation.k8s.tls.cacertfile", "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.cacertfile",
+    [{datatype, string}, {validators, ["file_accessible"]}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.cacertfile",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.k8s.tls.cacertfile", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+{mapping, "cluster_formation.k8s.tls.certfile", "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.certfile",
+    [{datatype, string}, {validators, ["file_accessible"]}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.certfile",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.k8s.tls.certfile", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+{mapping, "cluster_formation.k8s.tls.keyfile", "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.keyfile",
+    [{datatype, string}, {validators, ["file_accessible"]}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.keyfile",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.k8s.tls.keyfile", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+{mapping, "cluster_formation.k8s.tls.verify", "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.verify", [
+    {datatype, {enum, [verify_peer, verify_none]}}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.verify",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.k8s.tls.verify", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+{mapping, "cluster_formation.k8s.tls.fail_if_no_peer_cert", "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.fail_if_no_peer_cert", [
+    {datatype, {enum, [true, false]}}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_k8s.ssl_options.fail_if_no_peer_cert",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.k8s.tls.fail_if_no_peer_cert", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        Value     -> Value
+    end
+end}.
+
+
 %% Namespace path
 
 {mapping, "cluster_formation.k8s.namespace_path", "rabbit.cluster_formation.peer_discovery_k8s.k8s_namespace_path", [
-    {datatype, string}
+    {datatype, string}, {validators, ["file_accessible"]}
 ]}.
 
 {translation, "rabbit.cluster_formation.peer_discovery_k8s.k8s_namespace_path",

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/certs/cacert.pem
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/certs/cacert.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/certs/cert.pem
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/certs/cert.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/certs/key.pem
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/certs/key.pem
@@ -1,0 +1,1 @@
+I'm not a certificate

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/namespace.txt
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/namespace.txt
@@ -1,0 +1,1 @@
+example-namespace

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/rabbitmq_peer_discovery_k8s.snippets
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/rabbitmq_peer_discovery_k8s.snippets
@@ -101,33 +101,72 @@
     ], [rabbitmq_peer_discovery_k8s]
   }
 
-, {k8s_token_path, "cluster_formation.k8s.token_path = /a/b/c", [
+, {k8s_token_path, "cluster_formation.k8s.token_path = test/config_schema_SUITE_data/token.txt", [
         {rabbit, [
             {cluster_formation, [
                 {peer_discovery_k8s, [
-                    {k8s_token_path, "/a/b/c"}
+                    {k8s_token_path, "test/config_schema_SUITE_data/token.txt"}
                 ]}
             ]}
         ]}
     ], [rabbitmq_peer_discovery_k8s]
   }
 
-, {k8s_token_path, "cluster_formation.k8s.cert_path = /a/b/c", [
+, {k8s_ca_certificate_legacy_cert_path, "cluster_formation.k8s.cert_path = test/config_schema_SUITE_data/certs/cacert.pem", [
         {rabbit, [
             {cluster_formation, [
                 {peer_discovery_k8s, [
-                    {k8s_cert_path, "/a/b/c"}
+                    {k8s_cert_path, "test/config_schema_SUITE_data/certs/cacert.pem"}
                 ]}
             ]}
         ]}
     ], [rabbitmq_peer_discovery_k8s]
   }
 
-, {k8s_token_path, "cluster_formation.k8s.namespace_path = /a/b/c", [
+, {k8s_ca_certificate_modern_path, "cluster_formation.k8s.tls.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem", [
         {rabbit, [
             {cluster_formation, [
                 {peer_discovery_k8s, [
-                    {k8s_namespace_path, "/a/b/c"}
+                    {ssl_options, [
+                        {cacertfile, "test/config_schema_SUITE_data/certs/cacert.pem"}
+                    ]}
+                ]}
+            ]}
+        ]}
+    ], [rabbitmq_peer_discovery_k8s]
+  }
+
+, {k8s_client_certificate_modern_path, "cluster_formation.k8s.tls.certfile = test/config_schema_SUITE_data/certs/cert.pem", [
+        {rabbit, [
+            {cluster_formation, [
+                {peer_discovery_k8s, [
+                    {ssl_options, [
+                        {certfile, "test/config_schema_SUITE_data/certs/cert.pem"}
+                    ]}
+                ]}
+            ]}
+        ]}
+    ], [rabbitmq_peer_discovery_k8s]
+  }
+
+, {k8s_client_key_modern_path, "cluster_formation.k8s.tls.keyfile = test/config_schema_SUITE_data/certs/key.pem", [
+        {rabbit, [
+            {cluster_formation, [
+                {peer_discovery_k8s, [
+                    {ssl_options, [
+                        {keyfile, "test/config_schema_SUITE_data/certs/key.pem"}
+                    ]}
+                ]}
+            ]}
+        ]}
+    ], [rabbitmq_peer_discovery_k8s]
+  }
+
+, {k8s_namespace_path, "cluster_formation.k8s.namespace_path = test/config_schema_SUITE_data/namespace.txt", [
+        {rabbit, [
+            {cluster_formation, [
+                {peer_discovery_k8s, [
+                    {k8s_namespace_path, "test/config_schema_SUITE_data/namespace.txt"}
                 ]}
             ]}
         ]}

--- a/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/token.txt
+++ b/deps/rabbitmq_peer_discovery_k8s/test/config_schema_SUITE_data/token.txt
@@ -1,0 +1,1 @@
+example-token


### PR DESCRIPTION
## Changes

 * Use file path validators to improve error messages when a certificate, key or another file does not exist or cannot be read by the node
 * Introduce a number of standard TLS options in addition to the Kubelet-provided CA certificate

## Why are they Necessary?

Starting with Erlang 26, [peer verification](https://www.rabbitmq.com/docs/ssl#peer-verification) is enabled by default for TLS clients. This may
be highly inconvenient in certain environments, and there is currently no way to disable
peer verification for K8S API requests. For example, see https://github.com/rabbitmq/cluster-operator/issues/1602.

While adding new TLS client `rabbitmq.conf` schema keys, I've improved validation of the path keys we already have.