### PR TITLE
Always use GHCR when building the docker image

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -59,7 +59,6 @@ jobs:
             build:buildbuddy --color=yes
 
             build --action_env EXTRA_BUILDX_OPTS="--cache-from=type=gha --cache-to=type=gha"
-            build --action_env TEMP_REGISTRY="ghcr.io/rabbitmq/"
           EOF
 
       - name: Build package-generic-unix

--- a/packaging/docker-image/BUILD.bazel
+++ b/packaging/docker-image/BUILD.bazel
@@ -48,27 +48,22 @@ CONTEXT="$$(mktemp -d)"
 
 cp $(locations :context-files) "$$CONTEXT"
 
-BASE_IMAGE="$${{TEMP_REGISTRY:=}}rabbitmq-base:{arch}"
+BASE_IMAGE="ghcr.io/rabbitmq/rabbitmq-base"
 
 set -x
 
 docker import \\
     --platform linux/{arch} \\
     "$(location //packaging/base-image:image-{arch}.tar)" \\
-    $$BASE_IMAGE
+    $$BASE_IMAGE:{arch}
 
-if [[ -n "$${{TEMP_REGISTRY}}" ]]; then
-    DIGEST="$$(docker push $$BASE_IMAGE | sed -n 's/.*\\(sha256:[a-z0-9]*\\).*/\\1/p')"
-    # if we are pushing to the temp registry, then we use
-    # the digest to avoid race conditions on the tag
-    BASE_IMAGE="$${{TEMP_REGISTRY:=}}rabbitmq-base@$$DIGEST"
-fi
+DIGEST="$$(docker push $$BASE_IMAGE:{arch} | sed -n 's/.*\\(sha256:[a-z0-9]*\\).*/\\1/p')"
 
 docker buildx \\
     build \\
     "$$CONTEXT" \\
     --platform linux/{arch} \\
-    --build-arg BASE_IMAGE="$$BASE_IMAGE" \\
+    --build-arg BASE_IMAGE="$$BASE_IMAGE@$$DIGEST" \\
     --build-arg RABBITMQ_VERSION="{rmq_version}" \\
     --output type=tar,dest=$(location image-{arch}.tar) $${{EXTRA_BUILDX_OPTS:-}}
 """.format(

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=pivotalrabbitmq/rabbitmq-base:latest
+ARG BASE_IMAGE=ghcr.io/rabbitmq/rabbitmq-base:amd64
 FROM ${BASE_IMAGE}
 
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang


### PR DESCRIPTION
when splitting the image, depending on the platform, docker buildx cannot always see the imported image. So, we'll just push to GHCR always. Members of the rabbitmq github org can log into GHCR, and be able to perform local builds of the image