### PR TITLE
Have minimum queue TTL take effect for quorum queues

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -309,7 +309,7 @@ ra_machine_config(Q) when ?is_amqqueue(Q) ->
     MaxMemoryLength = args_policy_lookup(<<"max-in-memory-length">>, fun min/2, Q),
     MaxMemoryBytes = args_policy_lookup(<<"max-in-memory-bytes">>, fun min/2, Q),
     DeliveryLimit = args_policy_lookup(<<"delivery-limit">>, fun min/2, Q),
-    Expires = args_policy_lookup(<<"expires">>, fun policyHasPrecedence/2, Q),
+    Expires = args_policy_lookup(<<"expires">>, fun min/2, Q),
     MsgTTL = args_policy_lookup(<<"message-ttl">>, fun min/2, Q),
     #{name => Name,
       queue_resource => QName,


### PR DESCRIPTION
For classic queues, if both policy and queue argument are set for queue TTL, the minimum takes effect.

Prior to this commit, for quorum queues if both policy and queue argument are set for queue TTL, the policy always overrides the queue argument.

This commit brings the quorum queue queue TTL resolution to classic queue's behaviour. This allows developers to provide a custom lower queue TTL while the operator policy acts an upper bound safe-guard.