### PR TITLE
Remove duplicate code that built ssl options

### DIFF
--- a/deps/oauth2_client/src/oauth2_client.erl
+++ b/deps/oauth2_client/src/oauth2_client.erl
@@ -328,7 +328,7 @@ extract_ssl_options_as_list(Map) ->
 % Replace peer_verification with verify to make it more consistent with other
 % ssl_options in RabbitMQ and Erlang's ssl options
 % Eventually, peer_verification will be removed. For now, both are allowed
--spec get_verify_or_peer_verification(#{atom() => any()}, any()) -> proplists:proplist().
+-spec get_verify_or_peer_verification(#{atom() => any()}, verify_none | verify_peer ) -> verify_none | verify_peer.
 get_verify_or_peer_verification(Ssl_options, Default) ->
     case maps:get(verify, Ssl_options, undefined) of
         undefined ->
@@ -437,14 +437,13 @@ map_to_oauth_provider(Map) when is_map(Map) ->
         jwks_uri = maps:get(?RESPONSE_JWKS_URI, Map, undefined)
     };
 
-map_to_oauth_provider(PropList) when is_list(PropList) ->
+map_to_oauth_provider(PropList) when is_list(PropList) ->    
     #oauth_provider{
         issuer = proplists:get_value(issuer, PropList),
         token_endpoint = proplists:get_value(token_endpoint, PropList),
         authorization_endpoint = proplists:get_value(authorization_endpoint, PropList, undefined),
         jwks_uri = proplists:get_value(jwks_uri, PropList, undefined),
-        ssl_options = extract_ssl_options_as_list(maps:from_list(
-            proplists:get_value(https, PropList, [])))
+        ssl_options = extract_ssl_options_as_list(maps:from_list(proplists:get_value(https, PropList, [])))
     }.
 
 

--- a/deps/oauth2_client/src/oauth2_client.erl
+++ b/deps/oauth2_client/src/oauth2_client.erl
@@ -15,122 +15,125 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -spec get_access_token(oauth_provider_id() | oauth_provider(), access_token_request()) ->
-  {ok, successful_access_token_response()} | {error, unsuccessful_access_token_response() | any()}.
+    {ok, successful_access_token_response()} | {error, unsuccessful_access_token_response() | any()}.
 get_access_token(OAuth2ProviderId, Request) when is_binary(OAuth2ProviderId) ->
-  rabbit_log:debug("get_access_token using OAuth2ProviderId:~p and client_id:~p",
+    rabbit_log:debug("get_access_token using OAuth2ProviderId:~p and client_id:~p",
     [OAuth2ProviderId, Request#access_token_request.client_id]),
-  case get_oauth_provider(OAuth2ProviderId, [token_endpoint]) of
-    {error, _Error } = Error0 -> Error0;
-    {ok, Provider} -> get_access_token(Provider, Request)
-  end;
+    case get_oauth_provider(OAuth2ProviderId, [token_endpoint]) of
+        {error, _Error } = Error0 -> Error0;
+        {ok, Provider} -> get_access_token(Provider, Request)
+    end;
 
 get_access_token(OAuthProvider, Request) ->
-  rabbit_log:debug("get_access_token using OAuthProvider:~p and client_id:~p",
-    [OAuthProvider, Request#access_token_request.client_id]),
-  URL = OAuthProvider#oauth_provider.token_endpoint,
-  Header = [],
-  Type = ?CONTENT_URLENCODED,
-  Body = build_access_token_request_body(Request),
-  HTTPOptions = get_ssl_options_if_any(OAuthProvider) ++
-    get_timeout_of_default(Request#access_token_request.timeout),
-  Options = [],
-  Response = httpc:request(post, {URL, Header, Type, Body}, HTTPOptions, Options),
-  parse_access_token_response(Response).
+    rabbit_log:debug("get_access_token using OAuthProvider:~p and client_id:~p",
+        [OAuthProvider, Request#access_token_request.client_id]),
+        URL = OAuthProvider#oauth_provider.token_endpoint,
+    Header = [],
+    Type = ?CONTENT_URLENCODED,
+    Body = build_access_token_request_body(Request),
+    HTTPOptions = get_ssl_options_if_any(OAuthProvider) ++
+        get_timeout_of_default(Request#access_token_request.timeout),
+    Options = [],
+    Response = httpc:request(post, {URL, Header, Type, Body}, HTTPOptions, Options),
+    parse_access_token_response(Response).
 
 -spec refresh_access_token(oauth_provider(), refresh_token_request()) ->
-  {ok, successful_access_token_response()} | {error, unsuccessful_access_token_response() | any()}.
+    {ok, successful_access_token_response()} | {error, unsuccessful_access_token_response() | any()}.
 refresh_access_token(OAuthProvider, Request) ->
-  URL = OAuthProvider#oauth_provider.token_endpoint,
-  Header = [],
-  Type = ?CONTENT_URLENCODED,
-  Body = build_refresh_token_request_body(Request),
-  HTTPOptions = get_ssl_options_if_any(OAuthProvider) ++
-    get_timeout_of_default(Request#refresh_token_request.timeout),
-  Options = [],
-  Response = httpc:request(post, {URL, Header, Type, Body}, HTTPOptions, Options),
-  parse_access_token_response(Response).
+    URL = OAuthProvider#oauth_provider.token_endpoint,
+    Header = [],
+    Type = ?CONTENT_URLENCODED,
+    Body = build_refresh_token_request_body(Request),
+    HTTPOptions = get_ssl_options_if_any(OAuthProvider) ++
+        get_timeout_of_default(Request#refresh_token_request.timeout),
+    Options = [],
+    Response = httpc:request(post, {URL, Header, Type, Body}, HTTPOptions, Options),
+    parse_access_token_response(Response).
 
 append_paths(Path1, Path2) ->
-  erlang:iolist_to_binary([Path1, Path2]).
+    erlang:iolist_to_binary([Path1, Path2]).
 
 -spec get_openid_configuration(uri_string:uri_string(), erlang:iodata() | <<>>, ssl:tls_option() | []) -> {ok, oauth_provider()} | {error, term()}.
 get_openid_configuration(IssuerURI, OpenIdConfigurationPath, TLSOptions) ->
-  URLMap = uri_string:parse(IssuerURI),
-  Path = case maps:get(path, URLMap) of
-    "/" -> OpenIdConfigurationPath;
-    "" -> OpenIdConfigurationPath;
-    P -> append_paths(P, OpenIdConfigurationPath)
-  end,
-  URL = uri_string:resolve(Path, IssuerURI),
-  rabbit_log:debug("get_openid_configuration issuer URL ~p (~p)", [URL, TLSOptions]),
-  Options = [],
-  Response = httpc:request(get, {URL, []}, TLSOptions, Options),
-  enrich_oauth_provider(parse_openid_configuration_response(Response), TLSOptions).
+    URLMap = uri_string:parse(IssuerURI),
+    Path = case maps:get(path, URLMap) of
+        "/" -> OpenIdConfigurationPath;
+        "" -> OpenIdConfigurationPath;
+        P -> append_paths(P, OpenIdConfigurationPath)
+    end,
+    URL = uri_string:resolve(Path, IssuerURI),
+    rabbit_log:debug("get_openid_configuration issuer URL ~p (~p)", [URL, TLSOptions]),
+    Options = [],
+    Response = httpc:request(get, {URL, []}, TLSOptions, Options),
+    enrich_oauth_provider(parse_openid_configuration_response(Response), TLSOptions).
 
 -spec get_openid_configuration(uri_string:uri_string(), ssl:tls_option() | []) ->  {ok, oauth_provider()} | {error, term()}.
 get_openid_configuration(IssuerURI, TLSOptions) ->
-  get_openid_configuration(IssuerURI, ?DEFAULT_OPENID_CONFIGURATION_PATH, TLSOptions).
+    get_openid_configuration(IssuerURI, ?DEFAULT_OPENID_CONFIGURATION_PATH, TLSOptions).
 
 update_oauth_provider_endpoints_configuration(OAuthProvider) ->
-  LockId = lock(),
-  try do_update_oauth_provider_endpoints_configuration(OAuthProvider) of
-    V -> V
-  after
-    unlock(LockId)
-  end.
+    LockId = lock(),
+    try do_update_oauth_provider_endpoints_configuration(OAuthProvider) of
+        V -> V
+    after
+        unlock(LockId)
+    end.
 
 update_oauth_provider_endpoints_configuration(OAuthProviderId, OAuthProvider) ->
-  LockId = lock(),
-  try do_update_oauth_provider_endpoints_configuration(OAuthProviderId, OAuthProvider) of
-    V -> V
-  after
-    unlock(LockId)
-  end.
+    LockId = lock(),
+    try do_update_oauth_provider_endpoints_configuration(OAuthProviderId, OAuthProvider) of
+        V -> V
+    after
+        unlock(LockId)
+    end.
 
 do_update_oauth_provider_endpoints_configuration(OAuthProvider) ->
-  case OAuthProvider#oauth_provider.token_endpoint of
-    undefined ->  do_nothing;
-    TokenEndPoint -> application:set_env(rabbitmq_auth_backend_oauth2, token_endpoint, TokenEndPoint)
-  end,
-  case OAuthProvider#oauth_provider.authorization_endpoint of
-    undefined ->  do_nothing;
-    AuthzEndPoint -> application:set_env(rabbitmq_auth_backend_oauth2, authorization_endpoint, AuthzEndPoint)
-  end,
-  List = application:get_env(rabbitmq_auth_backend_oauth2, key_config, []),
-  ModifiedList = case OAuthProvider#oauth_provider.jwks_uri of
-    undefined ->  List;
-    JwksEndPoint -> [{jwks_url, JwksEndPoint} | List]
-  end,
-  application:set_env(rabbitmq_auth_backend_oauth2, key_config, ModifiedList),
-  rabbit_log:debug("Updated oauth_provider details: ~p ", [ OAuthProvider]),
-  OAuthProvider.
-
+    case OAuthProvider#oauth_provider.token_endpoint of
+        undefined ->
+            do_nothing;
+        TokenEndPoint ->
+            application:set_env(rabbitmq_auth_backend_oauth2, token_endpoint, TokenEndPoint)
+    end,
+    case OAuthProvider#oauth_provider.authorization_endpoint of
+        undefined ->
+            do_nothing;
+        AuthzEndPoint ->
+            application:set_env(rabbitmq_auth_backend_oauth2, authorization_endpoint, AuthzEndPoint)
+    end,
+    List = application:get_env(rabbitmq_auth_backend_oauth2, key_config, []),
+    ModifiedList = case OAuthProvider#oauth_provider.jwks_uri of
+        undefined ->  List;
+        JwksEndPoint -> [{jwks_url, JwksEndPoint} | List]
+    end,
+    application:set_env(rabbitmq_auth_backend_oauth2, key_config, ModifiedList),
+    rabbit_log:debug("Updated oauth_provider details: ~p ", [ OAuthProvider]),
+    OAuthProvider.
 
 do_update_oauth_provider_endpoints_configuration(OAuthProviderId, OAuthProvider) ->
-  OAuthProviders = application:get_env(rabbitmq_auth_backend_oauth2, oauth_providers, #{}),
-  LookupProviderPropList = maps:get(OAuthProviderId, OAuthProviders),
-  ModifiedList0 = case OAuthProvider#oauth_provider.token_endpoint of
-    undefined ->  LookupProviderPropList;
-    TokenEndPoint -> [{token_endpoint, TokenEndPoint} | LookupProviderPropList]
-  end,
-  ModifiedList1 = case OAuthProvider#oauth_provider.authorization_endpoint of
-    undefined ->  ModifiedList0;
-    AuthzEndPoint -> [{authorization_endpoint, AuthzEndPoint} | ModifiedList0]
-  end,
-  ModifiedList2 = case OAuthProvider#oauth_provider.jwks_uri of
-    undefined ->  ModifiedList1;
-    JwksEndPoint -> [{jwks_uri, JwksEndPoint} | ModifiedList1]
-  end,
-  ModifiedOAuthProviders = maps:put(OAuthProviderId, ModifiedList2, OAuthProviders),
-  application:set_env(rabbitmq_auth_backend_oauth2, oauth_providers, ModifiedOAuthProviders),
-  rabbit_log:debug("Replacing oauth_providers  ~p", [ ModifiedOAuthProviders]),
-  OAuthProvider.
+    OAuthProviders = application:get_env(rabbitmq_auth_backend_oauth2, oauth_providers, #{}),
+    LookupProviderPropList = maps:get(OAuthProviderId, OAuthProviders),
+    ModifiedList0 = case OAuthProvider#oauth_provider.token_endpoint of
+        undefined ->  LookupProviderPropList;
+        TokenEndPoint -> [{token_endpoint, TokenEndPoint} | LookupProviderPropList]
+    end,
+    ModifiedList1 = case OAuthProvider#oauth_provider.authorization_endpoint of
+        undefined ->  ModifiedList0;
+        AuthzEndPoint -> [{authorization_endpoint, AuthzEndPoint} | ModifiedList0]
+    end,
+    ModifiedList2 = case OAuthProvider#oauth_provider.jwks_uri of
+        undefined ->  ModifiedList1;
+        JwksEndPoint -> [{jwks_uri, JwksEndPoint} | ModifiedList1]
+    end,
+    ModifiedOAuthProviders = maps:put(OAuthProviderId, ModifiedList2, OAuthProviders),
+    application:set_env(rabbitmq_auth_backend_oauth2, oauth_providers, ModifiedOAuthProviders),
+    rabbit_log:debug("Replacing oauth_providers  ~p", [ ModifiedOAuthProviders]),
+    OAuthProvider.
 
 use_global_locks_on_all_nodes() ->
-  case application:get_env(rabbitmq_auth_backend_oauth2, use_global_locks, true) of
-    true -> {rabbit_nodes:list_running(), rabbit_nodes:lock_retries()};
-    _ -> {}
-  end.
+    case application:get_env(rabbitmq_auth_backend_oauth2, use_global_locks, true) of
+        true -> {rabbit_nodes:list_running(), rabbit_nodes:lock_retries()};
+        _ -> {}
+    end.
 
 lock() ->
     case use_global_locks_on_all_nodes() of
@@ -147,223 +150,231 @@ lock() ->
     end.
 
 unlock(LockId) ->
-  case LockId of
-    undefined -> ok;
-    Value ->
-      case use_global_locks_on_all_nodes() of
-        {} -> global:del_lock({oauth2_config_lock, Value});
-        {Nodes, _Retries} -> global:del_lock({oauth2_config_lock, Value}, Nodes)
-      end
-  end.
+    case LockId of
+        undefined -> ok;
+        Value ->
+            case use_global_locks_on_all_nodes() of
+                {} -> global:del_lock({oauth2_config_lock, Value});
+                {Nodes, _Retries} -> global:del_lock({oauth2_config_lock, Value}, Nodes)
+            end
+    end.
 
 -spec get_oauth_provider(list()) -> {ok, oauth_provider()} | {error, any()}.
 get_oauth_provider(ListOfRequiredAttributes) ->
-  case application:get_env(rabbitmq_auth_backend_oauth2, default_oauth_provider) of
-    undefined -> get_oauth_provider_from_keyconfig(ListOfRequiredAttributes);
-    {ok, DefaultOauthProvider} ->
-      rabbit_log:debug("Using default_oauth_provider ~p", [DefaultOauthProvider]),
-      get_oauth_provider(DefaultOauthProvider, ListOfRequiredAttributes)
-  end.
+    case application:get_env(rabbitmq_auth_backend_oauth2, default_oauth_provider) of
+        undefined -> get_oauth_provider_from_keyconfig(ListOfRequiredAttributes);
+        {ok, DefaultOauthProvider} ->
+            rabbit_log:debug("Using default_oauth_provider ~p", [DefaultOauthProvider]),
+            get_oauth_provider(DefaultOauthProvider, ListOfRequiredAttributes)
+    end.
 
 get_oauth_provider_from_keyconfig(ListOfRequiredAttributes) ->
-  OAuthProvider = lookup_oauth_provider_from_keyconfig(),
-  rabbit_log:debug("Using oauth_provider ~p from keyconfig", [OAuthProvider]),
-  case find_missing_attributes(OAuthProvider, ListOfRequiredAttributes) of
-    [] -> {ok, OAuthProvider};
-    _ -> Result2 = case OAuthProvider#oauth_provider.issuer of
-            undefined -> {error, {missing_oauth_provider_attributes, [issuer]}};
-            Issuer ->
-                rabbit_log:debug("Downloading oauth_provider using issuer ~p", [Issuer]),
-                case get_openid_configuration(Issuer, get_ssl_options_if_any(OAuthProvider)) of
-                  {ok, OauthProvider} -> {ok, update_oauth_provider_endpoints_configuration(OauthProvider)};
-                  {error, _} = Error2 -> Error2
-                end
-        end,
-        case Result2 of
-          {ok, OAuthProvider2} ->
-              case find_missing_attributes(OAuthProvider2, ListOfRequiredAttributes) of
-                [] ->
-                  rabbit_log:debug("Resolved oauth_provider ~p", [OAuthProvider]),
-                  {ok, OAuthProvider2};
-                _ = Attrs->
-                  {error, {missing_oauth_provider_attributes, Attrs}}
-              end;
-          {error, _} = Error3 -> Error3
-        end
+    OAuthProvider = lookup_oauth_provider_from_keyconfig(),
+    rabbit_log:debug("Using oauth_provider ~p from keyconfig", [OAuthProvider]),
+    case find_missing_attributes(OAuthProvider, ListOfRequiredAttributes) of
+        [] ->
+            {ok, OAuthProvider};
+        _ ->
+            Result2 = case OAuthProvider#oauth_provider.issuer of
+                undefined -> {error, {missing_oauth_provider_attributes, [issuer]}};
+                Issuer ->
+                    rabbit_log:debug("Downloading oauth_provider using issuer ~p", [Issuer]),
+                    case get_openid_configuration(Issuer, get_ssl_options_if_any(OAuthProvider)) of
+                        {ok, OauthProvider} ->
+                            {ok, update_oauth_provider_endpoints_configuration(OauthProvider)};
+                        {error, _} = Error2 -> Error2
+                    end
+                end,
+            case Result2 of
+                {ok, OAuthProvider2} ->
+                    case find_missing_attributes(OAuthProvider2, ListOfRequiredAttributes) of
+                        [] ->
+                            rabbit_log:debug("Resolved oauth_provider ~p", [OAuthProvider]),
+                            {ok, OAuthProvider2};
+                        _ = Attrs->
+                            {error, {missing_oauth_provider_attributes, Attrs}}
+                    end;
+                {error, _} = Error3 -> Error3
+            end
   end.
 
 
 -spec get_oauth_provider(oauth_provider_id(), list()) -> {ok, oauth_provider()} | {error, any()}.
 get_oauth_provider(OAuth2ProviderId, ListOfRequiredAttributes) when is_list(OAuth2ProviderId) ->
-  get_oauth_provider(list_to_binary(OAuth2ProviderId), ListOfRequiredAttributes);
+    get_oauth_provider(list_to_binary(OAuth2ProviderId), ListOfRequiredAttributes);
 
 get_oauth_provider(OAuth2ProviderId, ListOfRequiredAttributes) when is_binary(OAuth2ProviderId) ->
-  rabbit_log:debug("get_oauth_provider ~p with at least these attributes: ~p", [OAuth2ProviderId, ListOfRequiredAttributes]),
-  case lookup_oauth_provider_config(OAuth2ProviderId) of
-    {error, _} = Error0 ->
-    rabbit_log:debug("Failed to find oauth_provider ~p configuration due to ~p", [OAuth2ProviderId, Error0]),
-      Error0;
-    Config ->
-      rabbit_log:debug("Found oauth_provider configuration ~p", [Config]),
-      OAuthProvider = case Config of
-        {error,_} = Error -> Error;
-        _ -> map_to_oauth_provider(Config)
-      end,
-      rabbit_log:debug("Resolved oauth_provider ~p", [OAuthProvider]),
-      case find_missing_attributes(OAuthProvider, ListOfRequiredAttributes) of
-        [] -> {ok, OAuthProvider};
-        _ -> Result2 = case OAuthProvider#oauth_provider.issuer of
-                undefined -> {error, {missing_oauth_provider_attributes, [issuer]}};
-                Issuer ->
-                    rabbit_log:debug("Downloading oauth_provider ~p using issuer ~p", [OAuth2ProviderId, Issuer]),
-                    case get_openid_configuration(Issuer, get_ssl_options_if_any(OAuthProvider)) of
-                      {ok, OauthProvider} -> {ok, update_oauth_provider_endpoints_configuration(OAuth2ProviderId, OauthProvider)};
-                      {error, _} = Error2 -> Error2
-                    end
+    rabbit_log:debug("get_oauth_provider ~p with at least these attributes: ~p", [OAuth2ProviderId, ListOfRequiredAttributes]),
+    case lookup_oauth_provider_config(OAuth2ProviderId) of
+        {error, _} = Error0 ->
+            rabbit_log:debug("Failed to find oauth_provider ~p configuration due to ~p",
+                [OAuth2ProviderId, Error0]),
+            Error0;
+        Config ->
+            rabbit_log:debug("Found oauth_provider configuration ~p", [Config]),
+            OAuthProvider = case Config of
+                {error,_} = Error -> Error;
+                _ -> map_to_oauth_provider(Config)
             end,
-            case Result2 of
-              {ok, OAuthProvider2} ->
-                  case find_missing_attributes(OAuthProvider2, ListOfRequiredAttributes) of
-                    [] ->
-                      rabbit_log:debug("Resolved oauth_provider ~p", [OAuthProvider]),
-                      {ok, OAuthProvider2};
-                    _ = Attrs->
-                      {error, {missing_oauth_provider_attributes, Attrs}}
-                  end;
-              {error, _} = Error3 -> Error3
+            rabbit_log:debug("Resolved oauth_provider ~p", [OAuthProvider]),
+            case find_missing_attributes(OAuthProvider, ListOfRequiredAttributes) of
+                [] ->
+                    {ok, OAuthProvider};
+                _ ->
+                    Result2 = case OAuthProvider#oauth_provider.issuer of
+                        undefined -> {error, {missing_oauth_provider_attributes, [issuer]}};
+                        Issuer ->
+                            rabbit_log:debug("Downloading oauth_provider ~p using issuer ~p",
+                                [OAuth2ProviderId, Issuer]),
+                            case get_openid_configuration(Issuer, get_ssl_options_if_any(OAuthProvider)) of
+                                {ok, OauthProvider} ->
+                                    {ok, update_oauth_provider_endpoints_configuration(OAuth2ProviderId, OauthProvider)};
+                                {error, _} = Error2 -> Error2
+                            end
+                    end,
+                    case Result2 of
+                        {ok, OAuthProvider2} ->
+                            case find_missing_attributes(OAuthProvider2, ListOfRequiredAttributes) of
+                                [] ->
+                                    rabbit_log:debug("Resolved oauth_provider ~p", [OAuthProvider]),
+                                    {ok, OAuthProvider2};
+                                _ = Attrs->
+                                    {error, {missing_oauth_provider_attributes, Attrs}}
+                            end;
+                        {error, _} = Error3 -> Error3
+                    end
             end
-      end
-  end.
+    end.
 
 %% HELPER functions
 
 
 oauth_provider_to_proplists(#oauth_provider{} = OAuthProvider) ->
-  lists:zip(record_info(fields, oauth_provider), tl(tuple_to_list(OAuthProvider))).
+    lists:zip(record_info(fields, oauth_provider), tl(tuple_to_list(OAuthProvider))).
 filter_undefined_props(PropList) ->
-  lists:foldl(fun(Prop, Acc) ->
-    case Prop of
-      {Name, undefined} -> Acc ++ [Name];
-      _ -> Acc
-    end end, [], PropList).
+    lists:foldl(fun(Prop, Acc) ->
+        case Prop of
+            {Name, undefined} -> Acc ++ [Name];
+            _ -> Acc
+        end end, [], PropList).
 
 -spec intersection(list(), list()) -> list().
 intersection(L1, L2) ->
-  S1 = sets:from_list(L1),
-  S2 = sets:from_list(L2),
-  lists:usort(sets:to_list(sets:intersection(S1, S2))).
+    S1 = sets:from_list(L1),
+    S2 = sets:from_list(L2),
+    lists:usort(sets:to_list(sets:intersection(S1, S2))).
 
 find_missing_attributes(#oauth_provider{} = OAuthProvider, RequiredAttributes) ->
-  PropList = oauth_provider_to_proplists(OAuthProvider),
-  Filtered = filter_undefined_props(PropList),
-  intersection(Filtered, RequiredAttributes).
+    PropList = oauth_provider_to_proplists(OAuthProvider),
+    Filtered = filter_undefined_props(PropList),
+    intersection(Filtered, RequiredAttributes).
 
 lookup_oauth_provider_from_keyconfig() ->
-  Issuer = application:get_env(rabbitmq_auth_backend_oauth2, issuer, undefined),
-  TokenEndpoint = application:get_env(rabbitmq_auth_backend_oauth2, token_endpoint, undefined),
-  Map = maps:from_list(application:get_env(rabbitmq_auth_backend_oauth2, key_config, [])),
-  #oauth_provider{
-    issuer = Issuer,
-    jwks_uri = maps:get(jwks_url, Map, undefined), %% jwks_url not uri . _url is the legacy name
-    token_endpoint = TokenEndpoint,
-    ssl_options = extract_ssl_options_as_list(Map)
-  }.
+    Issuer = application:get_env(rabbitmq_auth_backend_oauth2, issuer, undefined),
+    TokenEndpoint = application:get_env(rabbitmq_auth_backend_oauth2, token_endpoint, undefined),
+    Map = maps:from_list(application:get_env(rabbitmq_auth_backend_oauth2, key_config, [])),
+    #oauth_provider{
+        issuer = Issuer,
+        jwks_uri = maps:get(jwks_url, Map, undefined), %% jwks_url not uri . _url is the legacy name
+        token_endpoint = TokenEndpoint,
+        ssl_options = extract_ssl_options_as_list(Map)
+    }.
 
 -spec extract_ssl_options_as_list(#{atom() => any()}) -> proplists:proplist().
 extract_ssl_options_as_list(Map) ->
-  {Verify, CaCerts, CaCertFile} = case maps:get(peer_verification, Map, verify_peer) of
-    verify_peer ->
-      case maps:get(cacertfile, Map, undefined) of
-        undefined ->
-          case public_key:cacerts_get() of
-            [] -> {verify_none, undefined, undefined};
-            Certs -> {verify_peer, Certs, undefined}
-          end;
-        CaCert -> {verify_peer, undefined, CaCert}
-      end;
-    verify_none -> {verify_none, undefined, undefined}
-  end,
+    {Verify, CaCerts, CaCertFile} = case maps:get(peer_verification, Map, verify_peer) of
+        verify_peer ->
+            case maps:get(cacertfile, Map, undefined) of
+                undefined ->
+                    case public_key:cacerts_get() of
+                        [] -> {verify_none, undefined, undefined};
+                        Certs -> {verify_peer, Certs, undefined}
+                    end;
+                CaCert -> {verify_peer, undefined, CaCert}
+            end;
+        verify_none -> {verify_none, undefined, undefined}
+    end,
 
-  [ {verify, Verify} ]
+    [ {verify, Verify} ]
     ++
     case Verify of
-      verify_none -> [];
-      _ ->
-        [
-          {depth, maps:get(depth, Map, 10)},
-          {crl_check, maps:get(crl_check, Map, false)},
-          {fail_if_no_peer_cert, maps:get(fail_if_no_peer_cert, Map, false)}
-        ]
+        verify_none -> [];
+        _ ->
+            [
+            {depth, maps:get(depth, Map, 10)},
+            {crl_check, maps:get(crl_check, Map, false)},
+            {fail_if_no_peer_cert, maps:get(fail_if_no_peer_cert, Map, false)}
+            ]
     end
     ++
     case Verify of
-      verify_none -> [];
-      _ ->
-        case {CaCerts, CaCertFile} of
-          {_, undefined} -> [{cacerts, CaCerts}];
-          {undefined, _} -> [{cacertfile, CaCertFile}]
-        end
+        verify_none -> [];
+        _ ->
+            case {CaCerts, CaCertFile} of
+                {_, undefined} -> [{cacerts, CaCerts}];
+                {undefined, _} -> [{cacertfile, CaCertFile}]
+            end
     end
     ++
     case maps:get(hostname_verification, Map, none) of
-      wildcard ->
-          [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]}];
-      none ->
-          []
+        wildcard ->
+            [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]}];
+        none ->
+            []
     end.
 
 lookup_oauth_provider_config(OAuth2ProviderId) ->
-  case application:get_env(rabbitmq_auth_backend_oauth2, oauth_providers) of
-    undefined -> {error, oauth_providers_not_found};
-    {ok, MapOfProviders} when is_map(MapOfProviders) ->
-        case maps:get(OAuth2ProviderId, MapOfProviders, undefined) of
-          undefined ->
-            {error, {oauth_provider_not_found, OAuth2ProviderId}};
-          Value -> Value
-        end;
-    _ ->  {error, invalid_oauth_provider_configuration}
-  end.
+    case application:get_env(rabbitmq_auth_backend_oauth2, oauth_providers) of
+        undefined -> {error, oauth_providers_not_found};
+        {ok, MapOfProviders} when is_map(MapOfProviders) ->
+            case maps:get(OAuth2ProviderId, MapOfProviders, undefined) of
+                undefined ->
+                    {error, {oauth_provider_not_found, OAuth2ProviderId}};
+                Value -> Value
+            end;
+        _ ->  {error, invalid_oauth_provider_configuration}
+    end.
 
 build_access_token_request_body(Request) ->
-  uri_string:compose_query([
-    grant_type_request_parameter(?CLIENT_CREDENTIALS_GRANT_TYPE),
-    client_id_request_parameter(Request#access_token_request.client_id),
-    client_secret_request_parameter(Request#access_token_request.client_secret)]
-    ++ scope_request_parameter_or_default(Request#access_token_request.scope, [])).
+    uri_string:compose_query([
+        grant_type_request_parameter(?CLIENT_CREDENTIALS_GRANT_TYPE),
+        client_id_request_parameter(Request#access_token_request.client_id),
+        client_secret_request_parameter(Request#access_token_request.client_secret)]
+        ++ scope_request_parameter_or_default(Request#access_token_request.scope, [])).
 
 build_refresh_token_request_body(Request) ->
-  uri_string:compose_query([
-    grant_type_request_parameter(?REFRESH_TOKEN_GRANT_TYPE),
-    refresh_token_request_parameter(Request#refresh_token_request.refresh_token),
-    client_id_request_parameter(Request#refresh_token_request.client_id),
-    client_secret_request_parameter(Request#refresh_token_request.client_secret)]
-     ++ scope_request_parameter_or_default(Request#refresh_token_request.scope, [])).
+    uri_string:compose_query([
+        grant_type_request_parameter(?REFRESH_TOKEN_GRANT_TYPE),
+        refresh_token_request_parameter(Request#refresh_token_request.refresh_token),
+        client_id_request_parameter(Request#refresh_token_request.client_id),
+        client_secret_request_parameter(Request#refresh_token_request.client_secret)]
+        ++ scope_request_parameter_or_default(Request#refresh_token_request.scope, [])).
 
 grant_type_request_parameter(Type) ->
-  {?REQUEST_GRANT_TYPE, Type}.
+    {?REQUEST_GRANT_TYPE, Type}.
 client_id_request_parameter(Client_id) ->
-  {?REQUEST_CLIENT_ID, binary_to_list(Client_id)}.
+    {?REQUEST_CLIENT_ID, binary_to_list(Client_id)}.
 client_secret_request_parameter(Client_secret) ->
-  {?REQUEST_CLIENT_SECRET, binary_to_list(Client_secret)}.
+    {?REQUEST_CLIENT_SECRET, binary_to_list(Client_secret)}.
 refresh_token_request_parameter(RefreshToken) ->
-  {?REQUEST_REFRESH_TOKEN, RefreshToken}.
+    {?REQUEST_REFRESH_TOKEN, RefreshToken}.
 scope_request_parameter_or_default(Scope, Default) ->
-  case Scope of
-    undefined -> Default;
-    <<>> -> Default;
-    Scope -> [{?REQUEST_SCOPE, Scope}]
-  end.
+    case Scope of
+        undefined -> Default;
+        <<>> -> Default;
+        Scope -> [{?REQUEST_SCOPE, Scope}]
+    end.
 
 get_ssl_options_if_any(OAuthProvider) ->
-  case OAuthProvider#oauth_provider.ssl_options of
-    undefined -> [];
-    Options ->  [{ssl, Options}]
-  end.
+    case OAuthProvider#oauth_provider.ssl_options of
+        undefined -> [];
+        Options ->  [{ssl, Options}]
+    end.
 get_timeout_of_default(Timeout) ->
-  case Timeout of
-    undefined -> [{timeout, ?DEFAULT_HTTP_TIMEOUT}];
-    Timeout -> [{timeout, Timeout}]
-  end.
+    case Timeout of
+        undefined -> [{timeout, ?DEFAULT_HTTP_TIMEOUT}];
+        Timeout -> [{timeout, Timeout}]
+    end.
 
 is_json(?CONTENT_JSON) -> true;
 is_json(_) -> false.
@@ -382,111 +393,111 @@ decode_body(?CONTENT_JSON, Body) ->
 decode_body(MimeType, Body) ->
     Items = string:split(MimeType, ";"),
     case lists:any(fun is_json/1, Items) of
-      true -> decode_body(?CONTENT_JSON, Body);
-      false -> {error, mime_type_is_not_json}
+        true -> decode_body(?CONTENT_JSON, Body);
+        false -> {error, mime_type_is_not_json}
     end.
 
 
 map_to_successful_access_token_response(Map) ->
-  #successful_access_token_response{
-    access_token = maps:get(?RESPONSE_ACCESS_TOKEN, Map),
-    token_type = maps:get(?RESPONSE_TOKEN_TYPE, Map, undefined),
-    refresh_token = maps:get(?RESPONSE_REFRESH_TOKEN, Map, undefined),
-    expires_in = maps:get(?RESPONSE_EXPIRES_IN, Map, undefined)
-  }.
+    #successful_access_token_response{
+        access_token = maps:get(?RESPONSE_ACCESS_TOKEN, Map),
+        token_type = maps:get(?RESPONSE_TOKEN_TYPE, Map, undefined),
+        refresh_token = maps:get(?RESPONSE_REFRESH_TOKEN, Map, undefined),
+        expires_in = maps:get(?RESPONSE_EXPIRES_IN, Map, undefined)
+    }.
 
 map_to_unsuccessful_access_token_response(Map) ->
-  #unsuccessful_access_token_response{
-    error = maps:get(?RESPONSE_ERROR, Map),
-    error_description = maps:get(?RESPONSE_ERROR_DESCRIPTION, Map, undefined)
-  }.
+    #unsuccessful_access_token_response{
+        error = maps:get(?RESPONSE_ERROR, Map),
+        error_description = maps:get(?RESPONSE_ERROR_DESCRIPTION, Map, undefined)
+    }.
 
 
 map_to_oauth_provider(Map) when is_map(Map) ->
-  #oauth_provider{
-    issuer = maps:get(?RESPONSE_ISSUER, Map),
-    token_endpoint = maps:get(?RESPONSE_TOKEN_ENDPOINT, Map, undefined),
-    authorization_endpoint = maps:get(?RESPONSE_AUTHORIZATION_ENDPOINT, Map, undefined),
-    jwks_uri = maps:get(?RESPONSE_JWKS_URI, Map, undefined)
-  };
+    #oauth_provider{
+        issuer = maps:get(?RESPONSE_ISSUER, Map),
+        token_endpoint = maps:get(?RESPONSE_TOKEN_ENDPOINT, Map, undefined),
+        authorization_endpoint = maps:get(?RESPONSE_AUTHORIZATION_ENDPOINT, Map, undefined),
+        jwks_uri = maps:get(?RESPONSE_JWKS_URI, Map, undefined)
+    };
 
 map_to_oauth_provider(PropList) when is_list(PropList) ->
-  #oauth_provider{
-    issuer = proplists:get_value(issuer, PropList),
-    token_endpoint = proplists:get_value(token_endpoint, PropList),
-    authorization_endpoint = proplists:get_value(authorization_endpoint, PropList, undefined),
-    jwks_uri = proplists:get_value(jwks_uri, PropList, undefined),
-    ssl_options = map_ssl_options(proplists:get_value(https, PropList, undefined))
+    #oauth_provider{
+        issuer = proplists:get_value(issuer, PropList),
+        token_endpoint = proplists:get_value(token_endpoint, PropList),
+        authorization_endpoint = proplists:get_value(authorization_endpoint, PropList, undefined),
+        jwks_uri = proplists:get_value(jwks_uri, PropList, undefined),
+        ssl_options = map_ssl_options(proplists:get_value(https, PropList, undefined))
     }.
 
 map_ssl_options(undefined) ->
-  [{verify, verify_none},
-      {depth, 10},
-      {fail_if_no_peer_cert, false},
-      {crl_check, false},
-      {crl_cache, {ssl_crl_cache, {internal, [{http, 10000}]}}}];
+    [{verify, verify_none},
+        {depth, 10},
+        {fail_if_no_peer_cert, false},
+        {crl_check, false},
+        {crl_cache, {ssl_crl_cache, {internal, [{http, 10000}]}}}];
 map_ssl_options(Ssl_options) ->
-  Ssl_options1 = [{verify, proplists:get_value(verify, Ssl_options, verify_none)},
-    {depth, proplists:get_value(depth, Ssl_options, 10)},
-    {fail_if_no_peer_cert, proplists:get_value(fail_if_no_peer_cert, Ssl_options, false)},
-    {crl_check, proplists:get_value(crl_check, Ssl_options, false)},
-    {crl_cache, {ssl_crl_cache, {internal, [{http, 10000}]}}} | cacertfile(Ssl_options)],
-  case proplists:get_value(hostname_verification, Ssl_options, none) of
-      wildcard ->
-          [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | Ssl_options1];
-      none ->
-          Ssl_options1
-  end.
+    Ssl_options1 = [{verify, proplists:get_value(verify, Ssl_options, verify_none)},
+        {depth, proplists:get_value(depth, Ssl_options, 10)},
+        {fail_if_no_peer_cert, proplists:get_value(fail_if_no_peer_cert, Ssl_options, false)},
+        {crl_check, proplists:get_value(crl_check, Ssl_options, false)},
+        {crl_cache, {ssl_crl_cache, {internal, [{http, 10000}]}}} | cacertfile(Ssl_options)],
+    case proplists:get_value(hostname_verification, Ssl_options, none) of
+        wildcard ->
+            [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | Ssl_options1];
+        none ->
+            Ssl_options1
+    end.
 
 cacertfile(Ssl_options) ->
-  case proplists:get_value(cacertfile, Ssl_options) of
-    undefined -> [];
-    CaCertFile -> [{cacertfile, CaCertFile}]
-  end.
+    case proplists:get_value(cacertfile, Ssl_options) of
+        undefined -> [];
+        CaCertFile -> [{cacertfile, CaCertFile}]
+    end.
 
 enrich_oauth_provider({ok, OAuthProvider}, TLSOptions) ->
-  {ok, OAuthProvider#oauth_provider{ssl_options=TLSOptions}};
+    {ok, OAuthProvider#oauth_provider{ssl_options=TLSOptions}};
 enrich_oauth_provider(Response, _) ->
-  Response.
+    Response.
 
 map_to_access_token_response(Code, Reason, Headers, Body) ->
-  case decode_body(proplists:get_value("content-type", Headers, ?CONTENT_JSON), Body) of
-    {error, {error, InternalError}} ->
-      {error, InternalError};
-    {error, _} = Error ->
-      Error;
-    Value ->
-      case Code of
-        200 -> {ok, map_to_successful_access_token_response(Value)};
-        201 -> {ok, map_to_successful_access_token_response(Value)};
-        204 -> {ok, []};
-        400 -> {error, map_to_unsuccessful_access_token_response(Value)};
-        401 -> {error, map_to_unsuccessful_access_token_response(Value)};
-        _ ->   {error, Reason}
-      end
-  end.
+    case decode_body(proplists:get_value("content-type", Headers, ?CONTENT_JSON), Body) of
+        {error, {error, InternalError}} ->
+            {error, InternalError};
+        {error, _} = Error ->
+            Error;
+        Value ->
+            case Code of
+                200 -> {ok, map_to_successful_access_token_response(Value)};
+                201 -> {ok, map_to_successful_access_token_response(Value)};
+                204 -> {ok, []};
+                400 -> {error, map_to_unsuccessful_access_token_response(Value)};
+                401 -> {error, map_to_unsuccessful_access_token_response(Value)};
+                _ ->   {error, Reason}
+            end
+    end.
 
 map_response_to_oauth_provider(Code, Reason, Headers, Body) ->
-  case decode_body(proplists:get_value("content-type", Headers, ?CONTENT_JSON), Body) of
-    {error, {error, InternalError}} ->
-      {error, InternalError};
-    {error, _} = Error ->
-      Error;
-    Value ->
-      case Code of
-        200 -> {ok, map_to_oauth_provider(Value)};
-        201 -> {ok, map_to_oauth_provider(Value)};
-        _ ->   {error, Reason}
-      end
-  end.
+    case decode_body(proplists:get_value("content-type", Headers, ?CONTENT_JSON), Body) of
+        {error, {error, InternalError}} ->
+            {error, InternalError};
+        {error, _} = Error ->
+            Error;
+        Value ->
+            case Code of
+                200 -> {ok, map_to_oauth_provider(Value)};
+                201 -> {ok, map_to_oauth_provider(Value)};
+                _ ->   {error, Reason}
+            end
+    end.
 
 
 parse_access_token_response({error, Reason}) ->
-  {error, Reason};
+    {error, Reason};
 parse_access_token_response({ok,{{_,Code,Reason}, Headers, Body}}) ->
-  map_to_access_token_response(Code, Reason, Headers, Body).
+    map_to_access_token_response(Code, Reason, Headers, Body).
 
 parse_openid_configuration_response({error, Reason}) ->
-  {error, Reason};
+    {error, Reason};
 parse_openid_configuration_response({ok,{{_,Code,Reason}, Headers, Body}}) ->
-  map_response_to_oauth_provider(Code, Reason, Headers, Body).
+    map_response_to_oauth_provider(Code, Reason, Headers, Body).

--- a/deps/oauth2_client/test/system_SUITE.erl
+++ b/deps/oauth2_client/test/system_SUITE.erl
@@ -177,7 +177,7 @@ groups() ->
     ssl_connection_error,
     {group, with_all_oauth_provider_settings},
     {group, without_all_oauth_providers_settings}
-  ]} 
+  ]}
 ].
 
 init_per_suite(Config) ->
@@ -463,8 +463,14 @@ build_https_oauth_provider(CaCertFile) ->
   }.
 oauth_provider_to_proplist(#oauth_provider{ issuer = Issuer, token_endpoint = TokenEndpoint,
   ssl_options = SslOptions, jwks_uri = Jwks_url}) ->
-  [ { issuer, Issuer}, {token_endpoint, TokenEndpoint},
-    { https, SslOptions}, {jwks_url, Jwks_url} ].
+  [ { issuer, Issuer},
+    {token_endpoint, TokenEndpoint},
+    { https,
+        case SslOptions of
+            undefined -> [];
+            Value -> Value
+        end}, 
+    {jwks_url, Jwks_url} ].
 
 start_http_oauth_server(Port, Expectations) when is_list(Expectations) ->
   Dispatch = cowboy_router:compile([

--- a/deps/oauth2_client/test/unit_SUITE.erl
+++ b/deps/oauth2_client/test/unit_SUITE.erl
@@ -25,8 +25,11 @@ groups() ->
 [
   {ssl_options, [], [
     no_ssl_options_triggers_verify_peer,
-    peer_verification_verify_none,
-    peer_verification_verify_peer_with_cacertfile
+    choose_verify_over_peer_verification,
+    verify_set_to_verify_none,
+    peer_verification_set_to_verify_none,
+    peer_verification_set_to_verify_peer_with_cacertfile,
+    verify_set_to_verify_peer_with_cacertfile
   ]}
 ].
 
@@ -39,7 +42,29 @@ no_ssl_options_triggers_verify_peer(_) ->
     {cacerts, _CaCerts}
   ], oauth2_client:extract_ssl_options_as_list(#{})).
 
-peer_verification_verify_none(_) ->
+choose_verify_over_peer_verification(_) ->
+  Expected1 = [
+    {verify, verify_none}
+  ],
+  ?assertEqual(Expected1, oauth2_client:extract_ssl_options_as_list(
+    #{verify => verify_none, peer_verification => verify_peer })).
+
+verify_set_to_verify_none(_) ->
+  Expected1 = [
+    {verify, verify_none}
+  ],
+  ?assertEqual(Expected1, oauth2_client:extract_ssl_options_as_list(#{verify => verify_none})),
+
+  Expected2 = [
+    {verify, verify_none}
+  ],
+  ?assertEqual(Expected2, oauth2_client:extract_ssl_options_as_list(#{
+    verify => verify_none,
+    cacertfile => "/tmp"
+  })).
+
+
+peer_verification_set_to_verify_none(_) ->
   Expected1 = [
     {verify, verify_none}
   ],
@@ -54,7 +79,7 @@ peer_verification_verify_none(_) ->
   })).
 
 
-peer_verification_verify_peer_with_cacertfile(_) ->
+peer_verification_set_to_verify_peer_with_cacertfile(_) ->
   Expected = [
     {verify, verify_peer},
     {depth, 10},
@@ -65,4 +90,18 @@ peer_verification_verify_peer_with_cacertfile(_) ->
   ?assertEqual(Expected, oauth2_client:extract_ssl_options_as_list(#{
     cacertfile => "/tmp",
     peer_verification => verify_peer
+  })).
+
+
+verify_set_to_verify_peer_with_cacertfile(_) ->
+  Expected = [
+    {verify, verify_peer},
+    {depth, 10},
+    {crl_check,false},
+    {fail_if_no_peer_cert,false},
+    {cacertfile, "/tmp"}
+  ],
+  ?assertEqual(Expected, oauth2_client:extract_ssl_options_as_list(#{
+    cacertfile => "/tmp",
+    verify => verify_peer
   })).

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -168,6 +168,12 @@
  "rabbitmq_auth_backend_oauth2.key_config.peer_verification",
  [{datatype, {enum, [verify_peer, verify_none]}}]}.
 
+% Alias configuration variable. `auth_oauth2.https.peer_verification` will be soon deprecated
+{mapping,
+ "auth_oauth2.https.verify",
+ "rabbitmq_auth_backend_oauth2.key_config.verify",
+ [{datatype, {enum, [verify_peer, verify_none]}}]}.
+
 {mapping,
  "auth_oauth2.https.cacertfile",
  "rabbitmq_auth_backend_oauth2.key_config.cacertfile",

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
@@ -1,5 +1,5 @@
 -module(uaa_jwks).
--export([get/2, ssl_options/1]).
+-export([get/2]).
 
 -spec get(string() | binary(), term()) -> {ok, term()} | {error, term()}.
 get(JwksUrl, SslOptions) ->

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwks.erl
@@ -5,28 +5,3 @@
 get(JwksUrl, SslOptions) ->
     Options = [{timeout, 60000}] ++ [{ssl, SslOptions}],
     httpc:request(get, {JwksUrl, []}, Options, []).
-
--spec ssl_options(term()) -> list().
-ssl_options(KeyConfig) ->
-    PeerVerification = proplists:get_value(peer_verification, KeyConfig, verify_none),
-    Depth = proplists:get_value(depth, KeyConfig, 10),
-    FailIfNoPeerCert = proplists:get_value(fail_if_no_peer_cert, KeyConfig, false),
-    CrlCheck = proplists:get_value(crl_check, KeyConfig, false),
-    SslOpts0 = [{verify, PeerVerification},
-                {depth, Depth},
-                {fail_if_no_peer_cert, FailIfNoPeerCert},
-                {crl_check, CrlCheck},
-                {crl_cache, {ssl_crl_cache, {internal, [{http, 10000}]}}} | cacertfile(KeyConfig)],
-
-    case proplists:get_value(hostname_verification, KeyConfig, none) of
-        wildcard ->
-            [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | SslOpts0];
-        none ->
-            SslOpts0
-    end.
-
-cacertfile(KeyConfig) ->
-    case proplists:get_value(cacertfile, KeyConfig) of
-        undefined -> [];
-        CaCertFile -> [{cacertfile, CaCertFile}]
-    end.

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -105,11 +105,13 @@ init_per_group(multi_resource, Config) ->
       #{
         <<"one">> => [
           {issuer, strict_jwks_url(Config, "/")},
-          {jwks_uri, strict_jwks_url(Config, "/jwks1")}
+          {jwks_uri, strict_jwks_url(Config, "/jwks1")},
+          {https, [{verify, verify_none}]}
         ],
         <<"two">> => [
           {issuer, strict_jwks_url(Config, "/")},
-          {jwks_uri, strict_jwks_url(Config, "/jwks2")}
+          {jwks_uri, strict_jwks_url(Config, "/jwks2")},
+          {https, [{verify, verify_none}]}
         ]
       },
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env, [rabbitmq_auth_backend_oauth2, resource_servers, ResourceServersConfig]),


### PR DESCRIPTION
## Proposed Changes

This is a refactoring change to eliminate duplicate functions which were building Erlang ssl_options in different code paths. This is a problem because those functions could have used different default values. 

There is an additional change somewhat unrelated to this refactoring. The change introduces an alias for the configuration variable `peer_verification` called `verify`. It is the name used by Erlang and also name used in other SSL options in RabbitMQ. Eventually, `peer_verification` will be deprecated.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
