### PR TITLE
Avoid creation of binaries in AMQP 1.0 generator

### DIFF
--- a/deps/amqp10_common/app.bzl
+++ b/deps/amqp10_common/app.bzl
@@ -13,6 +13,7 @@ def all_beam_files(name = "all_beam_files"):
             "src/amqp10_binary_parser.erl",
             "src/amqp10_framing.erl",
             "src/amqp10_framing0.erl",
+            "src/amqp10_util.erl",
             "src/serial_number.erl",
         ],
         hdrs = [":public_and_private_hdrs"],
@@ -35,6 +36,7 @@ def all_test_beam_files(name = "all_test_beam_files"):
             "src/amqp10_binary_parser.erl",
             "src/amqp10_framing.erl",
             "src/amqp10_framing0.erl",
+            "src/amqp10_util.erl",
             "src/serial_number.erl",
         ],
         hdrs = [":public_and_private_hdrs"],
@@ -64,6 +66,7 @@ def all_srcs(name = "all_srcs"):
             "src/amqp10_binary_parser.erl",
             "src/amqp10_framing.erl",
             "src/amqp10_framing0.erl",
+            "src/amqp10_util.erl",
             "src/serial_number.erl",
         ],
     )

--- a/deps/amqp10_common/codegen.py
+++ b/deps/amqp10_common/codegen.py
@@ -87,8 +87,7 @@ def print_hrl(types, defines):
             for opt in d.options:
                 print_define(opt, d.source)
     print("""
--define(DESCRIBED, 0:8).
--define(DESCRIBED_BIN, <<?DESCRIBED>>).
+-define(DESCRIBED, 0).
 """)
 
 

--- a/deps/amqp10_common/src/amqp10_framing.erl
+++ b/deps/amqp10_common/src/amqp10_framing.erl
@@ -177,7 +177,7 @@ encode_bin(X) ->
     amqp10_binary_generator:generate(encode(X)).
 
 decode_bin(X) ->
-    [decode(PerfDesc) || PerfDesc <- amqp10_binary_parser:parse_all(X)].
+    [decode(DescribedPerformative) || DescribedPerformative <- amqp10_binary_parser:parse_all(X)].
 
 symbol_for(X) ->
     amqp10_framing0:symbol_for(X).

--- a/deps/amqp10_common/src/amqp10_util.erl
+++ b/deps/amqp10_common/src/amqp10_util.erl
@@ -1,0 +1,20 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+%%
+
+-module(amqp10_util).
+-include_lib("amqp10_common/include/amqp10_types.hrl").
+-export([link_credit_snd/3]).
+
+%% AMQP 1.0 §2.6.7
+-spec link_credit_snd(sequence_no(), uint(), sequence_no()) -> uint().
+link_credit_snd(DeliveryCountRcv, LinkCreditRcv, DeliveryCountSnd) ->
+    LinkCreditSnd = serial_number:diff(
+                      serial_number:add(DeliveryCountRcv, LinkCreditRcv),
+                      DeliveryCountSnd),
+    %% LinkCreditSnd can be negative when receiver decreases credits
+    %% while messages are in flight. Maintain a floor of zero.
+    max(0, LinkCreditSnd).

--- a/deps/rabbit/src/rabbit_queue_consumers.erl
+++ b/deps/rabbit/src/rabbit_queue_consumers.erl
@@ -485,10 +485,8 @@ process_credit(DeliveryCountRcv, LinkCredit, ChPid, CTag, State) ->
                                 _ ->
                                     %% credit API v2
                                     %% LinkCredit refers to LinkCreditRcv
-                                    %% See AMQP §2.6.7
-                                    serial_number:diff(
-                                      serial_number:add(DeliveryCountRcv, LinkCredit),
-                                      DeliveryCountSnd)
+                                    amqp10_util:link_credit_snd(
+                                      DeliveryCountRcv, LinkCredit, DeliveryCountSnd)
                             end,
             C = C0#cr{link_states = maps:update(CTag, LinkState#link_state{credit = LinkCreditSnd}, LinkStates)},
             case OldLinkCreditSnd > 0 orelse

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -72,8 +72,7 @@
 -type queue_type() :: rabbit_classic_queue | rabbit_quorum_queue | rabbit_stream_queue.
 %% see AMQP 1.0 §2.6.7
 -type delivery_count() :: sequence_no().
-%% Link credit can be negative, see AMQP 1.0 §2.6.7
--type credit() :: integer().
+-type credit() :: uint().
 
 -define(STATE, ?MODULE).
 

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -473,9 +473,8 @@ credit(QName, CTag, DeliveryCountRcv, LinkCreditRcv, Drain, Echo,
                       local_pid = LocalPid} = State0) ->
     case Readers of
         #{CTag := Str0 = #stream{delivery_count = DeliveryCountSnd}} ->
-            LinkCreditSnd = serial_number:diff(
-                              serial_number:add(DeliveryCountRcv, LinkCreditRcv),
-                              DeliveryCountSnd),
+            LinkCreditSnd = amqp10_util:link_credit_snd(
+                              DeliveryCountRcv, LinkCreditRcv, DeliveryCountSnd),
             Str1 = Str0#stream{credit = LinkCreditSnd},
             {Str2 = #stream{delivery_count = DeliveryCount,
                             credit = Credit,

--- a/moduleindex.yaml
+++ b/moduleindex.yaml
@@ -44,6 +44,7 @@ amqp10_common:
 - amqp10_binary_parser
 - amqp10_framing
 - amqp10_framing0
+- amqp10_util
 - serial_number
 aten:
 - aten


### PR DESCRIPTION
When generating iodata() in the AMQP 1.0 generator, prefer integers over binaries.

Rename functions and variable names to better reflect the AMQP 1.0 spec instead of using AMQP 0.9.1 wording.

This commit also fixes a bug where RabbitMQ sends negative credit in the `uint` field to the client.