### PR TITLE
Fix function_clause when AMQP connection fails

### DIFF
--- a/deps/rabbit/test/amqp_auth_SUITE.erl
+++ b/deps/rabbit/test/amqp_auth_SUITE.erl
@@ -660,7 +660,7 @@ sasl_failure(Mechanism, Config) ->
     Reason.
 
 vhost_absent(Config) ->
-    OpnConf = connection_config(Config, <<"vhost does not exist">>),
+    OpnConf = connection_config(Config, <<"this vhost does not exist">>),
     {ok, Connection} = amqp10_client:open_connection(OpnConf),
     receive {amqp10_event, {connection, Connection, {closed, _}}} -> ok
     after 5000 -> ct:fail(missing_closed)


### PR DESCRIPTION
```
make -C deps/rabbit ct-amqp_auth t=address_v2:vhost_absent
```
previously resulted in a function_clause error printing the following crash report in the client:
```
=ERROR REPORT==== 10-Apr-2024::15:23:39.866688 ===
** State machine <0.207.0> terminating
** Last event = {info,{'DOWN',#Ref<0.1404963469.3720347649.257117>,process,
                              <0.208.0>,normal}}
** When server state  = {open_sent,
                         {state,1,<0.206.0>,
                          #Ref<0.1404963469.3720347649.257117>,<0.209.0>,[],
                          <0.208.0>,
                          {tcp,#Port<0.16>},
                          undefined,undefined,
                          #{notify => <0.204.0>,port => 21000,
                            address => "localhost",
                            sasl =>
                             {plaintext,
                              <<131,104,3,119,5,112,108,97,105,110,109,0,0,0,
                                9,116,101,115,116,32,117,115,101,114,109,0,0,
                                0,9,116,101,115,116,32,117,115,101,114>>},
                            hostname => <<"vhost:this vhost does not exist">>,
                            container_id => <<"my container">>,
                            max_frame_size => 1048576,
                            notify_when_opened => <0.204.0>,
                            notify_when_closed => <0.204.0>,
                            tls_opts => undefined,
                            transfer_limit_margin => 0}}}
** Reason for termination = error:function_clause
** Callback modules = [amqp10_client_connection]
** Callback mode = state_functions
** Stacktrace =
**  [{amqp10_client_connection,open_sent,
         [info,
          {'DOWN',#Ref<0.1404963469.3720347649.257117>,process,<0.208.0>,
              normal},
          {state,1,<0.206.0>,#Ref<0.1404963469.3720347649.257117>,<0.209.0>,
              [],<0.208.0>,
              {tcp,#Port<0.16>},
              undefined,undefined,
              #{notify => <0.204.0>,port => 21000,address => "localhost",
                sasl =>
                    {plaintext,
                        <<131,104,3,119,5,112,108,97,105,110,109,0,0,0,9,116,
                          101,115,116,32,117,115,101,114,109,0,0,0,9,116,101,
                          115,116,32,117,115,101,114>>},
                hostname => <<"vhost:this vhost does not exist">>,
                container_id => <<"my container">>,max_frame_size => 1048576,
                notify_when_opened => <0.204.0>,
                notify_when_closed => <0.204.0>,transfer_limit_margin => 0}}],
         [{file,"amqp10_client_connection.erl"},{line,255}]},
     {gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1395}]},
     {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]

=CRASH REPORT==== 10-Apr-2024::15:23:39.867521 ===
  crasher:
    initial call: amqp10_client_connection:init/1
    pid: <0.207.0>
    registered_name: []
    exception error: no function clause matching
                     amqp10_client_connection:open_sent(info,
                                                        {'DOWN',
                                                         #Ref<0.1404963469.3720347649.257117>,
                                                         process,<0.208.0>,
                                                         normal},
                                                        {state,1,<0.206.0>,
                                                         #Ref<0.1404963469.3720347649.257117>,
                                                         <0.209.0>,[],
                                                         <0.208.0>,
                                                         {tcp,#Port<0.16>},
                                                         undefined,undefined,
                                                         #{notify => <0.204.0>,
                                                           port => 21000,
                                                           address =>
                                                            "localhost",
                                                           sasl =>
                                                            {plaintext,
                                                             <<131,104,3,119,
                                                               5,112,108,97,
                                                               105,110,109,0,
                                                               0,0,9,116,101,
                                                               115,116,32,117,
                                                               115,101,114,
                                                               109,0,0,0,9,
                                                               116,101,115,
                                                               116,32,117,115,
                                                               101,114>>},
                                                           hostname =>
                                                            <<"vhost:this vhost does not exist">>,
                                                           container_id =>
                                                            <<"my container">>,
                                                           max_frame_size =>
                                                            1048576,
                                                           notify_when_opened =>
                                                            <0.204.0>,
                                                           notify_when_closed =>
                                                            <0.204.0>,
                                                           transfer_limit_margin =>
                                                            0}}) (amqp10_client_connection.erl, line 255)
      in function  gen_statem:loop_state_callback/11 (gen_statem.erl, line 1395)
    ancestors: [<0.206.0>,amqp10_client_sup,<0.182.0>]
    message_queue_len: 0
    messages: []
    links: [<0.206.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 10958
    stack_size: 28
    reductions: 16408
  neighbours:
```