### PR TITLE
GitHub Actions: Add GHCR login step to `test-{authnz,selenium}.yaml` workflows

### DIFF
--- a/.github/workflows/oci.yaml
+++ b/.github/workflows/oci.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -52,7 +52,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Configure OTP & Elixir
       uses: erlef/setup-beam@v1.17

--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -47,6 +47,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: 'Login to GitHub Container Registry'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_TOKEN }}
+
     - name: Configure OTP & Elixir
       uses: erlef/setup-beam@v1.17
       with:

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -44,6 +44,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: 'Login to GitHub Container Registry'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_TOKEN }}
+
     - name: Configure OTP & Elixir
       uses: erlef/setup-beam@v1.17
       with:

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -49,7 +49,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Configure OTP & Elixir
       uses: erlef/setup-beam@v1.17


### PR DESCRIPTION
## Why

Both workflows build and publish docker images but they currently fail to publish them because of a permission denied.

## How

This patch replicates (copy-pastes) what was done to the `oci.yaml` workflow.