### PR TITLE
changed log line to allow for MaxConsumers being an integer not a string

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1323,7 +1323,7 @@ handle_method(#'basic.consume'{queue        = <<"amq.rabbitmq.reply-to">>,
     case maps:find(CTag0, ConsumerMapping) of
         error when CurrentConsumers >= MaxConsumers ->  % false when MaxConsumers is 'infinity'
             rabbit_misc:protocol_error(
-              not_allowed, "reached maximum (~ts) of consumers per channel", [MaxConsumers]);
+              not_allowed, "reached maximum (~B) of consumers per channel", [MaxConsumers]);
         error ->
             case {ReplyConsumer, NoAck} of
                 {none, true} ->
@@ -1382,7 +1382,7 @@ handle_method(#'basic.consume'{queue        = QueueNameBin,
     case maps:find(ConsumerTag, ConsumerMapping) of
         error when CurrentConsumers >= MaxConsumers ->  % false when MaxConsumers is 'infinity'
         rabbit_misc:protocol_error(
-              not_allowed, "reached maximum (~ts) of consumers per channel", [MaxConsumers]);
+              not_allowed, "reached maximum (~B) of consumers per channel", [MaxConsumers]);
         error ->
             QueueName = qbin_to_resource(QueueNameBin, VHostPath),
             check_read_permitted(QueueName, User, AuthzContext),


### PR DESCRIPTION
## Proposed Changes

change control sequence modifier to allow for data in `MaxConsumers` variable as integer, not interpreted as string. Prevents `io_lib` crash when consumer max per channel is exceeded.

`MaxConsumers` can be either an integer or `infinity`, however this clause will never match if `infinity`, so shouldn't need to account for that.

background: https://github.com/rabbitmq/rabbitmq-server/discussions/10970


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ X ] Bug fix (non-breaking change which fixes issue #10970 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
