### PR TITLE
Avoid function clause

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -1693,11 +1693,8 @@ delivery_tag(MsgId = {Priority, Seq}, _)
 
 incoming_mgmt_link_transfer(
   #'v1_0.transfer'{
-     %% We only allow settled management requests
-     %% given that we are going to send a response anyway.
-     settled = true,
-     %% In the current implementation, we disallow large incoming management request messages.
-     more = false,
+     settled = Settled,
+     more = More,
      handle = IncomingHandle = ?UINT(IncomingHandleInt)},
   Request,
   #state{management_link_pairs = LinkPairs,
@@ -1712,15 +1709,19 @@ incoming_mgmt_link_transfer(
                     user = User,
                     reader_pid = ReaderPid}
         } = State0) ->
-
     IncomingLink0 = case maps:find(IncomingHandleInt, IncomingLinks) of
                         {ok, Link} ->
                             Link;
                         error ->
                             protocol_error(
-                              ?V_1_0_AMQP_ERROR_ILLEGAL_STATE,
+                              ?V_1_0_SESSION_ERROR_UNATTACHED_HANDLE,
                               "Unknown link handle: ~p", [IncomingHandleInt])
                     end,
+    %% We only allow settled management requests
+    %% given that we are going to send a response anyway.
+    true = Settled,
+    %% In the current implementation, we disallow large incoming management request messages.
+    false = More,
     #management_link{name = Name,
                      delivery_count = IncomingDeliveryCount0,
                      credit = IncomingCredit0,


### PR DESCRIPTION
Avoid following function clause error:
```
[{rabbit_amqp_session,incoming_mgmt_link_transfer,
     [{'v1_0.transfer',
          {uint,0},
          {uint,1},
          {binary,<<0>>},
          {uint,0},
          false,false,undefined,undefined,undefined,undefined,undefined},
      <<0,83,112,192,2,1,65>>,
      {state,
          {cfg,65528,<0.3506.0>,<0.3510.0>,
              {user,<<"guest">>,
                  [administrator],
                  [{rabbit_auth_backend_internal,
                       #Fun<rabbit_auth_backend_internal.3.111050101>}]},
              <<"/">>,1,0,#{},none,<<"127.0.0.1:43416 -> 127.0.0.1:5672">>},
          2,398,4294967292,1600,2147483645,
          {[],[]},
          0,#{},#{},#{},#{},#{},#{},[],[],[],[],
          {rabbit_queue_type,#{}},
          [{{resource,<<"/">>,exchange,<<>>},write},
           {{resource,<<"/">>,queue,
                <<"ResourceListenerTest_publisherIsClosedOnExchangeDeletion-aec3-6e1a90386458">>},
            configure}],
          []}],
     [{file,"rabbit_amqp_session.erl"},{line,1694}]},
 {rabbit_amqp_session,handle_control,2,
     [{file,"rabbit_amqp_session.erl"},{line,1068}]},
 {rabbit_amqp_session,handle_cast,2,
     [{file,"rabbit_amqp_session.erl"},{line,391}]},
 {gen_server,try_handle_cast,3,[{file,"gen_server.erl"},{line,1121}]},
 {gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1183}]},
 {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}] [condition = amqp:internal-error]
```

when the client keeps sending messages although its target queue got deleted and the server already sent a DETACH frame to the client.

From now on, the server instead closes the session with session error amqp:session:unattached-handle

The test case is included in the AMQP Java client.