### PR TITLE
erlang_ls: Add `deps/*/` to include dirs

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -17,6 +17,7 @@ diagnostics:
 include_dirs:
   - "deps"
   - "deps/*/include"
+  - "deps/*/"
   - "extra_deps"
   - "extra_deps/*/include"
 lenses:


### PR DESCRIPTION
This allows scanning for `src/*.hrl` files under each deps directory entry, fixing lookup for lines like:

    -include("src/rabbit_feature_flags.hrl").

in `deps/rabbit/src/rabbit_feature_flags.erl` or

    -include("src/amqp10_client.hrl").

in `deps/amqp10_client/test/mock_server.erl`.