### PR TITLE
Avoid loading all modules during boot

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1014,6 +1014,20 @@ do_run_postlaunch_phase(Plugins) ->
         ?LOG_DEBUG(""),
         ?LOG_DEBUG("== Plugins (postlaunch phase) =="),
 
+        %% Before loading plugins, set the prometheus collectors and
+        %% instrumenters to the empty list. By default, prometheus will attempt
+        %% to find all implementers of its collector and instrumenter
+        %% behaviours by scanning all available modules during application
+        %% start. This can take significant time (on the order of seconds) due
+        %% to the large number of modules available.
+        %%
+        %% * Collectors: the `rabbitmq_prometheus' plugin explicitly registers
+        %%   all collectors.
+        %% * Instrumenters: no instrumenters are used.
+        _ = application:load(prometheus),
+        ok = application:set_env(prometheus, collectors, [default]),
+        ok = application:set_env(prometheus, instrumenters, []),
+
         %% However, we want to run their boot steps and actually start
         %% them one by one, to ensure a dependency is fully started
         %% before a plugin which depends on it gets a chance to start.


### PR DESCRIPTION
A fairly large chunk of boot time is spent trying to look up modules that have certain attributes via `Module:module_info(attributes)`. Executing the builtin `module_info/1` function is very very fast but only after the module is initially loaded. For any unloaded module, attempting to execute the function loads the module. Code loading can be fairly slow with some modules taking around a millisecond individually, and all code loading is currently done in serial by the code server.

We use this for `rabbit_boot_step` and `rabbit_feature_flag` attributes for example and we can't avoid scanning many modules without much larger breaking changes. When we read those attributes though we only lookup modules from applications that depend on the `rabbit` app. This saves quite a lot of work because we avoid most dependencies and builtin modules from Erlang/OTP that we would never load anyways, for example the `wx` modules.

We can re-use that function in the management plugin to avoid scanning most available modules for the `rabbit_mgmt_extension` behaviour. We also need to stop the `prometheus` dependency from scanning for its interceptor and collector behaviours on boot. We can do this by setting explicit empty values for the application environment variables `prometheus` uses as defaults. This is a safe change because we don't use interceptors and we register all collectors explicitly.

**There is a functional change to the management plugin to be aware of**: any plugins that use the `rabbit_mgmt_extension` behaviour must declare a dependency on the `rabbit` application. This is true for all tier-1 plugins but should be kept in mind for community plugins.

For me locally this reduces single node boot (`bazel run broker`) time from ~6100ms to ~4300ms.