### PR TITLE
Fix mnesia deletion return value in recent history exchange cleanup

### DIFF
--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange.erl
@@ -142,7 +142,12 @@ delete() ->
        }).
 
 delete_in_mnesia() ->
-    mnesia:delete_table(?RH_TABLE).
+    case mnesia:delete_table(?RH_TABLE) of
+        {atomic, ok} ->
+            ok;
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
 
 delete_in_khepri() ->
     rabbit_khepri:delete(khepri_recent_history_path()).

--- a/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
+++ b/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
@@ -41,7 +41,8 @@ all_tests() ->
      wrong_argument_type_test,
      no_store_test,
      e2e_test,
-     multinode_test
+     multinode_test,
+     lifecycle_test
     ].
 
 %% -------------------------------------------------------------------
@@ -233,6 +234,16 @@ multinode_test(Config) ->
     amqp_channel:call(Chan2, #'queue.delete' { queue = Q2 }),
 
     rabbit_ct_client_helpers:close_connection_and_channel(Conn2, Chan2),
+    ok.
+
+lifecycle_test(Config) ->
+    %% Ensure that the boot and cleanup steps run as expected and return 'ok'.
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config,
+           rabbit, stop_apps, [[rabbitmq_recent_history_exchange]]),
+    ok = rabbit_ct_broker_helpers:rpc(
+           Config,
+           rabbit, start_apps, [[rabbitmq_recent_history_exchange]]),
     ok.
 
 test0(Config, MakeMethod, MakeMsg, DeclareArgs, Queues, MsgCount, ExpectedCount) ->


### PR DESCRIPTION
The recent history exchange currently returns `{atomic,ok}` when deactivating the plugin, but the boot steps expect an `ok | {error, Reason}` return spec.