### PR TITLE
Print more logs when stream connection fails to open

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -1502,14 +1502,14 @@ handle_frame_pre_auth(Transport,
                                                   Connection#stream_connection{connection_step = opened,
                                                                                virtual_host = VirtualHost}),
             Conn
-        catch
-            exit:_ ->
-                F = rabbit_stream_core:frame({response, CorrelationId,
-                                              {open,
-                                               ?RESPONSE_VHOST_ACCESS_FAILURE,
-                                               #{}}}),
-                send(Transport, S, F),
-                Connection#stream_connection{connection_step = failure}
+        catch exit:#amqp_error{explanation = Explanation} ->
+                  rabbit_log:warning("Opening connection failed: ~ts", [Explanation]),
+                  F = rabbit_stream_core:frame({response, CorrelationId,
+                                                {open,
+                                                 ?RESPONSE_VHOST_ACCESS_FAILURE,
+                                                 #{}}}),
+                  send(Transport, S, F),
+                  Connection#stream_connection{connection_step = failure}
         end,
 
     {Connection1, State};


### PR DESCRIPTION
This commit will print
```
[debug] <0.725.0> Transitioned from tcp_connected to peer_properties_exchanged
[debug] <0.725.0> Transitioned from peer_properties_exchanged to authenticating
[debug] <0.725.0> User 'guest' authenticated successfully by backend rabbit_auth_backend_internal
[debug] <0.725.0> Transitioned from authenticating to authenticated
[debug] <0.725.0> Tuning response 1048576 0
[debug] <0.725.0> Open frame received for fakevhost
[warning] <0.725.0> Opening connection failed: access to vhost 'fakevhost' refused for user 'guest'
[debug] <0.725.0> Transitioned from tuning to failure
[warning] <0.725.0> Closing socket #Port<0.48>. Invalid transition from tuning to failure.
[debug] <0.725.0> rabbit_stream_reader terminating in state 'tuning' with reason 'normal'
```
when the user doesn't have access to the vhost.