### PR TITLE
Update startup banner link for the new website

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1312,10 +1312,11 @@ print_banner() ->
               "~n  TLS Library: ~ts"
               "~n  Release series support status: ~ts"
               "~n"
-              "~n  Doc guides:  https://www.rabbitmq.com/docs/documentation"
+              "~n  Doc guides:  https://www.rabbitmq.com/docs"
               "~n  Support:     https://www.rabbitmq.com/docs/contact"
               "~n  Tutorials:   https://www.rabbitmq.com/tutorials"
               "~n  Monitoring:  https://www.rabbitmq.com/docs/monitoring"
+              "~n  Upgrading:   https://www.rabbitmq.com/docs/upgrade"
               "~n"
               "~n  Logs: ~ts" ++ LogFmt ++ "~n"
               "~n  Config file(s): ~ts" ++ CfgFmt ++ "~n"
@@ -1333,7 +1334,7 @@ maybe_warn_about_release_series_eol() ->
             %% we intentionally log this as an error for increased visibiity
             ?LOG_ERROR("This release series has reached end of life "
                        "and is no longer supported. "
-                       "Please visit https://rabbitmq.com/versions.html "
+                       "Please visit https://www.rabbitmq.com/release-information "
                        "to learn more and upgrade");
         _ -> ok
     end.


### PR DESCRIPTION
Plus add a new link, to the Upgrading guide, arguably one of the more important guides, in particular in the 3.13 and the upcoming 4.x era.
