### PR TITLE
Update management UI footer links for the new website

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
@@ -44,15 +44,14 @@
 <div id="footer">
   <ul>
     <li><a rel="noopener noreferrer" href="api/" target="_blank">HTTP API</a></li>
-    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/documentation.html" target="_blank">Documentation</a></li>
-    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/getstarted.html" target="_blank">Tutorials</a></li>
-    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/changelog.html" target="_blank">New releases</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/docs" target="_blank">Documentation</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/tutorials" target="_blank">Tutorials</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/release-information" target="_blank">New releases</a></li>
     <li><a rel="noopener noreferrer" href="https://www.vmware.com/products/rabbitmq.html" target="_blank">Commercial edition</a></li>
-    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/services.html" target="_blank">Commercial support</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/commercial-offerings" target="_blank">Commercial support</a></li>
     <li><a rel="noopener noreferrer" href="https://github.com/rabbitmq/rabbitmq-server/discussions" target="_blank">Discussions</a></li>
     <li><a rel="noopener noreferrer" href="https://rabbitmq.com/discord/" target="_blank">Discord</a></li>
-    <li><a rel="noopener noreferrer" href="https://rabbitmq.com/slack/" target="_blank">Slack</a></li>
-    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/plugins.html" target="_blank">Plugins</a></li>
-    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/github.html" target="_blank">GitHub</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/docs/plugins" target="_blank">Plugins</a></li>
+    <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/github" target="_blank">GitHub</a></li>
   </ul>
 </div>


### PR DESCRIPTION
and drop a link to Slack while at it. It's served us very well for many years but it has too many limitations in its free version at our scale.

Discord is the primary option now.
