### PR TITLE
Skip access check on absent will queue

### DIFF
--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -97,7 +97,8 @@ sub_groups() ->
        topic_read_permission,
        topic_write_permission,
        topic_write_permission_variable_expansion,
-       loopback_user_connects_from_remote_host
+       loopback_user_connects_from_remote_host,
+       connect_permission
       ]
      },
      {limit, [shuffle],
@@ -284,7 +285,8 @@ init_per_testcase(T, Config)
   when T =:= will_queue_create_permission_queue_read;
        T =:= will_queue_create_permission_exchange_write;
        T =:= will_queue_publish_permission_exchange_write;
-       T =:= will_queue_publish_permission_topic_write ->
+       T =:= will_queue_publish_permission_topic_write;
+       T =:= will_queue_delete_permission ->
     case ?config(mqtt_version, Config) of
         v4 -> {skip, "Will Delay Interval is an MQTT 5.0 feature"};
         v5 -> testcase_started(Config, T)
@@ -981,6 +983,12 @@ loopback_user_connects_from_remote_host(Config) ->
 
     true = rpc(Config, 0, meck, validate, [Mod]),
     ok = rpc(Config, 0, meck, unload, [Mod]).
+
+%% No specific configure, write, or read permissions should be required for only connecting.
+connect_permission(Config) ->
+    set_permissions("", "", "", Config),
+    C = open_mqtt_connection(Config),
+    ok = emqtt:disconnect(C).
 
 set_topic_permissions(WritePat, ReadPat, Config) ->
     rpc(Config, 0,


### PR DESCRIPTION
Resolves https://github.com/rabbitmq/rabbitmq-server/discussions/11021

Prior to this commit, an MQTT client that connects to RabbitMQ needed configure access to its will queue even if the will queue has never existed. This breaks client apps connecting with either v3 or v4 or with v5 without making use of the Will-Delay-Interval.

Specifically, in 3.13.0 and 3.13.1 an MQTT client that connects to RabbitMQ needs unnecessarily configure access to queue `mqtt-will-<MQTT client ID>`.

This commit only check for configure access, if the queue actually gets deleted, i.e. if it existed.