### PR TITLE
Use generic-unix tar.xz artifact in dockerfile

### DIFF
--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -10,13 +10,14 @@ ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ARG RABBITMQ_VERSION=4.0.0
+ARG RABBITMQ_BUILD
 ENV RABBITMQ_VERSION=${RABBITMQ_VERSION}
 ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
-COPY package-generic-unix.tar.xz /usr/local/src/rabbitmq-$RABBITMQ_VERSION.tar.xz
+COPY ${RABBITMQ_BUILD}.tar.xz /usr/local/src/rabbitmq-$RABBITMQ_VERSION.tar.xz
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/packaging/docker-image/Dockerfile
+++ b/packaging/docker-image/Dockerfile
@@ -10,14 +10,13 @@ ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ARG RABBITMQ_VERSION=4.0.0
-ARG RABBITMQ_BUILD
 ENV RABBITMQ_VERSION=${RABBITMQ_VERSION}
 ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
-COPY ${RABBITMQ_BUILD}.tar.xz /usr/local/src/rabbitmq-$RABBITMQ_VERSION.tar.xz
+COPY package-generic-unix.tar.xz /usr/local/src/rabbitmq-$RABBITMQ_VERSION.tar.xz
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -45,7 +45,7 @@ ALT2_PGP_KEYSERVER ?= pgpkeys.uk
 all: dist
 
 dist:
-	cp $(GENERIC_UNIX_ARCHIVE) rabbitmq_server-$(VERSION).tar.xz
+	cp $(GENERIC_UNIX_ARCHIVE) package-generic-unix.tar.xz
 	xzcat $(GENERIC_UNIX_ARCHIVE) | tar xvf -
 	docker build --pull \
 	  --build-arg SKIP_PGP_VERIFY=$(SKIP_PGP_VERIFY) \

--- a/packaging/docker-image/Makefile
+++ b/packaging/docker-image/Makefile
@@ -45,6 +45,7 @@ ALT2_PGP_KEYSERVER ?= pgpkeys.uk
 all: dist
 
 dist:
+	cp $(GENERIC_UNIX_ARCHIVE) rabbitmq_server-$(VERSION).tar.xz
 	xzcat $(GENERIC_UNIX_ARCHIVE) | tar xvf -
 	docker build --pull \
 	  --build-arg SKIP_PGP_VERIFY=$(SKIP_PGP_VERIFY) \


### PR DESCRIPTION
## Proposed Changes

Fix issue with the command `make docker-image`. It was failing because it was not locating the generic-unix file. 
The Makefile is uncompressing the generic-unix for no reason. It is not necessary as the dockerfile does not use it. Instead, it expects the uncompressed version. This PR should also remove that command which uncompresses the generic-unix file.

These changes are already addressed by this other PR https://github.com/rabbitmq/rabbitmq-server/pull/11042

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
