### PR TITLE
Make the OCI workflows conditional on push access

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -15,18 +15,32 @@ concurrency:
 jobs:
   build-package-generic-unix:
     runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.authorized.outputs.authorized }}
     steps:
+      - name: CHECK IF IMAGE WILL PUSH
+        id: authorized
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_PASSWORD }}" ]; then
+            echo "authorized=true" | tee -a $GITHUB_OUTPUT
+          else
+            echo "authorized=false" | tee -a $GITHUB_OUTPUT
+          fi
       - name: Checkout
+        if: steps.authorized.outputs.authorized == 'true'
         uses: actions/checkout@v4
       - name: Configure Erlang
+        if: steps.authorized.outputs.authorized == 'true'
         uses: erlef/setup-beam@v1
         with:
           otp-version: 26.2
           elixir-version: 1.15
       - name: make package-generic-unix
+        if: steps.authorized.outputs.authorized == 'true'
         run: |
           make package-generic-unix PROJECT_VERSION=4.0.0
       - name: Upload package-generic-unix
+        if: steps.authorized.outputs.authorized == 'true'
         uses: actions/upload-artifact@v4.3.1
         with:
           name: package-generic-unix
@@ -35,6 +49,7 @@ jobs:
   build:
     needs: build-package-generic-unix
     runs-on: ubuntu-latest
+    if: ${{ needs.build-package-generic-unix.outputs.authorized }} == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -106,9 +121,10 @@ jobs:
           retention-days: 1
 
   merge:
-    runs-on: ubuntu-latest
     needs:
       - build
+    runs-on: ubuntu-latest
+    if: ${{ needs.build-package-generic-unix.outputs.authorized }} == 'true'
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -19,24 +19,39 @@ jobs:
           - 26_2
     timeout-minutes: 45
     steps:
+    - name: CHECK IF IMAGE WILL PUSH
+      id: authorized
+      run: |
+        if [ -n "${{ secrets.DOCKERHUB_PASSWORD }}" ]; then
+          echo "authorized=true" | tee -a $GITHUB_OUTPUT
+        else
+          echo "authorized=false" | tee -a $GITHUB_OUTPUT
+        fi
     - name: CHECKOUT REPOSITORY
+      if: steps.authorized.outputs.authorized == 'true'
       uses: actions/checkout@v4
     - uses: docker/metadata-action@v5
+      if: steps.authorized.outputs.authorized == 'true'
       id: metadata
       with:
         images: pivotalrabbitmq/rabbitmq
         tags: |
           type=sha,format=long
     - uses: int128/wait-for-docker-image-action@v1
+      if: steps.authorized.outputs.authorized == 'true'
       with:
         tags: ${{ steps.metadata.outputs.tags }}
         timeout-seconds: 3600
         polling-seconds: 60
     - name: CONFIGURE BAZEL
+      if: steps.authorized.outputs.authorized == 'true'
       run: |
+        if [ -n "${{ secrets.BUILDBUDDY_API_KEY }}" ]; then
         cat << EOF >> user.bazelrc
           build:buildbuddy --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}
-
+        EOF
+        fi
+        cat << EOF >> user.bazelrc
           build:buildbuddy --build_metadata=ROLE=CI
           build:buildbuddy --build_metadata=VISIBILITY=PRIVATE
           build:buildbuddy --color=yes
@@ -44,6 +59,7 @@ jobs:
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
     - name: RUN INTEGRATION TESTS
+      if: steps.authorized.outputs.authorized == 'true'
       run: |
         sudo sysctl -w net.ipv4.tcp_keepalive_time=60
         sudo ethtool -K eth0 tso off gso off gro off tx off rx off lro off

--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -48,13 +48,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: 'Login to GitHub Container Registry'
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Configure OTP & Elixir
       uses: erlef/setup-beam@v1.17
       with:

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -44,13 +44,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: 'Login to GitHub Container Registry'
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Configure OTP & Elixir
       uses: erlef/setup-beam@v1.17
       with:


### PR DESCRIPTION
When dependabot creates PRs, secrets are not injected, and the OCI workflow can't push the image
