### PR TITLE
Set the PROJECT_VERSION to 4.0.0 to match the bazel behavior

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -25,7 +25,7 @@ jobs:
           elixir-version: 1.15
       - name: make package-generic-unix
         run: |
-          make package-generic-unix
+          make package-generic-unix PROJECT_VERSION=4.0.0
       - name: Upload package-generic-unix
         uses: actions/upload-artifact@v4.3.1
         with:


### PR DESCRIPTION
in the OCI workflow