### PR TITLE
Set durable annotation for MQTT messages

### DIFF
--- a/deps/rabbitmq_mqtt/src/mc_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/mc_mqtt.erl
@@ -23,14 +23,8 @@
         ]).
 
 init(Msg = #mqtt_msg{qos = Qos,
-                     props = Props})
-  when is_integer(Qos) ->
-    Anns0 = case Qos > 0 of
-                true ->
-                    #{};
-                false ->
-                    #{?ANN_DURABLE => false}
-            end,
+                     props = Props}) ->
+    Anns0 = #{?ANN_DURABLE => durable(Qos)},
     Anns1 = case Props of
                 #{'Message-Expiry-Interval' := Seconds} ->
                     Anns0#{ttl => timer:seconds(Seconds),
@@ -290,7 +284,7 @@ convert_to(mc_amqp, #mqtt_msg{qos = Qos,
              [] -> S2;
              _ -> [#'v1_0.message_annotations'{content = MsgAnns} | S2]
          end,
-    S = [#'v1_0.header'{durable = Qos > 0} | S3],
+    S = [#'v1_0.header'{durable = durable(Qos)} | S3],
     mc_amqp:convert_from(mc_amqp, S, Env);
 convert_to(mc_amqpl, #mqtt_msg{qos = Qos,
                                props = Props,
@@ -559,3 +553,6 @@ amqp_encode(Data, Acc0) ->
     Bin = amqp10_framing:encode_bin(Data),
     Acc = setelement(5, Acc0, [Bin | element(5, Acc0)]),
     setelement(7, Acc, ?CONTENT_TYPE_AMQP).
+
+durable(?QOS_0) -> false;
+durable(?QOS_1) -> true.


### PR DESCRIPTION
This is a follow up to https://github.com/rabbitmq/rabbitmq-server/pull/11012

 ## What?
For incoming MQTT messages, always set the `durable` message container annotation.

 ## Why?
Even though defaulting to `durable=true` when no durable annotation is set, as prior to this commit, is good enough, explicitly setting the durable annotation makes the code a bit more future proof and maintainable going forward in 4.0 where we will rely more on the durable annotation because AMQP 1.0 message headers will be omitted in classic and quorum queues (see https://github.com/rabbitmq/rabbitmq-server/pull/10964)

For MQTT messages, it's important to know whether the message was published with QoS 0 or QoS 1 because it affects the QoS of the MQTT message that will delivered to the MQTT subscriber.

The performance impact of always setting the durable annotation is negligible.