### PR TITLE
Fix failing auth test

### DIFF
--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -20,6 +20,7 @@ on:
     paths:
       - 'deps/rabbit/**'
       - 'deps/rabbitmq_auth_/**'
+      - 'deps/rabbitmq_mqtt/**'
       - 'deps/rabbitmq_management/selenium/full-suite-authnz-messaging'
       - 'deps/rabbitmq_management/selenium/suites/authnz-messaging'
       - 'deps/rabbitmq_management/selenium/test/authnz-msg-protocols'

--- a/deps/rabbitmq_management/selenium/test/authnz-msg-protocols/mqtt.js
+++ b/deps/rabbitmq_management/selenium/test/authnz-msg-protocols/mqtt.js
@@ -24,7 +24,6 @@ describe('Having MQTT protocol enbled and the following auth_backends: ' + backe
       reset()
       expectations.push(expectUser({ "username": username, "password": password, "client_id": client_id, "vhost": "/" }, "allow"))
       expectations.push(expectVhost({ "username": username, "vhost": "/"}, "allow"))
-      expectations.push(expectResource({ "username": username, "vhost": "/", "resource": "queue", "name": "mqtt-will-selenium-client", "permission":"configure", "tags":"", "client_id" : client_id }, "allow"))
     } else if (backends.includes("oauth") && username.includes("oauth")) {
       let oauthProviderUrl = process.env.OAUTH_PROVIDER_URL
       let oauthClientId = process.env.OAUTH_CLIENT_ID


### PR DESCRIPTION
This fixes the failing GitHub action `Test Authentication/Authorization backends via mutiple messaging protocols / selenium` originally caused by https://github.com/rabbitmq/rabbitmq-server/pull/11023