### PR TITLE
Ignore `ebusy` when deleting a directory

### DIFF
--- a/deps/rabbit/src/rabbit_file.erl
+++ b/deps/rabbit/src/rabbit_file.erl
@@ -244,7 +244,6 @@ recursive_delete1(Path) ->
         false -> case prim_file:delete(Path) of
                      ok              -> ok;
                      {error, enoent} -> ok; %% Path doesn't exist anyway
-                     {error, ebusy}  -> ok; %% Ignore (rabbitmq/rabbitmq-server#11047)
                      {error, Err}    -> {error, {Path, Err}}
                  end;
         true  -> case prim_file:list_dir(Path) of
@@ -259,6 +258,7 @@ recursive_delete1(Path) ->
                              ok ->
                                  case prim_file:del_dir(Path) of
                                      ok           -> ok;
+                                     {error, ebusy}  -> ok; %% Can't delete a mount point
                                      {error, Err} -> {error, {Path, Err}}
                                  end;
                              {error, _Err} = Error ->

--- a/deps/rabbit/src/rabbit_file.erl
+++ b/deps/rabbit/src/rabbit_file.erl
@@ -244,6 +244,7 @@ recursive_delete1(Path) ->
         false -> case prim_file:delete(Path) of
                      ok              -> ok;
                      {error, enoent} -> ok; %% Path doesn't exist anyway
+                     {error, ebusy}  -> ok; %% Ignore (rabbitmq/rabbitmq-server#11047)
                      {error, Err}    -> {error, {Path, Err}}
                  end;
         true  -> case prim_file:list_dir(Path) of

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -1042,6 +1042,7 @@ mnesia_and_msg_store_files() ->
              rabbit_node_monitor:coordination_filename(),
              rabbit_node_monitor:stream_filename(),
              rabbit_node_monitor:default_quorum_filename(),
+             rabbit_node_monitor:classic_filename(),
              rabbit_node_monitor:quorum_filename(),
              rabbit_feature_flags:enabled_feature_flags_list_file(),
              rabbit_khepri:dir()],

--- a/deps/rabbit/src/rabbit_node_monitor.erl
+++ b/deps/rabbit/src/rabbit_node_monitor.erl
@@ -14,6 +14,7 @@
          cluster_status_filename/0, coordination_filename/0,
          stream_filename/0,
          quorum_filename/0, default_quorum_filename/0,
+         classic_filename/0,
          prepare_cluster_status_files/0,
          write_cluster_status/1, read_cluster_status/0,
          update_cluster_status/0, reset_cluster_status/0]).
@@ -82,6 +83,9 @@ quorum_filename() ->
 
 default_quorum_filename() ->
     filename:join(rabbit:data_dir(), "quorum").
+
+classic_filename() ->
+    filename:join(rabbit:data_dir(), "msg_stores").
 
 -spec prepare_cluster_status_files() -> 'ok' | no_return().
 


### PR DESCRIPTION
Reported in https://github.com/rabbitmq/rabbitmq-server/discussions/11047

This error manifests when the quorum directory is its own mount point.