### PR TITLE
Speed up 'rabbitmqctl stop_app'

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_db_handler.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_db_handler.erl
@@ -92,6 +92,10 @@ handle_event(_, State) ->
 handle_info(_Info, State) ->
     {ok, State}.
 
+terminate(stop, _State) ->
+    %% if the node is stopping, we don't want to wait
+    %% 5 seconds for the statistics to get disabled
+    ok;
 terminate(_Arg, _State) ->
     ensure_statistics_disabled(),
     ok.


### PR DESCRIPTION
I noticed that `stop_app` would take over 5 seconds on an empty node which is strange. I found this gap in the logs:
```
2024-04-18 10:49:04.646450+09:00 [info] <0.599.0> Management plugin: to stop collect_statistics.
2024-04-18 10:49:09.647652+09:00 [debug] <0.247.0> Set stop reason to: normal
```
No point waiting for that stats to stop being emitted when we stop the node completely. It was added in https://github.com/rabbitmq/rabbitmq-server/commit/0e640da5 to ensure the stats stop when the management_agent gets disabled