### PR TITLE
Notify of permission and parameter deletions when deleting a vhost

### DIFF
--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -133,6 +133,7 @@
          clear_payload/1,
          delete/1, delete/2,
          delete_or_fail/1,
+         adv_delete_many/1,
 
          transaction/1,
          transaction/2,
@@ -949,6 +950,9 @@ delete_or_fail(Path) ->
         Error ->
             Error
     end.
+
+adv_delete_many(Path) ->
+    khepri_adv:delete_many(?STORE_ID, Path, ?DEFAULT_COMMAND_OPTIONS).
 
 put(PathPattern, Data) ->
     khepri:put(

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -170,6 +170,10 @@
 
 -export([force_shrink_member_to_current_member/0]).
 
+%% Helpers for working with the Khepri API / types.
+-export([collect_payloads/1,
+         collect_payloads/2]).
+
 -ifdef(TEST).
 -export([force_metadata_store/1,
          clear_forced_metadata_store/0]).
@@ -982,6 +986,48 @@ info() ->
 
 handle_async_ret(RaEvent) ->
     khepri:handle_async_ret(?STORE_ID, RaEvent).
+
+%% -------------------------------------------------------------------
+%% collect_payloads().
+%% -------------------------------------------------------------------
+
+-spec collect_payloads(Props) -> Ret when
+      Props :: khepri:node_props(),
+      Ret :: [Payload],
+      Payload :: term().
+
+%% @doc Collects all payloads from a node props map.
+%%
+%% This is the same as calling `collect_payloads(Props, [])'.
+%%
+%% @private
+
+collect_payloads(Props) when is_map(Props) ->
+    collect_payloads(Props, []).
+
+-spec collect_payloads(Props, Acc0) -> Ret when
+      Props :: khepri:node_props(),
+      Acc0 :: [Payload],
+      Ret :: [Payload],
+      Payload :: term().
+
+%% @doc Collects all payloads from a node props map into the accumulator list.
+%%
+%% This is meant to be used with the `khepri_adv' API to easily collect the
+%% payloads from the return value of `khepri_adv:delete_many/4' for example.
+%%
+%% @returns all payloads in the node props map collected into a list, with
+%% `Acc0' as the tail.
+%%
+%% @private
+
+collect_payloads(Props, Acc0) when is_map(Props) andalso is_list(Acc0) ->
+    maps:fold(
+      fun (_Path, #{data := Payload}, Acc) ->
+              [Payload | Acc];
+          (_Path, _NoPayload, Acc) ->
+              Acc
+      end, Acc0, Props).
 
 %% -------------------------------------------------------------------
 %% if_has_data_wildcard().

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -284,8 +284,6 @@ delete(VHost, ActingUser) ->
         #exchange{name = Name} <- rabbit_exchange:list(VHost)],
     rabbit_log:info("Clearing policies and runtime parameters in vhost '~ts' because it's being deleted", [VHost]),
     _ = rabbit_runtime_parameters:clear_vhost(VHost, ActingUser),
-    _ = [rabbit_policy:delete(VHost, proplists:get_value(name, Info), ActingUser)
-         || Info <- rabbit_policy:list(VHost)],
     rabbit_log:debug("Removing vhost '~ts' from the metadata storage because it's being deleted", [VHost]),
     case rabbit_db_vhost:delete(VHost) of
         true ->

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -272,8 +272,7 @@ delete(VHost, ActingUser) ->
     %% calls would be responsible for the atomicity, not this code.
     %% Clear the permissions first to prohibit new incoming connections when deleting a vhost
     rabbit_log:info("Clearing permissions in vhost '~ts' because it's being deleted", [VHost]),
-    _ = rabbit_auth_backend_internal:clear_permissions_for_vhost(VHost, ActingUser),
-    _ = rabbit_auth_backend_internal:clear_topic_permissions_for_vhost(VHost, ActingUser),
+    ok = rabbit_auth_backend_internal:clear_all_permissions_for_vhost(VHost, ActingUser),
     rabbit_log:info("Deleting queues in vhost '~ts' because it's being deleted", [VHost]),
     QDelFun = fun (Q) -> rabbit_amqqueue:delete(Q, false, false, ActingUser) end,
     [begin

--- a/deps/rabbit/src/rabbit_vhost_limit.erl
+++ b/deps/rabbit/src/rabbit_vhost_limit.erl
@@ -39,12 +39,14 @@ validate(_VHost, <<"vhost-limits">>, Name, Term, _User) ->
 
 notify(VHost, <<"vhost-limits">>, <<"limits">>, Limits, ActingUser) ->
     rabbit_event:notify(vhost_limits_set, [{name, <<"limits">>},
+                                           {vhost, VHost},
                                            {user_who_performed_action, ActingUser}
                                            | Limits]),
     update_vhost(VHost, Limits).
 
 notify_clear(VHost, <<"vhost-limits">>, <<"limits">>, ActingUser) ->
     rabbit_event:notify(vhost_limits_cleared, [{name, <<"limits">>},
+                                               {vhost, VHost},
                                                {user_who_performed_action, ActingUser}]),
     %% If the function is called as a part of vhost deletion, the vhost can
     %% be already deleted.

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -506,9 +506,15 @@ vhost_is_created_with_default_limits(Config) ->
     Env = [{vhosts, [{<<"id">>, Limits++Pattern}]}],
     ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, 0,
                             application, set_env, [rabbit, default_limits, Env])),
-    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
-    ?assertEqual(Limits, rabbit_ct_broker_helpers:rpc(Config, 0,
-                            rabbit_vhost_limit, list, [VHost])).
+    try
+        ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+        ?assertEqual(Limits, rabbit_ct_broker_helpers:rpc(Config, 0,
+                                rabbit_vhost_limit, list, [VHost]))
+    after
+        rabbit_ct_broker_helpers:rpc(
+          Config, 0,
+          application, unset_env, [rabbit, default_limits])
+    end.
 
 vhost_is_created_with_operator_policies(Config) ->
     VHost = <<"vhost1">>,
@@ -517,9 +523,15 @@ vhost_is_created_with_operator_policies(Config) ->
     Env = [{operator, [{PolicyName, Definition}]}],
     ?assertEqual(ok, rabbit_ct_broker_helpers:rpc(Config, 0,
                             application, set_env, [rabbit, default_policies, Env])),
-    ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
-    ?assertNotEqual(not_found, rabbit_ct_broker_helpers:rpc(Config, 0,
-                            rabbit_policy, lookup_op, [VHost, PolicyName])).
+    try
+        ?assertEqual(ok, rabbit_ct_broker_helpers:add_vhost(Config, VHost)),
+        ?assertNotEqual(not_found, rabbit_ct_broker_helpers:rpc(Config, 0,
+                                rabbit_policy, lookup_op, [VHost, PolicyName]))
+    after
+        rabbit_ct_broker_helpers:rpc(
+          Config, 0,
+          application, unset_env, [rabbit, default_policies])
+    end.
 
 vhost_is_created_with_default_user(Config) ->
     VHost = <<"vhost1">>,

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -456,9 +456,19 @@ vhost_deletion(Config) ->
                                false
                        end, Events))),
 
-        %% TODO: parameter_cleared and vhost_limits_cleared
-        %% ?assertMatch(#{name := PolicyName, vhost := VHost},
-        %%              proplists:get_value(policy_cleared, Events)),
+        ?assertMatch(
+          {value, {parameter_cleared, #{name := <<"limits">>,
+                                        vhost := VHost}}},
+          lists:search(
+            fun ({parameter_cleared, #{component := <<"vhost-limits">>}}) ->
+                    true;
+                (_Event) ->
+                    false
+            end, Events)),
+        ?assertMatch(#{name := <<"limits">>, vhost := VHost},
+                     proplists:get_value(vhost_limits_cleared, Events)),
+        ?assertMatch(#{name := PolicyName, vhost := VHost},
+                     proplists:get_value(policy_cleared, Events)),
 
         ?assertMatch(#{name := VHost,
                        user_who_performed_action := ActingUser},

--- a/deps/rabbit/test/vhost_SUITE.erl
+++ b/deps/rabbit/test/vhost_SUITE.erl
@@ -33,6 +33,7 @@ groups() ->
         vhost_failure_forces_connection_closure,
         vhost_creation_idempotency,
         vhost_update_idempotency,
+        vhost_deletion,
         parse_tags
     ],
     ClusterSize2Tests = [
@@ -41,7 +42,8 @@ groups() ->
         vhost_failure_forces_connection_closure_on_failure_node,
         node_starts_with_dead_vhosts,
         node_starts_with_dead_vhosts_with_mirrors,
-        vhost_creation_idempotency
+        vhost_creation_idempotency,
+        vhost_deletion
     ],
     [
       {cluster_size_1_network, [], ClusterSize1Tests},
@@ -373,6 +375,118 @@ vhost_update_idempotency(Config) ->
         rabbit_ct_broker_helpers:rpc(Config, 0,
                                      gen_event, delete_handler, [rabbit_event, test_rabbit_event_handler, []]),
         rabbit_ct_broker_helpers:delete_vhost(Config, VHost)
+    end.
+
+vhost_deletion(Config) ->
+    VHost = <<"deletion-vhost">>,
+    ActingUser = <<"acting-user">>,
+    Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+
+    set_up_vhost(Config, VHost),
+
+    Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, VHost),
+    {ok, Chan} = amqp_connection:open_channel(Conn),
+
+    %% Declare some resources under the vhost. These should be deleted when the
+    %% vhost is deleted.
+    QName = <<"vhost-deletion-queue">>,
+    #'queue.declare_ok'{} = amqp_channel:call(
+                              Chan, #'queue.declare'{queue = QName, durable = true}),
+    XName = <<"vhost-deletion-exchange">>,
+    #'exchange.declare_ok'{} = amqp_channel:call(
+                                 Chan,
+                                 #'exchange.declare'{exchange = XName,
+                                                     durable = true,
+                                                     type = <<"direct">>}),
+    RoutingKey = QName,
+    #'queue.bind_ok'{} = amqp_channel:call(
+                           Chan,
+                           #'queue.bind'{exchange = XName,
+                                         queue = QName,
+                                         routing_key = RoutingKey}),
+    PolicyName = <<"ttl-policy">>,
+    rabbit_ct_broker_helpers:set_policy_in_vhost(
+      Config, Node, VHost,
+      PolicyName, <<"policy_ttl-queue">>, <<"all">>, [{<<"message-ttl">>, 20}],
+      ActingUser),
+
+    % Load the dummy event handler module on the node.
+    ok = rabbit_ct_broker_helpers:rpc(Config, Node, test_rabbit_event_handler, okay, []),
+    ok = rabbit_ct_broker_helpers:rpc(Config, Node, gen_event, add_handler,
+                                      [rabbit_event, test_rabbit_event_handler, []]),
+    try
+        rabbit_ct_broker_helpers:delete_vhost(Config, VHost),
+
+        Events0 = rabbit_ct_broker_helpers:rpc(Config, Node,
+                                               gen_event, call,
+                                               [rabbit_event, test_rabbit_event_handler, events, 1000]),
+        ct:pal(
+          ?LOW_IMPORTANCE,
+          "Events emitted during deletion: ~p", [lists:reverse(Events0)]),
+
+        %% Reorganize the event props into maps for easier matching.
+        Events = [{Type, maps:from_list(Props)} ||
+                  #event{type = Type, props = Props} <- Events0],
+
+        ?assertMatch(#{user := <<"guest">>, vhost := VHost},
+                     proplists:get_value(permission_deleted, Events)),
+
+        ?assertMatch(#{source_name := XName,
+                       source_kind := exchange,
+                       destination_name := QName,
+                       destination_kind := queue,
+                       routing_key := RoutingKey,
+                       vhost := VHost},
+                     proplists:get_value(binding_deleted, Events)),
+
+        ?assertMatch(#{name := #resource{name = QName,
+                                         kind = queue,
+                                         virtual_host = VHost}},
+                     proplists:get_value(queue_deleted, Events)),
+
+        ?assertEqual(
+          lists:sort([<<>>, <<"amq.direct">>, <<"amq.fanout">>, <<"amq.headers">>,
+                      <<"amq.match">>, <<"amq.rabbitmq.trace">>, <<"amq.topic">>,
+                      <<"vhost-deletion-exchange">>]),
+          lists:sort(lists:filtermap(
+                       fun ({exchange_deleted,
+                             #{name := #resource{name = Name}}}) ->
+                               {true, Name};
+                           (_Event) ->
+                               false
+                       end, Events))),
+
+        %% TODO: parameter_cleared and vhost_limits_cleared
+        %% ?assertMatch(#{name := PolicyName, vhost := VHost},
+        %%              proplists:get_value(policy_cleared, Events)),
+
+        ?assertMatch(#{name := VHost,
+                       user_who_performed_action := ActingUser},
+                     proplists:get_value(vhost_deleted, Events)),
+        ?assertMatch(#{name := VHost,
+                       node := Node,
+                       user_who_performed_action := ?INTERNAL_USER},
+                     proplists:get_value(vhost_down, Events)),
+
+        ?assert(proplists:is_defined(channel_closed, Events)),
+        ?assert(proplists:is_defined(connection_closed, Events)),
+
+        %% VHost deletion is not idempotent - we return an error - but deleting
+        %% the same vhost again should not cause any more resources to be
+        %% deleted. So we should see no new events in the `rabbit_event'
+        %% handler.
+        ?assertEqual(
+          {error, {no_such_vhost, VHost}},
+          rabbit_ct_broker_helpers:delete_vhost(Config, VHost)),
+        ?assertEqual(
+          Events0,
+          rabbit_ct_broker_helpers:rpc(
+            Config, Node,
+            gen_event, call,
+            [rabbit_event, test_rabbit_event_handler, events, 1000]))
+    after
+        rabbit_ct_broker_helpers:rpc(Config, Node,
+                                     gen_event, delete_handler, [rabbit_event, test_rabbit_event_handler, []])
     end.
 
 vhost_is_created_with_default_limits(Config) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
@@ -88,11 +88,7 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
 
 delete_resource(ReqData, Context = #context{user = #user{username = Username}}) ->
     VHost = id(ReqData),
-    try
-        rabbit_vhost:delete(VHost, Username)
-    catch _:{error, {no_such_vhost, _}} ->
-        ok
-    end,
+    _ = rabbit_vhost:delete(VHost, Username),
     {true, ReqData, Context}.
 
 is_authorized(ReqData, Context) ->


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-server/pull/6430 caused some subtle regressions in the events sent through `rabbit_event:notify/2` when deleting a vhost. These notifications were thunks that mnesia transactions returned but that was refactored in https://github.com/rabbitmq/rabbitmq-server/pull/6430 to be explicit calls for most callers. Runtime parameters and permissions also need some changes so that they send notifications when deleted.

I've also added the vhost name to the `rabbit_vhost_limit` notifications for testing purposes but it should be useful anyways.