### PR TITLE
Fix AMQP fragmentation test in CI

### DIFF
--- a/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs
+++ b/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs
@@ -273,10 +273,10 @@ module Test =
 
     let fragmentation uri =
         for frameSize, size in
-            [512u, 512
-             512u, 600
-             512u, 1024
-             1024u, 1024] do
+            [1024u, 1024
+             1024u, 1100
+             1024u, 2048
+             2048u, 2048] do
             let addr = Address uri
             let opn = Open(ContainerId = Guid.NewGuid().ToString(),
                            HostName = addr.Host, ChannelMax = 256us,


### PR DESCRIPTION
```
make -C deps/rabbit ct-amqp_system t=dotnet:fragmentation
```

fails in the new make CI with:
```
amqp_system_SUITE > dotnet > fragmentation
    #1. {error,{{badmatch,{error,134,
                                 "Unhandled exception. Amqp.AmqpException: Invalid frame size:527, maximum frame size:512.\n   at Amqp.Connection.ThrowIfClosed(String operation)\n   at Amqp.Connection.AddSession(Session session)\n   at Amqp.Session..ctor(Connection connection, Begin begin, OnBegin onBegin)\n   at Amqp.Session..ctor(Connection connection)\n   at Program.AmqpClient.connectWithOpen(String uri, Open opn) in /home/runner/work/rabbitmq-server/rabbitmq-server/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs:line 53\n   at Program.Test.fragmentation(String uri) in /home/runner/work/rabbitmq-server/rabbitmq-server/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs:line 284\n   at Program.main(String[] argv) in /home/runner/work/rabbitmq-server/rabbitmq-server/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs:line 533\n"}},
                [{amqp_system_SUITE,run_dotnet_test,2,
                                    [{file,"amqp_system_SUITE.erl"},
                                     {line,228}]},
                 {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1793}]},
                 {test_server,run_test_case_eval1,6,
                              [{file,"test_server.erl"},{line,1302}]},
                 {test_server,run_test_case_eval,9,
                              [{file,"test_server.erl"},{line,1234}]}]}}
```

RabbitMQ includes its node name and cluster name in the open frame to the client. Running this test locally shows an open frame size of 467 bytes.
The suspicion is that the node name and cluster name in CI is longer causing the open frame from RabbitMQ to the client to exceed the frame size of 512 bytes.