### PR TITLE
Create rabbit_table:create_and_replicate_table/2

### DIFF
--- a/deps/rabbit/src/rabbit_db_maintenance.erl
+++ b/deps/rabbit/src/rabbit_db_maintenance.erl
@@ -39,47 +39,14 @@ setup_schema_in_mnesia() ->
     rabbit_log:info(
       "Creating table ~ts for maintenance mode status",
       [TableName]),
-    try
-        rabbit_table:create(
-          TableName,
-          status_table_definition()),
-        %% The `rabbit_node_maintenance_states' table used to be global but not
-        %% replicated. This leads to various errors during RabbitMQ boot or
-        %% operations on the Mnesia database. The reason is the table existed
-        %% on a single node and, if that node was stopped or MIA, other nodes
-        %% may wait forever on that node for the table to be available.
-        %%
-        %% The call below makes sure this node has a copy of the table.
-        case rabbit_table:ensure_table_copy(TableName, node(), ram_copies) of
-            ok ->
-                %% Next, we try to fix other nodes in the cluster if they are
-                %% running a version of RabbitMQ which does not replicate the
-                %% table. All nodes must have a replica for Mnesia operations
-                %% to work properly. Therefore the code below is to make older
-                %% compatible with newer nodes.
-                Replicas = mnesia:table_info(TableName, all_nodes),
-                Members = rabbit_nodes:list_running(),
-                MissingOn = Members -- Replicas,
-                lists:foreach(
-                  fun(Node) ->
-                          %% Errors from adding a replica on those older nodes
-                          %% are ignored however. They should not be fatal. The
-                          %% problem will solve by itself once all nodes are
-                          %% upgraded.
-                          _ = rpc:call(
-                                Node,
-                                rabbit_table, ensure_table_copy,
-                                [TableName, Node, ram_copies])
-                  end, MissingOn),
-                ok;
-            Error ->
-                Error
-        end
-    catch throw:Reason  ->
-            rabbit_log:error(
-              "Failed to create maintenance status table: ~tp",
-              [Reason])
-    end.
+    %% The `rabbit_node_maintenance_states' table used to be global but not
+    %% replicated. This leads to various errors during RabbitMQ boot or
+    %% operations on the Mnesia database. The reason is the table existed
+    %% on a single node and, if that node was stopped or MIA, other nodes
+    %% may wait forever on that node for the table to be available.
+    rabbit_table:create_and_replicate_table(
+      TableName,
+      status_table_definition()).
 
 -spec status_table_name() -> mnesia_table().
 status_table_name() ->

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -9,6 +9,7 @@
 
 -export([
     create/0, create/2, ensure_local_copies/1, ensure_table_copy/3,
+    create_and_replicate_table/2,
     wait_for_replicated/1, wait/1, wait/2,
     force_load/0, is_present/0, is_empty/0, needs_default_data/0,
     check_schema_integrity/1,
@@ -64,6 +65,7 @@ ensure_secondary_index(Table, Field) ->
 
 %% mnesia:table() and mnesia:storage_type() are not exported
 -type mnesia_table() :: atom().
+-type mnesia_table_definition() :: list().
 -type mnesia_storage_type() :: 'ram_copies' | 'disc_copies' | 'disc_only_copies'.
 
 -spec ensure_table_copy(mnesia_table(), node(), mnesia_storage_type()) ->
@@ -76,6 +78,44 @@ ensure_table_copy(TableName, Node, StorageType) ->
         {aborted, {already_exists, TableName, _}} -> ok;
         {aborted, Reason}                         -> {error, Reason}
     end.
+
+-spec create_and_replicate_table(mnesia_table(), mnesia_table_definition()) ->
+    ok | {error, any()}.
+create_and_replicate_table(TableName, TableDefinition) ->
+    try
+        rabbit_table:create(TableName, TableDefinition),
+        %% The call below makes sure this node has a copy of the table.
+        case rabbit_table:ensure_table_copy(TableName, node(), ram_copies) of
+            ok ->
+                %% Next, we try to fix other nodes in the cluster if they are
+                %% running a version of RabbitMQ which does not replicate the
+                %% table. All nodes must have a replica for Mnesia operations
+                %% to work properly. Therefore the code below is to make older
+                %% compatible with newer nodes.
+                Replicas = mnesia:table_info(TableName, all_nodes),
+                Members = rabbit_nodes:list_running(),
+                MissingOn = Members -- Replicas,
+                lists:foreach(
+                  fun(Node) ->
+                          %% Errors from adding a replica on those older nodes
+                          %% are ignored however. They should not be fatal. The
+                          %% problem will solve by itself once all nodes are
+                          %% upgraded.
+                          _ = rpc:call(
+                                Node,
+                                rabbit_table, ensure_table_copy,
+                                [TableName, Node, ram_copies])
+                  end, MissingOn),
+                ok;
+            Error ->
+                Error
+        end
+    catch throw:Reason  ->
+              rabbit_log:error(
+                "Failed to create ~tp table: ~tp",
+                [TableName, Reason])
+    end.
+
 
 %% This arity only exists for backwards compatibility with certain
 %% plugins. See https://github.com/rabbitmq/rabbitmq-clusterer/issues/19.

--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange.erl
@@ -29,50 +29,19 @@ setup_schema() ->
 
 setup_schema_in_mnesia() ->
     TableName = ?JMS_TOPIC_TABLE,
+    TableDefinition = [{attributes, record_info(fields, ?JMS_TOPIC_RECORD)},
+                       {record_name, ?JMS_TOPIC_RECORD},
+                       {type, set}],
     rabbit_log:info(
       "Creating table ~ts for JMS topic exchange",
       [TableName]),
-    _ = try
-            rabbit_table:create(
-              TableName,
-              [{attributes, record_info(fields, ?JMS_TOPIC_RECORD)},
-               {record_name, ?JMS_TOPIC_RECORD},
-               {type, set}]),
-            %% The JMS topic exchange table must be available on all nodes.
-            %% If it existed on only one node, messages could not be published
-            %% to JMS topic exchanges and routed to topic subscribers if the node
-            %% was unavailable.
-            %% The call below makes sure this node has a copy of the table.
-            case rabbit_table:ensure_table_copy(TableName, node(), ram_copies) of
-                ok ->
-                    %% Next, we try to fix other nodes in the cluster if they are
-                    %% running a version of RabbitMQ which does not replicate the
-                    %% table. All nodes must have a replica for Mnesia operations
-                    %% to work properly. Therefore the code below is to make older
-                    %% compatible with newer nodes.
-                    Replicas = mnesia:table_info(TableName, all_nodes),
-                    Members = rabbit_nodes:list_running(),
-                    MissingOn = Members -- Replicas,
-                    lists:foreach(
-                      fun(Node) ->
-                              %% Errors from adding a replica on those older nodes
-                              %% are ignored however. They should not be fatal. The
-                              %% problem will solve by itself once all nodes are
-                              %% upgraded.
-                              _ = rpc:call(
-                                    Node,
-                                    rabbit_table, ensure_table_copy,
-                                    [TableName, Node, ram_copies])
-                      end, MissingOn),
-                    ok;
-                Error ->
-                    Error
-            end
-        catch throw:Reason  ->
-                  rabbit_log:error(
-                    "Failed to create JMS topic exchange table: ~tp",
-                    [Reason])
-        end,
+    %% The JMS topic exchange table must be available on all nodes.
+    %% If it existed on only one node, messages could not be published
+    %% to JMS topic exchanges and routed to topic subscribers if the node
+    %% was unavailable.
+    _ = rabbit_table:create_and_replicate_table(
+          TableName,
+          TableDefinition),
     ok.
 
 %% -------------------------------------------------------------------


### PR DESCRIPTION
Used for the maintenance and JMS topic exchange Mnesia tables.