### PR TITLE
Cleanup shovels deleted from another node

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -82,8 +82,7 @@ stop_child({VHost, ShovelName} = Name) ->
                     TmpExpId = temp_experimental_id(Name),
                     _ = stop_and_delete_child(TmpExpId),
                     ok
-            end,
-            rabbit_shovel_status:remove(Name)
+            end
     end,
     rabbit_shovel_locks:unlock(LockId),
     ok.


### PR DESCRIPTION
There are two ways to delete a shovel - `rabbitmqctl delete_shovel` and `rabbitmqctl clear_parameter`. The former works correctly (to the extent I tried), the latter doesn't clean up the shovel status correctly when the shovel is deleted from a another node. The shovel process is actually stopped, but it's not removed from the ETS table and is therefore returned in `rabbitmqctl shovel_status`, Management UI, etc.

The problems was that `rabbit_shovel_status:remove(Name)` was called on the node where the command was executed, rather than on the node running the shovel. This PR addresses this by calling this function from the shovel (worker) process itself, upon termination.

To reproduce the problem:
1. start a cluster without this PR
2. declare the queues, for example: `perf-test -qq -u src -C 1; perf-test -qq -u dst -C 1` 
3. declare the shovel:
```
rabbitmqctl -n rabbit-1 set_parameter shovel test '{"ack-mode":"on-confirm","dest-add-forward-headers":false,"dest-protocol":"amqp091","dest-queue":"dst","dest-uri":"amqp://","src-delete-after":"never","src-protocol":"amqp091","src-queue":"src","src-uri":"amqp://"}'
```
4. delete the shovel by clearing the parameter from another node:
```
rabbitmqctl -n rabbit-2 clear_parameter shovel test
```
5. You will see `rabbitmqctl -n rabbit-1 shovel_status` still reporting this shovel as running, even though it doesn't exist at all (Management UI also shows this shovel)

With this PR, the last command should return an empty result.