### PR TITLE
Remove duplicate rabbitmq_auth_backend_http in plugins.mk

### DIFF
--- a/plugins.mk
+++ b/plugins.mk
@@ -8,7 +8,6 @@
 PLUGINS := rabbitmq_amqp1_0 \
 	   rabbitmq_auth_backend_cache \
 	   rabbitmq_auth_backend_http \
-	   rabbitmq_auth_backend_http \
 	   rabbitmq_auth_backend_ldap \
 	   rabbitmq_auth_backend_oauth2 \
 	   rabbitmq_auth_mechanism_ssl \


### PR DESCRIPTION
interferes with running `make xref` in some circumstances