### PR TITLE
List shovels on all nodes

### DIFF
--- a/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ShovelStatusCommand.erl
+++ b/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ShovelStatusCommand.erl
@@ -61,7 +61,7 @@ banner(_, #{node := Node}) ->
                              atom_to_binary(Node, utf8)]).
 
 run(_Args, #{node := Node}) ->
-    case rabbit_misc:rpc_call(Node, rabbit_shovel_status, status, []) of
+    case rabbit_misc:rpc_call(Node, rabbit_shovel_status, cluster_status, []) of
         {badrpc, _} = Error ->
             Error;
         Status ->


### PR DESCRIPTION
Previously `rabbitmqctl list_shovels` would only list shovels running on the local node (where the command was executed). For consistency with other commands, such as `list_connections` it should like all shovels in the cluster.