### PR TITLE
CI: Bump actions runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/gazelle-scheduled.yaml
+++ b/.github/workflows/gazelle-scheduled.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   bazel-run-gazelle:
     name: bazel run gazelle
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/gazelle.yaml
+++ b/.github/workflows/gazelle.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   bazel-run-gazelle:
     name: bazel run gazelle
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/perform-bazel-execution-comparison.yaml
+++ b/.github/workflows/perform-bazel-execution-comparison.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-a:
     name: Run A
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         erlang_version:
@@ -44,7 +44,7 @@ jobs:
   run-b:
     name: Run B
     needs: run-a
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         erlang_version:
@@ -79,7 +79,7 @@ jobs:
   parse-logs:
     name: Parse Logs
     needs: [run-a, run-b]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: CHECKOUT BAZEL
       uses: actions/checkout@v4

--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   peer-discovery-aws-integration-test:
     name: Integration Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         otp_version_id:

--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   selenium:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-erlang-git.yaml
+++ b/.github/workflows/test-erlang-git.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-erlang-git:
     name: Test (Erlang Git Master)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   ensure-mixed-version-archive:
     name: Prepare Artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
 
   test-mixed-versions:
     name: Test (Mixed Version Cluster)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: ensure-mixed-version-archive
     strategy:
       fail-fast: false

--- a/.github/workflows/test-selenium.yaml
+++ b/.github/workflows/test-selenium.yaml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   selenium:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-elixir-patches.yaml
+++ b/.github/workflows/update-elixir-patches.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-toolchains:
     name: Update Elixir Versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/update-otp-patches.yaml
+++ b/.github/workflows/update-otp-patches.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   update-toolchains:
     name: Update OTP Versions
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       fail-fast: false


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-ci/commit/e667dcf99bf9ac214bab69907afa8df027154286 updated the Bazel remote build image from Debian Bullseye to Bookworm. The Erlang produced by Bazel remote execution compiles Erlang against a newer GLIBC than what Ubuntu 20.04 uses. We can bump the actions runner to Ubuntu 22.04 to fix the GLIBC incompatibility.

`/deps/rabbit:feature_flags_with_unpriveleged_user_SUITE` fails from the GLIBC incompatibility because it's tagged to always run locally (for the sake of being able to change some file permissions not possible within the Bazel sandbox), so this change should  fix that failing test.