### PR TITLE
Fix compatibility with openldap 2.5.x

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/example/global.ldif
+++ b/deps/rabbitmq_auth_backend_ldap/example/global.ldif
@@ -5,6 +5,10 @@ cn: module
 olcModuleLoad: back_mdb.la
 
 # Create directory database
+dn: olcBackend=mdb,cn=config
+objectClass: olcBackendConfig
+olcBackend: mdb
+
 dn: olcDatabase=mdb,cn=config
 objectClass: olcDatabaseConfig
 objectClass: olcMdbConfig

--- a/deps/rabbitmq_auth_backend_ldap/example/global.ldif
+++ b/deps/rabbitmq_auth_backend_ldap/example/global.ldif
@@ -2,13 +2,13 @@
 dn: cn=module,cn=config
 objectclass: olcModuleList
 cn: module
-olcModuleLoad: back_bdb.la
+olcModuleLoad: back_mdb.la
 
 # Create directory database
-dn: olcDatabase=bdb,cn=config
+dn: olcDatabase=mdb,cn=config
 objectClass: olcDatabaseConfig
-objectClass: olcBdbConfig
-olcDatabase: bdb
+objectClass: olcMdbConfig
+olcDatabase: mdb
 # Domain name (e.g. rabbitmq.com)
 olcSuffix: dc=rabbitmq,dc=com
 # Location on system where database is stored

--- a/deps/rabbitmq_auth_backend_ldap/example/memberof_init.ldif
+++ b/deps/rabbitmq_auth_backend_ldap/example/memberof_init.ldif
@@ -4,7 +4,7 @@ objectClass: olcModuleList
 olcModuleLoad: memberof
 olcModulePath: /usr/lib/ldap
 
-dn: olcOverlay={0}memberof,olcDatabase={1}bdb,cn=config
+dn: olcOverlay={0}memberof,olcDatabase={1}mdb,cn=config
 objectClass: olcConfig
 objectClass: olcMemberOf
 objectClass: olcOverlayConfig

--- a/deps/rabbitmq_auth_backend_ldap/example/refint_2.ldif
+++ b/deps/rabbitmq_auth_backend_ldap/example/refint_2.ldif
@@ -1,4 +1,4 @@
-dn: olcOverlay={1}refint,olcDatabase={1}bdb,cn=config
+dn: olcOverlay={1}refint,olcDatabase={1}mdb,cn=config
 objectClass: olcConfig
 objectClass: olcOverlayConfig
 objectClass: olcRefintConfig

--- a/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
@@ -192,7 +192,11 @@ add(H, {A, B}) ->
     ok = eldap:add(H, A, B).
 
 connect({Host, Port}) ->
-    {ok, H} = eldap:open([Host], [{port, Port}]),
+    LogOpts = [],
+    %% This can be swapped with the line above to add verbose logging of the
+    %% LDAP operations used for seeding.
+    %% LogOpts = [{log, fun(_Level, FormatString, FormatArgs) -> ct:pal(FormatString, FormatArgs) end}],
+    {ok, H} = eldap:open([Host], [{port, Port} | LogOpts]),
     ok = eldap:simple_bind(H, "cn=admin,dc=rabbitmq,dc=com", "admin"),
     H.
 

--- a/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
@@ -8,6 +8,7 @@
 -module(rabbit_ldap_seed).
 
 -include_lib("eldap/include/eldap.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -export([seed/1,delete/1]).
 
@@ -32,16 +33,21 @@ rabbitmq_com() ->
 
 delete(Logon) ->
     H = connect(Logon),
-    eldap:delete(H, "ou=test,dc=rabbitmq,dc=com"),
-    eldap:delete(H, "ou=test,ou=vhosts,dc=rabbitmq,dc=com"),
-    eldap:delete(H, "ou=vhosts,dc=rabbitmq,dc=com"),
-    [ eldap:delete(H, P) || {P, _} <- groups() ],
-    [ eldap:delete(H, P) || {P, _} <- people() ],
-    eldap:delete(H, "ou=groups,dc=rabbitmq,dc=com"),
-    eldap:delete(H, "ou=people,dc=rabbitmq,dc=com"),
-    eldap:delete(H, "dc=rabbitmq,dc=com"),
-    eldap:close(H),
+    assert_benign(eldap:delete(H, "ou=test,dc=rabbitmq,dc=com")),
+    assert_benign(eldap:delete(H, "ou=test,ou=vhosts,dc=rabbitmq,dc=com")),
+    assert_benign(eldap:delete(H, "ou=vhosts,dc=rabbitmq,dc=com")),
+    [ assert_benign(eldap:delete(H, P)) || {P, _} <- groups() ],
+    [ assert_benign(eldap:delete(H, P)) || {P, _} <- people() ],
+    assert_benign(eldap:delete(H, "ou=groups,dc=rabbitmq,dc=com")),
+    assert_benign(eldap:delete(H, "ou=people,dc=rabbitmq,dc=com")),
+    assert_benign(eldap:delete(H, "dc=rabbitmq,dc=com")),
+    ok = eldap:close(H),
     ok.
+
+assert_benign({error,noSuchObject}) ->
+    ok;
+assert_benign(Other) ->
+    ?assertEqual(ok, Other).
 
 people() ->
     [ bob(),

--- a/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
@@ -158,10 +158,7 @@ peter() ->
                        "organizationalPerson",
                        "person"]},
       {"loginShell", ["/bin/bash"]},
-      {"userPassword", ["password"]},
-      {"memberOf", ["cn=wheel,ou=groups,dc=rabbitmq,dc=com",
-                    "cn=staff,ou=groups,dc=rabbitmq,dc=com",
-                    "cn=people,ou=groups,dc=rabbitmq,dc=com"]}]}.
+      {"userPassword", ["password"]}]}.
 
 carol() ->
     {"uid=carol,ou=people,dc=rabbitmq,dc=com",

--- a/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
@@ -142,9 +142,7 @@ init_per_group(Group, Config) ->
                                               base_conf_ldap(LdapPort,
                                                              idle_timeout(Group),
                                                              pool_size(Group))),
-    Logon = {"localhost", LdapPort},
-    rabbit_ldap_seed:delete(Logon),
-    rabbit_ldap_seed:seed(Logon),
+    rabbit_ldap_seed:seed({"localhost", LdapPort}),
     Config4 = rabbit_ct_helpers:set_config(Config3, {ldap_port, LdapPort}),
 
     rabbit_ct_helpers:run_steps(Config4,


### PR DESCRIPTION
Slapd 2.5 removed bdb, so switching to mdb

Debian bookworm, to which the buildbuddy CI image was recently updated, installs slapd 2.5