### PR TITLE
Avoid leaking nodes in rabbitmq_mqtt shared_SUITE

### DIFF
--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -212,7 +212,8 @@ init_per_group(Group, Config0) ->
 
 end_per_group(G, Config)
   when G =:= cluster_size_1;
-       G =:= cluster_size_3 ->
+       G =:= cluster_size_3;
+       G =:= mnesia_store ->
     rabbit_ct_helpers:run_steps(
       Config,
       rabbit_ct_client_helpers:teardown_steps() ++


### PR DESCRIPTION
Test nodes were not torn down in the inner group mnesia_store