### PR TITLE
Avoid oauth2_client being reported as a plugin

### DIFF
--- a/deps/oauth2_client/BUILD.bazel
+++ b/deps/oauth2_client/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load(
     "//:rabbitmq.bzl",
-    "BROKER_VERSION_REQUIREMENTS_ANY",
     "RABBITMQ_DIALYZER_OPTS",
     "assert_suites",
     "broker_for_integration_suites",
@@ -25,38 +24,19 @@ APP_DESCRIPTION = "OAuth 2.0 client from the RabbitMQ Project"
 
 APP_MODULE = "oauth2_client_app"
 
-APP_EXTRA_KEYS = """%% Hex.pm package informations.
-	{licenses, ["MPL-2.0"]},
-	{links, [
-	    {"Website", "https://www.rabbitmq.com/"},
-	    {"GitHub", "https://github.com/rabbitmq/rabbitmq-server/tree/main/deps/oauth2_client"}
-	  ]},
-	{build_tools, ["make", "rebar3"]},
-	{files, [
-	    "erlang.mk",
-	    "git-revisions.txt",
-	    "include",
-	    "LICENSE*",
-	    "Makefile",
-	    "rabbitmq-components.mk",
-	    "README",
-	    "README.md",
-	    "src"
-	  ]}
-"""
-
 # gazelle:erlang_app_extra_app ssl
 # gazelle:erlang_app_extra_app inets
 # gazelle:erlang_app_extra_app crypto
 # gazelle:erlang_app_extra_app public_key
+
+# gazelle:erlang_app_dep_exclude rabbit
 
 rabbitmq_app(
     name = "erlang_app",
     srcs = [":all_srcs"],
     hdrs = [":public_hdrs"],
     app_description = APP_DESCRIPTION,
-    app_extra_keys = APP_EXTRA_KEYS,
-    #    app_module = APP_MODULE,
+    app_module = APP_MODULE,
     app_name = APP_NAME,
     beam_files = [":beam_files"],
     extra_apps = [
@@ -67,14 +47,14 @@ rabbitmq_app(
     ],
     license_files = [":license_files"],
     priv = [":priv"],
-    deps = [
-        "//deps/rabbit:erlang_app",
-        "//deps/rabbit_common:erlang_app",
-    ],
+    deps = ["//deps/rabbit_common:erlang_app"],
 )
 
 xref(
     name = "xref",
+    additional_libs = [
+        "//deps/rabbit:erlang_app",  # keep
+    ],
     target = ":erlang_app",
 )
 
@@ -83,6 +63,9 @@ plt(
     for_target = ":erlang_app",
     ignore_warnings = True,
     plt = "//:base_plt",
+    deps = [
+        "//deps/rabbit:erlang_app",  # keep
+    ],
 )
 
 dialyze(

--- a/deps/oauth2_client/Makefile
+++ b/deps/oauth2_client/Makefile
@@ -2,9 +2,12 @@ PROJECT = oauth2_client
 PROJECT_DESCRIPTION = OAuth2 client from the RabbitMQ Project
 PROJECT_MOD = oauth2_client_app
 
-DEPS = rabbit rabbit_common
+BUILD_DEPS = rabbit
+DEPS = rabbit_common
 TEST_DEPS = rabbitmq_ct_helpers cowboy
 LOCAL_DEPS = ssl inets crypto public_key
+
+PLT_APPS = rabbit
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-test.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-macros.mk \


### PR DESCRIPTION
by making it's dependency on rabbit non-explicit