### PR TITLE
Added global default queue type config

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2512,7 +2512,19 @@ end}.
 }.
 
 {mapping, "default_queue_type", "rabbit.default_queue_type", [
-  {datatype, {enum, [quorum, classic, stream]}}]}.
+    {datatype, atom}
+]}.
+
+{translation, "rabbit.default_queue_type",
+fun(Conf) ->
+    case cuttlefish:conf_get("default_queue_type", Conf, rabbit_classic_queue) of
+        classic        -> rabbit_classic_queue;
+        quorum         -> rabbit_quorum_queue;
+        stream         -> rabbit_stream_queue;
+        Module         -> Module
+    end
+end}.
+
 
 
 %%

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2511,6 +2511,10 @@ end}.
   end
 }.
 
+{mapping, "default_queue_type", "rabbit.default_queue_type", [
+  {datatype, {enum, [quorum, classic, stream]}}]}.
+
+
 %%
 %% Backing queue version
 %%

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -275,15 +275,9 @@ feature_flag_name(_) ->
     undefined.
 
 default() ->
-    case rabbit_misc:get_env(rabbit,
-                             default_queue_type,
-                             classic)
-    of
-        quorum -> rabbit_quorum_queue;
-        classic -> rabbit_classic_queue;
-        stream -> rabbit_stream_queue;
-        _ -> rabbit_classic_queue
-    end.
+    rabbit_misc:get_env(rabbit,
+                        default_queue_type,
+                        rabbit_classic_queue).
 
 -spec to_binary(module()) -> binary().
 to_binary(rabbit_classic_queue) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -275,7 +275,15 @@ feature_flag_name(_) ->
     undefined.
 
 default() ->
-    rabbit_classic_queue.
+    case rabbit_misc:get_env(rabbit,
+                             default_queue_type,
+                             classic)
+    of
+        quorum -> rabbit_quorum_queue;
+        classic -> rabbit_classic_queue;
+        stream -> rabbit_stream_queue;
+        _ -> rabbit_classic_queue
+    end.
 
 -spec to_binary(module()) -> binary().
 to_binary(rabbit_classic_queue) ->


### PR DESCRIPTION
## Proposed Changes
A global setting for the default queue type. precedence would be x-queue-type -> vhost-default-queue-type -> config queue type -> rabbit_classic_queue 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
