### PR TITLE
Fix dead lettering

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -391,7 +391,13 @@ rabbitmq_integration_suite(
     additional_beam = [
         ":test_queue_utils_beam",
     ],
-    shard_count = 7,
+    shard_count = 8,
+)
+
+rabbitmq_integration_suite(
+    name = "message_containers_deaths_v2_SUITE",
+    size = "medium",
+    shard_count = 1,
 )
 
 rabbitmq_integration_suite(

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -2219,3 +2219,12 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp10_common:erlang_app", "//deps/rabbitmq_amqp_client:erlang_app"],
     )
+    erlang_bytecode(
+        name = "message_containers_deaths_v2_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/message_containers_deaths_v2_SUITE.erl"],
+        outs = ["test/message_containers_deaths_v2_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+        deps = ["//deps/amqp_client:erlang_app", "//deps/rabbitmq_ct_helpers:erlang_app"],
+    )

--- a/deps/rabbit/include/mc.hrl
+++ b/deps/rabbit/include/mc.hrl
@@ -1,17 +1,3 @@
--type death_key() :: {SourceQueue :: rabbit_misc:resource_name(), rabbit_dead_letter:reason()}.
--type death_anns() :: #{first_time := non_neg_integer(), %% the timestamp of the first
-                        last_time := non_neg_integer(), %% the timestamp of the last
-                        ttl => OriginalExpiration :: non_neg_integer()}.
--record(death, {exchange :: OriginalExchange :: rabbit_misc:resource_name(),
-                routing_keys = [] :: OriginalRoutingKeys :: [rabbit_types:routing_key()],
-                count = 0 :: non_neg_integer(),
-                anns :: death_anns()}).
-
--record(deaths, {first :: death_key(),
-                 last :: death_key(),
-                 records = #{} :: #{death_key() := #death{}}}).
-
-
 %% good enough for most use cases
 -define(IS_MC(Msg), element(1, Msg) == mc andalso tuple_size(Msg) == 5).
 
@@ -26,3 +12,25 @@
 -define(ANN_RECEIVED_AT_TIMESTAMP, rts).
 -define(ANN_DURABLE, d).
 -define(ANN_PRIORITY, p).
+
+-define(FF_MC_DEATHS_V2, message_containers_deaths_v2).
+
+-type death_key() :: {SourceQueue :: rabbit_misc:resource_name(), rabbit_dead_letter:reason()}.
+-type death_anns() :: #{%% timestamp of the first time this message
+                        %% was dead lettered from this queue for this reason
+                        first_time := pos_integer(),
+                        %% timestamp of the last time this message
+                        %% was dead lettered from this queue for this reason
+                        last_time := pos_integer(),
+                        ttl => OriginalTtlHeader :: non_neg_integer()}.
+
+-record(death, {exchange :: OriginalExchange :: rabbit_misc:resource_name(),
+                routing_keys :: OriginalRoutingKeys :: [rabbit_types:routing_key(),...],
+                %% how many times this message was dead lettered from this queue for this reason
+                count :: pos_integer(),
+                anns :: death_anns()}).
+
+-record(deaths, {first :: death_key(), % redundant to mc annotations x-first-death-*
+                 last :: death_key(), % redundant to mc annotations x-last-death-*
+                 records :: #{death_key() := #death{}}
+                }).

--- a/deps/rabbit/src/mc.erl
+++ b/deps/rabbit/src/mc.erl
@@ -34,9 +34,8 @@
          convert/3,
          protocol_state/1,
          prepare/2,
-         record_death/3,
+         record_death/4,
          is_death_cycle/2,
-         last_death/1,
          death_queue_names/1
         ]).
 
@@ -356,88 +355,102 @@ protocol_state(BasicMsg) ->
     mc_compat:protocol_state(BasicMsg).
 
 -spec record_death(rabbit_dead_letter:reason(),
-                   SourceQueue :: rabbit_misc:resource_name(),
-                   state()) -> state().
+                   rabbit_misc:resource_name(),
+                   state(),
+                   environment()) -> state().
 record_death(Reason, SourceQueue,
-             #?MODULE{protocol = _Mod,
-                      data = _Data,
-                      annotations = Anns0} = State)
-  when is_atom(Reason) andalso is_binary(SourceQueue) ->
+             #?MODULE{annotations = Anns0} = State,
+             Env)
+  when is_atom(Reason) andalso
+       is_binary(SourceQueue) ->
     Key = {SourceQueue, Reason},
     #{?ANN_EXCHANGE := Exchange,
       ?ANN_ROUTING_KEYS := RoutingKeys} = Anns0,
     Timestamp = os:system_time(millisecond),
     Ttl = maps:get(ttl, Anns0, undefined),
-
-    ReasonBin = atom_to_binary(Reason),
-    DeathAnns = rabbit_misc:maps_put_truthy(ttl, Ttl, #{first_time => Timestamp,
-                                                        last_time => Timestamp}),
-    case maps:get(deaths, Anns0, undefined) of
-        undefined ->
-            Ds = #deaths{last = Key,
-                         first = Key,
-                         records = #{Key => #death{count = 1,
-                                                   exchange = Exchange,
-                                                   routing_keys = RoutingKeys,
-                                                   anns = DeathAnns}}},
-            Anns = Anns0#{<<"x-first-death-reason">> => ReasonBin,
+    DeathAnns = rabbit_misc:maps_put_truthy(
+                  ttl, Ttl, #{first_time => Timestamp,
+                              last_time => Timestamp}),
+    NewDeath = #death{exchange = Exchange,
+                      routing_keys = RoutingKeys,
+                      count = 1,
+                      anns = DeathAnns},
+    Anns = case Anns0 of
+               #{deaths := Deaths0} ->
+                   Deaths = case Deaths0 of
+                                #deaths{records = Rs0} ->
+                                    Rs = maps:update_with(
+                                           Key,
+                                           fun(Death) ->
+                                                   update_death(Death, Timestamp)
+                                           end,
+                                           NewDeath,
+                                           Rs0),
+                                    Deaths0#deaths{last = Key,
+                                                   records = Rs};
+                                _ ->
+                                    %% Deaths are ordered by recency
+                                    case lists:keytake(Key, 1, Deaths0) of
+                                        {value, {Key, D0}, Deaths1} ->
+                                            D = update_death(D0, Timestamp),
+                                            [{Key, D} | Deaths1];
+                                        false ->
+                                            [{Key, NewDeath} | Deaths0]
+                                    end
+                            end,
+                   Anns0#{<<"x-last-death-reason">> := atom_to_binary(Reason),
+                          <<"x-last-death-queue">> := SourceQueue,
+                          <<"x-last-death-exchange">> := Exchange,
+                          deaths := Deaths};
+               _ ->
+                   Deaths = case Env of
+                                #{?FF_MC_DEATHS_V2 := false} ->
+                                    #deaths{last = Key,
+                                            first = Key,
+                                            records = #{Key => NewDeath}};
+                                _ ->
+                                    [{Key, NewDeath}]
+                            end,
+                   ReasonBin = atom_to_binary(Reason),
+                   Anns0#{<<"x-first-death-reason">> => ReasonBin,
                           <<"x-first-death-queue">> => SourceQueue,
                           <<"x-first-death-exchange">> => Exchange,
                           <<"x-last-death-reason">> => ReasonBin,
                           <<"x-last-death-queue">> => SourceQueue,
-                          <<"x-last-death-exchange">> => Exchange
-                         },
+                          <<"x-last-death-exchange">> => Exchange,
+                          deaths => Deaths}
+           end,
+    State#?MODULE{annotations = Anns};
+record_death(Reason, SourceQueue, BasicMsg, Env) ->
+    mc_compat:record_death(Reason, SourceQueue, BasicMsg, Env).
 
-            State#?MODULE{annotations = Anns#{deaths => Ds}};
-        #deaths{records = Rs} = Ds0 ->
-            Death = #death{count = C,
-                           anns = DA} = maps:get(Key, Rs,
-                                                 #death{exchange = Exchange,
-                                                        routing_keys = RoutingKeys,
-                                                        anns = DeathAnns}),
-            Ds = Ds0#deaths{last = Key,
-                            records = Rs#{Key =>
-                                          Death#death{count = C + 1,
-                                                      anns = DA#{last_time => Timestamp}}}},
-            Anns = Anns0#{deaths => Ds,
-                          <<"x-last-death-reason">> => ReasonBin,
-                          <<"x-last-death-queue">> => SourceQueue,
-                          <<"x-last-death-exchange">> => Exchange},
-            State#?MODULE{annotations = Anns}
-    end;
-record_death(Reason, SourceQueue, BasicMsg) ->
-    mc_compat:record_death(Reason, SourceQueue, BasicMsg).
-
+update_death(#death{count = Count,
+                    anns = DeathAnns} = Death, Timestamp) ->
+    Death#death{count = Count + 1,
+                anns = DeathAnns#{last_time := Timestamp}}.
 
 -spec is_death_cycle(rabbit_misc:resource_name(), state()) -> boolean().
+is_death_cycle(TargetQueue, #?MODULE{annotations = #{deaths := #deaths{records = Rs}}}) ->
+    is_cycle_v1(TargetQueue, maps:keys(Rs));
 is_death_cycle(TargetQueue, #?MODULE{annotations = #{deaths := Deaths}}) ->
-    is_cycle(TargetQueue, maps:keys(Deaths#deaths.records));
+    is_cycle_v2(TargetQueue, Deaths);
 is_death_cycle(_TargetQueue, #?MODULE{}) ->
     false;
 is_death_cycle(TargetQueue, BasicMsg) ->
     mc_compat:is_death_cycle(TargetQueue, BasicMsg).
 
+%% Returns death queue names ordered by recency.
 -spec death_queue_names(state()) -> [rabbit_misc:resource_name()].
-death_queue_names(#?MODULE{annotations = Anns}) ->
-    case maps:get(deaths, Anns, undefined) of
-        undefined ->
-            [];
-        #deaths{records = Records} ->
-            proplists:get_keys(maps:keys(Records))
-    end;
+death_queue_names(#?MODULE{annotations = #{deaths := #deaths{records = Rs}}}) ->
+    proplists:get_keys(maps:keys(Rs));
+death_queue_names(#?MODULE{annotations = #{deaths := Deaths}}) ->
+    lists:map(fun({{Queue, _Reason}, _Death}) ->
+                      Queue
+              end, Deaths);
+death_queue_names(#?MODULE{}) ->
+    [];
 death_queue_names(BasicMsg) ->
     mc_compat:death_queue_names(BasicMsg).
-
--spec last_death(state()) ->
-    undefined | {death_key(), #death{}}.
-last_death(#?MODULE{annotations = Anns})
-  when not is_map_key(deaths, Anns) ->
-    undefined;
-last_death(#?MODULE{annotations = #{deaths := #deaths{last = Last,
-                                                      records = Rs}}}) ->
-    {Last, maps:get(Last, Rs)};
-last_death(BasicMsg) ->
-    mc_compat:last_death(BasicMsg).
 
 -spec prepare(read | store, state()) -> state().
 prepare(For, #?MODULE{protocol = Proto,
@@ -448,24 +461,38 @@ prepare(For, State) ->
 
 %% INTERNAL
 
-%% if there is a death with a source queue that is the same as the target
+is_cycle_v2(TargetQueue, Deaths) ->
+    case lists:splitwith(fun({{SourceQueue, _Reason}, #death{}}) ->
+                                 SourceQueue =/= TargetQueue
+                         end, Deaths) of
+        {_, []} ->
+            false;
+        {L, [H | _]} ->
+            %% There is a cycle, but we only want to drop the message
+            %% if the cycle is "fully automatic", i.e. without a client
+            %% expliclity rejecting the message somewhere in the cycle.
+            lists:all(fun({{_SourceQueue, Reason}, _Death}) ->
+                              Reason =/= rejected
+                      end, [H | L])
+    end.
+
+%% The desired v1 behaviour is the following:
+%% "If there is a death with a source queue that is the same as the target
 %% queue name and there are no newer deaths with the 'rejected' reason then
-%% consider this a cycle
-is_cycle(_Queue, []) ->
+%% consider this a cycle."
+%% However, the correct death order cannot be reliably determined in v1.
+%% deaths_v2 fixes this bug.
+is_cycle_v1(_Queue, []) ->
     false;
-is_cycle(_Queue, [{_Q, rejected} | _]) ->
+is_cycle_v1(_Queue, [{_Q, rejected} | _]) ->
     %% any rejection breaks the cycle
     false;
-is_cycle(Queue, [{Queue, Reason} | _])
+is_cycle_v1(Queue, [{Queue, Reason} | _])
   when Reason =/= rejected ->
     true;
-is_cycle(Queue, [_ | Rem]) ->
-    is_cycle(Queue, Rem).
+is_cycle_v1(Queue, [_ | Rem]) ->
+    is_cycle_v1(Queue, Rem).
 
 set_received_at_timestamp(Anns) ->
     Millis = os:system_time(millisecond),
     Anns#{?ANN_RECEIVED_AT_TIMESTAMP => Millis}.
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -402,6 +402,10 @@ protocol_state_message_annotations(MA, Anns) ->
               maps_upsert(K, mc_util:infer_type(V), L);
          (<<"timestamp_in_ms">>, V, L) ->
               maps_upsert(<<"x-opt-rabbitmq-received-time">>, {timestamp, V}, L);
+         (deaths, Deaths, L)
+           when is_list(Deaths) ->
+              Maps = encode_deaths(Deaths),
+              maps_upsert(<<"x-opt-deaths">>, {array, map, Maps}, L);
          (_, _, Acc) ->
               Acc
       end, MA, Anns).
@@ -569,13 +573,6 @@ msg_body_encoded([{{pos, Pos}, {body, Code}}], BarePos, Msg)
 binary_part_bare_and_footer(Payload, Start) ->
     binary_part(Payload, Start, byte_size(Payload) - Start).
 
-key_find(K, [{{_, K}, {_, V}} | _]) ->
-    V;
-key_find(K, [_ | Rem]) ->
-    key_find(K, Rem);
-key_find(_K, []) ->
-    undefined.
-
 -spec first_acquirer(mc:annotations()) -> boolean().
 first_acquirer(Anns) ->
     Redelivered = case Anns of
@@ -584,48 +581,38 @@ first_acquirer(Anns) ->
                   end,
     not Redelivered.
 
-recover_deaths([], Acc) ->
-    Acc;
-recover_deaths([{map, Kvs} | Rem], Acc) ->
-    Queue = key_find(<<"queue">>, Kvs),
-    Reason = binary_to_existing_atom(key_find(<<"reason">>, Kvs)),
-    DA0 = case key_find(<<"original-expiration">>, Kvs) of
-              undefined ->
-                  #{};
-              Exp ->
-                  #{ttl => binary_to_integer(Exp)}
-          end,
-    RKeys = [RK || {_, RK} <- key_find(<<"routing-keys">>, Kvs)],
-    Ts = key_find(<<"time">>, Kvs),
-    DA = DA0#{first_time => Ts,
-              last_time => Ts},
-    recover_deaths(Rem,
-                   Acc#{{Queue, Reason} =>
-                        #death{anns = DA,
-                               exchange = key_find(<<"exchange">>, Kvs),
-                               count = key_find(<<"count">>, Kvs),
-                               routing_keys = RKeys}}).
+encode_deaths(Deaths) ->
+    lists:map(
+      fun({{Queue, Reason},
+           #death{exchange = Exchange,
+                  routing_keys = RoutingKeys,
+                  count = Count,
+                  anns = Anns = #{first_time := FirstTime,
+                                  last_time := LastTime}}}) ->
+              RKeys = [{utf8, Rk} || Rk <- RoutingKeys],
+              Map0 = [
+                      {{symbol, <<"queue">>}, {utf8, Queue}},
+                      {{symbol, <<"reason">>}, {symbol, atom_to_binary(Reason)}},
+                      {{symbol, <<"count">>}, {ulong, Count}},
+                      {{symbol, <<"first-time">>}, {timestamp, FirstTime}},
+                      {{symbol, <<"last-time">>}, {timestamp, LastTime}},
+                      {{symbol, <<"exchange">>}, {utf8, Exchange}},
+                      {{symbol, <<"routing-keys">>}, {array, utf8, RKeys}}
+                     ],
+              Map = case Anns of
+                        #{ttl := Ttl} ->
+                            [{{symbol, <<"ttl">>}, {uint, Ttl}} | Map0];
+                        _ ->
+                            Map0
+                    end,
+              {map, Map}
+      end, Deaths).
 
 essential_properties(#msg_body_encoded{message_annotations = MA} = Msg) ->
     Durable = get_property(durable, Msg),
     Priority = get_property(priority, Msg),
     Timestamp = get_property(timestamp, Msg),
     Ttl = get_property(ttl, Msg),
-
-    Deaths = case message_annotation(<<"x-death">>, Msg, undefined) of
-                 {list, DeathMaps}  ->
-                     %% TODO: make more correct?
-                     Def = {utf8, <<>>},
-                     {utf8, FstQ} = message_annotation(<<"x-first-death-queue">>, Msg, Def),
-                     {utf8, FstR} = message_annotation(<<"x-first-death-reason">>, Msg, Def),
-                     {utf8, LastQ} = message_annotation(<<"x-last-death-queue">>, Msg, Def),
-                     {utf8, LastR} = message_annotation(<<"x-last-death-reason">>, Msg, Def),
-                     #deaths{first = {FstQ, binary_to_existing_atom(FstR)},
-                             last = {LastQ, binary_to_existing_atom(LastR)},
-                             records = recover_deaths(DeathMaps, #{})};
-                 _ ->
-                     undefined
-             end,
     Anns0 = #{?ANN_DURABLE => Durable},
     Anns = maps_put_truthy(
              ?ANN_PRIORITY, Priority,
@@ -633,9 +620,7 @@ essential_properties(#msg_body_encoded{message_annotations = MA} = Msg) ->
                ?ANN_TIMESTAMP, Timestamp,
                maps_put_truthy(
                  ttl, Ttl,
-                 maps_put_truthy(
-                   deaths, Deaths,
-                   Anns0)))),
+                 Anns0))),
     case MA of
         [] ->
             Anns;

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -177,3 +177,11 @@
       stability     => stable,
       depends_on    => [message_containers]
      }}).
+
+-rabbit_feature_flag(
+   {message_containers_deaths_v2,
+    #{desc          => "Bug fix for dead letter cycle detection",
+      doc_url       => "https://github.com/rabbitmq/rabbitmq-server/issues/11159",
+      stability     => stable,
+      depends_on    => [message_containers]
+     }}).

--- a/deps/rabbit/src/rabbit_dead_letter.erl
+++ b/deps/rabbit/src/rabbit_dead_letter.erl
@@ -31,46 +31,53 @@ publish(Msg0, Reason, #exchange{name = XName} = DLX, RK,
                   _ ->
                       [RK]
               end,
-    Msg1 = mc:record_death(Reason, SourceQName, Msg0),
+    Env = case rabbit_feature_flags:is_enabled(?FF_MC_DEATHS_V2) of
+              true -> #{};
+              false -> #{?FF_MC_DEATHS_V2 => false}
+          end,
+    Msg1 = mc:record_death(Reason, SourceQName, Msg0, Env),
     {Ttl, Msg2} = mc:take_annotation(dead_letter_ttl, Msg1),
     Msg3 = mc:set_ttl(Ttl, Msg2),
     Msg4 = mc:set_annotation(?ANN_ROUTING_KEYS, DLRKeys, Msg3),
     DLMsg = mc:set_annotation(?ANN_EXCHANGE, XName#resource.name, Msg4),
-    Routed = rabbit_exchange:route(DLX, DLMsg, #{return_binding_keys => true}),
-    {QNames, Cycles} = detect_cycles(Reason, DLMsg, Routed),
+    Routed0 = rabbit_exchange:route(DLX, DLMsg, #{return_binding_keys => true}),
+    {Cycles, Routed} = detect_cycles(Reason, DLMsg, Routed0),
     lists:foreach(fun log_cycle_once/1, Cycles),
-    Qs0 = rabbit_amqqueue:lookup_many(QNames),
+    Qs0 = rabbit_amqqueue:lookup_many(Routed),
     Qs = rabbit_amqqueue:prepend_extra_bcc(Qs0),
     _ = rabbit_queue_type:deliver(Qs, DLMsg, #{}, stateless),
     ok.
 
 detect_cycles(rejected, _Msg, Queues) ->
-    {Queues, []};
+    %% shortcut
+    {[], Queues};
 detect_cycles(_Reason, Msg, Queues) ->
-    {Cycling, NotCycling} =
-        lists:partition(fun (#resource{name = Queue}) ->
-                                mc:is_death_cycle(Queue, Msg);
-                            ({#resource{name = Queue}, _RouteInfos}) ->
-                                mc:is_death_cycle(Queue, Msg)
-                        end, Queues),
-    DeathQueues = mc:death_queue_names(Msg),
-    CycleKeys = lists:foldl(fun(#resource{name = Q}, Acc) ->
-                                    [Q | Acc];
-                               ({#resource{name = Q}, _RouteInfos}, Acc) ->
-                                    [Q | Acc]
-                            end, DeathQueues, Cycling),
-    {NotCycling, CycleKeys}.
+    {Cycling,
+     NotCycling} = lists:partition(fun(#resource{name = Queue}) ->
+                                           mc:is_death_cycle(Queue, Msg);
+                                      ({#resource{name = Queue}, _RouteInfos}) ->
+                                           mc:is_death_cycle(Queue, Msg)
+                                   end, Queues),
+    Names = mc:death_queue_names(Msg),
+    Cycles = lists:map(fun(#resource{name = Q}) ->
+                               [Q | Names];
+                          ({#resource{name = Q}, _RouteInfos}) ->
+                               [Q | Names]
+                       end, Cycling),
+    {Cycles, NotCycling}.
 
-log_cycle_once(Queues) ->
-    %% using a hash won't eliminate this as a potential memory leak but it will
-    %% reduce the potential amount of memory used whilst probably being
-    %% "good enough"
-    Key = {queue_cycle, erlang:phash2(Queues)},
+log_cycle_once(Cycle) ->
+    %% Using a hash won't eliminate this as a potential memory leak but it will
+    %% reduce the potential amount of memory used whilst probably being "good enough".
+    Key = {dead_letter_cycle, erlang:phash2(Cycle)},
     case get(Key) of
-        true -> ok;
+        true ->
+            ok;
         undefined ->
-            rabbit_log:warning("Message dropped. Dead-letter queues cycle detected"
-                               ": ~tp~nThis cycle will NOT be reported again.",
-                               [Queues]),
+            rabbit_log:warning(
+              "Message dropped because the following list of queues (ordered by "
+              "death recency) contains a dead letter cycle without reason 'rejected'. "
+              "This list will not be logged again: ~tp",
+              [Cycle]),
             put(Key, true)
     end.

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -29,7 +29,9 @@ all_tests() ->
      amqpl_compat,
      amqpl_table_x_header,
      amqpl_table_x_header_array_of_tbls,
-     amqpl_death_records,
+     amqpl_death_v1_records,
+     amqpl_death_v2_records,
+     is_death_cycle,
      amqpl_amqp_bin_amqpl,
      amqpl_cc_amqp_bin_amqpl,
      amqp_amqpl_amqp_uuid_correlation_id,
@@ -191,27 +193,29 @@ amqpl_table_x_header_array_of_tbls(_Config) ->
 
     ok.
 
-amqpl_death_records(_Config) ->
+amqpl_death_v1_records(_Config) ->
+    ok = amqpl_death_records(#{?FF_MC_DEATHS_V2 => false}).
+
+amqpl_death_v2_records(_Config) ->
+    ok = amqpl_death_records(#{?FF_MC_DEATHS_V2 => true}).
+
+amqpl_death_records(Env) ->
     Content = #content{class_id = 60,
                        properties = #'P_basic'{headers = []},
                        payload_fragments_rev = [<<"data">>]},
     Msg0 = mc:prepare(store, mc:init(mc_amqpl, Content, annotations())),
 
-    Msg1 = mc:record_death(rejected, <<"q1">>, Msg0),
+    Msg1 = mc:record_death(rejected, <<"q1">>, Msg0, Env),
     ?assertEqual([<<"q1">>], mc:death_queue_names(Msg1)),
-    ?assertMatch({{<<"q1">>, rejected},
-                  #death{exchange = <<"exch">>,
-                         routing_keys = [<<"apple">>],
-                         count = 1}}, mc:last_death(Msg1)),
     ?assertEqual(false, mc:is_death_cycle(<<"q1">>, Msg1)),
 
     #content{properties = #'P_basic'{headers = H1}} = mc:protocol_state(Msg1),
     ?assertMatch({_, array, [_]}, header(<<"x-death">>, H1)),
     ?assertMatch({_, longstr, <<"q1">>}, header(<<"x-first-death-queue">>, H1)),
-    ?assertMatch({_, longstr, <<"q1">>}, header(<<"x-last-death-queue">>, H1)),
     ?assertMatch({_, longstr, <<"exch">>}, header(<<"x-first-death-exchange">>, H1)),
-    ?assertMatch({_, longstr, <<"exch">>}, header(<<"x-last-death-exchange">>, H1)),
     ?assertMatch({_, longstr, <<"rejected">>}, header(<<"x-first-death-reason">>, H1)),
+    ?assertMatch({_, longstr, <<"q1">>}, header(<<"x-last-death-queue">>, H1)),
+    ?assertMatch({_, longstr, <<"exch">>}, header(<<"x-last-death-exchange">>, H1)),
     ?assertMatch({_, longstr, <<"rejected">>}, header(<<"x-last-death-reason">>, H1)),
     {_, array, [{table, T1}]} = header(<<"x-death">>, H1),
     ?assertMatch({_, long, 1}, header(<<"count">>, T1)),
@@ -222,18 +226,79 @@ amqpl_death_records(_Config) ->
     ?assertMatch({_, array, [{longstr, <<"apple">>}]}, header(<<"routing-keys">>, T1)),
 
 
-    %% second dead letter, e.g. a ttl reason returning to source queue
+    %% second dead letter, e.g. an expired reason returning to source queue
 
     %% record_death uses a timestamp for death record ordering, ensure
     %% it is definitely higher than the last timestamp taken
     timer:sleep(2),
-    Msg2 = mc:record_death(ttl, <<"dl">>, Msg1),
+    Msg2 = mc:record_death(expired, <<"dl">>, Msg1, Env),
 
     #content{properties = #'P_basic'{headers = H2}} = mc:protocol_state(Msg2),
     {_, array, [{table, T2a}, {table, T2b}]} = header(<<"x-death">>, H2),
     ?assertMatch({_, longstr, <<"dl">>}, header(<<"queue">>, T2a)),
     ?assertMatch({_, longstr, <<"q1">>}, header(<<"queue">>, T2b)),
     ok.
+
+is_death_cycle(_Config) ->
+    Content = #content{class_id = 60,
+                       properties = #'P_basic'{headers = []},
+                       payload_fragments_rev = [<<"data">>]},
+    Msg0 = mc:prepare(store, mc:init(mc_amqpl, Content, annotations())),
+
+    %% Test the followig topology:
+    %% Q1 --rejected--> Q2 --expired--> Q3 --expired-->
+    %% Q1 --rejected--> Q2 --expired--> Q3
+
+    Msg1 = mc:record_death(rejected, <<"q1">>, Msg0, #{}),
+    ?assertNot(mc:is_death_cycle(<<"q1">>, Msg1),
+               "A queue that dead letters to itself due to rejected is not considered a cycle."),
+    ?assertNot(mc:is_death_cycle(<<"q2">>, Msg1)),
+    ?assertNot(mc:is_death_cycle(<<"q3">>, Msg1)),
+
+    Msg2 = mc:record_death(expired, <<"q2">>, Msg1, #{}),
+    ?assertNot(mc:is_death_cycle(<<"q1">>, Msg2)),
+    ?assert(mc:is_death_cycle(<<"q2">>, Msg2),
+            "A queue that dead letters to itself due to expired is considered a cycle."),
+    ?assertNot(mc:is_death_cycle(<<"q3">>, Msg2)),
+
+    Msg3 = mc:record_death(expired, <<"q3">>, Msg2, #{}),
+    ?assertNot(mc:is_death_cycle(<<"q1">>, Msg3)),
+    ?assert(mc:is_death_cycle(<<"q2">>, Msg3)),
+    ?assert(mc:is_death_cycle(<<"q3">>, Msg3)),
+
+    Msg4 = mc:record_death(rejected, <<"q1">>, Msg3, #{}),
+    ?assertNot(mc:is_death_cycle(<<"q1">>, Msg4)),
+    ?assertNot(mc:is_death_cycle(<<"q2">>, Msg4)),
+    ?assertNot(mc:is_death_cycle(<<"q3">>, Msg4)),
+
+    Msg5 = mc:record_death(expired, <<"q2">>, Msg4, #{}),
+    ?assertNot(mc:is_death_cycle(<<"q1">>, Msg5)),
+    ?assert(mc:is_death_cycle(<<"q2">>, Msg5)),
+    ?assertNot(mc:is_death_cycle(<<"q3">>, Msg5)),
+
+    DeathQsOrderedByRecency = [<<"q2">>, <<"q1">>, <<"q3">>],
+    ?assertEqual(DeathQsOrderedByRecency, mc:death_queue_names(Msg5)),
+
+    #content{properties = #'P_basic'{headers = H}} = mc:protocol_state(Msg5),
+    ?assertMatch({_, longstr, <<"q1">>}, header(<<"x-first-death-queue">>, H)),
+    ?assertMatch({_, longstr, <<"rejected">>}, header(<<"x-first-death-reason">>, H)),
+    ?assertMatch({_, longstr, <<"q2">>}, header(<<"x-last-death-queue">>, H)),
+    ?assertMatch({_, longstr, <<"expired">>}, header(<<"x-last-death-reason">>, H)),
+
+    %% We expect the array to be ordered by recency.
+    {_, array, [{table, T1}, {table, T2}, {table, T3}]} = header(<<"x-death">>, H),
+
+    ?assertMatch({_, longstr, <<"q2">>}, header(<<"queue">>, T1)),
+    ?assertMatch({_, longstr, <<"expired">>}, header(<<"reason">>, T1)),
+    ?assertMatch({_, long, 2}, header(<<"count">>, T1)),
+
+    ?assertMatch({_, longstr, <<"q1">>}, header(<<"queue">>, T2)),
+    ?assertMatch({_, longstr, <<"rejected">>}, header(<<"reason">>, T2)),
+    ?assertMatch({_, long, 2}, header(<<"count">>, T2)),
+
+    ?assertMatch({_, longstr, <<"q3">>}, header(<<"queue">>, T3)),
+    ?assertMatch({_, longstr, <<"expired">>}, header(<<"reason">>, T3)),
+    ?assertMatch({_, long, 1}, header(<<"count">>, T3)).
 
 header(K, H) ->
     rabbit_basic:header(K, H).

--- a/deps/rabbit/test/message_containers_deaths_v2_SUITE.erl
+++ b/deps/rabbit/test/message_containers_deaths_v2_SUITE.erl
@@ -1,0 +1,127 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+%% This SUITE should be deleted when feature flag message_containers_deaths_v2 becomes required.
+-module(message_containers_deaths_v2_SUITE).
+
+-define(FEATURE_FLAG, message_containers_deaths_v2).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
+
+all() ->
+    [
+     {group, cluster_size_1}
+    ].
+
+groups() ->
+    [
+     {cluster_size_1, [], [enable_feature_flag]}
+    ].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config, []).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(_Group, Config0) ->
+    Config = rabbit_ct_helpers:merge_app_env(
+               Config0, {rabbit, [{forced_feature_flags_on_init, []}]}),
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_broker_helpers:setup_steps() ++
+                                rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_client_helpers:teardown_steps() ++
+                                rabbit_ct_broker_helpers:teardown_steps()).
+
+enable_feature_flag(Config) ->
+    Ch = rabbit_ct_client_helpers:open_channel(Config),
+    Q1 = <<"q1">>,
+    Q2 = <<"q2">>,
+    #'queue.declare_ok'{} = amqp_channel:call(
+                              Ch, #'queue.declare'{queue = Q1,
+                                                   arguments = [{<<"x-dead-letter-exchange">>, longstr, <<>>},
+                                                                {<<"x-dead-letter-routing-key">>, longstr, Q2},
+                                                                {<<"x-message-ttl">>, long, 3}]}),
+    #'queue.declare_ok'{} = amqp_channel:call(
+                              Ch, #'queue.declare'{queue = Q2,
+                                                   arguments = [{<<"x-dead-letter-exchange">>, longstr, <<>>},
+                                                                {<<"x-dead-letter-routing-key">>, longstr, Q1}]}),
+    P1 = <<"payload 1">>,
+    P2 = <<"payload 2">>,
+    amqp_channel:call(Ch,
+                      #'basic.publish'{routing_key = Q1},
+                      #amqp_msg{payload = P1}),
+    ?assertNot(rabbit_ct_broker_helpers:is_feature_flag_enabled(Config, ?FEATURE_FLAG)),
+    ?assertEqual(ok, rabbit_ct_broker_helpers:enable_feature_flag(Config, ?FEATURE_FLAG)),
+    amqp_channel:call(Ch,
+                      #'basic.publish'{routing_key = Q1},
+                      #amqp_msg{payload = P2}),
+
+    %% We now have 2 messages in Q2 with different mc annotations:
+    %% * deaths for v1 in the 1st msg
+    %% * deaths_v2 for v2 in the 2nd msg
+
+    reject(Ch, Q2, P1),
+    reject(Ch, Q2, P2),
+    reject(Ch, Q2, P1),
+    reject(Ch, Q2, P2),
+
+    {#'basic.get_ok'{}, #amqp_msg{props = #'P_basic'{headers = H1}}} =
+    ?awaitMatch({#'basic.get_ok'{},
+                 #amqp_msg{payload = P1}},
+                amqp_channel:call(Ch, #'basic.get'{queue = Q2}),
+                5000),
+
+    {#'basic.get_ok'{}, #amqp_msg{props = #'P_basic'{headers = H2}}} =
+    ?awaitMatch({#'basic.get_ok'{},
+                 #amqp_msg{payload = P2}},
+                amqp_channel:call(Ch, #'basic.get'{queue = Q2}),
+                5000),
+
+    lists:foreach(
+      fun(Headers) ->
+              ?assertEqual({longstr, <<"expired">>}, rabbit_misc:table_lookup(Headers, <<"x-first-death-reason">>)),
+              ?assertEqual({longstr, Q1}, rabbit_misc:table_lookup(Headers, <<"x-first-death-queue">>)),
+              ?assertEqual({longstr, <<>>}, rabbit_misc:table_lookup(Headers, <<"x-first-death-exchange">>)),
+              ?assertEqual({longstr, <<"expired">>}, rabbit_misc:table_lookup(Headers, <<"x-last-death-reason">>)),
+              ?assertEqual({longstr, Q1}, rabbit_misc:table_lookup(Headers, <<"x-last-death-queue">>)),
+              ?assertEqual({longstr, <<>>}, rabbit_misc:table_lookup(Headers, <<"x-last-death-exchange">>)),
+
+              {array, [{table, Death1},
+                       {table, Death2}]} = rabbit_misc:table_lookup(H1, <<"x-death">>),
+
+              ?assertEqual({longstr, Q1}, rabbit_misc:table_lookup(Death1, <<"queue">>)),
+              ?assertEqual({longstr, <<"expired">>}, rabbit_misc:table_lookup(Death1, <<"reason">>)),
+              ?assertMatch({timestamp, _}, rabbit_misc:table_lookup(Death1, <<"time">>)),
+              ?assertEqual({longstr, <<>>}, rabbit_misc:table_lookup(Death1, <<"exchange">>)),
+              ?assertEqual({long, 3}, rabbit_misc:table_lookup(Death1, <<"count">>)),
+              ?assertEqual({array, [{longstr, Q1}]}, rabbit_misc:table_lookup(Death1, <<"routing-keys">>)),
+
+              ?assertEqual({longstr, Q2}, rabbit_misc:table_lookup(Death2, <<"queue">>)),
+              ?assertEqual({longstr, <<"rejected">>}, rabbit_misc:table_lookup(Death2, <<"reason">>)),
+              ?assertMatch({timestamp, _}, rabbit_misc:table_lookup(Death2, <<"time">>)),
+              ?assertEqual({longstr, <<>>}, rabbit_misc:table_lookup(Death2, <<"exchange">>)),
+              ?assertEqual({long, 2}, rabbit_misc:table_lookup(Death2, <<"count">>)),
+              ?assertEqual({array, [{longstr, Q2}]}, rabbit_misc:table_lookup(Death2, <<"routing-keys">>))
+      end, [H1, H2]),
+    ok.
+
+reject(Ch, Queue, Payload) ->
+    {#'basic.get_ok'{delivery_tag = DTag}, #amqp_msg{}} =
+    ?awaitMatch({#'basic.get_ok'{},
+                 #amqp_msg{payload = Payload}},
+                amqp_channel:call(Ch, #'basic.get'{queue = Queue}),
+                5000),
+    amqp_channel:cast(Ch, #'basic.reject'{delivery_tag = DTag,
+                                          requeue = false}).


### PR DESCRIPTION
# What?

This commit fixes https://github.com/rabbitmq/rabbitmq-server/issues/11159, https://github.com/rabbitmq/rabbitmq-server/issues/11160, https://github.com/rabbitmq/rabbitmq-server/issues/11173, and supersedes https://github.com/rabbitmq/rabbitmq-server/pull/11048

  # How?

  ## Background

RabbitMQ allows to dead letter messages for four different reasons, out
of which three reasons cause messages to be dead lettered automatically
internally in the broker: (maxlen, expired, delivery_limit) and 1 reason
is caused by an explicit client action (rejected).

RabbitMQ also allows dead letter topologies. When a message is dead
lettered, it is re-published to an exchange, and therefore zero to
multiple target queues. These target queues can in turn dead letter
messages. Hence it is possible to create a cycle of queues where
messages get dead lettered endlessly, which is what we want to avoid.

  ## Alternative approach

One approach to avoid such endless cycles is to use a similar concept of
the TTL field of the IPv4 datagram, or the hop limit field of an IPv6
datagram. These fields ensure that IP packets aren't cicrulating forever
in the Internet. Each router decrements this counter. If this counter
reaches 0, the sender will be notified and the message gets dropped.

We could use the same approach in RabbitMQ: Whenever a queue dead
letters a message, a dead_letter_hop_limit field could be decremented.
If this field reaches 0, the message will be dropped.
Such a hop limit field could have a sensible default value, for example
32. The sender of the message could override this value. Likewise, the
client rejecting a message could set a new value via the Modified
outcome.

Such an approach has multiple advantages:
1. No dead letter cycle detection per se needs to be performed within
   the broker which is a slight simplification to what we have today.
2. Simpler dead letter topologies. One very common use case is that
   clients re-try sending the message after some time by consuming from
   a dead-letter queue and rejecting the message such that the message
   gets republished to the original queue. Instead of requiring explicit
   client actions, which increases complexity, a x-message-ttl argument
   could be set on the dead-letter queue to automatically retry after
   some time. This is a big simplification because it eliminates the
   need of various frameworks that retry, such as
   https://docs.spring.io/spring-cloud-stream/reference/rabbit/rabbit_overview/rabbitmq-retry.html
3. No dead letter history information needs to be compressed because
   there is a clear limit on how often a message gets dead lettered.
   Therefore, the full history including timestamps of every dead letter
   event will be available to clients.

Disadvantages:
1. Breaks a lot of clients, even for 4.0.

  ## 3.12 approach

Instead of decrementing a counter, the approach up to 3.12 has been to
drop the message if the message cycled automatically. A message cycled
automatically if no client expliclity rejected the message, i.e. the
mesage got dead lettered due to maxlen, expired, or delivery_limit, but
not due to rejected.

In this approach, the broker must be able to detect such cycles
reliably.
Reliably detecting dead letter cycles broke in 3.13 due to https://github.com/rabbitmq/rabbitmq-server/issues/11159 and https://github.com/rabbitmq/rabbitmq-server/issues/11160.

To reliably detect cycles, the broker must be able to obtain the exact
order of dead letter events for a given message. In 3.13.0 - 3.13.2, the
order cannot exactly be determined because wall clock time is used to
record the death time.

This commit uses the same approach as done in 3.12: a list ordered by
death recency is used with the most recent death at the head of the
list.

To not grow this list endlessly (for example when a client rejects the
same message hundreds of times), this list should be compacted.
This commit, like 3.12, compacts by tuple `{Queue, Reason}`:
If this message got already dead lettered from this Queue for this
Reason, then only a counter is incremented and the element is moved to
the front of the list.

  ## Streams & AMQP 1.0 clients

Dead lettering from a stream doesn't make sense because:
1. a client cannot reject a message from a stream since the stream must
   maintain the total order of events to be consumed by multiple clients.
2. TTL is implemented by Stream retention where only old Stream segments
   are automatically deleted (or archived in the future).
3. same applies to maxlen

Although messages cannot be dead lettered **from** a stream, messages can be dead lettered
**into** a stream. This commit provides clients consuming from a stream the death history: https://github.com/rabbitmq/rabbitmq-server/issues/11173

Additionally, this commit provides AMQP 1.0 clients the death history via
message annotation `x-opt-deaths` which contains the same information as
AMQP 0.9.1 header `x-death`.

Both, storing the death history in a stream and providing death history
to an AMQP 1.0 client, use the same encoding: a message annoation
`x-opt-deaths` that contains an array of maps ordered by death recency.
The information encoded is the same as in the AMQP 0.9.1 x-death header.

Instead of providing an array of maps, a better approach could be to use
an array of a custom AMQP death type, such as:
```xml
<amqp name="rabbitmq">
    <section name="custom-types">
        <type name="death" class="composite" source="list">
            <descriptor name="rabbitmq:death:list"/>
            <field name="queue" type="string" mandatory="true" label="the name of the queue the message was dead lettered from"/>
            <field name="reason" type="symbol" mandatory="true" label="the reason why this message was dead lettered"/>
            <field name="count" type="ulong" default="1" label="how many times this message was dead lettered from this queue for this reason"/>
            <field name="time" mandatory="true" type="timestamp" label="the first time when this message was dead lettered from this queue for this reason"/>
            <field name="exchange" type="string" default="" label="the exchange this message was published to before it was dead lettered for the first time from this queue for this reason"/>
            <field name="routing-keys" type="string" default="" multiple="true" label="the routing keys this message was published with before it was dead lettered for the first time from this queue for this reason"/>
            <field name="ttl" type="milliseconds" label="the time to live of this message before it was dead lettered for the first time from this queue for reason ‘expired’"/>
        </type>
    </section>
</amqp>
```

However, encoding and decoding custom AMQP types that are nested within
arrays which in turn are nested within the message annotation map can be
difficult for clients and the broker. Also, each client will need to
know the custom AMQP type. For now, therefore we use an array of maps.

  ## Feature flag
The new way to record death information is done via mc annotation
`deaths_v2`.
Because old nodes do not know this new annotation, recording death
information via mc annotation `deaths_v2` is hidden behind a new feature
flag `message_containers_deaths_v2`.

If this feature flag is disabled, a message will continue to use the
3.13.0 - 3.13.2 way to record death information in mc annotation
`deaths`, or even the older way within `x-death` header directly if
feature flag message_containers is also disabled.

Only if feature flag `message_containers_deaths_v2` is enabled and this
message hasn't been dead lettered before, will the new mc annotation
`deaths_v2` be used.