### PR TITLE
jose dependency belongs to rabbitmq-components.mk

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -15,7 +15,6 @@ PLT_APPS += rabbitmqctl
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-dep_jose = git https://github.com/michaelklishin/erlang-jose mk-thoas-support
 dep_base64url = hex 1.0.1
 
 dep_emqtt = git https://github.com/rabbitmq/emqtt.git master

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -118,6 +118,7 @@ dep_cowlib = hex 2.13.0
 dep_credentials_obfuscation = hex 3.4.0
 dep_cuttlefish = hex 3.1.0
 dep_gen_batch_server = hex 0.8.8
+dep_jose = git https://github.com/michaelklishin/erlang-jose mk-thoas-support
 dep_khepri = hex 0.13.0
 dep_khepri_mnesia_migration = hex 0.4.0
 dep_looking_glass = git https://github.com/rabbitmq/looking_glass.git main


### PR DESCRIPTION
and not oauth2_client or the OAuth 2 plugin.

In follow-up to #10645.

Pair: @pjk25 
