### PR TITLE
Don't show disabled plugins as pending upgrade

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -146,7 +146,7 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
     ]
   end
 
-  defp augment_version(%{version: version, running_version: nil}) do
+  defp augment_version(%{version: version, running: false}) do
     to_string(version)
   end
 


### PR DESCRIPTION
## Proposed Changes

Since commit c0187ec15 the value of `running_version` is converted to_string (`nil` would become the empty string). But the formatter expected `running_version` to be `nil` if the plugin is not running. This did not match and not running/not enabled plugins were marked incorrectly as "pending upgrade to...".

For example:
```
$ rabbitmq-plugins list trust -q
[  ] rabbitmq_trust_store               (pending upgrade to 3.13.0+51.g9145b53)

$ rabbitmq-plugins list trust --formatter erlang -q
#{status => running,format => normal,
  plugins =>
      [#{enabled => not_enabled,name => rabbitmq_trust_store,running => false,
         version => <<"3.13.0+51.g9145b53">>,running_version => <<>>}]}
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
