### PR TITLE
Be more defensive when determining if a policy has CMQ keys

### DIFF
--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -1010,7 +1010,9 @@ has_ha_policies(Policies) ->
               does_policy_configure_cmq(KeyList)
       end, Policies).
 
-does_policy_configure_cmq(KeyList) ->
+does_policy_configure_cmq(Map) when is_map(Map) ->
+    lists:keymember(<<"ha-mode">>, 1, rabbit_data_coercion:to_proplist(Map));
+does_policy_configure_cmq(KeyList) when is_list(KeyList) ->
     lists:keymember(<<"ha-mode">>, 1, KeyList).
 
 list_policies_with_classic_queue_mirroring_for_cli() ->

--- a/deps/rabbit/src/rabbit_mirror_queue_misc.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_misc.erl
@@ -1011,7 +1011,7 @@ has_ha_policies(Policies) ->
       end, Policies).
 
 does_policy_configure_cmq(Map) when is_map(Map) ->
-    lists:keymember(<<"ha-mode">>, 1, rabbit_data_coercion:to_proplist(Map));
+    is_map_key(<<"ha-mode">>, Map);
 does_policy_configure_cmq(KeyList) when is_list(KeyList) ->
     lists:keymember(<<"ha-mode">>, 1, KeyList).
 


### PR DESCRIPTION
This avoids an exception reported in #11192 by @metron2.