### PR TITLE
3.13: correctly format disabled plugins in 'rabbitmq-plugins list'

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -146,7 +146,19 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
     ]
   end
 
+  defp augment_version(%{version: version, running: nil}) do
+    to_string(version)
+  end
+
   defp augment_version(%{version: version, running: false}) do
+    to_string(version)
+  end
+
+  defp augment_version(%{version: version, running_version: nil}) do
+    to_string(version)
+  end
+
+  defp augment_version(%{version: version, running_version: ""}) do
     to_string(version)
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -146,7 +146,7 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
     ]
   end
 
-  defp augment_version(%{version: version, running_version: nil}) do
+  defp augment_version(%{version: version, running: false}) do
     to_string(version)
   end
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/plugins.ex
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+## Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
 defmodule RabbitMQ.CLI.Formatters.Plugins do
@@ -144,10 +144,6 @@ defmodule RabbitMQ.CLI.Formatters.Plugins do
       "     Dependencies:\t#{prettified}",
       "     Description: \t#{description}"
     ]
-  end
-
-  defp augment_version(%{version: version, running: nil}) do
-    to_string(version)
   end
 
   defp augment_version(%{version: version, running: false}) do

--- a/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
+++ b/deps/rabbitmq_cli/test/plugins/plugins_formatter_test.exs
@@ -76,7 +76,7 @@ defmodule PluginsFormatterTest do
               enabled: :implicit,
               running: true,
               version: ~c"3.7.0",
-              running_version: nil
+              running_version: ""
             },
             %{
               name: :mock_rabbitmq_plugins_01,


### PR DESCRIPTION
This is #11190 by @gomoripeti that passes the formatter tests. I've also tweaked them a bit to make the input more diverse.

References #10865 #10870.