### PR TITLE
Fix rabbitmq.conf.example channel_max comment

### DIFF
--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -352,7 +352,7 @@
 ## Set the max permissible number of channels per connection.
 ## 0 means "no limit".
 ##
-# channel_max = 128
+# channel_max = 2047
 
 ## Customising TCP Listener (Socket) Configuration.
 ##


### PR DESCRIPTION
## Proposed Changes

It's a simple change in `channel_max` comment section in rabbitmq.conf.example, where it shows example value of `channel_max` as 128 (which is not the actual default value for channel_max).

Since other example configuration values are given with actual default value, I think the comment section can mislead developers to mistakenly think the default value of `channel_max` is 128.

Well at least it made me look through makefile of the source code to look at actual default channel_max value. And I believe this small change can save time for others as well.

Thank you.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
