### PR TITLE
Move feature flag check outside of mc

### DIFF
--- a/deps/rabbit/src/mc.erl
+++ b/deps/rabbit/src/mc.erl
@@ -440,14 +440,6 @@ last_death(BasicMsg) ->
     mc_compat:last_death(BasicMsg).
 
 -spec prepare(read | store, state()) -> state().
-prepare(store, #?MODULE{protocol = mc_amqp} = State) ->
-    case rabbit_feature_flags:is_enabled(message_containers_store_amqp_v1) of
-        true ->
-            State#?MODULE{data = mc_amqp:prepare(store, State#?MODULE.data)};
-        false ->
-            State1 = convert(mc_amqpl, State, #{message_containers_store_amqp_v1 => false}),
-            State1#?MODULE{data = mc_amqpl:prepare(store, State1#?MODULE.data)}
-    end;
 prepare(For, #?MODULE{protocol = Proto,
                       data = Data} = State) ->
     State#?MODULE{data = Proto:prepare(For, Data)};

--- a/deps/rabbit/test/amqp_system_SUITE.erl
+++ b/deps/rabbit/test/amqp_system_SUITE.erl
@@ -87,13 +87,13 @@ end_per_testcase(Testcase, Config) ->
 
 build_dotnet_test_project(Config) ->
     TestProjectDir = filename:join(
-      [?config(data_dir, Config), "fsharp-tests"]),
+                       [?config(data_dir, Config), "fsharp-tests"]),
     Ret = rabbit_ct_helpers:exec(["dotnet", "restore"],
-      [{cd, TestProjectDir}]),
+                                 [{cd, TestProjectDir}]),
     case Ret of
         {ok, _} ->
-            rabbit_ct_helpers:set_config(Config,
-              {dotnet_test_project_dir, TestProjectDir});
+            rabbit_ct_helpers:set_config(
+              Config, {dotnet_test_project_dir, TestProjectDir});
         _ ->
             {skip, "Failed to fetch .NET Core test project dependencies"}
     end.
@@ -119,6 +119,8 @@ roundtrip(Config) ->
                  {java, "RoundTripTest"}]).
 
 streams(Config) ->
+    _ = rabbit_ct_broker_helpers:enable_feature_flag(Config,
+                                                     message_containers_store_amqp_v1),
     Ch = rabbit_ct_client_helpers:open_channel(Config),
     amqp_channel:call(Ch, #'queue.declare'{queue = <<"stream_q2">>,
                                            durable = true,

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -113,15 +113,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
               Msg :: mc:state(),
               rabbit_queue_type:delivery_options()) ->
     {[], rabbit_queue_type:actions()}.
-deliver(Qs, Msg0, Options) ->
-    Msg = case rabbit_feature_flags:is_enabled(message_containers_store_amqp_v1) of
-              true ->
-                  Msg0;
-              false ->
-                  %% An old node might not understand our new mc_amqp state.
-                  %% The following line takes care of converting mc_amqp to mc_amqpl.
-                  mc:prepare(store, Msg0)
-          end,
+deliver(Qs, Msg, Options) ->
     Evt = {queue_event, ?MODULE,
            {?MODULE, _QPid = none, _QMsgId = none, _Redelivered = false, Msg}},
     {Pids, Actions} =


### PR DESCRIPTION
the `mc` module is ideally meant to be kept pure and portable
 and feature flags have external infrastructure dependencies
as well as impure semantics.

Moving the check of this feature flag into the amqp session
simplifies the code (as no message containers with the new
format will enter the system before the feature flag is enabled).