### PR TITLE
Enforce/honor per-vhost queue limit for all protocols

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1013,15 +1013,6 @@ check_msg_size(Content, GCThreshold) ->
               Fmt, [Size, MaxMessageSize])
     end.
 
-check_vhost_queue_limit(#resource{name = QueueName}, VHost) ->
-  case rabbit_vhost_limit:is_over_queue_limit(VHost) of
-    false         -> ok;
-    {true, Limit} -> rabbit_misc:precondition_failed("cannot declare queue '~ts': "
-                               "queue limit in vhost '~ts' (~tp) is reached",
-                               [QueueName, VHost, Limit])
-
-  end.
-
 qbin_to_resource(QueueNameBin, VHostPath) ->
     name_to_resource(queue, QueueNameBin, VHostPath).
 
@@ -2471,7 +2462,6 @@ handle_method(#'queue.declare'{queue       = QueueNameBin,
             {ok, QueueName, MessageCount, ConsumerCount};
         {error, not_found} ->
             %% enforce the limit for newly declared queues only
-            check_vhost_queue_limit(QueueName, VHostPath),
             DlxKey = <<"x-dead-letter-exchange">>,
             case rabbit_misc:r_arg(VHostPath, exchange, Args, DlxKey) of
                undefined ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -307,6 +307,7 @@ is_compatible(Type, Durable, Exclusive, AutoDelete) ->
 declare(Q0, Node) ->
     Q = rabbit_queue_decorator:set(rabbit_policy:set(Q0)),
     Mod = amqqueue:get_type(Q),
+    ok = check_vhost_queue_limit(Q),
     Mod:declare(Q, Node).
 
 -spec delete(amqqueue:amqqueue(), boolean(),
@@ -765,3 +766,13 @@ known_queue_type_names() ->
     {QueueTypes, _} = lists:unzip(Registered),
     QTypeBins = lists:map(fun(X) -> atom_to_binary(X) end, QueueTypes),
     ?KNOWN_QUEUE_TYPES ++ QTypeBins.
+
+check_vhost_queue_limit(Q) ->
+    #resource{name = QueueName} = amqqueue:get_name(Q),
+    VHost = amqqueue:get_vhost(Q),
+    case rabbit_vhost_limit:is_over_queue_limit(VHost) of
+        false         -> ok;
+        {true, Limit} -> rabbit_misc:precondition_failed("cannot declare queue '~ts': "
+                                                         "queue limit in vhost '~ts' (~tp) is reached",
+                                                         [QueueName, VHost, Limit])
+    end.

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -785,7 +785,7 @@ check_vhost_queue_limit(Q) ->
     #resource{name = QueueName} = amqqueue:get_name(Q),
     VHost = amqqueue:get_vhost(Q),
     case rabbit_vhost_limit:is_over_queue_limit(VHost) of
-        false->
+        false ->
             ok;
         {true, Limit} ->
             {protocol_error, precondition_failed,

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -772,6 +772,9 @@ known_queue_type_names() ->
     QTypeBins = lists:map(fun(X) -> atom_to_binary(X) end, QueueTypes),
     ?KNOWN_QUEUE_TYPES ++ QTypeBins.
 
+-spec check_queue_limits(amqqueue:amqqueue()) ->
+          ok |
+          {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 check_queue_limits(Q) ->
     maybe
         %% Prepare for more checks


### PR DESCRIPTION
## Proposed Changes

The current vhost queue limit  it's only applicable to AMQP 0.9.1 and "non-native" protocols.

This PR moves the check to `rabbit_queue_type:declare`

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
