### PR TITLE
Remove BCC from x-death routing-keys

### DIFF
--- a/deps/rabbit/src/mc.erl
+++ b/deps/rabbit/src/mc.erl
@@ -365,14 +365,22 @@ record_death(Reason, SourceQueue,
        is_binary(SourceQueue) ->
     Key = {SourceQueue, Reason},
     #{?ANN_EXCHANGE := Exchange,
-      ?ANN_ROUTING_KEYS := RoutingKeys} = Anns0,
+      ?ANN_ROUTING_KEYS := RKeys0} = Anns0,
+    %% The routing keys that we record in the death history and will
+    %% report to the client should include CC, but exclude BCC.
+    RKeys = case Anns0 of
+                #{bcc := BccKeys} ->
+                    RKeys0 -- BccKeys;
+                _ ->
+                    RKeys0
+            end,
     Timestamp = os:system_time(millisecond),
     Ttl = maps:get(ttl, Anns0, undefined),
     DeathAnns = rabbit_misc:maps_put_truthy(
                   ttl, Ttl, #{first_time => Timestamp,
                               last_time => Timestamp}),
     NewDeath = #death{exchange = Exchange,
-                      routing_keys = RoutingKeys,
+                      routing_keys = RKeys,
                       count = 1,
                       anns = DeathAnns},
     Anns = case Anns0 of

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -51,10 +51,11 @@
 
 %% mc implementation
 init(#content{} = Content0) ->
-    Content = rabbit_binary_parser:ensure_content_decoded(Content0),
+    Content1 = rabbit_binary_parser:ensure_content_decoded(Content0),
     %% project essential properties into annotations
-    Anns = essential_properties(Content),
-    {strip_header(Content, ?DELETED_HEADER), Anns}.
+    Anns = essential_properties(Content1),
+    Content = strip_header(Content1, ?DELETED_HEADER),
+    {Content, Anns}.
 
 convert_from(mc_amqp, Sections, Env) ->
     {H, MAnn, Prop, AProp, BodyRev, Footer} =
@@ -554,7 +555,7 @@ message(#resource{name = ExchangeNameBin},
             Error;
         HeaderRoutes ->
             {ok, mc:init(?MODULE,
-                         rabbit_basic:strip_bcc_header(Content),
+                         Content,
                          Anns#{?ANN_ROUTING_KEYS => [RoutingKey | HeaderRoutes],
                                ?ANN_EXCHANGE => ExchangeNameBin})}
     end.
@@ -795,7 +796,8 @@ message_id(undefined, _HKey, H) ->
 essential_properties(#content{} = C) ->
     #'P_basic'{delivery_mode = Mode,
                priority = Priority,
-               timestamp = TimestampRaw} = Props = C#content.properties,
+               timestamp = TimestampRaw,
+               headers = Headers} = Props = C#content.properties,
     {ok, MsgTTL} = rabbit_basic:parse_expiration(Props),
     Timestamp = case TimestampRaw of
                     undefined ->
@@ -805,6 +807,12 @@ essential_properties(#content{} = C) ->
                         TimestampRaw * 1000
                 end,
     Durable = Mode == 2,
+    BccKeys = case rabbit_basic:header(<<"BCC">>, Headers) of
+                  {<<"BCC">>, array, Routes} ->
+                      [Route || {longstr, Route} <- Routes];
+                  _ ->
+                      undefined
+              end,
     maps_put_truthy(
       ?ANN_PRIORITY, Priority,
       maps_put_truthy(
@@ -813,7 +821,9 @@ essential_properties(#content{} = C) ->
           ?ANN_TIMESTAMP, Timestamp,
           maps_put_falsy(
             ?ANN_DURABLE, Durable,
-            #{})))).
+            maps_put_truthy(
+              bcc, BccKeys,
+              #{}))))).
 
 %% headers that are added as annotations during conversions
 is_internal_header(<<"x-basic-", _/binary>>) ->


### PR DESCRIPTION
This commit is a follow up of https://github.com/rabbitmq/rabbitmq-server/pull/11174 which broke the following Java client test:
```
./mvnw verify -P '!setup-test-cluster' -Drabbitmqctl.bin=DOCKER:rabbitmq -Dit.test=DeadLetterExchange#deadLetterNewRK
```

The desired documented behaviour is the following:
> routing-keys: the routing keys (including CC keys but excluding BCC ones) the message was published with

This behaviour should be respected also for messages dead lettered into a stream. Therefore, instead of first including the BCC keys in the `#death.routing_keys` field and removing it again in mc_amqpl before sending the routing-keys to the client as done in v3.13.2 in
https://github.com/rabbitmq/rabbitmq-server/blob/dc25ef53292eb0b34588ab8eaae61082b966b784/deps/rabbit/src/mc_amqpl.erl#L527 we instead omit directly the BCC keys from `#death.routing_keys` when recording a death event.

This commit records the BCC keys in their own mc `bcc` annotation in `mc_amqpl:init/1`.