### PR TITLE
Prometheus: add segment file count to queue_metrics and expose

### DIFF
--- a/deps/rabbit/src/rabbit_osiris_metrics.erl
+++ b/deps/rabbit/src/rabbit_osiris_metrics.erl
@@ -27,7 +27,8 @@
          members,
          memory,
          readers,
-         consumers
+         consumers,
+         segments
         ]).
 
 -record(state, {timeout :: non_neg_integer()}).

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -66,7 +66,7 @@
 -define(INFO_KEYS, [name, durable, auto_delete, arguments, leader, members, online, state,
                     messages, messages_ready, messages_unacknowledged, committed_offset,
                     policy, operator_policy, effective_policy_definition, type, memory,
-                    consumers]).
+                    consumers, segments]).
 
 -type appender_seq() :: non_neg_integer().
 
@@ -768,6 +768,14 @@ i(committed_offset, Q) ->
             '';
         Data ->
             maps:get(committed_offset, Data, '')
+    end;
+i(segments, Q) ->
+    Key = {osiris_writer, amqqueue:get_name(Q)},
+    case osiris_counters:overview(Key) of
+        undefined ->
+            '';
+        Data ->
+            maps:get(segments, Data, '')
     end;
 i(policy, Q) ->
     case rabbit_policy:name(Q) of

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -160,7 +160,8 @@
         {2, undefined, queue_messages_paged_out_bytes, gauge, "Size in bytes of messages paged out to disk", message_bytes_paged_out},
         {2, undefined, queue_head_message_timestamp, gauge, "Timestamp of the first message in the queue, if any", head_message_timestamp},
         {2, undefined, queue_disk_reads_total, counter, "Total number of times queue read messages from disk", disk_reads},
-        {2, undefined, queue_disk_writes_total, counter, "Total number of times queue wrote messages to disk", disk_writes}
+        {2, undefined, queue_disk_writes_total, counter, "Total number of times queue wrote messages to disk", disk_writes},
+        {2, undefined, stream_segments, counter, "Total number of stream segment files", segments}
     ]},
 
 %%% Metrics that contain reference to a channel. Some of them also have
@@ -538,7 +539,7 @@ get_data(queue_consumer_count = MF, false, VHostsFilter, QueuesFilter) ->
                          end, empty(MF), Table),
     [{Table, [{consumers, A1}]}];
 get_data(queue_metrics = Table, false, VHostsFilter, QueuesFilter) ->
-    {Table, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16} =
+    {Table, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17} =
         ets:foldl(fun
                       ({#resource{kind = queue, virtual_host = VHost}, _, _}, Acc) when is_map(VHostsFilter), map_get(VHost, VHostsFilter) == false ->
                           Acc;
@@ -559,7 +560,7 @@ get_data(queue_metrics = Table, false, VHostsFilter, QueuesFilter) ->
                {messages_bytes_persistent, A9}, {message_bytes, A10},
                {message_bytes_ready, A11}, {message_bytes_unacknowledged, A12},
                {messages_paged_out, A13}, {message_bytes_paged_out, A14},
-               {disk_reads, A15}, {disk_writes, A16}]}];
+               {disk_reads, A15}, {disk_writes, A16}, {segments, A17}]}];
 get_data(Table, false, VHostsFilter, QueuesFilter) when Table == channel_exchange_metrics;
                            Table == queue_coarse_metrics;
                            Table == channel_queue_metrics;
@@ -668,7 +669,7 @@ get_data(Table, _, _, _) ->
 
 
 sum_queue_metrics(Props, {T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11,
-                          A12, A13, A14, A15, A16}) ->
+                          A12, A13, A14, A15, A16, A17}) ->
     {T,
      sum(proplists:get_value(consumers, Props), A1),
      sum(proplists:get_value(consumer_utilisation, Props), A2),
@@ -685,7 +686,8 @@ sum_queue_metrics(Props, {T, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11,
      sum(proplists:get_value(messages_paged_out, Props), A13),
      sum(proplists:get_value(message_bytes_paged_out, Props), A14),
      sum(proplists:get_value(disk_reads, Props), A15),
-     sum(proplists:get_value(disk_writes, Props), A16)
+     sum(proplists:get_value(disk_writes, Props), A16),
+     sum(proplists:get_value(segments, Props), A17)
     }.
 
 division(0, 0) ->
@@ -707,7 +709,7 @@ empty(T) when T == ra_metrics ->
 empty(T) when T == channel_queue_metrics; T == channel_metrics ->
     {T, 0, 0, 0, 0, 0, 0, 0};
 empty(queue_metrics = T) ->
-    {T, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}.
+    {T, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}.
 
 sum(undefined, B) ->
     B;


### PR DESCRIPTION
## Proposed Changes

Off the back of discussion in a previous PR: https://github.com/rabbitmq/rabbitmq-server/pull/10275#issuecomment-1940781880

Adding segment count to queue_metrics ets table and expose value prometheus. Exposing the current segment count of a stream can help users calculate a rough stream size using `segment counts * max-segment-size`. 

If merged, will add the necessary documentation to https://github.com/rabbitmq/rabbitmq-website in a separate PR. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
