### PR TITLE
Wrap maybe function in quotes, so it is treated as an atom

### DIFF
--- a/deps/rabbit_common/src/rabbit_heartbeat.erl
+++ b/deps/rabbit_common/src/rabbit_heartbeat.erl
@@ -19,7 +19,7 @@
 
 -export_type([heartbeaters/0]).
 
--type heartbeaters() :: {rabbit_types:maybe(pid()), rabbit_types:maybe(pid())}.
+-type heartbeaters() :: {rabbit_types:'maybe'(pid()), rabbit_types:'maybe'(pid())}.
 
 -type heartbeat_callback() :: fun (() -> any()).
 

--- a/deps/rabbit_common/src/rabbit_types.erl
+++ b/deps/rabbit_common/src/rabbit_types.erl
@@ -11,7 +11,7 @@
 
 -export_type([
               %% deprecated
-              maybe/1,
+              'maybe'/1,
               option/1,
               info/0, infos/0, info_key/0, info_keys/0,
               message/0, msg_id/0, basic_message/0,
@@ -35,7 +35,7 @@
 
 -type(option(T) :: T | 'none' | 'undefined').
 %% Deprecated, 'maybe' is a keyword in modern Erlang
--type(maybe(T) :: T | 'none').
+-type('maybe'(T) :: T | 'none').
 -type(timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}).
 
 -type(vhost() :: binary()).


### PR DESCRIPTION
## Proposed Changes

Since `maybe` is added as an optional keyword in OTP 25, quote its usage as an atom, so that it does not break syntax highlighting and other language service features.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
