### PR TITLE
Adopt otp 26.2.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -112,8 +112,8 @@ erlang_config.internal_erlang_from_github_release(
 erlang_config.internal_erlang_from_github_release(
     name = "26_2",
     extra_make_opts = ["-j 4"],
-    sha256 = "d537ff4ac5d8c1cb507aedaf7198fc1f155ea8aa65a8d83edb35c2802763cc28",
-    version = "26.2.2",
+    sha256 = "de155c4ad9baab2b9e6c96dbd03bf955575a04dd6feee9c08758beb28484c9f6",
+    version = "26.2.5",
 )
 
 erlang_config.internal_erlang_from_http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,9 +78,9 @@ http_file(
 
 http_file(
     name = "otp_src_26_2",
-    downloaded_file_path = "OTP-26.2.2.tar.gz",
-    sha256 = "93c09aa8814018c23d218ac68b2bcdba188e12086223fbfa08af5cc70edd7ee1",
-    urls = ["https://github.com/erlang/otp/archive/OTP-26.2.2.tar.gz"],
+    downloaded_file_path = "OTP-26.2.5.tar.gz",
+    sha256 = "d34b409cb5968ae47dd5a0c4f85b925d5601898d90788bbb08d514964a3a141d",
+    urls = ["https://github.com/erlang/otp/archive/OTP-26.2.5.tar.gz"],
 )
 
 new_git_repository(


### PR DESCRIPTION
Automated changes created by https://github.com/rabbitmq/rabbitmq-server/actions/runs/9114822325 using the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action in the Update OTP Patch Versions for Bazel Based Workflows workflow.