### PR TITLE
rabbit_direct client: drop virtual host tree readiness check

### DIFF
--- a/deps/rabbit/src/rabbit_direct.erl
+++ b/deps/rabbit/src/rabbit_direct.erl
@@ -96,22 +96,17 @@ connect(Creds, VHost, Protocol, Pid, Infos) ->
                         true  ->
                             {error, not_allowed};
                         false ->
-                            case is_vhost_alive(VHost, Creds, Pid) of
-                                false ->
-                                    {error, {internal_error, vhost_is_down}};
-                                true  ->
-                                    case AuthFun() of
-                                        {ok, User = #user{username = Username}} ->
-                                            notify_auth_result(Username,
-                                                               user_authentication_success, []),
-                                            connect1(User, VHost, Protocol, Pid, Infos);
-                                        {refused, Username, Msg, Args} ->
-                                            notify_auth_result(Username,
-                                                               user_authentication_failure,
-                                                               [{error, rabbit_misc:format(Msg, Args)}]),
-                                            {error, {auth_failure, "Refused"}}
-                                    end %% AuthFun()
-                            end %% is_vhost_alive
+                            case AuthFun() of
+                                {ok, User = #user{username = Username}} ->
+                                    notify_auth_result(Username,
+                                                       user_authentication_success, []),
+                                    connect1(User, VHost, Protocol, Pid, Infos);
+                                {refused, Username, Msg, Args} ->
+                                    notify_auth_result(Username,
+                                                       user_authentication_failure,
+                                                       [{error, rabbit_misc:format(Msg, Args)}]),
+                                    {error, {auth_failure, "Refused"}}
+                            end %% AuthFun()
                     end %% is_over_vhost_connection_limit
             end;
         false -> {error, broker_not_found_on_node}
@@ -148,22 +143,6 @@ maybe_call_connection_info_module(Protocol, Creds, VHost, Pid, Infos) ->
     ),
     Args = [Creds, VHost, Pid, Infos],
     code_server_cache:maybe_call_mfa(Module, additional_authn_params, Args, []).
-
-is_vhost_alive(VHost, {Username, _Password}, Pid) ->
-    PrintedUsername = case Username of
-        none -> "";
-        _    -> Username
-    end,
-    case rabbit_vhost_sup_sup:is_vhost_alive(VHost) of
-        true  -> true;
-        false ->
-            rabbit_log_connection:error(
-                "Error on Direct connection ~tp~n"
-                "access to vhost '~ts' refused for user '~ts': "
-                "vhost '~ts' is down",
-                [Pid, VHost, PrintedUsername, VHost]),
-            false
-    end.
 
 is_over_vhost_connection_limit(VHost, {Username, _Password}, Pid) ->
     PrintedUsername = case Username of


### PR DESCRIPTION
The check won't be perfectly stable during the initial cluster formation. Moreover, it does not offer much to clients after the cluster is formed because virtual hosts are up the vast majority of the time.
