### PR TITLE
QQs: check if schema database record needs an update on tick

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -552,6 +552,12 @@ handle_tick(QName,
                            | info(Q, Keys)],
                   rabbit_core_metrics:queue_stats(QName, Infos),
                   ok = repair_leader_record(Q, Self),
+                  case repair_amqqueue_nodes(Q) of
+                      ok ->
+                          ok;
+                      repaired ->
+                          rabbit_log:debug("Repaired quorum queue ~ts amqqueue record", [rabbit_misc:rs(QName)])
+                  end,
                   ExpectedNodes = rabbit_nodes:list_members(),
                   case Nodes -- ExpectedNodes of
                       [] ->
@@ -604,8 +610,8 @@ repair_amqqueue_nodes(QName = #resource{}) ->
     repair_amqqueue_nodes(Q0);
 repair_amqqueue_nodes(Q0) ->
     QName = amqqueue:get_name(Q0),
-    Leader = amqqueue:get_pid(Q0),
-    {ok, Members, _} = ra:members(Leader),
+    {Name, _} = amqqueue:get_pid(Q0),
+    Members = ra_leaderboard:lookup_members(Name),
     RaNodes = [N || {_, N} <- Members],
     #{nodes := Nodes} = amqqueue:get_type_state(Q0),
     case lists:sort(RaNodes) =:= lists:sort(Nodes) of


### PR DESCRIPTION
## Proposed Changes

Let QQ run `rabbit_quorum_queue:repair_amqqueue_nodes` on tick to repair potential membership discrepancy (RA members compared to amqqueue state members)

See #11029

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
