### PR TITLE
Reduce inefficiency introduced in b636f41

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-early-test.mk
+++ b/deps/rabbit_common/mk/rabbitmq-early-test.mk
@@ -16,7 +16,7 @@ endif
 
 DIALYZER_OPTS ?= -Werror_handling
 
-dialyze: ERL_LIBS := $(ERL_LIBS):$(DEPS_DIR):$(DEPS_DIR)/rabbitmq_cli/_build/dev/lib:$(dir $(shell elixir --eval ":io.format '~s~n', [:code.lib_dir :elixir ]"))
+dialyze: ERL_LIBS = $(APPS_DIR):$(DEPS_DIR):$(DEPS_DIR)/rabbitmq_cli/_build/dev/lib:$(dir $(shell elixir --eval ":io.format '~s~n', [:code.lib_dir :elixir ]"))
 
 # --------------------------------------------------------------------
 # %-on-concourse dependencies.


### PR DESCRIPTION
Use "ERL_LIBS =" instead of "ERL_LIBS :=" so that $(shell ... is not called so often

as per @lhoguin 's suggestion