### PR TITLE
Remove duplicated checks of vhost queue limit

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -201,6 +201,7 @@ find_recoverable_queues() ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'new', amqqueue:amqqueue(), rabbit_fifo_client:state()} |
     {'absent', amqqueue:amqqueue(), absent_reason()} |
+    {'error', Type :: atom(), Reason :: string(), Args :: term()} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 declare(QueueName, Durable, AutoDelete, Args, Owner, ActingUser) ->
     declare(QueueName, Durable, AutoDelete, Args, Owner, ActingUser, node()).
@@ -219,6 +220,7 @@ declare(QueueName, Durable, AutoDelete, Args, Owner, ActingUser) ->
               node() | {'ignore_location', node()}) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'absent', amqqueue:amqqueue(), absent_reason()} |
+    {'error', Type :: atom(), Reason :: string(), Args :: term()} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
 declare(QueueName = #resource{virtual_host = VHost}, Durable, AutoDelete, Args,
         Owner, ActingUser, Node) ->

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2503,6 +2503,8 @@ handle_method(#'queue.declare'{queue       = QueueNameBin,
                     %% connection has died. Pretend the queue exists though,
                     %% just so nothing fails.
                     {ok, QueueName, 0, 0};
+                {error, queue_limit_exceeded, Reason, ReasonArgs} ->
+                    rabbit_misc:precondition_failed(Reason, ReasonArgs);
                 {protocol_error, ErrorType, Reason, ReasonArgs} ->
                     rabbit_misc:protocol_error(ErrorType, Reason, ReasonArgs)
             end;

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -304,6 +304,7 @@ is_compatible(Type, Durable, Exclusive, AutoDelete) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'absent', amqqueue:amqqueue(), rabbit_amqqueue:absent_reason()} |
     {protocol_error, Type :: atom(), Reason :: string(), Args :: term()} |
+    {'error', Type :: atom(), Reason :: string(), Args :: term()} |
     {'error', Err :: term() }.
 declare(Q0, Node) ->
     Q = rabbit_queue_decorator:set(rabbit_policy:set(Q0)),
@@ -774,7 +775,7 @@ known_queue_type_names() ->
 
 -spec check_queue_limits(amqqueue:amqqueue()) ->
           ok |
-          {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
+          {error, queue_limit_exceeded, Reason :: string(), Args :: term()}.
 check_queue_limits(Q) ->
     maybe
         ok ?= check_vhost_queue_limit(Q),
@@ -788,10 +789,9 @@ check_vhost_queue_limit(Q) ->
         false ->
             ok;
         {true, Limit} ->
-            {protocol_error, precondition_failed,
-             "cannot declare queue '~ts': "
-             "queue limit in vhost '~ts' (~tp) is reached",
-             [QueueName, VHost, Limit]}
+            queue_limit_error("cannot declare queue '~ts': "
+                              "queue limit in vhost '~ts' (~tp) is reached",
+                              [QueueName, VHost, Limit])
     end.
 
 check_cluster_queue_limit(Q) ->
@@ -802,11 +802,13 @@ check_cluster_queue_limit(Q) ->
         Limit ->
             case rabbit_db_queue:count() >= Limit of
                 true ->
-                    {protocol_error, precondition_failed,
-                     "cannot declare queue '~ts': "
-                     "queue limit in cluster (~tp) is reached",
-                     [QueueName, Limit]};
+                    queue_limit_error("cannot declare queue '~ts': "
+                                      "queue limit in cluster (~tp) is reached",
+                                      [QueueName, Limit]);
                 false ->
                     ok
             end
     end.
+
+queue_limit_error(Reason, ReasonArgs) ->
+    {error, queue_limit_exceeded, Reason, ReasonArgs}.

--- a/deps/rabbit/test/amqp_auth_SUITE.erl
+++ b/deps/rabbit/test/amqp_auth_SUITE.erl
@@ -727,7 +727,7 @@ v1_vhost_queue_limit(Config) ->
                        Session1, <<"test-sender-1">>, TargetAddress),
     ExpectedErr = amqp_error(
                     ?V_1_0_AMQP_ERROR_RESOURCE_LIMIT_EXCEEDED,
-                    <<"cannot declare queue 'q1' in vhost 'test vhost': vhost queue limit (0) is reached">>),
+                    <<"cannot declare queue 'q1': queue limit in vhost 'test vhost' (0) is reached">>),
     receive {amqp10_event, {session, Session1, {ended, ExpectedErr}}} -> ok
     after 5000 -> flush(missing_ended),
                   ct:fail("did not receive expected error")
@@ -831,8 +831,7 @@ declare_queue_vhost_queue_limit(Config) ->
     ?assertMatch(#{subject := <<"403">>}, amqp10_msg:properties(Resp)),
     ?assertEqual(
        #'v1_0.amqp_value'{
-          content = {utf8, <<"refused to declare queue '", QName/binary, "' in vhost 'test vhost' ",
-                             "because vhost queue limit 0 is reached">>}},
+          content = {utf8, <<"cannot declare queue '", QName/binary, "': queue limit in vhost 'test vhost' (0) is reached">>}},
        amqp10_msg:body(Resp)),
 
     ok = cleanup_pair(Init),


### PR DESCRIPTION
## Proposed Changes

#11222 moved the check of vhost queue limit to `rabbit_queue_type:declare`. I did miss that there are checks from other sources too, so I have updated those sources to reflect the changes. Basically removed the check, and handle the precondition error better.

This 'might' have changed the logging msg some, which might or might not be OK?

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x]  I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
