### PR TITLE
Introduce outbound RabbitMQ internal AMQP flow control

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -902,9 +902,10 @@ handle_link_flow(#'v1_0.flow'{delivery_count = MaybeTheirDC,
 handle_link_flow(#'v1_0.flow'{delivery_count = TheirDC,
                               link_credit = {uint, TheirCredit},
                               available = Available,
-                              drain = Drain},
+                              drain = Drain0},
                  Link0 = #link{role = receiver}) ->
-    Link = case Drain andalso TheirCredit =< 0 of
+    Drain = default(Drain0, false),
+    Link = case Drain andalso TheirCredit =:= 0 of
                true ->
                    notify_credit_exhausted(Link0),
                    Link0#link{delivery_count = unpack(TheirDC),
@@ -1211,6 +1212,9 @@ boolean_to_role(?AMQP_ROLE_SENDER) ->
     sender;
 boolean_to_role(?AMQP_ROLE_RECEIVER) ->
     receiver.
+
+default(undefined, Default) -> Default;
+default(Thing, _Default) -> Thing.
 
 format_status(Status = #{data := Data0}) ->
     #state{channel = Channel,

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -53,12 +53,19 @@
 %% 400 for classic queues
 %% If link target is a queue (rather than an exchange), we could use one of these depending
 %% on target queue type. For the time being just use a static value that's something in between.
-%% An even better approach in future would be to dynamically grow (or shrink) the link credit
-%% we grant depending on how fast target queue(s) actually confirm messages.
+%% In future, we could dynamically grow (or shrink) the link credit we grant depending on how fast
+%% target queue(s) actually confirm messages: see paper "Credit-Based Flow Control for ATM Networks"
+%% from 1995, section 4.2 "Static vs. adaptive credit control" for pros and cons.
 -define(LINK_CREDIT_RCV, 128).
 -define(MANAGEMENT_LINK_CREDIT_RCV, 8).
 -define(MANAGEMENT_NODE_ADDRESS, <<"/management">>).
 -define(DEFAULT_EXCHANGE_NAME, <<>>).
+%% This is the maximum credit we grant to a sending queue.
+%% Only when we sent sufficient messages to the writer proc, we will again grant credits
+%% to the sending queue. We have this limit in place to ensure that our session proc won't be flooded
+%% with messages by the sending queue, especially if we are throttled sending messages to the client
+%% either by the writer proc or by remote-incoming window (i.e. session flow control).
+-define(LINK_CREDIT_RCV_FROM_QUEUE_MAX, 256).
 
 -export([start_link/8,
          process_frame/2,
@@ -81,6 +88,9 @@
         [add/2,
          diff/2,
          compare/2]).
+-import(rabbit_misc,
+        [queue_resource/2,
+         exchange_resource/2]).
 
 -type permission_cache() :: [{rabbit_types:r(exchange | queue),
                               rabbit_types:permission_atom()}].
@@ -113,7 +123,7 @@
 -record(management_link, {
           name :: binary(),
           delivery_count :: sequence_no(),
-          credit :: non_neg_integer(),
+          credit :: rabbit_queue_type:credit(),
           max_message_size :: unlimited | pos_integer()
          }).
 
@@ -129,13 +139,39 @@
           %% queue_name_bin is only set if the link target address refers to a queue.
           queue_name_bin :: undefined | rabbit_misc:resource_name(),
           delivery_count :: sequence_no(),
-          credit :: non_neg_integer(),
+          credit :: rabbit_queue_type:credit(),
           %% TRANSFER delivery IDs published to queues but not yet confirmed by queues
           incoming_unconfirmed_map = #{} :: #{delivery_number() =>
                                               {#{rabbit_amqqueue:name() := ok},
                                                IsTransferSettled :: boolean(),
                                                AtLeastOneQueueConfirmed :: boolean()}},
           multi_transfer_msg :: undefined | #multi_transfer_msg{}
+         }).
+
+%% A credit request from the client (receiver) as sent in the FLOW frame.
+-record(credit_req, {
+          delivery_count :: sequence_no(),
+          credit :: rabbit_queue_type:credit(),
+          drain :: boolean(),
+          echo :: boolean()
+         }).
+
+%% Link flow control state for link between client (receiver) and us (sender).
+-record(client_flow_ctl, {
+          delivery_count :: sequence_no(),
+          credit :: rabbit_queue_type:credit(),
+          echo :: boolean()
+         }).
+
+%% Link flow control state for link between us (receiver) and queue (sender).
+-record(queue_flow_ctl, {
+          delivery_count :: sequence_no(),
+          %% We cap the actual credit we grant to the sending queue.
+          credit :: 0..?LINK_CREDIT_RCV_FROM_QUEUE_MAX,
+          %% Credit as desired by the receiving client. If larger than
+          %% LINK_CREDIT_RCV_FROM_QUEUE_MAX, we will top up in batches to the sending queue.
+          desired_credit :: rabbit_queue_type:credit(),
+          drain :: boolean()
          }).
 
 -record(outgoing_link, {
@@ -145,10 +181,23 @@
           queue_type :: rabbit_queue_type:queue_type(),
           send_settled :: boolean(),
           max_message_size :: unlimited | pos_integer(),
+
+          %% When feature flag credit_api_v2 becomes required,
+          %% the following 2 fields should be deleted.
+          credit_api_version :: 1 | 2,
           %% When credit API v1 is used, our session process holds the delivery-count
-          %% When credit API v2 is used, the queue type implementation holds the delivery-count
-          %% When feature flag credit_api_v2 becomes required, this field should be deleted.
-          delivery_count :: {credit_api_v1, sequence_no()} | credit_api_v2
+          delivery_count :: sequence_no() | credit_api_v2,
+          %% We use a dual link approach for messages we send to the client.
+          %% We hold link flow control state for the link to the receiving
+          %% client and for the link to the sending queue.
+          client_flow_ctl :: #client_flow_ctl{} | credit_api_v1,
+          queue_flow_ctl :: #queue_flow_ctl{} | credit_api_v1,
+          %% True if we sent a credit request to the sending queue
+          %% but haven't processed the corresponding credit reply yet.
+          credit_req_in_flight :: boolean() | credit_api_v1,
+          %% While credit_req_in_flight is true, we stash the
+          %% latest credit request from the receiving client.
+          stashed_credit_req :: none | #credit_req{} | credit_api_v1
          }).
 
 -record(outgoing_unsettled, {
@@ -248,6 +297,7 @@
           %% and advanced delivery count. Otherwise, we would violate the AMQP protocol spec.
           outgoing_pending = queue:new() :: queue:queue(#pending_delivery{} |
                                                         #pending_management_delivery{} |
+                                                        rabbit_queue_type:credit_reply_action() |
                                                         #'v1_0.flow'{}),
 
           %% The link or session endpoint assigns each message a unique delivery-id
@@ -375,6 +425,10 @@ handle_call(Msg, _From, State) ->
     reply(Reply, State).
 
 handle_info(timeout, State) ->
+    noreply(State);
+handle_info({bump_credit, Msg}, State) ->
+    %% We are receiving credit from the writer proc.
+    credit_flow:handle_bump_msg(Msg),
     noreply(State);
 handle_info({{'DOWN', QName}, _MRef, process, QPid, Reason},
             #state{queue_states = QStates0,
@@ -947,16 +1001,16 @@ handle_control(#'v1_0.attach'{role = ?AMQP_ROLE_RECEIVER,
                                           user = User = #user{username = Username},
                                           reader_pid = ReaderPid}}) ->
     ok = validate_attach(Attach),
-    {SndSettled,
-     EffectiveSndSettleMode} = case SndSettleMode of
-                                   ?V_1_0_SENDER_SETTLE_MODE_SETTLED ->
-                                       {true, SndSettleMode};
-                                   _ ->
-                                       %% In the future, we might want to support sender settle
-                                       %% mode mixed where we would expect a settlement from the
-                                       %% client only for durable messages.
-                                       {false, ?V_1_0_SENDER_SETTLE_MODE_UNSETTLED}
-                               end,
+    {SndSettled, EffectiveSndSettleMode} =
+    case SndSettleMode of
+        ?V_1_0_SENDER_SETTLE_MODE_SETTLED ->
+            {true, SndSettleMode};
+        _ ->
+            %% In the future, we might want to support sender settle
+            %% mode mixed where we would expect a settlement from the
+            %% client only for durable messages.
+            {false, ?V_1_0_SENDER_SETTLE_MODE_UNSETTLED}
+    end,
     case ensure_source(Source, Vhost, User, PermCache0, TopicPermCache0) of
         {error, Reason} ->
             protocol_error(?V_1_0_AMQP_ERROR_INVALID_FIELD, "Attach rejected: ~tp", [Reason]);
@@ -984,14 +1038,32 @@ handle_control(#'v1_0.attach'{role = ?AMQP_ROLE_RECEIVER,
                            %% all consumers will use credit API v2.
                            %% Streams always use credit API v2 since the stream client (rabbit_stream_queue) holds the link
                            %% flow control state. Hence, credit API mixed version isn't an issue for streams.
-                           {Mode,
-                            DeliveryCount} = case rabbit_feature_flags:is_enabled(credit_api_v2) orelse
-                                                  QType =:= rabbit_stream_queue of
-                                                 true ->
-                                                     {{credited, ?INITIAL_DELIVERY_COUNT}, credit_api_v2};
-                                                 false ->
-                                                     {{credited, credit_api_v1}, {credit_api_v1, ?INITIAL_DELIVERY_COUNT}}
-                                             end,
+                           {CreditApiVsn, Mode, DeliveryCount, ClientFlowCtl,
+                            QueueFlowCtl, CreditReqInFlight, StashedCreditReq} =
+                           case rabbit_feature_flags:is_enabled(credit_api_v2) orelse
+                                QType =:= rabbit_stream_queue of
+                               true ->
+                                   {2,
+                                    {credited, ?INITIAL_DELIVERY_COUNT},
+                                    credit_api_v2,
+                                    #client_flow_ctl{delivery_count = ?INITIAL_DELIVERY_COUNT,
+                                                     credit = 0,
+                                                     echo = false},
+                                    #queue_flow_ctl{delivery_count = ?INITIAL_DELIVERY_COUNT,
+                                                    credit = 0,
+                                                    desired_credit = 0,
+                                                    drain = false},
+                                    false,
+                                    none};
+                               false ->
+                                   {1,
+                                    {credited, credit_api_v1},
+                                    ?INITIAL_DELIVERY_COUNT,
+                                    credit_api_v1,
+                                    credit_api_v1,
+                                    credit_api_v1,
+                                    credit_api_v1}
+                           end,
                            Spec = #{no_ack => SndSettled,
                                     channel_pid => self(),
                                     limiter_pid => none,
@@ -1020,11 +1092,17 @@ handle_control(#'v1_0.attach'{role = ?AMQP_ROLE_RECEIVER,
                                           %% Echo back that we will respect the client's requested max-message-size.
                                           max_message_size = MaybeMaxMessageSize},
                                    MaxMessageSize = max_message_size(MaybeMaxMessageSize),
-                                   Link = #outgoing_link{queue_name_bin = QNameBin,
-                                                         queue_type = QType,
-                                                         send_settled = SndSettled,
-                                                         max_message_size = MaxMessageSize,
-                                                         delivery_count = DeliveryCount},
+                                   Link = #outgoing_link{
+                                             queue_name_bin = QNameBin,
+                                             queue_type = QType,
+                                             send_settled = SndSettled,
+                                             max_message_size = MaxMessageSize,
+                                             credit_api_version = CreditApiVsn,
+                                             delivery_count = DeliveryCount,
+                                             client_flow_ctl = ClientFlowCtl,
+                                             queue_flow_ctl = QueueFlowCtl,
+                                             credit_req_in_flight = CreditReqInFlight,
+                                             stashed_credit_req = StashedCreditReq},
                                    OutgoingLinks = OutgoingLinks0#{HandleInt => Link},
                                    State1 = State0#state{queue_states = QStates,
                                                          outgoing_links = OutgoingLinks,
@@ -1138,10 +1216,10 @@ handle_control(Detach = #'v1_0.detach'{handle = ?UINT(HandleInt)},
     {QStates, Unsettled, OutgoingLinks}
     = case maps:take(HandleInt, OutgoingLinks0) of
           {#outgoing_link{queue_name_bin = QNameBin}, OutgoingLinks1} ->
-              QName = rabbit_misc:r(Vhost, queue, QNameBin),
+              QName = queue_resource(Vhost, QNameBin),
               case rabbit_amqqueue:lookup(QName) of
                   {ok, Q} ->
-                      %%TODO Consider adding a new rabbit_queue_type:remove_consumer API that - from the point of view of
+                      %%TODO Add a new rabbit_queue_type:remove_consumer API that - from the point of view of
                       %% the queue process - behaves as if our session process terminated: All messages checked out
                       %% to this consumer should be re-queued automatically instead of us requeueing them here after cancelling
                       %% consumption.
@@ -1154,6 +1232,8 @@ handle_control(Detach = #'v1_0.detach'{handle = ?UINT(HandleInt)},
                       %% first detaching and then re-attaching to the same session with the same link handle (the handle
                       %% becomes available for re-use once a link is closed): This will result in the same consumer tag,
                       %% and we ideally disallow "updating" an AMQP consumer.
+                      %% If such an API is not added, we also must return messages in the outgoing_pending queue
+                      %% which haven't made it to the outgoing_unsettled map yet.
                       case rabbit_queue_type:cancel(Q, Ctag, undefined, Username, QStates0) of
                           {ok, QStates1} ->
                               {Unsettled1, MsgIds} = remove_link_from_outgoing_unsettled_map(Ctag, Unsettled0),
@@ -1286,83 +1366,405 @@ handle_control(Frame, _State) ->
                    "Unexpected frame ~tp",
                    [amqp10_framing:pprint(Frame)]).
 
-send_pending(#state{remote_incoming_window = Space,
-                    outgoing_pending = Buf0,
-                    cfg = #cfg{writer_pid = WriterPid,
-                               channel_num = Ch}} = State0) ->
+send_pending(#state{remote_incoming_window = RemoteIncomingWindow,
+                    outgoing_pending = Buf0
+                   } = State) ->
     case queue:out(Buf0) of
         {empty, _} ->
-            State0;
+            State;
+        {{value, CreditReply}, Buf}
+          when element(1, CreditReply) =:= credit_reply ->
+            State1 = State#state{outgoing_pending = Buf},
+            State2 = handle_credit_reply(CreditReply, State1),
+            send_pending(State2);
         {{value, #'v1_0.flow'{} = Flow0}, Buf} ->
-            Flow = session_flow_fields(Flow0, State0),
+            #cfg{writer_pid = WriterPid,
+                 channel_num = Ch} = State#state.cfg,
+            State1 = State#state{outgoing_pending = Buf},
+            Flow = session_flow_fields(Flow0, State1),
             rabbit_amqp_writer:send_command(WriterPid, Ch, Flow),
-            send_pending(State0#state{outgoing_pending = Buf});
-        {{value, #pending_delivery{
-                    frames = Frames,
-                    queue_pid = QPid,
-                    outgoing_unsettled = #outgoing_unsettled{queue_name = QName}
-                   } = Pending}, Buf1}
-          when Space > 0 ->
+            send_pending(State1);
+        {{value, Delivery}, Buf} ->
+            case RemoteIncomingWindow =:= 0 orelse
+                 credit_flow:blocked() of
+                true ->
+                    State;
+                false ->
+                    {NewRemoteIncomingWindow, State1} =
+                    send_pending_delivery(Delivery, Buf, State),
+                    NumTransfersSent = RemoteIncomingWindow - NewRemoteIncomingWindow,
+                    State2 = session_flow_control_sent_transfers(NumTransfersSent, State1),
+                    %% Recurse to possibly send FLOW frames.
+                    send_pending(State2)
+            end
+    end.
+
+handle_credit_reply(Action = {credit_reply, Ctag, _DeliveryCount, _Credit, _Available, Drain},
+                    State = #state{outgoing_links = OutgoingLinks}) ->
+    Handle = ctag_to_handle(Ctag),
+    case OutgoingLinks of
+        #{Handle := Link = #outgoing_link{queue_flow_ctl = QFC,
+                                          credit_req_in_flight = CreditReqInFlight}} ->
+            %% Assert that we expect a credit reply for this consumer.
+            true = CreditReqInFlight,
+            %% Assert that "The sender's value is always the last known value indicated by the receiver."
+            Drain = QFC#queue_flow_ctl.drain,
+            handle_credit_reply0(Action, Handle, Link, State);
+        _ ->
+            %% Ignore credit reply for a detached link.
+            State
+    end.
+
+handle_credit_reply0(
+  {credit_reply, Ctag, DeliveryCount, Credit, Available, _Drain = false},
+  Handle,
+  #outgoing_link{
+     client_flow_ctl = #client_flow_ctl{
+                          delivery_count = CDeliveryCount,
+                          credit = CCredit,
+                          echo = CEcho
+                         },
+     queue_flow_ctl = #queue_flow_ctl{
+                         delivery_count = QDeliveryCount,
+                         credit = QCredit,
+                         desired_credit = DesiredCredit
+                        } = QFC,
+     stashed_credit_req = StashedCreditReq
+    } = Link0,
+  #state{outgoing_links = OutgoingLinks,
+         queue_states = QStates0
+        } = S0) ->
+
+    %% Assert that flow control state between us and the queue is in sync.
+    QCredit = Credit,
+    QDeliveryCount = DeliveryCount,
+
+    case StashedCreditReq of
+        #credit_req{} ->
+            %% We prioritise the stashed client request over finishing the current
+            %% top-up rounds because the latest link state from the client applies.
+            S = pop_credit_req(Handle, Ctag, Link0, S0),
+            echo(CEcho, Handle, CDeliveryCount, CCredit, Available, S),
+            S;
+        none when QCredit =:= 0 andalso
+                  DesiredCredit > 0 ->
+            %% Provide queue next batch of credits.
+            CappedCredit = cap_credit(DesiredCredit),
+            QName = queue_resource(S0#state.cfg#cfg.vhost,
+                                   Link0#outgoing_link.queue_name_bin),
+            {ok, QStates, Actions} =
+            rabbit_queue_type:credit(
+              QName, Ctag, DeliveryCount, CappedCredit, false, QStates0),
+            Link = Link0#outgoing_link{
+                     queue_flow_ctl = QFC#queue_flow_ctl{credit = CappedCredit}
+                    },
+            S = S0#state{queue_states = QStates,
+                         outgoing_links = OutgoingLinks#{Handle := Link}},
+            handle_queue_actions(Actions, S);
+        none ->
+            Link = Link0#outgoing_link{credit_req_in_flight = false},
+            S = S0#state{outgoing_links = OutgoingLinks#{Handle := Link}},
+            echo(CEcho, Handle, CDeliveryCount, DesiredCredit, Available, S),
+            S
+    end;
+handle_credit_reply0(
+  {credit_reply, Ctag, DeliveryCount, Credit, Available, _Drain = true},
+  Handle,
+  Link0 = #outgoing_link{
+             queue_name_bin = QNameBin,
+             client_flow_ctl = #client_flow_ctl{
+                                  delivery_count = CDeliveryCount0 } = CFC,
+             queue_flow_ctl = #queue_flow_ctl{
+                                 delivery_count = QDeliveryCount0,
+                                 desired_credit = DesiredCredit
+                                } = QFC,
+             stashed_credit_req = StashedCreditReq},
+  S0 = #state{cfg = #cfg{writer_pid = Writer,
+                         vhost = Vhost,
+                         channel_num = ChanNum},
+              outgoing_links = OutgoingLinks,
+              queue_states = QStates0}) ->
+    %% If the queue sent us a drain credit_reply,
+    %% the queue must have consumed all our granted credit.
+    0 = Credit,
+
+    case DeliveryCount =:= QDeliveryCount0 andalso
+         DesiredCredit > 0 of
+        true ->
+            %% We're in drain mode. The queue did not advance its delivery-count which means
+            %% it might still have messages available for us. We also desire more messages.
+            %% Therefore, we do the next round of credit top-up. We prioritise finishing
+            %% the current drain credit top-up rounds over a stashed credit request because
+            %% this is easier to reason about and the queue will reply promptly meaning
+            %% the stashed request will be processed soon enough.
+            CappedCredit = cap_credit(DesiredCredit),
+            Link = Link0#outgoing_link{queue_flow_ctl = QFC#queue_flow_ctl{credit = CappedCredit}},
+
+            QName = queue_resource(Vhost, QNameBin),
+            {ok, QStates, Actions} =
+            rabbit_queue_type:credit(
+              QName, Ctag, DeliveryCount, CappedCredit, true, QStates0),
+            S = S0#state{queue_states = QStates,
+                         outgoing_links = OutgoingLinks#{Handle := Link}},
+            handle_queue_actions(Actions, S);
+        false ->
+            %% We're in drain mode.
+            %% The queue either advanced its delivery-count which means it has
+            %% no more messages available for us, or we do not desire more messages.
+            %% Therefore, we're done with draining and we "the sender will (after sending
+            %% all available messages) advance the delivery-count as much as possible,
+            %% consuming all link-credit, and send the flow state to the receiver."
+            CDeliveryCount = add(CDeliveryCount0, DesiredCredit),
+            Flow0 = #'v1_0.flow'{handle = ?UINT(Handle),
+                                 delivery_count = ?UINT(CDeliveryCount),
+                                 link_credit = ?UINT(0),
+                                 drain = true,
+                                 available = ?UINT(Available)},
+            Flow = session_flow_fields(Flow0, S0),
+            rabbit_amqp_writer:send_command(Writer, ChanNum, Flow),
+            Link = Link0#outgoing_link{
+                     client_flow_ctl = CFC#client_flow_ctl{
+                                         delivery_count = CDeliveryCount,
+                                         credit = 0},
+                     queue_flow_ctl = QFC#queue_flow_ctl{
+                                        delivery_count = DeliveryCount,
+                                        credit = 0,
+                                        desired_credit = 0,
+                                        drain = false},
+                     credit_req_in_flight = false
+                    },
+            S = S0#state{outgoing_links = OutgoingLinks#{Handle := Link}},
+            case StashedCreditReq of
+                none ->
+                    S;
+                #credit_req{} ->
+                    pop_credit_req(Handle, Ctag, Link, S)
+            end
+    end.
+
+pop_credit_req(
+  Handle, Ctag,
+  Link0 = #outgoing_link{
+             queue_name_bin = QNameBin,
+             client_flow_ctl = #client_flow_ctl{
+                                  delivery_count = CDeliveryCount
+                                 } = CFC,
+             queue_flow_ctl = #queue_flow_ctl{
+                                 delivery_count = QDeliveryCount
+                                } = QFC,
+             stashed_credit_req = #credit_req{
+                                     delivery_count = DeliveryCountRcv,
+                                     credit = LinkCreditRcv,
+                                     drain = Drain,
+                                     echo = Echo
+                                    }},
+  S0 = #state{cfg = #cfg{vhost = Vhost},
+              outgoing_links = OutgoingLinks,
+              queue_states = QStates0}) ->
+    LinkCreditSnd = amqp10_util:link_credit_snd(
+                      DeliveryCountRcv, LinkCreditRcv, CDeliveryCount),
+    CappedCredit = cap_credit(LinkCreditSnd),
+    QName = queue_resource(Vhost, QNameBin),
+    {ok, QStates, Actions} =
+    rabbit_queue_type:credit(
+      QName, Ctag, QDeliveryCount, CappedCredit, Drain, QStates0),
+    Link = Link0#outgoing_link{
+             client_flow_ctl = CFC#client_flow_ctl{
+                                 credit = LinkCreditSnd,
+                                 echo = Echo},
+             queue_flow_ctl = QFC#queue_flow_ctl{
+                                credit = CappedCredit,
+                                desired_credit = LinkCreditSnd,
+                                drain = Drain
+                               },
+             credit_req_in_flight = true,
+             stashed_credit_req = none
+            },
+    S = S0#state{queue_states = QStates,
+                 outgoing_links = OutgoingLinks#{Handle := Link}},
+    handle_queue_actions(Actions, S).
+
+echo(Echo, HandleInt, DeliveryCount, LinkCredit, Available, State) ->
+    case Echo of
+        true ->
+            Flow0 = #'v1_0.flow'{handle = ?UINT(HandleInt),
+                                 delivery_count = ?UINT(DeliveryCount),
+                                 link_credit = ?UINT(LinkCredit),
+                                 available = ?UINT(Available)},
+            Flow = session_flow_fields(Flow0, State),
+            #cfg{writer_pid = Writer,
+                 channel_num = Channel} = State#state.cfg,
+            rabbit_amqp_writer:send_command(Writer, Channel, Flow);
+        false ->
+            ok
+    end.
+
+send_pending_delivery(#pending_delivery{
+                         frames = Frames,
+                         queue_pid = QPid,
+                         outgoing_unsettled = #outgoing_unsettled{consumer_tag = Ctag,
+                                                                  queue_name = QName}
+                        } = Pending,
+                      Buf0,
+                      #state{remote_incoming_window = Space,
+                             outgoing_links = OutgoingLinks,
+                             queue_states = QStates,
+                             cfg = #cfg{writer_pid = WriterPid,
+                                        channel_num = Ch}
+                            } = State0) ->
+    Handle = ctag_to_handle(Ctag),
+    case is_map_key(Handle, OutgoingLinks) of
+        true ->
             SendFun = case QPid of
                           credit_api_v2 ->
                               send_fun(WriterPid, Ch);
                           _ ->
-                              case rabbit_queue_type:module(QName, State0#state.queue_states) of
+                              case rabbit_queue_type:module(QName, QStates) of
                                   {ok, rabbit_classic_queue} ->
                                       %% Classic queue client and classic queue process that
                                       %% communicate via credit API v1 use RabbitMQ internal
                                       %% credit flow control.
                                       fun(Transfer, Sections) ->
                                               rabbit_amqp_writer:send_command_and_notify(
-                                                WriterPid, Ch, QPid, self(), Transfer, Sections)
+                                                WriterPid, QPid, Ch, Transfer, Sections)
                                       end;
                                   {ok, _QType} ->
                                       send_fun(WriterPid, Ch)
                               end
                       end,
-            {NumTransfersSent, Buf, State1} =
             case send_frames(SendFun, Frames, Space) of
                 {sent_all, SpaceLeft} ->
-                    {Space - SpaceLeft,
-                     Buf1,
-                     record_outgoing_unsettled(Pending, State0)};
-                {sent_some, Rest} ->
-                    {Space,
-                     queue:in_r(Pending#pending_delivery{frames = Rest}, Buf1),
-                     State0}
-            end,
-            State2 = session_flow_control_sent_transfers(NumTransfersSent, State1),
-            State = State2#state{outgoing_pending = Buf},
-            send_pending(State);
-        {{value, Pending = #pending_management_delivery{frames = Frames}}, Buf1}
-          when Space > 0 ->
-            SendFun = send_fun(WriterPid, Ch),
-            {NumTransfersSent, Buf} =
-            case send_frames(SendFun, Frames, Space) of
-                {sent_all, SpaceLeft} ->
-                    {Space - SpaceLeft, Buf1};
-                {sent_some, Rest} ->
-                    {Space, queue:in_r(Pending#pending_management_delivery{frames = Rest}, Buf1)}
-            end,
-            State1 = session_flow_control_sent_transfers(NumTransfersSent, State0),
-            State = State1#state{outgoing_pending = Buf},
-            send_pending(State);
-        _ when Space =:= 0 ->
-            State0
+                    State1 = State0#state{outgoing_pending = Buf0},
+                    State = sent_pending_delivery(Pending, Handle, State1),
+                    {SpaceLeft, State};
+                {sent_some, SpaceLeft, Rest} ->
+                    Buf = queue:in_r(Pending#pending_delivery{frames = Rest}, Buf0),
+                    State = State0#state{outgoing_pending = Buf},
+                    {SpaceLeft, State}
+            end;
+        false ->
+            %% Link got detached. Either the client closed the link in which case the queue
+            %% already requeued all checked out messages or the queue doesn't exist anymore
+            %% in which case there is no point in requeuing this message.
+            %% Therefore, ignore (drop) this delivery.
+            State = State0#state{outgoing_pending = Buf0},
+            {Space, State}
+    end;
+send_pending_delivery(#pending_management_delivery{frames = Frames} = Pending,
+                      Buf0,
+                      #state{remote_incoming_window = Space,
+                             cfg = #cfg{writer_pid = WriterPid,
+                                        channel_num = Ch}
+                            } = State0) ->
+    SendFun = send_fun(WriterPid, Ch),
+    case send_frames(SendFun, Frames, Space) of
+        {sent_all, SpaceLeft} ->
+            State = State0#state{outgoing_pending = Buf0},
+            {SpaceLeft, State};
+        {sent_some, SpaceLeft, Rest} ->
+            Buf = queue:in_r(Pending#pending_management_delivery{frames = Rest}, Buf0),
+            State = State0#state{outgoing_pending = Buf},
+            {SpaceLeft, State}
     end.
 
 send_frames(_, [], SpaceLeft) ->
     {sent_all, SpaceLeft};
-send_frames(_, Rest, 0) ->
-    {sent_some, Rest};
-send_frames(SendFun, [[Transfer, Sections] | Rest], SpaceLeft) ->
-    SendFun(Transfer, Sections),
-    send_frames(SendFun, Rest, SpaceLeft - 1).
+send_frames(_, Rest, SpaceLeft = 0) ->
+    {sent_some, SpaceLeft, Rest};
+send_frames(SendFun, [[Transfer, Sections] | Rest] = Frames, SpaceLeft) ->
+    case SendFun(Transfer, Sections) of
+        ok ->
+            send_frames(SendFun, Rest, SpaceLeft - 1);
+        {error, blocked} ->
+            {sent_some, SpaceLeft, Frames}
+    end.
 
 send_fun(WriterPid, Ch) ->
     fun(Transfer, Sections) ->
             rabbit_amqp_writer:send_command(WriterPid, Ch, Transfer, Sections)
     end.
+
+sent_pending_delivery(
+  Pending = #pending_delivery{
+               outgoing_unsettled = #outgoing_unsettled{
+                                       consumer_tag = Ctag,
+                                       queue_name = QName}},
+  Handle,
+  S0 = #state{outgoing_links = OutgoingLinks0,
+              queue_states = QStates0}) ->
+
+    #outgoing_link{
+       credit_api_version = CreditApiVsn,
+       client_flow_ctl = CFC0,
+       queue_flow_ctl = QFC0,
+       credit_req_in_flight = CreditReqInFlight0
+      } = Link0 = maps:get(Handle, OutgoingLinks0),
+
+    S = case CreditApiVsn of
+            2 ->
+                #client_flow_ctl{
+                   delivery_count = CDeliveryCount0,
+                   credit = CCredit0
+                  } = CFC0,
+                #queue_flow_ctl{
+                   delivery_count = QDeliveryCount0,
+                   credit = QCredit0,
+                   desired_credit = DesiredCredit0
+                  } = QFC0,
+
+                CDeliveryCount = add(CDeliveryCount0, 1),
+                %% Even though the spec mandates
+                %% "If the link-credit is less than or equal to zero, i.e.,
+                %% the delivery-count is the same as or greater than the
+                %% delivery-limit, a sender MUST NOT send more messages."
+                %% we forced the message through to be sent to the client.
+                %% Due to our dual link approach, we don't want to buffer any
+                %% messages in the session if the receiving client dynamically
+                %% decreased link credit. The alternative is to requeue messages.
+                %% "the receiver MAY either handle the excess messages normally
+                %% or detach the link with a transfer-limit-exceeded error code."
+                CCredit = max(0, CCredit0 - 1),
+
+                QDeliveryCount = add(QDeliveryCount0, 1),
+                QCredit1 = max(0, QCredit0 - 1),
+                DesiredCredit = max(0, DesiredCredit0 - 1),
+
+                {QCredit, CreditReqInFlight, QStates, Actions} =
+                case QCredit1 =:= 0 andalso
+                     DesiredCredit > 0 andalso
+                     not CreditReqInFlight0 of
+                    true ->
+                        %% assertion
+                        none = Link0#outgoing_link.stashed_credit_req,
+                        %% Provide queue next batch of credits.
+                        CappedCredit = cap_credit(DesiredCredit),
+                        {ok, QStates1, Actions0} =
+                        rabbit_queue_type:credit(
+                          QName, Ctag, QDeliveryCount, CappedCredit,
+                          QFC0#queue_flow_ctl.drain, QStates0),
+                        {CappedCredit, true, QStates1, Actions0};
+                    false ->
+                        {QCredit1, CreditReqInFlight0, QStates0, []}
+                end,
+
+                CFC = CFC0#client_flow_ctl{
+                        delivery_count = CDeliveryCount,
+                        credit = CCredit},
+                QFC = QFC0#queue_flow_ctl{
+                        delivery_count = QDeliveryCount,
+                        credit = QCredit,
+                        desired_credit = DesiredCredit},
+                Link = Link0#outgoing_link{client_flow_ctl = CFC,
+                                           queue_flow_ctl = QFC,
+                                           credit_req_in_flight = CreditReqInFlight},
+                OutgoingLinks = OutgoingLinks0#{Handle := Link},
+                S1 = S0#state{outgoing_links = OutgoingLinks,
+                              queue_states = QStates},
+                handle_queue_actions(Actions, S1);
+            1 ->
+                S0
+        end,
+    record_outgoing_unsettled(Pending, S).
 
 record_outgoing_unsettled(#pending_delivery{queue_ack_required = true,
                                             delivery_id = DeliveryId,
@@ -1554,30 +1956,23 @@ handle_queue_actions(Actions, State) ->
               lists:foldl(fun(Msg, S) ->
                                   handle_deliver(CTag, AckRequired, Msg, S)
                           end, S0, Msgs);
-          ({credit_reply, Ctag, DeliveryCount, Credit, Available,  Drain},
+          ({credit_reply, _Ctag, _DeliveryCount, _Credit, _Available, _Drain} = Action,
            S = #state{outgoing_pending = Pending}) ->
               %% credit API v2
-              Handle = ctag_to_handle(Ctag),
-              Flow = #'v1_0.flow'{
-                        handle = ?UINT(Handle),
-                        delivery_count = ?UINT(DeliveryCount),
-                        link_credit = ?UINT(Credit),
-                        available = ?UINT(Available),
-                        drain = Drain},
-              S#state{outgoing_pending = queue:in(Flow, Pending)};
+              S#state{outgoing_pending = queue:in(Action, Pending)};
           ({credit_reply_v1, Ctag, Credit0, Available, Drain},
            S0 = #state{outgoing_links = OutgoingLinks0,
                        outgoing_pending = Pending}) ->
               %% credit API v1
               %% Delete this branch when feature flag credit_api_v2 becomes required.
               Handle = ctag_to_handle(Ctag),
-              Link = #outgoing_link{delivery_count = {credit_api_v1, Count0}} = maps:get(Handle, OutgoingLinks0),
+              Link = #outgoing_link{delivery_count = Count0} = maps:get(Handle, OutgoingLinks0),
               {Count, Credit, S} = case Drain of
                                        true ->
                                            Count1 = add(Count0, Credit0),
                                            OutgoingLinks = maps:update(
                                                              Handle,
-                                                             Link#outgoing_link{delivery_count = {credit_api_v1,  Count1}},
+                                                             Link#outgoing_link{delivery_count = Count1},
                                                              OutgoingLinks0),
                                            S1 = S0#state{outgoing_links = OutgoingLinks},
                                            {Count1, 0, S1};
@@ -1617,6 +2012,7 @@ handle_deliver(ConsumerTag, AckRequired,
         #{Handle := #outgoing_link{queue_type = QType,
                                    send_settled = SendSettled,
                                    max_message_size = MaxMessageSize,
+                                   credit_api_version = CreditApiVsn,
                                    delivery_count = DelCount} = Link0} ->
             Dtag = delivery_tag(MsgId, SendSettled),
             Transfer = #'v1_0.transfer'{
@@ -1633,11 +2029,12 @@ handle_deliver(ConsumerTag, AckRequired,
             messages_delivered(Redelivered, QType),
             rabbit_trace:tap_out(Msg, ConnName, ChannelNum, Username, Trace),
             {OutgoingLinks, QPid
-            } = case DelCount of
-                    credit_api_v2 ->
+            } = case CreditApiVsn of
+                    2 ->
                         {OutgoingLinks0, credit_api_v2};
-                    {credit_api_v1, C} ->
-                        Link = Link0#outgoing_link{delivery_count = {credit_api_v1, add(C, 1)}},
+                    1 ->
+                        DelCount = Link0#outgoing_link.delivery_count,
+                        Link = Link0#outgoing_link{delivery_count = add(DelCount, 1)},
                         OutgoingLinks1 = maps:update(Handle, Link, OutgoingLinks0),
                         {OutgoingLinks1, QPid0}
                 end,
@@ -1943,7 +2340,7 @@ lookup_target(to, to, Mc, Vhost, User, PermCache0) ->
         {utf8, String} ->
             case parse_target_v2_string(String) of
                 {ok, XNameBin, RKey, _} ->
-                    XName = rabbit_misc:r(Vhost, exchange, XNameBin),
+                    XName = exchange_resource(Vhost, XNameBin),
                     PermCache = check_resource_access(XName, write, User, PermCache0),
                     case rabbit_exchange:lookup(XName) of
                         {ok, X} ->
@@ -2072,13 +2469,13 @@ ensure_source_v1(Address,
             case rabbit_routing_parser:parse_routing(Src) of
                 {"", QNameList} ->
                     true = string:equal(QNameList, QNameBin),
-                    QName = rabbit_misc:r(Vhost, queue, QNameBin),
+                    QName = queue_resource(Vhost, QNameBin),
                     {ok, QName, PermCache1, TopicPermCache0};
                 {XNameList, RoutingKeyList} ->
                     RoutingKey = unicode:characters_to_binary(RoutingKeyList),
                     XNameBin = unicode:characters_to_binary(XNameList),
-                    XName = rabbit_misc:r(Vhost, exchange, XNameBin),
-                    QName = rabbit_misc:r(Vhost, queue, QNameBin),
+                    XName = exchange_resource(Vhost, XNameBin),
+                    QName = queue_resource(Vhost, QNameBin),
                     Binding = #binding{source = XName,
                                        destination = QName,
                                        key = RoutingKey},
@@ -2101,7 +2498,7 @@ ensure_source_v1(Address,
 %% The only possible v2 source address format is:
 %%  /queue/:queue
 ensure_source_v2(<<"/queue/", QNameBin/binary>>, Vhost, PermCache, TopicPermCache) ->
-    QName = rabbit_misc:r(Vhost, queue, QNameBin),
+    QName = queue_resource(Vhost, QNameBin),
     ok = exit_if_absent(QName),
     {ok, QName, PermCache, TopicPermCache};
 ensure_source_v2(Address, _, _, _) ->
@@ -2148,7 +2545,7 @@ try_target_v2(Address, Vhost, User, PermCache) ->
     end.
 
 check_exchange(XNameBin, RKey, QNameBin, User, Vhost, PermCache0) ->
-    XName = rabbit_misc:r(Vhost, exchange, XNameBin),
+    XName = exchange_resource(Vhost, XNameBin),
     PermCache = check_resource_access(XName, write, User, PermCache0),
     case rabbit_exchange:lookup(XName) of
         {ok, X} ->
@@ -2277,31 +2674,73 @@ handle_outgoing_mgmt_link_flow_control(
 
 handle_outgoing_link_flow_control(
   #outgoing_link{queue_name_bin = QNameBin,
-                 delivery_count = MaybeDeliveryCountSnd},
+                 credit_api_version = CreditApiVsn,
+                 client_flow_ctl = CFC,
+                 queue_flow_ctl = QFC,
+                 credit_req_in_flight = CreditReqInFlight
+                } = Link0,
   #'v1_0.flow'{handle = ?UINT(HandleInt),
                delivery_count = MaybeDeliveryCountRcv,
                link_credit = ?UINT(LinkCreditRcv),
                drain = Drain0,
                echo = Echo0},
-  State0 = #state{queue_states = QStates0,
-                  cfg = #cfg{vhost = Vhost}}) ->
-    QName = rabbit_misc:r(Vhost, queue, QNameBin),
+  #state{outgoing_links = OutgoingLinks,
+         queue_states = QStates0,
+         cfg = #cfg{vhost = Vhost}
+        } = State0) ->
+    QName = queue_resource(Vhost, QNameBin),
     Ctag = handle_to_ctag(HandleInt),
     DeliveryCountRcv = delivery_count_rcv(MaybeDeliveryCountRcv),
     Drain = default(Drain0, false),
     Echo = default(Echo0, false),
-    case MaybeDeliveryCountSnd of
-        credit_api_v2 ->
-            {ok, QStates, Actions} = rabbit_queue_type:credit(
-                                       QName, Ctag, DeliveryCountRcv, LinkCreditRcv, Drain, Echo, QStates0),
-            State1 = State0#state{queue_states = QStates},
-            State = handle_queue_actions(Actions, State1),
-            %% We'll handle the credit_reply queue event async later
-            %% thanks to the queue event containing the consumer tag.
-            State;
-        {credit_api_v1, DeliveryCountSnd} ->
-            LinkCreditSnd = amqp10_util:link_credit_snd(DeliveryCountRcv, LinkCreditRcv, DeliveryCountSnd),
-            {ok, QStates, Actions} = rabbit_queue_type:credit_v1(QName, Ctag, LinkCreditSnd, Drain, QStates0),
+    case CreditApiVsn of
+        2 ->
+            case CreditReqInFlight of
+                false ->
+                    DesiredCredit = amqp10_util:link_credit_snd(
+                                      DeliveryCountRcv,
+                                      LinkCreditRcv,
+                                      CFC#client_flow_ctl.delivery_count),
+                    CappedCredit = cap_credit(DesiredCredit),
+                    Link = Link0#outgoing_link{
+                             credit_req_in_flight = true,
+                             client_flow_ctl = CFC#client_flow_ctl{
+                                                 credit = DesiredCredit,
+                                                 echo = Echo},
+                             queue_flow_ctl = QFC#queue_flow_ctl{
+                                                credit = CappedCredit,
+                                                desired_credit = DesiredCredit,
+                                                drain = Drain}},
+                    {ok, QStates, Actions} = rabbit_queue_type:credit(
+                                               QName, Ctag,
+                                               QFC#queue_flow_ctl.delivery_count,
+                                               CappedCredit, Drain, QStates0),
+                    State = State0#state{queue_states = QStates,
+                                         outgoing_links = OutgoingLinks#{HandleInt := Link}},
+                    handle_queue_actions(Actions, State);
+                true ->
+                    %% A credit request is currently in-flight. Let's first process its reply
+                    %% before sending the next request. This ensures our outgoing_pending
+                    %% queue won't contain lots of credit replies for the same consumer
+                    %% when the client floods us with credit requests, but closed its incoming-window.
+                    %% Processing one credit top up at a time between us and the queue is also easier
+                    %% to reason about. Therefore, we stash the new request. If there is already a
+                    %% stashed request, we replace it because the latest flow control state from the
+                    %% client applies.
+                    Link = Link0#outgoing_link{
+                             stashed_credit_req = #credit_req{
+                                                     delivery_count = DeliveryCountRcv,
+                                                     credit = LinkCreditRcv,
+                                                     drain = Drain,
+                                                     echo = Echo}},
+                    State0#state{outgoing_links = OutgoingLinks#{HandleInt := Link}}
+            end;
+        1 ->
+            DeliveryCountSnd = Link0#outgoing_link.delivery_count,
+            LinkCreditSnd = amqp10_util:link_credit_snd(
+                              DeliveryCountRcv, LinkCreditRcv, DeliveryCountSnd),
+            {ok, QStates, Actions} = rabbit_queue_type:credit_v1(
+                                       QName, Ctag, LinkCreditSnd, Drain, QStates0),
             State1 = State0#state{queue_states = QStates},
             State = handle_queue_actions(Actions, State1),
             process_credit_reply_sync(Ctag, QName, LinkCreditSnd, State)
@@ -2610,7 +3049,7 @@ declare_queue(QNameBin,
               User = #user{username = Username},
               TerminusDurability,
               PermCache0) ->
-    QName = rabbit_misc:r(Vhost, queue, QNameBin),
+    QName = queue_resource(Vhost, QNameBin),
     PermCache = check_resource_access(QName, configure, User, PermCache0),
     rabbit_core_metrics:queue_declared(QName),
     Q0 = amqqueue:new(QName,
@@ -2930,6 +3369,11 @@ not_found(Resource) ->
 
 address_v1_permitted() ->
     rabbit_deprecated_features:is_permitted(amqp_address_v1).
+
+-spec cap_credit(rabbit_queue_type:credit()) ->
+    0..?LINK_CREDIT_RCV_FROM_QUEUE_MAX.
+cap_credit(DesiredCredit) ->
+    min(DesiredCredit, ?LINK_CREDIT_RCV_FROM_QUEUE_MAX).
 
 format_status(
   #{state := #state{cfg = Cfg,

--- a/deps/rabbit/src/rabbit_amqp_writer.erl
+++ b/deps/rabbit/src/rabbit_amqp_writer.erl
@@ -15,7 +15,7 @@
          send_command/3,
          send_command/4,
          send_command_sync/3,
-         send_command_and_notify/6,
+         send_command_and_notify/5,
          internal_send_command/3]).
 
 %% gen_server callbacks
@@ -31,7 +31,8 @@
           reader :: rabbit_types:connection(),
           pending :: iolist(),
           %% This field is just an optimisation to minimize the cost of erlang:iolist_size/1
-          pending_size :: non_neg_integer()
+          pending_size :: non_neg_integer(),
+          monitored_sessions :: #{pid() => true}
          }).
 
 -define(HIBERNATE_AFTER, 6_000).
@@ -62,10 +63,10 @@ send_command(Writer, ChannelNum, Performative) ->
 -spec send_command(pid(),
                    rabbit_types:channel_number(),
                    performative(),
-                   payload()) -> ok.
+                   payload()) -> ok | {error, blocked}.
 send_command(Writer, ChannelNum, Performative, Payload) ->
-    Request = {send_command, ChannelNum, Performative, Payload},
-    gen_server:cast(Writer, Request).
+    Request = {send_command, self(), ChannelNum, Performative, Payload},
+    maybe_send(Writer, Request).
 
 -spec send_command_sync(pid(),
                         rabbit_types:channel_number(),
@@ -76,14 +77,13 @@ send_command_sync(Writer, ChannelNum, Performative) ->
 
 %% Delete this function when feature flag credit_api_v2 becomes required.
 -spec send_command_and_notify(pid(),
+                              pid(),
                               rabbit_types:channel_number(),
-                              pid(),
-                              pid(),
                               performative(),
-                              payload()) -> ok.
-send_command_and_notify(Writer, ChannelNum, QueuePid, SessionPid, Performative, Payload) ->
-    Request = {send_command_and_notify, ChannelNum, QueuePid, SessionPid, Performative, Payload},
-    gen_server:cast(Writer, Request).
+                              payload()) -> ok | {error, blocked}.
+send_command_and_notify(Writer, QueuePid, ChannelNum, Performative, Payload) ->
+    Request = {send_command_and_notify, QueuePid, self(), ChannelNum, Performative, Payload},
+    maybe_send(Writer, Request).
 
 -spec internal_send_command(rabbit_net:socket(),
                             performative(),
@@ -101,19 +101,22 @@ init({Sock, MaxFrame, ReaderPid}) ->
                    max_frame_size = MaxFrame,
                    reader = ReaderPid,
                    pending = [],
-                   pending_size = 0},
+                   pending_size = 0,
+                   monitored_sessions = #{}},
     process_flag(message_queue_data, off_heap),
     {ok, State}.
 
 handle_cast({send_command, ChannelNum, Performative}, State0) ->
     State = internal_send_command_async(ChannelNum, Performative, State0),
     no_reply(State);
-handle_cast({send_command, ChannelNum, Performative, Payload}, State0) ->
-    State = internal_send_command_async(ChannelNum, Performative, Payload, State0),
+handle_cast({send_command, SessionPid, ChannelNum, Performative, Payload}, State0) ->
+    State1 = internal_send_command_async(ChannelNum, Performative, Payload, State0),
+    State = credit_flow_ack(SessionPid, State1),
     no_reply(State);
 %% Delete below function clause when feature flag credit_api_v2 becomes required.
-handle_cast({send_command_and_notify, ChannelNum, QueuePid, SessionPid, Performative, Payload}, State0) ->
-    State = internal_send_command_async(ChannelNum, Performative, Payload, State0),
+handle_cast({send_command_and_notify, QueuePid, SessionPid, ChannelNum, Performative, Payload}, State0) ->
+    State1 = internal_send_command_async(ChannelNum, Performative, Payload, State0),
+    State = credit_flow_ack(SessionPid, State1),
     rabbit_amqqueue:notify_sent(QueuePid, SessionPid),
     no_reply(State).
 
@@ -125,6 +128,11 @@ handle_call({send_command, ChannelNum, Performative}, _From, State0) ->
 handle_info(timeout, State0) ->
     State = flush(State0),
     {noreply, State};
+handle_info({{'DOWN', session}, _MRef, process, SessionPid, _Reason},
+            State0 = #state{monitored_sessions = Sessions}) ->
+    credit_flow:peer_down(SessionPid),
+    State = State0#state{monitored_sessions = maps:remove(SessionPid, Sessions)},
+    no_reply(State);
 %% Delete below function clause when feature flag credit_api_v2 becomes required.
 handle_info({'DOWN', _MRef, process, QueuePid, _Reason}, State) ->
     rabbit_amqqueue:notify_sent_queue_down(QueuePid),
@@ -153,6 +161,25 @@ format_status(Status) ->
 
 no_reply(State) ->
     {noreply, State, 0}.
+
+maybe_send(Writer, Request) ->
+    case credit_flow:blocked() of
+        false ->
+            credit_flow:send(Writer),
+            gen_server:cast(Writer, Request);
+        true ->
+            {error, blocked}
+    end.
+
+credit_flow_ack(SessionPid, State = #state{monitored_sessions = Sessions}) ->
+    credit_flow:ack(SessionPid),
+    case is_map_key(SessionPid, Sessions) of
+        true ->
+            State;
+        false ->
+            _MonitorRef = monitor(process, SessionPid, [{tag, {'DOWN', session}}]),
+            State#state{monitored_sessions = maps:put(SessionPid, true, Sessions)}
+    end.
 
 internal_send_command_async(Channel, Performative,
                             State = #state{pending = Pending,

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1633,8 +1633,8 @@ handle_cast({credit, SessionPid, CTag, Credit, Drain},
     %% Behave like non-native AMQP 1.0: Send send_credit_reply before deliveries.
     rabbit_classic_queue:send_credit_reply_credit_api_v1(
       SessionPid, amqqueue:get_name(Q), BQ:len(BQS0)),
-    handle_cast({credit, SessionPid, CTag, credit_api_v1, Credit, Drain, false}, State);
-handle_cast({credit, SessionPid, CTag, DeliveryCountRcv, Credit, Drain, Echo},
+    handle_cast({credit, SessionPid, CTag, credit_api_v1, Credit, Drain}, State);
+handle_cast({credit, SessionPid, CTag, DeliveryCountRcv, Credit, Drain},
             #q{consumers = Consumers0,
                q = Q} = State0) ->
     QName = amqqueue:get_name(Q),
@@ -1666,8 +1666,7 @@ handle_cast({credit, SessionPid, CTag, DeliveryCountRcv, Credit, Drain, Echo},
             rabbit_classic_queue:send_credit_reply(
               SessionPid, QName, CTag, AdvancedDeliveryCount, 0, Avail, Drain);
         {PostDeliveryCountSnd, PostCred}
-          when is_integer(PostDeliveryCountSnd) andalso
-               Echo ->
+          when is_integer(PostDeliveryCountSnd) ->
             %% credit API v2
             Avail = BQ:len(PostBQS),
             rabbit_classic_queue:send_credit_reply(

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -42,7 +42,7 @@
          deliver/3,
          settle/5,
          credit_v1/5,
-         credit/7,
+         credit/6,
          dequeue/5,
          info/2,
          state_info/1,
@@ -306,8 +306,8 @@ credit_v1(_QName, Ctag, LinkCreditSnd, Drain, #?STATE{pid = QPid} = State) ->
     delegate:invoke_no_result(QPid, {gen_server2, cast, [Request]}),
     {State, []}.
 
-credit(_QName, Ctag, DeliveryCountRcv, LinkCreditRcv, Drain, Echo, #?STATE{pid = QPid} = State) ->
-    Request = {credit, self(), Ctag, DeliveryCountRcv, LinkCreditRcv, Drain, Echo},
+credit(_QName, Ctag, DeliveryCountRcv, LinkCreditRcv, Drain, #?STATE{pid = QPid} = State) ->
+    Request = {credit, self(), Ctag, DeliveryCountRcv, LinkCreditRcv, Drain},
     delegate:invoke_no_result(QPid, {gen_server2, cast, [Request]}),
     {State, []}.
 

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -119,7 +119,7 @@
          checked_out = #{} :: #{msg_id() => msg()},
          %% max number of messages that can be sent
          %% decremented for each delivery
-         credit = 0 : non_neg_integer(),
+         credit = 0 :: non_neg_integer(),
          %% AMQP 1.0 §2.6.7
          delivery_count :: rabbit_queue_type:delivery_count()
         }).

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -25,7 +25,7 @@
          delete_immediately/1]).
 -export([state_info/1, info/2, stat/1, infos/1, infos/2]).
 -export([settle/5, dequeue/5, consume/3, cancel/5]).
--export([credit_v1/5, credit/7]).
+-export([credit_v1/5, credit/6]).
 -export([purge/1]).
 -export([stateless_deliver/2, deliver/3]).
 -export([dead_letter_publish/5]).
@@ -810,8 +810,8 @@ settle(_QName, discard, CTag, MsgIds, QState) ->
 credit_v1(_QName, CTag, Credit, Drain, QState) ->
     rabbit_fifo_client:credit_v1(quorum_ctag(CTag), Credit, Drain, QState).
 
-credit(_QName, CTag, DeliveryCount, Credit, Drain, Echo, QState) ->
-    rabbit_fifo_client:credit(quorum_ctag(CTag), DeliveryCount, Credit, Drain, Echo, QState).
+credit(_QName, CTag, DeliveryCount, Credit, Drain, QState) ->
+    rabbit_fifo_client:credit(quorum_ctag(CTag), DeliveryCount, Credit, Drain, QState).
 
 -spec dequeue(rabbit_amqqueue:name(), NoAck :: boolean(), pid(),
               rabbit_types:ctag(), rabbit_fifo_client:state()) ->

--- a/deps/rabbit_common/src/credit_flow.erl
+++ b/deps/rabbit_common/src/credit_flow.erl
@@ -156,7 +156,7 @@ state_delayed(BlockedAt) ->
         B         -> Now = erlang:monotonic_time(),
                      Diff = erlang:convert_time_unit(Now - B,
                                                      native,
-                                                     micro_seconds),
+                                                     microsecond),
                      case Diff < ?STATE_CHANGE_INTERVAL of
                          true  -> flow;
                          false -> running

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -24,7 +24,8 @@
          precondition_failed/1, precondition_failed/2]).
 -export([type_class/1, assert_args_equivalence/4, assert_field_equivalence/4]).
 -export([table_lookup/2, set_table_value/4, amqp_table/1, to_amqp_table/1]).
--export([r/3, r/2, r_arg/4, rs/1]).
+-export([r/3, r/2, r_arg/4, rs/1,
+         queue_resource/2, exchange_resource/2]).
 -export([enable_cover/0, report_cover/0]).
 -export([enable_cover/1, report_cover/1]).
 -export([start_cover/1]).
@@ -436,6 +437,16 @@ rs(#resource{virtual_host = VHostPath, kind = topic, name = Name}) ->
     format("'~ts' in vhost '~ts'", [Name, VHostPath]);
 rs(#resource{virtual_host = VHostPath, kind = Kind, name = Name}) ->
     format("~ts '~ts' in vhost '~ts'", [Kind, Name, VHostPath]).
+
+-spec queue_resource(rabbit_types:vhost(), resource_name()) ->
+    rabbit_types:r(queue).
+queue_resource(VHostPath, Name) ->
+    r(VHostPath, queue, Name).
+
+-spec exchange_resource(rabbit_types:vhost(), resource_name()) ->
+    rabbit_types:r(exchange).
+exchange_resource(VHostPath, Name) ->
+    r(VHostPath, exchange, Name).
 
 enable_cover() -> enable_cover(["."]).
 

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -52,7 +52,7 @@
          handle_event/3,
          settle/5,
          credit_v1/5,
-         credit/7,
+         credit/6,
          dequeue/5,
          state_info/1
         ]).
@@ -281,8 +281,8 @@ settle(A1,A2,A3,A4,A5) ->
 credit_v1(A1,A2,A3,A4,A5) ->
     ?UNSUPPORTED([A1,A2,A3,A4,A5]).
 
-credit(A1,A2,A3,A4,A5,A6,A7) ->
-    ?UNSUPPORTED([A1,A2,A3,A4,A5,A6,A7]).
+credit(A1,A2,A3,A4,A5,A6) ->
+    ?UNSUPPORTED([A1,A2,A3,A4,A5,A6]).
 
 dequeue(A1,A2,A3,A4,A5) ->
     ?UNSUPPORTED([A1,A2,A3,A4,A5]).

--- a/deps/rabbitmq_shovel/test/shovel_test_utils.erl
+++ b/deps/rabbitmq_shovel/test/shovel_test_utils.erl
@@ -49,7 +49,9 @@ await_shovel(Config, Node, Name) ->
       ?MODULE, await_shovel1, [Config, Name]).
 
 await_shovel1(_Config, Name) ->
-    await(fun () -> lists:member(Name, shovels_from_status()) end).
+    await(fun() ->
+                  lists:member(Name, shovels_from_status())
+          end, 30_000).
 
 shovels_from_status() ->
     S = rabbit_shovel_status:status(),


### PR DESCRIPTION
## What?

Introduce RabbitMQ internal flow control for messages sent to AMQP
clients.

Prior this PR, when an AMQP client granted a large amount of link
credit (e.g. 100k) to the sending queue, the sending queue sent
that amount of messages to the session process no matter what.
This becomes problematic for memory usage when the session process
cannot send out messages fast enough to the AMQP client, especially if
1. The writer proc cannot send fast enough. This can happen when
the AMQP client does not receive fast enough and causes TCP
back-pressure to the server. Or
2. The server session proc is limited by remote-incoming-window.

Both scenarios are now added as test cases.
Tests
* tcp_back_pressure_rabbitmq_internal_flow_quorum_queue
* tcp_back_pressure_rabbitmq_internal_flow_classic_queue
cover scenario 1.

Tests
* incoming_window_closed_rabbitmq_internal_flow_quorum_queue
* incoming_window_closed_rabbitmq_internal_flow_classic_queue
cover scenario 2.

This PR sends messages from queues to AMQP clients in a more controlled
manner.

To illustrate:
```
make run-broker PLUGINS="rabbitmq_management" RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+S 4"
observer_cli:start()
mq
```
where `mq` sorts by message queue length.
Create a stream:
```
deps/rabbitmq_management/bin/rabbitmqadmin declare queue name=s1 queue_type=stream durable=true
```
Next, send and receive from the Stream via AMQP.
Grant a large number of link credit to the sending stream:
```
docker run -it --rm --add-host host.docker.internal:host-gateway ssorj/quiver:latest
bash-5.1# quiver --version
quiver 0.4.0-SNAPSHOT
bash-5.1# quiver //host.docker.internal//queue/s1 --durable -d 30s --credit 100000
```

**Before** to this PR:
```
RESULTS

Count ............................................... 100,696 messages
Duration ............................................... 30.0 seconds
Sender rate ......................................... 120,422 messages/s
Receiver rate ......................................... 3,363 messages/s
End-to-end rate ....................................... 3,359 messages/s
```
We observe that all 100k link credit worth of messages are buffered in the
writer proc's mailbox:
```
|No | Pid        | MsgQueue  |Name or Initial Call                 |      Memory | Reductions          |Current Function                  |
|1  |<0.845.0>   |100001     |rabbit_amqp_writer:init/1            |  126.0734 MB| 466633491           |prim_inet:send/5                  |
```

**After** to this PR:
```
RESULTS

Count ............................................. 2,973,440 messages
Duration ............................................... 30.0 seconds
Sender rate ......................................... 123,322 messages/s
Receiver rate ........................................ 99,250 messages/s
End-to-end rate ...................................... 99,148 messages/s
```
We observe that the message queue lengths of both writer and session
procs are low.

 ## How?

Our goal is to have queues send out messages in a controlled manner
without overloading RabbitMQ itself.
We want RabbitMQ internal flow control between:
```
AMQP writer proc <--- session proc <--- queue proc
```
A similar concept exists for classic queues sending via AMQP 0.9.1.
We want an approach that applies to AMQP and works generic for all queue
types.

For the interaction between AMQP writer proc and session proc we use a
simple credit based approach reusing module `credit_flow`.

For the interaction between session proc and queue proc, the following options
exist:

 ### Option 1
The session process provides expliclity feedback to the queue after it
has sent N messages.
This approach is implemented in
https://github.com/ansd/rabbitmq-server/tree/amqp-flow-control-poc-1
and works well.
A new `rabbit_queue_type:sent/4` API was added which lets the queue proc know
that it can send further messages to the session proc.

Pros:
* Will work equally well for AMQP 0.9.1, e.g. when quorum queues send messages
  in auto ack mode to AMQP 0.9.1 clients.
* Simple for the session proc

Cons:
* Sligthly added complexity in every queue type implementation
* Multiple Ra commands (settle, credit, sent) to decide when a quorum
  queue sends more messages.

 ### Option 2
A dual link approach where two AMQP links exists between
```
AMQP client <---link--> session proc <---link---> queue proc
```
When the client grants a large amount of credits, the session proc will
top up credits to the queue proc periodically in smaller batches.

Pros:
* No queue type modifications required.
* Re-uses AMQP link flow control

Cons:
* Significant added complexity in the session proc. A client can
  dynamically decrease or increase credits and dynamically change the drain
  mode while the session tops up credit to the queue.

 ### Option 3
Credit is a 32 bit unsigned integer.
The spec mandates that the receiver independently chooses a credit.
Nothing in the spec prevents the receiver to choose a credit of 1 billion.
However the credit value is merely a **maximum**:
> The link-credit variable defines the current maximum legal amount that the delivery-count can be increased by.

Therefore, the server is not required to send all available messages to this
receiver.

For delivery-count:
> Only the sender MAY independently modify this field.

"independently" could be interpreted as the sender could add to the delivery-count
irrespective of what the client chose for drain and link-credit.

Option 3: The queue proc could at credit time already consume credit
and advance the delivery-count if credit is too large before checking out any messages.
For example if credit is 100k, but the queue only wants to send 1k, the queue could
consume 99k of credits and advance the delivery-count, and subsequently send maximum 1k messages.
If the queue advanced the delivery-count, RabbitMQ must send a FLOW to the receiver,
otherwise the receiver wouldn’t know that it ran out of link-credit.

Pros:
* Very simple

Cons:
* Possibly unexpected behaviour for receiving AMQP clients
* Possibly poor end-to-end throughput in auto-ack mode because the queue
  would send a batch of messages followed by a FLOW containing the advanced
  delivery-count. Only therafter the client will learn that it ran out of
  credits and top-up again. This feels like synchronously pulling a batch
  of messages. In contrast, option 2 sends out more messages as soon as
  the previous messages left RabbitMQ without requiring again a credit top
  up from the receiver.
* drain mode with large credits requires the queue to send all available
  messages and only thereafter advance the delivery-count. Therefore,
  drain mode breaks option 3 somewhat.

 ### Option 4
Session proc drops message payload when its outgoing-pending queue gets
too large and re-reads payloads from the queue once the message can be
sent (see `get_checked_out` Ra command for quorum queues).

Cons:
* Would need to be implemented for every queue type, especially classic queues
* Doesn't limit the amount of message metadata in the session proc's
  outgoing-pending queue

 ### Decision: Option 2
This commit implements option 2 to avoid any queue type modification.
At most one credit request is in-flight between session process and
queue process for a given queue consumer.
If the AMQP client sends another FLOW in between, the session proc
stashes the FLOW until it processes the previous credit reply.

A delivery is only sent from the outgoing-pending queue if the
session proc is not blocked by
1. writer proc, or
2. remote-incoming-window

The credit reply is placed into the outgoing-pending queue.
This ensures that the session proc will only top up the next batch of
credits if sufficient messages were sent out to the writer proc.

A future commit could additionally have each queue limit the number of
unacked messages for a given AMQP consumer, or alternatively make use
of session outgoing-window.