### PR TITLE
Make rabbit_misc:which_applications/0 more resilient

### DIFF
--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -1099,8 +1099,8 @@ rabbitmq_and_erlang_versions() ->
 which_applications() ->
     try
         application:which_applications(10000)
-    catch
-        exit:{timeout, _} -> []
+    catch _:_:_Stacktrace ->
+        []
     end.
 
 sequence_error([T])                      -> T;


### PR DESCRIPTION
In certain shutdown scenarios this function on
Erlang 26 runs into exceptions that stem from
application_controller.

The objective of this function is to be
an exception-safe version of
application:which_applications/1, so let's
handle more cases.

This helps certain test suites avoid exceptions
(process crash reports) logged during shutdown,
which makes CT helpers fail test run even
though there were no exceptions in RabbitMQ
itself, and all the exception indicates is a
certain edge case (during system shutdown)
that application_controller does not care to handle.
