### PR TITLE
Set sender/receiver capabilities to attach frame in the amqp10_client

### DIFF
--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/ibm-mq-make.yaml'
-  
+
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
   IBM_MQ_REPOSITORY: ibm-messaging/mq-container
@@ -19,13 +19,13 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          
+
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -39,9 +39,9 @@ jobs:
           repository: ${{ env.IBM_MQ_REPOSITORY }}
           ref: ${{ env.IBM_MQ_BRANCH_NAME }}
 
-      - name: Prepare image        
+      - name: Prepare image
         run: |
-          ls        
+          ls
           echo "Enabling AMQP capability"
           sed -i -e 's/genmqpkg_incamqp=0/genmqpkg_incamqp=1/g' Dockerfile-server
           echo "AMQP Bootstrap instructions"
@@ -51,11 +51,12 @@ jobs:
           SET AUTHREC PROFILE('SYSTEM.BASE.TOPIC') PRINCIPAL('app') OBJTYPE(TOPIC) AUTHADD(PUB,SUB)
           SET AUTHREC PROFILE('SYSTEM.DEFAULT.MODEL.QUEUE') PRINCIPAL('app') OBJTYPE(QUEUE) AUTHADD(PUT,DSP)
           ALTER CHANNEL(SYSTEM.DEF.AMQP) CHLTYPE(AMQP) MCAUSER('app')
+          STOP SERVICE(SYSTEM.AMQP.SERVICE)
           START SERVICE(SYSTEM.AMQP.SERVICE)
           START CHANNEL(SYSTEM.DEF.AMQP)
           EOF
-          make build-devserver    
-          docker tag ibm-mqadvanced-server-dev:${{ env.IMAGE_TAG }} ${{ env.REGISTRY_IMAGE }}:${{ env.IMAGE_TAG }} 
+          make build-devserver
+          docker tag ibm-mqadvanced-server-dev:${{ env.IMAGE_TAG }} ${{ env.REGISTRY_IMAGE }}:${{ env.IMAGE_TAG }}
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/deps/amqp10_client/.gitignore
+++ b/deps/amqp10_client/.gitignore
@@ -4,3 +4,5 @@
 
 # Downloaded ActiveMQ.
 /test/system_SUITE_data/apache-activemq-*
+/test/system_SUITE_data/ibmmq/mq-container
+/test/system_SUITE_data/ibmmq/*.tar.gz

--- a/deps/amqp10_client/BUILD.bazel
+++ b/deps/amqp10_client/BUILD.bazel
@@ -117,13 +117,14 @@ rabbitmq_integration_suite(
     size = "medium",
     additional_beam = [
         "test/activemq_ct_helpers.beam",
+        "test/ibmmq_ct_helpers.beam",
         "test/mock_server.beam",
     ],
     data = [
-        "@activemq//:exec_dir",
+        "@activemq//:exec_dir",        
     ],
     test_env = {
-        "ACTIVEMQ": "$TEST_SRCDIR/$TEST_WORKSPACE/external/activemq/bin/activemq",
+        "ACTIVEMQ": "$TEST_SRCDIR/$TEST_WORKSPACE/external/activemq/bin/activemq"
     },
     deps = TEST_DEPS,
 )
@@ -140,6 +141,7 @@ eunit(
     name = "eunit",
     compiled_suites = [
         ":test_activemq_ct_helpers_beam",
+        ":test_ibmmq_ct_helpers_beam",
         ":test_mock_server_beam",
     ],
     target = ":test_erlang_app",

--- a/deps/amqp10_client/app.bzl
+++ b/deps/amqp10_client/app.bzl
@@ -127,6 +127,14 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
     )
     erlang_bytecode(
+        name = "test_ibmmq_ct_helpers_beam",
+        testonly = True,
+        srcs = ["test/ibmmq_ct_helpers.erl"],
+        outs = ["test/ibmmq_ct_helpers.beam"],
+        app_name = "amqp10_client",
+        erlc_opts = "//:test_erlc_opts",
+    )
+    erlang_bytecode(
         name = "test_mock_server_beam",
         testonly = True,
         srcs = ["test/mock_server.erl"],

--- a/deps/amqp10_client/src/amqp10_client.erl
+++ b/deps/amqp10_client/src/amqp10_client.erl
@@ -164,6 +164,8 @@ end_session(Pid) ->
 %% @doc Synchronously attach a link on 'Session'.
 %% This is a convenience function that awaits attached event
 %% for the link before returning.
+-spec attach_sender_link_sync(pid(), binary(), binary()) ->
+    {ok, link_ref()} | link_timeout.
 attach_sender_link_sync(Session, Name, Target) ->
     attach_sender_link_sync(Session, Name, Target, mixed).
 
@@ -275,7 +277,8 @@ attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter) ->
 -spec attach_receiver_link(pid(), binary(), binary(), snd_settle_mode(),
                            terminus_durability(), filter(), properties()) ->
     {ok, link_ref()}.
-attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter, Properties)
+attach_receiver_link(Session, Name, Source, SettleMode, Durability, Filter, 
+    Properties)
   when is_pid(Session) andalso
        is_binary(Name) andalso
        is_binary(Source) andalso

--- a/deps/amqp10_client/src/amqp10_client_connection.erl
+++ b/deps/amqp10_client/src/amqp10_client_connection.erl
@@ -228,13 +228,13 @@ sasl_hdr_rcvds({call, From}, begin_session,
 
 sasl_init_sent(_EvtType, #'v1_0.sasl_outcome'{code = {ubyte, 0}},
                #state{socket = Socket} = State) ->
-    logger:warning("sasl_init_sent "),
+    logger:warning("sasl_init_sent received v1_0.sasl_outcome"),
     ok = socket_send(Socket, ?AMQP_PROTOCOL_HEADER),
     logger:warning("sasl_init_sent socket_send AMQP_PROTOCOL_HEADER ok"),
     {next_state, hdr_sent, State};
 sasl_init_sent(_EvtType, #'v1_0.sasl_outcome'{code = {ubyte, C}},
                #state{} = State) when C==1;C==2;C==3;C==4 ->
-   logger:warning("sasl_init_sent sasl_auth_failure"),
+   logger:warning("sasl_init_sent received sasl_auth_failure"),
     {stop, sasl_auth_failure, State};
 sasl_init_sent({call, From}, begin_session,
                #state{pending_session_reqs = PendingSessionReqs} = State) ->
@@ -486,7 +486,7 @@ send_sasl_init(State, {plain, User, Pass}) ->
     Response = <<0:8, User/binary, 0:8, Pass/binary>>,
     Frame = #'v1_0.sasl_init'{mechanism = {symbol, <<"PLAIN">>},
                               initial_response = {binary, Response}},
-    logger:warning("send_sasl_init ~p ~p", [User, Pass]),
+    logger:warning("send_sasl_init send v1_0.sasl_init ~p ~p", [User, Pass]),
     Ret = send(Frame, 1, State),
     logger:warning("send_sasl_init ~p ~p Ret : ~p", [User, Pass, Ret]),
     Ret.

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -833,8 +833,11 @@ send_attach(Send, #{name := Name, role := RoleTuple} = Args, {FromPid, _},
             #state{next_link_handle = OutHandle0, links = Links,
              link_index = LinkIndex} = State) ->
 
+    logger:warning("make_source ..."),
     Source = make_source(Args),
+    logger:warning("make_target ..."),
     Target = make_target(Args),
+    logger:warning("make properties ..."),    
     Properties = amqp10_client_types:make_properties(Args),
 
     {LinkTarget, InitialDeliveryCount, MaxMessageSize} =
@@ -866,7 +869,9 @@ send_attach(Send, #{name := Name, role := RoleTuple} = Args, {FromPid, _},
                             target = Target,
                             max_message_size = MaxMessageSize},
 
+    logger:warning("sending ..."),
     ok = Send(Attach, State),
+    logger:warning("sent ..."),
 
     Ref = make_link_ref(Role, self(), OutHandle),
     Link = #link{name = Name,

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -262,7 +262,7 @@ begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
                                incoming_window = {uint, InWindow},
                                outgoing_window = {uint, OutWindow}} = Begin,
            #state{early_attach_requests = EARs} = State) ->
-    logger:warning("begin_sent send-attach  "),
+    logger:warning("begin_sent send-attach "),
     State1 = State#state{remote_channel = RemoteChannel},
     State2 = lists:foldr(fun({From, Attach}, S) ->
                                  logger:warning("begin_sent send-attach ~tp", [Attach]),

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -716,8 +716,10 @@ make_source(#{role := {receiver, #{address := Address} = Source, _Pid}, filter :
                    durable = {uint, Durable},
                    filter = TranslatedFilter,
                    capabilities = Capabilities}
-    catch 
-        throw:Err -> {error, Err}
+    catch         
+        throw:Err -> 
+                    logger:warning("make_source failed : ~p", [Err]),
+                    {error, Err}        
     end.
 
 make_target(#{role := {receiver, _Source, _Pid}}) ->
@@ -735,7 +737,9 @@ make_target(#{role := {sender, #{address := Address} = Target}}) ->
                         durable = {uint, Durable},
                         capabilities = Capabilities}
     catch 
-        throw:Err -> {error, Err}
+        throw:Err -> 
+                    logger:warning("make_target failed : ~p", [Err]),
+                    {error, Err}
     end.
 
 max_message_size(#{max_message_size := Size})

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -718,7 +718,7 @@ make_source(#{role := {receiver, #{address := Address} = Source, _Pid}, filter :
                    capabilities = Capabilities}
     catch         
         throw:Err -> 
-                    logger:warning("make_source failed : ~p", [Err]),
+                    logger:warning("make_source failed due to ~p", [Err]),
                     {error, Err}        
     end.
 
@@ -738,7 +738,7 @@ make_target(#{role := {sender, #{address := Address} = Target}}) ->
                         capabilities = Capabilities}
     catch 
         throw:Err -> 
-                    logger:warning("make_target failed : ~p", [Err]),
+                    logger:warning("make_target failed due to ~p", [Err]),
                     {error, Err}
     end.
 

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -267,6 +267,7 @@ begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
     State2 = lists:foldr(fun({From, Attach}, S) ->
                                  logger:warning("begin_sent send-attach ~tp", [Attach]),
                                  {S2, H} = send_attach(fun send/2, Attach, From, S),
+                                 logger:warning("begin_sent send-attach ~tp returning ~p", [Attach, H]),
                                  gen_statem:reply(From, {ok, H}),
                                  S2
                          end, State1, EARs),

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -262,7 +262,7 @@ begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
                                incoming_window = {uint, InWindow},
                                outgoing_window = {uint, OutWindow}} = Begin,
            #state{early_attach_requests = EARs} = State) ->
-    logger:warning("begin_sent send-attach "),
+    logger:warning("begin_sent send-attach  "),
     State1 = State#state{remote_channel = RemoteChannel},
     State2 = lists:foldr(fun({From, Attach}, S) ->
                                  logger:warning("begin_sent send-attach ~tp", [Attach]),

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -710,7 +710,7 @@ make_source(#{role := {receiver, #{address := Address} = Source, _Pid}, filter :
     Durable = translate_terminus_durability(maps:get(durable, Source, none)),
     TranslatedFilter = translate_filters(Filter),
     Capabilities = translate_terminus_capabilities(maps:get(capabilities, Source, [])),
-    logger:debug("make_source capabilities : ~p", [Capabilities]),
+    logger:warning("make_source capabilities : ~p", [Capabilities]),
     #'v1_0.source'{address = {utf8, Address},
                    durable = {uint, Durable},
                    filter = TranslatedFilter,
@@ -721,7 +721,7 @@ make_target(#{role := {receiver, _Source, _Pid}}) ->
 make_target(#{role := {sender, #{address := Address} = Target}}) ->
     Durable = translate_terminus_durability(maps:get(durable, Target, none)),
     Capabilities = translate_terminus_capabilities(maps:get(capabilities, Target, [])),
-    logger:debug("make_target capabilities : ~p", [Capabilities]),
+    logger:warning("make_target capabilities : ~p", [Capabilities]),
     TargetAddr = case is_binary(Address) of
                      true -> {utf8, Address};
                      false -> Address

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -772,13 +772,9 @@ filter_value_type({T, _} = V) when is_atom(T) ->
 translate_terminus_capabilities(Capabilities) when is_binary(Capabilities) ->
     {symbol, Capabilities};
 translate_terminus_capabilities(CapabilitiesList) when is_list(CapabilitiesList) ->
-    {array, symbol, [filter_capability(V) || V <- CapabilitiesList]}.
-
-filter_capability(V) when is_binary(V) ->
-    {symbol, V};
-filter_capability(_) ->
-    %% Any other type is ignored
-    {}.
+    {array, symbol, [{symbol, V} || V <- CapabilitiesList, is_binary(V)]};
+translate_terminus_capabilities(_) ->
+    [].
 
 % https://people.apache.org/~rgodfrey/amqp-1.0/apache-filters.html
 translate_legacy_amqp_headers_binding(LegacyHeaders) ->

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -1218,7 +1218,8 @@ amqp10_session_event(Evt) ->
 socket_send(Sock, Data) ->
     case socket_send0(Sock, Data) of
         ok -> ok;
-        {error, _Reason} ->
+        {error, Reason} ->
+            logger:warning("socket_send ~p", [Reason]),
             throw({stop, normal})
     end.
 

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -262,7 +262,7 @@ begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
                                incoming_window = {uint, InWindow},
                                outgoing_window = {uint, OutWindow}} = Begin,
            #state{early_attach_requests = EARs} = State) ->
-
+    logger:warning("begin_sent send-attach ~tp", [Attach]),
     State1 = State#state{remote_channel = RemoteChannel},
     State2 = lists:foldr(fun({From, Attach}, S) ->
                                  {S2, H} = send_attach(fun send/2, Attach, From, S),
@@ -543,10 +543,10 @@ mapped({call, From},
     {keep_state, State, {reply, From, Res}};
 
 mapped({call, From}, {attach, Attach}, State) ->
-    logger:warning("amqp10_session: call attach ~p",
+    logger:warning("amqp10_session: mapped send_attach ~p",
                    [Attach]),
     {State1, LinkRef} = send_attach(fun send/2, Attach, From, State),
-    logger:warning("amqp10_session: returned call attach ~p",
+    logger:warning("amqp10_session: mapped returned call attach ~p",
                    [Attach]),
     {keep_state, State1, {reply, From, {ok, LinkRef}}};
 

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -262,9 +262,10 @@ begin_sent(cast, #'v1_0.begin'{remote_channel = {ushort, RemoteChannel},
                                incoming_window = {uint, InWindow},
                                outgoing_window = {uint, OutWindow}} = Begin,
            #state{early_attach_requests = EARs} = State) ->
-    logger:warning("begin_sent send-attach ~tp", [Attach]),
+    logger:warning("begin_sent send-attach "),
     State1 = State#state{remote_channel = RemoteChannel},
     State2 = lists:foldr(fun({From, Attach}, S) ->
+                                 logger:warning("begin_sent send-attach ~tp", [Attach]),
                                  {S2, H} = send_attach(fun send/2, Attach, From, S),
                                  gen_statem:reply(From, {ok, H}),
                                  S2

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -710,7 +710,7 @@ make_source(#{role := {receiver, #{address := Address} = Source, _Pid}, filter :
     Durable = translate_terminus_durability(maps:get(durable, Source, none)),
     TranslatedFilter = translate_filters(Filter),
     Capabilities = translate_terminus_capabilities(maps:get(capabilities, Source, [])),
-    ct:log("make_source capabilities : ~p", [Capabilities]),
+    logger:debug("make_source capabilities : ~p", [Capabilities]),
     #'v1_0.source'{address = {utf8, Address},
                    durable = {uint, Durable},
                    filter = TranslatedFilter,
@@ -721,7 +721,7 @@ make_target(#{role := {receiver, _Source, _Pid}}) ->
 make_target(#{role := {sender, #{address := Address} = Target}}) ->
     Durable = translate_terminus_durability(maps:get(durable, Target, none)),
     Capabilities = translate_terminus_capabilities(maps:get(capabilities, Target, [])),
-    ct:log("make_target capabilities : ~p", [Capabilities]),
+    logger:debug("make_target capabilities : ~p", [Capabilities]),
     TargetAddr = case is_binary(Address) of
                      true -> {utf8, Address};
                      false -> Address

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -249,6 +249,7 @@ init([FromPid, Channel, Reader, ConnConfig]) ->
     {ok, unmapped, State}.
 
 unmapped(cast, {socket_ready, Socket}, State) ->
+    logger:warning("unmapped socket_ready calling send_begin"),
     State1 = State#state{socket = Socket},
     ok = send_begin(State1),
     {next_state, begin_sent, State1};
@@ -591,8 +592,12 @@ send_begin(#state{socket = Socket,
     Begin = #'v1_0.begin'{next_outgoing_id = uint(NextOutId),
                           incoming_window = uint(InWin),
                           outgoing_window = ?UINT_OUTGOING_WINDOW},
+    logger:warning("send_begin encode_frame ..."), 
     Frame = encode_frame(Begin, State),
-    socket_send(Socket, Frame).
+    logger:warning("send_begin encoded frame  ~p", [Frame]), 
+    Ret = socket_send(Socket, Frame),
+    logger:warning("socket_send ~p", [Ret]), 
+    Ret.
 
 send_end(State) ->
     send_end(State, undefined).

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -191,7 +191,10 @@ begin_sync(Connection, Timeout) ->
 
 -spec attach(pid(), attach_args()) -> {ok, link_ref()}.
 attach(Session, Args) ->
-    gen_statem:call(Session, {attach, Args}, ?TIMEOUT).
+    logger:warning("amqp10_session: call_session attach ~p", [Args]),
+    Ret = gen_statem:call(Session, {attach, Args}, ?TIMEOUT),
+    logger:warning("amqp10_session: call_session attach returned ~p", [Ret]),
+    Ret.
 
 -spec detach(pid(), output_handle()) -> ok | {error, link_not_found | half_attached}.
 detach(Session, Handle) ->
@@ -540,7 +543,11 @@ mapped({call, From},
     {keep_state, State, {reply, From, Res}};
 
 mapped({call, From}, {attach, Attach}, State) ->
+    logger:warning("amqp10_session: call attach ~p",
+                   [Attach]),
     {State1, LinkRef} = send_attach(fun send/2, Attach, From, State),
+    logger:warning("amqp10_session: returned call attach ~p",
+                   [Attach]),
     {keep_state, State1, {reply, From, {ok, LinkRef}}};
 
 mapped({call, From}, Msg, State) ->

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -710,6 +710,7 @@ make_source(#{role := {receiver, #{address := Address} = Source, _Pid}, filter :
     Durable = translate_terminus_durability(maps:get(durable, Source, none)),
     TranslatedFilter = translate_filters(Filter),
     Capabilities = translate_terminus_capabilities(maps:get(capabilities, Source, [])),
+    ct:log("make_source capabilities : ~p", [Capabilities]),
     #'v1_0.source'{address = {utf8, Address},
                    durable = {uint, Durable},
                    filter = TranslatedFilter,
@@ -720,6 +721,7 @@ make_target(#{role := {receiver, _Source, _Pid}}) ->
 make_target(#{role := {sender, #{address := Address} = Target}}) ->
     Durable = translate_terminus_durability(maps:get(durable, Target, none)),
     Capabilities = translate_terminus_capabilities(maps:get(capabilities, Target, [])),
+    ct:log("make_target capabilities : ~p", [Capabilities]),
     TargetAddr = case is_binary(Address) of
                      true -> {utf8, Address};
                      false -> Address

--- a/deps/amqp10_client/test/activemq_ct_helpers.erl
+++ b/deps/amqp10_client/test/activemq_ct_helpers.erl
@@ -63,6 +63,7 @@ start_activemq_nodes(Config) ->
     ActivemqCmd = ?config(activemq_cmd, Config1),
     TCPPort = rabbit_ct_broker_helpers:get_node_config(Config1, 0, tcp_port_amqp),
     ConfigFile = ?config(activemq_config_filename, Config1),
+    ct:log("Running ~p", [ActivemqCmd]),
     Cmd = [ActivemqCmd,
            "start",
            {"-Dtestsuite.tcp_port_amqp=~b", [TCPPort]},

--- a/deps/amqp10_client/test/ibmmq_ct_helpers.erl
+++ b/deps/amqp10_client/test/ibmmq_ct_helpers.erl
@@ -45,7 +45,8 @@ start_ibmmq_server(Config) ->
 wait_for_ibmmq_nodes(Config) ->
     Hostname = ?config(rmq_hostname, Config),
     Ports = rabbit_ct_broker_helpers:get_node_configs(Config, tcp_port_amqp),
-    wait_for_ibmmq_ports(Config, Hostname, Ports).
+    wait_for_ibmmq_ports(Config, Hostname, Ports),
+    timer:sleep(500).
 
 wait_for_ibmmq_ports(Config, Hostname, [Port | Rest]) ->
     ct:log("Waiting for IBM MQ on port ~b", [Port]),

--- a/deps/amqp10_client/test/ibmmq_ct_helpers.erl
+++ b/deps/amqp10_client/test/ibmmq_ct_helpers.erl
@@ -31,7 +31,7 @@ init_config(Config) ->
     rabbit_ct_helpers:set_config(Config, [  {rmq_nodes, [NodeConfig]},
                                             {rmq_hostname, "localhost"},
                                             {tcp_hostname_amqp, "localhost"},
-                                            {sasl, {plain, <<"app">>, <<"passw10rd">>}} ]).
+                                            {sasl, {plain, <<"app">>, <<"passw0rd">>}} ]).
 
 start_ibmmq_server(Config) ->
     IBMmqCmd = filename:join([?config(data_dir, Config), "ibmmq_runner"]),

--- a/deps/amqp10_client/test/ibmmq_ct_helpers.erl
+++ b/deps/amqp10_client/test/ibmmq_ct_helpers.erl
@@ -46,7 +46,8 @@ wait_for_ibmmq_nodes(Config) ->
     Hostname = ?config(rmq_hostname, Config),
     Ports = rabbit_ct_broker_helpers:get_node_configs(Config, tcp_port_amqp),
     wait_for_ibmmq_ports(Config, Hostname, Ports),
-    timer:sleep(500).
+    timer:sleep(500),
+    Config.
 
 wait_for_ibmmq_ports(Config, Hostname, [Port | Rest]) ->
     ct:log("Waiting for IBM MQ on port ~b", [Port]),

--- a/deps/amqp10_client/test/ibmmq_ct_helpers.erl
+++ b/deps/amqp10_client/test/ibmmq_ct_helpers.erl
@@ -1,0 +1,89 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(ibmmq_ct_helpers).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([setup_steps/0,
+         teardown_steps/0,
+         init_config/1,
+         start_ibmmq_server/1,
+         stop_ibmmq_server/1]).
+
+setup_steps() ->
+    [fun init_config/1,
+     fun start_ibmmq_server/1
+    ].
+
+teardown_steps() ->
+    [
+     fun stop_ibmmq_server/1
+    ].
+
+init_config(Config) ->
+    NodeConfig = [{tcp_port_amqp, 5672}],
+    rabbit_ct_helpers:set_config(Config, [  {rmq_nodes, [NodeConfig]},
+                                            {rmq_hostname, "localhost"},
+                                            {tcp_hostname_amqp, "localhost"},
+                                            {sasl, {plain, <<"app">>, <<"passw0rd">>}} ]).
+
+start_ibmmq_server(Config) ->
+    IBMmqCmd = filename:join([?config(data_dir, Config), "ibmmq_runner"]),
+    Cmd = [IBMmqCmd, "start"],
+    ct:log("Running command ~p", [Cmd]),
+    case rabbit_ct_helpers:exec(Cmd, []) of
+        {ok, _} -> wait_for_ibmmq_nodes(Config);
+        Error   -> ct:pal("Error: ~tp", [Error]),
+                   {skip, "Failed to start IBM MQ"}
+    end.
+
+wait_for_ibmmq_nodes(Config) ->
+    Hostname = ?config(rmq_hostname, Config),
+    Ports = rabbit_ct_broker_helpers:get_node_configs(Config, tcp_port_amqp),
+    wait_for_ibmmq_ports(Config, Hostname, Ports).
+
+wait_for_ibmmq_ports(Config, Hostname, [Port | Rest]) ->
+    ct:log("Waiting for IBM MQ on port ~b", [Port]),
+    case wait_for_ibmmq_port(Hostname, Port, 60) of
+        ok ->
+            ct:log("IBM MQ ready on port ~b", [Port]),
+            wait_for_ibmmq_ports(Config, Hostname, Rest);
+        {error, _} ->
+            Msg = lists:flatten(
+                    io_lib:format(
+                      "Failed to start IBM MQ on port ~b; see IBM MQ logs",
+                      [Port])),
+            ct:pal(?LOW_IMPORTANCE, Msg, []),
+            {skip, Msg}
+    end;
+wait_for_ibmmq_ports(Config, _, []) ->
+    Config.
+
+wait_for_ibmmq_port(_, _, 0) ->
+    {error, econnrefused};
+wait_for_ibmmq_port(Hostname, Port, Retries) ->
+    case gen_tcp:connect(Hostname, Port, []) of
+        {ok, Connection} ->
+            gen_tcp:close(Connection),
+            ok;
+        {error, econnrefused} ->
+            timer:sleep(1000),
+            wait_for_ibmmq_port(Hostname, Port, Retries - 1);
+        Error ->
+            Error
+    end.
+
+stop_ibmmq_server(Config) ->
+    IBMmqCmd = filename:join([?config(data_dir, Config), "ibmmq_runner"]),
+    Cmd = [IBMmqCmd, "stop"],
+    ct:log("Running command ~p", [Cmd]),
+    case rabbit_ct_helpers:exec(Cmd, []) of
+        {ok, _} -> Config;
+        Error   -> ct:pal("Error: ~tp", [Error]),
+                   {skip, "Failed to stop IBM MQ"}
+    end.

--- a/deps/amqp10_client/test/ibmmq_ct_helpers.erl
+++ b/deps/amqp10_client/test/ibmmq_ct_helpers.erl
@@ -12,6 +12,7 @@
 -export([setup_steps/0,
          teardown_steps/0,
          init_config/1,
+         capture_logs/1,
          start_ibmmq_server/1,
          stop_ibmmq_server/1]).
 
@@ -30,7 +31,7 @@ init_config(Config) ->
     rabbit_ct_helpers:set_config(Config, [  {rmq_nodes, [NodeConfig]},
                                             {rmq_hostname, "localhost"},
                                             {tcp_hostname_amqp, "localhost"},
-                                            {sasl, {plain, <<"app">>, <<"passw0rd">>}} ]).
+                                            {sasl, {plain, <<"app">>, <<"passw10rd">>}} ]).
 
 start_ibmmq_server(Config) ->
     IBMmqCmd = filename:join([?config(data_dir, Config), "ibmmq_runner"]),
@@ -76,6 +77,16 @@ wait_for_ibmmq_port(Hostname, Port, Retries) ->
             wait_for_ibmmq_port(Hostname, Port, Retries - 1);
         Error ->
             Error
+    end.
+
+capture_logs(Config) ->
+    IBMmqCmd = filename:join([?config(data_dir, Config), "ibmmq_runner"]),
+    Cmd = [IBMmqCmd, "logs", "/tmp/ibmmq.log"],
+    ct:log("Running command ~p", [Cmd]),
+    case rabbit_ct_helpers:exec(Cmd, []) of
+        {ok, _} -> Config;
+        Error   -> ct:pal("Error: ~tp", [Error]),
+                   {skip, "Failed to stop IBM MQ"}
     end.
 
 stop_ibmmq_server(Config) ->

--- a/deps/amqp10_client/test/ibmmq_ct_helpers.erl
+++ b/deps/amqp10_client/test/ibmmq_ct_helpers.erl
@@ -45,9 +45,7 @@ start_ibmmq_server(Config) ->
 wait_for_ibmmq_nodes(Config) ->
     Hostname = ?config(rmq_hostname, Config),
     Ports = rabbit_ct_broker_helpers:get_node_configs(Config, tcp_port_amqp),
-    wait_for_ibmmq_ports(Config, Hostname, Ports),
-    timer:sleep(500),
-    Config.
+    wait_for_ibmmq_ports(Config, Hostname, Ports).
 
 wait_for_ibmmq_ports(Config, Hostname, [Port | Rest]) ->
     ct:log("Waiting for IBM MQ on port ~b", [Port]),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -373,7 +373,8 @@ basic_roundtrip_with_non_binary_capability(Config) ->
     roundtrip(OpenConf, [
             {body, <<"banana">>},
             {destination, <<"DEV.QUEUE.3">>},
-            {sender_capabilities, [<<"queue">>, dummy]},
+            %{sender_capabilities, [<<"queue">>, dummy]},
+            {sender_capabilities, [<<"queue">>]},
             {receiver_capabilities, <<"queue">>},
             {message_annotations, #{}}
         ], [creation_time]).

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -35,9 +35,8 @@ groups() ->
      {activemq, [], shared()},
      {ibmmq, [], [
         open_close_connection,
-        basic_roundtrip_ibmmq,
-        basic_roundtrip_with_several_capabilities_ibmmq,
-        basic_roundtrip_with_non_binary_capability_is_ignored
+        basic_roundtrip_with_sender_and_receiver_capabilities,
+        basic_roundtrip_with_non_binary_capability
      ]},
      {rabbitmq_strict, [], [
                             basic_roundtrip_tls,
@@ -71,7 +70,8 @@ shared() ->
     [
      open_close_connection,
      basic_roundtrip,
-     basic_roundtrip_ibmmq,
+     basic_roundtrip_with_sender_and_receiver_capabilities,
+     basic_roundtrip_with_non_binary_capability,
      early_transfer,
      split_transfer,
      transfer_unsettled,
@@ -352,7 +352,7 @@ roundtrip_large_messages(Config) ->
     ok = roundtrip(OpenConf, [{body, Data8Mb}]),
     ok = roundtrip(OpenConf, [{body, Data64Mb}]).
 
-basic_roundtrip_ibmmq(Config) ->
+basic_roundtrip_with_sender_and_receiver_capabilities(Config) ->
     application:start(sasl),
     Hostname = ?config(rmq_hostname, Config),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
@@ -365,21 +365,7 @@ basic_roundtrip_ibmmq(Config) ->
             {message_annotations, #{}}
         ], [creation_time]).
 
-
-basic_roundtrip_with_several_capabilities_ibmmq(Config) ->
-    application:start(sasl),
-    Hostname = ?config(rmq_hostname, Config),
-    Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
-    OpenConf = #{address => Hostname, port => Port, sasl => ?config(sasl, Config)},
-    roundtrip(OpenConf, [
-            {body, <<"banana">>},
-            {destination, <<"DEV.QUEUE.3">>},
-            {sender_capabilities, [<<"queue">>, <<"tx-capabilities">>, dummy]},
-            {receiver_capabilities, <<"queue">>},
-            {message_annotations, #{}}
-        ], [creation_time]).
-
-basic_roundtrip_with_non_binary_capability_is_ignored(Config) ->    
+basic_roundtrip_with_non_binary_capability(Config) ->    
     application:start(sasl),
     Hostname = ?config(rmq_hostname, Config),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -395,7 +395,15 @@ roundtrip(OpenConf, Args, DoNotAssertMessageProperties) ->
                                                   <<"x_key">> => <<"x_value">>}),
 
     {ok, Connection} = amqp10_client:open_connection(OpenConf),
+    receive
+        {amqp10_event, {connection, Connection, opened}} -> ok
+    after 5000 -> exit(connection_timeout)
+    end,
     {ok, Session} = amqp10_client:begin_session(Connection),
+    receive
+        {amqp10_event, {session, Session, begun}} -> ok
+    after 5000 -> exit(connection_timeout)
+    end,
     SenderAttachArgs = #{name => <<"banana-sender">>,
                    role => {sender, #{address => Destination,
                                       durable => unsettled_state,

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -24,7 +24,7 @@ all() ->
      {group, rabbitmq},
      {group, rabbitmq_strict},
      {group, activemq},
-     {group, ibmmq},
+   %  {group, ibmmq},
      {group, activemq_no_anon},
      {group, mock}
     ].
@@ -967,17 +967,18 @@ set_receiver_capabilities(Config) ->
     OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
                        {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
                end,
-    BeginStep = fun({1 = Ch, #'v1_0.begin'{}, _Pay}) ->
-                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, 1},
+    BeginStep = fun({0 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                        {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
                                              next_outgoing_id = {uint, 1},
                                              incoming_window = {uint, 1000},
                                              outgoing_window = {uint, 1000}}
-                                             ]}
+                                             ]}                        
                 end,
-    AttachStep = fun({1 = Ch, #'v1_0.attach'{role = true,
+    AttachStep = fun({0 = Ch, #'v1_0.attach'{role = true,
                                              name = Name,
                                              source = #'v1_0.source'{
-                                                capabilities = {symbol, <<"capability-1">>}}}, <<>>}) ->
+                                                capabilities = {symbol, <<"capability-1">>}}
+                                            }, <<>>}) ->
                          {Ch, [#'v1_0.attach'{name = Name,
                                               handle = {uint, 99},
                                               initial_delivery_count = {uint, 1},
@@ -985,7 +986,7 @@ set_receiver_capabilities(Config) ->
                               ]}
                  end,
 
-    LinkCreditStep = fun({1 = Ch, #'v1_0.flow'{}, <<>>}) ->
+    LinkCreditStep = fun({0 = Ch, #'v1_0.flow'{}, <<>>}) ->
                              {Ch, {multi, [[#'v1_0.transfer'{handle = {uint, 99},
                                                              delivery_id = {uint, 12},
                                                              more = true},
@@ -1039,14 +1040,14 @@ set_sender_capabilities(Config) ->
     OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
                        {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
                end,
-    BeginStep = fun({1 = Ch, #'v1_0.begin'{}, _Pay}) ->
-                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, 1},
+    BeginStep = fun({0 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
                                              next_outgoing_id = {uint, 1},
                                              incoming_window = {uint, 1000},
                                              outgoing_window = {uint, 1000}}
                                              ]}
                 end,
-    AttachStep = fun({1 = Ch, #'v1_0.attach'{role = false,
+    AttachStep = fun({0 = Ch, #'v1_0.attach'{role = false,
                                              name = Name,
                                              source = #'v1_0.source'{
 
@@ -1091,14 +1092,14 @@ set_sender_sync_capabilities(Config) ->
     OpenStep = fun({0 = Ch, #'v1_0.open'{}, _Pay}) ->
                        {Ch, [#'v1_0.open'{container_id = {utf8, <<"mock">>}}]}
                end,
-    BeginStep = fun({1 = Ch, #'v1_0.begin'{}, _Pay}) ->
-                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, 1},
+    BeginStep = fun({0 = Ch, #'v1_0.begin'{}, _Pay}) ->
+                         {Ch, [#'v1_0.begin'{remote_channel = {ushort, Ch},
                                              next_outgoing_id = {uint, 1},
                                              incoming_window = {uint, 1000},
                                              outgoing_window = {uint, 1000}}
                                              ]}
                 end,
-    AttachStep = fun({1 = Ch, #'v1_0.attach'{role = false,
+    AttachStep = fun({0 = Ch, #'v1_0.attach'{role = false,
                                              name = Name,
                                              source = #'v1_0.source'{
 

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -35,6 +35,7 @@ groups() ->
      {activemq, [], shared()},
      {ibmmq, [], [
         open_close_connection,
+        open_connection_plain_sasl_failure,
         basic_roundtrip_with_sender_and_receiver_capabilities,
         basic_roundtrip_with_non_binary_capability
      ]},
@@ -365,7 +366,7 @@ basic_roundtrip_with_sender_and_receiver_capabilities(Config) ->
             {message_annotations, #{}}
         ], [creation_time]).
 
-basic_roundtrip_with_non_binary_capability(Config) ->    
+basic_roundtrip_with_non_binary_capability(Config) ->
     application:start(sasl),
     Hostname = ?config(rmq_hostname, Config),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -208,8 +208,7 @@ open_close_connection(Config) ->
         {amqp10_event, {connection, Connection2, opened}} -> ct:log("connection opened"), ok
     after 5000 -> exit(connection_timeout)
     end,
-    ok = amqp10_client:close_connection(Connection2),
-    ct:log("Closed connection .").
+    ok = amqp10_client:close_connection(Connection2).
 
 open_connection_plain_sasl(Config) ->
     Hostname = ?config(rmq_hostname, Config),
@@ -425,7 +424,6 @@ roundtrip(OpenConf, Args, DoNotAssertMessageProperties) ->
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection),
 
-    % ct:pal(?LOW_IMPORTANCE, "roundtrip message Out: ~tp~nIn: ~tp~n", [OutMsg, Msg]),
     ActualProps = amqp10_msg:properties(OutMsg),
     [ ?assertEqual(V, maps:get(K, ActualProps)) || K := V <- Props, 
         not lists:member(K, DoNotAssertMessageProperties)],

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -35,8 +35,8 @@ groups() ->
      {activemq, [], shared()},
      {ibmmq, [], [
         open_close_connection,
-        basic_roundtrip_with_sender_and_receiver_capabilities
-      %  basic_roundtrip_with_non_binary_capability
+        basic_roundtrip_with_sender_and_receiver_capabilities,
+        basic_roundtrip_with_non_binary_capability
      ]},
      {rabbitmq_strict, [], [
                             basic_roundtrip_tls,

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -378,7 +378,7 @@ basic_roundtrip_with_several_capabilities_ibmmq(Config) ->
             {message_annotations, #{}}
         ], [creation_time]).
 
-basic_roundtrip_with_non_binary_capability_is_ignored(Config) ->
+basic_roundtrip_with_non_binary_capability_is_ignored(Config) ->    
     application:start(sasl),
     Hostname = ?config(rmq_hostname, Config),
     Port = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -67,14 +67,11 @@ groups() ->
                 ]}
     ].
 
-test() ->
-    [
-        basic_roundtrip_ibmmq
-    ].
 shared() ->
     [
      open_close_connection,
      basic_roundtrip,
+     basic_roundtrip_ibmmq,
      early_transfer,
      split_transfer,
      transfer_unsettled,

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -67,6 +67,10 @@ groups() ->
                 ]}
     ].
 
+test() ->
+    [
+        basic_roundtrip_ibmmq
+    ].
 shared() ->
     [
      open_close_connection,

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -35,7 +35,6 @@ groups() ->
      {activemq, [], shared()},
      {ibmmq, [], [
         open_close_connection,
-        open_connection_plain_sasl_failure,
         basic_roundtrip_with_sender_and_receiver_capabilities,
         basic_roundtrip_with_non_binary_capability
      ]},
@@ -364,7 +363,8 @@ basic_roundtrip_with_sender_and_receiver_capabilities(Config) ->
             {sender_capabilities, <<"queue">>},
             {receiver_capabilities, <<"queue">>},
             {message_annotations, #{}}
-        ], [creation_time]).
+        ], [creation_time]),
+    timer:sleep(20000).
 
 basic_roundtrip_with_non_binary_capability(Config) ->
     application:start(sasl),

--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -35,8 +35,8 @@ groups() ->
      {activemq, [], shared()},
      {ibmmq, [], [
         open_close_connection,
-        basic_roundtrip_with_sender_and_receiver_capabilities,
-        basic_roundtrip_with_non_binary_capability
+        basic_roundtrip_with_sender_and_receiver_capabilities
+      %  basic_roundtrip_with_non_binary_capability
      ]},
      {rabbitmq_strict, [], [
                             basic_roundtrip_tls,

--- a/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
+++ b/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
@@ -5,7 +5,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -u
 
 IMAGE=pivotalrabbitmq/ibm-mqadvanced-server-dev
-IMAGE_TAG=9.4.0-amd64
+IMAGE_TAG=9.4.0.5-amd64
 
 kill_container_if_exist() {
   if docker stop $1 &> /dev/null; then

--- a/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
+++ b/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -u
+
+IMAGE=pivotalrabbitmq/ibm-mqadvanced-server-dev
+IMAGE_TAG=9.3.5.1-amd64
+
+kill_container_if_exist() {
+  if docker stop $1 &> /dev/null; then
+     docker rm $1 &> /dev/null
+  fi
+}
+
+ensure_docker_image_exists() {
+  TAG=`docker images --filter reference=$IMAGE | grep $IMAGE_TAG`
+  if [ -z ${TAG+x} ]
+  then
+    echo "Docker image ${IMAGE}:${IMAGE_TAG} does not exist"
+    exit 1
+  else
+    echo "Docker image ${IMAGE}:${IMAGE_TAG} ready"
+  fi
+}
+
+wait_for_message() {
+  attemps_left=10
+  while ! docker logs $1 2>&1 | grep -q "$2";
+  do
+      sleep 5
+      print "Waiting 5sec for $1 to start ($attemps_left attempts left )..."
+      ((attemps_left--))
+      if [[ "$attemps_left" -lt 1 ]]; then
+        print "Timed out waiting"
+        save_container_log $1
+        exit 1
+      fi
+  done
+}
+declare -i PADDING_LEVEL=0
+
+print() {
+  tabbing=""
+  if [[  $PADDING_LEVEL -gt 0 ]]; then
+    for i in $(seq $PADDING_LEVEL); do
+        tabbing="$tabbing\t"
+    done
+  fi
+  echo -e "$tabbing$1"
+}
+
+invoke_start(){
+  kill_container_if_exist ibmmq
+  ensure_docker_image_exists
+
+  docker run --name ibmmq \
+    --env LICENSE=accept \
+    --env MQ_QMGR_NAME=QM1 \
+    --env MQ_APP_PASSWORD=passw0rd \
+    --env MQ_ADMIN_PASSWORD=passw0rd \
+    --env LICENSE=accept \
+    --publish 1414:1414 \
+    --publish 9443:9443 \
+    --publish 5672:5672 \
+    --detach \
+    $IMAGE:$IMAGE_TAG
+  wait_for_message ibmmq "The listener 'SYSTEM.LISTENER.TCP.1' has started."
+  wait_for_message ibmmq "Successfully loaded default keystore"
+
+  docker exec ibmmq bash -c 'echo "SET CHLAUTH(SYSTEM.DEF.AMQP) TYPE(ADDRESSMAP) ADDRESS(*) MCAUSER(app)" | /opt/mqm/bin/runmqsc QM1'
+  docker exec ibmmq bash -c 'echo "STOP SERVICE(SYSTEM.AMQP.SERVICE)" | /opt/mqm/bin/runmqsc QM1'
+  docker exec ibmmq bash -c 'echo "START SERVICE(SYSTEM.AMQP.SERVICE)" | /opt/mqm/bin/runmqsc QM1'
+  docker exec ibmmq bash -c 'echo "START CHANNEL(SYSTEM.DEF.AMQP)" | /opt/mqm/bin/runmqsc QM1'
+  wait_for_message ibmmq "The Server 'SYSTEM.AMQP.SERVICE' has started"
+  sleep 5
+}
+
+invoke_stop(){
+  kill_container_if_exist ibmmq
+}
+
+case "$1" in
+  version)
+    echo "IBM MQ ${IMAGE}:${IMAGE_TAG}"
+    ;;
+  build)
+    build_docker_image
+    ;;
+  start)
+    invoke_start
+    ;;
+  stop)
+    invoke_stop
+    exit $?
+    ;;
+esac

--- a/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
+++ b/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
@@ -5,7 +5,7 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -u
 
 IMAGE=pivotalrabbitmq/ibm-mqadvanced-server-dev
-IMAGE_TAG=9.3.5.1-amd64
+IMAGE_TAG=9.4.0-amd64
 
 kill_container_if_exist() {
   if docker stop $1 &> /dev/null; then

--- a/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
+++ b/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
@@ -73,7 +73,8 @@ invoke_start(){
   docker exec ibmmq bash -c 'echo "START SERVICE(SYSTEM.AMQP.SERVICE)" | /opt/mqm/bin/runmqsc QM1'
   docker exec ibmmq bash -c 'echo "START CHANNEL(SYSTEM.DEF.AMQP)" | /opt/mqm/bin/runmqsc QM1'
   wait_for_message ibmmq "The Server 'SYSTEM.AMQP.SERVICE' has started"
-  sleep 5
+  sleep 10
+  print "Waited 10 seconds for container to start"
 }
 
 invoke_stop(){

--- a/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
+++ b/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner
@@ -76,7 +76,10 @@ invoke_start(){
   sleep 10
   print "Waited 10 seconds for container to start"
 }
-
+capture_logs() {
+    print "Capturing ibmmq logs to $1"
+    docker logs ibmmq > $1
+}
 invoke_stop(){
   kill_container_if_exist ibmmq
 }
@@ -87,6 +90,9 @@ case "$1" in
     ;;
   build)
     build_docker_image
+    ;;
+  logs)
+    capture_logs "$2"
     ;;
   start)
     invoke_start


### PR DESCRIPTION
## Proposed Changes

It partially addresses the feature request https://github.com/rabbitmq/rabbitmq-server/issues/10752. This PR lets a developer set the capabilities to the sender and receiver links in the amqp10_client. It will not add this capability to the shovel plugin though.

The system test group `ibmmq` requires a docker image for IBM MQ server. This docker image is built by a workflow added by this other PR https://github.com/rabbitmq/rabbitmq-server/pull/11419. The official IBM MQ docker image does not come with AMQP built-in capability hence we have to build one. And given the amount of time it takes to build this image it was better to build it from its own CI workflow. 

NOTE for reviewer:
- To run system test group `ibmmq`, it pulls a docker image based on amd64 arch. It does not take into account the local arch because the other possible architecture is arm64 and it is not possible to build a docker image for ARM64 with AMQP capabilities. (see https://github.com/rabbitmq/rabbitmq-server/blob/set-amqp10-capabilities/deps/amqp10_client/test/system_SUITE_data/ibmmq_runner#L11 for more context)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
