### PR TITLE
Interpret x-death header from AMQP 0.9.1 client

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -815,6 +815,9 @@ rabbitmq_suite(
 rabbitmq_suite(
     name = "mc_unit_SUITE",
     size = "small",
+    runtime_deps = [
+        "@meck//:erlang_app",
+    ],
     deps = [
         "//deps/amqp10_common:erlang_app",
         "//deps/rabbit_common:erlang_app",

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -1721,6 +1721,7 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         testonly = True,
         srcs = ["test/unit_classic_mirrored_queue_sync_throttling_SUITE.erl"],
         outs = ["test/unit_classic_mirrored_queue_sync_throttling_SUITE.beam"],
+        hdrs = ["include/mc.hrl"],
         app_name = "rabbit",
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/rabbit_common:erlang_app"],

--- a/deps/rabbit/include/mc.hrl
+++ b/deps/rabbit/include/mc.hrl
@@ -14,6 +14,11 @@
 -define(ANN_PRIORITY, p).
 
 -define(FF_MC_DEATHS_V2, message_containers_deaths_v2).
+-define(MC_ENV,
+        case rabbit_feature_flags:is_enabled(?FF_MC_DEATHS_V2) of
+            true -> #{};
+            false -> #{?FF_MC_DEATHS_V2 => false}
+        end).
 
 -type death_key() :: {SourceQueue :: rabbit_misc:resource_name(), rabbit_dead_letter:reason()}.
 -type death_anns() :: #{%% timestamp of the first time this message

--- a/deps/rabbit/src/mc.erl
+++ b/deps/rabbit/src/mc.erl
@@ -93,7 +93,7 @@
 %% protocol specific init function
 %% returns a map of additional annotations to merge into the
 %% protocol generic annotations map, e.g. ttl, priority and durable
--callback init(term()) ->
+-callback init(term(), environment()) ->
     {proto_state(), annotations()}.
 
 %% the size of the payload and other meta data respectively
@@ -147,7 +147,7 @@ init(Proto, Data, Anns0, Env)
   when is_atom(Proto)
        andalso is_map(Anns0)
        andalso is_map(Env) ->
-    {ProtoData, ProtoAnns} = Proto:init(Data),
+    {ProtoData, ProtoAnns} = Proto:init(Data, Env),
     Anns = case maps:size(Env) == 0 of
                true ->
                    Anns0;
@@ -389,9 +389,9 @@ record_death(Reason, SourceQueue,
                                             [{Key, NewDeath} | Deaths0]
                                     end
                             end,
-                   Anns0#{<<"x-last-death-reason">> := atom_to_binary(Reason),
-                          <<"x-last-death-queue">> := SourceQueue,
-                          <<"x-last-death-exchange">> := Exchange,
+                   Anns0#{<<"x-last-death-reason">> => atom_to_binary(Reason),
+                          <<"x-last-death-queue">> => SourceQueue,
+                          <<"x-last-death-exchange">> => Exchange,
                           deaths := Deaths};
                _ ->
                    Deaths = case Env of

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -5,7 +5,7 @@
 -include("mc.hrl").
 
 -export([
-         init/1,
+         init/2,
          size/1,
          x_header/2,
          property/2,
@@ -59,18 +59,18 @@
              ]).
 
 %% mc implementation
-init(Sections) when is_list(Sections) ->
+init(Sections, Env) when is_list(Sections) ->
     Msg = decode(Sections, #msg{}),
-    init(Msg);
-init(#msg{} = Msg) ->
+    init(Msg, Env);
+init(#msg{} = Msg, _Env) ->
     %% TODO: as the essential annotations, durable, priority, ttl and delivery_count
     %% is all we are interested in it isn't necessary to keep hold of the
     %% incoming AMQP header inside the state
     Anns = essential_properties(Msg),
     {Msg, Anns}.
 
-convert_from(?MODULE, Sections, _Env) ->
-    element(1, init(Sections));
+convert_from(?MODULE, Sections, Env) ->
+    element(1, init(Sections, Env));
 convert_from(_SourceProto, _, _Env) ->
     not_implemented.
 

--- a/deps/rabbit/src/rabbit_dead_letter.erl
+++ b/deps/rabbit/src/rabbit_dead_letter.erl
@@ -31,11 +31,7 @@ publish(Msg0, Reason, #exchange{name = XName} = DLX, RK,
                   _ ->
                       [RK]
               end,
-    Env = case rabbit_feature_flags:is_enabled(?FF_MC_DEATHS_V2) of
-              true -> #{};
-              false -> #{?FF_MC_DEATHS_V2 => false}
-          end,
-    Msg1 = mc:record_death(Reason, SourceQName, Msg0, Env),
+    Msg1 = mc:record_death(Reason, SourceQName, Msg0, ?MC_ENV),
     {Ttl, Msg2} = mc:take_annotation(dead_letter_ttl, Msg1),
     Msg3 = mc:set_ttl(Ttl, Msg2),
     Msg4 = mc:set_annotation(?ANN_ROUTING_KEYS, DLRKeys, Msg3),

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -324,11 +324,7 @@ forward(ConsumedMsg, ConsumedMsgId, ConsumedQRef, DLX, Reason,
                   _ ->
                       [RKey]
               end,
-    Env = case rabbit_feature_flags:is_enabled(?FF_MC_DEATHS_V2) of
-              true -> #{};
-              false -> #{?FF_MC_DEATHS_V2 => false}
-          end,
-    Msg0 = mc:record_death(Reason, SourceQName, ConsumedMsg, Env),
+    Msg0 = mc:record_death(Reason, SourceQName, ConsumedMsg, ?MC_ENV),
     Msg1 = mc:set_ttl(undefined, Msg0),
     Msg2 = mc:set_annotation(?ANN_ROUTING_KEYS, DLRKeys, Msg1),
     Msg = mc:set_annotation(?ANN_EXCHANGE, DLXName, Msg2),

--- a/deps/rabbit/test/per_node_limit_SUITE.erl
+++ b/deps/rabbit/test/per_node_limit_SUITE.erl
@@ -156,7 +156,7 @@ channel_consumers_limit(Config) ->
     ok = rabbit_ct_broker_helpers:set_full_permissions(Config, User, VHost),
     Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0, VHost),
     {ok, Ch} = open_channel(Conn1),
-    Q = <<"Q">>, Tag = <<"Tag">>,
+    Q = <<"Q">>,
 
     {ok, _} = consume(Ch, Q, <<"Tag1">>),
     {ok, _} = consume(Ch, Q, <<"Tag2">>),

--- a/deps/rabbit/test/unit_classic_mirrored_queue_sync_throttling_SUITE.erl
+++ b/deps/rabbit/test/unit_classic_mirrored_queue_sync_throttling_SUITE.erl
@@ -2,6 +2,7 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbit_common/include/rabbit_framing.hrl").
+-include_lib("rabbit/include/mc.hrl").
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -65,8 +66,9 @@ append_to_acc(_Config) ->
                                                priority = 2},
                        payload_fragments_rev = [[<<"1234567890">>]]  %% 10 bytes
                       },
-    ExName = rabbit_misc:r(<<>>, exchange, <<>>),
-    {ok, Msg} = mc_amqpl:message(ExName, <<>>, Content, #{id => 1}, true),
+    Msg = mc:init(mc_amqpl, Content, #{id => 1,
+                                       ?ANN_EXCHANGE => <<>>,
+                                       ?ANN_ROUTING_KEYS => [<<>>]}),
     BQDepth = 10,
     SyncThroughput_0 = 0,
     FoldAcc1 = {[], 0, {0, erlang:monotonic_time(), SyncThroughput_0}, {0, BQDepth}, erlang:monotonic_time()},

--- a/deps/rabbitmq_mqtt/src/mc_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/mc_mqtt.erl
@@ -11,7 +11,7 @@
 -define(CONTENT_TYPE_AMQP, <<"message/vnd.rabbitmq.amqp">>).
 
 -export([
-         init/1,
+         init/2,
          size/1,
          x_header/2,
          property/2,
@@ -23,7 +23,7 @@
         ]).
 
 init(Msg = #mqtt_msg{qos = Qos,
-                     props = Props}) ->
+                     props = Props}, _Env) ->
     Anns0 = #{?ANN_DURABLE => durable(Qos)},
     Anns1 = case Props of
                 #{'Message-Expiry-Interval' := Seconds} ->


### PR DESCRIPTION
This PR supersedes https://github.com/rabbitmq/rabbitmq-server/pull/11043 and fixes #10709, #11331.

    Interpret x-death header from AMQP 0.9.1 client

    Fixes #10709
    Fixes #11331

    This commit fixes the following regression which worked in 3.12.x, but
    stopped working in 3.13.0 - 3.13.2:

    ```
    AMQP 0.9.1 client    --publish-->
    Q                    --dead-letter-->
    DLQ                  --consume-->
    AMQP 0.9.1 client (death count is now 1) --republish-same-message-with-headers-as-just-received-->
    Q                    --dead-letter-->
    DLQ                  --consume -->
    AMQP 0.9.1 (death count is now 1, but should be 2)
    ```

    The reason this behaviour stopped to work in 3.13.0 is that the broker
    won't specially interpret x-headers in general, and the x-death header
    specifically in this case anymore.

    In other words, the new desired 3.13 behaviour with message containers
    is that "x-headers belong to the broker".

    While this is correct, it does break client applications which depended
    on the previous use case.
    One simple fix is that the client application does not re-publish with
    the x-death header, but instead sets its own custom count header to
    determine the number of times it retries.

    This commit will only be packported to v3.13.x branch.
    In other words, 4.0 won't interpret x-headers as done in 3.13.0 - 3.13.2.

    The reason we backport this commit to v3.13.x is that the Spring
    documentation expliclity recommends re-publishing the message with
    x-death header being set:
    https://cloud.spring.io/spring-cloud-static/spring-cloud-stream-binder-rabbit/3.0.6.RELEASE/reference/html/spring-cloud-stream-binder-rabbit.html#_retry_with_the_rabbitmq_binder