### PR TITLE
Put credit flow config into persistent term

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1710,7 +1710,8 @@ persist_static_configuration() ->
       [classic_queue_index_v2_segment_entry_count,
        classic_queue_store_v2_max_cache_size,
        classic_queue_store_v2_check_crc32,
-       incoming_message_interceptors
+       incoming_message_interceptors,
+       credit_flow_default_credit
       ]),
 
     %% Disallow 0 as it means unlimited:
@@ -1726,12 +1727,11 @@ persist_static_configuration() ->
     ok = persistent_term:put(max_message_size, MaxMsgSize).
 
 persist_static_configuration(Params) ->
-    App = ?MODULE,
     lists:foreach(
       fun(Param) ->
-              case application:get_env(App, Param) of
+              case application:get_env(?MODULE, Param) of
                   {ok, Value} ->
-                      ok = persistent_term:put({App, Param}, Value);
+                      ok = persistent_term:put(Param, Value);
                   undefined ->
                       ok
               end

--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -1252,7 +1252,7 @@ segment_entry_count() ->
     %% A value lower than the max write_buffer size results in nothing needing
     %% to be written to disk as long as the consumer consumes as fast as the
     %% producer produces.
-    persistent_term:get({rabbit, classic_queue_index_v2_segment_entry_count}, 4096).
+    persistent_term:get(classic_queue_index_v2_segment_entry_count, 4096).
 
 %% Note that store files will also be removed if there are any in this directory.
 %% Currently the v2 per-queue store expects this function to remove its own files.

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -561,13 +561,13 @@ delete_segments(Segments, State0 = #qs{ write_buffer = WriteBuffer0,
 
 segment_entry_count() ->
     %% We use the same value as the index.
-    persistent_term:get({rabbit, classic_queue_index_v2_segment_entry_count}, 4096).
+    persistent_term:get(classic_queue_index_v2_segment_entry_count, 4096).
 
 max_cache_size() ->
-    persistent_term:get({rabbit, classic_queue_store_v2_max_cache_size}, 512000).
+    persistent_term:get(classic_queue_store_v2_max_cache_size, 512000).
 
 check_crc32() ->
-    persistent_term:get({rabbit, classic_queue_store_v2_check_crc32}, true).
+    persistent_term:get(classic_queue_store_v2_check_crc32, true).
 
 %% Same implementation as rabbit_classic_queue_index_v2:segment_file/2,
 %% but with a different state record.

--- a/deps/rabbit/src/rabbit_message_interceptor.erl
+++ b/deps/rabbit/src/rabbit_message_interceptor.erl
@@ -18,7 +18,7 @@
 
 -spec intercept(mc:state()) -> mc:state().
 intercept(Msg) ->
-    Interceptors = persistent_term:get({rabbit, incoming_message_interceptors}, []),
+    Interceptors = persistent_term:get(incoming_message_interceptors, []),
     lists:foldl(fun({InterceptorName, Overwrite}, M) ->
                         intercept(M, InterceptorName, Overwrite)
                 end, Msg, Interceptors).

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -3049,7 +3049,7 @@ available_messages(QType, Config) ->
     ok = rabbit_ct_client_helpers:close_channel(Ch).
 
 incoming_message_interceptors(Config) ->
-    Key = {rabbit, ?FUNCTION_NAME},
+    Key = ?FUNCTION_NAME,
     ok = rpc(Config, persistent_term, put, [Key, [{set_header_routing_node, false},
                                                   {set_header_timestamp, false}]]),
     Stream = <<"my stream">>,

--- a/deps/rabbit/test/classic_queue_prop_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_prop_SUITE.erl
@@ -745,7 +745,7 @@ do_wait_updated_amqqueue(Name, Pid) ->
     end.
 
 cmd_set_v2_check_crc32(Value) ->
-    application:set_env(rabbit, classic_queue_store_v2_check_crc32, Value).
+    persistent_term:put(classic_queue_store_v2_check_crc32, Value).
 
 cmd_set_version(Version) ->
     ?DEBUG("~0p ~0p", [Version]),

--- a/deps/rabbit_common/src/credit_flow.erl
+++ b/deps/rabbit_common/src/credit_flow.erl
@@ -37,19 +37,7 @@
 %% synchronization has not been documented, since this doesn't affect
 %% client publishes.
 
--define(DEFAULT_INITIAL_CREDIT, 200).
--define(DEFAULT_MORE_CREDIT_AFTER, 100).
-
--define(DEFAULT_CREDIT,
-        case get(credit_flow_default_credit) of
-            undefined ->
-                Val = rabbit_misc:get_env(rabbit, credit_flow_default_credit,
-                                           {?DEFAULT_INITIAL_CREDIT,
-                                            ?DEFAULT_MORE_CREDIT_AFTER}),
-                put(credit_flow_default_credit, Val),
-                Val;
-            Val       -> Val
-        end).
+-define(DEFAULT_CREDIT, persistent_term:get(credit_flow_default_credit)).
 
 -export([send/1, send/2, ack/1, ack/2, handle_bump_msg/1, blocked/0, state/0, state_delayed/1]).
 -export([peer_down/1]).

--- a/deps/rabbitmq_shovel/test/dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/dynamic_SUITE.erl
@@ -790,12 +790,9 @@ shovels_from_parameters() ->
     [rabbit_misc:pget(name, Shovel) || Shovel <- L].
 
 set_default_credit(Config, Value) ->
-    {ok, OrigValue} =
-        rabbit_ct_broker_helpers:rpc(
-          Config, 0, application, get_env, [rabbit, credit_flow_default_credit]),
-    ok =
-        rabbit_ct_broker_helpers:rpc(
-          Config, 0, application, set_env, [rabbit, credit_flow_default_credit, Value]),
+    Key = credit_flow_default_credit,
+    OrigValue = rabbit_ct_broker_helpers:rpc(Config, persistent_term, get, [Key]),
+    ok = rabbit_ct_broker_helpers:rpc(Config, persistent_term, put, [Key, Value]),
     OrigValue.
 
 set_vm_memory_high_watermark(Config, Limit) ->


### PR DESCRIPTION
Put configuration `credit_flow_default_credit` into persistent term such that the tuple doesn't have to be copied on the hot path.

Also, change persistent term keys from `{rabbit, AtomKey}` to `AtomKey` so that hashing becomes cheaper.