### PR TITLE
OTP27 support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -188,11 +188,11 @@ erlang_package.hex_package(
     version = "1.3.3",
 )
 
-erlang_package.git_package(
+erlang_package.hex_package(
     name = "horus",
     build_file = "@rabbitmq-server//bazel:BUILD.horus",
-    commit = "253f9af23e539b7370a5105df19dcbb66762b247",
-    repository = "rabbitmq/horus",
+    sha256 = "f75317a5f15dd153395d0ee40401a126a87360af0f995c3377b8042eb222d082",
+    version = "0.2.5",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1686,7 +1686,7 @@ ensure_working_fhc() ->
                   #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
         ?LOG_INFO("FHC write buffering: ~ts", [WriteBuf],
                   #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
-        Filename = filename:join(code:lib_dir(kernel, ebin), "kernel.app"),
+        Filename = filename:join(code:lib_dir(kernel), "ebin/kernel.app"),
         {ok, Fd} = file_handle_cache:open(Filename, [raw, binary, read], []),
         {ok, _} = file_handle_cache:read(Fd, 1),
         ok = file_handle_cache:close(Fd),

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -192,7 +192,7 @@ find_recoverable_queues() ->
               boolean(),
               boolean(),
               rabbit_framing:amqp_table(),
-              rabbit_types:maybe(pid()),
+              rabbit_types:'maybe'(pid()),
               rabbit_types:username()) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
     {'new', amqqueue:amqqueue(), rabbit_fifo_client:state()} |
@@ -211,7 +211,7 @@ declare(QueueName, Durable, AutoDelete, Args, Owner, ActingUser) ->
               boolean(),
               boolean(),
               rabbit_framing:amqp_table(),
-              rabbit_types:maybe(pid()),
+              rabbit_types:'maybe'(pid()),
               rabbit_types:username(),
               node() | {'ignore_location', node()}) ->
     {'new' | 'existing' | 'owner_died', amqqueue:amqqueue()} |
@@ -658,7 +658,7 @@ priv_absent(QueueName, QPid, _IsDurable, alive) ->
 
 -spec assert_equivalence
         (amqqueue:amqqueue(), boolean(), boolean(),
-         rabbit_framing:amqp_table(), rabbit_types:maybe(pid())) ->
+         rabbit_framing:amqp_table(), rabbit_types:'maybe'(pid())) ->
             'ok' | rabbit_types:channel_exit() | rabbit_types:connection_exit().
 
 assert_equivalence(Q, DurableDeclare, AutoDeleteDeclare, Args1, Owner) ->

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -265,7 +265,7 @@ do(Pid, Method) ->
 
 -spec do
         (pid(), rabbit_framing:amqp_method_record(),
-         rabbit_types:maybe(rabbit_types:content())) ->
+         rabbit_types:'maybe'(rabbit_types:content())) ->
             'ok'.
 
 do(Pid, Method, Content) ->
@@ -273,7 +273,7 @@ do(Pid, Method, Content) ->
 
 -spec do_flow
         (pid(), rabbit_framing:amqp_method_record(),
-         rabbit_types:maybe(rabbit_types:content())) ->
+         rabbit_types:'maybe'(rabbit_types:content())) ->
             'ok'.
 
 do_flow(Pid, Method, Content) ->

--- a/deps/rabbit/src/rabbit_channel_interceptor.erl
+++ b/deps/rabbit/src/rabbit_channel_interceptor.erl
@@ -18,8 +18,8 @@
 -type(method_name() :: rabbit_framing:amqp_method_name()).
 -type(original_method() :: rabbit_framing:amqp_method_record()).
 -type(processed_method() :: rabbit_framing:amqp_method_record()).
--type(original_content() :: rabbit_types:maybe(rabbit_types:content())).
--type(processed_content() :: rabbit_types:maybe(rabbit_types:content())).
+-type(original_content() :: rabbit_types:'maybe'(rabbit_types:content())).
+-type(processed_content() :: rabbit_types:'maybe'(rabbit_types:content())).
 -type(interceptor_state() :: term()).
 
 -callback description() -> [proplists:property()].

--- a/deps/rabbit/src/rabbit_networking_store.erl
+++ b/deps/rabbit/src/rabbit_networking_store.erl
@@ -13,7 +13,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
 
@@ -41,6 +41,3 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-format_status(_Opt, Status) ->
-    Status.

--- a/deps/rabbit/src/rabbit_tracking_store.erl
+++ b/deps/rabbit/src/rabbit_tracking_store.erl
@@ -13,7 +13,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 
 -define(SERVER, ?MODULE).
 
@@ -42,6 +42,3 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-format_status(_Opt, Status) ->
-    Status.

--- a/deps/rabbit_common/src/supervisor2.erl
+++ b/deps/rabbit_common/src/supervisor2.erl
@@ -71,7 +71,7 @@
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3]).
 
 %% For release_handler only
 -export([get_callback_module/1]).
@@ -1605,12 +1605,6 @@ report_progress(Child, SupName) ->
                 report_cb=>fun logger:format_otp_report/1,
                 logger_formatter=>#{title=>"PROGRESS REPORT"},
                 error_logger=>#{tag=>info_report,type=>progress}}).
-
-format_status(terminate, [_PDict, State]) ->
-    State;
-format_status(_, [_PDict, State]) ->
-    [{data, [{"State", State}]},
-     {supervisor, [{"Callback", State#state.module}]}].
 
 %%%-----------------------------------------------------------------
 %%% Dynamics database access

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -417,8 +417,7 @@ ensure_rabbitmq_run_secondary_cmd(Config) ->
     end.
 
 ensure_erl_call_cmd(Config) ->
-    ErlCallDir = code:lib_dir(erl_interface, bin),
-    ErlCall = filename:join(ErlCallDir, "erl_call"),
+    ErlCall = filename:join(code:lib_dir(erl_interface), "bin/erl_call"),
     Cmd = [ErlCall],
     case exec(Cmd, [{match_stdout, "Usage: "}]) of
         {ok, _} -> set_config(Config, {erl_call_cmd, ErlCall});

--- a/deps/rabbitmq_prometheus/docker/docker-entrypoint.sh
+++ b/deps/rabbitmq_prometheus/docker/docker-entrypoint.sh
@@ -395,7 +395,7 @@ if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then
 	# More ENV vars for make clustering happiness
 	# we don't handle clustering in this script, but these args should ensure
 	# clustered SSL-enabled members will talk nicely
-	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [filename:join(code:lib_dir(ssl), "ebin")]),halt().' -noshell)"
 	sslErlArgs="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_opt server_certfile $combinedSsl -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
 	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS:-} $sslErlArgs"
 	export RABBITMQ_CTL_ERL_ARGS="${RABBITMQ_CTL_ERL_ARGS:-} $sslErlArgs"


### PR DESCRIPTION
With these changes we should be able to run the broker and pass tests on OTP27. However, the OCI image is still built using OTP26 to allow easier performance regression testing vs 3.13, since we are aware of OTP27-specific regressions. I will maintain a [separate branch](https://github.com/rabbitmq/rabbitmq-server/tree/oci-otp27) for now with an OCI built using OTP27.

since `maybe` is now a keyword, it's quoted. However, I think we should consider renaming it. We already have a bunch of `opt` and `option` types in different modules that serve the same or very similar purpose (although they use `undefined` instead of `none`). We can unify this in a separate PR.