### PR TITLE
Deflake AMQP connection close test

### DIFF
--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -994,7 +994,7 @@ connections_test_amqp(Config) ->
     after 5000 -> ct:fail(closed_timeout)
     end,
     eventually(?_assertNot(is_process_alive(C1))),
-    ?assertEqual([], http_get(Config, "/connections")),
+    eventually(?_assertEqual([], http_get(Config, "/connections")), 10, 5),
 
     {ok, C2} = amqp10_client:open_connection(OpnConf),
     receive {amqp10_event, {connection, C2, opened}} -> ok
@@ -1011,7 +1011,8 @@ connections_test_amqp(Config) ->
                 <<"Connection forced: \"Closed via management plugin\"">>}}}} -> ok
     after 5000 -> ct:fail(closed_timeout)
     end,
-    ?assertEqual([], http_get(Config, "/connections")),
+    eventually(?_assertNot(is_process_alive(C2))),
+    eventually(?_assertEqual([], http_get(Config, "/connections")), 10, 5),
     ?assertEqual(0, length(rpc(Config, rabbit_amqp1_0, list_local, []))).
 
 flush(Prefix) ->


### PR DESCRIPTION
The test expected GET /connections to not return
a connection immediately after it was closed. However, while the connection is closed synchronously during the DELETE request (the reader process is terminated), connection tracking is an asynchronous process and therefore the connection may still be listed for a brief moment after it was closed.

To deflake this test without redesigning connection tracking, we make sure that:
* the client connection process is no longer alive (it's closed because the server side of the connection is closed)
* /connections doesn't return this connection shorly after it was closed; however, we do allow this to take up to 50ms