### PR TITLE
Add number of cores used by RabbitMQ nodes to the management overview.

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1993,12 +1993,6 @@ or:
         </td>
       </tr>
       <tr>
-        <td><code>processors</code></td>
-        <td>
-          Number of cores detected and usable by Erlang.
-        </td>
-      </tr>
-      <tr>
         <td><code>queue_index_journal_write_count</code></td>
         <td>
           Number of records written to the queue index journal. Each

--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -2068,6 +2068,12 @@ or:
           Time since the Erlang VM started, in milliseconds.
         </td>
       </tr>
+      <tr>
+        <td><code>processors</code></td>
+        <td>
+          Number of logical CPU cores used by RabbitMQ.
+        </td>
+      </tr>
     </table>
 
     <h2>/api/nodes/(name)</h2>

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -141,6 +141,7 @@ var ALL_COLUMNS =
                      ['memory',             'Memory',             true],
                      ['disk_space',         'Disk space',         true]],
       'General': [['uptime',    'Uptime',       true],
+                  ['cores',     'Cores',        true],
                   ['info',      'Info',         true],
                   ['reset_stats',     'Reset stats',        true]]}};
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/node.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/node.ejs
@@ -23,22 +23,16 @@
       <th>Uptime</th>
       <td><%= fmt_uptime(node.uptime) %></td>
     </tr>
+    <tr>
+      <th>Cores</th>
+      <td><%= fmt_string(node.processors) %></td>
+    </tr>
 <% if (rabbit_versions_interesting) { %>
     <tr>
       <th>RabbitMQ Version</th>
       <td><%= fmt_rabbit_version(node.applications) %></td>
     </tr>
 <% } %>
-    <tr>
-      <th>Type</th>
-      <td>
-       <% if (node.type == 'disc') { %>
-         <abbr title="Broker definitions are held on disc.">Disc</abbr>
-       <% } else { %>
-         <abbr title="Broker definitions are held in RAM. Messages will still be written to disc if necessary.">RAM</abbr>
-       <% } %>
-      </td>
-    </tr>
     <tr>
       <th>
         <a href="https://www.rabbitmq.com/configure.html" target="_blank">Config file</a>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
@@ -99,6 +99,9 @@
   <% if (show_column('overview', 'uptime')) { %>
     <th>Uptime</th>
   <% } %>
+  <% if (show_column('overview', 'cores')) { %>
+    <th>Cores</th>
+  <% } %>
   <% if (show_column('overview', 'info')) { %>
     <th>Info</th>
   <% } %>
@@ -188,17 +191,15 @@
   <% if (show_column('overview', 'uptime')) { %>
      <td><span><%= fmt_uptime(node.uptime) %></span></td>
   <% } %>
+  <% if (show_column('overview', 'cores')) { %>
+     <td><span><%= fmt_string(node.processors) %></span></td>
+  <% } %>
   <% if (show_column('overview', 'info')) { %>
      <td>
        <% if (node.being_drained) { %>
          <abbr class="status-yellow" title="Node was put under maintenance">maintenance mode</abbr>
        <% } %>
          <abbr title="Message rates"><%= fmt_string(node.rates_mode) %></abbr>
-       <% if (node.type == 'disc') { %>
-         <abbr title="Broker definitions are held on disc.">disc</abbr>
-       <% } else { %>
-         <abbr title="Broker definitions are held in RAM. Messages will still be written to disc if necessary.">RAM</abbr>
-       <% } %>
        <%= fmt_plugins_small(node) %>
         <abbr title="Memory calculation strategy"><%= fmt_string(node.mem_calculation_strategy) %></abbr>
      </td>


### PR DESCRIPTION
Also remove the deprectated node type field from the UI to reclaim some screen estate.

RAM nodes are deprecated and almost never used.
