### PR TITLE
rabbitmq-diagnostics status: adjust the (date-based) support status field to match the current community support policy

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -710,7 +710,6 @@ maybe_print_boot_progress(true, IterationsLeft) ->
 status() ->
     Version = base_product_version(),
     [CryptoLibInfo] = crypto:info_lib(),
-    SeriesSupportStatus = rabbit_release_series:readable_support_status(),
     S1 = [{pid,                  list_to_integer(os:getpid())},
           %% The timeout value used is twice that of gen_server:call/2.
           {running_applications, rabbit_misc:which_applications()},
@@ -718,7 +717,6 @@ status() ->
           {rabbitmq_version,     Version},
           {crypto_lib_info,      CryptoLibInfo},
           {erlang_version,       erlang:system_info(system_version)},
-          {release_series_support_status, SeriesSupportStatus},
           {memory,               rabbit_vm:memory()},
           {alarms,               alarms()},
           {is_under_maintenance, rabbit_maintenance:is_being_drained_local_read(node())},
@@ -917,7 +915,6 @@ start(normal, []) ->
                     ?COPYRIGHT_MESSAGE, ?INFORMATION_MESSAGE],
                    #{domain => ?RMQLOG_DOMAIN_PRELAUNCH})
         end,
-        maybe_warn_about_release_series_eol(),
         log_motd(),
         {ok, SupPid} = rabbit_sup:start_link(),
 
@@ -1291,7 +1288,6 @@ print_banner() ->
     %% padded list lines
     {LogFmt, LogLocations} = LineListFormatter("~n        ~ts", log_locations()),
     {CfgFmt, CfgLocations} = LineListFormatter("~n                  ~ts", config_locations()),
-    SeriesSupportStatus    = rabbit_release_series:readable_support_status(),
     {MOTDFormat, MOTDArgs} = case motd() of
                                  undefined ->
                                      {"", []};
@@ -1309,7 +1305,7 @@ print_banner() ->
               MOTDFormat ++
               "~n  Erlang:      ~ts [~ts]"
               "~n  TLS Library: ~ts"
-              "~n  Release series support status: ~ts"
+              "~n  Release series support status: see https://www.rabbitmq.com/release-information"
               "~n"
               "~n  Doc guides:  https://www.rabbitmq.com/docs"
               "~n  Support:     https://www.rabbitmq.com/docs/contact"
@@ -1321,22 +1317,10 @@ print_banner() ->
               "~n  Config file(s): ~ts" ++ CfgFmt ++ "~n"
               "~n  Starting broker...",
               [Product, Version, ?COPYRIGHT_MESSAGE, ?INFORMATION_MESSAGE] ++
-              [rabbit_misc:otp_release(), emu_flavor(), crypto_version(),
-               SeriesSupportStatus] ++
+              [rabbit_misc:otp_release(), emu_flavor(), crypto_version()] ++
               MOTDArgs ++
               LogLocations ++
               CfgLocations).
-
-maybe_warn_about_release_series_eol() ->
-    case rabbit_release_series:is_currently_supported() of
-        false ->
-            %% we intentionally log this as an error for increased visibiity
-            ?LOG_ERROR("This release series has reached end of life "
-                       "and is no longer supported. "
-                       "Please visit https://www.rabbitmq.com/release-information "
-                       "to learn more and upgrade");
-        _ -> ok
-    end.
 
 emu_flavor() ->
     %% emu_flavor was introduced in Erlang 24 so we need to catch the error on Erlang 23

--- a/deps/rabbit/src/rabbit_release_series.erl
+++ b/deps/rabbit/src/rabbit_release_series.erl
@@ -10,30 +10,16 @@
 -define(EOL_DATE_KEY, release_series_eol_date).
 
 -export([
-  eol_date/0,
   is_currently_supported/0,
   readable_support_status/0
 ]).
 
--spec eol_date() -> rabbit_types:maybe(calendar:date()).
-eol_date() ->
-  case application:get_env(rabbit, ?EOL_DATE_KEY) of
-    undefined                  -> none;
-    {ok, none}                -> none;
-    {ok, {_Y, _M, _D} = Date} -> Date;
-      _                       -> none
-  end.
-
+%% Retained for backwards compatibility with older CLI tools.
 -spec is_currently_supported() -> boolean().
 is_currently_supported() ->
-  case eol_date() of
-    none -> true;
-    Date -> not rabbit_date_time:is_in_the_past(Date)
-  end.
+  true.
 
+%% Retained for backwards compatibility with older CLI tools.
 -spec readable_support_status() -> binary().
 readable_support_status() ->
-    case is_currently_supported() of
-      false -> <<"out of support">>;
-      _     -> <<"supported">>
-  end.
+  <<"supported">>.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -101,7 +101,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
         product_version_section ++
         [
           "RabbitMQ version: #{m[:rabbitmq_version]}",
-          "RabbitMQ release series support status: #{m[:release_series_support_status]}",
+          "RabbitMQ release series support status: see https://www.rabbitmq.com/release-information",
           "Node name: #{node_name}",
           "Erlang configuration: #{m[:erlang_version]}",
           "Crypto library: #{m[:crypto_lib_version]}",


### PR DESCRIPTION
As of [1], this field has become irrelevant or even misleading.

1. https://www.rabbitmq.com/blog/2024/05/31/new-community-support-policy
