### PR TITLE
Avoid deadlock on terminating ff controller

### DIFF
--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -306,6 +306,14 @@ terminate(_Reason, _State, _Data) ->
     ok.
 
 wait_for_in_flight_operations() ->
+    case global:whereis_name(?GLOBAL_NAME) of
+        Pid when Pid == self() ->
+            ok;
+        _ ->
+            wait_for_in_flight_operations0()
+    end.
+
+wait_for_in_flight_operations0() ->
     case register_globally() of
         yes ->
             %% We don't unregister so the controller holds the lock until it


### PR DESCRIPTION
If the global process is itself, it means it just crashed. It shouldn't wait but terminate.

As discussed with @dumbbell 

Probably supersedes https://github.com/rabbitmq/rabbitmq-server/pull/11392