### PR TITLE
Build IBM MQ docker image with AMQP built-in capability 

### DIFF
--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - 'main'
-      - ibm-mq-docker-workflow
     paths:
       - '.github/workflows/ibm-mq-make.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/ibm-mq-make.yaml'
+  
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
   IBM_MQ_REPOSITORY: ibm-messaging/mq-container

--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -1,0 +1,64 @@
+name: IBM MQ docker image (make)
+
+on:
+  push:
+    branches:
+      - 'main'
+      - ibm-mq-docker-workflow
+    paths:
+      - '.github/workflows/ibm-mq-make.yaml'
+env:
+  REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
+  IBM_MQ_REPOSITORY: ibm-messaging/mq-container
+  IBM_MQ_BRANCH_NAME: 9.3.5
+  IMAGE_TAG: 9.3.5.1-amd64
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout ibm-mqadvanced-server-dev
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.IBM_MQ_REPOSITORY }}
+          ref: ${{ env.IBM_MQ_BRANCH_NAME }}
+
+      - name: Prepare image        
+        run: |
+          ls        
+          echo "Enabling AMQP capability"
+          sed -i -e 's/genmqpkg_incamqp=0/genmqpkg_incamqp=1/g' Dockerfile-server
+          echo "AMQP Bootstrap instructions"
+          cat << EOF >> incubating/mqadvanced-server-dev/10-dev.mqsc.tpl
+          SET AUTHREC PRINCIPAL('app') OBJTYPE(QMGR) AUTHADD(CONNECT,INQ,ALTUSR)
+          SET CHLAUTH('SYSTEM.DEF.AMQP') TYPE(ADDRESSMAP) ADDRESS('*') USERSRC(CHANNEL) CHCKCLNT({{ .ChckClnt }}) DESCR('Allows connection via APP channel') ACTION(REPLACE)
+          SET AUTHREC PROFILE('SYSTEM.BASE.TOPIC') PRINCIPAL('app') OBJTYPE(TOPIC) AUTHADD(PUB,SUB)
+          SET AUTHREC PROFILE('SYSTEM.DEFAULT.MODEL.QUEUE') PRINCIPAL('app') OBJTYPE(QUEUE) AUTHADD(PUT,DSP)
+          ALTER CHANNEL(SYSTEM.DEF.AMQP) CHLTYPE(AMQP) MCAUSER('app')
+          START SERVICE(SYSTEM.AMQP.SERVICE)
+          START CHANNEL(SYSTEM.DEF.AMQP)
+          EOF
+          make build-devserver    
+          docker tag ibm-mqadvanced-server-dev:${{ env.IMAGE_TAG }} ${{ env.REGISTRY_IMAGE }}:${{ env.IMAGE_TAG }} 
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Push
+        run: |
+          docker push ${{ env.REGISTRY_IMAGE }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
## Proposed Changes

Build an IBM MQ docker image following instructions announced here https://developer.ibm.com/tutorials/mq-setting-up-amqp-with-mq/. There are already built docker images however these docker images do not come with AMQP capability built in which means we cannot use AMQP Channels. 

Given that it takes several minutes to build the docker image, it was considered more appropriate to build this docker image once and just start/stop ibm mq docker containers whenever it was required. 

It publishes a docker image with this image name and tag:  `pivotalrabbitmq/ibm-mqadvanced-server-dev:9.3.5.1-amd64` 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
