### PR TITLE
Dynamically load oauth-related libraries 

### DIFF
--- a/deps/rabbitmq_management/priv/www/index.html
+++ b/deps/rabbitmq_management/priv/www/index.html
@@ -22,7 +22,7 @@
     <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>    
     
     <script type="module">
-      window.oauth = oauth_initialize_if_required("index");
+      window.oauth = oauth_initialize_if_required();
       
     </script>
     

--- a/deps/rabbitmq_management/priv/www/index.html
+++ b/deps/rabbitmq_management/priv/www/index.html
@@ -16,47 +16,16 @@
     <script src="js/prefs.js" type="text/javascript"></script>
     <script src="js/formatters.js" type="text/javascript"></script>
     <script src="js/charts.js" type="text/javascript"></script>
-    <script src="js/oidc-oauth/helper.js"></script>
-    <script src="js/oidc-oauth/oidc-client-ts.js" type="text/javascript"></script>
-    <script src="js/oidc-oauth/bootstrap.js"></script>
-
+    <script src="js/oidc-oauth/bootstrap.js" type="module"></script>
+    
     <link href="css/main.css" rel="stylesheet" type="text/css"/>
-    <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-
-    <script type="application/javascript">
-      var oauth = oauth_initialize_if_required();
-
-      if (oauth.enabled) {
-        if (!oauth.sp_initiated) {
-            oauth.logged_in = has_auth_credentials();
-            oauth.access_token = get_auth_credentials(); // DEPRECATED
-        } else {
-          oauth_is_logged_in().then( status => {
-            if (status.loggedIn && !has_auth_credentials()) {
-              oauth.logged_in = false;
-              oauth_initiateLogout();
-            } else {
-              if (!status.loggedIn) {
-                clear_auth();
-              } else {
-                oauth.logged_in = true;
-                oauth.access_token = status.user.access_token;  // DEPRECATED
-                oauth.expiryDate = new Date(status.user.expires_at * 1000);  // it is epoch in seconds
-                let current = new Date();
-                _management_logger.debug('token expires in ', (oauth.expiryDate-current)/1000,
-                  'secs at : ', oauth.expiryDate );
-                oauth.user_name = status.user.profile['user_name'];
-                if (!oauth.user_name || oauth.user_name == '') {
-                  oauth.user_name = status.user.profile['sub'];
-                }
-                oauth.scopes = status.user.scope;
-              }
-            }
-          });
-        }
-      }
-
+    <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>    
+    
+    <script type="module">
+      window.oauth = oauth_initialize_if_required("index");
+      
     </script>
+    
 
 <!--[if lte IE 8]>
     <script src="js/excanvas.min.js" type="text/javascript"></script>

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -698,9 +698,6 @@ function DisplayControl() {
 
 }
 
-function is_internal_user(user) {
-  return user.backends.includes("rabbit_auth_backend_internal");
-}
 
 // Set up the above vars
 function setup_global_vars(overview) {
@@ -717,9 +714,9 @@ function setup_global_vars(overview) {
       '<li>Cluster ' + (user_administrator ?  '<a href="#/cluster-name">' + cluster_name + '</a>' : cluster_name) + '</li>'
     );
 
-    user_name = fmt_escape_html(user.name);
+    user_name = fmt_escape_html(user.name); 
     $('#header #logout').prepend(
-      'User ' + (user_administrator && is_internal_user(user) ?  '<a href="#/users/' + user_name + '">' + user_name + '</a>' : user_name)
+      'User ' + (user_administrator && user.is_internal_user ?  '<a href="#/users/' + user_name + '">' + user_name + '</a>' : user_name)
     );
 
     var product = overview.rabbitmq_version;

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -698,6 +698,10 @@ function DisplayControl() {
 
 }
 
+function is_internal_user(user) {
+  return user.backends.includes("rabbit_auth_backend_internal");
+}
+
 // Set up the above vars
 function setup_global_vars(overview) {
     rates_mode = overview.rates_mode;
@@ -715,7 +719,7 @@ function setup_global_vars(overview) {
 
     user_name = fmt_escape_html(user.name);
     $('#header #logout').prepend(
-      'User ' + (user_administrator && !oauth.enabled ?  '<a href="#/users/' + user_name + '">' + user_name + '</a>' : user_name)
+      'User ' + (user_administrator && is_internal_user(user) ?  '<a href="#/users/' + user_name + '">' + user_name + '</a>' : user_name)
     );
 
     var product = overview.rabbitmq_version;

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -1,3 +1,4 @@
+import {oidc} from './oidc-client-ts.js';
 
 var mgr;
 var _management_logger;
@@ -85,9 +86,38 @@ function auth_settings_apply_defaults(authSettings) {
   return authSettings;
 }
 
-
+export function oauth_initiate(oauth) {
+  if (oauth.enabled) {
+    if (!oauth.sp_initiated) {
+        oauth.logged_in = has_auth_credentials();        
+    } else {
+      oauth_is_logged_in().then( status => {
+        if (status.loggedIn && !has_auth_credentials()) {
+          oauth.logged_in = false;
+          oauth_initiateLogout();
+        } else {
+          if (!status.loggedIn) {
+            clear_auth();
+          } else {
+            oauth.logged_in = true;            
+            oauth.expiryDate = new Date(status.user.expires_at * 1000);  // it is epoch in seconds
+            let current = new Date();
+            _management_logger.debug('token expires in ', (oauth.expiryDate-current)/1000,
+              'secs at : ', oauth.expiryDate );
+            oauth.user_name = status.user.profile['user_name'];
+            if (!oauth.user_name || oauth.user_name == '') {
+              oauth.user_name = status.user.profile['sub'];
+            }
+            oauth.scopes = status.user.scope;
+          }
+        }
+      });
+    }
+  }
+  return oauth;
+}
 function oauth_initialize_user_manager(resource_server) {
-    oidcSettings = {
+    let oidcSettings = {
         userStore: new oidc.WebStorageStateStore({ store: window.localStorage }),
         authority: resource_server.oauth_provider_url,
         client_id: resource_server.oauth_client_id,
@@ -119,7 +149,7 @@ function oauth_initialize_user_manager(resource_server) {
     oidc.Log.setLogger(console);
 
     mgr = new oidc.UserManager(oidcSettings);
-    oauth.readiness_url = mgr.settings.metadataUrl;
+//    oauth.readiness_url = mgr.settings.metadataUrl;
 
     _management_logger = new oidc.Logger("Management");
 
@@ -133,15 +163,13 @@ function oauth_initialize_user_manager(resource_server) {
       _management_logger.error("token expiring failed due to ", err);
     });
     mgr.events.addUserLoaded(function(user) {
-      console.log("addUserLoaded  setting oauth.access_token ")
-      oauth.access_token = user.access_token  // DEPRECATED
-      set_token_auth(oauth.access_token)
+      set_token_auth(user.access_token)
     });
 
 }
-function oauth_initialize(authSettings) {
+export function oauth_initialize(authSettings) {
     authSettings = auth_settings_apply_defaults(authSettings);
-    oauth = {
+    let oauth = {
       "logged_in": false,
       "enabled" : authSettings.oauth_enabled,
       "resource_servers" : authSettings.resource_servers,
@@ -149,12 +177,12 @@ function oauth_initialize(authSettings) {
     }
     if (!oauth.enabled) return oauth;
 
-    resource_server = null
+    let resource_server = null;
 
     if (oauth.resource_servers.length == 1) {
       resource_server = oauth.resource_servers[0]
     } else if (has_auth_resource()) {
-      resource_server = lookup_resource_server(get_auth_resource())
+      resource_server = lookup_resource_server(get_auth_resource(), oauth.resource_servers)
     }
 
     if (resource_server) {
@@ -189,18 +217,18 @@ function oauth_is_logged_in() {
         return { "user": user, "loggedIn": !user.expired };
     });
 }
-function lookup_resource_server(resource_server_id) {
+function lookup_resource_server(resource_server_id, resource_servers) {
   let i = 0;
 
-  while (i < oauth.resource_servers.length && oauth.resource_servers[i].id != resource_server_id) {
+  while (i < resource_servers.length && resource_servers[i].id != resource_server_id) {
     i++;
   }
-  if (i < oauth.resource_servers.length) return oauth.resource_servers[i]
+  if (i < resource_servers.length) return resource_servers[i]
   else return null
 }
 
-function oauth_initiateLogin(resource_server_id) {
-  resource_server = lookup_resource_server(resource_server_id)
+export function oauth_initiateLogin(resource_server_id) {
+  let resource_server = lookup_resource_server(resource_server_id, oauth.resource_servers)
   if (!resource_server) return;
   set_auth_resource(resource_server_id)
 
@@ -220,19 +248,15 @@ function oauth_initiateLogin(resource_server_id) {
   }
 }
 
-function oauth_redirectToHome(oauth) {
-  set_token_auth(oauth.access_token)
-
-  path = get_pref("oauth-return-to");
+function oauth_redirectToHome() {
+  let path = get_pref("oauth-return-to")
   clear_pref("oauth-return-to")
-  go_to(path)
+  go_to( !path ? "" : path)
 }
 function go_to(path) {
   location.href = rabbit_path_prefix() + "/" + path
 }
-function go_to_home() {
-  location.href = rabbit_path_prefix() + "/"
-}
+
 function go_to_authority() {
   location.href = oauth.authority
 }
@@ -242,18 +266,21 @@ function oauth_redirectToLogin(error) {
     location.href = rabbit_path_prefix() + "/?error=" + error
   }
 }
-function oauth_completeLogin() {
-    mgr.signinRedirectCallback().then(user => oauth_redirectToHome(user)).catch(function(err) {
-        _management_logger.error(err)
-        oauth_redirectToLogin(err)
+export function oauth_completeLogin() {
+    mgr.signinRedirectCallback().then(function(user) {
+      set_token_auth(user.access_token);
+      oauth_redirectToHome();
+    }).catch(function(err) {
+      _management_logger.error(err)
+      oauth_redirectToLogin(err)
     });
 }
 
-function oauth_initiateLogout() {
+export function oauth_initiateLogout() {
   if (oauth.sp_initiated) {
     mgr.metadataService.getEndSessionEndpoint().then(endpoint => {
       if (endpoint == undefined) {
-        // Logout only from management UI 
+        // Logout only from management UI
         mgr.removeUser().then(res => {
           clear_auth()
           oauth_redirectToLogin()
@@ -268,7 +295,7 @@ function oauth_initiateLogout() {
   }
 }
 
-function oauth_completeLogout() {
+export function oauth_completeLogout() {
     clear_auth()
     mgr.signoutRedirectCallback().then(_ => oauth_redirectToLogin())
 }
@@ -286,4 +313,75 @@ function validate_openid_configuration(payload) {
     throw new Error("Missing jwks_uri")
   }
 
+}
+
+function warningMessageOAuthResource(oauthResource, reason) {
+  return "OAuth resource [<b>" + (oauthResource["label"] != null ? oauthResource.label : oauthResource.id) +
+    "</b>] not available. OpenId Discovery endpoint " + readiness_url(oauthResource) + reason
+}
+function warningMessageOAuthResources(commonProviderURL, oauthResources, reason) {
+  return "OAuth resources [ <b>" + oauthResources.map(resource => resource["label"] != null ? resource.label : resource.id).join("</b>,<b>")
+    + "</b>] not available. OpenId Discovery endpoint " + commonProviderURL + reason
+}
+
+export function hasAnyResourceServerReady(oauth, onReadyCallback) {
+  // Find out how many distinct oauthServers are configured
+  let oauthServers = removeDuplicates(oauth.resource_servers.filter((resource) => resource.sp_initiated))
+  oauthServers.forEach(function(entry) { console.log(readiness_url(entry)) })
+  if (oauthServers.length > 0) {   // some resources are sp_initiated but there could be idp_initiated too
+    Promise.allSettled(oauthServers.map(oauthServer => fetch(readiness_url(oauthServer)).then(res => res.json())))
+      .then(results => {
+        results.forEach(function(entry) { console.log(entry) })
+        let notReadyServers = []
+        let notCompliantServers = []
+
+        for (let i = 0; i < results.length; i++) {
+          switch (results[i].status) {
+            case "fulfilled":
+              try {
+                validate_openid_configuration(results[i].value)
+              }catch(e) {
+                console.log("Unable to connect to " + oauthServers[i].oauth_provider_url + ". " + e)
+                notCompliantServers.push(oauthServers[i].oauth_provider_url)
+              }
+              break
+            case "rejected":
+              notReadyServers.push(oauthServers[i].oauth_provider_url)
+              break
+          }
+        }
+        const spOauthServers = oauth.resource_servers.filter((resource) => resource.sp_initiated)
+        const groupByProviderURL = spOauthServers.reduce((group, oauthServer) => {
+          const { oauth_provider_url } = oauthServer;
+          group[oauth_provider_url] = group[oauth_provider_url] ?? [];
+          group[oauth_provider_url].push(oauthServer);
+          return group;
+        }, {})
+        let warnings = []
+        for(var url in groupByProviderURL){
+          console.log(url + ': ' + groupByProviderURL[url]);
+          const notReadyResources = groupByProviderURL[url].filter((oauthserver) => notReadyServers.includes(oauthserver.oauth_provider_url))
+          const notCompliantResources = groupByProviderURL[url].filter((oauthserver) => notCompliantServers.includes(oauthserver.oauth_provider_url))
+          if (notReadyResources.length == 1) {
+            warnings.push(warningMessageOAuthResource(notReadyResources[0], " not reachable"))
+          }else if (notReadyResources.length > 1) {
+            warnings.push(warningMessageOAuthResources(url, notReadyResources, " not reachable"))
+          }
+          if (notCompliantResources.length == 1) {
+            warnings.push(warningMessageOAuthResource(notCompliantResources[0], " not compliant"))
+          }else if (notCompliantResources.length > 1) {
+            warnings.push(warningMessageOAuthResources(url, notCompliantResources, " not compliant"))
+          }
+        }
+        console.log("warnings:" + warnings)
+        oauth.declared_resource_servers_count = oauth.resource_servers.length
+        oauth.resource_servers = oauth.resource_servers.filter((resource) =>
+          !notReadyServers.includes(resource.oauth_provider_url) && !notCompliantServers.includes(resource.oauth_provider_url))
+
+          onReadyCallback(oauth, warnings)
+
+      })
+  }else {
+    onReadyCallback(oauth, [])
+  }
 }

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/helper.js
@@ -86,6 +86,29 @@ function auth_settings_apply_defaults(authSettings) {
   return authSettings;
 }
 
+var oauth_settings = { oauth_enabled : false}
+
+export function set_oauth_settings(settings) {
+  oauth_settings = settings
+}
+function get_oauth_settings() {
+  return oauth_settings
+}
+
+export function oauth_initialize_if_required(state = "index") {
+  let oauth = oauth_initialize(get_oauth_settings())
+  if (!oauth.enabled) return oauth;
+  switch (state) { 
+    case 'login-callback': 
+      oauth_completeLogin(); break; 
+    case 'logout-callback': 
+      oauth_completeLogout(); break; 
+    default: 
+      oauth = oauth_initiate(oauth);
+  }
+  return oauth; 
+}
+
 export function oauth_initiate(oauth) {
   if (oauth.enabled) {
     if (!oauth.sp_initiated) {

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/login-callback.html
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/login-callback.html
@@ -7,12 +7,11 @@
   <script src="../jquery-3.5.1.min.js"></script>
   <script src="../base64.js" type="text/javascript"></script>
   <script src="../prefs.js" ></script>
-  <script src="./oidc-client-ts.js" ></script>
-  <script src="./helper.js"></script>
-  <script src="./bootstrap.js"></script>
-    <script type="text/javascript">
-
-      if (oauth_initialize_if_required()) oauth_completeLogin()
-    </script>
+  <script src="./bootstrap.js" type="module" ></script>
+  <script type="module">
+    window.oauth = oauth_initialize_if_required("login-callback");
+    
+  </script>
+ 
 </body>
 </html>

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/logout-callback.html
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/logout-callback.html
@@ -4,15 +4,15 @@
 
 </head>
 <body>
-  <script src="./oidc-client-ts.js" ></script>
-  <script src="./helper.js"></script>
-  <script src="./bootstrap.js"></script>
-    <script type="text/javascript">
-      if (oauth_initialize_if_required()) {
-        oauth_completeLogout()
-      }
-    </script>
+  <script src="./bootstrap.js" type="module" ></script>
+  <script type="module">
+    window.oauth = oauth_initialize_if_required("logout-callback");
+    
+  </script>
 
 
 </body>
+
+ 
+
 </html>

--- a/deps/rabbitmq_management/priv/www/js/oidc-oauth/oidc-client-ts.js
+++ b/deps/rabbitmq_management/priv/www/js/oidc-oauth/oidc-client-ts.js
@@ -3180,3 +3180,4 @@ var oidc = (() => {
   return __toCommonJS(src_exports);
 })();
 //# sourceMappingURL=oidc-client-ts.js.map
+export {oidc};

--- a/deps/rabbitmq_management/selenium/bin/components/devkeycloak
+++ b/deps/rabbitmq_management/selenium/bin/components/devkeycloak
@@ -47,7 +47,7 @@ start_devkeycloak() {
 
   wait_for_oidc_endpoint devkeycloak $DEVKEYCLOAK_URL $MOUNT_DEVKEYCLOAK_CONF_DIR/ca_certificate.pem
   end "devkeycloak is ready"
-  print " Note: If you modify devkeycloak configuration. Make sure to run the following command to export the configuration."
+  print " Note: If you modify devkeycloak configuration, make sure to run the following command to export the configuration."
   print " docker exec -it devkeycloak /opt/keycloak/bin/kc.sh export --users realm_file --realm test --dir /opt/keycloak/data/import/"
 
 }

--- a/deps/rabbitmq_management/selenium/bin/components/prodkeycloak
+++ b/deps/rabbitmq_management/selenium/bin/components/prodkeycloak
@@ -46,7 +46,7 @@ start_prodkeycloak() {
 
   wait_for_oidc_endpoint prodkeycloak $PRODKEYCLOAK_URL $MOUNT_PRODKEYCLOAK_CONF_DIR/ca_certificate.pem
   end "prodkeycloak is ready"
-  print " Note: If you modify prodkeycloak configuration. Make sure to run the following command to export the configuration."
+  print " Note: If you modify prodkeycloak configuration, make sure to run the following command to export the configuration."
   print " docker exec -it prodkeycloak /opt/keycloak/bin/kc.sh export --users realm_file --realm test --dir /opt/keycloak/data/import/"
 
 }

--- a/deps/rabbitmq_management/selenium/full-suite-management-ui
+++ b/deps/rabbitmq_management/selenium/full-suite-management-ui
@@ -1,5 +1,6 @@
 authnz-mgt/basic-auth-behind-proxy.sh
 authnz-mgt/basic-auth.sh
+authnz-mgt/basic-auth-with-mgt-prefix.sh
 authnz-mgt/multi-oauth-with-basic-auth-when-idps-down.sh
 authnz-mgt/multi-oauth-with-basic-auth.sh
 authnz-mgt/multi-oauth-without-basic-auth-and-resource-label-and-scopes.sh

--- a/deps/rabbitmq_management/selenium/package.json
+++ b/deps/rabbitmq_management/selenium/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chromedriver": "^123.0.0",
+    "chromedriver": "^125.0.0",
     "ejs": "^3.1.8",
     "express": "^4.18.2",
     "geckodriver": "^3.0.2",

--- a/deps/rabbitmq_management/selenium/suites/authnz-mgt/basic-auth-with-mgt-prefix.sh
+++ b/deps/rabbitmq_management/selenium/suites/authnz-mgt/basic-auth-with-mgt-prefix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEST_CASES_PATH=/basic-auth
+PROFILES="mgt-prefix"
+
+source $SCRIPT/../../bin/suite_template $@
+run

--- a/deps/rabbitmq_management/selenium/test/basic-auth/imports/users.json
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/imports/users.json
@@ -44,6 +44,13 @@
         "monitoring"
       ],
       "limits": {}
+    },
+    {
+      "name": "rabbit_no_management",
+      "password_hash": "Joz9zzUBOrX10lB3GisWN5oTXK+wj0gxS/nyrfTYmBOuhps5",
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "tags": [ ],
+      "limits": {}
     }
   ],
   "vhosts": [
@@ -61,6 +68,13 @@
     },
     {
       "user": "management",
+      "vhost": "/",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    },
+    {
+      "user": "rabbit_no_management",
       "vhost": "/",
       "configure": ".*",
       "write": ".*",

--- a/deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.conf
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.conf
@@ -1,4 +1,4 @@
 auth_backends.1 = rabbit_auth_backend_internal
 
-management.login_session_timeout = 150
+management.login_session_timeout = 1
 load_definitions = ${IMPORT_DIR}/users.json

--- a/deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.mgt-prefix.conf
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/rabbitmq.mgt-prefix.conf
@@ -1,0 +1,1 @@
+management.path_prefix = /my-prefix/another-prefix

--- a/deps/rabbitmq_management/selenium/test/basic-auth/session-expired.js
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/session-expired.js
@@ -1,0 +1,39 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+require('chromedriver')
+const assert = require('assert')
+const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
+
+const LoginPage = require('../pageobjects/LoginPage')
+const OverviewPage = require('../pageobjects/OverviewPage')
+
+describe('Once user is logged in', function () {
+  let homePage
+  let idpLogin
+  let overview
+  let captureScreen
+  this.timeout(65000) // hard-coded to 25secs because this test requires 35sec to run
+
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    login = new LoginPage(driver)
+    overview = new OverviewPage(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+    await login.login('guest', 'guest')
+    await overview.isLoaded()
+
+  })
+
+  it('it has to login after the session expires', async function () {
+    
+    await delay(60000)
+    await login.isLoaded() 
+    await login.login('guest', 'guest')
+    await overview.isLoaded() 
+    await overview.clickOnConnectionsTab() // and we can still interact with the ui
+  })
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})

--- a/deps/rabbitmq_management/selenium/test/basic-auth/unauthorized.js
+++ b/deps/rabbitmq_management/selenium/test/basic-auth/unauthorized.js
@@ -1,0 +1,59 @@
+const { By, Key, until, Builder } = require('selenium-webdriver')
+require('chromedriver')
+const assert = require('assert')
+const { buildDriver, goToHome, captureScreensFor, teardown, delay } = require('../utils')
+
+const LoginPage = require('../pageobjects/LoginPage')
+const OverviewPage = require('../pageobjects/OverviewPage')
+
+describe('An user without management tag', function () {
+  let homePage
+  let idpLogin
+  let overview
+  let captureScreen
+
+  before(async function () {
+    driver = buildDriver()
+    await goToHome(driver)
+    login = new LoginPage(driver)
+    overview = new OverviewPage(driver)
+    captureScreen = captureScreensFor(driver, __filename)
+
+    assert.ok(!await login.isPopupWarningDisplayed())
+    await login.login('rabbit_no_management', 'rabbit_no_management')
+    await !overview.isLoaded()
+  })
+
+  it('cannot log in into the management ui', async function () {    
+    const visible = await login.isWarningVisible()
+    assert.ok(visible)
+  })
+
+  it('should get "Login failed" warning message', async function(){
+    assert.equal('Login failed', await login.getWarning())
+  })
+
+  it('should get popup warning dialog', async function(){
+    assert.ok(login.isPopupWarningDisplayed())
+    assert.equal('Not_Authorized', await login.getPopupWarning())
+  })
+
+  describe("After clicking on popup warning dialog button", function() {
+
+      before(async function () {
+          await login.closePopupWarning()
+      })
+
+      it('should close popup warning', async function(){
+      await delay(1000)
+        const visible = await login.isPopupWarningDisplayed()
+        assert.ok(!visible)
+      })
+
+  })
+
+
+  after(async function () {
+    await teardown(driver, this, captureScreen)
+  })
+})

--- a/deps/rabbitmq_management/selenium/test/oauth/enabled_plugins
+++ b/deps/rabbitmq_management/selenium/test/oauth/enabled_plugins
@@ -1,5 +1,5 @@
 [accept,amqp10_client,amqp_client,base64url,cowboy,cowlib,eetcd,gun,jose,
- oauth2_client,prometheus,rabbitmq_auth_backend_cache,
+ oauth2_client,prometheus,rabbitmq_amqp1_0,rabbitmq_auth_backend_cache,
  rabbitmq_auth_backend_http,rabbitmq_auth_backend_ldap,
  rabbitmq_auth_backend_oauth2,rabbitmq_auth_mechanism_ssl,rabbitmq_aws,
  rabbitmq_consistent_hash_exchange,rabbitmq_event_exchange,

--- a/deps/rabbitmq_management/selenium/test/oauth/imports/users.json
+++ b/deps/rabbitmq_management/selenium/test/oauth/imports/users.json
@@ -44,6 +44,13 @@
         "monitoring"
       ],
       "limits": {}
+    },
+    {
+      "name": "rabbit_no_management",
+      "password_hash": "Joz9zzUBOrX10lB3GisWN5oTXK+wj0gxS/nyrfTYmBOuhps5",
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "tags": [ ],
+      "limits": {}
     }
   ],
   "vhosts": [
@@ -61,6 +68,13 @@
     },
     {
       "user": "management",
+      "vhost": "/",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    },
+    {
+      "user": "rabbit_no_management",
       "vhost": "/",
       "configure": ".*",
       "write": ".*",

--- a/deps/rabbitmq_management/selenium/test/oauth/with-basic-auth/unauthorized.js
+++ b/deps/rabbitmq_management/selenium/test/oauth/with-basic-auth/unauthorized.js
@@ -22,18 +22,17 @@ describe('An user without management tag', function () {
 
     await homePage.clickToLogin()
     await idpLogin.login('rabbit_no_management', 'rabbit_no_management')
-
-  })
-
-  it('cannot log in into the management ui', async function () {
     if (!await homePage.isLoaded()) {
       throw new Error('Failed to login')
     }
+  })
+
+  it('cannot log in into the management ui', async function () {    
     const visible = await homePage.isWarningVisible()
     assert.ok(visible)
   })
 
-  it('should get "Not authorized" warning message and logout button but no login button', async function(){
+  it('should get "Not authorized" warning message', async function(){
     assert.equal('Not authorized', await homePage.getWarning())
     assert.equal('Click here to logout', await homePage.getLogoutButton())
     assert.ok(!await homePage.isBasicAuthSectionVisible())

--- a/deps/rabbitmq_management/selenium/test/pageobjects/LoginPage.js
+++ b/deps/rabbitmq_management/selenium/test/pageobjects/LoginPage.js
@@ -6,6 +6,7 @@ const FORM = By.css('div#login form')
 const USERNAME = By.css('input[name="username"]')
 const PASSWORD = By.css('input[name="password"]')
 const LOGIN_BUTTON = By.css('div#outer div#login form input[type=submit]')
+const WARNING = By.css('div#outer div#login div#login-status p')
 
 module.exports = class LoginPage extends BasePage {
   async isLoaded () {
@@ -22,4 +23,26 @@ module.exports = class LoginPage extends BasePage {
   async getLoginButton () {
     return this.getValue(LOGIN_BUTTON)
   }
+
+
+  async isWarningVisible () {
+    try {
+      await this.waitForDisplayed(WARNING)
+      return Promise.resolve(true)
+    } catch (e) {
+      return Promise.resolve(false)
+    }
+  }
+  async getWarnings() {
+    try
+    {
+      return driver.findElements(WARNING)
+    } catch (NoSuchElement) {
+      return Promise.resolve([])
+    }
+  }
+  async getWarning () {
+    return this.getText(WARNING)
+  }
+  
 }

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
@@ -9,28 +9,50 @@
 
 -export([init/2]).
 
--include_lib("amqp_client/include/amqp_client.hrl").
-
 %%--------------------------------------------------------------------
 
 init(Req0, State) ->
-  bootstrap_oauth(rabbit_mgmt_headers:set_no_cache_headers(
-     rabbit_mgmt_headers:set_common_permission_headers(Req0, ?MODULE), ?MODULE), State).
+    bootstrap_oauth(rabbit_mgmt_headers:set_no_cache_headers(
+        rabbit_mgmt_headers:set_common_permission_headers(Req0, ?MODULE), ?MODULE), State).
 
 bootstrap_oauth(Req0, State) ->
-  JSContent = oauth_initialize_if_required() ++ set_token_auth(Req0),
-  {ok, cowboy_req:reply(200, #{<<"content-type">> => <<"text/javascript; charset=utf-8">>}, JSContent, Req0), State}.
+    AuthSettings = rabbit_mgmt_wm_auth:authSettings(),
+    Dependencies = oauth_dependencies(),
+    JSContent = case proplists:get_value(oauth_enabled, AuthSettings, false) of 
+        false -> declare_oauth_initialize_if_required(AuthSettings); 
+        true -> import_dependencies(Dependencies) ++ 
+                declare_oauth_initialize_if_required(AuthSettings) ++ 
+                set_token_auth(Req0) ++ 
+                export_dependencies(Dependencies)
+                
+    end ++ export_dependencies(["oauth_initialize_if_required"]),
+    {ok, cowboy_req:reply(200, #{<<"content-type">> => <<"text/javascript; charset=utf-8">>}, JSContent, Req0), State}.
 
-oauth_initialize_if_required() ->
-  ["function oauth_initialize_if_required() { return oauth_initialize(" ,
-    rabbit_json:encode(rabbit_mgmt_format:format_nulls(rabbit_mgmt_wm_auth:authSettings())) , ") }" ].
+declare_oauth_initialize_if_required(AuthSettings) ->
+    case proplists:get_value(oauth_enabled, AuthSettings, false) of 
+        true ->  ["export default function oauth_initialize_if_required(state) { ",
+                "let oauth = oauth_initialize(", rabbit_json:encode(rabbit_mgmt_format:format_nulls(AuthSettings)), "); ", 
+                "if (!oauth.enabled) return oauth;"
+                "switch (state) { case 'login-callback': oauth_completeLogin(); break; case 'logout-callback': oauth_completeLogout(); break; default: oauth = oauth_initiate(oauth);}",
+                "return oauth; }"];
+        false -> ["export default function oauth_initialize_if_required(state) { return {oauth_enabled: false}; }"] 
+    end.
 
 set_token_auth(Req0) ->
-  case application:get_env(rabbitmq_management, oauth_enabled, false) of
-    true ->
-      case cowboy_req:parse_header(<<"authorization">>, Req0) of
-        {bearer, Token} ->  ["set_token_auth('", Token, "');"];
-        _ -> []
-      end;
-    false -> []
-  end.
+    case application:get_env(rabbitmq_management, oauth_enabled, false) of
+        true ->
+            case cowboy_req:parse_header(<<"authorization">>, Req0) of
+                {bearer, Token} ->  ["set_token_auth('", Token, "');"];
+                _ -> []
+            end;
+        false -> []
+    end.
+
+import_dependencies(Dependencies) ->
+    ["import {", string:join(Dependencies, ","), "} from './helper.js';"].
+
+oauth_dependencies() ->
+    ["hasAnyResourceServerReady", "oauth_initialize", "oauth_initiate", "oauth_initiateLogin", "oauth_initiateLogout", "oauth_completeLogin", "oauth_completeLogout"].
+
+export_dependencies(Dependencies) ->
+    [ io_lib:format("window.~s = ~s;", [Dep, Dep]) || Dep <- Dependencies ].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
@@ -18,24 +18,18 @@ init(Req0, State) ->
 bootstrap_oauth(Req0, State) ->
     AuthSettings = rabbit_mgmt_wm_auth:authSettings(),
     Dependencies = oauth_dependencies(),
-    JSContent = case proplists:get_value(oauth_enabled, AuthSettings, false) of 
-        false -> declare_oauth_initialize_if_required(AuthSettings); 
-        true -> import_dependencies(Dependencies) ++ 
-                declare_oauth_initialize_if_required(AuthSettings) ++ 
-                set_token_auth(Req0) ++ 
-                export_dependencies(Dependencies)
-                
-    end ++ export_dependencies(["oauth_initialize_if_required"]),
+    JSContent = import_dependencies(Dependencies) ++ 
+                set_oauth_settings(AuthSettings) ++ 
+                case proplists:get_value(oauth_enabled, AuthSettings, false) of             
+                    true -> set_token_auth(Req0) ++ export_dependencies(oauth_dependencies());
+                    false -> export_dependencies(["oauth_initialize_if_required", "set_oauth_settings"])
+                end,
     {ok, cowboy_req:reply(200, #{<<"content-type">> => <<"text/javascript; charset=utf-8">>}, JSContent, Req0), State}.
 
-declare_oauth_initialize_if_required(AuthSettings) ->
+set_oauth_settings(AuthSettings) ->    
     case proplists:get_value(oauth_enabled, AuthSettings, false) of 
-        true ->  ["export default function oauth_initialize_if_required(state) { ",
-                "let oauth = oauth_initialize(", rabbit_json:encode(rabbit_mgmt_format:format_nulls(AuthSettings)), "); ", 
-                "if (!oauth.enabled) return oauth;"
-                "switch (state) { case 'login-callback': oauth_completeLogin(); break; case 'logout-callback': oauth_completeLogout(); break; default: oauth = oauth_initiate(oauth);}",
-                "return oauth; }"];
-        false -> ["export default function oauth_initialize_if_required(state) { return {oauth_enabled: false}; }"] 
+        true ->  ["set_oauth_settings(", rabbit_json:encode(rabbit_mgmt_format:format_nulls(AuthSettings)), "); "];
+        false -> ["set_oauth_settings({oauth_enabled: false});"] 
     end.
 
 set_token_auth(Req0) ->
@@ -52,7 +46,7 @@ import_dependencies(Dependencies) ->
     ["import {", string:join(Dependencies, ","), "} from './helper.js';"].
 
 oauth_dependencies() ->
-    ["hasAnyResourceServerReady", "oauth_initialize", "oauth_initiate", "oauth_initiateLogin", "oauth_initiateLogout", "oauth_completeLogin", "oauth_completeLogout"].
+    ["oauth_initialize_if_required", "hasAnyResourceServerReady", "oauth_initialize", "oauth_initiate", "oauth_initiateLogin", "oauth_initiateLogout", "oauth_completeLogin", "oauth_completeLogout", "set_oauth_settings"].
 
 export_dependencies(Dependencies) ->
     [ io_lib:format("window.~s = ~s;", [Dep, Dep]) || Dep <- Dependencies ].

--- a/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_oauth_bootstrap.erl
@@ -27,10 +27,8 @@ bootstrap_oauth(Req0, State) ->
     {ok, cowboy_req:reply(200, #{<<"content-type">> => <<"text/javascript; charset=utf-8">>}, JSContent, Req0), State}.
 
 set_oauth_settings(AuthSettings) ->    
-    case proplists:get_value(oauth_enabled, AuthSettings, false) of 
-        true ->  ["set_oauth_settings(", rabbit_json:encode(rabbit_mgmt_format:format_nulls(AuthSettings)), "); "];
-        false -> ["set_oauth_settings({oauth_enabled: false});"] 
-    end.
+    JsonAuthSettings = rabbit_json:encode(rabbit_mgmt_format:format_nulls(AuthSettings)),
+    ["set_oauth_settings(", JsonAuthSettings, ");"].
 
 set_token_auth(Req0) ->
     case application:get_env(rabbitmq_management, oauth_enabled, false) of

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -444,7 +444,7 @@ auth_test(Config) ->
     %% because user/password are ok, tags are not
     test_auth(Config, ?NOT_AUTHORISED, [auth_header("user", "user")]),
     WrongAuthResponseHeaders = test_auth(Config, ?NOT_AUTHORISED, [auth_header("guest", "gust")]),
-    ?assertEqual(true, lists:keymember("www-authenticate", 1,  WrongAuthResponseHeaders)),
+    %?assertEqual(true, lists:keymember("www-authenticate", 1,  WrongAuthResponseHeaders)),
     test_auth(Config, ?OK, [auth_header("guest", "guest")]),
     http_delete(Config, "/users/user", {group, '2xx'}),
     passed.

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -265,7 +265,8 @@ internal_user(User) ->
 
 user(User) ->
     [{name, User#user.username},
-     {tags, tags_as_binaries(User#user.tags)}].
+     {tags, tags_as_binaries(User#user.tags)},
+     {backends, [ Module || {Module, _} <- User#user.authz_backends]}].
 
 tags_as_binaries(Tags) ->
     [to_binary(T) || T <- Tags].

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -263,10 +263,11 @@ internal_user(User) ->
      {tags,              tags_as_binaries(internal_user:get_tags(User))},
      {limits,            internal_user:get_limits(User)}].
 
-user(User) ->
+user(User) ->    
     [{name, User#user.username},
      {tags, tags_as_binaries(User#user.tags)},
-     {backends, [ Module || {Module, _} <- User#user.authz_backends]}].
+     {is_internal_user, lists:any(fun({Module,_}) -> Module == rabbit_auth_backend_internal  end, 
+                                    User#user.authz_backends)}].
 
 tags_as_binaries(Tags) ->
     [to_binary(T) || T <- Tags].

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
@@ -277,15 +277,8 @@ halt_response(Code, Type, Reason, ReqData, Context) ->
         rabbit_json:encode(Json), ReqData),
     {stop, ReqData1, Context}.
 
-not_authenticated(Reason, ReqData, Context,
-                  #auth_settings{auth_realm = AuthRealm} = AuthConfig) ->
-    case is_oauth2_enabled(AuthConfig) of
-      false ->
-            ReqData1 = cowboy_req:set_resp_header(<<"www-authenticate">>, AuthRealm, ReqData),
-            halt_response(401, not_authorized, Reason, ReqData1, Context);
-       true ->
-            halt_response(401, not_authorized, Reason, ReqData, Context)
-    end.
+not_authenticated(Reason, ReqData, Context, _AuthConfig) ->
+    halt_response(401, not_authorized, Reason, ReqData, Context).
 
 format_reason(Tuple) when is_tuple(Tuple) ->
     tuple(Tuple);
@@ -366,6 +359,3 @@ log_access_control_result(NotOK) ->
 
 is_basic_auth_disabled(#auth_settings{basic_auth_enabled = Enabled}) ->
     not Enabled.
-
-is_oauth2_enabled(#auth_settings{oauth2_enabled = Enabled}) ->
-    Enabled.


### PR DESCRIPTION
## Proposed Changes

It addresses one issue raised and two more issues found but not raised:
- https://github.com/rabbitmq/rabbitmq-server/issues/11421
- the  logged in user's name should only be a hyperlink to the user's record when the user is an administrator and it has been authenticated with the internal backend. In other words, if the user was authenticated with oauth or ldap or http, there is no internal record of the user hence the username should not be rendered as a hyperlink.
- disable browser login dialog-box and instead always redirect the user to the login html page when either the credentials are wrong or user is not authorized  or session has expired  

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

