### PR TITLE
Reduce default maximum message size to 16MB

### DIFF
--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -105,14 +105,20 @@ stop_amqp10_client_app(Config) ->
 init_per_group(rabbitmq, Config0) ->
     Config = rabbit_ct_helpers:set_config(Config0,
                                           {sasl, {plain, <<"guest">>, <<"guest">>}}),
-    rabbit_ct_helpers:run_steps(Config, rabbit_ct_broker_helpers:setup_steps());
+    Config1 = rabbit_ct_helpers:merge_app_env(Config,
+                                              [{rabbit,
+                                                [{max_message_size, 134217728}]}]),
+    rabbit_ct_helpers:run_steps(Config1, rabbit_ct_broker_helpers:setup_steps());
+
 init_per_group(rabbitmq_strict, Config0) ->
     Config = rabbit_ct_helpers:set_config(Config0,
                                           {sasl, {plain, <<"guest">>, <<"guest">>}}),
     Config1 = rabbit_ct_helpers:merge_app_env(Config,
                                               [{rabbit,
-                                                [{amqp1_0_default_user, none}]}]),
+                                                [{amqp1_0_default_user, none},
+                                                 {max_message_size, 134217728}]}]),
     rabbit_ct_helpers:run_steps(Config1, rabbit_ct_broker_helpers:setup_steps());
+
 init_per_group(activemq, Config0) ->
     Config = rabbit_ct_helpers:set_config(Config0, {sasl, anon}),
     rabbit_ct_helpers:run_steps(Config,

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -129,8 +129,8 @@ _APP_ENV = """[
 	    {default_consumer_prefetch, {false, 0}},
 		%% interval at which the channel can perform periodic actions
 	    {channel_tick_interval, 60000},
-	    %% Default max message size is 128 MB
-	    {max_message_size, 134217728},
+	    %% Default max message size is 16 MB
+	    {max_message_size, 16777216},
 	    %% Socket writer will run GC every 1 GB of outgoing data
 	    {writer_gc_threshold, 1000000000},
 	    %% interval at which connection/channel tracking executes post operations

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -112,8 +112,8 @@ define PROJECT_ENV
 	    {default_consumer_prefetch, {false, 0}},
 		  %% interval at which the channel can perform periodic actions
 	    {channel_tick_interval, 60000},
-	    %% Default max message size is 128 MB
-	    {max_message_size, 134217728},
+	    %% Default max message size is 16 MB
+	    {max_message_size, 16777216},
 	    %% Socket writer will run GC every 1 GB of outgoing data
 	    {writer_gc_threshold, 1000000000},
 	    %% interval at which connection/channel tracking executes post operations


### PR DESCRIPTION
Following this discussion https://github.com/rabbitmq/rabbitmq-server/issues/11187 we are setting the default maximum message size to 16MB.

This is just a default, and can be increased or decreased through the configuration setting `rabbit.max_message_size`.

Closes #11187.