### PR TITLE
make: Fix circular dependency

### DIFF
--- a/deps/rabbitmq_amqp1_0/Makefile
+++ b/deps/rabbitmq_amqp1_0/Makefile
@@ -1,8 +1,6 @@
 PROJECT = rabbitmq_amqp1_0
 PROJECT_DESCRIPTION = Deprecated no-op AMQP 1.0 plugin
 
-DEPS = rabbit
-
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 


### PR DESCRIPTION
Running "make -C deps/rabbit ct-feature_flags_v2" on a clean repository would not work due to a circular dependency. Since the plugin in question is a no-op in 4.x, only used in tests, we make the plugin depend on nothing to avoid the issue.

This shouldn't be backported to 3.x because there this is a real plugin.