### PR TITLE
Handle unknown QQ state

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -404,7 +404,8 @@ all_replica_states() ->
                              {K, promotable};
                          ({K, follower, non_voter}) ->
                              {K, non_voter};
-                         ({K, S, voter}) ->
+                         ({K, S, _}) ->
+                             %% voter or unknown
                              {K, S};
                          (T) ->
                              T

--- a/deps/rabbit/test/unit_quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/unit_quorum_queue_SUITE.erl
@@ -53,16 +53,18 @@ all_replica_states_includes_nonvoters(_Config) ->
                           {q1, leader, voter},
                           {q2, follower, voter},
                           {q3, follower, promotable},
+                          {q4, init, unknown},
                           %% pre ra-2.7.0
-                          {q4, leader},
-                          {q5, follower}
+                          {q5, leader},
+                          {q6, follower}
                          ]),
     {_, #{
           q1 := leader,
           q2 := follower,
           q3 := promotable,
-          q4 := leader,
-          q5 := follower
+          q4 := init,
+          q5 := leader,
+          q6 := follower
          }} = rabbit_quorum_queue:all_replica_states(),
 
     true = ets:delete(ra_state),


### PR DESCRIPTION
ra_state may contain a QQ state such as {'foo',init,unknown}. Before this fix, all_replica_states did not map such states to a 2-tuple which leads to a crash in maps:from_list because a 3-tuple can't be handled.

A crash in rabbit_quorum_queue:all_replica_states leads to no results being returned from a given node when the CLI asks for QQs with minimum quorum.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/11514