### PR TITLE
GET /api/definitions now returns virtual host metadata

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -254,7 +254,7 @@ export_name(_Name)                -> true.
 
 rw_state() ->
     [{users,              [name, password_hash, hashing_algorithm, tags, limits]},
-     {vhosts,             [name]},
+     {vhosts,             [name, description, tags, default_queue_type, metadata]},
      {permissions,        [user, vhost, configure, write, read]},
      {topic_permissions,  [user, vhost, exchange, write, read]},
      {parameters,         [vhost, component, name, value]},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhosts.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhosts.erl
@@ -55,7 +55,7 @@ augment(Basic, ReqData) ->
 
 augmented(ReqData, #context{user = User}) ->
     case rabbit_mgmt_util:disable_stats(ReqData) of
-        false ->            
+        false ->
             rabbit_mgmt_db:augment_vhosts(
               [rabbit_vhost:info(V) || V <- rabbit_mgmt_util:list_visible_vhosts(User)],
               rabbit_mgmt_util:range(ReqData));
@@ -64,4 +64,4 @@ augmented(ReqData, #context{user = User}) ->
     end.
 
 basic() ->
-    rabbit_vhost:info_all([name]).
+    rabbit_vhost:info_all([name, description, tags, default_queue_type, metadata]).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -118,6 +118,7 @@ all_tests() -> [
     definitions_server_named_queue_test,
     definitions_with_charset_test,
     definitions_default_queue_type_test,
+    definitions_vhost_metadata_test,
     long_definitions_test,
     long_definitions_multipart_test,
     aliveness_test,
@@ -454,7 +455,6 @@ auth_test(Config) ->
     %% NOTE: this one won't have www-authenticate in the response,
     %% because user/password are ok, tags are not
     test_auth(Config, ?NOT_AUTHORISED, [auth_header("user", "user")]),
-    WrongAuthResponseHeaders = test_auth(Config, ?NOT_AUTHORISED, [auth_header("guest", "gust")]),
     %?assertEqual(true, lists:keymember("www-authenticate", 1,  WrongAuthResponseHeaders)),
     test_auth(Config, ?OK, [auth_header("guest", "guest")]),
     http_delete(Config, "/users/user", {group, '2xx'}),
@@ -1889,6 +1889,48 @@ defs_default_queue_type_vhost(Config, QueueType) ->
     %% And check whether it was indeed created with the default type
     Q = http_get(Config, "/queues/test-vhost/test-queue", ?OK),
     ?assertEqual(QueueType, maps:get(type, Q)),
+
+    %% Remove the test vhost
+    http_delete(Config, "/vhosts/test-vhost", {group, '2xx'}),
+    ok.
+
+definitions_vhost_metadata_test(Config) ->
+    register_parameters_and_policy_validator(Config),
+
+    VHostName = <<"test-vhost">>,
+    Desc = <<"Created by definitions_vhost_metadata_test">>,
+    DQT = <<"quorum">>,
+    Tags = [<<"one">>, <<"tag-two">>],
+    Metadata = #{
+        description => Desc,
+        default_queue_type => DQT,
+        tags => Tags
+    },
+
+    %% Create a test vhost
+    http_put(Config, "/vhosts/test-vhost", Metadata, {group, '2xx'}),
+    PermArgs = [{configure, <<".*">>}, {write, <<".*">>}, {read, <<".*">>}],
+    http_put(Config, "/permissions/test-vhost/guest", PermArgs, {group, '2xx'}),
+
+    %% Get the definitions
+    Definitions = http_get(Config, "/definitions", ?OK),
+
+    %% Check if vhost definition is correct
+    VHosts = maps:get(vhosts, Definitions),
+    {value, VH} = lists:search(fun(VH) ->
+                                   maps:get(name, VH) =:= VHostName
+                               end, VHosts),
+    ct:pal("VHost: ~p", [VH]),
+    ?assertEqual(#{
+        name => VHostName,
+        description => Desc,
+        default_queue_type => DQT,
+        tags => Tags,
+        metadata => Metadata
+    }, VH),
+
+    %% Post the definitions back
+    http_post(Config, "/definitions", Definitions, {group, '2xx'}),
 
     %% Remove the test vhost
     http_delete(Config, "/vhosts/test-vhost", {group, '2xx'}),


### PR DESCRIPTION
Closes #10515.
References #11454.
