### PR TITLE
Tracing: expose directory path setting as tracing.dir

### DIFF
--- a/deps/rabbitmq_tracing/BUILD.bazel
+++ b/deps/rabbitmq_tracing/BUILD.bazel
@@ -90,6 +90,10 @@ eunit(
 broker_for_integration_suites()
 
 rabbitmq_integration_suite(
+    name = "config_schema_SUITE",
+)
+
+rabbitmq_integration_suite(
     name = "rabbit_tracing_SUITE",
 )
 

--- a/deps/rabbitmq_tracing/BUILD.bazel
+++ b/deps/rabbitmq_tracing/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@rules_erlang//:eunit2.bzl", "eunit")
 load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
+load("//:rabbitmq_home.bzl", "rabbitmq_home")
+load("//:rabbitmq_run.bzl", "rabbitmq_run")
 load(
     "//:rabbitmq.bzl",
     "BROKER_VERSION_REQUIREMENTS_ANY",

--- a/deps/rabbitmq_tracing/app.bzl
+++ b/deps/rabbitmq_tracing/app.bzl
@@ -129,3 +129,11 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp_client:erlang_app", "//deps/rabbitmq_ct_helpers:erlang_app"],
     )
+    erlang_bytecode(
+        name = "config_schema_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/config_schema_SUITE.erl"],
+        outs = ["test/config_schema_SUITE.beam"],
+        app_name = "rabbitmq_tracing",
+        erlc_opts = "//:test_erlc_opts",
+    )

--- a/deps/rabbitmq_tracing/app.bzl
+++ b/deps/rabbitmq_tracing/app.bzl
@@ -82,6 +82,7 @@ def all_srcs(name = "all_srcs"):
     filegroup(
         name = "priv",
         srcs = [
+            "priv/schema/rabbitmq_tracing.schema",
             "priv/www/js/tmpl/traces.ejs",
             "priv/www/js/tracing.js",
         ],

--- a/deps/rabbitmq_tracing/priv/schema/rabbitmq_tracing.schema
+++ b/deps/rabbitmq_tracing/priv/schema/rabbitmq_tracing.schema
@@ -1,0 +1,10 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+{mapping, "tracing.dir", "rabbitmq_tracing.directory", [
+    {datatype, string},
+    {validators, ["dir_writable"]}]}.

--- a/deps/rabbitmq_tracing/priv/schema/rabbitmq_tracing.schema
+++ b/deps/rabbitmq_tracing/priv/schema/rabbitmq_tracing.schema
@@ -8,3 +8,11 @@
 {mapping, "tracing.dir", "rabbitmq_tracing.directory", [
     {datatype, string},
     {validators, ["dir_writable"]}]}.
+
+{mapping, "tracing.username", "rabbitmq_tracing.username", [
+    {datatype, string}
+]}.
+
+{mapping, "tracing.password", "rabbitmq_tracing.password", [
+    {datatype, string}
+]}.

--- a/deps/rabbitmq_tracing/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_tracing/test/config_schema_SUITE.erl
@@ -1,0 +1,55 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(config_schema_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+        run_snippets
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:run_setup_steps(Config),
+    rabbit_ct_config_schema:init_schemas(rabbitmq_tracing, Config1).
+
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase}
+    ]),
+    rabbit_ct_helpers:run_steps(Config1,
+        rabbit_ct_broker_helpers:setup_steps() ++
+        rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+        rabbit_ct_client_helpers:teardown_steps() ++
+        rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+run_snippets(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+        ?MODULE, run_snippets1, [Config]).
+
+run_snippets1(Config) ->
+    rabbit_ct_config_schema:run_snippets(Config).
+

--- a/deps/rabbitmq_tracing/test/config_schema_SUITE_data/rabbitmq_tracing.snippets
+++ b/deps/rabbitmq_tracing/test/config_schema_SUITE_data/rabbitmq_tracing.snippets
@@ -1,0 +1,15 @@
+[
+    {tracing_username,
+        "tracing.username = generated-93da9f621",
+        [{rabbitmq_tracing, [
+            {username, "generated-93da9f621"}
+        ]}],
+        [rabbitmq_trust_store]},
+
+    {tracing_password,
+        "tracing.password = 6bc258e9eac005659a84afcc41be61d93da9f621",
+        [{rabbitmq_tracing, [
+            {password, "6bc258e9eac005659a84afcc41be61d93da9f621"}
+        ]}],
+        [rabbitmq_tracing]}
+].


### PR DESCRIPTION
in `rabbitmq.conf` using the same validator `log.dir` uses, and a similar
configuration key:

``` ini
tracing.dir = /path/to/a/writeable/directory
```

The error produced when the directory specified is not
writeable looks like this:

```
[error] <0.164.0> tracing.dir invalid, Directory must be writable
[error] <0.164.0> Error preparing configuration in phase validation:
[error] <0.164.0>   - tracing.dir invalid, Directory must be writable
```

Note that the path setting is not covered by the tests because
the test would have to use a writeable directory,
and it is not obvious what kind of cross-platform
path that is not computed programmatically they
could use.

It's a trivial schema file that uses an existing
core validator => let's leave it as is.

Closes #11554.