### PR TITLE
make: Better restrict FAST_RUN_BROKER

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -165,14 +165,7 @@ virgin-node-tmpdir:
 ifdef LEAVE_PLUGINS_DISABLED
 RABBITMQ_ENABLED_PLUGINS ?=
 else
-# When running "make -C deps/plugin run-broker" we only want
-# "plugin" to be enabled. See rabbitmq-components.mk for where
-# this variable comes from.
-ifdef deps_dir_overriden
-RABBITMQ_ENABLED_PLUGINS ?= $(filter-out rabbit,$(PROJECT))
-else
 RABBITMQ_ENABLED_PLUGINS ?= ALL
-endif
 endif
 
 # --------------------------------------------------------------------

--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -98,11 +98,18 @@ RABBITMQ_ENABLED_PLUGINS_FILE ?= $(call node_enabled_plugins_file,$(RABBITMQ_NOD
 RABBITMQ_LOG ?= debug,+color
 export RABBITMQ_LOG
 
-FAST_RUN_BROKER ?= 1
+FAST_RUN_BROKER ?= $(if $(filter run-broker run-tls-broker start-brokers start-cluster,$(MAKECMDGOALS)),1,0)
 
 ifeq ($(FAST_RUN_BROKER),1)
 DIST_TARGET = $(if $(NOBUILD),,all)
 PLUGINS_FROM_DEPS_DIR = 1
+
+# When running "make -C deps/plugin run-broker" we only want
+# "plugin" to be enabled. See rabbitmq-components.mk for where
+# this variable comes from.
+ifdef deps_dir_overriden
+RABBITMQ_ENABLED_PLUGINS ?= $(filter-out rabbit,$(PROJECT))
+endif
 endif
 
 ifdef PLUGINS_FROM_DEPS_DIR

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -746,7 +746,6 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
       {"RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=+S 2 +sbwt very_short +A 24 ~ts", [AdditionalErlArgs]},
       "RABBITMQ_LOG=debug",
       "RMQCTL_WAIT_TIMEOUT=180",
-      "FAST_RUN_BROKER=0",
       {"TEST_TMPDIR=~ts", [PrivDir]}
       | ExtraArgs],
     Cmd = ["start-background-broker" | MakeVars],


### PR DESCRIPTION
Enable by default only when run-broker, run-tls-broker, start-brokers or start-cluster is explicitly used.

Should avoid issues with running the broker in tests.

I will work on some refactoring to ensure we can easily iterate dev run-broker without risking breaking tests.