### PR TITLE
Fix message IDs settlement order

### DIFF
--- a/deps/amqp10_common/src/serial_number.erl
+++ b/deps/amqp10_common/src/serial_number.erl
@@ -59,10 +59,7 @@ compare(A, B) ->
     [serial_number()].
 usort(L) ->
     lists:usort(fun(A, B) ->
-                        case compare(A, B) of
-                            greater -> false;
-                            _ -> true
-                        end
+                        compare(A, B) =/= greater
                 end, L).
 
 %% Takes a list of serial numbers and returns tuples

--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -403,6 +403,10 @@ rabbitmq_integration_suite(
 )
 
 rabbitmq_integration_suite(
+    name = "amqpl_consumer_ack_SUITE",
+)
+
+rabbitmq_integration_suite(
     name = "message_containers_deaths_v2_SUITE",
     size = "medium",
     shard_count = 1,

--- a/deps/rabbit/app.bzl
+++ b/deps/rabbit/app.bzl
@@ -2134,3 +2134,12 @@ def test_suite_beam_files(name = "test_suite_beam_files"):
         erlc_opts = "//:test_erlc_opts",
         deps = ["//deps/amqp_client:erlang_app"],
     )
+    erlang_bytecode(
+        name = "amqpl_consumer_ack_SUITE_beam_files",
+        testonly = True,
+        srcs = ["test/amqpl_consumer_ack_SUITE.erl"],
+        outs = ["test/amqpl_consumer_ack_SUITE.beam"],
+        app_name = "rabbit",
+        erlc_opts = "//:test_erlc_opts",
+        deps = ["//deps/amqp_client:erlang_app"],
+    )

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1972,7 +1972,7 @@ collect_acks(AcknowledgedAcc, RemainingAcc, UAMQ, DeliveryTag, Multiple) ->
     end.
 
 %% Settles (acknowledges) messages at the queue replica process level.
-%% This happens in the youngest-first order (ascending by delivery tag).
+%% This happens in the oldest-first order (ascending by delivery tag).
 settle_acks(Acks, State = #ch{queue_states = QueueStates0}) ->
     {QueueStates, Actions} =
         foreach_per_queue(

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -275,9 +275,7 @@ cancel(Q, ConsumerTag, OkMsg, ActingUser, State) ->
 -spec settle(rabbit_amqqueue:name(), rabbit_queue_type:settle_op(),
              rabbit_types:ctag(), [non_neg_integer()], state()) ->
     {state(), rabbit_queue_type:actions()}.
-settle(_QName, Op, _CTag, MsgIds0, State = #?STATE{pid = Pid}) ->
-    %% Classic queues expect message IDs in sorted order.
-    MsgIds = lists:usort(MsgIds0),
+settle(_QName, Op, _CTag, MsgIds, State = #?STATE{pid = Pid}) ->
     Arg = case Op of
               complete ->
                   {ack, MsgIds, self()};

--- a/deps/rabbit/src/rabbit_queue_consumers.erl
+++ b/deps/rabbit/src/rabbit_queue_consumers.erl
@@ -40,8 +40,8 @@
 %% channel record
 -record(cr, {ch_pid,
              monitor_ref,
-             acktags,
-             consumer_count,
+             acktags :: ?QUEUE:?QUEUE({ack(), rabbit_types:ctag() | none}),
+             consumer_count :: non_neg_integer(),
              %% Queue of {ChPid, #consumer{}} for consumers which have
              %% been blocked (rate/prefetch limited) for any reason
              blocked_consumers,

--- a/deps/rabbit/test/amqpl_consumer_ack_SUITE.erl
+++ b/deps/rabbit/test/amqpl_consumer_ack_SUITE.erl
@@ -1,0 +1,259 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+%%
+
+-module(amqpl_consumer_ack_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+-compile([nowarn_export_all,
+          export_all]).
+
+-import(rabbit_ct_broker_helpers,
+        [rpc/4]).
+-import(rabbit_ct_helpers,
+        [eventually/3]).
+
+all() ->
+    [
+     {group, tests}
+    ].
+
+groups() ->
+    [
+     {tests, [shuffle],
+      [
+       requeue_one_channel_classic_queue,
+       requeue_one_channel_quorum_queue,
+       requeue_two_channels_classic_queue,
+       requeue_two_channels_quorum_queue
+      ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:merge_app_env(
+      Config, {rabbit, [{quorum_tick_interval, 1000}]}).
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(_Group, Config) ->
+    Nodes = 1,
+    Suffix = rabbit_ct_helpers:testcase_absname(Config, "", "-"),
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [{rmq_nodes_count, Nodes},
+                         {rmq_nodename_suffix, Suffix}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+requeue_one_channel_classic_queue(Config) ->
+    requeue_one_channel(<<"classic">>, Config).
+
+requeue_one_channel_quorum_queue(Config) ->
+    requeue_one_channel(<<"quorum">>, Config).
+
+requeue_one_channel(QType, Config) ->
+    QName = atom_to_binary(?FUNCTION_NAME),
+    Ctag = <<"my consumer tag">>,
+    Ch = rabbit_ct_client_helpers:open_channel(Config),
+
+    #'queue.declare_ok'{} = amqp_channel:call(
+                              Ch,
+                              #'queue.declare'{
+                                 queue = QName,
+                                 durable = true,
+                                 arguments = [{<<"x-queue-type">>, longstr, QType}]}),
+
+    amqp_channel:subscribe(Ch,
+                           #'basic.consume'{queue = QName,
+                                            consumer_tag = Ctag},
+                           self()),
+
+    receive #'basic.consume_ok'{consumer_tag = Ctag} -> ok
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+
+    [begin
+         amqp_channel:cast(
+           Ch,
+           #'basic.publish'{routing_key = QName},
+           #amqp_msg{payload = integer_to_binary(N)})
+     end || N <- lists:seq(1, 4)],
+
+    receive {#'basic.deliver'{},
+             #amqp_msg{payload = <<"1">>}} -> ok
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    receive {#'basic.deliver'{},
+             #amqp_msg{payload = <<"2">>}} -> ok
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    D3 = receive {#'basic.deliver'{delivery_tag = Del3},
+                  #amqp_msg{payload = <<"3">>}} -> Del3
+         after 5000 -> ct:fail({missing_event, ?LINE})
+         end,
+    receive {#'basic.deliver'{},
+             #amqp_msg{payload = <<"4">>}} -> ok
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    assert_messages(QName, 4, 4, Config),
+
+    %% Requeue the first 3 messages.
+    amqp_channel:cast(Ch, #'basic.nack'{delivery_tag = D3,
+                                        requeue = true,
+                                        multiple = true}),
+
+    %% First 3 messages should be redelivered.
+    receive {#'basic.deliver'{},
+             #amqp_msg{payload = P1}} ->
+                ?assertEqual(<<"1">>, P1)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    receive {#'basic.deliver'{},
+             #amqp_msg{payload = P2}} ->
+                ?assertEqual(<<"2">>, P2)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    D3b = receive {#'basic.deliver'{delivery_tag = Del3b},
+                   #amqp_msg{payload = P3}} ->
+                      ?assertEqual(<<"3">>, P3),
+                      Del3b
+          after 5000 -> ct:fail({missing_event, ?LINE})
+          end,
+    assert_messages(QName, 4, 4, Config),
+
+    %% Ack all 4 messages.
+    amqp_channel:cast(Ch, #'basic.ack'{delivery_tag = D3b,
+                                       multiple = true}),
+    assert_messages(QName, 0, 0, Config),
+
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch, #'queue.delete'{queue = QName})).
+
+requeue_two_channels_classic_queue(Config) ->
+    requeue_two_channels(<<"classic">>, Config).
+
+requeue_two_channels_quorum_queue(Config) ->
+    requeue_two_channels(<<"quorum">>, Config).
+
+requeue_two_channels(QType, Config) ->
+    QName = atom_to_binary(?FUNCTION_NAME),
+    Ctag1 = <<"consumter tag 1">>,
+    Ctag2 = <<"consumter tag 2">>,
+    Ch1 = rabbit_ct_client_helpers:open_channel(Config),
+    Ch2 = rabbit_ct_client_helpers:open_channel(Config),
+
+    #'queue.declare_ok'{} = amqp_channel:call(
+                              Ch1,
+                              #'queue.declare'{
+                                 queue = QName,
+                                 durable = true,
+                                 arguments = [{<<"x-queue-type">>, longstr, QType}]}),
+
+    amqp_channel:subscribe(Ch1,
+                           #'basic.consume'{queue = QName,
+                                            consumer_tag = Ctag1},
+                           self()),
+
+    receive #'basic.consume_ok'{consumer_tag = Ctag1} -> ok
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+
+    amqp_channel:subscribe(Ch2,
+                           #'basic.consume'{queue = QName,
+                                            consumer_tag = Ctag2},
+                           self()),
+    receive #'basic.consume_ok'{consumer_tag = Ctag2} -> ok
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+
+    [begin
+         amqp_channel:cast(
+           Ch1,
+           #'basic.publish'{routing_key = QName},
+           #amqp_msg{payload = integer_to_binary(N)})
+     end || N <- lists:seq(1,4)],
+
+    %% Queue should deliver round robin.
+    receive {#'basic.deliver'{consumer_tag = C1},
+             #amqp_msg{payload = <<"1">>}} ->
+                ?assertEqual(Ctag1, C1)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    receive {#'basic.deliver'{consumer_tag = C2},
+             #amqp_msg{payload = <<"2">>}} ->
+                ?assertEqual(Ctag2, C2)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    receive {#'basic.deliver'{consumer_tag = C3},
+             #amqp_msg{payload = <<"3">>}} ->
+                ?assertEqual(Ctag1, C3)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    receive {#'basic.deliver'{consumer_tag = C4},
+             #amqp_msg{payload = <<"4">>}} ->
+                ?assertEqual(Ctag2, C4)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    assert_messages(QName, 4, 4, Config),
+
+    %% Closing Ch1 should cause both messages to be requeued and delivered to the Ch2.
+    ok = rabbit_ct_client_helpers:close_channel(Ch1),
+
+    receive {#'basic.deliver'{consumer_tag = C5},
+             #amqp_msg{payload = <<"1">>}} ->
+                ?assertEqual(Ctag2, C5)
+    after 5000 -> ct:fail({missing_event, ?LINE})
+    end,
+    DelTag = receive {#'basic.deliver'{consumer_tag = C6,
+                                       delivery_tag = D},
+                      #amqp_msg{payload = <<"3">>}} ->
+                         ?assertEqual(Ctag2, C6),
+                         D
+             after 5000 -> ct:fail({missing_event, ?LINE})
+             end,
+    assert_messages(QName, 4, 4, Config),
+
+    %% Ch2 acks all 4 messages
+    amqp_channel:cast(Ch2, #'basic.ack'{delivery_tag = DelTag,
+                                        multiple = true}),
+    assert_messages(QName, 0, 0, Config),
+
+    ?assertMatch(#'queue.delete_ok'{},
+                 amqp_channel:call(Ch2, #'queue.delete'{queue = QName})).
+
+assert_messages(QNameBin, NumTotalMsgs, NumUnackedMsgs, Config) ->
+    Vhost = ?config(rmq_vhost, Config),
+    eventually(
+      ?_assertEqual(
+         lists:sort([{messages, NumTotalMsgs}, {messages_unacknowledged, NumUnackedMsgs}]),
+         begin
+             {ok, Q} = rpc(Config, rabbit_amqqueue, lookup, [QNameBin, Vhost]),
+             Infos = rpc(Config, rabbit_amqqueue, info, [Q, [messages, messages_unacknowledged]]),
+             lists:sort(Infos)
+         end
+        ), 500, 5).


### PR DESCRIPTION
 ## What?

This commit fixes issues that were present only on `main` branch and were introduced by #9022.

1. Classic queues (specifically `rabbit_queue_consumers:subtract_acks/3`) expect message IDs to be (n)acked in the order as they were delivered to the channel / session proc. Hence, the `lists:usort(MsgIds0)` in `rabbit_classic_queue:settle/5` was wrong causing not all messages to be acked adding a regression to also AMQP 0.9.1.
2. The order in which the session proc requeues or rejects multiple message IDs at once is important. For example, if the client sends a DISPOSITION with first=3 and last=5, the message IDs corresponding to delivery IDs 3,4,5 must be requeued or rejected in exactly that order. For example, quorum queues use this order of message IDs in https://github.com/rabbitmq/rabbitmq-server/blob/34d3f943742bdcf7d34859edff8d45f35e4007d4/deps/rabbit/src/rabbit_fifo.erl#L226-L234 to dead letter in that order.

 ## How?

The session proc will settle (internal) message IDs to queues in ascending (AMQP) delivery ID order, i.e. in the order messages were sent to the client and in the order messages were settled by the client.

This commit chooses to keep the session's outgoing_unsettled_map map data structure.

An alternative would have been to use a queue or lqueue for the outgoing_unsettled_map as done in
* https://github.com/rabbitmq/rabbitmq-server/blob/34d3f943742bdcf7d34859edff8d45f35e4007d4/deps/rabbit/src/rabbit_channel.erl#L135
* https://github.com/rabbitmq/rabbitmq-server/blob/34d3f943742bdcf7d34859edff8d45f35e4007d4/deps/rabbit/src/rabbit_queue_consumers.erl#L43

Whether a queue (as done by `rabbit_channel`) or a map (as done by `rabbit_amqp_session`) performs better depends on the pattern how clients ack messages.

A queue will likely perform good enough because usually the oldest delivered messages will be acked first.
However, given that there can be many different consumers on an AQMP 0.9.1 channel or AMQP 1.0 session, this commit favours a map because it will likely generate less garbage and is very efficient when for example a single new message (or few new messages) gets acked while many (older) messages are still checked out by the session (but by possibly different AMQP 1.0 receivers).