### PR TITLE
Actions: use a secondary cache bucket for mixed versions tests.

### DIFF
--- a/.github/workflows/templates/test-mixed-versions.template.yaml
+++ b/.github/workflows/templates/test-mixed-versions.template.yaml
@@ -106,9 +106,9 @@ jobs:
       if: env.exists != 'true'
       working-directory: secondary-umbrella
       run: |
-        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME }}" ]; then
+        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME_MIXED }}" ]; then
         cat << EOF >> user.bazelrc
-          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME }}
+          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME_MIXED }}
           build --google_default_credentials
 
           build --remote_download_toplevel

--- a/.github/workflows/test-mixed-versions.yaml
+++ b/.github/workflows/test-mixed-versions.yaml
@@ -84,9 +84,9 @@ jobs:
       if: env.exists != 'true'
       working-directory: secondary-umbrella
       run: |
-        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME }}" ]; then
+        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME_MIXED }}" ]; then
         cat << EOF >> user.bazelrc
-          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME }}
+          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME_MIXED }}
           build --google_default_credentials
 
           build --remote_download_toplevel

--- a/.github/workflows/test-plugin-mixed.yaml
+++ b/.github/workflows/test-plugin-mixed.yaml
@@ -15,7 +15,7 @@ on:
         default: 1
         type: number
     secrets:
-      REMOTE_CACHE_BUCKET_NAME:
+      REMOTE_CACHE_BUCKET_NAME_MIXED:
         required: true
       REMOTE_CACHE_CREDENTIALS_JSON:
         required: true
@@ -56,9 +56,9 @@ jobs:
         credentials_json: ${{ secrets.REMOTE_CACHE_CREDENTIALS_JSON }}
     - name: CONFIGURE BAZEL
       run: |
-        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME }}" ]; then
+        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME_MIXED }}" ]; then
         cat << EOF >> user.bazelrc
-          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME }}
+          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME_MIXED }}
           build --google_default_credentials
 
           build --experimental_guard_against_concurrent_changes


### PR DESCRIPTION
To hopefully reduce the amount of write limiting seen in ci.
