### PR TITLE
Classic queue removes consumer

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -1231,7 +1231,10 @@ handle_control(Detach = #'v1_0.detach'{handle = ?UINT(HandleInt)},
                       %% and we ideally disallow "updating" an AMQP consumer.
                       %% If such an API is not added, we also must return messages in the outgoing_pending queue
                       %% which haven't made it to the outgoing_unsettled map yet.
-                      case rabbit_queue_type:cancel(Q, Ctag, undefined, Username, QStates0) of
+                      Spec = #{consumer_tag => Ctag,
+                               reason => remove,
+                               user => Username},
+                      case rabbit_queue_type:cancel(Q, Spec, QStates0) of
                           {ok, QStates1} ->
                               {Unsettled1, MsgIds} = remove_link_from_outgoing_unsettled_map(Ctag, Unsettled0),
                               case MsgIds of

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -285,9 +285,9 @@
           %% However, they are buffered here due to session flow control
           %% (when remote_incoming_window <= 0) before being sent to the AMQP client.
           %%
-          %% FLOW frames are stored here as well because for a specific outgoing link the order
-          %% in which we send TRANSFER and FLOW frames is important. An outgoing FLOW frame with link flow
-          %% control information must not overtake a TRANSFER frame for the same link just because
+          %% FLOW frames (and credit reply actions) are stored here as well because for a specific outgoing link
+          %% the order in which we send TRANSFER and FLOW frames is important. An outgoing FLOW frame with link
+          %% flow control information must not overtake a TRANSFER frame for the same link just because
           %% we are throttled by session flow control. (However, we can still send outgoing FLOW frames
           %% that contain only session flow control information, i.e. where the FLOW's 'handle' field is not set.)
           %% Example:
@@ -296,8 +296,8 @@
           %% client (once the remote_incoming_window got opened) followed by the FLOW with drain=true and credit=0
           %% and advanced delivery count. Otherwise, we would violate the AMQP protocol spec.
           outgoing_pending = queue:new() :: queue:queue(#pending_delivery{} |
-                                                        #pending_management_delivery{} |
                                                         rabbit_queue_type:credit_reply_action() |
+                                                        #pending_management_delivery{} |
                                                         #'v1_0.flow'{}),
 
           %% The link or session endpoint assigns each message a unique delivery-id
@@ -757,7 +757,8 @@ destroy_links(#resource{kind = queue,
               GrantCredits0,
               #state{incoming_links = IncomingLinks0,
                      outgoing_links = OutgoingLinks0,
-                     outgoing_unsettled_map = Unsettled0} = State0) ->
+                     outgoing_unsettled_map = Unsettled0,
+                     outgoing_pending = Pending0} = State0) ->
     {Frames1,
      GrantCredits,
      IncomingLinks} = maps:fold(fun(Handle, Link, Acc) ->
@@ -765,15 +766,20 @@ destroy_links(#resource{kind = queue,
                                 end, {Frames0, GrantCredits0, IncomingLinks0}, IncomingLinks0),
     {Frames,
      Unsettled,
+     Pending,
      OutgoingLinks} = maps:fold(fun(Handle, Link, Acc) ->
                                         destroy_outgoing_link(Handle, Link, QNameBin, Acc)
-                                end, {Frames1, Unsettled0, OutgoingLinks0}, OutgoingLinks0),
+                                end, {Frames1, Unsettled0, Pending0, OutgoingLinks0}, OutgoingLinks0),
     State = State0#state{incoming_links = IncomingLinks,
                          outgoing_links = OutgoingLinks,
-                         outgoing_unsettled_map = Unsettled},
+                         outgoing_unsettled_map = Unsettled,
+                         outgoing_pending = Pending},
     {Frames, GrantCredits, State}.
 
-destroy_incoming_link(Handle, Link = #incoming_link{queue_name_bin = QNameBin}, QNameBin, {Frames, GrantCreds, Links}) ->
+destroy_incoming_link(Handle,
+                      Link = #incoming_link{queue_name_bin = QNameBin},
+                      QNameBin,
+                      {Frames, GrantCreds, Links}) ->
     {[detach(Handle, Link, ?V_1_0_AMQP_ERROR_RESOURCE_DELETED) | Frames],
      %% Don't grant credits for a link that we destroy.
      maps:remove(Handle, GrantCreds),
@@ -781,10 +787,14 @@ destroy_incoming_link(Handle, Link = #incoming_link{queue_name_bin = QNameBin}, 
 destroy_incoming_link(_, _, _, Acc) ->
     Acc.
 
-destroy_outgoing_link(Handle, Link = #outgoing_link{queue_name = #resource{name = QNameBin}}, QNameBin, {Frames, Unsettled0, Links}) ->
-    {Unsettled, _RemovedMsgIds} = remove_link_from_outgoing_unsettled_map(Handle, Unsettled0),
+destroy_outgoing_link(Handle,
+                      Link = #outgoing_link{queue_name = #resource{name = QNameBin}},
+                      QNameBin,
+                      {Frames, Unsettled0, Pending0, Links}) ->
+    {Unsettled, Pending} = remove_outgoing_link(Handle, Unsettled0, Pending0),
     {[detach(Handle, Link, ?V_1_0_AMQP_ERROR_RESOURCE_DELETED) | Frames],
      Unsettled,
+     Pending,
      maps:remove(Handle, Links)};
 destroy_outgoing_link(_, _, _, Acc) ->
     Acc.
@@ -1203,70 +1213,43 @@ handle_control(#'v1_0.flow'{handle = Handle} = Flow,
     {noreply, S};
 
 handle_control(Detach = #'v1_0.detach'{handle = ?UINT(HandleInt)},
-               State0 = #state{queue_states = QStates0,
-                               incoming_links = IncomingLinks,
+               State0 = #state{incoming_links = IncomingLinks,
                                outgoing_links = OutgoingLinks0,
                                outgoing_unsettled_map = Unsettled0,
+                               outgoing_pending = Pending0,
+                               queue_states = QStates0,
                                cfg = #cfg{user = #user{username = Username}}}) ->
-    Ctag = handle_to_ctag(HandleInt),
-    %% TODO delete queue if closed flag is set to true? see 2.6.6
-    %% TODO keep the state around depending on the lifetime
-    {QStates, Unsettled, OutgoingLinks}
-    = case maps:take(HandleInt, OutgoingLinks0) of
-          {#outgoing_link{queue_name = QName}, OutgoingLinks1} ->
-              case rabbit_amqqueue:lookup(QName) of
-                  {ok, Q} ->
-                      %%TODO Add a new rabbit_queue_type:remove_consumer API that - from the point of view of
-                      %% the queue process - behaves as if our session process terminated: All messages checked out
-                      %% to this consumer should be re-queued automatically instead of us requeueing them here after cancelling
-                      %% consumption.
-                      %% For AMQP legacy (and STOMP / MQTT) consumer cancellation not requeueing messages is a good approach as
-                      %% clients may want to ack any in-flight messages.
-                      %% For AMQP however, the consuming client can stop cancellations via link-credit=0 and drain=true being
-                      %% sure that no messages are in flight before detaching the link. Hence, AMQP doesn't need the
-                      %% rabbit_queue_type:cancel API semantics.
-                      %% A rabbit_queue_type:remove_consumer API has also the advantage to simplify reasoning about clients
-                      %% first detaching and then re-attaching to the same session with the same link handle (the handle
-                      %% becomes available for re-use once a link is closed): This will result in the same consumer tag,
-                      %% and we ideally disallow "updating" an AMQP consumer.
-                      %% If such an API is not added, we also must return messages in the outgoing_pending queue
-                      %% which haven't made it to the outgoing_unsettled map yet.
-                      Spec = #{consumer_tag => Ctag,
-                               reason => remove,
-                               user => Username},
-                      case rabbit_queue_type:cancel(Q, Spec, QStates0) of
-                          {ok, QStates1} ->
-                              {Unsettled1, MsgIds} = remove_link_from_outgoing_unsettled_map(Ctag, Unsettled0),
-                              case MsgIds of
-                                  [] ->
-                                      {QStates1, Unsettled0, OutgoingLinks1};
-                                  _ ->
-                                      case rabbit_queue_type:settle(QName, requeue, Ctag, MsgIds, QStates1) of
-                                          {ok, QStates2, _Actions = []} ->
-                                              {QStates2, Unsettled1, OutgoingLinks1};
-                                          {protocol_error, _ErrorType, Reason, ReasonArgs} ->
-                                              protocol_error(?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                                             Reason, ReasonArgs)
-                                      end
-                              end;
-                          {error, Reason} ->
-                              protocol_error(
-                                ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                "Failed to cancel consuming from ~s: ~tp",
-                                [rabbit_misc:rs(amqqueue:get_name(Q)), Reason])
-                      end;
-                  {error, not_found} ->
-                      {Unsettled1, _RemovedMsgIds} = remove_link_from_outgoing_unsettled_map(Ctag, Unsettled0),
-                      {QStates0, Unsettled1, OutgoingLinks1}
-              end;
-          error ->
-              {Unsettled1, _RemovedMsgIds} = remove_link_from_outgoing_unsettled_map(Ctag, Unsettled0),
-              {QStates0, Unsettled1, OutgoingLinks0}
-      end,
-    State1 = State0#state{queue_states = QStates,
-                          incoming_links = maps:remove(HandleInt, IncomingLinks),
+    {OutgoingLinks, Unsettled, Pending, QStates} =
+    case maps:take(HandleInt, OutgoingLinks0) of
+        {#outgoing_link{queue_name = QName}, OutgoingLinks1} ->
+            Ctag = handle_to_ctag(HandleInt),
+            {Unsettled1, Pending1} = remove_outgoing_link(Ctag, Unsettled0, Pending0),
+            case rabbit_amqqueue:lookup(QName) of
+                {ok, Q} ->
+                    Spec = #{consumer_tag => Ctag,
+                             reason => remove,
+                             user => Username},
+                    case rabbit_queue_type:cancel(Q, Spec, QStates0) of
+                        {ok, QStates1} ->
+                            {OutgoingLinks1, Unsettled1, Pending1, QStates1};
+                        {error, Reason} ->
+                            protocol_error(
+                              ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
+                              "Failed to remove consumer from ~s: ~tp",
+                              [rabbit_misc:rs(amqqueue:get_name(Q)), Reason])
+                    end;
+                {error, not_found} ->
+                    {OutgoingLinks1, Unsettled1, Pending1, QStates0}
+            end;
+        error ->
+            {OutgoingLinks0, Unsettled0, Pending0, QStates0}
+    end,
+
+    State1 = State0#state{incoming_links = maps:remove(HandleInt, IncomingLinks),
                           outgoing_links = OutgoingLinks,
-                          outgoing_unsettled_map = Unsettled},
+                          outgoing_unsettled_map = Unsettled,
+                          outgoing_pending = Pending,
+                          queue_states = QStates},
     State = maybe_detach_mgmt_link(HandleInt, State1),
     maybe_detach_reply(Detach, State, State0),
     publisher_or_consumer_deleted(State, State0),
@@ -3102,23 +3085,30 @@ queue_is_durable(undefined) ->
     %% [3.5.3]
     queue_is_durable(?V_1_0_TERMINUS_DURABILITY_NONE).
 
--spec remove_link_from_outgoing_unsettled_map(link_handle() | rabbit_types:ctag(), Map) ->
-    {Map, [rabbit_amqqueue:msg_id()]}
+-spec remove_outgoing_link(link_handle() | rabbit_types:ctag(), Map, queue:queue()) ->
+    {Map, queue:queue()}
       when Map :: #{delivery_number() => #outgoing_unsettled{}}.
-remove_link_from_outgoing_unsettled_map(Handle, Map)
+remove_outgoing_link(Handle, Map, Queue)
   when is_integer(Handle) ->
-    remove_link_from_outgoing_unsettled_map(handle_to_ctag(Handle), Map);
-remove_link_from_outgoing_unsettled_map(Ctag, Map)
+    Ctag = handle_to_ctag(Handle),
+    remove_outgoing_link(Ctag, Map, Queue);
+remove_outgoing_link(Ctag, OutgoingUnsettledMap0, OutgoingPending0)
   when is_binary(Ctag) ->
-    maps:fold(fun(DeliveryId,
-                  #outgoing_unsettled{consumer_tag = Tag,
-                                      msg_id = Id},
-                  {M, Ids})
-                    when Tag =:= Ctag ->
-                      {maps:remove(DeliveryId, M), [Id | Ids]};
-                 (_, _, Acc) ->
-                      Acc
-              end, {Map, []}, Map).
+    OutgoingUnsettledMap = maps:filter(
+                             fun(_DeliveryId, #outgoing_unsettled{consumer_tag = Tag}) ->
+                                     Tag =/= Ctag
+                             end, OutgoingUnsettledMap0),
+    OutgoingPending = queue:filter(
+                        fun(#pending_delivery{outgoing_unsettled = #outgoing_unsettled{consumer_tag = Tag}}) ->
+                                Tag =/= Ctag;
+                           ({credit_reply, Tag, _DeliveryCount, _Credit, _Available, _Drain}) ->
+                                Tag =/= Ctag;
+                           (#pending_management_delivery{}) ->
+                                true;
+                           (#'v1_0.flow'{}) ->
+                                true
+                        end, OutgoingPending0),
+    {OutgoingUnsettledMap, OutgoingPending}.
 
 messages_received(Settled) ->
     rabbit_global_counters:messages_received(?PROTOCOL, 1),

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -30,7 +30,7 @@
 -export([list_by_type/1, sample_local_queues/0, sample_n_by_name/2, sample_n/2]).
 -export([force_event_refresh/1, notify_policy_changed/1]).
 -export([consumers/1, consumers_all/1,  emit_consumers_all/4, consumer_info_keys/0]).
--export([basic_get/5, basic_consume/12, basic_cancel/5, notify_decorators/1]).
+-export([basic_get/5, basic_consume/12, notify_decorators/1]).
 -export([notify_sent/2, notify_sent_queue_down/1, resume/2]).
 -export([notify_down_all/2, notify_down_all/3, activate_limit_all/2]).
 -export([on_node_up/1, on_node_down/1]).
@@ -1741,14 +1741,6 @@ basic_consume(Q, NoAck, ChPid, LimiterPid,
              ok_msg => OkMsg,
              acting_user =>  ActingUser},
     rabbit_queue_type:consume(Q, Spec, QStates).
-
--spec basic_cancel(amqqueue:amqqueue(), rabbit_types:ctag(), any(),
-                   rabbit_types:username(),
-                   rabbit_queue_type:state()) ->
-    {ok, rabbit_queue_type:state()} | {error, term()}.
-basic_cancel(Q, ConsumerTag, OkMsg, ActingUser, QStates) ->
-    rabbit_queue_type:cancel(Q, ConsumerTag,
-                             OkMsg, ActingUser, QStates).
 
 -spec notify_decorators(amqqueue:amqqueue()) -> 'ok'.
 

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1428,8 +1428,9 @@ handle_method(#'basic.cancel'{consumer_tag = ConsumerTag, nowait = NoWait},
                    fun () -> {error, not_found} end,
                    fun () ->
                            rabbit_queue_type:cancel(
-                             Q, ConsumerTag, ok_msg(NoWait, OkMsg),
-                             Username, QueueStates0)
+                             Q, #{consumer_tag => ConsumerTag,
+                                  ok_msg => ok_msg(NoWait, OkMsg),
+                                  user => Username}, QueueStates0)
                    end) of
                 {ok, QueueStates} ->
                     rabbit_global_counters:consumer_deleted(amqp091),

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -37,7 +37,7 @@
          close/1,
          update/2,
          consume/3,
-         cancel/5,
+         cancel/3,
          handle_event/3,
          deliver/3,
          settle/5,
@@ -262,7 +262,9 @@ consume_backwards_compat({credited, credit_api_v1}, Args) ->
      [{<<"x-credit">>, table, [{<<"credit">>, long, 0},
                                {<<"drain">>,  bool, false}]} | Args]}.
 
-cancel(Q, ConsumerTag, OkMsg, ActingUser, State) ->
+cancel(Q, #{consumer_tag := ConsumerTag,
+            user := ActingUser} = Spec, State) ->
+    OkMsg = maps:get(ok_msg, Spec, undefined),
     QPid = amqqueue:get_pid(Q),
     case delegate:invoke(QPid, {gen_server2, call,
                                 [{basic_cancel, self(), ConsumerTag,

--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -167,7 +167,7 @@
 
 -rabbit_feature_flag(
    {credit_api_v2,
-    #{desc          => "Credit API v2 between queue clients and queue processes",
+    #{desc          => "Credit and cancel API v2 between queue clients and queue processes",
       stability     => stable
      }}).
 

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -808,7 +808,7 @@ purge_node(Meta, Node, State, Effects) ->
                         {S, E0 ++ E}
                 end, {State, Effects}, all_pids_for(Node, State)).
 
-%% any downs that re not noconnection
+%% any downs that are not noconnection
 handle_down(Meta, Pid, #?MODULE{consumers = Cons0,
                                 enqueuers = Enqs0} = State0) ->
     % Remove any enqueuer for the down pid

--- a/deps/rabbit/src/rabbit_queue_consumers.erl
+++ b/deps/rabbit/src/rabbit_queue_consumers.erl
@@ -8,7 +8,7 @@
 -module(rabbit_queue_consumers).
 
 -export([new/0, max_active_priority/1, inactive/1, all/1, all/3, count/0,
-         unacknowledged_message_count/0, add/9, remove/3, erase_ch/2,
+         unacknowledged_message_count/0, add/9, remove/4, erase_ch/2,
          deliver/5, record_ack/3, subtract_acks/3,
          possibly_unblock/3,
          resume_fun/0, notify_sent_fun/1, activate_limit_fun/0,
@@ -176,29 +176,43 @@ add(ChPid, CTag, NoAck, LimiterPid, LimiterActive,
     State#state{consumers = add_consumer({ChPid, Consumer}, Consumers),
                 use       = update_use(CUInfo, active)}.
 
--spec remove(ch(), rabbit_types:ctag(), state()) ->
-                    'not_found' | state().
-
-remove(ChPid, CTag, State = #state{consumers = Consumers}) ->
+-spec remove(ch(), rabbit_types:ctag(), rabbit_queue_type:cancel_reason(), state()) ->
+    not_found | {[ack()], state()}.
+remove(ChPid, CTag, Reason, State = #state{consumers = Consumers}) ->
     case lookup_ch(ChPid) of
         not_found ->
             not_found;
-        C = #cr{consumer_count    = Count,
-                limiter           = Limiter,
+        C = #cr{acktags = AckTags0,
+                consumer_count = Count,
+                limiter = Limiter,
                 blocked_consumers = Blocked,
                 link_states = LinkStates} ->
-            Blocked1 = remove_consumer(ChPid, CTag, Blocked),
+            {Acks, AckTags} = case Reason of
+                                  remove ->
+                                      AckTags1 = ?QUEUE:to_list(AckTags0),
+                                      {AckTags2, AckTags3} = lists:partition(
+                                                               fun({_, Tag})
+                                                                     when Tag =:= CTag ->
+                                                                       true;
+                                                                  (_) ->
+                                                                       false
+                                                               end, AckTags1),
+                                      {lists:map(fun({Ack, _}) -> Ack end, AckTags2),
+                                       ?QUEUE:from_list(AckTags3)};
+                                  _ ->
+                                      {[], AckTags0}
+                              end,
             Limiter1 = case Count of
                            1 -> rabbit_limiter:deactivate(Limiter);
                            _ -> Limiter
                        end,
             Limiter2 = rabbit_limiter:forget_consumer(Limiter1, CTag),
-            update_ch_record(C#cr{consumer_count    = Count - 1,
-                                  limiter           = Limiter2,
-                                  blocked_consumers = Blocked1,
+            update_ch_record(C#cr{acktags = AckTags,
+                                  consumer_count = Count - 1,
+                                  limiter = Limiter2,
+                                  blocked_consumers = remove_consumer(ChPid, CTag, Blocked),
                                   link_states = maps:remove(CTag, LinkStates)}),
-            State#state{consumers =
-                        remove_consumer(ChPid, CTag, Consumers)}
+            {Acks, State#state{consumers = remove_consumer(ChPid, CTag, Consumers)}}
     end.
 
 -spec erase_ch(ch(), state()) ->

--- a/deps/rabbit/src/rabbit_queue_consumers.erl
+++ b/deps/rabbit/src/rabbit_queue_consumers.erl
@@ -191,11 +191,8 @@ remove(ChPid, CTag, Reason, State = #state{consumers = Consumers}) ->
                                   remove ->
                                       AckTags1 = ?QUEUE:to_list(AckTags0),
                                       {AckTags2, AckTags3} = lists:partition(
-                                                               fun({_, Tag})
-                                                                     when Tag =:= CTag ->
-                                                                       true;
-                                                                  (_) ->
-                                                                       false
+                                                               fun({_, Tag}) ->
+                                                                       Tag =:= CTag
                                                                end, AckTags1),
                                       {lists:map(fun({Ack, _}) -> Ack end, AckTags2),
                                        ?QUEUE:from_list(AckTags3)};

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -126,8 +126,9 @@
                           args => rabbit_framing:amqp_table(),
                           ok_msg := term(),
                           acting_user := rabbit_types:username()}.
+-type cancel_reason() :: cancel | remove.
 -type cancel_spec() :: #{consumer_tag := rabbit_types:ctag(),
-                         reason => cancel | remove,
+                         reason => cancel_reason(),
                          ok_msg => term(),
                          user := rabbit_types:username()}.
 
@@ -139,6 +140,7 @@
 -export_type([state/0,
               consume_mode/0,
               consume_spec/0,
+              cancel_reason/0,
               cancel_spec/0,
               delivery_options/0,
               credit_reply_action/0,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -24,7 +24,7 @@
          delete/4,
          delete_immediately/1]).
 -export([state_info/1, info/2, stat/1, infos/1, infos/2]).
--export([settle/5, dequeue/5, consume/3, cancel/5]).
+-export([settle/5, dequeue/5, consume/3, cancel/3]).
 -export([credit_v1/5, credit/6]).
 -export([purge/1]).
 -export([stateless_deliver/2, deliver/3]).
@@ -912,8 +912,8 @@ consume(Q, Spec, QState0) when ?amqqueue_is_quorum(Q) ->
             {ok, QState}
     end.
 
-cancel(_Q, ConsumerTag, OkMsg, _ActingUser, State) ->
-    maybe_send_reply(self(), OkMsg),
+cancel(_Q, #{consumer_tag := ConsumerTag} = Spec, State) ->
+    maybe_send_reply(self(), maps:get(ok_msg, Spec, undefined)),
     rabbit_fifo_client:cancel_checkout(quorum_ctag(ConsumerTag), State).
 
 emit_consumer_created(ChPid, CTag, Exclusive, AckRequired, QName, PrefetchCount, Args, Ref, ActingUser) ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -48,7 +48,7 @@
          close/1,
          update/2,
          consume/3,
-         cancel/5,
+         cancel/3,
          handle_event/3,
          settle/5,
          credit_v1/5,
@@ -269,8 +269,8 @@ update(A1,A2) ->
 consume(A1,A2,A3) ->
     ?UNSUPPORTED([A1,A2,A3]).
 
-cancel(A1,A2,A3,A4,A5) ->
-    ?UNSUPPORTED([A1,A2,A3,A4,A5]).
+cancel(A1,A2,A3) ->
+    ?UNSUPPORTED([A1,A2,A3]).
 
 handle_event(A1,A2,A3) ->
     ?UNSUPPORTED([A1,A2,A3]).


### PR DESCRIPTION
 ## What?

The rabbit_queue_type API has allowed to cancel a consumer.
Cancelling a consumer merely stops the queue sending more messages
to the consumer. However, messages checked out to the cancelled consumer
remain checked out until acked by the client. It's up to the client when
and whether it wants to ack the remaining checked out messages.

For AMQP 0.9.1, this behaviour is necessary because the client may
receive messages between the point in time it sends the basic.cancel
request and the point in time it receives the basic.cancel_ok response.

AMQP 1.0 is a better designed protocol because a receiver can stop a
link as shown in figure 2.46.
After a link is stopped, the client knows that the queue won't deliver
any more messages.
Once the link is stopped, the client can subsequently detach the link.

This commit extends the rabbit_queue_type API to allow a consumer being
immediately removed:
1. Any checked out messages to that receiver will be requeued by the
   queue. (As explained previously, a client that first stops a link
   by sending a FLOW with `link_credit=0` and `echo=true` and waiting
   for the FLOW reply from the server and settles any messages before
   it sends the DETACH frame, won't have any checked out messages).
2. The queue entirely forgets this consumer and therefore stops
   delivering messages to the receiver.

This new behaviour of consumer removal is similar to what happens when
an AMQP 0.9.1 channel is closed: All checked out messages to that
channel will be requeued.

 ## Why?

Removing the consumer immediately simplifies many aspects:
1. The server session process doesn't need to requeue any checked out
   messages for the receiver when the receiver detaches the link.
   Specifically, messages in the outgoing_unsettled_map and
   outgoing_pending queue don't need to be requeued because the queue
   takes care of requeueing any checked out messages.
2. It simplifies reasoning about clients first detaching and then
   re-attaching in the same session with the same link handle (the handle
   becomes available for re-use once a link is closed): This will result
   in the same RabbitMQ queue consumer tag.
3. It simplifies queue implementations since state needs to be hold and
   special logic needs to be applied to consumers that are only
   cancelled (basic.cancel AMQP 0.9.1) but not removed.
4. It makes the single active consumer feature safer when it comes to
   maintaining message order: If a client cancels consumption via AMQP
   0.9.1 basic.cancel, but still has in-flight checked out messages,
   the queue will activate the next consumer. If the AMQP 0.9.1 client
   shortly after crashes, messages to the old consumer will be requeued
   which results in messages being out of order. To maintain message order,
   an AMQP 0.9.1 client must close the whole channel such that messages
   are requeued before the next consumer is activated.
   For AMQP 1.0, the client can either stop the link first (preferred)
   or detach the link directly. Detaching the link will requeue all
   messages before activating the next consumer, therefore maintaining
   message order. In this sense, the AMQP 1.0 implementation allows for the
   single active consumer to gracefully handoff consumption to the next consumer.
   Even if the session crashes, message order will be maintained. 

  ## How?

`rabbit_queue_type:cancel` accepts a spec as argument.
The new interaction between session proc and classic queue proc (let's
call it cancel API v2) must be hidden behind a feature flag.
This commit re-uses feature flag credit_api_v2 since it also gets
introduced in 4.0.