### PR TITLE
Remove x-cancel-on-ha-failover

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -877,7 +877,6 @@ declare_args() ->
      {<<"x-queue-leader-locator">>, fun check_queue_leader_locator_arg/2}].
 
 consume_args() -> [{<<"x-priority">>,              fun check_int_arg/2},
-                   {<<"x-cancel-on-ha-failover">>, fun check_bool_arg/2},
                    {<<"x-stream-offset">>, fun check_stream_offset_arg/2}].
 
 check_int_arg({Type, _}, _) ->

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1752,19 +1752,7 @@ handle_consuming_queue_down_or_eol(QName,
                    end,
     gb_sets:fold(
       fun (CTag, StateN = #ch{consumer_mapping = CMap}) ->
-              case queue_down_consumer_action(CTag, CMap) of
-                  remove ->
-                      cancel_consumer(CTag, QName, StateN);
-                  {recover, {NoAck, ConsumerPrefetch, Exclusive, Args}} ->
-                      case catch basic_consume(
-                                   QName, NoAck, ConsumerPrefetch, CTag,
-                                   Exclusive, Args, true, StateN) of
-                          {ok, StateN1} ->
-                              StateN1;
-                          _Err ->
-                              cancel_consumer(CTag, QName, StateN)
-                      end
-              end
+              cancel_consumer(CTag, QName, StateN)
       end, State#ch{queue_consumers = maps:remove(QName, QCons)}, ConsumerTags).
 
 %% [0] There is a slight danger here that if a queue is deleted and
@@ -1786,13 +1774,6 @@ cancel_consumer(CTag, QName,
                                            {channel,      self()},
                                            {queue,        QName}]),
     State#ch{consumer_mapping = maps:remove(CTag, CMap)}.
-
-queue_down_consumer_action(CTag, CMap) ->
-    {_, {_, _, _, Args} = ConsumeSpec} = maps:get(CTag, CMap),
-    case rabbit_misc:table_lookup(Args, <<"x-cancel-on-ha-failover">>) of
-        {bool, true} -> remove;
-        _            -> {recover, ConsumeSpec}
-    end.
 
 binding_action_with_checks(
   Action, SourceNameBin0, DestinationType, DestinationNameBin0,

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1751,7 +1751,7 @@ handle_consuming_queue_down_or_eol(QName,
                        {ok, CTags} -> CTags
                    end,
     gb_sets:fold(
-      fun (CTag, StateN = #ch{consumer_mapping = CMap}) ->
+      fun (CTag, StateN = #ch{}) ->
               cancel_consumer(CTag, QName, StateN)
       end, State#ch{queue_consumers = maps:remove(QName, QCons)}, ConsumerTags).
 

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -511,8 +511,7 @@ capabilities() ->
                           <<"x-overflow">>, <<"x-queue-mode">>, <<"x-queue-version">>,
                           <<"x-single-active-consumer">>, <<"x-queue-type">>,
                           <<"x-queue-master-locator">>],
-      consumer_arguments => [<<"x-cancel-on-ha-failover">>,
-                             <<"x-priority">>, <<"x-credit">>],
+      consumer_arguments => [<<"x-priority">>, <<"x-credit">>],
       server_named => true}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->


### PR DESCRIPTION
Remove `x-cancel-on-ha-failover`and default to cancel as discussed in #9815
Closes #11540
