### PR TITLE
Management UI: Fix internal_server_error args for put vhost failures

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -18,7 +18,8 @@
          is_authorized_vhost_visible_for_monitoring/2,
          is_authorized_global_parameters/2]).
 -export([user/1]).
--export([bad_request/3, service_unavailable/3, bad_request_exception/4, internal_server_error/4,
+-export([bad_request/3, service_unavailable/3, bad_request_exception/4,
+         internal_server_error/3, internal_server_error/4,
          id/2, parse_bool/1, parse_int/1, redirect_to_home/3]).
 -export([with_decode/4, not_found/3]).
 -export([with_channel/4, with_channel/5]).
@@ -673,6 +674,9 @@ not_found(Reason, ReqData, Context) ->
 
 method_not_allowed(Reason, ReqData, Context) ->
     halt_response(405, method_not_allowed, Reason, ReqData, Context).
+
+internal_server_error(Reason, ReqData, Context) ->
+    internal_server_error(internal_server_error, Reason, ReqData, Context).
 
 internal_server_error(Error, Reason, ReqData, Context) ->
     rabbit_log:error("~ts~n~ts", [Error, Reason]),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_vhost.erl
@@ -72,14 +72,18 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
               case rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQT, Trace, Username) of
                   ok ->
                       {true, ReqData, Context};
-                  {error, timeout} = E ->
+                  {error, timeout} ->
                       rabbit_mgmt_util:internal_server_error(
-                        "Timed out while waiting for the vhost to initialise", E,
+                        timeout,
+                        "Timed out waiting for the vhost to initialise",
                         ReqData0, Context);
                   {error, E} ->
+                      Reason = iolist_to_binary(
+                                 io_lib:format(
+                                   "Error occurred while adding vhost: ~tp",
+                                   [E])),
                       rabbit_mgmt_util:internal_server_error(
-                        "Error occured while adding vhost", E,
-                        ReqData0, Context);
+                        Reason, ReqData0, Context);
                   {'EXIT', {vhost_limit_exceeded,
                       Explanation}} ->
                       rabbit_mgmt_util:bad_request(list_to_binary(Explanation), ReqData, Context)


### PR DESCRIPTION
`rabbit_mgmt_util:internal_server_error/4` expects an atom or binary and a string formattable term (`~ts`) as arguments but `rabbit_mgmt_wm_vhost` passes charlists and any term. This can cause a log formatter crash and an unexpected message in the management UI when attempting to add a vhost while a cluster is in a minority with Khepri enabled for example.

We can pass atoms for the `Error` parameter and binaries or strings for the `Reason` parameter to fix both issues.