### PR TITLE
Add logging for when hitting vhost_max and component limits

### DIFF
--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -165,7 +165,11 @@ is_within_limit(Component) ->
     Limit = proplists:get_value(Component, Limits, -1),
     case Limit < 0 orelse count_component(Component) < Limit of
        true -> ok;
-       false -> {errors, [{"component ~ts is limited to ~tp per node", [Component, Limit]}]}
+       false ->
+            ErrorMsg = "Limit reached: component ~ts is limited to ~tp per node",
+            ErrorArgs = [Component, Limit],
+            rabbit_log:error(ErrorMsg, ErrorArgs),
+            {errors, [{"component ~ts is limited to ~tp per node", [Component, Limit]}]}
     end.
 
 count_component(Component) -> length(list_component(Component)).

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -354,6 +354,7 @@ is_over_vhost_limit(Name, Limit) when is_integer(Limit) ->
             ErrorMsg = rabbit_misc:format("cannot create vhost '~ts': "
                                           "vhost limit of ~tp is reached",
                                           [Name, Limit]),
+            rabbit_log:error(ErrorMsg),
             exit({vhost_limit_exceeded, ErrorMsg})
     end.
 


### PR DESCRIPTION
Add log entries when hitting vhost max limit and component limits such as shovels and federation.

Chose to add it on the 'error' level to be similar to the error log entries you get when you hit connection, consumer, queue limits etc.

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
