### PR TITLE
3.13.x only: fix timestamp when recovering x-death header

### DIFF
--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -725,13 +725,15 @@ recover_deaths([Map = #{<<"exchange">> := Exchange,
                         <<"routing-keys">> := RKeys,
                         <<"reason">> := ReasonBin,
                         <<"count">> := Count,
-                        <<"time">> := Ts} | Rem], Acc0) ->
+                        <<"time">> := TsSeconds} | Rem], Acc0)
+  when is_integer(TsSeconds) ->
     Reason = binary_to_existing_atom(ReasonBin),
-    DeathAnns0 = #{first_time => Ts,
+    TsMillis = TsSeconds * 1000,
+    DeathAnns0 = #{first_time => TsMillis,
                    %% Given that this timestamp is absent in the AMQP 0.9.1
                    %% x-death header, the last_time we set here is incorrect
                    %% if the message was dead lettered more than one time.
-                   last_time => Ts},
+                   last_time => TsMillis},
     DeathAnns = case Map of
                     #{<<"original-expiration">> := Exp} ->
                         DeathAnns0#{ttl => binary_to_integer(Exp)};

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -245,6 +245,7 @@ amqpl_death_records(Env) ->
 amqpl_parse_x_death(_Config) ->
     Q = <<"my queue">>,
     DLQ = <<"my dead letter queue">>,
+    Ts = os:system_time(second),
 
     Content0 = #content{class_id = 60,
                         properties = #'P_basic'{headers = [],
@@ -273,7 +274,9 @@ amqpl_parse_x_death(_Config) ->
     ?assertMatch({_, longstr, <<"rejected">>}, header(<<"reason">>, T1)),
     ?assertMatch({_, longstr, Q}, header(<<"queue">>, T1)),
     ?assertMatch({_, longstr, <<"exch">>}, header(<<"exchange">>, T1)),
-    ?assertMatch({_, timestamp, _}, header(<<"time">>, T1)),
+    {_, timestamp, Ts1} = header(<<"time">>, T1),
+    ?assert(Ts1 > Ts - 10),
+    ?assert(Ts1 < Ts + 10),
     ?assertMatch({_, array, [{longstr, <<"apple">>}]}, header(<<"routing-keys">>, T1)),
     ?assertMatch({_, longstr, <<"9999">>}, header(<<"original-expiration">>, T1)),
 


### PR DESCRIPTION
This commit fixes a bug present in 3.13.3 which was introduced by https://github.com/rabbitmq/rabbitmq-server/pull/11339

When an AMQP 0.9.1 client re-publishes a message with the x-death header set, the `time` field was not converted from the AMQP 0.9.1 seconds resolution to the internal millisecond resolution of `mc` fields `first_time` and `last_time`.

Additionally, this commit will ignore invalid `time` fields sent in the `x-death` header from AMQP 0.9.1 clients as reported in https://rabbitmq.slack.com/archives/C1EDN83PA/p1719986557420719 which results in the following crash later on when the message gets consumed:
```
 supervisor: {<0.476725.0>,rabbit_channel_sup}
    errorContext: child_terminated
    reason: {badarith,
                [{erlang,'div',
                     [<<"2024-07-02T02:58:50.000-07:00">>,1000],
                     [{error_info,#{module => erl_erts_errors}}]},
                 {mc_amqpl,death_table,7,[{file,"mc_amqpl.erl"},{line,806}]},
                 {lists,map,2,[{file,"lists.erl"},{line,1559}]},
                 {mc_amqpl,deaths_to_headers,2,
                     [{file,"mc_amqpl.erl"},{line,764}]},
                 {mc_amqpl,protocol_state,2,
                     [{file,"mc_amqpl.erl"},{line,406}]},
                 {rabbit_channel,handle_deliver0,4,
                     [{file,"rabbit_channel.erl"},{line,2685}]},
                 {lists,foldl,3,[{file,"lists.erl"},{line,1594}]},
                 {rabbit_channel,handle_cast,2,
                     [{file,"rabbit_channel.erl"},{line,732}]}]}
```