### PR TITLE
rabbit_runtime_parameters: Remove dead 'value_global/2', 'value/4'

### DIFF
--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -12,7 +12,6 @@
 
 -export([set/2, set/4,
          get/1,
-         get_or_set/2,
          get_all/0, get_all/2,
          delete/1, delete/3,
          delete_vhost/1]).
@@ -156,61 +155,6 @@ get_in_khepri(Key) ->
         []       -> undefined;
         [Record] -> Record
     end.
-
-%% -------------------------------------------------------------------
-%% get_or_set().
-%% -------------------------------------------------------------------
-
--spec get_or_set(Key, Default) -> Ret when
-      Key :: atom() | {vhost:name(), binary(), binary()},
-      Default :: any(),
-      Ret :: #runtime_parameters{}.
-%% @doc Returns a runtime parameter or sets its value if it does not exist.
-%%
-%% @private
-
-get_or_set({VHostName, Comp, Name} = Key, Default)
-  when is_binary(VHostName) andalso
-       is_binary(Comp) andalso
-       (is_binary(Name) orelse is_atom(Name)) ->
-    rabbit_khepri:handle_fallback(
-      #{mnesia => fun() -> get_or_set_in_mnesia(Key, Default) end,
-        khepri => fun() -> get_or_set_in_khepri(Key, Default) end});
-get_or_set(Key, Default) ->
-    rabbit_khepri:handle_fallback(
-      #{mnesia => fun() -> get_or_set_in_mnesia(Key, Default) end,
-        khepri => fun() -> get_or_set_in_khepri(Key, Default) end
-       }).
-
-get_or_set_in_mnesia(Key, Default) ->
-    rabbit_mnesia:execute_mnesia_transaction(
-      fun() -> get_or_set_in_mnesia_tx(Key, Default) end).
-
-get_or_set_in_mnesia_tx(Key, Default) ->
-    case mnesia:read(?MNESIA_TABLE, Key, read) of
-        [Record] ->
-            Record;
-        [] ->
-            Record = #runtime_parameters{key   = Key,
-                                         value = Default},
-            mnesia:write(?MNESIA_TABLE, Record, write),
-            Record
-    end.
-
-get_or_set_in_khepri(Key, Default) ->
-    Path = khepri_rp_path(Key),
-    rabbit_khepri:transaction(
-      fun () ->
-              case khepri_tx:get(Path) of
-                  {ok, undefined} ->
-                      Record = #runtime_parameters{key   = Key,
-                                                   value = Default},
-                      ok = khepri_tx:put(Path, Record),
-                      Record;
-                  {ok, R} ->
-                      R
-              end
-      end).
 
 %% -------------------------------------------------------------------
 %% get_all().

--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -44,10 +44,10 @@
 
 -export([parse_set/5, set/5, set_any/5, clear/4, clear_any/4, list/0, list/1,
          list_component/1, list/2, list_formatted/1, list_formatted/3,
-         lookup/3, value/3, value/4, info_keys/0, clear_vhost/2,
+         lookup/3, value/3, info_keys/0, clear_vhost/2,
          clear_component/2]).
 
--export([parse_set_global/3, set_global/3, value_global/1, value_global/2,
+-export([parse_set_global/3, set_global/3, value_global/1,
          list_global/0, list_global_formatted/0, list_global_formatted/2,
          lookup_global/1, global_info_keys/0, clear_global/2]).
 
@@ -347,19 +347,10 @@ lookup_global(Name)  ->
 
 value(VHost, Comp, Name) -> value0({VHost, Comp, Name}).
 
--spec value(rabbit_types:vhost(), binary(), binary(), term()) -> term().
-
-value(VHost, Comp, Name, Def) -> value0({VHost, Comp, Name}, Def).
-
 -spec value_global(atom()) -> term() | 'not_found'.
 
 value_global(Key) ->
     value0(Key).
-
--spec value_global(atom(), term()) -> term().
-
-value_global(Key, Default) ->
-    value0(Key, Default).
 
 value0(Key) ->
     case lookup0(Key, rabbit_misc:const(not_found)) of
@@ -367,18 +358,11 @@ value0(Key) ->
         Params    -> Params#runtime_parameters.value
     end.
 
-value0(Key, Default) ->
-    Params = lookup0(Key, fun () -> lookup_missing(Key, Default) end),
-    Params#runtime_parameters.value.
-
 lookup0(Key, DefaultFun) ->
     case rabbit_db_rtparams:get(Key) of
         undefined -> DefaultFun();
         Record    -> Record
     end.
-
-lookup_missing(Key, Default) ->
-    rabbit_db_rtparams:get_or_set(Key, Default).
 
 p(#runtime_parameters{key = {VHost, Component, Name}, value = Value}) ->
     [{vhost,     VHost},


### PR DESCRIPTION
`rabbit_runtime_parameters:value_global/2` was only used in `rabbit_nodes:cluster_name/0` since near the beginning of the commit history of the server and its usage was eliminated in 06932b9fcbc (#3085, released in v3.8.17+ and v3.9.0+).

`rabbit_runtime_parameters:value/4` doesn't appear to have been ever used since it was introduced near the beginning of the commit history. It may have been added just to mirror `value_global/2`'s interface.

Eliminating these dead functions allows us to also eliminate a somewhat complicated function `rabbit_db_rtparams:get_or_set/2`.

This change is ported out of #10915 and was introduced there so we don't need to refactor these functions to handle database errors.