### PR TITLE
Use GHA cache for OCI; reenable ARM

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -55,11 +55,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          # These are built on x86 runners in CPU emulation mode, which is very slow
-          # (over an hour to build the image, instead of minutes). It'd be nice to have
-          # these back at some point but for now - they are blocking the publication of
-          # amd64 images
-          # - linux/arm64
+          - linux/arm64
     steps:
       - name: Prepare
         run: |
@@ -108,8 +104,8 @@ jobs:
           context: packaging/docker-image
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-to: type=registry,ref=ghcr.io/rabbitmq/rabbitmq:buildcache-${{ env.PLATFORM_PAIR }},mode=max
-          cache-from: type=registry,ref=ghcr.io/rabbitmq/rabbitmq:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha
+          cache-from: type=gha
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |


### PR DESCRIPTION
OpenSSL and OTP were rebuilt on every OCI build which is wasteful. Additionally, it takes forever to build them for the ARM image, because it is built on an x86 machine with CPU emulation, which is slow.
With these changes, caching should work and since the generic packages is shared between the two images, it should just take a few minutes for the OCI to be built and pushed for both architectures.