### PR TITLE
Upgrade AMQP address format in tests

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -1231,7 +1231,7 @@ rabbitmq_integration_suite(
 rabbitmq_integration_suite(
     name = "amqp_credit_api_v2_SUITE",
     runtime_deps = [
-        "//deps/amqp10_client:erlang_app",
+        "//deps/rabbitmq_amqp_client:erlang_app",
     ],
 )
 

--- a/deps/rabbit/test/amqp_credit_api_v2_SUITE.erl
+++ b/deps/rabbit/test/amqp_credit_api_v2_SUITE.erl
@@ -63,8 +63,8 @@ end_per_testcase(_TestCase, Config) ->
 credit_api_v2(Config) ->
     CQ = <<"classic queue">>,
     QQ = <<"quorum queue">>,
-    CQAddr = <<"/amq/queue/", CQ/binary>>,
-    QQAddr = <<"/amq/queue/", QQ/binary>>,
+    CQAddr = rabbitmq_amqp_address:queue(CQ),
+    QQAddr = rabbitmq_amqp_address:queue(QQ),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config),
     #'queue.declare_ok'{} = amqp_channel:call(Ch, #'queue.declare'{queue = CQ}),


### PR DESCRIPTION
Upgrade AMQP address format in tests from v1 to v2.

We still use AMQP address format v1 when connecting to an old 3.13 node.