### PR TITLE
Take `-setcookie` argument into account for peer args

### DIFF
--- a/deps/rabbit/src/rabbit_peer_discovery.erl
+++ b/deps/rabbit/src/rabbit_peer_discovery.erl
@@ -409,7 +409,12 @@ query_node_props(Nodes) when Nodes =/= [] ->
                     var_origins := #{erlang_cookie := environment}} ->
                       ["-setcookie", atom_to_list(ErlangCookie) | VMArgs1];
                   _ ->
-                      VMArgs1
+                      case init:get_argument(setcookie) of
+                          {ok, [[SetCookieArg]]} ->
+                              ["-setcookie", SetCookieArg | VMArgs1];
+                          _ ->
+                              VMArgs1
+                      end
               end,
     VMArgs3 = maybe_add_proto_dist_arguments(VMArgs2),
     VMArgs4 = maybe_add_inetrc_arguments(VMArgs3),


### PR DESCRIPTION
Fixes issue raised in discussion #11653

The user used the following env var:

```
RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-setcookie FOOBARBAZ"
```

...and the cookie was not passed to the peer node for peer discovery.