### PR TITLE
For 4.0: Require all stable feature flags added up to 3.13.0

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -101,7 +101,7 @@
    {restart_streams,
     #{desc          => "Support for restarting streams with optional preferred next leader argument."
       "Used to implement stream leader rebalancing",
-      stability     => stable,
+      stability     => required,
       depends_on    => [stream_queue]
      }}).
 
@@ -109,14 +109,14 @@
    {stream_sac_coordinator_unblock_group,
     #{desc          => "Bug fix to unblock a group of consumers in a super stream partition",
       doc_url       => "https://github.com/rabbitmq/rabbitmq-server/issues/7743",
-      stability     => stable,
+      stability     => required,
       depends_on    => [stream_single_active_consumer]
      }}).
 
 -rabbit_feature_flag(
    {stream_filtering,
     #{desc          => "Support for stream filtering.",
-      stability     => stable,
+      stability     => required,
       depends_on    => [stream_queue]
      }}).
 
@@ -153,7 +153,7 @@
    {stream_update_config_command,
     #{desc          => "A new internal command that is used to update streams as "
                         "part of a policy.",
-      stability     => stable,
+      stability     => required,
       depends_on    => [stream_queue]
      }}).
 

--- a/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
@@ -632,22 +632,19 @@ handle_consumer_removal(Group0, Consumer, Stream, ConsumerName) ->
 notify_consumer_effect(Pid, SubId, Stream, Name, Active) ->
     notify_consumer_effect(Pid, SubId, Stream, Name, Active, false).
 
-notify_consumer_effect(Pid, SubId, Stream, Name, Active, SteppingDown) ->
-    notify_consumer_effect(Pid, SubId, Stream, Name, Active, SteppingDown, map).
-
-notify_consumer_effect(Pid, SubId, Stream, Name, Active, false = _SteppingDown, map) ->
+notify_consumer_effect(Pid, SubId, Stream, Name, Active, false = _SteppingDown) ->
     mod_call_effect(Pid,
                     {sac, #{subscription_id => SubId,
                             stream => Stream,
                             consumer_name => Name,
                             active => Active}});
-notify_consumer_effect(Pid, SubId, Stream, Name, Active, true = _SteppingDown, map) ->
+notify_consumer_effect(Pid, SubId, Stream, Name, Active, true = SteppingDown) ->
     mod_call_effect(Pid,
                     {sac, #{subscription_id => SubId,
                             stream => Stream,
                             consumer_name => Name,
                             active => Active,
-                            stepping_down => true}}).
+                            stepping_down => SteppingDown}}).
 
 maybe_create_group(VirtualHost,
                    Stream,

--- a/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_sac_coordinator.erl
@@ -629,32 +629,12 @@ handle_consumer_removal(Group0, Consumer, Stream, ConsumerName) ->
             end
     end.
 
-message_type() ->
-    case has_unblock_group_support() of
-        true ->
-            map;
-        false ->
-            tuple
-    end.
-
 notify_consumer_effect(Pid, SubId, Stream, Name, Active) ->
     notify_consumer_effect(Pid, SubId, Stream, Name, Active, false).
 
 notify_consumer_effect(Pid, SubId, Stream, Name, Active, SteppingDown) ->
-    notify_consumer_effect(Pid, SubId, Stream, Name, Active, SteppingDown, message_type()).
+    notify_consumer_effect(Pid, SubId, Stream, Name, Active, SteppingDown, map).
 
-notify_consumer_effect(Pid, SubId, _Stream, _Name, Active, false = _SteppingDown, tuple) ->
-    mod_call_effect(Pid,
-                    {sac,
-                     {{subscription_id, SubId},
-                      {active, Active},
-                      {extra, []}}});
-notify_consumer_effect(Pid, SubId, _Stream, _Name, Active, true = _SteppingDown, tuple) ->
-    mod_call_effect(Pid,
-                    {sac,
-                     {{subscription_id, SubId},
-                      {active, Active},
-                      {extra, [{stepping_down, true}]}}});
 notify_consumer_effect(Pid, SubId, Stream, Name, Active, false = _SteppingDown, map) ->
     mod_call_effect(Pid,
                     {sac, #{subscription_id => SubId,
@@ -776,6 +756,3 @@ mod_call_effect(Pid, Msg) ->
 send_message(ConnectionPid, Msg) ->
     ConnectionPid ! Msg,
     ok.
-
-has_unblock_group_support() ->
-    rabbit_feature_flags:is_enabled(stream_sac_coordinator_unblock_group).

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -3138,7 +3138,6 @@ global_counters(Config) ->
     ok = amqp10_client:close_connection(Connection).
 
 stream_filtering(Config) ->
-    ok = rabbit_ct_broker_helpers:enable_feature_flag(Config, ?FUNCTION_NAME),
     Stream = atom_to_binary(?FUNCTION_NAME),
     Address = rabbitmq_amqp_address:queue(Stream),
     Ch = rabbit_ct_client_helpers:open_channel(Config),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -239,27 +239,10 @@ init_per_group1(Group, Config) ->
         {skip, _} ->
             Ret;
         Config2 ->
-            EnableFF = rabbit_ct_broker_helpers:enable_feature_flag(
-                         Config2, stream_queue),
-            case EnableFF of
-                ok ->
-                    if Clustered ->
-                           rabbit_ct_broker_helpers:enable_feature_flag(
-                             Config2, stream_update_config_command);
-                       true ->
-                           ok
-                    end,
-                    ok = rabbit_ct_broker_helpers:rpc(
-                           Config2, 0, application, set_env,
-                           [rabbit, channel_tick_interval, 100]),
-                    Config2;
-                {skip, _} = Skip ->
-                    end_per_group(Group, Config2),
-                    Skip;
-                Other ->
-                    end_per_group(Group, Config2),
-                    {skip, Other}
-            end
+            ok = rabbit_ct_broker_helpers:rpc(
+                   Config2, 0, application, set_env,
+                   [rabbit, channel_tick_interval, 100]),
+            Config2
     end.
 
 end_per_group(_, Config) ->
@@ -1437,34 +1420,27 @@ tracking_status(Config) ->
     rabbit_ct_broker_helpers:rpc(Config, Server, ?MODULE, delete_testcase_queue, [Q]).
 
 restart_stream(Config) ->
-    case rabbit_ct_broker_helpers:enable_feature_flag(Config, restart_stream) of
-        ok ->
-            [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
-            Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
-            Q = ?config(queue_name, Config),
-            ?assertEqual({'queue.declare_ok', Q, 0, 0},
-                         declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', Q, 0, 0},
+                 declare(Config, Server, Q, [{<<"x-queue-type">>, longstr, <<"stream">>}])),
 
-            publish_confirm(Ch, Q, [<<"msg">>]),
-            Vhost = ?config(rmq_vhost, Config),
-            QName = #resource{virtual_host = Vhost,
-                              kind = queue,
-                              name = Q},
-            %% restart the stream
-            ?assertMatch({ok, _},
-                         rabbit_ct_broker_helpers:rpc(Config, Server,
-                                                      rabbit_stream_coordinator,
-                                                      ?FUNCTION_NAME, [QName])),
+    publish_confirm(Ch, Q, [<<"msg">>]),
+    Vhost = ?config(rmq_vhost, Config),
+    QName = #resource{virtual_host = Vhost,
+                      kind = queue,
+                      name = Q},
+    %% restart the stream
+    ?assertMatch({ok, _},
+                 rabbit_ct_broker_helpers:rpc(Config, Server,
+                                              rabbit_stream_coordinator,
+                                              ?FUNCTION_NAME, [QName])),
 
-            publish_confirm(Ch, Q, [<<"msg2">>]),
-            rabbit_ct_broker_helpers:rpc(Config, Server, ?MODULE, delete_testcase_queue, [Q]),
-            ok;
-        _ ->
-            ct:pal("skipping test ~s as feature flag `restart_stream` not supported",
-                   [?FUNCTION_NAME]),
-            ok
-    end.
+    publish_confirm(Ch, Q, [<<"msg2">>]),
+    rabbit_ct_broker_helpers:rpc(Config, Server, ?MODULE, delete_testcase_queue, [Q]),
+    ok.
 
 format(Config) ->
     %% tests rabbit_stream_queue:format/2
@@ -2817,18 +2793,7 @@ ensure_retention_applied(Config, Server) ->
     rabbit_ct_broker_helpers:rpc(Config, Server, gen_server, call, [osiris_retention, test]).
 
 rebalance(Config) ->
-    case rabbit_ct_broker_helpers:enable_feature_flag(Config, restart_stream) of
-        ok ->
-            rebalance0(Config);
-        _ ->
-            ct:pal("skipping test ~s as feature flag `restart_stream` not supported",
-                   [?FUNCTION_NAME]),
-            ok
-    end.
-
-rebalance0(Config) ->
-    [Server0 | _] =
-        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [Server0 | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
 
     Q1 = <<"st1">>,

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1239,7 +1239,7 @@ recover_after_leader_and_coordinator_kill(Config) ->
 
 
     ct:pal("sys state ~p", [CState]),
-
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]),
     ok.
 
 keep_consuming_on_leader_restart(Config) ->
@@ -2194,6 +2194,7 @@ leader_locator_balanced_maintenance(Config) ->
       end, 60000),
 
     true = rabbit_ct_broker_helpers:unmark_as_being_drained(Config, Server3),
+    rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_queues, [[Q1, Q]]),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 
 select_nodes_with_least_replicas(Config) ->
@@ -2803,20 +2804,20 @@ rebalance(Config) ->
     Q5 = <<"st5">>,
 
     ?assertEqual({'queue.declare_ok', Q1, 0, 0},
-                 declare(Ch, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 3}])),
+                 declare(Config, Server0, Q1, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-initial-cluster-size">>, long, 3}])),
     ?assertEqual({'queue.declare_ok', Q2, 0, 0},
-                 declare(Ch, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 3}])),
+                 declare(Config, Server0, Q2, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-initial-cluster-size">>, long, 3}])),
     ?assertEqual({'queue.declare_ok', Q3, 0, 0},
-                 declare(Ch, Q3, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 3}])),
+                 declare(Config, Server0, Q3, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-initial-cluster-size">>, long, 3}])),
     ?assertEqual({'queue.declare_ok', Q4, 0, 0},
-                 declare(Ch, Q4, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 3}])),
+                 declare(Config, Server0, Q4, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-initial-cluster-size">>, long, 3}])),
     ?assertEqual({'queue.declare_ok', Q5, 0, 0},
-                 declare(Ch, Q5, [{<<"x-queue-type">>, longstr, <<"stream">>},
-                                 {<<"x-initial-cluster-size">>, long, 3}])),
+                 declare(Config, Server0, Q5, [{<<"x-queue-type">>, longstr, <<"stream">>},
+                                               {<<"x-initial-cluster-size">>, long, 3}])),
 
     NumMsgs = 100,
     Data = crypto:strong_rand_bytes(100),

--- a/deps/rabbitmq_stomp/test/system_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/system_SUITE.erl
@@ -103,13 +103,6 @@ init_per_testcase0(publish_unauthorized_error, Config) ->
     StompPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     {ok, ClientFoo} = rabbit_stomp_client:connect(Version, "user", "pass", StompPort),
     rabbit_ct_helpers:set_config(Config, [{client_foo, ClientFoo}]);
-init_per_testcase0(stream_filtering, Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "mixed version clusters are not supported for stream filtering"};
-        _ ->
-            Config
-    end;
 init_per_testcase0(_, Config) ->
     Config.
 

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.hrl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.hrl
@@ -93,7 +93,6 @@
          deliver_version :: rabbit_stream_core:command_version(),
          request_timeout :: pos_integer(),
          outstanding_requests_timer :: undefined | erlang:reference(),
-         filtering_supported :: boolean(),
          %% internal sequence used for publishers
          internal_sequence = 0 :: integer(),
          token_expiry_timer = undefined :: undefined | erlang:reference()}).

--- a/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_utils.erl
@@ -34,7 +34,6 @@
          filter_defined/1,
          filter_spec/1,
          command_versions/0,
-         filtering_supported/0,
          check_super_stream_management_permitted/4,
          offset_lag/4,
          consumer_offset/3]).
@@ -298,14 +297,8 @@ filter_spec(Properties) ->
     end.
 
 command_versions() ->
-    PublishMaxVersion = case filtering_supported() of
-                            false ->
-                                ?VERSION_1;
-                            true ->
-                                ?VERSION_2
-                        end,
     [{declare_publisher, ?VERSION_1, ?VERSION_1},
-     {publish, ?VERSION_1, PublishMaxVersion},
+     {publish, ?VERSION_1, ?VERSION_2},
      {query_publisher_sequence, ?VERSION_1, ?VERSION_1},
      {delete_publisher, ?VERSION_1, ?VERSION_1},
      {subscribe, ?VERSION_1, ?VERSION_1},
@@ -323,9 +316,6 @@ command_versions() ->
      {stream_stats, ?VERSION_1, ?VERSION_1},
      {create_super_stream, ?VERSION_1, ?VERSION_1},
      {delete_super_stream, ?VERSION_1, ?VERSION_1}].
-
-filtering_supported() ->
-    rabbit_feature_flags:is_enabled(stream_filtering).
 
 q(VirtualHost, Name) ->
     rabbit_misc:r(VirtualHost, queue, Name).

--- a/rabbitmq.bzl
+++ b/rabbitmq.bzl
@@ -281,7 +281,7 @@ def rabbitmq_integration_suite(
             # required starting from 3.12.0 in rabbitmq_management_agent:
             # empty_basic_get_metric, drop_unroutable_metric
             # required starting from 4.0 in rabbit:
-            "message_containers",
+            "message_containers,stream_update_config_command,stream_filtering,stream_sac_coordinator_unblock_group,restart_streams",
             "RABBITMQ_RUN": "$(location :rabbitmq-for-tests-run)",
             "RABBITMQCTL": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmqctl".format(package),
             "RABBITMQ_PLUGINS": "$TEST_SRCDIR/$TEST_WORKSPACE/{}/broker-for-tests-home/sbin/rabbitmq-plugins".format(package),


### PR DESCRIPTION
Since feature flag `message_containers` introduced in 3.13.0 is required in 4.0, we can also require all other feature flags introduced in or before 3.13.0 and remove their compatibility code for 4.0:

* `restart_streams`
* `stream_sac_coordinator_unblock_group`
* `stream_filtering`
* `stream_update_config_command`

Related to https://github.com/rabbitmq/rabbitmq-server/pull/11642