### PR TITLE
Turn off mixed version tests against Khepri

### DIFF
--- a/.github/workflows/test-plugin-mixed.yaml
+++ b/.github/workflows/test-plugin-mixed.yaml
@@ -29,7 +29,10 @@ jobs:
         - 26
         metadata_store:
           - mnesia
-          - khepri
+          # Khepri is currently skipped because Khepri is an unstable feature: we don't guarantee upgrability.
+          # Mixed-version tests currently fail with Khepri because of a new machine version introduced in
+          # Khepri v0.14.0.
+          # - khepri
         include:
         - erlang_version: 26
           elixir_version: 1.15

--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -54,13 +54,20 @@ suite() ->
 %% Testsuite setup/teardown.
 %% -------------------------------------------------------------------
 
-init_per_suite(Config0) ->
+init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
-    Config = rabbit_ct_helpers:set_config(Config0, [{metadata_store, khepri}]),
-    rabbit_ct_helpers:run_setup_steps(Config,
-                                      [
-                                       fun rabbit_ct_broker_helpers:configure_dist_proxy/1
-                                      ]).
+    case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
+        mnesia ->
+            %% This SUITE is meant to test how Khepri behaves in a minority,
+            %% so mnesia should be skipped.
+            {skip, "Minority testing not supported by mnesia"};
+        _ ->
+            rabbit_ct_helpers:run_setup_steps(
+              Config,
+              [
+               fun rabbit_ct_broker_helpers:configure_dist_proxy/1
+              ])
+    end.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).

--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -129,10 +129,20 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
-init_per_group(mnesia_store, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{metadata_store, mnesia}]);
 init_per_group(khepri_store, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{metadata_store, khepri}]);
+    case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
+        mnesia ->
+            {skip, "These tests target Khepri"};
+        _ ->
+            Config
+    end;
+init_per_group(mnesia_store, Config) ->
+    case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
+        {khepri, _} ->
+            {skip, "These tests target mnesia"};
+        _ ->
+            Config
+    end;
 init_per_group(unclustered_2_nodes, Config) ->
     rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, false}]);
 init_per_group(unclustered_3_nodes, Config) ->

--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -72,9 +72,19 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_group(khepri_store, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{metadata_store, khepri}]);
+    case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
+        mnesia ->
+            {skip, "These tests target Khepri"};
+        _ ->
+            Config
+    end;
 init_per_group(mnesia_store, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{metadata_store, mnesia}]);
+    case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
+        {khepri, _} ->
+            {skip, "These tests target mnesia"};
+        _ ->
+            Config
+    end;
 init_per_group(clustered_3_nodes, Config) ->
     rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, true}]);
 init_per_group(clustered_5_nodes, Config) ->

--- a/deps/rabbit/test/metadata_store_clustering_SUITE.erl
+++ b/deps/rabbit/test/metadata_store_clustering_SUITE.erl
@@ -58,7 +58,14 @@ cluster_size_3_tests() ->
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
-    rabbit_ct_helpers:run_setup_steps(Config, []).
+    case rabbit_ct_helpers:is_mixed_versions() of
+        true ->
+            %% Khepri is not yet compatible with mixed version testing and this
+            %% suite enables Khepri.
+            {skip, "This suite does not yet support mixed version testing"};
+        false ->
+            rabbit_ct_helpers:run_setup_steps(Config, [])
+    end.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config).

--- a/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
+++ b/deps/rabbitmq_consistent_hash_exchange/BUILD.bazel
@@ -82,7 +82,6 @@ broker_for_integration_suites()
 
 rabbitmq_integration_suite(
     name = "rabbit_exchange_type_consistent_hash_SUITE",
-    shard_count = 7,
     runtime_deps = [
         "//deps/rabbitmq_amqp_client:erlang_app",
     ],


### PR DESCRIPTION
Khepri v0.14.0 creates problems for mixed-version tests: the new machine version causes commands and queries to fail on the nodes running the old version. We should separately fix these issues and eventually re-enable mixed version tests with Khepri as the feature stabilizes.