### PR TITLE
rabbit_db_*: Wrap `ets` calls to projections in `whereis/1` checks

### DIFF
--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -151,9 +151,14 @@ get_in_mnesia(Key) ->
     end.
 
 get_in_khepri(Key) ->
-    case ets:lookup(?KHEPRI_PROJECTION, Key) of
-        []       -> undefined;
-        [Record] -> Record
+    case ets:whereis(?KHEPRI_PROJECTION) of
+        undefined ->
+            undefined;
+        Table ->
+            case ets:lookup(Table, Key) of
+                []       -> undefined;
+                [Record] -> Record
+            end
     end.
 
 %% -------------------------------------------------------------------
@@ -177,7 +182,12 @@ get_all_in_mnesia() ->
     rabbit_mnesia:dirty_read_all(?MNESIA_TABLE).
 
 get_all_in_khepri() ->
-    ets:tab2list(?KHEPRI_PROJECTION).
+    case ets:whereis(?KHEPRI_PROJECTION) of
+        undefined ->
+            [];
+        Table ->
+            ets:tab2list(Table)
+    end.
 
 -spec get_all(VHostName, Comp) -> Ret when
       VHostName :: vhost:name() | '_',
@@ -214,9 +224,14 @@ get_all_in_khepri(VHostName, Comp) ->
         '_' -> ok;
         _   -> rabbit_vhost:assert(VHostName)
     end,
-    Match = #runtime_parameters{key = {VHostName, Comp, '_'},
-                                _   = '_'},
-    ets:match_object(?KHEPRI_PROJECTION, Match).
+    case ets:whereis(?KHEPRI_PROJECTION) of
+        undefined ->
+            [];
+        Table ->
+            Match = #runtime_parameters{key = {VHostName, Comp, '_'},
+                                        _   = '_'},
+            ets:match_object(Table, Match)
+    end.
 
 %% -------------------------------------------------------------------
 %% delete().


### PR DESCRIPTION
Projections might not be available in a mixed-version scenario where a cluster has nodes which are all blank/uninitialized and the majority of nodes run a version of Khepri with a new machine version while the minority does not have the new machine version's code.

In this case, the cluster's effective machine version will be set to the newer version as the majority of members have access to the new code. The older version members will be unable to apply commands including the `register_projection` commands that set up these ETS tables. When these ETS tables don't exist, calls like `ets:tab2list/1` or `ets:lookup/2` cause `badarg` errors.

We use default empty values when `ets:whereis/1` returns `undefined` for a projection table name. Instead we could use local queries or leader queries. Writing equivalent queries is a fair amount more work and the code would be hard to test. `ets:whereis/1` should only return `undefined` in the above scenario which should only be a problem in our mixed-version testing - not in practice.