### PR TITLE
Fix elixir warning on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ XREF_IGNORE = [ \
     {'Elixir.RabbitMQ.CLI.Core.DataCoercion',impl_for,1}]
 
 # Include Elixir libraries in the Xref checks.
-xref: ERL_LIBS := $(ERL_LIBS):$(CURDIR)/apps:$(CURDIR)/deps:$(dir $(shell elixir --eval ":io.format '~s~n', [:code.lib_dir :elixir ]"))
+xref: ERL_LIBS := $(ERL_LIBS):$(CURDIR)/apps:$(CURDIR)/deps:$(dir $(shell elixir --eval ':io.format "~s~n", [:code.lib_dir :elixir ]'))
 endif
 
 ifneq ($(wildcard deps/.hex/cache.erl),)


### PR DESCRIPTION
This is the warning:
```
warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
```
