### PR TITLE
Simplify

### DIFF
--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -140,13 +140,11 @@ handle_cast({close_connection, Reason},
 
 handle_cast(QueueEvent = {queue_event, _, _},
             State = #state{proc_state = PState0}) ->
-    try
-        case rabbit_mqtt_processor:handle_queue_event(QueueEvent, PState0) of
-            {ok, PState} ->
-                maybe_process_deferred_recv(control_throttle(pstate(State, PState)));
-            {error, Reason0, PState} ->
-                {stop, Reason0, pstate(State, PState)}
-        end
+    try rabbit_mqtt_processor:handle_queue_event(QueueEvent, PState0) of
+        {ok, PState} ->
+            maybe_process_deferred_recv(control_throttle(pstate(State, PState)));
+        {error, Reason0, PState} ->
+            {stop, Reason0, pstate(State, PState)}
     catch throw:{send_failed, Reason1} ->
               network_error(Reason1, State)
     end;


### PR DESCRIPTION
This is follow-up of https://github.com/rabbitmq/rabbitmq-server/pull/11676
Protect only `rabbit_mqtt_processor:handle_queue_event/2` since only that call might throw a `{send_failed, Reason}`.