### PR TITLE
Fix queue type consumer arguments

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -572,7 +572,7 @@ capabilities() ->
                                  true -> [<<"x-queue-leader-locator">>];
                                  false -> []
                              end,
-      consumer_arguments => [<<"x-priority">>, <<"x-credit">>],
+      consumer_arguments => [<<"x-priority">>],
       server_named => true}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1267,7 +1267,9 @@ capabilities() ->
       queue_arguments => [<<"x-max-length-bytes">>, <<"x-queue-type">>,
                           <<"x-max-age">>, <<"x-stream-max-segment-size-bytes">>,
                           <<"x-initial-cluster-size">>, <<"x-queue-leader-locator">>],
-      consumer_arguments => [<<"x-stream-offset">>],
+      consumer_arguments => [<<"x-stream-offset">>,
+                             <<"x-stream-filter">>,
+                             <<"x-stream-match-unfiltered">>],
       server_named => false}.
 
 notify_decorators(Q) when ?is_amqqueue(Q) ->


### PR DESCRIPTION
see https://www.rabbitmq.com/blog/2023/10/24/stream-filtering-internals#bonus-stream-filtering-on-amqp

`x-credit` was used by the 3.13 AMQP 1.0 plugin
