### PR TITLE
Support consumer priority in AMQP

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_types.erl
+++ b/deps/amqp10_client/src/amqp10_client_types.erl
@@ -82,8 +82,7 @@ utf8(B) when is_binary(B) -> {utf8, B}.
 uint(N) -> {uint, N}.
 
 make_properties(#{properties := Props})
-  when is_map(Props) andalso
-       map_size(Props) > 0 ->
+  when map_size(Props) > 0 ->
     {map, maps:fold(fun(K, V, L) ->
                             [{{symbol, K}, V} | L]
                     end, [], Props)};

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -110,7 +110,7 @@
          %% command: `{consumer_credit, ReceiverDeliveryCount, Credit}'
          credit_mode :: credit_mode(), % part of snapshot data
          lifetime = once :: once | auto,
-         priority = 0 :: non_neg_integer()}).
+         priority = 0 :: integer()}).
 
 -record(consumer,
         {cfg = #consumer_cfg{},


### PR DESCRIPTION
Arguments
* `rabbitmq:stream-offset-spec`,
* `rabbitmq:stream-filter`,
* `rabbitmq:stream-match-unfiltered` are set in the `filter` field of the `Source`.
This makes sense for these consumer arguments because:
> A filter acts as a function on a message which returns a boolean result
> indicating whether the message can pass through that filter or not.

Consumer priority is not really such a predicate.
Therefore, it makes more sense to set consumer priority in the `properties` field of the `Attach` frame.

We call the key `rabbitmq:priority` which maps to consumer argument `x-priority`.

While AMQP 0.9.1 consumers are allowed to set any integer data type for the priority level, this commit decides to enforce an `int` value (range -(2^31) to 2^31 - 1 inclusive).
Consumer priority levels outside of this range are not needed in practice.