### PR TITLE
Handle timeouts possible in Khepri minority in `rabbit_db_vhost`

### DIFF
--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -62,7 +62,7 @@
       VHostName :: vhost:name(),
       Limits :: vhost:limits(),
       Metadata :: vhost:metadata(),
-      Ret :: {existing | new, VHost},
+      Ret :: {existing | new, VHost} | no_return(),
       VHost :: vhost:vhost().
 %% @doc Writes a virtual host record if it doesn't exist already or returns
 %% the existing one.

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -190,7 +190,7 @@ merge_metadata_in_khepri(VHostName, Metadata) ->
 -spec set_tags(VHostName, Tags) -> VHost when
       VHostName :: vhost:name(),
       Tags :: [vhost:tag() | binary() | string()],
-      VHost :: vhost:vhost().
+      VHost :: vhost:vhost() | no_return().
 %% @doc Sets the tags of an existing virtual host record.
 %%
 %% @returns the updated virtual host record if the record existed and the

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -117,7 +117,9 @@ create_or_get_in_khepri(VHostName, VHost) ->
 -spec merge_metadata(VHostName, Metadata) -> Ret when
       VHostName :: vhost:name(),
       Metadata :: vhost:metadata(),
-      Ret :: {ok, VHost} | {error, {no_such_vhost, VHostName}},
+      Ret :: {ok, VHost} |
+             {error, {no_such_vhost, VHostName}} |
+             rabbit_khepri:timeout_error(),
       VHost :: vhost:vhost().
 %% @doc Updates the metadata of an existing virtual host record.
 %%

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -349,7 +349,7 @@ list_in_khepri() ->
 -spec update(VHostName, UpdateFun) -> VHost when
       VHostName :: vhost:name(),
       UpdateFun :: fun((VHost) -> VHost),
-      VHost :: vhost:vhost().
+      VHost :: vhost:vhost() | no_return().
 %% @doc Updates an existing virtual host record using the result of
 %% `UpdateFun'.
 %%

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -441,9 +441,10 @@ with_fun_in_khepri_tx(VHostName, Thunk) ->
 %% delete().
 %% -------------------------------------------------------------------
 
--spec delete(VHostName) -> Existed when
+-spec delete(VHostName) -> Ret when
       VHostName :: vhost:name(),
-      Existed :: boolean().
+      Existed :: boolean(),
+      Ret :: Existed | rabbit_khepri:timeout_error().
 %% @doc Deletes a virtual host record from the database.
 %%
 %% @returns a boolean indicating if the vhost existed or not. It throws an
@@ -470,7 +471,7 @@ delete_in_khepri(VHostName) ->
     case rabbit_khepri:delete_or_fail(Path) of
         ok -> true;
         {error, {node_not_found, _}} -> false;
-        _ -> false
+        {error, _} = Err -> Err
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -773,7 +773,7 @@ add_policy(VHost, Param, Username) ->
                              exit(rabbit_data_coercion:to_binary(rabbit_misc:escape_html_tags(E ++ S)))
     end.
 
--spec add_vhost(map(), rabbit_types:username()) -> ok.
+-spec add_vhost(map(), rabbit_types:username()) -> ok | no_return().
 
 add_vhost(VHost, ActingUser) ->
     Name             = maps:get(name, VHost, undefined),
@@ -783,7 +783,12 @@ add_vhost(VHost, ActingUser) ->
     Tags             = maps:get(tags, VHost, maps:get(tags, Metadata, [])),
     DefaultQueueType = maps:get(default_queue_type, Metadata, undefined),
 
-    rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQueueType, IsTracingEnabled, ActingUser).
+    case rabbit_vhost:put_vhost(Name, Description, Tags, DefaultQueueType, IsTracingEnabled, ActingUser) of
+        ok ->
+            ok;
+        {error, _} = Err ->
+            throw(Err)
+    end.
 
 add_permission(Permission, ActingUser) ->
     rabbit_auth_backend_internal:set_permissions(maps:get(user,      Permission, undefined),

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -287,7 +287,9 @@ delete(VHost, ActingUser) ->
                         [{name, VHost},
                          {user_who_performed_action, ActingUser}]);
              false ->
-                 {error, {no_such_vhost, VHost}}
+                 {error, {no_such_vhost, VHost}};
+             {error, _} = Err ->
+                 Err
          end,
     %% After vhost was deleted from the database, we try to stop vhost
     %% supervisors on all the nodes.


### PR DESCRIPTION
Like #11685 this handles `{error, timeout}` tuples for a database module, this time `rabbit_db_vhost`. `rabbit_db_vhost` mostly handles the errors well but needs a few small tweaks to specs and some updates for callers like the management UI.

The only problem function in `rabbit_db_vhost` is `update/2` which is called by the `rabbit_vhost_limit` runtime parameter module in its `notify/5` and `notify_clear/4` callbacks. Those callbacks have no way of passing the error back to the user. Ideally the runtime parameter and vhost records would be updated at the same time transactionally but I think that would be a large refactor. Since you have to modify the runtime parameter in order for the notifications to trigger, it should be a very rare error that we time out just for the vhost update, so I think we can leave a large refactor to future work.

~Marking this as a draft since it shares 9a715199c03a with https://github.com/rabbitmq/rabbitmq-server/pull/11685.~