### PR TITLE
mc: increase utf8 scanning limit for longstr conversions.

### DIFF
--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -600,7 +600,7 @@ amqp_amqpl(_Config) ->
     ?assertMatch({_, long, 5}, header(<<"long">>, HL)),
     ?assertMatch({_, long, 5}, header(<<"ulong">>, HL)),
     ?assertMatch({_, longstr, <<"a-string">>}, header(<<"utf8">>, HL)),
-    ?assertMatch({_, binary, <<"data">>}, header(<<"binary">>, HL)),
+    ?assertMatch({_, longstr, <<"data">>}, header(<<"binary">>, HL)),
     ?assertMatch({_, longstr, <<"symbol">>}, header(<<"symbol">>, HL)),
     ?assertMatch({_, unsignedbyte, 255}, header(<<"ubyte">>, HL)),
     ?assertMatch({_, short, 2}, header(<<"short">>, HL)),


### PR DESCRIPTION
The AMQP 0.9.1 longstr type is problematic as it can contain arbitrary binary data but is typically used for utf8 by users.

The current conversion into AMQP avoids scanning arbitrarily large longstr to see if they only contain valid utf8 by treating all longstr data longer than 255 bytes as binary. This is in hindsight too strict and thus this commit increases the scanning limit to 4096 bytes - enough to cover the vast majority of AMQP 0.9.1 header values.

This change also conversts the AMQP binary types into longstr to ensure that existing data (held in streams for example) is converted to an AMQP 0.9.1 type most likely what the user intended.
