### PR TITLE
rabbit_db_exchange: Remove dead `set/1`

### DIFF
--- a/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_exchange_SUITE.erl
@@ -207,16 +207,6 @@ update1(_Config) ->
     ?assertEqual(topic, Exchange0#exchange.type),
     passed.
 
-set(Config) ->
-    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, set1, [Config]).
-
-set1(_Config) ->
-    XName = rabbit_misc:r(?VHOST, exchange, <<"test-exchange">>),
-    Exchange = #exchange{name = XName, durable = true},
-    ?assertEqual(ok, rabbit_db_exchange:set([Exchange])),
-    ?assertEqual([Exchange], rabbit_db_exchange:get_all_durable()),
-    passed.
-
 peek_serial(Config) ->
     passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, peek_serial1, [Config]).
 


### PR DESCRIPTION
`rabbit_db_exchange:set/2` was only used by `rabbit_policy:recover/0` which was removed by 3.13.0 in c84bc83ce18b2741bd5c75fd4f70793a67efc445 (#7727). That function was part of the old upgrade system (predating feature flags) so this code path has been dead code for quite a while.