### PR TITLE
Handle empty HTTP body in response from AWS JSON

### DIFF
--- a/deps/rabbitmq_aws/src/rabbitmq_aws_json.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_json.erl
@@ -14,6 +14,8 @@
 %% @end
 decode(Value) when is_list(Value) ->
   decode(list_to_binary(Value));
+decode(<<>>) ->
+  [];
 decode(Value) when is_binary(Value) ->
   Decoded0 = rabbit_json:decode(Value),
   Decoded  = maps:to_list(Decoded0),


### PR DESCRIPTION
Noticed that some some AWS endpoints return an empty body on 200 OK, which gets translated to an empty binary, which the code did not handle!

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
