### PR TITLE
Fix unupported modified outcome behaviour

### DIFF
--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -300,14 +300,9 @@ reliable_send_receive_with_outcomes_quorum_queue(Config) ->
     reliable_send_receive_with_outcomes(<<"quorum">>, Config).
 
 reliable_send_receive_with_outcomes(QType, Config) ->
-    Outcomes = [
-                accepted,
-                modified,
-                {modified, true, false, #{<<"fruit">> => <<"banana">>}},
-                {modified, false, true, #{}},
+    Outcomes = [accepted,
                 rejected,
-                released
-               ],
+                released],
     [ok = reliable_send_receive(QType, Outcome, Config) || Outcome <- Outcomes].
 
 reliable_send_receive(QType, Outcome, Config) ->

--- a/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs
+++ b/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs
@@ -261,7 +261,7 @@ module Test =
              "amqp:rejected:list", null
              "amqp:released:list", null
              "amqp:modified:list", null
-             "amqp:madeup:list", "amqp:not-implemented"] do
+             "amqp:madeup:list", null] do
 
             let source = new Source(Address = "outcomes_q",
                                     Outcomes = [| Symbol outcome |])


### PR DESCRIPTION
The modified outcome has not been supported in RabbitMQ 3.13 and won't be supported in RabbitMQ 4.0.

Specifically, neither in 3.13 nor in 4.0 are any of the modified fields implemented correctly:
```
<field name="delivery-failed" type="boolean"/>
<field name="undeliverable-here" type="boolean"/>
<field name="message-annotations" type="fields"/>
```

However in 3.13, RabbitMQ pretends to support the modified outcome by including the modified outcome in the `outcomes` field of the `Source`. When the receiver settles with the modified outcome, RabbitMQ either requeues or discards the message depending on some specific modified field combinations.

To follow the principle of least surprise, RabbitMQ 4.0 will make it clear in the `outcomes` field of the `Source` in the replying `Attach` frame, that RabbitMQ won't support the modified outcome. If a receiver nevertheless settles with the modified outcome, RabbitMQ will close the session.

This is a breaking change in RabbitMQ 4.0.

RabbitMQ 3.13 already documents in
https://github.com/rabbitmq/rabbitmq-server/tree/v3.13.x/deps/rabbitmq_amqp1_0 that the modified outcome is unsupported.
The same should be documented in RabbitMQ 4.0.