### PR TITLE
rabbit_khepri: Retry register_projections during boot

### DIFF
--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -306,7 +306,7 @@ wait_for_register_projections(Timeout, Retries) ->
     try
         register_projections()
     catch
-        throw : {timeout, _ServerId} ->
+        throw : timeout ->
             wait_for_register_projections(Timeout, Retries -1)
     end.
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/default_output.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/default_output.ex
@@ -82,6 +82,10 @@ defmodule RabbitMQ.CLI.DefaultOutput do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_tempfail(), khepri_timeout_error(node_name)}
   end
 
+  defp format_khepri_output({:error, :timeout_waiting_for_khepri_projections}, %{node: node_name}) do
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_tempfail(), khepri_timeout_error(node_name)}
+  end
+
   defp format_khepri_output(result, _opts) do
     result
   end


### PR DESCRIPTION
Gives some time to form a majority during the boot process, allowing nodes to boot more easily.

See discussion https://github.com/rabbitmq/rabbitmq-server/pull/11685#discussion_r1679756356 