### PR TITLE
Handle more failure types in the rabbitmqqueue:declare/6 when declaring a stream

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -126,7 +126,6 @@ handle_http_req(HttpMethod = <<"PUT">>,
     ok = prohibit_reserved_amq(QName),
     PermCache1 = check_resource_access(QName, configure, User, PermCache0),
     rabbit_core_metrics:queue_declared(QName),
-
     {Q1, NumMsgs, NumConsumers, StatusCode, PermCache} =
     case rabbit_amqqueue:with(
            QName,
@@ -147,29 +146,40 @@ handle_http_req(HttpMethod = <<"PUT">>,
             Result;
         {error, not_found} ->
             PermCache2 = check_dead_letter_exchange(QName, QArgs, User, PermCache1),
-            case rabbit_amqqueue:declare(
-                   QName, Durable, AutoDelete, QArgs, Owner, Username) of
-                {new, Q} ->
+            try rabbit_amqqueue:declare(
+              QName, Durable, AutoDelete, QArgs, Owner, Username) of
+              ARGS ->
+                case ARGS of
+                  {new, Q} ->
                     rabbit_core_metrics:queue_created(QName),
                     {Q, 0, 0, <<"201">>, PermCache2};
-                {owner_died, Q} ->
+                  {owner_died, Q} ->
                     %% Presumably our own days are numbered since the
                     %% connection has died. Pretend the queue exists though,
                     %% just so nothing fails.
                     {Q, 0, 0, <<"201">>, PermCache2};
-                {absent, Q, Reason} ->
+                  {absent, Q, Reason} ->
                     absent(Q, Reason);
-                {existing, _Q} ->
+                  {existing, _Q} ->
                     %% Must have been created in the meantime. Loop around again.
                     handle_http_req(HttpMethod, PathSegments, Query, ReqPayload,
-                                    Vhost, User, ConnPid, {PermCache2, TopicPermCache});
-                {error, queue_limit_exceeded, Reason, ReasonArgs} ->
+                      Vhost, User, ConnPid, {PermCache2, TopicPermCache});
+                  {error, queue_limit_exceeded, Reason, ReasonArgs} ->
                     throw(<<"403">>,
-                          Reason,
-                          ReasonArgs);
-                {protocol_error, _ErrorType, Reason, ReasonArgs} ->
-                    throw(<<"400">>, Reason, ReasonArgs)
+                      Reason,
+                      ReasonArgs);
+                  {protocol_error, _ErrorType, Reason, ReasonArgs} ->
+                    throw(<<"400">>, Reason, ReasonArgs);
+                  {precondition_failed, Reason, ReasonArgs} ->
+                    throw(<<"409">>, Reason, ReasonArgs)
+                end
+            catch exit:#amqp_error{name = precondition_failed,
+                explanation = Expl} ->
+                throw(<<"409">>, Expl, []);
+              exit:#amqp_error{explanation = Expl} ->
+                throw(<<"400">>, Expl, [])
             end;
+
         {error, {absent, Q, Reason}} ->
             absent(Q, Reason)
     end,

--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -146,10 +146,8 @@ handle_http_req(HttpMethod = <<"PUT">>,
             Result;
         {error, not_found} ->
             PermCache2 = check_dead_letter_exchange(QName, QArgs, User, PermCache1),
-            try rabbit_amqqueue:declare(
+            try case rabbit_amqqueue:declare(
               QName, Durable, AutoDelete, QArgs, Owner, Username) of
-              ARGS ->
-                case ARGS of
                   {new, Q} ->
                     rabbit_core_metrics:queue_created(QName),
                     {Q, 0, 0, <<"201">>, PermCache2};
@@ -169,9 +167,7 @@ handle_http_req(HttpMethod = <<"PUT">>,
                       Reason,
                       ReasonArgs);
                   {protocol_error, _ErrorType, Reason, ReasonArgs} ->
-                    throw(<<"400">>, Reason, ReasonArgs);
-                  {precondition_failed, Reason, ReasonArgs} ->
-                    throw(<<"409">>, Reason, ReasonArgs)
+                    throw(<<"400">>, Reason, ReasonArgs)
                 end
             catch exit:#amqp_error{name = precondition_failed,
                 explanation = Expl} ->


### PR DESCRIPTION
The rabbitmqqueue:declare is handled, and in case of known errors, the correct error code is sent back.

## Proposed Changes

In case a queue is created with the wrong parameters, like:                  
```
management.queue().name("stream").type(STREAM).deadLetterExchange("aaaa").declare();
```
The server raised:
```
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0> ** Reason for termination ==
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0> ** {{amqp_error,precondition_failed,
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0>                 "invalid arg 'x-dead-letter-exchange' for queue 'stream' in vhost '/' of queue type rabbit_stream_queue",
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0>                 none},
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0>     [{rabbit_misc,protocol_error,1,[{file,"rabbit_misc.erl"},{line,291}]},
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0>      {lists,foreach_1,2,[{file,"lists.erl"},{line,1686}]},
2024-07-18 09:10:03 2024-07-18 07:10:03.875080+00:00 [error] <0.98045.0>      {rabbit_amqqueue,declare,7,
```
because the  [`rabbit_amqqueue:declare`](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_amqp_management.erl#L150) could go in error. 

With this PR the error is handled like [other cases](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_amqp_management.erl#L131)



## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

To reproduce the issue is enough to:
```
management.queue().name("stream").type(STREAM).deadLetterExchange("aaaa").declare();
```

With this fix the call returns:
```
Exception in thread "main" com.rabbitmq.client.amqp.AmqpException: Unexpected response code: 400 instead of 204
```
that is correct 

