### PR TITLE
Handle timeouts possible in Khepri minority in `rabbit_db_exchange`

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -218,9 +218,9 @@ handle_http_req(<<"PUT">>,
                     {error, timeout} ->
                         throw(
                           <<"503">>,
-                          "Could not create exchange '~ts' in vhost '~ts' "
-                          "because the operation timed out",
-                          [XName, Vhost])
+                          "Could not create ~ts because the operation "
+                          "timed out",
+                          [rabbit_misc:rs(XName)])
                 end
         end,
     try rabbit_exchange:assert_equivalence(
@@ -300,8 +300,8 @@ handle_http_req(<<"DELETE">>,
         {error, timeout} ->
             throw(
               <<"503">>,
-              "failed to delete exchange '~ts' due to a timeout",
-              [XNameBin])
+              "failed to delete ~ts due to a timeout",
+              [rabbit_misc:rs(XName)])
     end;
 
 handle_http_req(<<"POST">>,

--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -217,7 +217,7 @@ handle_http_req(<<"PUT">>,
                         DeclaredX;
                     {error, timeout} ->
                         throw(
-                          <<"500">>,
+                          <<"503">>,
                           "Could not create exchange '~ts' in vhost '~ts' "
                           "because the operation timed out",
                           [XName, Vhost])
@@ -299,7 +299,7 @@ handle_http_req(<<"DELETE">>,
             {<<"204">>, null, {PermCache, TopicPermCache}};
         {error, timeout} ->
             throw(
-              <<"500">>,
+              <<"503">>,
               "failed to delete exchange '~ts' due to a timeout",
               [XNameBin])
     end;

--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -210,9 +210,18 @@ handle_http_req(<<"PUT">>,
             {error, not_found} ->
                 ok = prohibit_cr_lf(XNameBin),
                 ok = prohibit_reserved_amq(XName),
-                rabbit_exchange:declare(
-                  XName, XTypeAtom, Durable, AutoDelete,
-                  Internal, XArgs, Username)
+                case rabbit_exchange:declare(
+                       XName, XTypeAtom, Durable, AutoDelete,
+                       Internal, XArgs, Username) of
+                    {ok, DeclaredX} ->
+                        DeclaredX;
+                    {error, timeout} ->
+                        throw(
+                          <<"500">>,
+                          "Could not create exchange '~ts' in vhost '~ts' "
+                          "because the operation timed out",
+                          [XName, Vhost])
+                end
         end,
     try rabbit_exchange:assert_equivalence(
           X, XTypeAtom, Durable, AutoDelete, Internal, XArgs) of

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2581,9 +2581,9 @@ handle_method(#'exchange.declare'{exchange    = XNameBin,
                     {error, timeout} ->
                         rabbit_misc:protocol_error(
                           internal_error,
-                          "failed to declare exchange '~ts' in vhost '~ts' "
-                          "because the operation timed out",
-                          [XNameBinStripped, VHostPath])
+                          "failed to declare ~ts because the operation "
+                          "timed out",
+                          [rabbit_misc:rs(ExchangeName)])
                 end
         end,
     ok = rabbit_exchange:assert_equivalence(X, CheckedType, Durable,

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2520,7 +2520,7 @@ handle_method(#'exchange.delete'{exchange  = ExchangeNameBin,
         {error, timeout} ->
             rabbit_misc:protocol_error(
               internal_error,
-              "failed to delete exchange '~ts' due to a timeout",
+              "failed to delete ~ts due to a timeout",
               [rabbit_misc:rs(ExchangeName)])
     end;
 handle_method(#'queue.purge'{queue = QueueNameBin},

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -524,17 +524,15 @@ next_serial_in_khepri(XName) ->
             UpdatePath =
                 khepri_path:combine_with_conditions(
                   Path, [#if_payload_version{version = Vsn}]),
-            case rabbit_khepri:put(UpdatePath, Serial + 1) of
+            case rabbit_khepri:put(UpdatePath, Serial + 1, #{timeout => infinity}) of
                 ok ->
                     Serial;
                 {error, {khepri, mismatching_node, _}} ->
-                    next_serial_in_khepri(XName);
-                Err ->
-                    Err
+                    next_serial_in_khepri(XName)
             end;
         _ ->
             Serial = 1,
-            ok = rabbit_khepri:put(Path, Serial + 1),
+            ok = rabbit_khepri:put(Path, Serial + 1, #{timeout => infinity}),
             Serial
     end.
 

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -265,9 +265,10 @@ count_in_khepri() ->
 %% update().
 %% -------------------------------------------------------------------
 
--spec update(ExchangeName, UpdateFun) -> ok when
+-spec update(ExchangeName, UpdateFun) -> Ret when
       ExchangeName :: rabbit_exchange:name(),
-      UpdateFun :: fun((Exchange) -> Exchange).
+      UpdateFun :: fun((Exchange) -> Exchange),
+      Ret :: ok | rabbit_khepri:timeout_error().
 %% @doc Updates an existing exchange record using the result of
 %% `UpdateFun'.
 %%

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -368,7 +368,9 @@ update_in_khepri_tx(Name, Fun) ->
 
 -spec create_or_get(Exchange) -> Ret when
       Exchange :: rabbit_types:exchange(),
-      Ret :: {new, Exchange} | {existing, Exchange}.
+      Ret :: {new, Exchange} |
+             {existing, Exchange} |
+             rabbit_khepri:timeout_error().
 %% @doc Writes an exchange record if it doesn't exist already or returns
 %% the existing one.
 %%
@@ -400,7 +402,9 @@ create_or_get_in_khepri(#exchange{name = XName} = X) ->
         ok ->
             {new, X};
         {error, {khepri, mismatching_node, #{node_props := #{data := ExistingX}}}} ->
-            {existing, ExistingX}
+            {existing, ExistingX};
+        {error, timeout} = Err ->
+            Err
     end.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -561,7 +561,10 @@ next_serial_in_khepri_tx(#exchange{name = XName}) ->
       Exchange :: rabbit_types:exchange(),
       Binding :: rabbit_types:binding(),
       Deletions :: dict:dict(),
-      Ret :: {error, not_found} | {error, in_use} | {deleted, Exchange, [Binding], Deletions}.
+      Ret :: {deleted, Exchange, [Binding], Deletions} |
+             {error, not_found} |
+             {error, in_use} |
+             rabbit_khepri:timeout_error().
 %% @doc Deletes an exchange record from the database. If `IfUnused' is set
 %% to `true', it is only deleted when there are no bindings present on the
 %% exchange.

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -731,7 +731,7 @@ update_durable_in_khepri(UpdateFun, FilterFun) ->
                         end, [], Props),
             Res = rabbit_khepri:transaction(
                     fun() ->
-                            for_each_while_ok(
+                            rabbit_misc:for_each_while_ok(
                               fun({Path, Q}) -> khepri_tx:put(Path, Q) end,
                               Updates)
                     end),
@@ -748,16 +748,6 @@ update_durable_in_khepri(UpdateFun, FilterFun) ->
         {error, _} = Error ->
             Error
     end.
-
-for_each_while_ok(Fun, [Elem | Rest]) ->
-    case Fun(Elem) of
-        ok ->
-            for_each_while_ok(Fun, Rest);
-        {error, _} = Error ->
-            Error
-    end;
-for_each_while_ok(_, []) ->
-    ok.
 
 %% -------------------------------------------------------------------
 %% exists().

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -863,13 +863,18 @@ add_exchange_int(Exchange, Name, ActingUser) ->
                            undefined -> false; %% =< 2.2.0
                            I         -> I
                        end,
-            rabbit_exchange:declare(Name,
-                                    rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
-                                    maps:get(durable,                         Exchange, undefined),
-                                    maps:get(auto_delete,                     Exchange, undefined),
-                                    Internal,
-                                    args(maps:get(arguments, Exchange, undefined)),
-                                    ActingUser)
+            case rabbit_exchange:declare(Name,
+                                         rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
+                                         maps:get(durable,                         Exchange, undefined),
+                                         maps:get(auto_delete,                     Exchange, undefined),
+                                         Internal,
+                                         args(maps:get(arguments, Exchange, undefined)),
+                                         ActingUser) of
+                {ok, _Exchange} ->
+                    ok;
+                {error, timeout} = Err ->
+                    throw(Err)
+            end
     end.
 
 add_binding(Binding, ActingUser) ->

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -13,7 +13,8 @@
          lookup/1, lookup_many/1, lookup_or_die/1, list/0, list/1, lookup_scratch/2,
          update_scratch/3, update_decorators/2, immutable/1,
          info_keys/0, info/1, info/2, info_all/1, info_all/2, info_all/4,
-         route/2, route/3, delete/3, validate_binding/2, count/0]).
+         route/2, route/3, delete/3, validate_binding/2, count/0,
+         ensure_deleted/3]).
 -export([list_names/0]).
 -export([serialise_events/1]).
 -export([serial/1, peek_serial/1]).
@@ -444,9 +445,13 @@ cons_if_present(XName, L) ->
 
 -spec delete
         (name(),  'true', rabbit_types:username()) ->
-                    'ok'| rabbit_types:error('not_found' | 'in_use');
+                    'ok' |
+                    rabbit_types:error('not_found' | 'in_use') |
+                    rabbit_khepri:timeout_error();
         (name(), 'false', rabbit_types:username()) ->
-                    'ok' | rabbit_types:error('not_found').
+                    'ok' |
+                    rabbit_types:error('not_found') |
+                    rabbit_khepri:timeout_error().
 
 delete(XName, IfUnused, Username) ->
     try
@@ -477,6 +482,26 @@ process_deletions({deleted, #exchange{name = XName} = X, Bs, Deletions}) ->
     rabbit_binding:process_deletions(
       rabbit_binding:add_deletion(
         XName, {X, deleted, Bs}, Deletions)).
+
+-spec ensure_deleted(ExchangeName, IfUnused, Username) -> Ret when
+      ExchangeName :: name(),
+      IfUnused :: boolean(),
+      Username :: rabbit_types:username(),
+      Ret :: ok |
+             rabbit_types:error('in_use') |
+             rabbit_khepri:timeout_error().
+%% @doc A wrapper around `delete/3' which returns `ok' in the case that the
+%% exchange did not exist at time of deletion.
+
+ensure_deleted(XName, IfUnused, Username) ->
+    case delete(XName, IfUnused, Username) of
+        ok ->
+            ok;
+        {error, not_found} ->
+            ok;
+        {error, _} = Err ->
+            Err
+    end.
 
 -spec validate_binding
         (rabbit_types:exchange(), rabbit_types:binding())

--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -171,16 +171,21 @@ setup_proc(
 declare_exchange(
   #{config := #{exchange := #resource{name = Name,
                                       virtual_host = VHost} = Exchange}}) ->
-    try
-        %% Durable.
-        #exchange{} = rabbit_exchange:declare(
-                        Exchange, topic, true, false, true, [],
-                        ?INTERNAL_USER),
-        ?LOG_DEBUG(
-           "Declared exchange '~ts' in vhost '~ts'",
-           [Name, VHost],
-           #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
-        ok
+    try rabbit_exchange:declare(
+          Exchange, topic, true, false, true, [], ?INTERNAL_USER) of
+        {ok, #exchange{}} ->
+            ?LOG_DEBUG(
+               "Declared exchange '~ts' in vhost '~ts'",
+               [Name, VHost],
+               #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
+            ok;
+        {error, timeout} ->
+            ?LOG_DEBUG(
+               "Could not declare exchange '~ts' in vhost '~ts' because the "
+               "operation timed out",
+               [Name, VHost],
+               #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
+            error
     catch
         Class:Reason ->
             ?LOG_DEBUG(

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -275,7 +275,7 @@ delete(VHost, ActingUser) ->
          assert_benign(rabbit_amqqueue:with(Name, QDelFun), ActingUser)
      end || Q <- rabbit_amqqueue:list(VHost)],
     rabbit_log:info("Deleting exchanges in vhost '~ts' because it's being deleted", [VHost]),
-    [assert_benign(rabbit_exchange:delete(Name, false, ActingUser), ActingUser) ||
+    [ok = rabbit_exchange:ensure_deleted(Name, false, ActingUser) ||
         #exchange{name = Name} <- rabbit_exchange:list(VHost)],
     rabbit_log:info("Clearing policies and runtime parameters in vhost '~ts' because it's being deleted", [VHost]),
     _ = rabbit_runtime_parameters:clear_vhost(VHost, ActingUser),

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -201,32 +201,56 @@ do_add(Name, Metadata, ActingUser) ->
             ok
     end,
     rabbit_db_vhost_defaults:apply(Name, ActingUser),
-    _ = [begin
-         Resource = rabbit_misc:r(Name, exchange, ExchangeName),
-         rabbit_log:debug("Will declare an exchange ~tp", [Resource]),
-         _ = rabbit_exchange:declare(Resource, Type, true, false, Internal, [], ActingUser)
-     end || {ExchangeName, Type, Internal} <-
-            [{<<"">>,                   direct,  false},
-             {<<"amq.direct">>,         direct,  false},
-             {<<"amq.topic">>,          topic,   false},
-             %% per 0-9-1 pdf
-             {<<"amq.match">>,          headers, false},
-             %% per 0-9-1 xml
-             {<<"amq.headers">>,        headers, false},
-             {<<"amq.fanout">>,         fanout,  false},
-             {<<"amq.rabbitmq.trace">>, topic,   true}]],
-    case rabbit_vhost_sup_sup:start_on_all_nodes(Name) of
+    case declare_default_exchanges(Name, ActingUser) of
         ok ->
-            rabbit_event:notify(vhost_created, info(VHost)
-                                ++ [{user_who_performed_action, ActingUser},
-                                    {description, Description},
-                                    {tags, Tags}]),
-            ok;
-        {error, Reason} ->
-            Msg = rabbit_misc:format("failed to set up vhost '~ts': ~tp",
-                                     [Name, Reason]),
+            case rabbit_vhost_sup_sup:start_on_all_nodes(Name) of
+                ok ->
+                    rabbit_event:notify(vhost_created, info(VHost)
+                                        ++ [{user_who_performed_action, ActingUser},
+                                            {description, Description},
+                                            {tags, Tags}]),
+                    ok;
+                {error, Reason} ->
+                    Msg = rabbit_misc:format("failed to set up vhost '~ts': ~tp",
+                                             [Name, Reason]),
+                    {error, Msg}
+            end;
+        {error, timeout} ->
+            Msg = rabbit_misc:format(
+                    "failed to set up vhost '~ts' because a timeout occurred "
+                    "while adding default exchanges",
+                    [Name]),
             {error, Msg}
     end.
+
+-spec declare_default_exchanges(VHostName, ActingUser) -> Ret when
+      VHostName :: vhost:name(),
+      ActingUser :: rabbit_types:username(),
+      Ret :: ok | {error, timeout}.
+
+declare_default_exchanges(VHostName, ActingUser) ->
+    DefaultExchanges = [{<<"">>,                   direct,  false},
+                        {<<"amq.direct">>,         direct,  false},
+                        {<<"amq.topic">>,          topic,   false},
+                        %% per 0-9-1 pdf
+                        {<<"amq.match">>,          headers, false},
+                        %% per 0-9-1 xml
+                        {<<"amq.headers">>,        headers, false},
+                        {<<"amq.fanout">>,         fanout,  false},
+                        {<<"amq.rabbitmq.trace">>, topic,   true}],
+    rabbit_misc:for_each_while_ok(
+      fun({ExchangeName, Type, Internal}) ->
+              Resource = rabbit_misc:r(VHostName, exchange, ExchangeName),
+              rabbit_log:debug("Will declare an exchange ~tp", [Resource]),
+              case rabbit_exchange:declare(
+                     Resource, Type, true, false, Internal, [],
+                     ActingUser) of
+                   {ok, _} ->
+                       ok;
+                   {error, timeout} = Err ->
+                       Err
+              end
+      end, DefaultExchanges).
 
 -spec update_metadata(vhost:name(), vhost:metadata(), rabbit_types:username()) -> rabbit_types:ok_or_error(any()).
 update_metadata(Name, Metadata0, ActingUser) ->

--- a/deps/rabbit/test/bindings_SUITE.erl
+++ b/deps/rabbit/test/bindings_SUITE.erl
@@ -873,7 +873,8 @@ delete_queues() ->
      || Q <- rabbit_amqqueue:list()].
 
 delete_exchange(Name) ->
-    _ = rabbit_exchange:delete(rabbit_misc:r(<<"/">>, exchange, Name), false, <<"dummy">>).
+    ok = rabbit_exchange:ensure_deleted(
+           rabbit_misc:r(<<"/">>, exchange, Name), false, <<"dummy">>).
 
 declare(Ch, Q, Args) ->
     declare(Ch, Q, Args, true).

--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -24,6 +24,7 @@ groups() ->
      {client_operations, [], [open_connection,
                               open_channel,
                               declare_exchange,
+                              delete_exchange,
                               declare_binding,
                               delete_binding,
                               declare_queue,
@@ -100,6 +101,8 @@ init_per_group(Group, Config0) when Group == client_operations;
             #'exchange.bind_ok'{} = amqp_channel:call(Ch, #'exchange.bind'{destination = <<"amq.fanout">>,
                                                                            source = <<"amq.direct">>,
                                                                            routing_key = <<"binding-to-be-deleted">>}),
+            %% To be used in delete_exchange
+            #'exchange.declare_ok'{} = amqp_channel:call(Ch, #'exchange.declare'{exchange = <<"exchange-to-be-deleted">>}),
 
             %% Lower the default Khepri command timeout. By default this is set
             %% to 30s in `rabbit_khepri:setup/1' which makes the cases in this
@@ -156,6 +159,12 @@ declare_exchange(Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, A),
     ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
                 amqp_channel:call(Ch, #'exchange.declare'{exchange = <<"test-exchange">>})).
+
+delete_exchange(Config) ->
+    [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, A),
+    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+                amqp_channel:call(Ch, #'exchange.delete'{exchange = <<"exchange-to-be-deleted">>})).
 
 declare_binding(Config) ->
     [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),

--- a/deps/rabbit/test/exchanges_SUITE.erl
+++ b/deps/rabbit/test/exchanges_SUITE.erl
@@ -340,7 +340,8 @@ delete_queues() ->
      || Q <- rabbit_amqqueue:list()].
 
 delete_exchange(Name) ->
-    _ = rabbit_exchange:delete(rabbit_misc:r(<<"/">>, exchange, Name), false, <<"dummy">>).
+    ok = rabbit_exchange:ensure_deleted(
+           rabbit_misc:r(<<"/">>, exchange, Name), false, <<"dummy">>).
 
 declare(Ch, Q, Args) ->
     declare(Ch, Q, Args, true).

--- a/deps/rabbit/test/routing_SUITE.erl
+++ b/deps/rabbit/test/routing_SUITE.erl
@@ -84,9 +84,9 @@ topic(Config) ->
 
 topic1(_Config) ->
     XName = rabbit_misc:r(?VHOST, exchange, <<"topic_matching-exchange">>),
-    X = rabbit_exchange:declare(
-          XName, topic, _Durable = true, _AutoDelete = false,
-          _Internal = false, _Args = [], ?USER),
+    {ok, X} = rabbit_exchange:declare(
+                XName, topic, _Durable = true, _AutoDelete = false,
+                _Internal = false, _Args = [], ?USER),
 
     %% add some bindings
     Bindings = [#binding{source = XName,

--- a/deps/rabbitmq_cli/test/ctl/list_exchanges_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_exchanges_command_test.exs
@@ -96,7 +96,7 @@ defmodule ListExchangesCommandTest do
 
   test "run: default options test", context do
     exchange_name = "test_exchange"
-    declare_exchange(exchange_name, @vhost)
+    {:ok, _} = declare_exchange(exchange_name, @vhost)
 
     assert MapSet.new(run_command_to_list(@command, [["name", "type"], context[:opts]])) ==
              MapSet.new(
@@ -106,8 +106,8 @@ defmodule ListExchangesCommandTest do
   end
 
   test "run: list multiple exchanges", context do
-    declare_exchange("test_exchange_1", @vhost, :direct)
-    declare_exchange("test_exchange_2", @vhost, :fanout)
+    {:ok, _} = declare_exchange("test_exchange_1", @vhost, :direct)
+    {:ok, _} = declare_exchange("test_exchange_2", @vhost, :fanout)
 
     non_default_exchanges =
       run_command_to_list(@command, [["name", "type"], context[:opts]])
@@ -124,8 +124,8 @@ defmodule ListExchangesCommandTest do
   end
 
   test "run: info keys filter single key", context do
-    declare_exchange("test_exchange_1", @vhost)
-    declare_exchange("test_exchange_2", @vhost)
+    {:ok, _} = declare_exchange("test_exchange_1", @vhost)
+    {:ok, _} = declare_exchange("test_exchange_2", @vhost)
 
     non_default_exchanges =
       run_command_to_list(@command, [["name"], context[:opts]])
@@ -138,8 +138,8 @@ defmodule ListExchangesCommandTest do
   end
 
   test "run: info keys add additional keys", context do
-    declare_exchange("durable_exchange", @vhost, :direct, true)
-    declare_exchange("auto_delete_exchange", @vhost, :fanout, false, true)
+    {:ok, _} = declare_exchange("durable_exchange", @vhost, :direct, true)
+    {:ok, _} = declare_exchange("auto_delete_exchange", @vhost, :fanout, false, true)
 
     non_default_exchanges =
       run_command_to_list(@command, [["name", "type", "durable", "auto_delete"], context[:opts]])
@@ -162,8 +162,8 @@ defmodule ListExchangesCommandTest do
       delete_vhost(other_vhost)
     end)
 
-    declare_exchange("test_exchange_1", @vhost)
-    declare_exchange("test_exchange_2", other_vhost)
+    {:ok, _} = declare_exchange("test_exchange_1", @vhost)
+    {:ok, _} = declare_exchange("test_exchange_2", other_vhost)
 
     non_default_exchanges1 =
       run_command_to_list(@command, [["name"], context[:opts]])

--- a/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
+++ b/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
@@ -43,8 +43,13 @@ register() ->
     gen_event:add_handler(rabbit_event, ?MODULE, []).
 
 unregister() ->
-    _ = rabbit_exchange:delete(exchange(), false, ?INTERNAL_USER),
-    gen_event:delete_handler(rabbit_event, ?MODULE, []).
+    case rabbit_exchange:ensure_deleted(exchange(), false, ?INTERNAL_USER) of
+        ok ->
+            gen_event:delete_handler(rabbit_event, ?MODULE, []),
+            ok;
+        {error, _} = Err ->
+            Err
+    end.
 
 exchange() ->
     exchange(get_vhost()).

--- a/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
+++ b/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
@@ -38,9 +38,13 @@ info(_X) -> [].
 info(_X, _) -> [].
 
 register() ->
-    _ = rabbit_exchange:declare(exchange(), topic, true, false, true, [],
-                                ?INTERNAL_USER),
-    gen_event:add_handler(rabbit_event, ?MODULE, []).
+    case rabbit_exchange:declare(exchange(), topic, true, false, true, [],
+                                 ?INTERNAL_USER) of
+        {ok, _Exchange} ->
+            gen_event:add_handler(rabbit_event, ?MODULE, []);
+        {error, timeout} = Err ->
+            Err
+    end.
 
 unregister() ->
     case rabbit_exchange:ensure_deleted(exchange(), false, ?INTERNAL_USER) of

--- a/deps/rabbitmq_federation/test/unit_inbroker_SUITE.erl
+++ b/deps/rabbitmq_federation/test/unit_inbroker_SUITE.erl
@@ -200,10 +200,12 @@ upstream_validation(_Config) ->
     ok.
 
 with_exchanges(Fun) ->
-    rabbit_exchange:declare(r(?US_NAME), fanout, false, false, false, [],
-                            <<"acting-user">>),
-    X = rabbit_exchange:declare(r(?DS_NAME), fanout, false, false, false, [],
-                                <<"acting-user">>),
+    {ok, _} = rabbit_exchange:declare(
+                r(?US_NAME), fanout, false, false, false, [],
+                <<"acting-user">>),
+    {ok, X} = rabbit_exchange:declare(
+                r(?DS_NAME), fanout, false, false, false, [],
+                <<"acting-user">>),
     Fun(X),
     %% Delete downstream first or it will recreate the upstream
     rabbit_exchange:delete(r(?DS_NAME), false, <<"acting-user">>),

--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -889,11 +889,12 @@ delete_super_stream_exchange(VirtualHost, Name, Username) ->
     case rabbit_stream_utils:enforce_correct_name(Name) of
         {ok, CorrectName} ->
             ExchangeName = rabbit_misc:r(VirtualHost, exchange, CorrectName),
-            case rabbit_exchange:delete(ExchangeName, false, Username) of
-                {error, not_found} ->
-                    ok;
+            case rabbit_exchange:ensure_deleted(
+                   ExchangeName, false, Username) of
                 ok ->
-                    ok
+                    ok;
+                {error, timeout} = Err ->
+                    Err
             end;
         error ->
             {error, validation_failed}


### PR DESCRIPTION
Continuation of the changes like in https://github.com/rabbitmq/rabbitmq-server/issues/11685 and https://github.com/rabbitmq/rabbitmq-server/pull/11706 but for exchanges.

The changes for exchanges are a bit more involved than prior PRs. Here's a summary of the changes:

* `rabbit_exchange:declare/7`'s spec is updated to return `{ok, #exchange{}} | {error, timeout}` where it returned just `#exchange{}` before
    * this is safe to change since the function is only ever called through RPC in the CLI's test helpers
* Callers of `rabbit_exchange:delete/3` need some small changes to handle an `{error, timeout}` return
    * I've added a `rabbit_exchange:ensure_deleted/3` wrapper that covers the common case for callers where `ok | {error, not_found}` are handled the same way.
* Set `timeout => infinity` for calls for updating the exchange serial
    * Serial updates are always made after another database operation (for example adding or deleting an exchange)
    * Ideally we would update the serial in a transaction but this would take a larger change, so I've left it for future work.