### PR TITLE
Unify Khepri paths API

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -32,12 +32,13 @@
          delete_transient_for_destination_in_mnesia/1,
          has_for_source_in_mnesia/1,
          has_for_source_in_khepri/1,
-         match_source_and_destination_in_khepri_tx/2
+         match_source_and_destination_in_khepri_tx/2,
+         clear_in_khepri/0
         ]).
 
 -export([
-         khepri_route_path/1,
-         khepri_routes_path/0,
+         khepri_route_path/1, khepri_route_path/5,
+         khepri_route_path_to_args/1,
          khepri_route_exchange_path/1
         ]).
 
@@ -610,9 +611,12 @@ fold_in_mnesia(Fun, Acc) ->
               end, Acc, ?MNESIA_TABLE).
 
 fold_in_khepri(Fun, Acc) ->
-    Path = khepri_routes_path() ++ [_VHost = ?KHEPRI_WILDCARD_STAR,
-                                    _SrcName = ?KHEPRI_WILDCARD_STAR,
-                                    rabbit_khepri:if_has_data_wildcard()],
+    Path = khepri_route_path(
+             _VHost = ?KHEPRI_WILDCARD_STAR,
+             _SrcName = ?KHEPRI_WILDCARD_STAR,
+             _Kind = ?KHEPRI_WILDCARD_STAR,
+             _DstName = ?KHEPRI_WILDCARD_STAR,
+             _RoutingKey = #if_has_data{}),
     {ok, Res} = rabbit_khepri:fold(
                   Path,
                   fun(_, #{data := SetOfBindings}, Acc0) ->
@@ -828,9 +832,14 @@ delete_all_for_exchange_in_khepri(X = #exchange{name = XName}, OnlyDurable, Remo
     {deleted, X, Bindings, delete_for_destination_in_khepri(XName, OnlyDurable)}.
 
 delete_for_source_in_khepri(#resource{virtual_host = VHost, name = Name}) ->
-    Path = khepri_routes_path() ++ [VHost, Name],
-    {ok, Bindings} = khepri_tx:get_many(Path ++ [rabbit_khepri:if_has_data_wildcard()]),
-    ok = khepri_tx:delete(Path),
+    Path = khepri_route_path(
+             VHost,
+             Name,
+             _Kind = ?KHEPRI_WILDCARD_STAR,
+             _DstName = ?KHEPRI_WILDCARD_STAR,
+             _RoutingKey = #if_has_data{}),
+    {ok, Bindings} = khepri_tx:get_many(Path),
+    ok = khepri_tx:delete_many(Path),
     maps:fold(fun(_P, Set, Acc) ->
                       sets:to_list(Set) ++ Acc
               end, [], Bindings).
@@ -885,7 +894,12 @@ delete_for_destination_in_khepri(DstName, OnlyDurable) ->
                                        lists:keysort(#binding.source, Bindings), OnlyDurable).
 
 match_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, name = Name}) ->
-    Path = khepri_routes_path() ++ [VHost, ?KHEPRI_WILDCARD_STAR, Kind, Name, ?KHEPRI_WILDCARD_STAR_STAR],
+    Path = khepri_route_path(
+             VHost,
+             _SrcName = ?KHEPRI_WILDCARD_STAR,
+             Kind,
+             Name,
+             _RoutingKey = ?KHEPRI_WILDCARD_STAR),
     {ok, Map} = khepri_tx:get_many(Path),
     Map.
 
@@ -926,7 +940,12 @@ has_for_source_in_mnesia(SrcName) ->
 -spec has_for_source_in_khepri(rabbit_types:binding_source()) -> boolean().
 
 has_for_source_in_khepri(#resource{virtual_host = VHost, name = Name}) ->
-    Path = khepri_routes_path() ++ [VHost, Name, rabbit_khepri:if_has_data_wildcard()],
+    Path = khepri_route_path(
+             VHost,
+             Name,
+             _Kind = ?KHEPRI_WILDCARD_STAR,
+             _DstName = ?KHEPRI_WILDCARD_STAR,
+             _RoutingKey = #if_has_data{}),
     case khepri_tx:get_many(Path) of
         {ok, Map} ->
             maps:size(Map) > 0;
@@ -945,7 +964,8 @@ has_for_source_in_khepri(#resource{virtual_host = VHost, name = Name}) ->
 
 match_source_and_destination_in_khepri_tx(#resource{virtual_host = VHost, name = Name},
                                           #resource{kind = Kind, name = DstName}) ->
-    Path = khepri_routes_path() ++ [VHost, Name, Kind, DstName, rabbit_khepri:if_has_data_wildcard()],
+    Path = khepri_route_path(
+             VHost, Name, Kind, DstName, _RoutingKey = #if_has_data{}),
     case khepri_tx:get_many(Path) of
         {ok, Map} -> maps:values(Map);
         _         -> []
@@ -974,7 +994,12 @@ clear_in_mnesia() ->
     ok.
 
 clear_in_khepri() ->
-    Path = khepri_routes_path(),
+    Path = khepri_route_path(
+             _VHost = ?KHEPRI_WILDCARD_STAR,
+             _SrcName = ?KHEPRI_WILDCARD_STAR,
+             _Kind = ?KHEPRI_WILDCARD_STAR,
+             _DstName = ?KHEPRI_WILDCARD_STAR,
+             _RoutingKey = ?KHEPRI_WILDCARD_STAR),
     case rabbit_khepri:delete(Path) of
         ok -> ok;
         Error -> throw(Error)
@@ -983,13 +1008,44 @@ clear_in_khepri() ->
 %% --------------------------------------------------------------
 %% Paths
 %% --------------------------------------------------------------
-khepri_route_path(#binding{source = #resource{virtual_host = VHost, name = SrcName},
-                           destination = #resource{kind = Kind, name = DstName},
-                           key = RoutingKey}) ->
+
+khepri_route_path(
+  #binding{source = #resource{virtual_host = VHost, name = SrcName},
+           destination = #resource{kind = Kind, name = DstName},
+           key = RoutingKey}) ->
+    khepri_route_path(VHost, SrcName, Kind, DstName, RoutingKey).
+
+khepri_route_path(VHost, SrcName, Kind, DstName, RoutingKey)
+  when ?IS_KHEPRI_PATH_CONDITION(VHost) andalso
+       ?IS_KHEPRI_PATH_CONDITION(SrcName) andalso
+       ?IS_KHEPRI_PATH_CONDITION(Kind) andalso
+       ?IS_KHEPRI_PATH_CONDITION(DstName) andalso
+       ?IS_KHEPRI_PATH_CONDITION(RoutingKey) ->
     [?MODULE, routes, VHost, SrcName, Kind, DstName, RoutingKey].
 
-khepri_routes_path() ->
-    [?MODULE, routes].
+khepri_route_path_to_args(Path) ->
+    Pattern = khepri_route_path(
+                '$VHost', '$SrcName', '$Kind', '$DstName', '$RoutingKey'),
+    khepri_route_path_to_args(Pattern, Path, #{}).
+
+khepri_route_path_to_args([Var | Pattern], [Value | Path], Result)
+  when Var =:= '$VHost' orelse
+       Var =:= '$SrcName' orelse
+       Var =:= '$Kind' orelse
+       Var =:= '$DstName' orelse
+       Var =:= '$RoutingKey' ->
+    Result1 = Result#{Var => Value},
+    khepri_route_path_to_args(Pattern, Path, Result1);
+khepri_route_path_to_args([Comp | Pattern], [Comp | Path], Result) ->
+    khepri_route_path_to_args(Pattern, Path, Result);
+khepri_route_path_to_args(
+  [], _,
+  #{'$VHost' := VHost,
+    '$SrcName' := SrcName,
+    '$Kind' := Kind,
+    '$DstName' := DstName,
+    '$RoutingKey' := RoutingKey}) ->
+    {VHost, SrcName, Kind, DstName, RoutingKey}.
 
 khepri_route_exchange_path(#resource{virtual_host = VHost, name = SrcName}) ->
     [?MODULE, routes, VHost, SrcName].

--- a/deps/rabbit/src/rabbit_db_binding_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_binding_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -111,8 +112,4 @@ delete_from_khepri(rabbit_route = Table, Key, State) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_route) ->
-    Path = rabbit_db_binding:khepri_routes_path(),
-    case rabbit_khepri:delete(Path) of
-        ok -> ok;
-        Error -> throw(Error)
-    end.
+    rabbit_db_binding:clear_in_khepri().

--- a/deps/rabbit/src/rabbit_db_exchange_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_exchange_m2k_converter.erl
@@ -129,12 +129,6 @@ delete_from_khepri(rabbit_exchange_serial = Table, Key, State) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_exchange) ->
-    khepri_delete(rabbit_db_exchange:khepri_exchanges_path());
+    rabbit_db_exchange:clear_exchanges_in_khepri();
 clear_data_in_khepri(rabbit_exchange_serial) ->
-    khepri_delete(rabbit_db_exchange:khepri_exchange_serials_path()).
-
-khepri_delete(Path) ->
-    case rabbit_khepri:delete(Path) of
-        ok -> ok;
-        Error -> throw(Error)
-    end.
+    rabbit_db_exchange:clear_exchange_serials_in_khepri().

--- a/deps/rabbit/src/rabbit_db_maintenance.erl
+++ b/deps/rabbit/src/rabbit_db_maintenance.erl
@@ -7,6 +7,7 @@
 
 -module(rabbit_db_maintenance).
 
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -export([
@@ -17,8 +18,7 @@
         ]).
 
 -export([
-         khepri_maintenance_path/1,
-         khepri_maintenance_path/0
+         khepri_maintenance_path/1
         ]).
 
 -define(TABLE, rabbit_node_maintenance_states).
@@ -167,8 +167,5 @@ get_consistent_in_khepri(Node) ->
 %% Khepri paths
 %% -------------------------------------------------------------------
 
-khepri_maintenance_path() ->
-    [?MODULE, maintenance].
-
-khepri_maintenance_path(Node) ->
+khepri_maintenance_path(Node) when ?IS_KHEPRI_PATH_CONDITION(Node) ->
     [?MODULE, maintenance, Node].

--- a/deps/rabbit/src/rabbit_db_maintenance_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_maintenance_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -95,7 +96,7 @@ delete_from_khepri(rabbit_node_maintenance_states = Table, Key, State) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_node_maintenance_states) ->
-    Path = rabbit_db_maintenance:khepri_maintenance_path(),
+    Path = rabbit_db_maintenance:khepri_maintenance_path(?KHEPRI_WILDCARD_STAR),
     case rabbit_khepri:delete(Path) of
         ok -> ok;
         Error -> throw(Error)

--- a/deps/rabbit/src/rabbit_db_msup_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_msup_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("mirrored_supervisor.hrl").
@@ -96,8 +97,4 @@ delete_from_khepri(
       Table :: atom().
 
 clear_data_in_khepri(mirrored_sup_childspec) ->
-    Path = rabbit_db_msup:khepri_mirrored_supervisor_path(),
-    case rabbit_khepri:delete(Path) of
-        ok -> ok;
-        Error -> throw(Error)
-    end.
+    rabbit_db_msup:clear_in_khepri().

--- a/deps/rabbit/src/rabbit_db_queue_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_queue_m2k_converter.erl
@@ -95,12 +95,6 @@ delete_from_khepri(rabbit_queue = Table, Key, State) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_queue) ->
-    khepri_delete(rabbit_db_queue:khepri_queues_path());
+    rabbit_db_queue:clear_in_khepri();
 clear_data_in_khepri(rabbit_durable_queue) ->
-    khepri_delete(rabbit_db_queue:khepri_queues_path()).
-
-khepri_delete(Path) ->
-    case rabbit_khepri:delete(Path) of
-        ok -> ok;
-        Error -> throw(Error)
-    end.
+    rabbit_db_queue:clear_in_khepri().

--- a/deps/rabbit/src/rabbit_db_rtparams_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -99,8 +100,16 @@ rtparams_path(Key) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_runtime_parameters) ->
-    Path = rabbit_db_rtparams:khepri_rp_path(),
-    case rabbit_khepri:delete(Path) of
+    Path1 = rabbit_db_rtparams:khepri_global_rp_path(?KHEPRI_WILDCARD_STAR),
+    case rabbit_khepri:delete(Path1) of
         ok -> ok;
-        Error -> throw(Error)
+        Error1 -> throw(Error1)
+    end,
+    Path2 = rabbit_db_rtparams:khepri_vhost_rp_path(
+              ?KHEPRI_WILDCARD_STAR,
+              ?KHEPRI_WILDCARD_STAR,
+              ?KHEPRI_WILDCARD_STAR),
+    case rabbit_khepri:delete(Path2) of
+        ok -> ok;
+        Error2 -> throw(Error2)
     end.

--- a/deps/rabbit/src/rabbit_db_user_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_user_m2k_converter.erl
@@ -192,10 +192,6 @@ delete_from_khepri(rabbit_topic_permission = Table, Key, State) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_user) ->
-    Path = rabbit_db_user:khepri_users_path(),
-    case rabbit_khepri:delete(Path) of
-        ok    -> ok;
-        Error -> throw(Error)
-    end;
+    rabbit_db_user:clear_in_khepri();
 clear_data_in_khepri(_) ->
     ok.

--- a/deps/rabbit/src/rabbit_db_vhost_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_vhost_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("vhost.hrl").
@@ -95,8 +96,4 @@ delete_from_khepri(rabbit_vhost = Table, Key, State) ->
       Table :: atom().
 
 clear_data_in_khepri(rabbit_vhost) ->
-    Path = rabbit_db_vhost:khepri_vhosts_path(),
-    case rabbit_khepri:delete(Path) of
-        ok    -> ok;
-        Error -> throw(Error)
-    end.
+    rabbit_db_vhost:clear_in_khepri().

--- a/deps/rabbit/src/rabbit_table.erl
+++ b/deps/rabbit/src/rabbit_table.erl
@@ -183,15 +183,8 @@ needs_default_data() ->
     end.
 
 needs_default_data_in_khepri() ->
-    Paths = [rabbit_db_vhost:khepri_vhosts_path(),
-             rabbit_db_user:khepri_users_path()],
-    lists:all(
-      fun(Path) ->
-              case rabbit_khepri:list(Path) of
-                  {ok, List} when is_map(List) andalso List =:= #{} -> true;
-                  _                                                 -> false
-              end
-      end, Paths).
+    rabbit_db_user:count_all() =:= {ok, 0} orelse
+    rabbit_db_vhost:count_all() =:= {ok, 0}.
 
 needs_default_data_in_mnesia() ->
     is_empty([rabbit_user, rabbit_user_permission,

--- a/deps/rabbit/test/metadata_store_phase1_SUITE.erl
+++ b/deps/rabbit/test/metadata_store_phase1_SUITE.erl
@@ -293,15 +293,6 @@ init_feature_flags(Config) ->
 %% This simply avoids compiler warnings.
 -define(with(T), fun(_With) -> T end).
 
--define(vhost_path(V),
-        [rabbit_db_vhost, V]).
--define(user_path(U),
-        [rabbit_db_user, users, U]).
--define(user_perm_path(U, V),
-        [rabbit_db_user, users, U, user_permissions, V]).
--define(topic_perm_path(U, V, E),
-        [rabbit_db_user, users, U, topic_permissions, V, E]).
-
 %%
 %% Virtual hosts.
 %%
@@ -330,8 +321,8 @@ write_non_existing_vhost(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [VHost]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -371,8 +362,8 @@ write_existing_vhost(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [VHost]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -404,8 +395,8 @@ check_vhost_exists(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [VHost]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -447,9 +438,9 @@ list_vhost_names(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [VHostA, VHostB]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostNameA) => VHostA,
-                 ?vhost_path(VHostNameB) => VHostB}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostNameA) => VHostA,
+                 rabbit_db_vhost:khepri_vhost_path(VHostNameB) => VHostB}}]))
     ],
 
     ?assertEqual(
@@ -491,9 +482,9 @@ list_vhost_objects(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [VHostA, VHostB]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostNameA) => VHostA,
-                 ?vhost_path(VHostNameB) => VHostB}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostNameA) => VHostA,
+                 rabbit_db_vhost:khepri_vhost_path(VHostNameB) => VHostB}}]))
     ],
 
     ?assertEqual(
@@ -530,8 +521,7 @@ update_non_existing_vhost(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, []},
-              {khepri, [rabbit_db_vhost],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -571,8 +561,8 @@ update_existing_vhost(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [UpdatedVHost]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => UpdatedVHost}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => UpdatedVHost}}]))
     ],
 
     ?assertEqual(
@@ -601,8 +591,7 @@ update_non_existing_vhost_desc_and_tags(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, []},
-              {khepri, [rabbit_db_vhost],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -647,8 +636,8 @@ update_existing_vhost_desc_and_tags(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, [UpdatedVHost]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => UpdatedVHost}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => UpdatedVHost}}]))
     ],
 
     ?assertEqual(
@@ -675,8 +664,7 @@ delete_non_existing_vhost(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, []},
-              {khepri, [rabbit_db_vhost],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -713,8 +701,7 @@ delete_existing_vhost(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_vhost, []},
-              {khepri, [rabbit_db_vhost],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -746,8 +733,8 @@ write_non_existing_user(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, [User]},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -781,8 +768,8 @@ write_existing_user(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, [User]},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -812,9 +799,9 @@ list_users(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, [UserA, UserB]},
-              {khepri, [rabbit_db_user],
-               #{?user_path(UsernameA) => UserA,
-                 ?user_path(UsernameB) => UserB}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(UsernameA) => UserA,
+                 rabbit_db_user:khepri_user_path(UsernameB) => UserB}}]))
     ],
 
     ?assertEqual(
@@ -846,8 +833,7 @@ update_non_existing_user(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, []},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -882,8 +868,8 @@ update_existing_user(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, [UpdatedUser]},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => UpdatedUser}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => UpdatedUser}}]))
     ],
 
     ?assertEqual(
@@ -910,8 +896,7 @@ delete_non_existing_user(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, []},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -942,8 +927,7 @@ delete_existing_user(_) ->
      ?with(check_storage(
              _With,
              [{mnesia, rabbit_user, []},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none, #{}}]))
     ],
 
     ?assertEqual(
@@ -987,10 +971,8 @@ write_user_permission_for_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -1036,10 +1018,8 @@ write_user_permission_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -1091,11 +1071,10 @@ write_user_permission_for_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, [UserPermission]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User,
-                 ?user_perm_path(Username, VHostName) => UserPermission}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost,
+                 rabbit_db_user:khepri_user_path(Username) => User,
+                 rabbit_db_user:khepri_user_permission_path(Username, VHostName) => UserPermission}}]))
     ],
 
     ?assertEqual(
@@ -1175,9 +1154,8 @@ list_user_permissions_on_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost], #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -1217,8 +1195,8 @@ list_user_permissions_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost], #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user], #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -1320,17 +1298,16 @@ list_user_permissions(_) ->
               {mnesia, rabbit_user_permission, [UserPermissionA1,
                                                 UserPermissionA2,
                                                 UserPermissionB1]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostNameA) => VHostA,
-                 ?vhost_path(VHostNameB) => VHostB}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(UsernameA) => UserA,
-                 ?user_path(UsernameB) => UserB,
-                 ?user_perm_path(UsernameA, VHostNameA) =>
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostNameA) => VHostA,
+                 rabbit_db_vhost:khepri_vhost_path(VHostNameB) => VHostB,
+                 rabbit_db_user:khepri_user_path(UsernameA) => UserA,
+                 rabbit_db_user:khepri_user_path(UsernameB) => UserB,
+                 rabbit_db_user:khepri_user_permission_path(UsernameA, VHostNameA) =>
                  UserPermissionA1,
-                 ?user_perm_path(UsernameA, VHostNameB) =>
+                 rabbit_db_user:khepri_user_permission_path(UsernameA, VHostNameB) =>
                  UserPermissionA2,
-                 ?user_perm_path(UsernameB, VHostNameA) =>
+                 rabbit_db_user:khepri_user_permission_path(UsernameB, VHostNameA) =>
                  UserPermissionB1}}]))
     ],
 
@@ -1363,10 +1340,8 @@ clear_user_permission_for_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -1404,10 +1379,8 @@ clear_user_permission_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -1462,10 +1435,9 @@ clear_user_permission(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost,
+                 rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -1524,10 +1496,8 @@ delete_user_and_check_resource_access(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -1581,10 +1551,8 @@ delete_vhost_and_check_resource_access(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, [UserPermission]},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     %% In mnesia the permissions have to be deleted explicitly
@@ -1657,10 +1625,8 @@ write_topic_permission_for_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_topic_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -1718,10 +1684,8 @@ write_topic_permission_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_topic_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -1786,11 +1750,10 @@ write_topic_permission_for_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_topic_permission, [TopicPermission]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User,
-                 ?topic_perm_path(Username, VHostName, Exchange) =>
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost,
+                 rabbit_db_user:khepri_user_path(Username) => User,
+                 rabbit_db_user:khepri_topic_permission_path(Username, VHostName, Exchange) =>
                  TopicPermission}}]))
     ],
 
@@ -1823,10 +1786,8 @@ list_topic_permissions_on_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_topic_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -1866,8 +1827,8 @@ list_topic_permissions_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_topic_permission, []},
-              {khepri, [rabbit_db_vhost], #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user], #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -1980,17 +1941,16 @@ list_topic_permissions(_) ->
               {mnesia, rabbit_topic_permission, [TopicPermissionA1,
                                                  TopicPermissionA2,
                                                  TopicPermissionB1]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostNameA) => VHostA,
-                 ?vhost_path(VHostNameB) => VHostB}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(UsernameA) => UserA,
-                 ?user_path(UsernameB) => UserB,
-                 ?topic_perm_path(UsernameA, VHostNameA, ExchangeA) =>
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostNameA) => VHostA,
+                 rabbit_db_vhost:khepri_vhost_path(VHostNameB) => VHostB,
+                 rabbit_db_user:khepri_user_path(UsernameA) => UserA,
+                 rabbit_db_user:khepri_user_path(UsernameB) => UserB,
+                 rabbit_db_user:khepri_topic_permission_path(UsernameA, VHostNameA, ExchangeA) =>
                  TopicPermissionA1,
-                 ?topic_perm_path(UsernameA, VHostNameB, ExchangeB) =>
+                 rabbit_db_user:khepri_topic_permission_path(UsernameA, VHostNameB, ExchangeB) =>
                  TopicPermissionA2,
-                 ?topic_perm_path(UsernameB, VHostNameA, ExchangeA) =>
+                 rabbit_db_user:khepri_topic_permission_path(UsernameB, VHostNameA, ExchangeA) =>
                  TopicPermissionB1}}]))
     ],
 
@@ -2031,10 +1991,8 @@ clear_specific_topic_permission_for_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -2080,10 +2038,8 @@ clear_specific_topic_permission_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -2186,11 +2142,10 @@ clear_specific_topic_permission(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_topic_permission, [TopicPermissionB]},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User,
-                 ?topic_perm_path(Username, VHostName, ExchangeB) =>
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost,
+                 rabbit_db_user:khepri_user_path(Username) => User,
+                 rabbit_db_user:khepri_topic_permission_path(Username, VHostName, ExchangeB) =>
                  TopicPermissionB}}]))
     ],
 
@@ -2231,10 +2186,8 @@ clear_all_topic_permission_for_non_existing_vhost(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -2280,10 +2233,8 @@ clear_all_topic_permission_for_non_existing_user(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_user_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -2388,10 +2339,9 @@ clear_all_topic_permissions(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_topic_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost,
+                 rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     ?assertEqual(
@@ -2464,10 +2414,8 @@ delete_user_and_check_topic_access(_) ->
              [{mnesia, rabbit_vhost, [VHost]},
               {mnesia, rabbit_user, []},
               {mnesia, rabbit_topic_permission, []},
-              {khepri, [rabbit_db_vhost],
-               #{?vhost_path(VHostName) => VHost}},
-              {khepri, [rabbit_db_user],
-               #{}}]))
+              {khepri, none,
+               #{rabbit_db_vhost:khepri_vhost_path(VHostName) => VHost}}]))
     ],
 
     ?assertEqual(
@@ -2530,10 +2478,8 @@ delete_vhost_and_check_topic_access(_) ->
              [{mnesia, rabbit_vhost, []},
               {mnesia, rabbit_user, [User]},
               {mnesia, rabbit_topic_permission, [TopicPermission]},
-              {khepri, [rabbit_db_vhost],
-               #{}},
-              {khepri, [rabbit_db_user],
-               #{?user_path(Username) => User}}]))
+              {khepri, none,
+               #{rabbit_db_user:khepri_user_path(Username) => User}}]))
     ],
 
     %% In mnesia the permissions have to be deleted explicitly
@@ -2768,8 +2714,8 @@ check_storage(_, []) ->
 
 check_storage(mnesia, Table, Content) ->
     ?assertEqual(Content, lists:sort(ets:tab2list(Table)));
-check_storage(khepri, Path, Content) ->
+check_storage(khepri, none, Content) ->
     rabbit_khepri:info(),
-    Path1 = Path ++ [#if_all{conditions = [?KHEPRI_WILDCARD_STAR_STAR,
-                                           #if_has_data{has_data = true}]}],
-    ?assertEqual({ok, Content}, rabbit_khepri:match(Path1)).
+    Path = [#if_all{conditions = [?KHEPRI_WILDCARD_STAR_STAR,
+                                  #if_has_data{}]}],
+    ?assertEqual({ok, Content}, rabbit_khepri:match(Path)).

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange.erl
@@ -20,8 +20,8 @@
         ]).
 
 -export([
-         khepri_consistent_hash_path/0,
-         khepri_consistent_hash_path/1
+         khepri_consistent_hash_path/1,
+         khepri_consistent_hash_path/2
         ]).
 
 -define(HASH_RING_STATE_TABLE, rabbit_exchange_type_consistent_hash_ring_state).
@@ -222,7 +222,9 @@ delete_binding_in_khepri(#binding{source = S, destination = D}, DeleteFun) ->
 khepri_consistent_hash_path(#exchange{name = Name}) ->
     khepri_consistent_hash_path(Name);
 khepri_consistent_hash_path(#resource{virtual_host = VHost, name = Name}) ->
-    [?MODULE, exchange_type_consistent_hash_ring_state, VHost, Name].
+    khepri_consistent_hash_path(VHost, Name).
 
-khepri_consistent_hash_path() ->
-    [?MODULE, exchange_type_consistent_hash_ring_state].
+khepri_consistent_hash_path(VHost, Name)
+  when ?IS_KHEPRI_PATH_CONDITION(VHost) andalso
+       ?IS_KHEPRI_PATH_CONDITION(Name) ->
+    [?MODULE, exchange_type_consistent_hash_ring_state, VHost, Name].

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange_m2k_converter.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -93,7 +94,8 @@ delete_from_khepri(?HASH_RING_STATE_TABLE = Table, Key, State) ->
       end, State).
 
 clear_data_in_khepri(?HASH_RING_STATE_TABLE) ->
-    Path = rabbit_db_ch_exchange:khepri_consistent_hash_path(),
+    Path = rabbit_db_ch_exchange:khepri_consistent_hash_path(
+             ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
     case rabbit_khepri:delete(Path) of
         ok ->
             ok;

--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange.erl
@@ -20,8 +20,8 @@
         ]).
 
 -export([
-         khepri_jms_topic_exchange_path/0,
-         khepri_jms_topic_exchange_path/1
+         khepri_jms_topic_exchange_path/1,
+         khepri_jms_topic_exchange_path/2
         ]).
 
 -rabbit_mnesia_tables_to_khepri_db(
@@ -233,7 +233,9 @@ remove_items(Dict, [Key | Keys]) -> remove_items(dict:erase(Key, Dict), Keys).
 %% -------------------------------------------------------------------
 
 khepri_jms_topic_exchange_path(#resource{virtual_host = VHost, name = Name}) ->
-    [?MODULE, jms_topic_exchange, VHost, Name].
+    khepri_jms_topic_exchange_path(VHost, Name).
 
-khepri_jms_topic_exchange_path() ->
-    [?MODULE, jms_topic_exchange].
+khepri_jms_topic_exchange_path(VHost, Name)
+  when ?IS_KHEPRI_PATH_CONDITION(VHost) andalso
+       ?IS_KHEPRI_PATH_CONDITION(Name) ->
+    [?MODULE, jms_topic_exchange, VHost, Name].

--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange_m2k_converter.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange_m2k_converter.erl
@@ -10,6 +10,7 @@
 -behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("khepri/include/khepri.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").
 -include_lib("rabbit_common/include/rabbit.hrl").
 
@@ -91,7 +92,8 @@ delete_from_khepri(?JMS_TOPIC_TABLE = Table, Key, State) ->
     end, State).
 
 clear_data_in_khepri(?JMS_TOPIC_TABLE) ->
-    Path = rabbit_db_jms_exchange:khepri_jms_topic_exchange_path(),
+    Path = rabbit_db_jms_exchange:khepri_jms_topic_exchange_path(
+             ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
     case rabbit_khepri:delete(Path) of
         ok ->
             ok;

--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange.erl
@@ -16,11 +16,11 @@
          get/1,
          insert/3,
          delete/0,
-         delete/1
+         delete/1,
+         delete_in_khepri/0
         ]).
 
--export([khepri_recent_history_path/1,
-         khepri_recent_history_path/0]).
+-export([khepri_recent_history_path/1]).
 
 -rabbit_mnesia_tables_to_khepri_db(
    [{?RH_TABLE, rabbit_db_rh_exchange_m2k_converter}]).
@@ -150,7 +150,9 @@ delete_in_mnesia() ->
     end.
 
 delete_in_khepri() ->
-    rabbit_khepri:delete(khepri_recent_history_path()).
+    Path = khepri_recent_history_path(
+             ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
+    rabbit_khepri:delete(Path).
 
 delete(XName) ->
     rabbit_khepri:handle_fallback(
@@ -165,14 +167,17 @@ delete_in_mnesia(XName) ->
       end).
 
 delete_in_khepri(XName) ->
-    rabbit_khepri:delete(khepri_recent_history_path(XName)).
+    Path = khepri_recent_history_path(XName),
+    rabbit_khepri:delete(Path).
 
 %% -------------------------------------------------------------------
 %% paths
 %% -------------------------------------------------------------------
 
-khepri_recent_history_path() ->
-    [?MODULE, recent_history_exchange].
-
 khepri_recent_history_path(#resource{virtual_host = VHost, name = Name}) ->
+    khepri_recent_history_path(VHost, Name).
+
+khepri_recent_history_path(VHost, Name)
+  when ?IS_KHEPRI_PATH_CONDITION(VHost) andalso
+       ?IS_KHEPRI_PATH_CONDITION(Name) ->
     [?MODULE, recent_history_exchange, VHost, Name].

--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange_m2k_converter.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange_m2k_converter.erl
@@ -90,8 +90,7 @@ delete_from_khepri(?RH_TABLE = Table, Key, State) ->
       end, State).
 
 clear_data_in_khepri(?RH_TABLE) ->
-    Path = rabbit_db_rh_exchange:khepri_recent_history_path(),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_db_rh_exchange:delete_in_khepri() of
         ok ->
             ok;
         Error ->

--- a/deps/rabbitmq_shovel/test/rolling_upgrade_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/rolling_upgrade_SUITE.erl
@@ -257,12 +257,14 @@ child_id_format(Config) ->
         mnesia ->
             ok;
         khepri ->
-            Path = rabbit_db_msup:khepri_mirrored_supervisor_path(),
+            Pattern = rabbit_db_msup:khepri_mirrored_supervisor_path(
+                        ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR_STAR),
+            Path = rabbit_db_msup:khepri_mirrored_supervisor_path(
+                     rabbit_shovel_dyn_worker_sup_sup, {VHost, ShovelName}),
+            ct:pal("Pattern=~0p~nPath=~0p", [Pattern, Path]),
             ?assertMatch(
-               {ok,
-                #{[rabbit_db_msup, mirrored_supervisor_childspec,
-                   rabbit_shovel_dyn_worker_sup_sup, VHost, ShovelName] := _}},
+               {ok, #{Path := _}},
                rabbit_ct_broker_helpers:rpc(
                  Config, NewNode, rabbit_khepri, list,
-                 [Path ++ [?KHEPRI_WILDCARD_STAR_STAR]]))
+                 [Pattern]))
     end.


### PR DESCRIPTION
## Why

Currently, `rabbit_db_*` modules use and export the following kind of functions to return the path to the resources they manage:

```erlang
khepri_db_thing:khepri_things_path(),
khepri_db_thing:khepri_thing_path(Identifier).
```

Internally, `khepri_db_thing:khepri_thing_path(Identifier)` appends `Identifier` to the list returned by `khepri_db_thing:khepri_things_path()`. This works for the organization of the records we have today in Khepri:

```
|-- thing
|   |-- <<"identifier1">>
|   |   <<"identifier2">>
`-- other_thing
    `-- <<"other_identifier1">>
```

However, with the upcoming organization that leverages the tree in Khepri, identifiers may be in the middle of the path instead of a leaf component. We may also put `other_thing` under `thing` in the tree.

That's why, we can't really expose a parent directory for `thing` and `other_thing`. Therefore, `khepri_db_thing:khepri_things_path/0` needs to go away. Only `khepri_db_thing:khepri_thing_path/1` should be exported and used.

In addition to that, there are several places where paths are hard-coded (i.e. their definition is duplicated).

## How

The patch does exactly that. Uses of `khepri_db_thing:khepri_things_path()` are generally replaced by `rabbit_db_thing:khepri_thing_path(?KHEPRI_WILDCARD_STAR)`.

Places where the path definitions were duplicated are fixed too by calling the path building functions.

In the future, for a resource that depends on another one, the corresponding module will call the `rabbit_db_thing:khepri_thing_path/1` for that other resource and build its path on top of that.