### PR TITLE
Fix crash in consistent hash exchange

### DIFF
--- a/deps/rabbitmq_consistent_hash_exchange/README.md
+++ b/deps/rabbitmq_consistent_hash_exchange/README.md
@@ -84,7 +84,7 @@ ring partitions, and thus queues according to their binding weights.
 #### One Binding Per Queue
 
 This exchange type **assumes a single binding between a queue and an exchange**.
-Starting with RabbitMQ `3.10.6` and `3.9.21` this will be enforced in the code:
+This will be enforced in the code:
 when multiple bindings are created, only the first one will actually update the ring.
 
 This limitation makes most semantic sense: the purpose is to achieve
@@ -376,7 +376,7 @@ exchange to route based on a named header instead. To do this, declare the
 exchange with a string argument called "hash-header" naming the header to
 be used.
 
-When a `"hash-header"` is specified, the chosen header **must be provided**.
+When a `"hash-header"` is specified, the chosen header should be provided.
 If published messages do not contain the header, they will all get
 routed to the same **arbitrarily chosen** queue.
 
@@ -579,7 +579,7 @@ declare the exchange with a string argument called ``"hash-property"`` naming th
 property to be used.
 The `"hash-header"` and `"hash-property"` are mutually exclusive.
 
-When a `"hash-property"` is specified, the chosen property **must be provided**.
+When a `"hash-property"` is specified, the chosen property should be provided.
 If published messages do not contain the property, they will all get
 routed to the same **arbitrarily chosen** queue.
 

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
@@ -261,8 +261,9 @@ jump_consistent_hash_value(_B0, J0, NumberOfBuckets, SeedState0) ->
 
 value_to_hash(undefined, Msg) ->
     mc:routing_keys(Msg);
-value_to_hash({header, Header}, Msg0) ->
-    maps:get(Header, mc:routing_headers(Msg0, [x_headers]));
+value_to_hash({header, Header}, Msg) ->
+    Headers = mc:routing_headers(Msg, [x_headers]),
+    maps:get(Header, Headers, undefined);
 value_to_hash({property, Property}, Msg) ->
     case Property of
         <<"correlation_id">> ->


### PR DESCRIPTION
Prior to this commit, a crash occurred when a consistent hash exchange got declared with a `hash-header` argument, but the publishing client didn't set that header on the message.

This bug is present in RabbitMQ 3.13.0 - 3.13.6.

Fixes https://github.com/rabbitmq/rabbitmq-server/discussions/11671