### PR TITLE
QQ: use a dedicated function for queue recovery after Ra system restart.

### DIFF
--- a/deps/rabbit/src/rabbit_ra_systems.erl
+++ b/deps/rabbit/src/rabbit_ra_systems.erl
@@ -130,7 +130,8 @@ get_config(quorum_queues = RaSystem) ->
                    wal_max_entries => WalMaxEntries,
                    segment_compute_checksums => SegmentChecksums,
                    compress_mem_tables => CompressMemTables,
-                   server_recovery_strategy => registered};
+                   server_recovery_strategy => {rabbit_quorum_queue,
+                                                system_recover, []}};
 get_config(coordination = RaSystem) ->
     DefaultConfig = get_default_config(),
     CoordDataDir = filename:join(


### PR DESCRIPTION
Previously we used the `registered` approach where all Ra servers that have a registered name would be recovered. This could have unintended side effects for queues that e.g. were deleted when not all members of a quorum queueu were running when the queue was deleted. In this case the Ra system would have recovered the members that were not deleted which is not ideal as a dangling member would just sit and loop in pre vote state and a future declaration of the queue may partially fail.

Instead we rely on the meta data store for the truth about which members should be restarted after a ra system restart.
