### PR TITLE
Fix rabbit_priority_queue:update_rates bug

### DIFF
--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -329,7 +329,7 @@ depth(#passthrough{bq = BQ, bqs = BQS}) ->
     BQ:depth(BQS).
 
 update_rates(State = #state{bq = BQ}) ->
-    fold_min2(fun (_P, BQSN) -> BQ:update_rates(BQSN) end, State);
+    foreach1(fun (_P, BQSN) -> BQ:update_rates(BQSN) end, State);
 update_rates(State = #passthrough{bq = BQ, bqs = BQS}) ->
     ?passthrough1(update_rates(BQS)).
 
@@ -489,13 +489,6 @@ fold_add2(Fun, State) ->
                   {Res, BQSN1} = Fun(P, BQSN),
                   {add_maybe_infinity(Res, Acc), BQSN1}
           end, 0, State).
-
-%% Fold over results assuming results are numbers and we want the minimum
-fold_min2(Fun, State) ->
-    fold2(fun (P, BQSN, Acc) ->
-                  {Res, BQSN1} = Fun(P, BQSN),
-                  {erlang:min(Res, Acc), BQSN1}
-          end, infinity, State).
 
 %% Fold over results assuming results are lists and we want to append
 %% them, and also that we have some AckTags we want to pass in to each


### PR DESCRIPTION
updates_rates fails after publishing a message to a queue with priorities enabled.

```
crasher:
  initial call: rabbit_amqqueue_process:init/1
  pid: <0.960.0>
  registered_name: []
  exception exit: {{badmatch,
                       {vqstate,
                           {0,[],[]},
                           {0,[],[]},
                           {delta,undefined,0,0,undefined},
                           {0,[],[]},
                           {0,[],[]},
                           0,0,#{},#{},undefined,undefined,
                           {qi,{resource,<<"/">>,queue,<<99,113,0,2>>},
                               <<"/Users/mkuratczyk/data/rabbit@K6L59PF0JR/mnesia/rabbit@K6L59PF0JR/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/queues/BPWWR1U7IEHC4L1Q5XY02T7PC/">>,
                               #{},0,#{},#{},#{},#{},
                               #Fun<rabbit_variable_queue.2.111551927>,
                               #Fun<rabbit_variable_queue.3.111551927>},
                           {qs,<<"/Users/mkuratczyk/data/rabbit@K6L59PF0JR/mnesia/rabbit@K6L59PF0JR/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/queues/BPWWR1U7IEHC4L1Q5XY02T7PC/">>,
                               undefined,64,#{},0,#{},undefined,undefined},
                           {{client_msstate,<0.655.0>,
                                <<251,1,246,93,24,26,254,147,143,94,222,220,
                                  193,217,33,30>>,
                                undefined,
                                #Ref<0.2192576155.4007788549.111221>,
                                <<"/Users/mkuratczyk/data/rabbit@K6L59PF0JR/mnesia/rabbit@K6L59PF0JR/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent">>,
                                #Ref<0.2192576155.4007788549.111222>,
                                #Ref<0.2192576155.4007788549.111223>,
                                #Ref<0.2192576155.4007788549.111224>,
                                {4000,800}},
                            {client_msstate,<0.651.0>,
                                <<189,161,86,32,42,229,118,111,100,98,137,
                                  173,165,187,168,179>>,
                                undefined,
                                #Ref<0.2192576155.4007788551.110779>,
                                <<"/Users/mkuratczyk/data/rabbit@K6L59PF0JR/mnesia/rabbit@K6L59PF0JR/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L/msg_store_transient">>,
                                #Ref<0.2192576155.4007788551.110780>,
                                #Ref<0.2192576155.4007788551.110781>,
                                #Ref<0.2192576155.4007788551.110782>,
                                {4000,800}}},
                           true,0,4096,0,0,0,0,0,0,infinity,0,0,0,0,0,0,
                           {rates,0.0,0.0,0.0,0.0,-576460739236874125},
                           #{},#{},#{},#{},0,0,0,0,4096,default,2,#{},
                           <<"/">>,false}},
                   [{rabbit_priority_queue,'-fold_min2/2-fun-0-',4,
                        [{file,"rabbit_priority_queue.erl"},{line,496}]},
                    {rabbit_priority_queue,fold2,4,
                        [{file,"rabbit_priority_queue.erl"},{line,474}]},
                    {rabbit_priority_queue,fold2,3,
                        [{file,"rabbit_priority_queue.erl"},{line,470}]},
                    {rabbit_amqqueue_process,handle_pre_hibernate,1,
                        [{file,"rabbit_amqqueue_process.erl"},{line,1694}]},
                    {gen_server2,pre_hibernate,1,
                        [{file,"gen_server2.erl"},{line,729}]},
                    {proc_lib,init_p_do_apply,3,
                        [{file,"proc_lib.erl"},{line,329}]}]}
```