### PR TITLE
Fix quorum queue credit reply crash in AMQP session

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -666,7 +666,7 @@ seq_applied({Seq, Response},
           when Response /= not_enqueued ->
             {[Corr | Corrs], Actions, State#state{pending = Pending}};
         _ ->
-            {Corrs, Actions, State#state{}}
+            {Corrs, Actions, State}
     end;
 seq_applied(_Seq, Acc) ->
     Acc.


### PR DESCRIPTION
Fixes #11841

PR #11307 introduced the assertion that at most one credit request between session proc and quorum queue proc can be in flight at any given time. However, this is not the case when `rabbit_fifo_client` re-sends credit requests on behalf of the session proc when the quorum queue leader changes.

This commit therefore removes assertions which assumed only a single credit request to be in flight.

This commit also removes field `queue_flow_ctl.desired_credit` since it is redundant to field `client_flow_ctl.credit`