### PR TITLE
Move projection registration out of Khepri setup

### DIFF
--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -67,8 +67,8 @@ init() ->
     end,
 
     Ret = case rabbit_khepri:is_enabled() of
-              true  -> init_using_khepri();
-              false -> init_using_mnesia()
+              true  -> init_using_khepri(IsVirgin);
+              false -> init_using_mnesia(IsVirgin)
           end,
     case Ret of
         ok ->
@@ -91,7 +91,7 @@ pre_init(IsVirgin) ->
     OtherMembers = rabbit_nodes:nodes_excl_me(Members),
     rabbit_db_cluster:ensure_feature_flags_are_in_sync(OtherMembers, IsVirgin).
 
-init_using_mnesia() ->
+init_using_mnesia(_IsVirgin) ->
     ?LOG_DEBUG(
       "DB: initialize Mnesia",
       #{domain => ?RMQLOG_DOMAIN_DB}),
@@ -99,11 +99,11 @@ init_using_mnesia() ->
     ?assertEqual(rabbit:data_dir(), mnesia_dir()),
     rabbit_sup:start_child(mnesia_sync).
 
-init_using_khepri() ->
+init_using_khepri(IsVirgin) ->
     ?LOG_DEBUG(
       "DB: initialize Khepri",
       #{domain => ?RMQLOG_DOMAIN_DB}),
-    rabbit_khepri:init().
+    rabbit_khepri:init(IsVirgin).
 
 init_finished() ->
     %% Used during initialisation by rabbit_logger_exchange_h.erl

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -100,6 +100,7 @@
 
 -export([setup/0,
          setup/1,
+         register_projections/0,
          init/0,
          can_join_cluster/1,
          add_member/2,

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -269,7 +269,6 @@ setup(_) ->
             RetryTimeout = retry_timeout(),
             case khepri_cluster:wait_for_leader(?STORE_ID, RetryTimeout) of
                 ok ->
-                    wait_for_register_projections(),
                     ?LOG_DEBUG(
                        "Khepri-based " ?RA_FRIENDLY_NAME " ready",
                        #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
@@ -287,27 +286,6 @@ retry_timeout() ->
     case application:get_env(rabbit, khepri_leader_wait_retry_timeout) of
         {ok, T}   -> T;
         undefined -> 30000
-    end.
-
-retry_limit() ->
-    case application:get_env(rabbit, khepri_leader_wait_retry_limit) of
-        {ok, T}   -> T;
-        undefined -> 10
-    end.
-
-wait_for_register_projections() ->
-    wait_for_register_projections(retry_timeout(), retry_limit()).
-
-wait_for_register_projections(_Timeout, 0) ->
-    exit(timeout_waiting_for_khepri_projections);
-wait_for_register_projections(Timeout, Retries) ->
-    rabbit_log:info("Waiting for Khepri projections for ~tp ms, ~tp retries left",
-                    [Timeout, Retries - 1]),
-    case register_projections() of
-        ok ->
-            ok;
-        {error, timeout} ->
-            wait_for_register_projections(Timeout, Retries -1)
     end.
 
 %% @private

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -87,6 +87,8 @@
 
 -module(rabbit_khepri).
 
+-feature(maybe_expr, enable).
+
 -include_lib("kernel/include/logger.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
@@ -1518,9 +1520,10 @@ get_feature_state(Node) ->
 %% @private
 
 khepri_db_migration_enable(#{feature_name := FeatureName}) ->
-    case sync_cluster_membership_from_mnesia(FeatureName) of
-        ok    -> migrate_mnesia_tables(FeatureName);
-        Error -> Error
+    maybe
+        ok ?= sync_cluster_membership_from_mnesia(FeatureName),
+        ok ?= register_projections(),
+        migrate_mnesia_tables(FeatureName)
     end.
 
 %% @private

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1192,7 +1192,7 @@ register_rabbit_user_permissions_projection() ->
 register_simple_projection(Name, PathPattern, KeyPos) ->
     Options = #{keypos => KeyPos},
     Projection = khepri_projection:new(Name, copy, Options),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 register_rabbit_bindings_projection() ->
     MapFun = fun(_Path, Binding) ->
@@ -1208,7 +1208,7 @@ register_rabbit_bindings_projection() ->
                     _Kind = ?KHEPRI_WILDCARD_STAR,
                     _DstName = ?KHEPRI_WILDCARD_STAR,
                     _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 register_rabbit_index_route_projection() ->
     MapFun = fun(Path, _) ->
@@ -1240,7 +1240,7 @@ register_rabbit_index_route_projection() ->
                     _Kind = ?KHEPRI_WILDCARD_STAR,
                     _DstName = ?KHEPRI_WILDCARD_STAR,
                     _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 %% Routing information is stored in the Khepri store as a `set'.
 %% In order to turn these bindings into records in an ETS `bag', we use a
@@ -1341,7 +1341,7 @@ register_rabbit_topic_graph_projection() ->
                     _Kind = ?KHEPRI_WILDCARD_STAR,
                     _DstName = ?KHEPRI_WILDCARD_STAR,
                     _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 -spec follow_down_update(Table, Exchange, Words, UpdateFn) -> Ret when
       Table :: ets:tid(),

--- a/deps/rabbit/test/metadata_store_phase1_SUITE.erl
+++ b/deps/rabbit/test/metadata_store_phase1_SUITE.erl
@@ -192,6 +192,7 @@ setup_khepri(Config) ->
     %% Configure Khepri. It takes care of configuring Ra system & cluster. It
     %% uses the Mnesia directory to store files.
     ok = rabbit_khepri:setup(undefined),
+    ok = rabbit_khepri:register_projections(),
 
     ct:pal("Khepri info below:"),
     rabbit_khepri:info(),

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -981,7 +981,7 @@ enable_khepri_metadata_store(Config, FFs0) ->
                         case enable_feature_flag(C, FF) of
                             ok ->
                                 C;
-                            Skip ->
+                            {skip, _} = Skip ->
                                 ct:pal("Enabling metadata store failed: ~p", [Skip]),
                                 Skip
                         end


### PR DESCRIPTION
`rabbit_khepri:setup/0` is always called during boot for the sake of clustering. Previously we registered projections during `rabbit_khepri:setup/0` meaning that even if you run Rabbit 3.13.x without enabling the `khepri_db` feature flag you will attempt to register projections. It's a benign bug - it doesn't cause any bad behavior other than a potential timeout on boot if a server is in a minority - but it modifies the Khepri store so we need to consider the projections when we reorganize the tree (#11225).

Instead of registering projections during `rabbit_khepri:setup/0` we should register them in two spots:

* In init (`rabbit_db:init/0`), a boot step run after `rabbit_khepri:setup/0` which has a Khepri-specific branch, and only if we detect that the database is blank. (We could always register on init when Khepri is enabled but there's no need to unless the database is blank.)
* In the enable callback for the `khepri_db` feature flag.

In the future when we want to unregister projections, we can add that step before `rabbit_khepri:register_projections/0` to the enable callback for the `khepri_db` feature flag (using https://github.com/rabbitmq/khepri/pull/282).