### PR TITLE
Speed up AMQP connection and session (de)registration

### DIFF
--- a/deps/rabbit/src/rabbit_amqp1_0.erl
+++ b/deps/rabbit/src/rabbit_amqp1_0.erl
@@ -6,8 +6,6 @@
 %%
 -module(rabbit_amqp1_0).
 
--define(PROCESS_GROUP_NAME, rabbit_amqp10_connections).
-
 -export([list_local/0,
          register_connection/1]).
 
@@ -36,8 +34,11 @@ emit_connection_info_local(Items, Ref, AggregatorPid) ->
 
 -spec list_local() -> [pid()].
 list_local() ->
-    pg:get_local_members(node(), ?PROCESS_GROUP_NAME).
+    pg:which_groups(pg_scope()).
 
 -spec register_connection(pid()) -> ok.
 register_connection(Pid) ->
-    ok = pg:join(node(), ?PROCESS_GROUP_NAME, Pid).
+    ok = pg:join(pg_scope(), Pid, Pid).
+
+pg_scope() ->
+    rabbit:pg_local_scope(amqp_connection).

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
@@ -29,7 +29,7 @@ init([{Listeners, SslListeners0}]) ->
           end,
     %% Use separate process group scope per RabbitMQ node. This achieves a local-only
     %% process group which requires less memory with millions of connections.
-    PgScope = list_to_atom(io_lib:format("~s_~s", [?PG_SCOPE, node()])),
+    PgScope = rabbit:pg_local_scope(?PG_SCOPE),
     persistent_term:put(?PG_SCOPE, PgScope),
     {ok,
      {#{strategy => one_for_all,


### PR DESCRIPTION
 ## What?

Prior to this commit connecting 40k AMQP clients with 5 sessions each, i.e. 200k sessions in total, took 7m55s.

After to this commit the same scenario takes 1m37s.

Additionally, prior to this commit, disconnecting all connections and sessions at once caused the pg process to become overloaded taking ~14 minutes to process its mailbox.

After this commit, these same de-registrations take less than 5 seconds.

<details>
<summary>To repro</summary>

```go

package main

import (
	"context"
	"log"
	"time"

	"github.com/Azure/go-amqp"
)

func main() {
	for i := 0; i < 40_000; i++ {
		if i%1000 == 0 {
			log.Printf("opened %d connections", i)
		}
		conn, err := amqp.Dial(
			context.TODO(),
			"amqp://localhost",
			&amqp.ConnOptions{SASLType: amqp.SASLTypeAnonymous()})
		if err != nil {
			log.Fatal("open connection:", err)
		}
		for j := 0; j < 5; j++ {
			_, err = conn.NewSession(context.TODO(), nil)
			if err != nil {
				log.Fatal("begin session:", err)
			}
		}
	}
	log.Println("opened all connections")
	time.Sleep(5 * time.Hour)
}
```
</details>

 ## How?

This commit uses separate pg scopes (that is processes and ETS tables) to register AMQP connections and AMQP sessions. Since each Pid is now its own group, registration and de-registration is fast.