### PR TITLE
QQs: try an alternative process name in case of a conflict

### DIFF
--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -1013,6 +1013,35 @@
 # log.exchange.level = info
 
 
+## File size-based log rotation
+
+## Note that `log.file.rotation.size` cannot be combined with `log.file.rotation.date`,
+## the two options are mutually exclusive.
+
+## rotate when the file reaches 10 MiB
+# log.file.rotation.size = 10485760
+
+## keep up to 5 archived log files in addition to the current one
+# log.file.rotation.count = 5
+
+## compress the archived logs
+# log.file.rotation.compress = true
+
+
+## Date-based log rotation
+
+## Note that `log.file.rotation.date` cannot be combined with `log.file.rotation.size`,
+## the two options are mutually exclusive.
+
+## rotate every night at midnight
+# log.file.rotation.date = $D0
+
+## keep up to 5 archived log files in addition to the current one
+# log.file.rotation.count = 5
+
+## compress the archived logs
+# log.file.rotation.compress = true
+
 
 ## ----------------------------------------------------------------------------
 ## RabbitMQ LDAP Plugin

--- a/deps/rabbit/src/rabbit_amqp1_0.erl
+++ b/deps/rabbit/src/rabbit_amqp1_0.erl
@@ -6,8 +6,6 @@
 %%
 -module(rabbit_amqp1_0).
 
--define(PROCESS_GROUP_NAME, rabbit_amqp10_connections).
-
 -export([list_local/0,
          register_connection/1]).
 
@@ -36,8 +34,11 @@ emit_connection_info_local(Items, Ref, AggregatorPid) ->
 
 -spec list_local() -> [pid()].
 list_local() ->
-    pg:get_local_members(node(), ?PROCESS_GROUP_NAME).
+    pg:which_groups(pg_scope()).
 
 -spec register_connection(pid()) -> ok.
 register_connection(Pid) ->
-    ok = pg:join(node(), ?PROCESS_GROUP_NAME, Pid).
+    ok = pg:join(pg_scope(), Pid, Pid).
+
+pg_scope() ->
+    rabbit:pg_local_scope(amqp_connection).

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_sup.erl
@@ -29,7 +29,7 @@ init([{Listeners, SslListeners0}]) ->
           end,
     %% Use separate process group scope per RabbitMQ node. This achieves a local-only
     %% process group which requires less memory with millions of connections.
-    PgScope = list_to_atom(io_lib:format("~s_~s", [?PG_SCOPE, node()])),
+    PgScope = rabbit:pg_local_scope(?PG_SCOPE),
     persistent_term:put(?PG_SCOPE, PgScope),
     {ok,
      {#{strategy => one_for_all,


### PR DESCRIPTION
This is #11866 by @alexnkdev, rebased on top of `main`, submitted under my account so that Actions have access to Bazel GCP cache secrets.