### PR TITLE
Reuse timestamp in rabbit_message_interceptor

### DIFF
--- a/deps/rabbit/src/rabbit_message_interceptor.erl
+++ b/deps/rabbit/src/rabbit_message_interceptor.erl
@@ -27,9 +27,9 @@ intercept(Msg, set_header_routing_node, Overwrite) ->
     Node = atom_to_binary(node()),
     set_annotation(Msg, ?HEADER_ROUTING_NODE, Node, Overwrite);
 intercept(Msg0, set_header_timestamp, Overwrite) ->
-    Millis = os:system_time(millisecond),
-    Msg = set_annotation(Msg0, ?HEADER_TIMESTAMP, Millis, Overwrite),
-    set_timestamp(Msg, Millis, Overwrite).
+    Ts = mc:get_annotation(?ANN_RECEIVED_AT_TIMESTAMP, Msg0),
+    Msg = set_annotation(Msg0, ?HEADER_TIMESTAMP, Ts, Overwrite),
+    set_timestamp(Msg, Ts, Overwrite).
 
 -spec set_annotation(mc:state(), mc:ann_key(), mc:ann_value(), boolean()) -> mc:state().
 set_annotation(Msg, Key, Value, Overwrite) ->


### PR DESCRIPTION
 ## What?
`mc:init()` already sets mc annotation `rts` (received timestamp). This commit reuses this timestamp in `rabbit_message_interceptor`.

 ## Why?
`os:system_time/1` can jump forward or backward between invocations. Using two different timestamps for the same meaning, the time the message was received by RabbitMQ, can be misleading.