### PR TITLE
Avoid returning leader info when leader is unknown

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -433,12 +433,13 @@ encode_queue(Q, NumMsgs, NumConsumers) ->
                  Replicas =:= undefined ->
                      KVList0
               end,
-    KVList = if is_atom(Leader) ->
-                    [{{utf8, <<"leader">>},
-                      {utf8, atom_to_binary(Leader)}
-                     } | KVList1];
-                Leader =:= undefined ->
-                    KVList1
+    KVList = case Leader of
+                 undefined ->
+                     KVList1;
+                 _ ->
+                     [{{utf8, <<"leader">>},
+                       {utf8, atom_to_binary(Leader)}
+                      } | KVList1]
              end,
     {map, KVList}.
 


### PR DESCRIPTION
Prior to this commit, atom `undefined` was turned into a binary.

Tested in the Java client suite.