### PR TITLE
QQ: refactor and improve leader detection code.

### DIFF
--- a/deps/rabbit/test/cli_forget_cluster_node_SUITE.erl
+++ b/deps/rabbit/test/cli_forget_cluster_node_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 -import(clustering_utils, [


### PR DESCRIPTION
The leader returned in rabbit_quorum_queue:info/2 only ever queried the pid field from the queue record when more up to date info could have been available in the ra_leaderboard table.

This PR also improves `rabbit_quorum_queue:shrink_all/1` to retry once if cluster change is not permitted
This could happen if a leader election occurred just before the member removal was initiated. In particular this could
happen when stopping and forgetting an existing rabbit node.
