### PR TITLE
QQ: introduce a default delivery limit

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -850,10 +850,9 @@ overview(#?STATE{consumers = Cons,
                           #{}
                   end,
     MsgsRet = lqueue:len(Returns),
-
-    #{len := _MsgsLen,
-      num_hi := MsgsHi,
+    #{num_hi := MsgsHi,
       num_lo := MsgsLo} = rabbit_fifo_q:overview(Messages),
+
     Overview = #{type => ?STATE,
                  config => Conf,
                  num_consumers => map_size(Cons),

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -256,6 +256,9 @@ var HELP = {
     'queue-dead-lettered':
       'Applies to messages dead-lettered with dead-letter-strategy <code>at-least-once</code>.',
 
+    'queue-delivery-limit':
+      'The number of times a message can be returned to this queue before it is dead-lettered (if configured) or dropped.',
+
     'queue-message-body-bytes':
       '<p>The sum total of the sizes of the message bodies in this queue. This only counts message bodies; it does not include message properties (including headers) or metadata used by the queue.</p><p>Note that "in memory" and "persistent" are not mutually exclusive; persistent messages can be in memory as well as on disc, and transient messages can be paged out if memory is tight. Non-durable queues will consider all messages to be transient.</p><p>If a message is routed to multiple queues on publication, its body will be stored only once (in memory and on disk) and shared between queues. The value shown here does not take account of this effect.</p>',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -92,10 +92,16 @@
         <td><%= fmt_string(queue.consumer_details.length) %></td>
       </tr>
       <% } %>
-      <% if (!is_stream(queue)) { %>
+      <% if (is_classic(queue)) { %>
       <tr>
         <th>Consumer capacity <span class="help" id="queue-consumer-capacity"></th>
         <td><%= fmt_percent(queue.consumer_capacity) %></td>
+      </tr>
+      <% } %>
+      <% if(queue.hasOwnProperty('publishers')) { %>
+      <tr>
+        <th>Publishers</th>
+        <td><%= fmt_string(queue.publishers) %></td>
       </tr>
       <% } %>
       <% if (is_quorum(queue)) { %>
@@ -103,6 +109,12 @@
         <th>Open files</th>
         <td><%= fmt_table_short(queue.open_files) %></td>
       </tr>
+      <% if (queue.hasOwnProperty('delivery_limit')) { %>
+      <tr>
+        <th>Delivery limit <span class="help" id="queue-delivery-limit"></th>
+        <td><%= fmt_string(queue.delivery_limit) %></td>
+      </tr>
+      <% } %>
       <% } %>
       <% if (is_stream(queue)) { %>
       <tr>
@@ -187,11 +199,10 @@
         <td class="r">
           <%= fmt_bytes(queue.message_bytes_unacknowledged) %>
         </td>
-        <td class="r">
-          <%= fmt_bytes(queue.message_bytes_ram) %>
-        </td>
         <% } %>
         <% if (is_quorum(queue)) { %>
+        <td class="r">
+        </td>
         <td class="r">
         </td>
         <td class="r">
@@ -201,6 +212,9 @@
         </td>
         <% } %>
         <% if (is_classic(queue)) { %>
+        <td class="r">
+          <%= fmt_bytes(queue.message_bytes_ram) %>
+        </td>
         <td class="r">
           <%= fmt_bytes(queue.message_bytes_persistent) %>
         </td>

--- a/release-notes/4.0.0.md
+++ b/release-notes/4.0.0.md
@@ -33,6 +33,7 @@ See Compatibility Notes below to learn about **breaking or potentially breaking 
 * RabbitMQ 3.13 `rabbitmq.conf` setting `rabbitmq_amqp1_0.default_vhost` is unsupported in RabbitMQ 4.0.
   Instead `default_vhost` will be used to determine the default vhost an AMQP 1.0 client connects to(i.e. when the AMQP 1.0 client does not define the vhost in the `hostname` field of the `open` frame)
 * RabbitMQ Shovels will be able connect to a RabbitMQ 4.0 node via AMQP 1.0 only when the Shovel runs on a RabbitMQ node >= `3.13.7`
+* Quorum queues will now always set a default `delivery-limit` of 20 which can be increased or decreased by policies and queue arguments but cannot be unset. Some applications or configurations may need to be updated to handle this.
 
 ## Erlang/OTP Compatibility Notes
 
@@ -83,8 +84,11 @@ periods of time (no more than a few hours).
 
 ### Recommended Post-upgrade Procedures
 
-TBD
+Set a low priority dead lettering policy for all quorum queues to dead letter to a stream or similar
+so that messages that reach the new default delivery limit of 20 aren't lost completely
+when no dead lettering policy is in place.
 
+TBD
 
 ## Changes Worth Mentioning
 


### PR DESCRIPTION
If the delivery_limit of a quorum queue is not set by queue arg and/or policy it will now be defaulted to 20.

Deliver limits are recommended for safe and smooth quorum queue operations. The downside is that poorly written applications and RabbitMQ configurations that frequently return messages to the queue now could be dropped when they reach the delivery limit. This is a breaking change in terms of some applications.

Hence, it will be recommended to put a blanket, low priority policy in place to set a dead letter configuration for all quorum queues to dead letter dropped messages to, e.g. a single stream, at least until applications and configurations can be properly updated.

This PR also exposes the delivery limit on the queue page (and adds a publisher count because it was easy).

<img width="791" alt="Screenshot 2024-08-16 at 09 00 02" src="https://github.com/user-attachments/assets/880f996a-ffc5-43db-88d9-d2e502a71e13">


