### PR TITLE
STOMP: add support for consumer priorities

### DIFF
--- a/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
+++ b/deps/rabbitmq_stomp/include/rabbit_stomp_headers.hrl
@@ -30,6 +30,7 @@
 -define(HEADER_X_STREAM_FILTER, "x-stream-filter").
 -define(HEADER_X_STREAM_MATCH_UNFILTERED, "x-stream-match-unfiltered").
 -define(HEADER_PRIORITY, "priority").
+-define(HEADER_X_PRIORITY, "x-priority").
 -define(HEADER_RECEIPT, "receipt").
 -define(HEADER_REDELIVERED, "redelivered").
 -define(HEADER_REPLY_TO, "reply-to").

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -718,7 +718,8 @@ do_subscribe(Destination, DestHdr, Frame,
 subscribe_arguments(Frame) ->
     subscribe_arguments([?HEADER_X_STREAM_OFFSET,
                          ?HEADER_X_STREAM_FILTER,
-                         ?HEADER_X_STREAM_MATCH_UNFILTERED], Frame, []).
+                         ?HEADER_X_STREAM_MATCH_UNFILTERED,
+                         ?HEADER_X_PRIORITY], Frame, []).
 
 subscribe_arguments([], _Frame , Acc) ->
     Acc;
@@ -747,6 +748,14 @@ subscribe_argument(?HEADER_X_STREAM_MATCH_UNFILTERED, Frame, Acc) ->
     case MatchUnfiltered of
         {ok, MU} ->
             [{list_to_binary(?HEADER_X_STREAM_MATCH_UNFILTERED), bool, MU}] ++ Acc;
+        not_found ->
+            Acc
+    end;
+subscribe_argument(?HEADER_X_PRIORITY, Frame, Acc) ->
+    Priority = rabbit_stomp_frame:integer_header(Frame, ?HEADER_X_PRIORITY),
+    case Priority of
+        {ok, P} ->
+            [{list_to_binary(?HEADER_X_PRIORITY), byte, P}] ++ Acc;
         not_found ->
             Acc
     end.


### PR DESCRIPTION
x-priority header allows to specify the consumer priority