### PR TITLE
Log AMQP connection name and container-id

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -392,7 +392,7 @@ handle_connection_frame(
                                                user = User = #user{username = Username}},
       helper_sup = HelperSupPid,
       sock = Sock} = State0) ->
-    logger:update_process_metadata(#{container_id => ContainerId}),
+    logger:update_process_metadata(#{amqp_container => ContainerId}),
     Vhost = vhost(Hostname),
     ok = check_user_loopback(State0),
     ok = check_vhost_exists(Vhost, State0),
@@ -404,7 +404,7 @@ handle_connection_frame(
     rabbit_core_metrics:auth_attempt_succeeded(<<>>, Username, amqp10),
     notify_auth(user_authentication_success, Username, State0),
     rabbit_log_connection:info(
-      "AMQP 1.0 connection from container '~ts': user '~ts' "
+      "Connection from AMQP 1.0 container '~ts': user '~ts' "
       "authenticated and granted access to vhost '~ts'",
       [ContainerId, Username, Vhost]),
 


### PR DESCRIPTION
Fixes #11958 and supersedes https://github.com/rabbitmq/rabbitmq-server/pull/11961

 ## What
Log container-id and connection name.
Example JSON log:
```
{"time":"2024-08-12 17:08:12.451830+02:00","level":"info","msg":"accepting AMQP connection [::1]:57213 -> [::1]:5672","pid":"<0.1078.0>","domain":"rabbitmq.connection"}
{"time":"2024-08-12 17:08:12.461291+02:00","level":"debug","msg":"User 'guest' authenticated successfully by backend rabbit_auth_backend_internal","pid":"<0.1078.0>","domain":"rabbitmq","connection":"[::1]:57213 -> [::1]:5672"}
{"time":"2024-08-12 17:08:12.461633+02:00","level":"info","msg":"Connection from AMQP 1.0 container 'my container ID': user 'guest' authenticated and granted access to vhost '/'","pid":"<0.1078.0>","domain":"rabbitmq.connection","connection":"[::1]:57213 -> [::1]:5672","amqp_container":"my container ID"}
{"time":"2024-08-12 17:08:12.461712+02:00","level":"debug","msg":"AMQP 1.0 connection.open frame: hostname = localhost, extracted vhost = /, idle-time-out = {uint,\n                                                                                            30000}","pid":"<0.1078.0>","domain":"rabbitmq","connection":"[::1]:57213 -> [::1]:5672","amqp_container":"my container ID"}
{"time":"2024-08-12 17:08:12.465915+02:00","level":"debug","msg":"AMQP 1.0 created session process <0.1084.0> for channel number 0","pid":"<0.1078.0>","domain":"rabbitmq","connection":"[::1]:57213 -> [::1]:5672","amqp_container":"my container ID"}

{"time":"2024-08-12 17:08:14.467547+02:00","level":"debug","msg":"AMQP 1.0 closed session process <0.1084.0> with channel number 0","pid":"<0.1078.0>","domain":"rabbitmq","connection":"[::1]:57213 -> [::1]:5672","amqp_container":"my container ID"}
{"time":"2024-08-12 17:08:14.467805+02:00","level":"info","msg":"closing AMQP connection ([::1]:57213 -> [::1]:5672)","pid":"<0.1078.0>","domain":"rabbitmq.connection","connection":"[::1]:57213 -> [::1]:5672","amqp_container":"my container ID"}
```

If JSON logging is not used, this commit still includes the container-ID once at info level:
```
2024-08-12 17:09:09.124945+02:00 [info] <0.1034.0> accepting AMQP connection [::1]:57276 -> [::1]:5672
2024-08-12 17:09:09.134166+02:00 [debug] <0.1034.0> User 'guest' authenticated successfully by backend rabbit_auth_backend_internal
2024-08-12 17:09:09.134457+02:00 [info] <0.1034.0> Connection from AMQP 1.0 container 'my container ID': user 'guest' authenticated and granted access to vhost '/'
2024-08-12 17:09:09.134521+02:00 [debug] <0.1034.0> AMQP 1.0 connection.open frame: hostname = localhost, extracted vhost = /, idle-time-out = {uint,
2024-08-12 17:09:09.134521+02:00 [debug] <0.1034.0>                                                                                             30000}
2024-08-12 17:09:09.138513+02:00 [debug] <0.1034.0> AMQP 1.0 created session process <0.1040.0> for channel number 0

2024-08-12 17:09:11.140208+02:00 [debug] <0.1034.0> AMQP 1.0 closed session process <0.1040.0> with channel number 0
2024-08-12 17:09:11.140504+02:00 [info] <0.1034.0> closing AMQP connection ([::1]:57276 -> [::1]:5672)
```

 ## Why?
See #11958 and https://www.rabbitmq.com/docs/connections#client-provided-names

To provide a similar feature to AMQP 0.9.1 this commit uses container-id as sent by the client in the open frame.
> Examples of containers are brokers and client applications.

The advantage is that the `container-id` is mandatory. Hence, in AMQP 1.0, we can enforce the desired behaviour that we document on our website for AMQP 0.9.1:
> The name is optional; however, developers are strongly encouraged to provide one as it would significantly simplify certain operational tasks.