### PR TITLE
Restrict username and password in AMQPLAIN

### DIFF
--- a/deps/rabbit/src/rabbit_auth_mechanism_amqplain.erl
+++ b/deps/rabbit/src/rabbit_auth_mechanism_amqplain.erl
@@ -30,14 +30,17 @@ should_offer(_Sock) ->
 init(_Sock) ->
     [].
 
--define(IS_STRING_TYPE(Type), Type =:= longstr orelse Type =:= shortstr).
+-define(IS_STRING_TYPE(Type),
+        Type =:= longstr orelse
+        Type =:= shortstr orelse
+        Type =:= binary).
 
 handle_response(Response, _State) ->
     LoginTable = rabbit_binary_parser:parse_table(Response),
     case {lists:keysearch(<<"LOGIN">>, 1, LoginTable),
           lists:keysearch(<<"PASSWORD">>, 1, LoginTable)} of
         {{value, {_, UserType, User}},
-         {value, {_, PassType, Pass}}} when ?IS_STRING_TYPE(UserType);
+         {value, {_, PassType, Pass}}} when ?IS_STRING_TYPE(UserType) andalso
                                             ?IS_STRING_TYPE(PassType) ->
             rabbit_access_control:check_user_pass_login(User, Pass);
         {{value, {_, _UserType, _User}},


### PR DESCRIPTION
Restrict both username and password in SASL mechanism AMQPLAIN to be a binary.
