### PR TITLE
Make it possible to specify encrypted values in rabbitmq conf

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -229,7 +229,12 @@ end}.
     [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "definitions.tls.password", "rabbit.definitions.ssl_options.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
+
+{translation, "rabbit.definitions.ssl_options.password",
+fun(Conf) ->
+    rabbit_cuttlefish:optionally_tagged_string("definitions.tls.password", Conf)
+end}.
 
 {mapping, "definitions.tls.secure_renegotiate", "rabbit.definitions.ssl_options.secure_renegotiate",
     [{datatype, {enum, [true, false]}}]}.
@@ -395,7 +400,12 @@ end}.
     [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "ssl_options.password", "rabbit.ssl_options.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
+
+{translation, "rabbit.ssl_options.password",
+fun(Conf) ->
+    rabbit_cuttlefish:optionally_tagged_binary("ssl_options.password", Conf)
+end}.
 
 {mapping, "ssl_options.psk_identity", "rabbit.ssl_options.psk_identity",
     [{datatype, string}]}.
@@ -656,12 +666,12 @@ fun(Conf) ->
 end}.
 
 {mapping, "default_pass", "rabbit.default_pass", [
-    {datatype, string}
+    {datatype, [tagged_binary, binary]}
 ]}.
 
 {translation, "rabbit.default_pass",
 fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("default_pass", Conf))
+    rabbit_cuttlefish:optionally_tagged_binary("default_pass", Conf)
 end}.
 
 {mapping, "default_permissions.configure", "rabbit.default_permissions", [

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -706,7 +706,7 @@ end}.
 ]}.
 
 {mapping, "default_users.$name.password", "rabbit.default_users", [
-    {datatype, string}
+    {datatype, [tagged_binary, binary]}
 ]}.
 
 {mapping, "default_users.$name.configure", "rabbit.default_users", [

--- a/deps/rabbit/src/rabbit_cuttlefish.erl
+++ b/deps/rabbit/src/rabbit_cuttlefish.erl
@@ -9,7 +9,10 @@
 
 -export([
     aggregate_props/2,
-    aggregate_props/3
+    aggregate_props/3,
+
+    optionally_tagged_binary/2,
+    optionally_tagged_string/2
 ]).
 
 -type keyed_props() :: [{binary(), [{binary(), any()}]}].
@@ -41,3 +44,25 @@ aggregate_props(Conf, Prefix, KeyFun) ->
             FlatList
         )
     ).
+
+optionally_tagged_binary(Key, Conf) ->
+    case cuttlefish:conf_get(Key, Conf) of
+        undefined                            -> cuttlefish:unset();
+        {encrypted, Bin} when is_binary(Bin) -> {encrypted, Bin};
+        {_,         Bin} when is_binary(Bin) -> {encrypted, Bin};
+        {encrypted, Str} when is_list(Str) -> {encrypted, list_to_binary(Str)};
+        {_,         Str} when is_list(Str) -> {encrypted, list_to_binary(Str)};
+        Bin when is_binary(Bin) -> Bin;
+        Str when is_list(Str) -> list_to_binary(Str)
+    end.
+
+optionally_tagged_string(Key, Conf) ->
+    case cuttlefish:conf_get(Key, Conf) of
+        undefined                          -> cuttlefish:unset();
+        {encrypted, Str} when is_list(Str) -> {encrypted, Str};
+        {_,         Str} when is_list(Str) -> {encrypted, Str};
+        {encrypted, Bin} when is_binary(Bin) -> {encrypted, binary_to_list(Bin)};
+        {_,         Bin} when is_binary(Bin) -> {encrypted, binary_to_list(Bin)};
+        Str when is_list(Str) -> Str;
+        Bin when is_binary(Bin) -> binary_to_list(Bin)
+    end.

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -182,7 +182,7 @@ ssl_options.fail_if_no_peer_cert = true",
   [{rabbit, [{default_users, [
       {<<"a">>, [{<<"vhost_pattern">>, "banana"},
                  {<<"tags">>, [administrator, operator]},
-                 {<<"password">>, "SECRET"},
+                 {<<"password">>, <<"SECRET">>},
                  {<<"read">>, ".*"}]}]}]}],
   []},
 
@@ -510,7 +510,7 @@ tcp_listen_options.exit_on_close = false",
             [{cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
-             {password,"t0p$3kRe7"}]}]}],
+             {password,<<"t0p$3kRe7">>}]}]}],
   []},
  {ssl_options_tls_ver_old,
   "listeners.ssl.1 = 5671

--- a/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
+++ b/deps/rabbitmq_auth_backend_http/priv/schema/rabbitmq_auth_backend_http.schema
@@ -116,7 +116,7 @@ end}.
     [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "auth_http.ssl_options.password", "rabbitmq_auth_backend_http.ssl_options.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {mapping, "auth_http.ssl_options.psk_identity", "rabbitmq_auth_backend_http.ssl_options.psk_identity",
     [{datatype, string}]}.

--- a/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
+++ b/deps/rabbitmq_auth_backend_http/test/config_schema_SUITE_data/rabbitmq_auth_backend_http.snippets
@@ -78,7 +78,7 @@
       [{cacertfile,"test/config_schema_SUITE_data/certs/invalid_cacert.pem"},
        {certfile,"test/config_schema_SUITE_data/certs/invalid_cert.pem"},
        {keyfile,"test/config_schema_SUITE_data/certs/invalid_key.pem"},
-       {password,"t0p$3kRe7"}]}]}],
+       {password,<<"t0p$3kRe7">>}]}]}],
   []},
  {ssl_options_tls_versions,
   "auth_http.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/invalid_cacert.pem

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -117,7 +117,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def banner(_, _) do
-    "Decrypting value..."
+    "Decrypting an advanced.config (Erlang term) value..."
   end
 
   def usage,
@@ -125,7 +125,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
 
   def usage_additional() do
     [
-      ["<value>", "config value to decode"],
+      ["<value>", "advanced.config (Erlang term) value to decode"],
       ["<passphrase>", "passphrase to use with the config value encryption key"],
       ["--cipher <cipher>", "cipher suite to use"],
       ["--hash <hash>", "hashing function to use"],
@@ -141,7 +141,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Decrypts an encrypted configuration value"
+  def description(), do: "Decrypts an encrypted advanced.config value"
 
   #
   # Implementation

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -86,6 +86,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
           {:ok, result}
         catch
           _, _ ->
+            IO.inspect(__STACKTRACE__)
             {:error,
              "Failed to decrypt the value. Things to check: is the passphrase correct? Are the cipher and hash algorithms the same as those used for encryption?"}
         end
@@ -109,6 +110,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
       {:ok, result}
     catch
       _, _ ->
+        IO.inspect(__STACKTRACE__)
         {:error,
          "Failed to decrypt the value. Things to check: is the passphrase correct? Are the cipher and hash algorithms the same as those used for encryption?"}
     end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decrypt_conf_value_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/decrypt_conf_value_command.ex
@@ -4,8 +4,10 @@
 ##
 ## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
-  alias RabbitMQ.CLI.Core.{DocGuide, Helpers, Input}
+alias RabbitMQ.CLI.Core.Helpers
+
+defmodule RabbitMQ.CLI.Ctl.Commands.DecryptConfValueCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide, Input}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -19,6 +21,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   end
 
   @atomized_keys [:cipher, :hash]
+  @prefix "encrypted:"
 
   def distribution(_), do: :none
 
@@ -36,6 +39,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     {args, Helpers.atomize_values(with_defaults, @atomized_keys)}
   end
 
+  def validate(args, _) when length(args) < 1 do
+    {:validation_failure, {:not_enough_args, "Please provide a value to decode and a passphrase"}}
+  end
+
   def validate(args, _) when length(args) > 2 do
     {:validation_failure, :too_many_args}
   end
@@ -43,43 +50,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   def validate(_args, opts) do
     case {supports_cipher(opts.cipher), supports_hash(opts.hash), opts.iterations > 0} do
       {false, _, _} ->
-        {:validation_failure, {:bad_argument, "The requested cipher is not supported."}}
+        {:validation_failure, {:bad_argument, "The requested cipher is not supported"}}
 
       {_, false, _} ->
         {:validation_failure, {:bad_argument, "The requested hash is not supported"}}
 
       {_, _, false} ->
-        {:validation_failure, {:bad_argument, "The requested number of iterations is incorrect"}}
+        {:validation_failure,
+         {:bad_argument,
+          "The requested number of iterations is incorrect (must be a positive integer)"}}
 
       {true, true, true} ->
         :ok
-    end
-  end
-
-  def run([], %{cipher: cipher, hash: hash, iterations: iterations} = opts) do
-    case Input.consume_single_line_string_with_prompt("Value to encode: ", opts) do
-      :eof ->
-        {:error, :not_enough_args}
-
-      value ->
-        case Input.consume_single_line_string_with_prompt("Passphrase: ", opts) do
-          :eof ->
-            {:error, :not_enough_args}
-
-          passphrase ->
-            try do
-              term_value = Helpers.evaluate_input_as_term(value)
-
-              result =
-                {:encrypted, _} =
-                :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
-
-              {:ok, result}
-            catch
-              _, _ ->
-                {:error, "Error during cipher operation"}
-            end
-        end
     end
   end
 
@@ -92,14 +74,25 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
         try do
           term_value = Helpers.evaluate_input_as_term(value)
 
-          result =
-            {:encrypted, _} =
-            :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+          term_to_decrypt =
+            case term_value do
+              prefixed_val when is_bitstring(prefixed_val) or is_list(prefixed_val) ->
+                tag_input_value_with_encrypted(prefixed_val)
 
+              {:encrypted, _} = encrypted ->
+                encrypted
+
+              _ ->
+                {:encrypted, term_value}
+            end
+
+          result = :rabbit_pbe.decrypt_term(cipher, hash, iterations, passphrase, term_to_decrypt)
           {:ok, result}
         catch
           _, _ ->
-            {:error, "Error during cipher operation"}
+            IO.inspect(__STACKTRACE__)
+            {:error,
+             "Failed to decrypt the value. Things to check: is the passphrase correct? Are the cipher and hash algorithms the same as those used for encryption?"}
         end
     end
   end
@@ -108,29 +101,40 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     try do
       term_value = Helpers.evaluate_input_as_term(value)
 
-      result =
-        {:encrypted, _} =
-        :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
+      term_to_decrypt =
+        case term_value do
+          prefixed_val when is_bitstring(prefixed_val) or is_list(prefixed_val) ->
+            tag_input_value_with_encrypted(prefixed_val)
 
+          {:encrypted, _} = encrypted ->
+            encrypted
+
+          _ ->
+            {:encrypted, term_value}
+        end
+
+      result = :rabbit_pbe.decrypt_term(cipher, hash, iterations, passphrase, term_to_decrypt)
       {:ok, result}
     catch
       _, _ ->
-        {:error, "Error during cipher operation"}
+        IO.inspect(__STACKTRACE__)
+        {:error,
+         "Failed to decrypt the value. Things to check: is the passphrase correct? Are the cipher and hash algorithms the same as those used for encryption?"}
     end
   end
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def banner(_, _) do
-    "Encrypting value to be used in advanced.config..."
+    "Decrypting a rabbitmq.conf string value..."
   end
 
   def usage,
-    do: "encode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
+    do: "decrypt_conf_value value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
 
   def usage_additional() do
     [
-      ["<value>", "value to encode, to be used in advanced.config"],
+      ["<value>", "a double-quoted rabbitmq.conf string value to decode"],
       ["<passphrase>", "passphrase to use with the config value encryption key"],
       ["--cipher <cipher>", "cipher suite to use"],
       ["--hash <hash>", "hashing function to use"],
@@ -146,7 +150,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Encrypts a sensitive configuration value to be used in the advanced.config file"
+  def description(), do: "Decrypts an encrypted configuration value"
 
   #
   # Implementation
@@ -155,4 +159,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   defp supports_cipher(cipher), do: Enum.member?(:rabbit_pbe.supported_ciphers(), cipher)
 
   defp supports_hash(hash), do: Enum.member?(:rabbit_pbe.supported_hashes(), hash)
+
+  defp tag_input_value_with_encrypted(value) when is_bitstring(value) or is_list(value) do
+    bin_val = :rabbit_data_coercion.to_binary(value)
+    untagged_val = String.replace_prefix(bin_val, @prefix, "")
+
+    {:encrypted, untagged_val}
+  end
+  defp tag_input_value_with_encrypted(value) do
+    {:encrypted, value}
+  end
 end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -77,6 +77,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
               {:ok, result}
             catch
               _, _ ->
+                IO.inspect(__STACKTRACE__)
                 {:error, "Error during cipher operation"}
             end
         end
@@ -99,6 +100,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
           {:ok, result}
         catch
           _, _ ->
+            IO.inspect(__STACKTRACE__)
             {:error, "Error during cipher operation"}
         end
     end
@@ -115,6 +117,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
       {:ok, result}
     catch
       _, _ ->
+        IO.inspect(__STACKTRACE__)
         {:error, "Error during cipher operation"}
     end
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encrypt_conf_value_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encrypt_conf_value_command.ex
@@ -4,7 +4,7 @@
 ##
 ## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
+defmodule RabbitMQ.CLI.Ctl.Commands.EncryptConfValueCommand do
   alias RabbitMQ.CLI.Core.{DocGuide, Helpers, Input}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -70,8 +70,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
             try do
               term_value = Helpers.evaluate_input_as_term(value)
 
-              result =
-                {:encrypted, _} =
+              {:encrypted, result} =
                 :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
 
               {:ok, result}
@@ -92,8 +91,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
         try do
           term_value = Helpers.evaluate_input_as_term(value)
 
-          result =
-            {:encrypted, _} =
+          {:encrypted, result} =
             :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
 
           {:ok, result}
@@ -108,8 +106,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     try do
       term_value = Helpers.evaluate_input_as_term(value)
 
-      result =
-        {:encrypted, _} =
+      {:encrypted, result} =
         :rabbit_pbe.encrypt_term(cipher, hash, iterations, passphrase, term_value)
 
       {:ok, result}
@@ -119,14 +116,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     end
   end
 
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
+  def formatter(), do: RabbitMQ.CLI.Formatters.EncryptedConfValue
 
   def banner(_, _) do
-    "Encrypting value to be used in advanced.config..."
+    "Encrypting value to be used in rabbitmq.conf..."
   end
 
   def usage,
-    do: "encode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
+    do: "encrypt_conf_value value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
 
   def usage_additional() do
     [

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encrypt_conf_value_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encrypt_conf_value_command.ex
@@ -97,6 +97,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncryptConfValueCommand do
           {:ok, result}
         catch
           _, _ ->
+            IO.inspect(__STACKTRACE__)
             {:error, "Error during cipher operation"}
         end
     end
@@ -112,6 +113,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncryptConfValueCommand do
       {:ok, result}
     catch
       _, _ ->
+        IO.inspect(__STACKTRACE__)
         {:error, "Error during cipher operation"}
     end
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encrypt_conf_value_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/encrypt_conf_value_command.ex
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+## Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.EncryptConfValueCommand do
   alias RabbitMQ.CLI.Core.{DocGuide, Helpers, Input}

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/encrypted_conf_value.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/encrypted_conf_value.ex
@@ -1,0 +1,26 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+## Prints values from a command as strings(if possible)
+defmodule RabbitMQ.CLI.Formatters.EncryptedConfValue do
+  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Formatters.FormatterHelpers
+
+  @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+  def format_output(output, _) do
+    Helpers.string_or_inspect("encrypted:#{output}")
+  end
+
+  def format_stream(stream, options) do
+    Stream.map(
+      stream,
+      FormatterHelpers.without_errors_1(fn el ->
+        format_output(el, options)
+      end)
+    )
+  end
+end

--- a/deps/rabbitmq_cli/test/ctl/decrypt_conf_value_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/decrypt_conf_value_command_test.exs
@@ -1,0 +1,83 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule DecryptConfValueCommandTest do
+  use ExUnit.Case, async: false
+  @command RabbitMQ.CLI.Ctl.Commands.DecryptConfValueCommand
+
+  setup _context do
+    {:ok,
+     opts: %{
+       cipher: :rabbit_pbe.default_cipher(),
+       hash: :rabbit_pbe.default_hash(),
+       iterations: :rabbit_pbe.default_iterations()
+     }}
+  end
+
+  test "validate: providing exactly 2 positional arguments passes", context do
+    assert :ok == @command.validate(["value", "secret"], context[:opts])
+  end
+
+  test "validate: providing no positional arguments fails", context do
+    assert match?(
+             {:validation_failure, {:not_enough_args, _}},
+             @command.validate([], context[:opts])
+           )
+  end
+
+  test "validate: providing one positional argument passes", context do
+    assert :ok == @command.validate(["value"], context[:opts])
+  end
+
+  test "validate: providing three or more positional argument fails", context do
+    assert match?(
+             {:validation_failure, :too_many_args},
+             @command.validate(["value", "secret", "incorrect"], context[:opts])
+           )
+  end
+
+  test "validate: hash and cipher must be supported", context do
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher})
+             )
+           )
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{hash: :funny_hash})
+             )
+           )
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher, hash: :funny_hash})
+             )
+           )
+
+    assert :ok == @command.validate(["value", "secret"], context[:opts])
+  end
+
+  test "validate: number of iterations must greater than 0", context do
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: 0}))
+           )
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: -1}))
+           )
+
+    assert :ok == @command.validate(["value", "secret"], context[:opts])
+  end
+end

--- a/deps/rabbitmq_cli/test/ctl/encrypt_conf_value_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/encrypt_conf_value_command_test.exs
@@ -1,0 +1,78 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule EncryptConfValueCommandTest do
+  use ExUnit.Case, async: false
+
+  @command RabbitMQ.CLI.Ctl.Commands.EncryptConfValueCommand
+
+  setup _context do
+    {:ok,
+     opts: %{
+       cipher: :rabbit_pbe.default_cipher(),
+       hash: :rabbit_pbe.default_hash(),
+       iterations: :rabbit_pbe.default_iterations()
+     }}
+  end
+
+  test "validate: providing exactly 2 positional arguments passes", context do
+    assert :ok == @command.validate(["value", "secret"], context[:opts])
+  end
+
+  test "validate: providing zero or one positional argument passes", context do
+    assert :ok == @command.validate([], context[:opts])
+    assert :ok == @command.validate(["value"], context[:opts])
+  end
+
+  test "validate: providing three or more positional argument fails", context do
+    assert match?(
+             {:validation_failure, :too_many_args},
+             @command.validate(["value", "secret", "incorrect"], context[:opts])
+           )
+  end
+
+  test "validate: hash and cipher must be supported", context do
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher})
+             )
+           )
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{hash: :funny_hash})
+             )
+           )
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(
+               ["value", "secret"],
+               Map.merge(context[:opts], %{cipher: :funny_cipher, hash: :funny_hash})
+             )
+           )
+
+    assert :ok == @command.validate(["value", "secret"], context[:opts])
+  end
+
+  test "validate: number of iterations must greater than 0", context do
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: 0}))
+           )
+
+    assert match?(
+             {:validation_failure, {:bad_argument, _}},
+             @command.validate(["value", "secret"], Map.merge(context[:opts], %{iterations: -1}))
+           )
+
+    assert :ok == @command.validate(["value", "secret"], context[:opts])
+  end
+end

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -87,7 +87,7 @@ end}.
 {mapping, "management.ssl.cacertfile", "rabbitmq_management.ssl_config.cacertfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "management.ssl.password", "rabbitmq_management.ssl_config.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {mapping, "management.ssl.verify", "rabbitmq_management.ssl_config.verify", [
     {datatype, {enum, [verify_peer, verify_none]}}]}.
@@ -295,7 +295,7 @@ end}.
     [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "management.listener.ssl_opts.password", "rabbitmq_management.listener.ssl_opts.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {mapping, "management.listener.ssl_opts.psk_identity", "rabbitmq_management.listener.ssl_opts.psk_identity",
     [{datatype, string}]}.

--- a/deps/rabbitmq_trust_store/priv/schema/rabbitmq_trust_store.schema
+++ b/deps/rabbitmq_trust_store/priv/schema/rabbitmq_trust_store.schema
@@ -124,7 +124,7 @@ end}.
     [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "trust_store.ssl_options.password", "rabbitmq_trust_store.ssl_options.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {mapping, "trust_store.ssl_options.psk_identity", "rabbitmq_trust_store.ssl_options.psk_identity",
     [{datatype, string}]}.

--- a/deps/rabbitmq_trust_store/test/config_schema_SUITE_data/rabbitmq_trust_store.snippets
+++ b/deps/rabbitmq_trust_store/test/config_schema_SUITE_data/rabbitmq_trust_store.snippets
@@ -24,5 +24,5 @@
            {url,"https://example.com"},
            {ssl_options,
                [{certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
-                {password,"i_am_password"}]}]}],
+                {password,<<"i_am_password">>}]}]}],
      [rabbitmq_trust_store]}].

--- a/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
+++ b/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
@@ -56,7 +56,7 @@
 {mapping, "web_mqtt.ssl.cacertfile", "rabbitmq_web_mqtt.ssl_config.cacertfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "web_mqtt.ssl.password", "rabbitmq_web_mqtt.ssl_config.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {translation,
     "rabbitmq_web_mqtt.ssl_config",

--- a/deps/rabbitmq_web_mqtt/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
+++ b/deps/rabbitmq_web_mqtt/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
@@ -85,7 +85,7 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"}]}]}],
+             {password,<<"changeme">>}]}]}],
   [rabbitmq_web_mqtt]},
 
  {ssl,
@@ -108,7 +108,7 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"},
+             {password,<<"changeme">>},
 
              {versions,['tlsv1.2','tlsv1.1']}
             ]}]}],
@@ -145,7 +145,7 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"},
+             {password,<<"changeme">>},
 
              {honor_cipher_order,   true},
              {honor_ecc_order,      true},

--- a/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
+++ b/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
@@ -65,7 +65,7 @@
 {mapping, "web_stomp.ssl.cacertfile", "rabbitmq_web_stomp.ssl_config.cacertfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "web_stomp.ssl.password", "rabbitmq_web_stomp.ssl_config.password",
-    [{datatype, string}]}.
+    [{datatype, [tagged_binary, binary]}]}.
 
 {translation,
     "rabbitmq_web_stomp.ssl_config",

--- a/deps/rabbitmq_web_stomp/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
+++ b/deps/rabbitmq_web_stomp/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
@@ -79,7 +79,7 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"}]}]}],
+             {password,<<"changeme">>}]}]}],
   [rabbitmq_web_stomp]},
 
  {ssl,
@@ -99,7 +99,7 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"},
+             {password,<<"changeme">>},
 
              {versions,['tlsv1.2','tlsv1.1']}
             ]}]}],
@@ -136,7 +136,7 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"},
+             {password,<<"changeme">>},
 
              {honor_cipher_order,   true},
              {honor_ecc_order,      true},


### PR DESCRIPTION
This is an extension of an [existent `advanced.config` feature](https://www.rabbitmq.com/docs/configure#configuration-encryption):

``` ini
default_user = bunnies-444
default_pass = encrypted:F/bjQkteQENB4rMUXFKdgsJEpYMXYLzBY/AmcYG83Tg8AOUwYP7Oa0Q33ooNEpK9
```

``` ini
definitions.tls.cacertfile = /tmp/tls-gen/basic/result/ca_certificate.pem
definitions.tls.certfile   = /tmp/tls-gen/basic/result/client_sunnyside_certificate.pem
definitions.tls.keyfile    = /tmp/tls-gen/basic/result/client_sunnyside_key.pem
definitions.tls.password   = encrypted:0GhvdGjqQ/EAPqr27/PtLj04ikzC7p4IBmM6X7Vqk4fDJGrCnXf5VV4MTAOyPQV5
```