### PR TITLE
Fixes to rabbit_maintenance:revive/0

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1260,8 +1260,8 @@ list_local_followers() ->
     [Q
       || Q <- list(),
          amqqueue:is_quorum(Q),
-         amqqueue:get_state(Q) =/= crashed,
          amqqueue:get_leader(Q) =/= node(),
+         lists:member(node(), get_quorum_nodes(Q)),
          rabbit_quorum_queue:is_recoverable(Q)
          ].
 

--- a/deps/rabbit/src/rabbit_maintenance.erl
+++ b/deps/rabbit/src/rabbit_maintenance.erl
@@ -291,28 +291,21 @@ random_nth(Nodes) ->
 
 revive_local_quorum_queue_replicas() ->
     Queues = rabbit_amqqueue:list_local_followers(),
-    [begin
-        Name = amqqueue:get_name(Q),
-        rabbit_log:debug("Will trigger a leader election for local quorum queue ~ts",
-                         [rabbit_misc:rs(Name)]),
-        %% start local QQ replica (Ra server) of this queue
-        {Prefix, _Node} = amqqueue:get_pid(Q),
-        RaServer = {Prefix, node()},
-        rabbit_log:debug("Will start quorum queue replica (Ra server) ~tp", [RaServer]),
-        case rabbit_quorum_queue:restart_server(RaServer) of
-            ok     ->
-                rabbit_log:debug("Successfully restarted a quorum queue replica ~tp", [RaServer]);
-            {error, {already_started, _Pid}} ->
-                rabbit_log:debug("Quorum queue replica ~tp is already running", [RaServer]);
-            {error, nodedown} ->
-                rabbit_log:error("Failed to restart quorum queue replica ~tp: target node was reported as down", [RaServer]);
-            {error, name_not_registered} ->
-                rabbit_log:error("Failed to restart quorum queue replica ~tp: it reported as not registered (was deleted very recently?)", [RaServer]);
-            {error, Other} ->
-                rabbit_log:error("Failed to restart quorum queue replica ~tp: ~tp", [RaServer, Other])
-        end
-     end || Q <- Queues],
-    rabbit_log:info("Restart of local quorum queue replicas is complete").
+    %% NB: this function ignores the first argument so we can just pass the
+    %% empty binary as the vhost name.
+    {Recovered, Failed} = rabbit_quorum_queue:recover(<<>>, Queues),
+    rabbit_log:debug("Successfully revived ~b quorum queue replicas",
+                     [length(Recovered)]),
+    case length(Failed) of
+        0 ->
+            ok;
+        NumFailed ->
+            rabbit_log:error("Failed to revive ~b quorum queue replicas",
+                             [NumFailed])
+    end,
+
+    rabbit_log:info("Restart of local quorum queue replicas is complete"),
+    ok.
 
 %%
 %% Implementation

--- a/deps/rabbit/test/maintenance_mode_SUITE.erl
+++ b/deps/rabbit/test/maintenance_mode_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 all() ->


### PR DESCRIPTION
Fix `rabbit_amqqueue:list_local_follower/1` to ensure it only returns followers for queues that actually have a local member.

Also change `rabbit_maintenance:revive/0` to use `rabbit_quorum_queue:recever/2` to restart local quorum queue members.
