### PR TITLE
Use SASL layer in AMQP 1.0 Erlang client

### DIFF
--- a/deps/amqp10_client/src/amqp10_client.erl
+++ b/deps/amqp10_client/src/amqp10_client.erl
@@ -424,8 +424,8 @@ parse_result(Map) ->
                    throw(plain_sasl_missing_userinfo);
                _ ->
                    case UserInfo of
-                       [] -> none;
-                       undefined -> none;
+                       [] -> anon;
+                       undefined -> anon;
                        U -> parse_usertoken(U)
                    end
            end,
@@ -452,10 +452,6 @@ parse_result(Map) ->
     end.
 
 
-parse_usertoken(undefined) ->
-    none;
-parse_usertoken("") ->
-    none;
 parse_usertoken(U) ->
     [User, Pass] = string:tokens(U, ":"),
     {plain,
@@ -527,7 +523,7 @@ parse_uri_test_() ->
     [?_assertEqual({ok, #{address => "my_host",
                           port => 9876,
                           hostname => <<"my_host">>,
-                          sasl => none}}, parse_uri("amqp://my_host:9876")),
+                          sasl => anon}}, parse_uri("amqp://my_host:9876")),
      %% port defaults
      ?_assertMatch({ok, #{port := 5671}}, parse_uri("amqps://my_host")),
      ?_assertMatch({ok, #{port := 5672}}, parse_uri("amqp://my_host")),


### PR DESCRIPTION
This commit ensures that AMQP 1.0 shovels will always use a SASL security layer when connecting to an AMQP 1.0 broker. Instead of skipping SASL, the client will use SASL mechanism ANONYMOUS.

https://github.com/rabbitmq/rabbitmq-server/pull/11999 mandates that AMQP 1.0 clients use a SASL security layer when connecting to a RabbitMQ 4.0 node.

This commit is only applied to the `v3.13.x` branch such that a shovel running on a 3.13.7 node will be able to connect via AMQP 1.0 to a RabbitMQ 4.x node.