### PR TITLE
Maintain order of configured SASL mechanisms

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -455,10 +455,11 @@ end}.
     {datatype, atom}]}.
 
 {translation, "rabbit.auth_mechanisms",
-fun(Conf) ->
-    Settings = cuttlefish_variable:filter_by_prefix("auth_mechanisms", Conf),
-    [ V || {_, V} <- Settings ]
-end}.
+ fun(Conf) ->
+         Settings = cuttlefish_variable:filter_by_prefix("auth_mechanisms", Conf),
+         Sorted = lists:keysort(1, Settings),
+         [V || {_, V} <- Sorted]
+ end}.
 
 
 %% Select an authentication backend to use. RabbitMQ provides an

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -239,6 +239,20 @@ default_permissions.write = .*",
   [{rabbit,
        [{anonymous_login_user, none}]}],
   []},
+
+ {auth_mechanisms_ordered,
+  "auth_mechanisms.1 = PLAIN
+auth_mechanisms.2 = AMQPLAIN
+auth_mechanisms.3 = ANONYMOUS",
+  [],
+  [{rabbit,
+    %% We expect the mechanisms in the order as declared.
+    [{auth_mechanisms, ['PLAIN', 'AMQPLAIN', 'ANONYMOUS']}]
+   }],
+  [],
+  nosort
+ },
+
  {cluster_formation,
   "cluster_formation.peer_discovery_backend = rabbit_peer_discovery_classic_config
 cluster_formation.classic_config.nodes.peer1 = rabbit@hostname1


### PR DESCRIPTION
RabbitMQ should advertise the SASL mechanisms in the order as configured in `rabbitmq.conf`.

Starting RabbitMQ with the following `rabbitmq.conf`:
```
auth_mechanisms.1 = PLAIN
auth_mechanisms.2 = AMQPLAIN
auth_mechanisms.3 = ANONYMOUS
```

translates prior to this commit to:
```
1> application:get_env(rabbit, auth_mechanisms).
{ok,['ANONYMOUS','AMQPLAIN','PLAIN']}
```

and after this commit to:
```
1> application:get_env(rabbit, auth_mechanisms).
{ok,['PLAIN','AMQPLAIN','ANONYMOUS']}
```

In our 4.0 docs we write:
> The server mechanisms are ordered in decreasing level of preference.

which complies with https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-security-v1.0-os.html#type-sasl-mechanisms.