### PR TITLE
Management: Add segment count to stream queue page

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -253,6 +253,9 @@ var HELP = {
     'queue-messages':
       '<p>Message counts.</p><p>Note that "in memory" and "persistent" are not mutually exclusive; persistent messages can be in memory as well as on disc, and transient messages can be paged out if memory is tight. Non-durable queues will consider all messages to be transient.</p>',
 
+    'queue-messages-stream':
+      '<p>Approximate message counts.</p><p>Note that streams store some entries that are not user messages such as offset tracking data which is included in this count. Thus this value will never be completely correct.</p>',
+
     'queue-dead-lettered':
       'Applies to messages dead-lettered with dead-letter-strategy <code>at-least-once</code>.',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -121,6 +121,10 @@
         <th>Readers</th>
         <td><%= fmt_table_short(queue.readers) %></td>
       </tr>
+      <tr>
+        <th>Segments</th>
+        <td><%= fmt_string(queue.segments) %></td>
+      </tr>
       <% } %>
     </table>
 
@@ -128,8 +132,10 @@
       <tr>
         <td></td>
         <th class="horizontal">Total</th>
+        <% if (!is_stream(queue)) { %>
         <th class="horizontal">Ready</th>
         <th class="horizontal">Unacked</th>
+        <% } %>
         <% if (is_quorum(queue)) { %>
         <th class="horizontal">High priority</th>
         <th class="horizontal">Low priority</th>
@@ -147,17 +153,23 @@
       <tr>
         <th>
           Messages
+          <% if (is_stream(queue)) { %>
+          <span class="help" id="queue-messages-stream"></span>
+          <% } else { %>
           <span class="help" id="queue-messages"></span>
+          <% } %>
         </th>
         <td class="r">
           <%= fmt_num_thousands(queue.messages) %>
         </td>
+        <% if (!is_stream(queue)) { %>
         <td class="r">
           <%= fmt_num_thousands(queue.messages_ready) %>
         </td>
         <td class="r">
           <%= fmt_num_thousands(queue.messages_unacknowledged) %>
         </td>
+        <% } %>
         <% if (is_quorum(queue)) { %>
         <td class="r">
           <%= fmt_num_thousands(queue.messages_ready_high) %>


### PR DESCRIPTION
Also improve the help message for the 'Messages' count.

![image](https://github.com/user-attachments/assets/1d686d7a-472d-4107-8996-4593a1b8b311)