### PR TITLE
Remove unused `rabbit_db_queue:set_many/1`

### DIFF
--- a/deps/rabbit/test/rabbit_db_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_queue_SUITE.erl
@@ -40,7 +40,6 @@ all_tests() ->
      count,
      count_by_vhost,
      set,
-     set_many,
      delete,
      update,
      exists,
@@ -280,23 +279,6 @@ set1(_Config) ->
     ?assertEqual(ok, rabbit_db_queue:set(Q)),
     ?assertEqual(ok, rabbit_db_queue:set(Q)),
     ?assertEqual({ok, Q}, rabbit_db_queue:get(QName)),
-    passed.
-
-set_many(Config) ->
-    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, set_many1, [Config]).
-
-set_many1(_Config) ->
-    QName1 = rabbit_misc:r(?VHOST, queue, <<"test-queue1">>),
-    QName2 = rabbit_misc:r(?VHOST, queue, <<"test-queue2">>),
-    QName3 = rabbit_misc:r(?VHOST, queue, <<"test-queue3">>),
-    Q1 = new_queue(QName1, rabbit_classic_queue),
-    Q2 = new_queue(QName2, rabbit_classic_queue),
-    Q3 = new_queue(QName3, rabbit_classic_queue),
-    ?assertEqual(ok, rabbit_db_queue:set_many([])),
-    ?assertEqual(ok, rabbit_db_queue:set_many([Q1, Q2, Q3])),
-    ?assertEqual({ok, Q1}, rabbit_db_queue:get_durable(QName1)),
-    ?assertEqual({ok, Q2}, rabbit_db_queue:get_durable(QName2)),
-    ?assertEqual({ok, Q3}, rabbit_db_queue:get_durable(QName3)),
     passed.
 
 delete(Config) ->

--- a/deps/rabbit/test/rabbit_db_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_queue_SUITE.erl
@@ -42,6 +42,7 @@ all_tests() ->
      set,
      delete,
      update,
+     update_decorators,
      exists,
      get_all_durable,
      get_all_durable_by_type,
@@ -323,7 +324,7 @@ update_decorators1(_Config) ->
     ?assertEqual({ok, Q}, rabbit_db_queue:get(QName)),
     ?assertEqual(undefined, amqqueue:get_decorators(Q)),
     %% Not really testing we set a decorator, but at least the field is being updated
-    ?assertEqual(ok, rabbit_db_queue:update_decorators(QName)),
+    ?assertEqual(ok, rabbit_db_queue:update_decorators(QName, [])),
     {ok, Q1} = rabbit_db_queue:get(QName),
     ?assertEqual([], amqqueue:get_decorators(Q1)),
     passed.


### PR DESCRIPTION
This function was only used in the classic mirrored queue code removed in 3bbda5bdba799f1d4ec3c2ab055b4177f35ae78c.

Also included is an unrelated fix for the `rabbit_db_queue:update_decorators/2` unit test in `rabbit_db_queue_SUITE`