### PR TITLE
Shovel HTTP API: actually implement GET /api/shovels/vhost/{vhost}/{name}

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_parameters.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_parameters.erl
@@ -41,8 +41,7 @@ is_authorized(ReqData, Context) ->
 %%--------------------------------------------------------------------
 
 %% Hackish fix to make sure we return a JSON object instead of an empty list
-%% when the publish-properties value is empty. Should be removed in 3.7.0
-%% when we switch to a new JSON library.
+%% when the publish-properties value is empty.
 fix_shovel_publish_properties(P) ->
     case lists:keyfind(component, 1, P) of
         {_, <<"shovel">>} ->

--- a/deps/rabbitmq_shovel_management/app.bzl
+++ b/deps/rabbitmq_shovel_management/app.bzl
@@ -9,7 +9,8 @@ def all_beam_files(name = "all_beam_files"):
     erlang_bytecode(
         name = "other_beam",
         srcs = [
-            "src/rabbit_shovel_mgmt.erl",
+            "src/rabbit_shovel_mgmt_shovel.erl",
+            "src/rabbit_shovel_mgmt_shovels.erl",
             "src/rabbit_shovel_mgmt_util.erl",
         ],
         hdrs = [":public_and_private_hdrs"],
@@ -33,7 +34,8 @@ def all_test_beam_files(name = "all_test_beam_files"):
         name = "test_other_beam",
         testonly = True,
         srcs = [
-            "src/rabbit_shovel_mgmt.erl",
+            "src/rabbit_shovel_mgmt_shovel.erl",
+            "src/rabbit_shovel_mgmt_shovels.erl",
             "src/rabbit_shovel_mgmt_util.erl",
         ],
         hdrs = [":public_and_private_hdrs"],
@@ -72,7 +74,8 @@ def all_srcs(name = "all_srcs"):
     filegroup(
         name = "srcs",
         srcs = [
-            "src/rabbit_shovel_mgmt.erl",
+            "src/rabbit_shovel_mgmt_shovel.erl",
+            "src/rabbit_shovel_mgmt_shovels.erl",
             "src/rabbit_shovel_mgmt_util.erl",
         ],
     )

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_shovels.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_shovels.erl
@@ -1,0 +1,57 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_shovel_mgmt_shovels).
+
+-behaviour(rabbit_mgmt_extension).
+
+-export([dispatcher/0, web_ui/0]).
+-export([init/2, to_json/2, resource_exists/2, content_types_provided/2,
+         is_authorized/2, allowed_methods/2]).
+
+-import(rabbit_misc, [pget/2]).
+
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include("rabbit_shovel_mgmt.hrl").
+
+dispatcher() -> [{"/shovels",        ?MODULE, []},
+                 {"/shovels/:vhost", ?MODULE, []}].
+
+web_ui()     -> [{javascript, <<"shovel.js">>}].
+
+%%--------------------------------------------------------------------
+
+init(Req, _Opts) ->
+    {cowboy_rest, rabbit_mgmt_cors:set_headers(Req, ?MODULE), #context{}}.
+
+content_types_provided(ReqData, Context) ->
+   {[{<<"application/json">>, to_json}], ReqData, Context}.
+
+allowed_methods(ReqData, Context) ->
+    {[<<"HEAD">>, <<"GET">>, <<"OPTIONS">>], ReqData, Context}.
+
+resource_exists(ReqData, Context) ->
+    Reply = case rabbit_mgmt_util:vhost(ReqData) of
+                not_found -> false;
+                _Found -> true
+            end,
+    {Reply, ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    rabbit_mgmt_util:reply_list(
+      filter_vhost_req(rabbit_shovel_mgmt_util:status(ReqData, Context), ReqData), ReqData, Context).
+
+is_authorized(ReqData, Context) ->
+    rabbit_mgmt_util:is_authorized_monitor(ReqData, Context).
+
+filter_vhost_req(List, ReqData) ->
+    case rabbit_mgmt_util:vhost(ReqData) of
+        none      -> List;
+        VHost     -> [I || I <- List,
+                           pget(vhost, I) =:= VHost]
+    end.

--- a/moduleindex.yaml
+++ b/moduleindex.yaml
@@ -1131,7 +1131,8 @@ rabbitmq_shovel:
 - rabbit_shovel_worker
 - rabbit_shovel_worker_sup
 rabbitmq_shovel_management:
-- rabbit_shovel_mgmt
+- rabbit_shovel_mgmt_shovel
+- rabbit_shovel_mgmt_shovels
 - rabbit_shovel_mgmt_util
 rabbitmq_shovel_prometheus:
 - rabbit_shovel_prometheus_app


### PR DESCRIPTION
By splitting the module into one that operates on collections of shovels and one that performs operations on a single shovel.

Closes #12040.