### PR TITLE
Remove randomized_startup_delay_range config

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1352,28 +1352,6 @@ fun(Conf) ->
     end
 end}.
 
-%% Cluster formation: Randomized startup delay
-%%
-%% DEPRECATED: This is a no-op. Old configs are still allowed, but a warning will be printed.
-
-{mapping, "cluster_formation.randomized_startup_delay_range.min", "rabbit.cluster_formation.randomized_startup_delay_range", []}.
-{mapping, "cluster_formation.randomized_startup_delay_range.max", "rabbit.cluster_formation.randomized_startup_delay_range", []}.
-
-{translation, "rabbit.cluster_formation.randomized_startup_delay_range",
-fun(Conf) ->
-    Min = cuttlefish:conf_get("cluster_formation.randomized_startup_delay_range.min", Conf, undefined),
-    Max = cuttlefish:conf_get("cluster_formation.randomized_startup_delay_range.max", Conf, undefined),
-
-    case {Min, Max} of
-      {undefined, undefined} ->
-        ok;
-      _ ->
-        cuttlefish:warn("cluster_formation.randomized_startup_delay_range.min and "
-                               "cluster_formation.randomized_startup_delay_range.max are deprecated")
-    end,
-    cuttlefish:unset()
-end}.
-
 %% Cluster formation: lock acquisition retries as passed to https://erlang.org/doc/man/global.html#set_lock-3
 %%
 %% Currently used in classic, k8s, and aws peer discovery backends.

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -770,22 +770,6 @@ tcp_listen_options.exit_on_close = false",
   [{rabbit,[{tcp_listen_options,[{linger,{false,100}}]}]}],
   []},
 
- {cluster_formation_randomized_startup_delay_both_values,
-  "cluster_formation.randomized_startup_delay_range.min = 10
-   cluster_formation.randomized_startup_delay_range.max = 30",
-  [],
-  []},
-
- {cluster_formation_randomized_startup_delay_min_only,
-  "cluster_formation.randomized_startup_delay_range.min = 10",
-  [],
-  []},
-
- {cluster_formation_randomized_startup_delay_max_only,
-  "cluster_formation.randomized_startup_delay_range.max = 30",
-  [],
-  []},
-
  {cluster_formation_internal_lock_retries,
   "cluster_formation.internal_lock_retries = 10",
   [{rabbit,[{cluster_formation,[{internal_lock_retries,10}]}]}],

--- a/release-notes/4.0.0.md
+++ b/release-notes/4.0.0.md
@@ -62,6 +62,15 @@ classic_queue.default_version = 1
 nodes will now fail to start. Removing the line will make the node start and perform
 the migration from CQv1 to CQv2.
 
+### Settings `cluster_formation.randomized_startup_delay_range.*` were Removed
+
+The following two deprecated `rabbitmq.conf` settings were [removed](https://github.com/rabbitmq/rabbitmq-server/pull/12050):
+```
+cluster_formation.randomized_startup_delay_range.min
+cluster_formation.randomized_startup_delay_range.max
+```
+RabbitMQ 4.0 will fail to boot if these settings are configured in `rabbitmq.conf`.
+
 ### Several Disk I/O-Related Metrics were Removed
 
 Several I/O-related metrics are dropped, they should be [monitored at the infrastructure and kernel layers](https://www.rabbitmq.com/docs/monitoring#system-metrics)


### PR DESCRIPTION
For RabbitMQ 4.0, this commit removes support for the deprecated `rabbitmq.conf` settings
```
cluster_formation.randomized_startup_delay_range.min
cluster_formation.randomized_startup_delay_range.max
```

The rabbitmq/cluster-operator already removed these settings in https://github.com/rabbitmq/cluster-operator/commit/b81e0f9bb81df0df6a126c54c059fa6bb7547649