### PR TITLE
rabbit_db_exchange: List exchange names from Khepri projection

### DIFF
--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -151,11 +151,13 @@ list_in_mnesia() ->
     mnesia:dirty_all_keys(?MNESIA_TABLE).
 
 list_in_khepri() ->
-    case rabbit_khepri:match(khepri_exchanges_path() ++
-                                 [rabbit_khepri:if_has_data_wildcard()]) of
-        {ok, Map} ->
-            maps:fold(fun(_K, X, Acc) -> [X#exchange.name | Acc] end, [], Map);
-        _ ->
+    try
+        ets:foldr(
+          fun(#exchange{name = Name}, Acc) ->
+                  [Name | Acc]
+          end, [], ?KHEPRI_PROJECTION)
+    catch
+        error:badarg ->
             []
     end.
 


### PR DESCRIPTION
## Why

All other queries are based on projections, not direct queries to Khepri. Using projections for exchange names should be faster and more consistent with the rest of the module.

## How

The Khepri query is replaced by an ETS query.