### PR TITLE
Return non-0 exit code when failing to enable an experimental feature flag

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_feature_flag_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_feature_flag_command.ex
@@ -40,7 +40,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnableFeatureFlagCommand do
     ])} do
           {_, {:badrpc, _} = err} -> err
           {false, :experimental} ->
-              IO.puts("Feature flag #{feature_flag} is experimental. If you understand the risk, use --experimental to enable it.")
+              {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "Feature flag #{feature_flag} is experimental. If you understand the risk, use --experimental to enable it."}
           _ ->
                 case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :enable, [
                   String.to_atom(feature_flag)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_feature_flag_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/enable_feature_flag_command.ex
@@ -25,7 +25,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnableFeatureFlagCommand do
   def run(["all"], %{node: node_name, experimental: experimental}) do
     case experimental do
       true ->
-        {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "`--experiemntal` flag is not allowed when enabling all feature flags.\nUse --experimental with a specific feature flag if you want to enable an experimental feature."}
+        {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "`--experimental` flag is not allowed when enabling all feature flags.\nUse --experimental with a specific feature flag if you want to enable an experimental feature."}
       false ->
         case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :enable_all, []) do
           {:badrpc, _} = err -> err

--- a/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/enable_feature_flag_test.exs
@@ -10,6 +10,8 @@ defmodule EnableFeatureFlagCommandTest do
 
   @command RabbitMQ.CLI.Ctl.Commands.EnableFeatureFlagCommand
   @feature_flag :ff_from_enable_ff_testsuite
+  @experimental_flag :ff_from_enable_ff_testsuite_experimental
+  @usage_exit_code RabbitMQ.CLI.Core.ExitCodes.exit_usage()
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -22,6 +24,11 @@ defmodule EnableFeatureFlagCommandTest do
         desc: ~c"My feature flag",
         provided_by: :EnableFeatureFlagCommandTest,
         stability: :stable
+      },
+      @experimental_flag => %{
+        desc: ~c"An **experimental** feature!",
+        provided_by: :EnableFeatureFlagCommandTest,
+        stability: :experimental
       }
     }
 
@@ -35,7 +42,9 @@ defmodule EnableFeatureFlagCommandTest do
 
     {
       :ok,
-      opts: %{node: get_rabbit_hostname(), experimental: false}, feature_flag: @feature_flag
+      opts: %{node: get_rabbit_hostname(), experimental: false},
+      feature_flag: @feature_flag,
+      experimental_flag: @experimental_flag
     }
   end
 
@@ -63,6 +72,16 @@ defmodule EnableFeatureFlagCommandTest do
     assert match?({:badrpc, _}, @command.run(["na"], opts))
   end
 
+  test "run: enabling an experimental flag requires '--experimental'", context do
+    experimental_flag = Atom.to_string(context[:experimental_flag])
+    assert match?(
+             {:error, @usage_exit_code, _},
+             @command.run([experimental_flag], context[:opts])
+           )
+    opts = Map.put(context[:opts], :experimental, true)
+    assert @command.run([experimental_flag], opts) == :ok
+  end
+
   test "run: enabling the same feature flag twice is idempotent", context do
     enable_feature_flag(context[:feature_flag])
     assert @command.run([Atom.to_string(context[:feature_flag])], context[:opts]) == :ok
@@ -73,6 +92,12 @@ defmodule EnableFeatureFlagCommandTest do
     enable_feature_flag(context[:feature_flag])
     assert @command.run(["all"], context[:opts]) == :ok
     assert list_feature_flags(:enabled) |> Map.has_key?(context[:feature_flag])
+  end
+
+  test "run: enabling all feature flags with '--experimental' returns an error", context do
+    enable_feature_flag(context[:feature_flag])
+    opts = Map.put(context[:opts], :experimental, true)
+    assert match?({:error, @usage_exit_code, _}, @command.run(["all"], opts))
   end
 
   test "banner", context do


### PR DESCRIPTION
This is a follow-up to #11998. The main change is to return a non-zero exit code for `rabbitmqctl enable_feature_flag <expermental-flag>`. When enabling `khepri_db` locally I wasn't 100% sure `rabbitmqctl` didn't attempt to enable the flag regardless (i.e. the message seemed more like a warning) and I thought a non-zero exit code and the error text would make it more obvious.

Also included are a typo fix and unit tests for the `--experimental` flag, one for `all` and another for a given experimental feature flag name.