### PR TITLE
Osiris v1.8.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,7 +56,7 @@ bazel_dep(
 
 bazel_dep(
     name = "rabbitmq_osiris",
-    version = "1.8.2",
+    version = "1.8.3",
     repo_name = "osiris",
 )
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -142,7 +142,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers meck proper amqp_clie
 PLT_APPS += mnesia runtime_tools
 
 dep_syslog = git https://github.com/schlagert/syslog 4.0.0
-dep_osiris = git https://github.com/rabbitmq/osiris v1.8.2
+dep_osiris = git https://github.com/rabbitmq/osiris v1.8.3
 dep_systemd = hex 0.6.1
 
 define usage_xml_to_erl


### PR DESCRIPTION
This release contains fixes around certain recovery failures where there are either orphaned segment files (that do not have a corresponding index file) or index files that do not have a corresponding segment file.
