### PR TITLE
Return errors when a queue record fails to be removed

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1770,7 +1770,10 @@ notify_sent_queue_down(QPid) ->
 resume(QPid, ChPid) -> delegate:invoke_no_result(QPid, {gen_server2, cast,
                                                         [{resume, ChPid}]}).
 
--spec internal_delete(amqqueue:amqqueue(), rabbit_types:username()) -> 'ok'.
+-spec internal_delete(Queue, ActingUser) -> Ret when
+      Queue :: amqqueue:amqqueue(),
+      ActingUser :: rabbit_types:username(),
+      Ret :: ok | {error, timeout}.
 
 internal_delete(Queue, ActingUser) ->
     internal_delete(Queue, ActingUser, normal).
@@ -1780,6 +1783,8 @@ internal_delete(Queue, ActingUser, Reason) ->
     case rabbit_db_queue:delete(QueueName, Reason) of
         ok ->
             ok;
+        {error, timeout} = Err ->
+            Err;
         Deletions ->
             _ = rabbit_binding:process_deletions(Deletions),
             rabbit_binding:notify_deletions(Deletions, ?INTERNAL_USER),

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1662,6 +1662,11 @@ delete_with(QueueName, ConnPid, IfUnused, IfEmpty, Username, CheckExclusive) whe
         {error, {exit, _, _}} ->
             %% delete()/delegate:invoke might return {error, {exit, _, _}}
             {ok, 0};
+        {error, timeout} ->
+            rabbit_misc:protocol_error(
+              internal_error,
+              "The operation to delete the queue from the metadata store "
+              "timed out", []);
         {ok, Count} ->
             {ok, Count};
         {protocol_error, Type, Reason, ReasonArgs} ->

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -376,7 +376,9 @@ list_for_count_in_khepri(VHostName) ->
 -spec delete(QName, Reason) -> Ret when
       QName :: rabbit_amqqueue:name(),
       Reason :: atom(),
-      Ret :: ok | Deletions :: rabbit_binding:deletions().
+      Ret :: ok |
+             Deletions :: rabbit_binding:deletions() |
+             rabbit_khepri:timeout_error().
 
 delete(QueueName, Reason) ->
     rabbit_khepri:handle_fallback(

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -219,7 +219,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
         {ok, Reply} ->
             Reply;
         Error ->
-            {protocol_error, internal_error, "Cannot delete queue '~ts' on node '~ts': ~255p ",
+            {protocol_error, internal_error, "Cannot delete ~ts on node '~ts': ~255p ",
              [rabbit_misc:rs(amqqueue:get_name(Q)), node(), Error]}
     end.
 

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -467,7 +467,7 @@ assert_benign({error, not_found}, _) -> ok;
 assert_benign({error, {absent, Q, _}}, ActingUser) ->
     %% Removing the database entries here is safe. If/when the down node
     %% restarts, it will clear out the on-disk storage of the queue.
-    rabbit_amqqueue:internal_delete(Q, ActingUser).
+    ok = rabbit_amqqueue:internal_delete(Q, ActingUser).
 
 -spec exists(vhost:name()) -> boolean().
 

--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -28,6 +28,7 @@ groups() ->
                               declare_binding,
                               delete_binding,
                               declare_queue,
+                              delete_queue,
                               publish_to_exchange,
                               publish_and_consume_to_local_classic_queue,
                               consume_from_queue,
@@ -97,6 +98,16 @@ init_per_group(Group, Config0) when Group == client_operations;
             %% To be used in consume_from_queue
             #'queue.declare_ok'{} = amqp_channel:call(Ch, #'queue.declare'{queue = <<"test-queue">>,
                                                                            arguments = [{<<"x-queue-type">>, longstr, <<"classic">>}]}),
+            %% To be used in consume_from_queue
+            #'queue.declare_ok'{} = amqp_channel:call(Ch, #'queue.declare'{queue = <<"test-queue-delete-classic">>,
+                                                                           durable = true,
+                                                                           arguments = [{<<"x-queue-type">>, longstr, <<"classic">>}]}),
+            #'queue.declare_ok'{} = amqp_channel:call(Ch, #'queue.declare'{queue = <<"test-queue-delete-stream">>,
+                                                                           durable = true,
+                                                                           arguments = [{<<"x-queue-type">>, longstr, <<"stream">>}]}),
+            #'queue.declare_ok'{} = amqp_channel:call(Ch, #'queue.declare'{queue = <<"test-queue-delete-quorum">>,
+                                                                           durable = true,
+                                                                           arguments = [{<<"x-queue-type">>, longstr, <<"quorum">>}]}),
             %% To be used in delete_binding
             #'exchange.bind_ok'{} = amqp_channel:call(Ch, #'exchange.bind'{destination = <<"amq.fanout">>,
                                                                            source = <<"amq.direct">>,
@@ -187,6 +198,22 @@ declare_queue(Config) ->
     {_, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, A),
     ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
                 amqp_channel:call(Ch, #'queue.declare'{queue = <<"test-queue-2">>})).
+
+delete_queue(Config) ->
+    [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Conn1 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, A),
+    {ok, Ch1} = amqp_connection:open_channel(Conn1),
+    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+                amqp_channel:call(Ch1, #'queue.delete'{queue = <<"test-queue-delete-classic">>})),
+    Conn2 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, A),
+    {ok, Ch2} = amqp_connection:open_channel(Conn2),
+    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+                amqp_channel:call(Ch2, #'queue.delete'{queue = <<"test-queue-delete-stream">>})),
+    Conn3 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, A),
+    {ok, Ch3} = amqp_connection:open_channel(Conn3),
+    ?assertExit({{shutdown, {connection_closing, {server_initiated_close, 541, _}}}, _},
+                amqp_channel:call(Ch3, #'queue.delete'{queue = <<"test-queue-delete-quorum">>})),
+    ok.
 
 publish_to_exchange(Config) ->
     [A | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
This change exposes and handles the possible `{error, timeout}` return from `rabbit_db_queue:delete/2` / `rabbit_amqqueue:delete_internal/2,3` for classic and quorum queues. When a cluster is running with only a minority of members stream queues already gracefully fail to delete because the coordinator is not available.

We attempt to terminate and delete the underlying queue but notify the caller of the error to remove the queue record from the metadata store when that operation times out.

For classic queues this change is not very straightforward. Currently classic queue deletion happens in the `gen_server2` `terminate/2` callback which doesn't normally have a way to reply to the caller for the `{delete,_,_,_}` call. For this case we take a similar approach to this existing shutdown mechanism: https://github.com/rabbitmq/rabbitmq-server/blob/733ec1ec2312db92224f51fc502f4a1bc436dac6/deps/rabbit/src/rabbit_amqqueue_process.erl#L298-L302

(which triggers from [here](https://github.com/rabbitmq/rabbitmq-server/blob/733ec1ec2312db92224f51fc502f4a1bc436dac6/deps/rabbit/src/rabbit_amqqueue_process.erl#L198-L200)): we pass the `From` for the call with the shutdown term and use `gen_server2:reply/2` to tell the caller whether the deletion succeeded or failed.

We could instead refactor deletion to be done in the `handle_call/3` callback but there are many other ways to for the queue to terminate which rely on the deletion behavior in the terminate callback, so this seemed like the most minimal and safe way to change this behavior.

With this change, queue deletion commands (via a `queue.delete` rpc in amqpl for example) now block until the underlying backing queue state is removed and the record is removed from the metadata store (or that operation fails). This is a behavior change: previously we replied `{ok, BQ:len(BQS)}` immediately and then terminated. I think the new behavior makes more sense but since we're changing behaviors here I haven't marked this to backport to 3.13.x.

The change is more straightforward for quorum queues: we simply check the result of `rabbit_amqqueue:internal_delete/3` and return `{ok, MsgCount}` or `{protocol_error,internal_error,Msg,Args}` based on that.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/10753