### PR TITLE
Don't return khepri status when khperi_db is disabled

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/metadata_store_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/metadata_store_status_command.ex
@@ -14,7 +14,12 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MetadataStoreStatusCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([] = _args, %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_khepri, :status, [])
+    case :rabbit_misc.rpc_call(node_name, :rabbit_feature_flags, :is_enabled, [:khepri_db]) do
+      true ->
+        :rabbit_misc.rpc_call(node_name, :rabbit_khepri, :status, [])
+      false ->
+         [[{<<"Metadata Store">>, "mnesia"}]]
+    end
   end
 
   use RabbitMQ.CLI.DefaultOutput


### PR DESCRIPTION
When khepri_db feature flag is disabled, Khepri servers are running but are not clustered. In this case `rabbit_khepri:status/0` shows that all nodes are leaders, which is confusing and scary (even though actually harmless). Instead, we now just print that mnesia is in use.