### PR TITLE
rabbit_khepri: Set `default_ra_system` Khepri setting

### DIFF
--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -257,7 +257,8 @@ setup(_) ->
     Timeout = application:get_env(rabbit, khepri_default_timeout, 30000),
     ok = application:set_env(
            [{khepri, [{default_timeout, Timeout},
-                      {default_store_id, ?STORE_ID}]}],
+                      {default_store_id, ?STORE_ID},
+                      {default_ra_system, ?RA_SYSTEM}]}],
            [{persistent, true}]),
     RaServerConfig = #{cluster_name => ?RA_CLUSTER_NAME,
                        friendly_name => ?RA_FRIENDLY_NAME},


### PR DESCRIPTION
## Why

It allows to restart Khepri using `khepri:start()`, e.g. from a shell.