### PR TITLE
Run with default wal_sync_method

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -115,7 +115,7 @@ RABBITMQ_STREAM_DIR="$(call node_stream_dir,$(2))" \
 RABBITMQ_FEATURE_FLAGS_FILE="$(call node_feature_flags_file,$(2))" \
 RABBITMQ_PLUGINS_DIR="$(call node_plugins_dir)" \
 RABBITMQ_PLUGINS_EXPAND_DIR="$(call node_plugins_expand_dir,$(2))" \
-RABBITMQ_SERVER_START_ARGS="-ra wal_sync_method sync $(RABBITMQ_SERVER_START_ARGS)" \
+RABBITMQ_SERVER_START_ARGS="$(RABBITMQ_SERVER_START_ARGS)" \
 RABBITMQ_ENABLED_PLUGINS="$(RABBITMQ_ENABLED_PLUGINS)"
 endef
 
@@ -189,8 +189,7 @@ $(if $(RABBITMQ_NODE_PORT),      {tcp_listeners$(comma) [$(shell echo "$$((5552 
 $(if $(RABBITMQ_NODE_PORT),      {tcp_config$(comma) [{port$(comma) $(shell echo "$$((15692 + $(RABBITMQ_NODE_PORT) - 5672))")}]},)
     ]},
   {ra, [
-      {data_dir, "$(RABBITMQ_QUORUM_DIR)"},
-      {wal_sync_method, sync}
+      {data_dir, "$(RABBITMQ_QUORUM_DIR)"}
     ]},
   {osiris, [
       {data_dir, "$(RABBITMQ_STREAM_DIR)"}
@@ -227,8 +226,7 @@ define test_rabbitmq_config_with_tls
         ]}
   ]},
   {ra, [
-      {data_dir, "$(RABBITMQ_QUORUM_DIR)"},
-      {wal_sync_method, sync}
+      {data_dir, "$(RABBITMQ_QUORUM_DIR)"}
     ]},
   {osiris, [
       {data_dir, "$(RABBITMQ_STREAM_DIR)"}

--- a/scripts/bazel/rabbitmq-run.bat
+++ b/scripts/bazel/rabbitmq-run.bat
@@ -81,10 +81,6 @@ set RABBITMQ_PLUGINS_EXPAND_DIR=%NODE_TMPDIR%\plugins
 set RABBITMQ_FEATURE_FLAGS_FILE=%NODE_TMPDIR%\feature_flags
 set RABBITMQ_ENABLED_PLUGINS_FILE=%NODE_TMPDIR%\enabled_plugins
 
-if not defined RABBITMQ_SERVER_START_ARGS (
-    set RABBITMQ_SERVER_START_ARGS=-ra wal_sync_method sync
-)
-
 if not defined RABBITMQ_LOG (
     set RABBITMQ_LOG=debug,+color
 )
@@ -115,8 +111,7 @@ if "%CMD%" == "run-broker" (
         @echo   {rabbitmq_mqtt, []},
         @echo   {rabbitmq_stomp, []},
         @echo   {ra, [
-        @echo     {data_dir, "!RABBITMQ_QUORUM_DIR:\=\\!"},
-        @echo     {wal_sync_method, sync}
+        @echo     {data_dir, "!RABBITMQ_QUORUM_DIR:\=\\!"}
         @echo   ]},
         @echo   {osiris, [
         @echo     {data_dir, "!RABBITMQ_STREAM_DIR:\=\\!"}

--- a/scripts/bazel/rabbitmq-run.sh
+++ b/scripts/bazel/rabbitmq-run.sh
@@ -78,8 +78,7 @@ write_config_file() {
       ${rabbitmq_prometheus_fragment}
     ]},
   {ra, [
-      {data_dir, "${RABBITMQ_QUORUM_DIR}"},
-      {wal_sync_method, sync}
+      {data_dir, "${RABBITMQ_QUORUM_DIR}"}
     ]},
   {osiris, [
       {data_dir, "${RABBITMQ_STREAM_DIR}"}
@@ -195,8 +194,6 @@ fi
 
 RABBITMQ_PLUGINS_DIR=${RABBITMQ_PLUGINS_DIR:=${DEFAULT_PLUGINS_DIR}}
 export RABBITMQ_PLUGINS_DIR
-RABBITMQ_SERVER_START_ARGS="${RABBITMQ_SERVER_START_ARGS:=-ra wal_sync_method sync}"
-export RABBITMQ_SERVER_START_ARGS
 
 # Enable colourful debug logging by default
 # To change this, set RABBITMQ_LOG to info, notice, warning etc.


### PR DESCRIPTION
...which is `datasync`

RA never pre-allocates the WAL anymore unless explicitly configured to.
