### PR TITLE
Prevent exchange logging crash

### DIFF
--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -44,8 +44,18 @@ log(#{meta := #{mfa := {?MODULE, _, _}}}, _) ->
     ok;
 log(LogEvent, Config) ->
     case rabbit_boot_state:get() of
-        ready -> do_log(LogEvent, Config);
-        _     -> ok
+        ready ->
+            try
+                do_log(LogEvent, Config)
+            catch
+                C:R:S ->
+                    %% don't let logging crash, because then OTP logger
+                    %% removes the logger_exchange handler, which in
+                    %% turn deletes the log exchange and its bindings
+                    erlang:display({?MODULE, crashed, {C, R, S}})
+            end,
+            ok;
+        _ -> ok
     end.
 
 do_log(LogEvent, #{config := #{exchange := Exchange}} = Config) ->


### PR DESCRIPTION
This is #12100 by @gomoripeti submitted by me so that Actions can run with access to GCP Bazel cache.