### PR TITLE
MQTT and Streams: handle connection shutdown via CLI command gracefully

### DIFF
--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -427,11 +427,7 @@ close_connection(#tracked_connection{pid = Pid, type = direct}, Message) ->
     %% Do an RPC call to the node running the direct client.
     Node = node(Pid),
     rpc:call(Node, amqp_direct_connection, server_close, [Pid, 320, Message]);
-close_connection(#tracked_connection{pid = Pid,
-                                     protocol = {'Web MQTT', _}}, Message) ->
-    % this will work for connections to web mqtt plugin
-    Pid ! {shutdown, Message};
 close_connection(#tracked_connection{pid = Pid}, Message) ->
-    % best effort, this will work for connections to the stream plugin
-    Node = node(Pid),
-    rpc:call(Node, gen_server, call, [Pid, {shutdown, Message}, infinity]).
+    %% Best effort will work for following plugins:
+    %% rabbitmq_stream, rabbitmq_mqtt, rabbitmq_web_mqtt
+    Pid ! {shutdown, Message}.

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -427,6 +427,10 @@ close_connection(#tracked_connection{pid = Pid, type = direct}, Message) ->
     %% Do an RPC call to the node running the direct client.
     Node = node(Pid),
     rpc:call(Node, amqp_direct_connection, server_close, [Pid, 320, Message]);
+close_connection(#tracked_connection{pid = Pid,
+                                     protocol = {'Web MQTT', _}}, Message) ->
+    % this will work for connections to web mqtt plugin
+    Pid ! {shutdown, Message};
 close_connection(#tracked_connection{pid = Pid}, Message) ->
     % best effort, this will work for connections to the stream plugin
     Node = node(Pid),

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -531,9 +531,8 @@ close_connections(Pids, Explanation) ->
 
 -spec close_all_user_connections(rabbit_types:username(), string()) -> 'ok'.
 close_all_user_connections(Username, Explanation) ->
-    Pids = [Pid || #tracked_connection{pid = Pid} <- rabbit_connection_tracking:list_of_user(Username)],
-    [close_connection(Pid, Explanation) || Pid <- Pids],
-    ok.
+    Tracked = rabbit_connection_tracking:list_of_user(Username),
+    rabbit_connection_tracking:close_connections(Tracked, Explanation, 0).
 
 %% Meant to be used by tests only
 -spec close_all_connections(string()) -> 'ok'.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -109,11 +109,6 @@ init(Ref) ->
 handle_call({info, InfoItems}, _From, State) ->
     {reply, infos(InfoItems, State), State, ?HIBERNATE_AFTER};
 
-handle_call({shutdown, Explanation} = Reason, _From, State = #state{conn_name = ConnName}) ->
-    %% rabbit_networking:close_all_user_connections -> rabbit_reader:shutdow
-    ?LOG_INFO("MQTT closing connection ~tp: ~p", [ConnName, Explanation]),
-    {stop, Reason, ok, State};
-
 handle_call(Msg, From, State) ->
     {stop, {mqtt_unexpected_call, Msg, From}, State}.
 
@@ -252,7 +247,7 @@ handle_info({'DOWN', _MRef, process, QPid, _Reason}, State) ->
     {noreply, State, ?HIBERNATE_AFTER};
 
 handle_info({shutdown, Explanation} = Reason, State = #state{conn_name = ConnName}) ->
-    %% rabbitmq_management plugin requests to close connection.
+    %% rabbitmq_management plugin or CLI command requests to close connection.
     ?LOG_INFO("MQTT closing connection ~tp: ~p", [ConnName, Explanation]),
     {stop, Reason, State};
 

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -109,6 +109,11 @@ init(Ref) ->
 handle_call({info, InfoItems}, _From, State) ->
     {reply, infos(InfoItems, State), State, ?HIBERNATE_AFTER};
 
+handle_call({shutdown, Explanation} = Reason, _From, State = #state{conn_name = ConnName}) ->
+    %% rabbit_networking:close_all_user_connections -> rabbit_reader:shutdow
+    ?LOG_INFO("MQTT closing connection ~tp: ~p", [ConnName, Explanation]),
+    {stop, Reason, ok, State};
+
 handle_call(Msg, From, State) ->
     {stop, {mqtt_unexpected_call, Msg, From}, State}.
 

--- a/deps/rabbitmq_mqtt/test/shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/shared_SUITE.erl
@@ -91,6 +91,8 @@ cluster_size_1_tests() ->
      ,block_only_publisher
      ,many_qos1_messages
      ,session_expiry
+     ,cli_close_all_connections
+     ,cli_close_all_user_connections
      ,management_plugin_connection
      ,management_plugin_enable
      ,disconnect
@@ -129,8 +131,6 @@ cluster_size_1_tests() ->
      ,retained_message_conversion
      ,bind_exchange_to_exchange
      ,bind_exchange_to_exchange_single_message
-     ,cli_close_all_connections
-     ,cli_close_all_user_connections
     ].
 
 cluster_size_3_tests() ->
@@ -143,8 +143,6 @@ cluster_size_3_tests() ->
      rabbit_mqtt_qos0_queue,
      rabbit_mqtt_qos0_queue_kill_node,
      cli_list_queues,
-     cli_close_all_connections,
-     cli_close_all_user_connections,
      delete_create_queue,
      session_reconnect,
      session_takeover,
@@ -211,9 +209,7 @@ end_per_group(_, Config) ->
 
 init_per_testcase(T, Config)
   when T =:= management_plugin_connection;
-       T =:= management_plugin_enable;
-       T =:= cli_close_all_user_connections;
-       T =:= cli_close_all_connections ->
+       T =:= management_plugin_enable ->
     inets:start(),
     init_per_testcase0(T, Config);
 init_per_testcase(Testcase, Config) ->
@@ -226,9 +222,7 @@ init_per_testcase0(Testcase, Config) ->
 
 end_per_testcase(T, Config)
   when T =:= management_plugin_connection;
-       T =:= management_plugin_enable;
-       T =:= cli_close_all_user_connections;
-       T =:= cli_close_all_connections ->
+       T =:= management_plugin_enable ->
     ok = inets:stop(),
     end_per_testcase0(T, Config);
 end_per_testcase(Testcase, Config) ->
@@ -1173,6 +1167,24 @@ rabbit_mqtt_qos0_queue_kill_node(Config) ->
     ok = rabbit_ct_broker_helpers:start_node(Config, 1),
     ?assertEqual([], rpc(Config, rabbit_db_binding, get_all, [])).
 
+cli_close_all_connections(Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    C = connect(ClientId, Config),
+    process_flag(trap_exit, true),
+    {ok, String} = rabbit_ct_broker_helpers:rabbitmqctl(
+                     Config, 0, ["close_all_connections", "bye"]),
+    ?assertEqual(match, re:run(String, "Closing .* reason: bye", [{capture, none}])),
+    ok = await_exit(C).
+
+cli_close_all_user_connections(Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    C = connect(ClientId, Config),
+    process_flag(trap_exit, true),
+    {ok, String} = rabbit_ct_broker_helpers:rabbitmqctl(
+                     Config, 0, ["close_all_user_connections","guest", "bye"]),
+    ?assertEqual(match, re:run(String, "Closing .* reason: bye", [{capture, none}])),
+    ok = await_exit(C).
+
 %% Test that MQTT connection can be listed and closed via the rabbitmq_management plugin.
 management_plugin_connection(Config) ->
     KeepaliveSecs = 99,
@@ -1215,36 +1227,6 @@ management_plugin_enable(Config) ->
     eventually(?_assertEqual(1, length(http_get(Config, "/connections"))), 1000, 10),
 
     ok = emqtt:disconnect(C).
-
-cli_close_all_connections(Config) ->
-    KeepaliveSecs = 99,
-    ClientId = atom_to_binary(?FUNCTION_NAME),
-
-    _ = connect(ClientId, Config, [{keepalive, KeepaliveSecs}]),
-    eventually(?_assertEqual(1, length(http_get(Config, "/connections"))), 1000, 10),
-
-    process_flag(trap_exit, true),
-    {ok, String} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["close_all_connections", "bye"]),
-    ?assertEqual(match, re:run(String, "Closing .* reason: bye", [{capture, none}])),
-
-    process_flag(trap_exit, false),
-    eventually(?_assertEqual([], http_get(Config, "/connections")),
-               1000, 10).
-
-cli_close_all_user_connections(Config) ->
-    KeepaliveSecs = 99,
-    ClientId = atom_to_binary(?FUNCTION_NAME),
-
-    _ = connect(ClientId, Config, [{keepalive, KeepaliveSecs}]),
-    eventually(?_assertEqual(1, length(http_get(Config, "/connections"))), 1000, 10),
-
-    process_flag(trap_exit, true),
-    {ok, String} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["close_all_user_connections","guest", "bye"]),
-    ?assertEqual(match, re:run(String, "Closing .* reason: bye", [{capture, none}])),
-
-    process_flag(trap_exit, false),
-    eventually(?_assertEqual([], http_get(Config, "/connections")),
-               1000, 10).
 
 %% Test that queues of type rabbit_mqtt_qos0_queue can be listed via rabbitmqctl.
 cli_list_queues(Config) ->


### PR DESCRIPTION
`{shutdown, Reason}` must be handled into handle_call and not handle_info `rabbitmqctl close_all_user_connections` calls rabbit_reader which does a call into the process, the same as rabbitmq_management

Fixes #11985 