### PR TITLE
Use 3.13.7 as secondary umbrella

### DIFF
--- a/bazel/bzlmod/secondary_umbrella.bzl
+++ b/bazel/bzlmod/secondary_umbrella.bzl
@@ -28,9 +28,9 @@ def secondary_umbrella():
         name = "rabbitmq-server-generic-unix-3.13",
         build_file = "@//:BUILD.package_generic_unix",
         patch_cmds = [ADD_PLUGINS_DIR_BUILD_FILE],
-        strip_prefix = "rabbitmq_server-3.13.1",
+        strip_prefix = "rabbitmq_server-3.13.7",
         # This file is produced just in time by the test-mixed-versions.yaml GitHub Actions workflow.
         urls = [
-            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/26.1/package-generic-unix-for-mixed-version-testing-v3.13.1.tar.xz",
+            "https://rabbitmq-github-actions.s3.eu-west-1.amazonaws.com/secondary-umbrellas/26.1/package-generic-unix-for-mixed-version-testing-v3.13.7.tar.xz",
         ],
     )

--- a/deps/rabbitmq_shovel/test/amqp10_inter_cluster_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_inter_cluster_SUITE.erl
@@ -72,25 +72,13 @@ end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 old_to_new_on_old(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "TODO: Unskip when lower version is >= 3.13.7 "
-             "because AMQP 1.0 client must use SASL when connecting to 4.0"};
-        false ->
-            ok = shovel(?OLD, ?NEW, ?OLD, Config)
-    end.
+    ok = shovel(?OLD, ?NEW, ?OLD, Config).
 
 old_to_new_on_new(Config) ->
     ok = shovel(?OLD, ?NEW, ?NEW, Config).
 
 new_to_old_on_old(Config) ->
-    case rabbit_ct_helpers:is_mixed_versions() of
-        true ->
-            {skip, "TODO: Unskip when lower version is >= 3.13.7 "
-             "because AMQP 1.0 client must use SASL when connecting to 4.0"};
-        false ->
-            ok = shovel(?NEW, ?OLD, ?OLD, Config)
-    end.
+    ok = shovel(?NEW, ?OLD, ?OLD, Config).
 
 new_to_old_on_new(Config) ->
     ok = shovel(?NEW, ?OLD, ?NEW, Config).


### PR DESCRIPTION
for mixed version tests. This allows us unskipping shovel tests.