### PR TITLE
Support unicode messages by exchange logging

### DIFF
--- a/deps/rabbit/src/rabbit_logger_exchange_h.erl
+++ b/deps/rabbit/src/rabbit_logger_exchange_h.erl
@@ -110,12 +110,18 @@ make_headers(_, _) ->
     [{<<"node">>, longstr, Node}].
 
 try_format_body(LogEvent, #{formatter := {Formatter, FormatterConfig}}) ->
-    Formatted = try_format_body(LogEvent, Formatter, FormatterConfig),
-    erlang:iolist_to_binary(Formatted).
+    try_format_body(LogEvent, Formatter, FormatterConfig).
 
 try_format_body(LogEvent, Formatter, FormatterConfig) ->
     try
-        Formatter:format(LogEvent, FormatterConfig)
+        Formatted = Formatter:format(LogEvent, FormatterConfig),
+        case unicode:characters_to_binary(Formatted) of
+            Binary when is_binary(Binary) ->
+                Binary;
+            Error ->
+                %% The formatter returned invalid or incomplete unicode
+                throw(Error)
+        end
     catch
         C:R:S ->
             case {?DEFAULT_FORMATTER, ?DEFAULT_FORMATTER_CONFIG} of


### PR DESCRIPTION
## Proposed Changes

Before this commit formatting the amqp body would crash and the log message would not be published to the log exchange.

Before commit 34bcb911 it even crashed the whole exchange logging handler which caused the log exchange to be deleted.

This is the root cause (or at least one of them) why log exchange was seen deleted as described in https://github.com/rabbitmq/rabbitmq-server/pull/12100

A real world example logging unicode:
```
MQTT connection failed: access refused for user 'Aðª':user 'A𪛔' - invalid credentials
```

Kudos to @johanrhodin who found the bug with extraordinary intuition.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

