### PR TITLE
Minor optimisation: Hibernate 2 metrics gc processes

### DIFF
--- a/deps/rabbit/src/rabbit_core_metrics_gc.erl
+++ b/deps/rabbit/src/rabbit_core_metrics_gc.erl
@@ -6,6 +6,8 @@
 %%
 -module(rabbit_core_metrics_gc).
 
+-behaviour(gen_server).
+
 -record(state, {timer,
                 interval
                }).
@@ -17,7 +19,7 @@
 -spec start_link() -> rabbit_types:ok_pid_or_error().
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], [{hibernate_after, 0}]).
 
 init(_) ->
     Interval = rabbit_misc:get_env(rabbit, core_metrics_gc_interval, 120000),

--- a/deps/rabbitmq_stream/src/rabbit_stream_metrics_gc.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_metrics_gc.erl
@@ -32,7 +32,7 @@
 
 -spec start_link() -> rabbit_types:ok_pid_or_error().
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], [{hibernate_after, 0}]).
 
 init(_) ->
     Interval =


### PR DESCRIPTION
## Proposed Changes

It was observed that `rabbit_core_metrics_gc` and `rabbit_stream_metrics_gc` processes can grow to several MBs of memory (probably because fetching the list of all queues). As they execute infrequently (every 2 minutes by default) it can save some memory to hibernate them in-between (similar to other similar processes).

On an idle test server with 30K queues the `rabbit_core_metrics_gc` process consumed ~50MB memory.

This is an ad-hoc optimisation (low-hanging fruit) mostly to follow good practice of hibernating similar processes.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
