### PR TITLE
Update .NET to 8.0

### DIFF
--- a/.github/workflows/test-plugin-mixed.yaml
+++ b/.github/workflows/test-plugin-mixed.yaml
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/setup-dotnet@v4
       if: inputs.plugin == 'rabbit'
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '8.0'
     - name: deps/amqp10_client SETUP
       if: inputs.plugin == 'amqp10_client'
       run: |

--- a/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/fsharp-tests.fsproj
+++ b/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/fsharp-tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
Update .NET to 8.0 in amqp_system tests. .NET6 will reach end of life in November 2024:
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core