### PR TITLE
Remove queue-version CQ argument

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -232,9 +232,6 @@ var HELP = {
     'queue-max-age':
       'Sets the data retention for stream queues in time units </br>(Y=Years, M=Months, D=Days, h=hours, m=minutes, s=seconds).<br/>E.g. "1h" configures the stream to only keep the last 1 hour of received messages.</br></br>(Sets the x-max-age argument.)',
 
-    'queue-version':
-      'Set the queue version. Defaults to version 1.<br/>Version 1 has a journal-based index that embeds small messages.<br/>Version 2 has a different index which improves memory usage and performance in many scenarios, as well as a per-queue store for messages that were previously embedded.<br/>(Sets the "x-queue-version" argument.)',
-
     'queue-overflow':
       'Sets the <a target="_blank" href="https://www.rabbitmq.com/maxlength.html#overflow-behaviour">queue overflow behaviour</a>. This determines what happens to messages when the maximum length of a queue is reached. Valid values are <code>drop-head</code>, <code>reject-publish</code> or <code>reject-publish-dlx</code>. The quorum queue type only supports <code>drop-head</code> and <code>reject-publish</code>.',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -112,12 +112,6 @@
                   <span class="argument-link" field="definition" key="queue-leader-locator" type="string">Leader locator</span><span class="help" id="queue-leader-locator"></span></br>
                 </td>
               <tr>
-                <td>Queues [Classic]</td>
-                <td>
-                  <span class="argument-link" field="definition" key="queue-version" type="number">Version</span> <span class="help" id="queue-version"></span> |
-                </td>
-              </tr>
-              <tr>
                 <td>Queues [Quorum]</td>
                 <td>
                   <span class="argument-link" field="definition" key="delivery-limit" type="number">Delivery limit</span>
@@ -275,7 +269,6 @@
                   <span class="argument-link" field="definitionop" key="max-length-bytes" type="number">Max length bytes</span> |
                   <span class="argument-link" field="definitionop" key="message-ttl" type="number">Message TTL</span> |
                   <span class="help" id="queue-message-ttl"></span> |
-                  <span class="argument-link" field="definitionop" key="queue-version" type="number">Version</span> <span class="help" id="queue-version"></span> </br>
                   <span class="argument-link" field="definitionop" key="overflow" type="string">Length limit overflow behaviour</span> <span class="help" id="queue-overflow"></span> </br>
                 </td>
               </tr>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -325,7 +325,6 @@
                   <span class="argument-link" field="arguments" key="x-max-length-bytes" type="number">Max length bytes</span> <span class="help" id="queue-max-length-bytes"></span><br/>
                 <% if (queue_type == "classic") { %>
                 <span class="argument-link" field="arguments" key="x-max-priority" type="number">Maximum priority</span> <span class="help" id="queue-max-priority"></span>
-                | <span class="argument-link" field="arguments" key="x-queue-version" type="number">Version</span> <span class="help" id="queue-version"></span>
                 <% } %>
                 <% if (queue_type == "quorum") { %>
                   <span class="argument-link" field="arguments" key="x-delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span>


### PR DESCRIPTION
It is no longer possible to set the version
when declaring a queue/policy, since only v2 is supported.