### PR TITLE
Transactionally delete all exchanges during vhost deletion

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -835,9 +835,8 @@ delete_for_source_in_khepri(#resource{virtual_host = VHost, name = Name}) ->
              _Kind = ?KHEPRI_WILDCARD_STAR,
              _DstName = ?KHEPRI_WILDCARD_STAR,
              _RoutingKey = #if_has_data{}),
-    {ok, Bindings} = khepri_tx:get_many(Path),
-    ok = khepri_tx:delete_many(Path),
-    maps:fold(fun(_P, Set, Acc) ->
+    {ok, Bindings} = khepri_tx_adv:delete_many(Path),
+    maps:fold(fun(_P, #{data := Set}, Acc) ->
                       sets:to_list(Set) ++ Acc
               end, [], Bindings).
 
@@ -881,24 +880,19 @@ delete_for_destination_in_mnesia(DstName, OnlyDurable, Fun) ->
       OnlyDurable :: boolean(),
       Deletions :: rabbit_binding:deletions().
 
-delete_for_destination_in_khepri(DstName, OnlyDurable) ->
-    BindingsMap = match_destination_in_khepri(DstName),
-    maps:foreach(fun(K, _V) -> khepri_tx:delete(K) end, BindingsMap),
-    Bindings = maps:fold(fun(_, Set, Acc) ->
+delete_for_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, name = Name}, OnlyDurable) ->
+    Pattern = khepri_route_path(
+                VHost,
+                _SrcName = ?KHEPRI_WILDCARD_STAR,
+                Kind,
+                Name,
+                _RoutingKey = ?KHEPRI_WILDCARD_STAR),
+    {ok, BindingsMap} = khepri_tx_adv:delete_many(Pattern),
+    Bindings = maps:fold(fun(_, #{data := Set}, Acc) ->
                                  sets:to_list(Set) ++ Acc
                          end, [], BindingsMap),
     rabbit_binding:group_bindings_fold(fun maybe_auto_delete_exchange_in_khepri/4,
                                        lists:keysort(#binding.source, Bindings), OnlyDurable).
-
-match_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, name = Name}) ->
-    Path = khepri_route_path(
-             VHost,
-             _SrcName = ?KHEPRI_WILDCARD_STAR,
-             Kind,
-             Name,
-             _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    {ok, Map} = khepri_tx:get_many(Path),
-    Map.
 
 %% -------------------------------------------------------------------
 %% delete_transient_for_destination_in_mnesia().

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -299,8 +299,7 @@ delete(VHost, ActingUser) ->
          assert_benign(rabbit_amqqueue:with(Name, QDelFun), ActingUser)
      end || Q <- rabbit_amqqueue:list(VHost)],
     rabbit_log:info("Deleting exchanges in vhost '~ts' because it's being deleted", [VHost]),
-    [ok = rabbit_exchange:ensure_deleted(Name, false, ActingUser) ||
-        #exchange{name = Name} <- rabbit_exchange:list(VHost)],
+    ok = rabbit_exchange:delete_all(VHost, ActingUser),
     rabbit_log:info("Clearing policies and runtime parameters in vhost '~ts' because it's being deleted", [VHost]),
     _ = rabbit_runtime_parameters:clear_vhost(VHost, ActingUser),
     rabbit_log:debug("Removing vhost '~ts' from the metadata storage because it's being deleted", [VHost]),


### PR DESCRIPTION
Currently we delete each exchange one-by-one which requires three commands: the delete itself plus a put and delete for a runtime parameter that acts as a lock to prevent a client from declaring an exchange while it's being deleted. The lock is unnecessary during vhost deletion because permissions are cleared for the vhost before any resources are deleted. We can use a transaction to delete all exchanges and bindings for a vhost. This is especially useful for Khepri since it only takes one command rather than three per exchange, minimizing the latency of the deletion.

In a quick test with a vhost containing only 10,000 exchanges (no bindings, queues, users, etc.), this is an order of magnitude speedup when running Khepri: the prior commit takes 22s to delete the vhost while with this commit the vhost is deleted in 2s.

This is currently based on #11225 and can be merged after that PR.