### PR TITLE
QQ: a delivery-limit of -1 disables the delivery limit.

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -222,7 +222,7 @@
                     max_bytes => non_neg_integer(),
                     overflow_strategy => drop_head | reject_publish,
                     single_active_consumer_on => boolean(),
-                    delivery_limit => non_neg_integer(),
+                    delivery_limit => non_neg_integer() | -1,
                     expires => non_neg_integer(),
                     msg_ttl => non_neg_integer(),
                     created => non_neg_integer()

--- a/deps/rabbit/test/unit_policy_validators_SUITE.erl
+++ b/deps/rabbit/test/unit_policy_validators_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-compile(nowarn_export_all).
 -compile(export_all).
 
 all() ->
@@ -93,7 +94,7 @@ max_in_memory_length(_Config) ->
     requires_non_negative_integer_value(<<"max-in-memory-bytes">>).
 
 delivery_limit(_Config) ->
-    requires_non_negative_integer_value(<<"delivery-limit">>).
+    requires_integer_value(<<"delivery-limit">>).
 
 classic_queue_lazy_mode(_Config) ->
     test_valid_and_invalid_values(<<"queue-mode">>,
@@ -142,3 +143,8 @@ requires_non_negative_integer_value(Key) ->
     test_valid_and_invalid_values(Key,
         [0, 1, 1000],
         [-1000, -1, <<"a.binary">>]).
+
+requires_integer_value(Key) ->
+    test_valid_and_invalid_values(Key,
+        [-1, 0, 1, 1000, -10000],
+        [<<"a.binary">>, 0.1]).

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -179,7 +179,7 @@ const QUEUE_EXTRA_CONTENT_REQUESTS = [];
 // All help ? popups
 var HELP = {
     'delivery-limit':
-      'The number of allowed unsuccessful delivery attempts. Once a message has been delivered unsuccessfully more than this many times it will be dropped or dead-lettered, depending on the queue configuration.',
+      'The number of allowed unsuccessful delivery attempts. Once a message has been delivered unsuccessfully more than this many times it will be dropped or dead-lettered, depending on the queue configuration. The default is always 20. A value of -1 or lower sets the limit to "unlimited".',
 
     'exchange-auto-delete':
       'If yes, the exchange will delete itself after at least one queue or exchange has been bound to this one, and then all queues or exchanges have been unbound.',

--- a/release-notes/4.0.0.md
+++ b/release-notes/4.0.0.md
@@ -56,9 +56,14 @@ for such queues. The recommended way of doing that is via a [policy](https://www
 See the [Position Messaging Handling](https://www.rabbitmq.com/docs/next/quorum-queues#poison-message-handling) section
 in the quorum queue documentation guide.
 
-Mote that increasing the limit is recommended against: usually the presence of messages that have been redelivered 20 times or more suggests
+Note that increasing the limit is recommended against: usually the presence of messages that have been redelivered 20 times or more suggests
 that a consumer has entered a fail-requeue-fail-requeue loop, in which case even a much higher limit
 won't help avoid the dead-lettering.
+
+For specific cases where the RabbitMQ configuration cannot be updated to include a dead letter policy
+the delivery limit can be disabled by setting a delivery limit configuration of `-1`. However, the RabbitMQ team
+strongly recommends keeping the delivery limit in place to ensure cluster availability isn't
+accidentally sacrificed.
 
 ### CQv1 Storage Implementation was Removed
 


### PR DESCRIPTION
For cases where users want to live a bit more dangerously this commit maps a delivery limit of -1 (or any negative value) such that it disables the delivery limit and restores the 3.13.x behaviour.
