### PR TITLE
Consistently use singular names for Khepri projections

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -53,7 +53,7 @@
 -define(MNESIA_SEMI_DURABLE_TABLE, rabbit_semi_durable_route).
 -define(MNESIA_REVERSE_TABLE, rabbit_reverse_route).
 -define(MNESIA_INDEX_TABLE, rabbit_index_route).
--define(KHEPRI_BINDINGS_PROJECTION, rabbit_khepri_bindings).
+-define(KHEPRI_BINDINGS_PROJECTION, rabbit_khepri_binding).
 -define(KHEPRI_INDEX_ROUTE_PROJECTION, rabbit_khepri_index_route).
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -23,8 +23,8 @@
         ]).
 
 -define(MNESIA_TABLE, rabbit_runtime_parameters).
--define(KHEPRI_GLOBAL_PROJECTION, rabbit_khepri_global_rtparams).
--define(KHEPRI_VHOST_PROJECTION, rabbit_khepri_per_vhost_rtparams).
+-define(KHEPRI_GLOBAL_PROJECTION, rabbit_khepri_global_rtparam).
+-define(KHEPRI_VHOST_PROJECTION, rabbit_khepri_per_vhost_rtparam).
 -define(any(Value), case Value of
                         '_' -> ?KHEPRI_WILDCARD_STAR;
                         _ -> Value

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -75,8 +75,8 @@
 -define(MNESIA_TABLE, rabbit_user).
 -define(PERM_MNESIA_TABLE, rabbit_user_permission).
 -define(TOPIC_PERM_MNESIA_TABLE, rabbit_topic_permission).
--define(KHEPRI_USERS_PROJECTION, rabbit_khepri_users).
--define(KHEPRI_PERMISSIONS_PROJECTION, rabbit_khepri_user_permissions).
+-define(KHEPRI_USERS_PROJECTION, rabbit_khepri_user).
+-define(KHEPRI_PERMISSIONS_PROJECTION, rabbit_khepri_user_permission).
 
 %% -------------------------------------------------------------------
 %% create().

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1190,21 +1190,21 @@ register_rabbit_vhost_projection() ->
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_users_projection() ->
-    Name = rabbit_khepri_users,
+    Name = rabbit_khepri_user,
     PathPattern = rabbit_db_user:khepri_user_path(
                     _UserName = ?KHEPRI_WILDCARD_STAR),
     KeyPos = 2, %% #internal_user.username
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_global_runtime_parameters_projection() ->
-    Name = rabbit_khepri_global_rtparams,
+    Name = rabbit_khepri_global_rtparam,
     PathPattern = rabbit_db_rtparams:khepri_global_rp_path(
                     _Key = ?KHEPRI_WILDCARD_STAR_STAR),
     KeyPos = #runtime_parameters.key,
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_per_vhost_runtime_parameters_projection() ->
-    Name = rabbit_khepri_per_vhost_rtparams,
+    Name = rabbit_khepri_per_vhost_rtparam,
     PathPattern = rabbit_db_rtparams:khepri_vhost_rp_path(
                     _VHost = ?KHEPRI_WILDCARD_STAR_STAR,
                     _Component = ?KHEPRI_WILDCARD_STAR_STAR,
@@ -1213,7 +1213,7 @@ register_rabbit_per_vhost_runtime_parameters_projection() ->
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_user_permissions_projection() ->
-    Name = rabbit_khepri_user_permissions,
+    Name = rabbit_khepri_user_permission,
     PathPattern = rabbit_db_user:khepri_user_permission_path(
                     _UserName = ?KHEPRI_WILDCARD_STAR,
                     _VHost = ?KHEPRI_WILDCARD_STAR),
@@ -1232,7 +1232,7 @@ register_rabbit_bindings_projection() ->
     ProjectionFun = projection_fun_for_sets(MapFun),
     Options = #{keypos => #route.binding},
     Projection = khepri_projection:new(
-                   rabbit_khepri_bindings, ProjectionFun, Options),
+                   rabbit_khepri_binding, ProjectionFun, Options),
     PathPattern = rabbit_db_binding:khepri_route_path(
                     _VHost = ?KHEPRI_WILDCARD_STAR,
                     _ExchangeName = ?KHEPRI_WILDCARD_STAR,


### PR DESCRIPTION
This is a cosmetic change to make all Khepri projection names singular. About half were pluralized before and they were only plural to match their mnesia counterparts.