### PR TITLE
Management UI: remove disk read and write metrics from overview page.

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/charts.js
+++ b/deps/rabbitmq_management/priv/www/js/charts.js
@@ -15,9 +15,7 @@ function message_rates(id, stats) {
                  ['Get (auto ack)', 'get_no_ack'],
                  ['Get (empty)', 'get_empty'],
                  ['Unroutable (return)', 'return_unroutable'],
-                 ['Unroutable (drop)', 'drop_unroutable'],
-                 ['Disk read', 'disk_reads'],
-                 ['Disk write', 'disk_writes']];
+                 ['Unroutable (drop)', 'drop_unroutable']];
     return rates_chart_or_text(id, stats, items, fmt_rate, fmt_rate_axis, true, 'Message rates', 'message-rates');
 }
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -445,10 +445,6 @@ var HELP = {
         <dd>Rate at which empty queues are hit in response to basic.get.</dd>\
         <dt>Return</dt>\
         <dd>Rate at which basic.return is sent to publishers for unroutable messages published with the \'mandatory\' flag set.</dd>\
-        <dt>Disk read</dt>\
-        <dd>Rate at which queues read messages from disk.</dd>\
-        <dt>Disk write</dt>\
-        <dd>Rate at which queues write messages to disk.</dd>\
       </dl>\
       <p>\
         Note that the last two items originate in queues rather than \


### PR DESCRIPTION
These metrics do not include most of the disk io that RabbitMQ does so are effectively useless.
