### PR TITLE
Use openssl.cnf config when generating new CSR

### DIFF
--- a/deps/rabbitmq_ct_helpers/tools/tls-certs/Makefile
+++ b/deps/rabbitmq_ct_helpers/tools/tls-certs/Makefile
@@ -52,11 +52,11 @@ $(DIR)/testca/cacert.pem:
 $(DIR)/%/cert.pem: $(DIR)/testca/cacert.pem
 	$(gen_verbose) mkdir -p $(DIR)/$(TARGET)
 	$(verbose) { ( cd $(DIR)/$(TARGET) && \
+	    sed -e 's/@HOSTNAME@/$(HOSTNAME)/g' $(CURDIR)/openssl.cnf.in > $(CURDIR)/openssl.cnf && \
 	    openssl genrsa -out key.pem 2048 && \
-	    openssl req -new -key key.pem -out req.pem -outform PEM \
+	    openssl req -config $(CURDIR)/openssl.cnf -new -key key.pem -out req.pem -outform PEM \
 	      -subj /C=UK/ST=England/CN=$(HOSTNAME)/O=$(TARGET)/L=$$$$/ -nodes && \
 	    cd ../testca && \
-	    sed -e 's/@HOSTNAME@/$(HOSTNAME)/g' $(CURDIR)/openssl.cnf.in > $(CURDIR)/openssl.cnf && \
 	    openssl ca -config $(CURDIR)/openssl.cnf -in ../$(TARGET)/req.pem -out \
 	      ../$(TARGET)/cert.pem -notext -batch -extensions \
 	      $(TARGET)_ca_extensions && \


### PR DESCRIPTION
## Proposed Changes

Noticed in one of our environments running tests that has multiple openssl installations, the default one was used and not the one in the config file (as the config file was not used in this target generating the CSR). Noticed by  @alexnkdev

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
