### PR TITLE
Backport #11879, #12214, #12266 to v4.0.x

### DIFF
--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -67,8 +67,8 @@ init() ->
     end,
 
     Ret = case rabbit_khepri:is_enabled() of
-              true  -> init_using_khepri();
-              false -> init_using_mnesia()
+              true  -> init_using_khepri(IsVirgin);
+              false -> init_using_mnesia(IsVirgin)
           end,
     case Ret of
         ok ->
@@ -91,7 +91,7 @@ pre_init(IsVirgin) ->
     OtherMembers = rabbit_nodes:nodes_excl_me(Members),
     rabbit_db_cluster:ensure_feature_flags_are_in_sync(OtherMembers, IsVirgin).
 
-init_using_mnesia() ->
+init_using_mnesia(_IsVirgin) ->
     ?LOG_DEBUG(
       "DB: initialize Mnesia",
       #{domain => ?RMQLOG_DOMAIN_DB}),
@@ -99,11 +99,11 @@ init_using_mnesia() ->
     ?assertEqual(rabbit:data_dir(), mnesia_dir()),
     rabbit_sup:start_child(mnesia_sync).
 
-init_using_khepri() ->
+init_using_khepri(IsVirgin) ->
     ?LOG_DEBUG(
       "DB: initialize Khepri",
       #{domain => ?RMQLOG_DOMAIN_DB}),
-    rabbit_khepri:init().
+    rabbit_khepri:init(IsVirgin).
 
 init_finished() ->
     %% Used during initialisation by rabbit_logger_exchange_h.erl

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -835,9 +835,8 @@ delete_for_source_in_khepri(#resource{virtual_host = VHost, name = Name}) ->
              _Kind = ?KHEPRI_WILDCARD_STAR,
              _DstName = ?KHEPRI_WILDCARD_STAR,
              _RoutingKey = #if_has_data{}),
-    {ok, Bindings} = khepri_tx:get_many(Path),
-    ok = khepri_tx:delete_many(Path),
-    maps:fold(fun(_P, Set, Acc) ->
+    {ok, Bindings} = khepri_tx_adv:delete_many(Path),
+    maps:fold(fun(_P, #{data := Set}, Acc) ->
                       sets:to_list(Set) ++ Acc
               end, [], Bindings).
 
@@ -881,24 +880,19 @@ delete_for_destination_in_mnesia(DstName, OnlyDurable, Fun) ->
       OnlyDurable :: boolean(),
       Deletions :: rabbit_binding:deletions().
 
-delete_for_destination_in_khepri(DstName, OnlyDurable) ->
-    BindingsMap = match_destination_in_khepri(DstName),
-    maps:foreach(fun(K, _V) -> khepri_tx:delete(K) end, BindingsMap),
-    Bindings = maps:fold(fun(_, Set, Acc) ->
+delete_for_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, name = Name}, OnlyDurable) ->
+    Pattern = khepri_route_path(
+                VHost,
+                _SrcName = ?KHEPRI_WILDCARD_STAR,
+                Kind,
+                Name,
+                _RoutingKey = ?KHEPRI_WILDCARD_STAR),
+    {ok, BindingsMap} = khepri_tx_adv:delete_many(Pattern),
+    Bindings = maps:fold(fun(_, #{data := Set}, Acc) ->
                                  sets:to_list(Set) ++ Acc
                          end, [], BindingsMap),
     rabbit_binding:group_bindings_fold(fun maybe_auto_delete_exchange_in_khepri/4,
                                        lists:keysort(#binding.source, Bindings), OnlyDurable).
-
-match_destination_in_khepri(#resource{virtual_host = VHost, kind = Kind, name = Name}) ->
-    Path = khepri_route_path(
-             VHost,
-             _SrcName = ?KHEPRI_WILDCARD_STAR,
-             Kind,
-             Name,
-             _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    {ok, Map} = khepri_tx:get_many(Path),
-    Map.
 
 %% -------------------------------------------------------------------
 %% delete_transient_for_destination_in_mnesia().

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -53,7 +53,7 @@
 -define(MNESIA_SEMI_DURABLE_TABLE, rabbit_semi_durable_route).
 -define(MNESIA_REVERSE_TABLE, rabbit_reverse_route).
 -define(MNESIA_INDEX_TABLE, rabbit_index_route).
--define(KHEPRI_BINDINGS_PROJECTION, rabbit_khepri_bindings).
+-define(KHEPRI_BINDINGS_PROJECTION, rabbit_khepri_binding).
 -define(KHEPRI_INDEX_ROUTE_PROJECTION, rabbit_khepri_index_route).
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -23,8 +23,8 @@
         ]).
 
 -define(MNESIA_TABLE, rabbit_runtime_parameters).
--define(KHEPRI_GLOBAL_PROJECTION, rabbit_khepri_global_rtparams).
--define(KHEPRI_VHOST_PROJECTION, rabbit_khepri_per_vhost_rtparams).
+-define(KHEPRI_GLOBAL_PROJECTION, rabbit_khepri_global_rtparam).
+-define(KHEPRI_VHOST_PROJECTION, rabbit_khepri_per_vhost_rtparam).
 -define(any(Value), case Value of
                         '_' -> ?KHEPRI_WILDCARD_STAR;
                         _ -> Value

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -75,8 +75,8 @@
 -define(MNESIA_TABLE, rabbit_user).
 -define(PERM_MNESIA_TABLE, rabbit_user_permission).
 -define(TOPIC_PERM_MNESIA_TABLE, rabbit_topic_permission).
--define(KHEPRI_USERS_PROJECTION, rabbit_khepri_users).
--define(KHEPRI_PERMISSIONS_PROJECTION, rabbit_khepri_user_permissions).
+-define(KHEPRI_USERS_PROJECTION, rabbit_khepri_user).
+-define(KHEPRI_PERMISSIONS_PROJECTION, rabbit_khepri_user_permission).
 
 %% -------------------------------------------------------------------
 %% create().

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1552,7 +1552,15 @@ get_feature_state(Node) ->
 khepri_db_migration_enable(#{feature_name := FeatureName}) ->
     maybe
         ok ?= sync_cluster_membership_from_mnesia(FeatureName),
+        ?LOG_INFO(
+           "Feature flag `~s`: unregistering legacy projections",
+           [FeatureName],
+           #{domain => ?RMQLOG_DOMAIN_DB}),
         ok ?= unregister_legacy_projections(),
+        ?LOG_INFO(
+           "Feature flag `~s`: registering projections",
+           [FeatureName],
+           #{domain => ?RMQLOG_DOMAIN_DB}),
         ok ?= register_projections(),
         migrate_mnesia_tables(FeatureName)
     end.

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1190,21 +1190,21 @@ register_rabbit_vhost_projection() ->
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_users_projection() ->
-    Name = rabbit_khepri_users,
+    Name = rabbit_khepri_user,
     PathPattern = rabbit_db_user:khepri_user_path(
                     _UserName = ?KHEPRI_WILDCARD_STAR),
     KeyPos = 2, %% #internal_user.username
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_global_runtime_parameters_projection() ->
-    Name = rabbit_khepri_global_rtparams,
+    Name = rabbit_khepri_global_rtparam,
     PathPattern = rabbit_db_rtparams:khepri_global_rp_path(
                     _Key = ?KHEPRI_WILDCARD_STAR_STAR),
     KeyPos = #runtime_parameters.key,
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_per_vhost_runtime_parameters_projection() ->
-    Name = rabbit_khepri_per_vhost_rtparams,
+    Name = rabbit_khepri_per_vhost_rtparam,
     PathPattern = rabbit_db_rtparams:khepri_vhost_rp_path(
                     _VHost = ?KHEPRI_WILDCARD_STAR_STAR,
                     _Component = ?KHEPRI_WILDCARD_STAR_STAR,
@@ -1213,7 +1213,7 @@ register_rabbit_per_vhost_runtime_parameters_projection() ->
     register_simple_projection(Name, PathPattern, KeyPos).
 
 register_rabbit_user_permissions_projection() ->
-    Name = rabbit_khepri_user_permissions,
+    Name = rabbit_khepri_user_permission,
     PathPattern = rabbit_db_user:khepri_user_permission_path(
                     _UserName = ?KHEPRI_WILDCARD_STAR,
                     _VHost = ?KHEPRI_WILDCARD_STAR),
@@ -1232,7 +1232,7 @@ register_rabbit_bindings_projection() ->
     ProjectionFun = projection_fun_for_sets(MapFun),
     Options = #{keypos => #route.binding},
     Projection = khepri_projection:new(
-                   rabbit_khepri_bindings, ProjectionFun, Options),
+                   rabbit_khepri_binding, ProjectionFun, Options),
     PathPattern = rabbit_db_binding:khepri_route_path(
                     _VHost = ?KHEPRI_WILDCARD_STAR,
                     _ExchangeName = ?KHEPRI_WILDCARD_STAR,

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -100,6 +100,7 @@
 
 -export([setup/0,
          setup/1,
+         register_projections/0,
          init/0,
          can_join_cluster/1,
          add_member/2,

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -269,7 +269,6 @@ setup(_) ->
             RetryTimeout = retry_timeout(),
             case khepri_cluster:wait_for_leader(?STORE_ID, RetryTimeout) of
                 ok ->
-                    wait_for_register_projections(),
                     ?LOG_DEBUG(
                        "Khepri-based " ?RA_FRIENDLY_NAME " ready",
                        #{domain => ?RMQLOG_DOMAIN_GLOBAL}),
@@ -287,27 +286,6 @@ retry_timeout() ->
     case application:get_env(rabbit, khepri_leader_wait_retry_timeout) of
         {ok, T}   -> T;
         undefined -> 30000
-    end.
-
-retry_limit() ->
-    case application:get_env(rabbit, khepri_leader_wait_retry_limit) of
-        {ok, T}   -> T;
-        undefined -> 10
-    end.
-
-wait_for_register_projections() ->
-    wait_for_register_projections(retry_timeout(), retry_limit()).
-
-wait_for_register_projections(_Timeout, 0) ->
-    exit(timeout_waiting_for_khepri_projections);
-wait_for_register_projections(Timeout, Retries) ->
-    rabbit_log:info("Waiting for Khepri projections for ~tp ms, ~tp retries left",
-                    [Timeout, Retries - 1]),
-    case register_projections() of
-        ok ->
-            ok;
-        {error, timeout} ->
-            wait_for_register_projections(Timeout, Retries -1)
     end.
 
 %% @private

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -87,6 +87,8 @@
 
 -module(rabbit_khepri).
 
+-feature(maybe_expr, enable).
+
 -include_lib("kernel/include/logger.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
@@ -1518,9 +1520,10 @@ get_feature_state(Node) ->
 %% @private
 
 khepri_db_migration_enable(#{feature_name := FeatureName}) ->
-    case sync_cluster_membership_from_mnesia(FeatureName) of
-        ok    -> migrate_mnesia_tables(FeatureName);
-        Error -> Error
+    maybe
+        ok ?= sync_cluster_membership_from_mnesia(FeatureName),
+        ok ?= register_projections(),
+        migrate_mnesia_tables(FeatureName)
     end.
 
 %% @private

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1192,7 +1192,7 @@ register_rabbit_user_permissions_projection() ->
 register_simple_projection(Name, PathPattern, KeyPos) ->
     Options = #{keypos => KeyPos},
     Projection = khepri_projection:new(Name, copy, Options),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 register_rabbit_bindings_projection() ->
     MapFun = fun(_Path, Binding) ->
@@ -1208,7 +1208,7 @@ register_rabbit_bindings_projection() ->
                     _Kind = ?KHEPRI_WILDCARD_STAR,
                     _DstName = ?KHEPRI_WILDCARD_STAR,
                     _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 register_rabbit_index_route_projection() ->
     MapFun = fun(Path, _) ->
@@ -1240,7 +1240,7 @@ register_rabbit_index_route_projection() ->
                     _Kind = ?KHEPRI_WILDCARD_STAR,
                     _DstName = ?KHEPRI_WILDCARD_STAR,
                     _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 %% Routing information is stored in the Khepri store as a `set'.
 %% In order to turn these bindings into records in an ETS `bag', we use a
@@ -1341,7 +1341,7 @@ register_rabbit_topic_graph_projection() ->
                     _Kind = ?KHEPRI_WILDCARD_STAR,
                     _DstName = ?KHEPRI_WILDCARD_STAR,
                     _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    khepri:register_projection(?RA_CLUSTER_NAME, PathPattern, Projection).
+    khepri:register_projection(?STORE_ID, PathPattern, Projection).
 
 -spec follow_down_update(Table, Exchange, Words, UpdateFn) -> Ret when
       Table :: ets:tid(),

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -299,8 +299,7 @@ delete(VHost, ActingUser) ->
          assert_benign(rabbit_amqqueue:with(Name, QDelFun), ActingUser)
      end || Q <- rabbit_amqqueue:list(VHost)],
     rabbit_log:info("Deleting exchanges in vhost '~ts' because it's being deleted", [VHost]),
-    [ok = rabbit_exchange:ensure_deleted(Name, false, ActingUser) ||
-        #exchange{name = Name} <- rabbit_exchange:list(VHost)],
+    ok = rabbit_exchange:delete_all(VHost, ActingUser),
     rabbit_log:info("Clearing policies and runtime parameters in vhost '~ts' because it's being deleted", [VHost]),
     _ = rabbit_runtime_parameters:clear_vhost(VHost, ActingUser),
     rabbit_log:debug("Removing vhost '~ts' from the metadata storage because it's being deleted", [VHost]),

--- a/deps/rabbit/test/metadata_store_phase1_SUITE.erl
+++ b/deps/rabbit/test/metadata_store_phase1_SUITE.erl
@@ -192,6 +192,7 @@ setup_khepri(Config) ->
     %% Configure Khepri. It takes care of configuring Ra system & cluster. It
     %% uses the Mnesia directory to store files.
     ok = rabbit_khepri:setup(undefined),
+    ok = rabbit_khepri:register_projections(),
 
     ct:pal("Khepri info below:"),
     rabbit_khepri:info(),

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -992,7 +992,7 @@ enable_khepri_metadata_store(Config, FFs0) ->
                         case enable_feature_flag(C, FF) of
                             ok ->
                                 C;
-                            Skip ->
+                            {skip, _} = Skip ->
                                 ct:pal("Enabling metadata store failed: ~p", [Skip]),
                                 Skip
                         end


### PR DESCRIPTION
This is a backport of #11879, #12214 and #12266 and commit fcb90e40162ad89b90afe8effa80bb0fc8d23c30 from `main` to `v4.0.x`. These are some Khepri related changes that build on the tree reorg in #11225.