### PR TITLE
Increase the timeout when batch deleting permissions

### DIFF
--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -640,7 +640,7 @@ clear_all_permissions_for_vhost_in_khepri(VHostName) ->
                             TopicProps,
                             rabbit_khepri:collect_payloads(UserProps)),
               {ok, Deletions}
-      end, rw).
+      end, rw, #{timeout => infinity}).
 
 %% -------------------------------------------------------------------
 %% get_topic_permissions().

--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -245,7 +245,11 @@ update_vhost(Config) ->
                                               [<<"/">>, [carrots], <<"user">>])).
 
 delete_vhost(Config) ->
-    ?assertMatch({'EXIT', _}, rabbit_ct_broker_helpers:delete_vhost(Config, <<"vhost1">>)).
+    ?assertError(
+       {erpc, timeout},
+       rabbit_ct_broker_helpers:rpc(
+         Config, 0,
+         rabbit_vhost, delete, [<<"vhost1">>, <<"acting-user">>], 1_000)).
 
 add_user(Config) ->
     ?assertMatch({error, timeout},


### PR DESCRIPTION
Deleting a vhost with many user/topic permissions (10k-100k users with one permission each) is very slow in the current implementation of Khepri. `khepri_tree:eval_keep_while_conditions` is particularly slow, mainly on OS X but it is also a bit slower in Linux (tested in Ubuntu) than the equivalent Mnesia operation to delete the permissions. 

This PR allows the `rabbitmqctl delete_vhost <vhost>` command to finish without a timeout, even if still equally slow.