### PR TITLE
Handle Khepri timeouts when deleting MQTT QOS0 queues

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1691,7 +1691,10 @@ delete_crashed(Q) when ?amqqueue_is_classic(Q) ->
 delete_crashed(Q, ActingUser) when ?amqqueue_is_classic(Q) ->
     rabbit_classic_queue:delete_crashed(Q, ActingUser).
 
--spec delete_crashed_internal(amqqueue:amqqueue(), rabbit_types:username()) -> 'ok'.
+-spec delete_crashed_internal(Q, ActingUser) -> Ret when
+      Q :: amqqueue:amqqueue(),
+      ActingUser :: rabbit_types:username(),
+      Ret :: ok | {error, timeout}.
 delete_crashed_internal(Q, ActingUser) when ?amqqueue_is_classic(Q) ->
     rabbit_classic_queue:delete_crashed_internal(Q, ActingUser).
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -825,8 +825,8 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
                     {ok, ReadyMsgs};
                 {error, timeout} ->
                     {protocol_error, internal_error,
-                     "The operation to delete queue ~ts from the metadata "
-                     "store timed out", [rabbit_misc:rs(QName)]}
+                     "The operation to delete ~ts from the metadata store "
+                     "timed out", [rabbit_misc:rs(QName)]}
             end;
         {error, {no_more_servers_to_try, Errs}} ->
             case lists:all(fun({{error, noproc}, _}) -> true;

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -113,8 +113,14 @@ declare(Q0, _Node) ->
 delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
     QName = amqqueue:get_name(Q),
     log_delete(QName, amqqueue:get_exclusive_owner(Q)),
-    ok = rabbit_amqqueue:internal_delete(Q, ActingUser),
-    {ok, 0}.
+    case rabbit_amqqueue:internal_delete(Q, ActingUser) of
+        ok ->
+            {ok, 0};
+        {error, timeout} ->
+            {protocol_error, internal_error,
+             "The operation to delete ~ts from the metadata store timed "
+             "out", [rabbit_misc:rs(QName)]}
+    end.
 
 -spec deliver([{amqqueue:amqqueue(), stateless}],
               Msg :: mc:state(),


### PR DESCRIPTION
This is a continuation of https://github.com/rabbitmq/rabbitmq-server/pull/12082 to cover the MQTT QOS0 queue type. When deleting a queue of this type the operation can timeout and cause a bad match. Spotted by @mkuratczyk