### PR TITLE
Tweak wording around experimental feature flags (Khepri)

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -129,7 +129,7 @@
 
 -rabbit_feature_flag(
    {khepri_db,
-    #{desc          => "Use the new Khepri Raft-based metadata store",
+    #{desc          => "New Raft-based metadata store",
       doc_url       => "", %% TODO
       stability     => experimental,
       depends_on    => [feature_flags_v2,

--- a/deps/rabbitmq_management/priv/www/js/tmpl/feature-flags.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/feature-flags.ejs
@@ -87,7 +87,8 @@
   <div class="hider">
 <% if (feature_flags.length > 0) { %>
 <p class="warning">
-  Feature flags listed below are experimental. They should not be enabled in a production deployment.
+  Feature flags listed below are experimental (maturing). They can be enabled in production deployments
+  after careful consideration and testing in non-production environments.
 </p>
 <table class="list">
   <thead>
@@ -119,7 +120,7 @@
            <% if (feature_flag.state == "disabled") { %>
 	      <div>
               <input id="<%= feature_flag.name %>" type="checkbox" class="riskCheckbox" onclick="this.parentNode.querySelector('.enable-feature-flag input[type=submit]').disabled = !this.checked;">
-              <label for="<%= feature_flag.name %>"> I understand the risk</label><br>
+              <label for="<%= feature_flag.name %>">I understand the potential risks and want to enable this feature flag</label><br>
 	      <br>
               <form action="#/feature-flags-enable" method="put" style="display: inline-block" class="enable-feature-flag">
               <input type="hidden" name="name" value="<%= fmt_string(feature_flag.name) %>"/>


### PR DESCRIPTION
This updates Khepri FF description to be more correct and to the point.

It also tweaks the management UI copywriting so
that it does not recommend against the use of
Khepri in production as it is much more mature
in 4.0.