### PR TITLE
Display container-id in the UI and CLI

### DIFF
--- a/deps/rabbit/include/rabbit_amqp.hrl
+++ b/deps/rabbit/include/rabbit_amqp.hrl
@@ -37,6 +37,7 @@
         [pid,
          frame_max,
          timeout,
+         container_id,
          vhost,
          user,
          node

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -35,6 +35,7 @@
 
 -record(v1_connection,
         {name :: binary(),
+         container_id :: none | binary(),
          vhost :: none | rabbit_types:vhost(),
          %% server host
          host :: inet:ip_address() | inet:hostname(),
@@ -104,6 +105,7 @@ unpack_from_0_9_1(
         connection_state = received_amqp3100,
         connection = #v1_connection{
                         name = ConnectionName,
+                        container_id = none,
                         vhost = none,
                         host = Host,
                         peer_host = PeerHost,
@@ -491,6 +493,7 @@ handle_connection_frame(
                           end,
     State1 = State0#v1{connection_state = running,
                        connection = Connection#v1_connection{
+                                      container_id = ContainerId,
                                       vhost = Vhost,
                                       incoming_max_frame_size = IncomingMaxFrameSize,
                                       outgoing_max_frame_size = OutgoingMaxFrameSize,
@@ -968,6 +971,8 @@ i(connection_state, #v1{connection_state = Val}) ->
 i(connected_at, #v1{connection = #v1_connection{connected_at = Val}}) ->
     Val;
 i(name, #v1{connection = #v1_connection{name = Val}}) ->
+    Val;
+i(container_id, #v1{connection = #v1_connection{container_id = Val}}) ->
     Val;
 i(vhost, #v1{connection = #v1_connection{vhost = Val}}) ->
     Val;

--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -25,9 +25,9 @@
          node_listeners/1, node_client_listeners/1,
          register_connection/1, unregister_connection/1,
          register_non_amqp_connection/1, unregister_non_amqp_connection/1,
-         connections/0, non_amqp_connections/0, connection_info_keys/0,
-         connection_info/1, connection_info/2,
-         connection_info_all/0, connection_info_all/1,
+         connections/0, non_amqp_connections/0,
+         connection_info/2,
+         connection_info_all/1,
          emit_connection_info_all/4, emit_connection_info_local/3,
          close_connection/2, close_connections/2, close_all_connections/1,
          close_all_user_connections/2,
@@ -482,22 +482,10 @@ non_amqp_connections() ->
 local_non_amqp_connections() ->
   pg_local:get_members(rabbit_non_amqp_connections).
 
--spec connection_info_keys() -> rabbit_types:info_keys().
-
-connection_info_keys() -> rabbit_reader:info_keys().
-
--spec connection_info(rabbit_types:connection()) -> rabbit_types:infos().
-
-connection_info(Pid) -> rabbit_reader:info(Pid).
-
 -spec connection_info(rabbit_types:connection(), rabbit_types:info_keys()) ->
           rabbit_types:infos().
 
 connection_info(Pid, Items) -> rabbit_reader:info(Pid, Items).
-
--spec connection_info_all() -> [rabbit_types:infos()].
-
-connection_info_all() -> cmap(fun (Q) -> connection_info(Q) end).
 
 -spec connection_info_all(rabbit_types:info_keys()) ->
           [rabbit_types:infos()].

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -1662,18 +1662,19 @@ events(Config) ->
 
     Protocol = {protocol, {1, 0}},
     AuthProps = [{name, <<"guest">>},
-                       {auth_mechanism, <<"PLAIN">>},
-                       {ssl, false},
-                       Protocol],
+                 {auth_mechanism, <<"PLAIN">>},
+                 {ssl, false},
+                 Protocol],
     ?assertMatch(
-      {value, _},
-      find_event(user_authentication_success, AuthProps, Events)),
+       {value, _},
+       find_event(user_authentication_success, AuthProps, Events)),
 
     Node = get_node_config(Config, 0, nodename),
     ConnectionCreatedProps = [Protocol,
                               {node, Node},
                               {vhost, <<"/">>},
                               {user, <<"guest">>},
+                              {container_id, <<"my container">>},
                               {type, network}],
     {value, ConnectionCreatedEvent} = find_event(
                                         connection_created,
@@ -1694,8 +1695,8 @@ events(Config) ->
                              Pid,
                              ClientProperties],
     ?assertMatch(
-      {value, _},
-      find_event(connection_closed, ConnectionClosedProps, Events)),
+       {value, _},
+       find_event(connection_closed, ConnectionClosedProps, Events)),
     ok.
 
 sync_get_unsettled_classic_queue(Config) ->
@@ -3696,8 +3697,12 @@ list_connections(Config) ->
     [ok = rabbit_ct_client_helpers:close_channels_and_connection(Config, Node) || Node <- [0, 1, 2]],
 
     Connection091 = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 0),
-    {ok, C0} = amqp10_client:open_connection(connection_config(0, Config)),
-    {ok, C2} = amqp10_client:open_connection(connection_config(2, Config)),
+    ContainerId0 = <<"ID 0">>,
+    ContainerId2 = <<"ID 2">>,
+    Cfg0 = maps:put(container_id, ContainerId0, connection_config(0, Config)),
+    Cfg2 = maps:put(container_id, ContainerId2, connection_config(2, Config)),
+    {ok, C0} = amqp10_client:open_connection(Cfg0),
+    {ok, C2} = amqp10_client:open_connection(Cfg2),
     receive {amqp10_event, {connection, C0, opened}} -> ok
     after 5000 -> ct:fail({missing_event, ?LINE})
     end,
@@ -3705,8 +3710,8 @@ list_connections(Config) ->
     after 5000 -> ct:fail({missing_event, ?LINE})
     end,
 
-    {ok, StdOut} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["list_connections", "--silent", "protocol"]),
-    Protocols0 = re:split(StdOut, <<"\n">>, [trim]),
+    {ok, StdOut0} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["list_connections", "--silent", "protocol"]),
+    Protocols0 = re:split(StdOut0, <<"\n">>, [trim]),
     %% Remove any whitespaces.
     Protocols1 = [binary:replace(Subject, <<" ">>, <<>>, [global]) || Subject <- Protocols0],
     Protocols = lists:sort(Protocols1),
@@ -3714,6 +3719,13 @@ list_connections(Config) ->
                   <<"{1,0}">>,
                   <<"{1,0}">>],
                  Protocols),
+
+    %% CLI should list AMQP 1.0 container-id
+    {ok, StdOut1} = rabbit_ct_broker_helpers:rabbitmqctl(Config, 0, ["list_connections", "--silent", "container_id"]),
+    ContainerIds0 = re:split(StdOut1, <<"\n">>, [trim]),
+    ContainerIds = lists:sort(ContainerIds0),
+    ?assertEqual([<<>>, ContainerId0, ContainerId2],
+                 ContainerIds),
 
     ok = rabbit_ct_client_helpers:close_connection(Connection091),
     ok = close_connection_sync(C0),
@@ -6021,8 +6033,8 @@ find_event(Type, Props, Events) when is_list(Props), is_list(Events) ->
       fun(#event{type = EventType, props = EventProps}) ->
               Type =:= EventType andalso
                 lists:all(
-                  fun({Key, _Value}) ->
-                          lists:keymember(Key, 1, EventProps)
+                  fun(Prop) ->
+                          lists:member(Prop, EventProps)
                   end, Props)
       end, Events).
 

--- a/deps/rabbit/test/disconnect_detected_during_alarm_SUITE.erl
+++ b/deps/rabbit/test/disconnect_detected_during_alarm_SUITE.erl
@@ -96,7 +96,7 @@ disconnect_detected_during_alarm(Config) ->
 
     ListConnections =
         fun() ->
-            rpc:call(A, rabbit_networking, connection_info_all, [])
+            rpc:call(A, rabbit_networking, connection_info_all, [[state]])
         end,
 
     %% We've already disconnected, but blocked connection still should still linger on.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -17,7 +17,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
   @info_keys ~w(pid name port host peer_port peer_host ssl ssl_protocol
                 ssl_key_exchange ssl_cipher ssl_hash peer_cert_subject
                 peer_cert_issuer peer_cert_validity state
-                channels protocol auth_mechanism user vhost timeout frame_max
+                channels protocol auth_mechanism user vhost container_id timeout frame_max
                 channel_max client_properties recv_oct recv_cnt send_oct
                 send_cnt send_pend connected_at)a
 
@@ -79,7 +79,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists AMQP 0.9.1 connections for the node"
+  def description(), do: "Lists AMQP connections for the node"
 
   def banner(_, _), do: "Listing connections ..."
 end

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -108,7 +108,8 @@ var ALL_COLUMNS =
                         ['rate-redeliver', 'redelivered',        false],
                         ['rate-ack',       'ack',                true]]},
      'connections':
-     {'Overview': [['user',   'User name', true],
+     {'Overview': [['container_id', 'Container ID', true],
+                   ['user',   'User name', true],
                    ['state',  'State',     true]],
       'Details': [['ssl',            'TLS',      true],
                   ['ssl_info',       'TLS details',    false],
@@ -585,7 +586,10 @@ var HELP = {
         <dd>Rate at which queues are created. Declaring a queue that already exists counts for a "Declared" event, but not for a "Created" event. </dd>\
         <dt>Deleted</dt>\
         <dd>Rate at which queues are deleted.</dd>\
-     </dl> '
+     </dl> ',
+
+    'container-id':
+      'Name of the client application as sent from client to RabbitMQ in field container-id of the AMQP 1.0 <a target="_blank" href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-open">open</a> frame.'
 
 };
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
@@ -17,8 +17,17 @@
 
 <% if (connection.client_properties.connection_name) { %>
 <tr>
-  <th>Client-provided name</th>
+  <th>Client-provided connection name</th>
   <td><%= fmt_string(connection.client_properties.connection_name) %></td>
+</tr>
+<% } %>
+
+<% if (connection.container_id) { %>
+<tr>
+  <th>Container ID
+    <span class="help" id="container-id"></span>
+  </th>
+  <td><%= fmt_string(connection.container_id) %></td>
 </tr>
 <% } %>
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/connections.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/connections.ejs
@@ -26,6 +26,9 @@
 <% if (nodes_interesting) { %>
     <th><%= fmt_sort('Node',           'node') %></th>
 <% } %>
+<% if (show_column('connections',      'container_id')) { %>
+    <th>Container ID <span class="help" id="container-id"></span></th>
+<% } %>
 <% if (show_column('connections',      'user')) { %>
     <th><%= fmt_sort('User name',      'user') %></th>
 <% } %>
@@ -84,13 +87,22 @@
 <% if(connection.client_properties) { %>
     <td>
       <%= link_conn(connection.name) %>
-      <sub><%= fmt_string(short_conn(connection.client_properties.connection_name)) %></sub>
+      <% if (connection.client_properties.connection_name) { %>
+            <sub><%= fmt_string(short_conn(connection.client_properties.connection_name)) %></sub>
+      <% } %>
     </td>
 <% } else { %>
     <td><%= link_conn(connection.name) %></td>
 <% } %>
 <% if (nodes_interesting) { %>
     <td><%= fmt_node(connection.node) %></td>
+<% } %>
+<% if (show_column('connections', 'container_id')) { %>
+    <td class="c">
+    <% if (connection.container_id) { %>
+      <%= fmt_string(connection.container_id) %>
+    <% } %>
+    </td>
 <% } %>
 <% if (show_column('connections', 'user')) { %>
     <td class="c"><%= fmt_string(connection.user) %></td>

--- a/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
+++ b/deps/rabbitmq_stream_management/priv/www/js/tmpl/streamConnection.ejs
@@ -17,7 +17,7 @@
 
 <% if (connection.client_properties.connection_name) { %>
 <tr>
-  <th>Client-provided name</th>
+  <th>Client-provided connection name</th>
   <td><%= fmt_string(connection.client_properties.connection_name) %></td>
 </tr>
 <% } %>


### PR DESCRIPTION
Example:
1. Connect via AMQP 1.0
```go
	conn, err := amqp.Dial(context.TODO(), "amqp://localhost", &amqp.ConnOptions{
		SASLType:    amqp.SASLTypeAnonymous(),
		ContainerID: "my container ID",
		Properties: map[string]any{
			"foo":             1,
			"connection_name": "my connection"},
	})
```
2. Connect via AMQP 0.9.1 `java -jar target/perf-test.jar -x 0 -y 0`

CLI will the AMQP 1.0 container-id:
```
./sbin/rabbitmqctl list_connections pid protocol name container_id --formatter=pretty_table
Listing connections ...
┌────────────────┬──────────┬───────────────────────────────────┬─────────────────┐
│ pid            │ protocol │ name                              │ container_id    │
├────────────────┼──────────┼───────────────────────────────────┼─────────────────┤
│ <13445.1162.0> │ {1,0}    │ [::1]:53091 -> [::1]:5672         │ my container ID │
├────────────────┼──────────┼───────────────────────────────────┼─────────────────┤
│ <13445.1366.0> │ {0,9,1}  │ 127.0.0.1:53366 -> 127.0.0.1:5672 │                 │
└────────────────┴──────────┴───────────────────────────────────┴─────────────────┘
```

UI Connection(s) tabs shows the container ID (including help text):

<img width="1169" alt="Screenshot 2024-09-13 at 14 02 05" src="https://github.com/user-attachments/assets/68ea8cc3-71ac-4fdc-96a1-41a3bef94fe1">

<img width="1653" alt="Screenshot 2024-09-13 at 14 04 26" src="https://github.com/user-attachments/assets/bbbbde80-092f-4d3b-8fb8-cc532f77b7d8">

