### PR TITLE
Khepri feature flag: add a documentation URL

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -130,7 +130,7 @@
 -rabbit_feature_flag(
    {khepri_db,
     #{desc          => "New Raft-based metadata store. Fully supported as of RabbitMQ 4.0",
-      doc_url       => "", %% TODO
+      doc_url       => "https://www.rabbitmq.com/docs/next/metadata-store",
       stability     => experimental,
       depends_on    => [feature_flags_v2,
                         direct_exchange_routing_v2,


### PR DESCRIPTION
That links to the vNext version of the site for
now. In 4.0.x, we can change it to the vCurrent
version.
