### PR TITLE
Decrease default MQTT Maximum Packet Size

### DIFF
--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -49,7 +49,8 @@ APP_ENV = """[
 	    {mailbox_soft_limit, 200},
 	    {max_packet_size_unauthenticated, 65536},
 	    %% 256 MB is upper limit defined by MQTT spec
-	    {max_packet_size_authenticated, 268435455},
+	    %% We set 16 MB as defined in deps/rabbit/Makefile max_message_size
+	    {max_packet_size_authenticated, 16777216},
 	    {topic_alias_maximum, 16}
 	  ]
 """

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -27,7 +27,8 @@ define PROJECT_ENV
 	    {mailbox_soft_limit, 200},
 	    {max_packet_size_unauthenticated, 65536},
 	    %% 256 MB is upper limit defined by MQTT spec
-	    {max_packet_size_authenticated, 268435455},
+	    %% We set 16 MB as defined in deps/rabbit/Makefile max_message_size
+	    {max_packet_size_authenticated, 16777216},
 	    {topic_alias_maximum, 16}
 	  ]
 endef

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt.erl
@@ -112,6 +112,8 @@ persist_static_configuration() ->
 
     {ok, MaxSizeAuth} = application:get_env(?APP_NAME, max_packet_size_authenticated),
     assert_valid_max_packet_size(MaxSizeAuth),
+    {ok, MaxMsgSize} = application:get_env(rabbit, max_message_size),
+    ?assert(MaxSizeAuth =< MaxMsgSize),
     ok = persistent_term:put(?PERSISTENT_TERM_MAX_PACKET_SIZE_AUTHENTICATED, MaxSizeAuth).
 
 assert_valid_max_packet_size(Val) ->

--- a/release-notes/4.1.0.md
+++ b/release-notes/4.1.0.md
@@ -1,0 +1,5 @@
+## RabbitMQ 4.1.0
+
+## Potential incompatibilities
+
+* The default MQTT [Maximum Packet Size](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901086) changed from 256 MiB to 16 MiB. This default can be overriden by [configuring](https://www.rabbitmq.com/docs/configure#config-file) `mqtt.max_packet_size_authenticated`. Note that this value must not be greater than `max_message_size` (which also defaults to 16 MiB).


### PR DESCRIPTION
Given that the default max_message_size got decreased from 128 MiB to 16 MiB in RabbitMQ 4.0 in https://github.com/rabbitmq/rabbitmq-server/pull/11455, it makes sense to also decrease the default MQTT Maximum Packet Size from 256 MiB to 16 MiB. Since this change was missed in RabbitMQ 4.0, it is scheduled for RabbitMQ 4.1.