### PR TITLE
QQ: fix off-by-one bug in release cursor effects.

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1064,7 +1064,7 @@ handle_aux(_RaState, cast, tick, #?AUX{name = Name,
                undefined ->
                    [{release_cursor, ra_aux:last_applied(RaAux)}];
                Smallest ->
-                   [{release_cursor, Smallest}]
+                   [{release_cursor, Smallest - 1}]
            end,
     {no_reply, Aux, RaAux, Effs};
 handle_aux(_RaState, cast, eol, #?AUX{name = Name} = Aux, RaAux) ->
@@ -2915,7 +2915,10 @@ release_cursor(LastSmallest, Smallest)
   when is_integer(LastSmallest) andalso
        is_integer(Smallest) andalso
        Smallest > LastSmallest ->
-    [{release_cursor, Smallest}];
+    [{release_cursor, Smallest - 1}];
+release_cursor(undefined, Smallest)
+  when is_integer(Smallest) ->
+    [{release_cursor, Smallest - 1}];
 release_cursor(_, _) ->
     [].
 


### PR DESCRIPTION
{release_cursor, Idx} effects promote checkpoints with an index lower or _equal_ to the release cursor index. rabbit_fifo is emitting the smallest active raft index instead which could cause the log to truncate one index too many after a checkpoint promotion.
