### PR TITLE
Avoid duplicate vhost label for Prometheus queue-exchange metrics

### DIFF
--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -489,6 +489,13 @@ label({RemoteAddress, Username, Protocol}) when is_binary(RemoteAddress), is_bin
                          V =/= <<>>
                  end, [{remote_address, RemoteAddress}, {username, Username},
                        {protocol, atom_to_binary(Protocol, utf8)}]);
+label({
+    #resource{kind=queue, virtual_host=VHost, name=QName},
+    #resource{kind=exchange, name=ExName}
+ }) ->
+    <<"vhost=\"", (escape_label_value(VHost))/binary, "\",",
+      "exchange=\"", (escape_label_value(ExName))/binary, "\",",
+      "queue=\"", (escape_label_value(QName))/binary, "\"">>;
 label({I1, I2}) ->
     case {label(I1), label(I2)} of
         {<<>>, L} -> L;

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -493,6 +493,7 @@ label({
     #resource{kind=queue, virtual_host=VHost, name=QName},
     #resource{kind=exchange, name=ExName}
  }) ->
+    %% queue_exchange_metrics {queue_id, exchange_id}
     <<"vhost=\"", (escape_label_value(VHost))/binary, "\",",
       "exchange=\"", (escape_label_value(ExName))/binary, "\",",
       "queue=\"", (escape_label_value(QName))/binary, "\"">>;


### PR DESCRIPTION
## Proposed Changes

Addresses #12347 

Adds a specific clause on the
`prometheus_rabbitmq_core_metrics_collector:labels` function when the associated metric item is a Queue + Exchange combo (`{Queue, Exchange}`).


## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
.
