### PR TITLE
rabbitmqadmin v1: add default-queue-type to vhost declaration

### DIFF
--- a/deps/rabbitmq_management/bin/rabbitmqadmin
+++ b/deps/rabbitmq_management/bin/rabbitmqadmin
@@ -134,7 +134,7 @@ DECLARABLE = {
                    'optional':  {'destination_type': 'queue',
                                  'routing_key': '', 'arguments': {}}},
     'vhost':      {'mandatory': ['name'],
-                   'optional':  {'tracing': None}},
+                   'optional':  {'tracing': None, 'default_queue_type': None}},
     'user':       {'mandatory': ['name', ['password', 'password_hash'], 'tags'],
                    'optional':  {'hashing_algorithm': None}},
     'permission': {'mandatory': ['vhost', 'user', 'configure', 'write', 'read'],


### PR DESCRIPTION
## Proposed Changes

Allow setting the `default-queue-type` when creating or modifying a vhost via `rabbitmqadmin`. This is already possible via the Management API and `rabbitmqctl`. This is a small change that I ran into while trying to update the `default-queue-type` on a vhost to `quorum`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I couldn't find tests for `rabbitmqadmin`. Here are the test cases I ran manually.
1. `rabbitmqadmin declare vhost name=new` It created a vhost with no default queue type defined.
2. `rabbitmqadmin delcare vhost name=new default_queue_type=quorum` It updated the default queue type on the vhost.
3. `rabbitmqadmin declare vhost name=new2 default_queue_type=quorum` It create a vhost with the default queue type set to `quorum`.
