### PR TITLE
Deprecate two OAuth2 settings: auth_oauth2.jwks_url and management.metadata_url

### DIFF
--- a/deps/oauth2_client/src/oauth2_client.erl
+++ b/deps/oauth2_client/src/oauth2_client.erl
@@ -218,7 +218,7 @@ do_update_oauth_provider_endpoints_configuration(OAuthProvider) when
     List = get_env(key_config, []),
     ModifiedList = case OAuthProvider#oauth_provider.jwks_uri of
         undefined ->  List;
-        JwksEndPoint -> [{jwks_url, JwksEndPoint} | proplists:delete(jwks_url, List)]
+        JwksEndPoint -> [{jwks_uri, JwksEndPoint} | proplists:delete(jwks_uri, List)]
     end,
     set_env(key_config, ModifiedList),
     rabbit_log:debug("Updated oauth_provider details: ~p ", 
@@ -393,7 +393,7 @@ lookup_oauth_provider_from_keyconfig() ->
         id = root,
         issuer = Issuer,
         discovery_endpoint = DiscoverEndpoint,
-        jwks_uri = maps:get(jwks_url, Map, undefined), %% jwks_url not uri . _url is the legacy name
+        jwks_uri = maps:get(jwks_uri, Map, undefined),
         token_endpoint = get_env(token_endpoint),
         authorization_endpoint = get_env(authorization_endpoint),
         end_session_endpoint = get_env(end_session_endpoint),
@@ -437,7 +437,8 @@ extract_ssl_options_as_list(Map) ->
     ++
     case maps:get(hostname_verification, Map, none) of
         wildcard ->
-            [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]}];
+            [{customize_hostname_check, [{match_fun, 
+                public_key:pkix_verify_hostname_match_fun(https)}]}];
         none ->
             []
     end.
@@ -445,7 +446,8 @@ extract_ssl_options_as_list(Map) ->
 % Replace peer_verification with verify to make it more consistent with other
 % ssl_options in RabbitMQ and Erlang's ssl options
 % Eventually, peer_verification will be removed. For now, both are allowed
--spec get_verify_or_peer_verification(#{atom() => any()}, verify_none | verify_peer ) -> verify_none | verify_peer.
+-spec get_verify_or_peer_verification(#{atom() => 
+    any()}, verify_none | verify_peer ) -> verify_none | verify_peer.
 get_verify_or_peer_verification(Ssl_options, Default) ->
     case maps:get(verify, Ssl_options, undefined) of
         undefined ->
@@ -464,7 +466,8 @@ lookup_oauth_provider_config(OAuth2ProviderId) ->
                 undefined ->
                     {error, {oauth_provider_not_found, OAuth2ProviderId}};
                 OAuthProvider ->
-                    ensure_oauth_provider_has_id_property(OAuth2ProviderId, OAuthProvider)
+                    ensure_oauth_provider_has_id_property(OAuth2ProviderId, 
+                        OAuthProvider)
             end;
         _ ->  {error, invalid_oauth_provider_configuration}
     end.
@@ -535,8 +538,9 @@ get_timeout_of_default(Timeout) ->
 is_json(?CONTENT_JSON) -> true;
 is_json(_) -> false.
 
--spec decode_body(string(), string() | binary() | term()) -> 'false' | 'null' | 'true' |
-                                                              binary() | [any()] | number() | map() | {error, term()}.
+-spec decode_body(string(), string() | binary() | term()) -> 
+    'false' | 'null' | 'true' | binary() | [any()] | number() | map() | 
+    {error, term()}.
 
 decode_body(_, []) -> [];
 decode_body(?CONTENT_JSON, Body) ->
@@ -615,7 +619,8 @@ format_ssl_options(TlsOptions) ->
         [] -> 0;
         Certs -> length(Certs)
     end,
-    lists:flatten(io_lib:format("{verify: ~p, fail_if_no_peer_cert: ~p, crl_check: ~p, depth: ~p, cacertfile: ~p, cacerts(count): ~p }", [
+    lists:flatten(io_lib:format("{verify: ~p, fail_if_no_peer_cert: ~p, " ++
+        "crl_check: ~p, depth: ~p, cacertfile: ~p, cacerts(count): ~p }", [
         proplists:get_value(verify, TlsOptions),
         proplists:get_value(fail_if_no_peer_cert, TlsOptions),
         proplists:get_value(crl_check, TlsOptions),

--- a/deps/oauth2_client/test/system_SUITE.erl
+++ b/deps/oauth2_client/test/system_SUITE.erl
@@ -198,7 +198,7 @@ configure_all_oauth_provider_settings(Config) ->
         OAuthProvider#oauth_provider.end_session_endpoint),
     application:set_env(rabbitmq_auth_backend_oauth2, authorization_endpoint,
         OAuthProvider#oauth_provider.authorization_endpoint),
-    KeyConfig = [ { jwks_url, OAuthProvider#oauth_provider.jwks_uri } ] ++
+    KeyConfig = [ { jwks_uri, OAuthProvider#oauth_provider.jwks_uri } ] ++
         case OAuthProvider#oauth_provider.ssl_options of
             undefined ->
                 [];
@@ -474,7 +474,7 @@ verify_get_oauth_provider_returns_oauth_provider_from_key_config() ->
         oauth2_client:get_oauth_provider([issuer, token_endpoint, jwks_uri]),
     ExpectedIssuer = application:get_env(rabbitmq_auth_backend_oauth2, issuer, undefined),
     ExpectedTokenEndPoint = application:get_env(rabbitmq_auth_backend_oauth2, token_endpoint, undefined),
-    ExpectedJwks_uri = proplists:get_value(jwks_url,
+    ExpectedJwks_uri = proplists:get_value(jwks_uri,
         application:get_env(rabbitmq_auth_backend_oauth2, key_config, [])),
     ?assertEqual(root, Id),
     ?assertEqual(ExpectedIssuer, Issuer),

--- a/deps/oauth2_client/test/system_SUITE.erl
+++ b/deps/oauth2_client/test/system_SUITE.erl
@@ -27,8 +27,8 @@ all() ->
 [
     {group, https_down},
     {group, https},
-    {group, with_all_oauth_provider_settings}
-   % {group, without_all_oauth_providers_settings}
+    {group, with_all_oauth_provider_settings},
+    {group, without_all_oauth_providers_settings}
 
 ].
 

--- a/deps/rabbitmq_auth_backend_oauth2/README.md
+++ b/deps/rabbitmq_auth_backend_oauth2/README.md
@@ -149,13 +149,13 @@ In that case, the configuration would look like this:
   {rabbitmq_auth_backend_oauth2, [
     {resource_server_id, <<"my_rabbit_server">>},
     {key_config, [
-      {jwks_url, <<"https://jwt-issuer.my-domain.local/jwks.json">>}
+      {jwks_uri, <<"https://jwt-issuer.my-domain.local/jwks.json">>}
     ]}
   ]},
 ].
 ```
 
-Note: if both are configured, `jwks_url` takes precedence over `signing_keys`.
+Note: if both are configured, `jwks_uri` takes precedence over `signing_keys`.
 
 ### Variables Configurable in rabbitmq.conf
 
@@ -166,7 +166,7 @@ Note: if both are configured, `jwks_url` takes precedence over `signing_keys`.
 | `auth_oauth2.additional_scopes_key`      | Key to fetch additional scopes from (maps to `additional_rabbitmq_scopes` in the `advanced.config` format)
 | `auth_oauth2.default_key`                | ID (name) of the default signing key
 | `auth_oauth2.signing_keys`               | Paths to signing key files
-| `auth_oauth2.jwks_url`                   | The URL of key server. According to the [JWT Specification](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2) key server URL must be https
+| `auth_oauth2.jwks_uri`                   | The URL of key server. According to the [JWT Specification](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2) key server URL must be https
 | `auth_oauth2.https.cacertfile`           | Path to a file containing PEM-encoded CA certificates. The CA certificates are used during key server [peer verification](https://rabbitmq.com/ssl.html#peer-verification)
 | `auth_oauth2.https.depth`                | The maximum number of non-self-issued intermediate certificates that may follow the peer certificate in a valid [certification path](https://rabbitmq.com/ssl.html#peer-verification-depth). Default is 10.
 | `auth_oauth2.https.peer_verification`    | Should [peer verification](https://rabbitmq.com/ssl.html#peer-verification) be enabled Available values: `verify_none`, `verify_peer`. Default is `verify_none`. It is recommended to configure `verify_peer`. Peer verification requires a certain amount of setup and is more secure.
@@ -194,7 +194,7 @@ auth_oauth2.algorithms.2 = RS256
 
 ```
 auth_oauth2.resource_server_id = new_resource_server_id
-auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
+auth_oauth2.jwks_uri = https://my-jwt-issuer/jwks.json
 auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
 auth_oauth2.https.peer_verification = verify_peer
 auth_oauth2.https.depth = 5
@@ -234,7 +234,7 @@ resolve the user's identity: `username`, `user_name`, `email`, `sub`, `client_id
     {resource_server_id, <<"my_rabbit_server">>},
     {preferred_username_claims, [ <<"username">>, <<"user_name">>, <<"email">> ]}
     {key_config, [
-      {jwks_url, <<"https://jwt-issuer.my-domain.local/jwks.json">>}
+      {jwks_uri, <<"https://jwt-issuer.my-domain.local/jwks.json">>}
     ]}
   ]},
 ].

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -143,9 +143,16 @@
  "rabbitmq_auth_backend_oauth2.token_endpoint",
  [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
 
+%% DEPRECATES auth_oauth2.jwks_url
 {mapping,
  "auth_oauth2.jwks_uri",
- "rabbitmq_auth_backend_oauth2.key_config.jwks_uri",
+ "rabbitmq_auth_backend_oauth2.jwks_uri",
+ [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
+
+%% DEPRECATED
+{mapping,
+ "auth_oauth2.jwks_url",
+ "rabbitmq_auth_backend_oauth2.key_config.jwks_url",
  [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
 
 {mapping,

--- a/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
+++ b/deps/rabbitmq_auth_backend_oauth2/priv/schema/rabbitmq_auth_backend_oauth2.schema
@@ -144,8 +144,8 @@
  [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
 
 {mapping,
- "auth_oauth2.jwks_url",
- "rabbitmq_auth_backend_oauth2.key_config.jwks_url",
+ "auth_oauth2.jwks_uri",
+ "rabbitmq_auth_backend_oauth2.key_config.jwks_uri",
  [{datatype, string}, {validators, ["uri", "https_uri"]}]}.
 
 {mapping,

--- a/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/uaa_jwt.erl
@@ -124,7 +124,7 @@ get_jwk(KeyId, InternalOAuthProvider, AllowUpdateJwks) ->
                             case update_jwks_signing_keys(OAuthProvider) of
                                 ok ->
                                     get_jwk(KeyId, InternalOAuthProvider, false);
-                                {error, no_jwks_url} ->
+                                {error, no_jwks_uri} ->
                                     {error, key_not_found};
                                 {error, _} = Err ->
                                     Err

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -11,6 +11,7 @@
         auth_oauth2.default_key = id1
         auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
         auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem
+        auth_oauth2.jwks_uri = https://my-jwt-issuer/jwks.json
         auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
         auth_oauth2.issuer = https://my-jwt-issuer
         auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
@@ -36,6 +37,7 @@
             {discovery_endpoint_params, [
                 {<<"param1">>, <<"value1">>}
             ]},
+            {jwks_uri, "https://my-jwt-issuer/jwks.json"},
             {key_config, [
               {default_key, <<"id1">>},
               {signing_keys,
@@ -69,6 +71,7 @@
         auth_oauth2.default_key = id1
         auth_oauth2.signing_keys.id1 = test/config_schema_SUITE_data/certs/key.pem
         auth_oauth2.signing_keys.id2 = test/config_schema_SUITE_data/certs/cert.pem
+        auth_oauth2.jwks_uri = https://my-jwt-issuer/jwks.json
         auth_oauth2.jwks_url = https://my-jwt-issuer/jwks.json
         auth_oauth2.https.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
         auth_oauth2.https.peer_verification = verify_none
@@ -90,6 +93,7 @@
             {extra_scopes_source, <<"my_custom_scope_key">>},
             {preferred_username_claims, [<<"user_name">>, <<"username">>, <<"email">>]},
             {verify_aud, true},
+            {jwks_uri, "https://my-jwt-issuer/jwks.json"},
             {resource_servers,
               #{
                 <<"rabbitmq-operations">> => [

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_provider_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_provider_SUITE.erl
@@ -110,7 +110,7 @@ init_per_group(oauth_provider_with_jwks_uri, Config) ->
     URL = case ?config(oauth_provider_id, Config) of
         root ->
             RootUrl = build_url_to_oauth_provider(<<"/keys">>),
-            set_env(key_config, [{jwks_uri, RootUrl}]),
+            set_env(jwks_uri, RootUrl),
             RootUrl;
         <<"A">> ->
             AUrl = build_url_to_oauth_provider(<<"/A/keys">>),

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_provider_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_provider_SUITE.erl
@@ -110,7 +110,7 @@ init_per_group(oauth_provider_with_jwks_uri, Config) ->
     URL = case ?config(oauth_provider_id, Config) of
         root ->
             RootUrl = build_url_to_oauth_provider(<<"/keys">>),
-            set_env(key_config, [{jwks_url, RootUrl}]),
+            set_env(key_config, [{jwks_uri, RootUrl}]),
             RootUrl;
         <<"A">> ->
             AUrl = build_url_to_oauth_provider(<<"/A/keys">>),
@@ -211,7 +211,7 @@ end_per_group(oauth_provider_with_issuer, Config) ->
     Config;
 end_per_group(oauth_provider_with_jwks_uri, Config) ->
     case ?config(oauth_provider_id, Config) of
-        root -> unset_env(jwks_url);
+        root -> unset_env(jwks_uri);
         Id -> unset_oauth_provider_properties(Id, [jwks_uri])
     end,
     Config;

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -73,16 +73,10 @@ groups() ->
 init_per_suite(Config) ->
     application:load(rabbitmq_auth_backend_oauth2),
     Env = application:get_all_env(rabbitmq_auth_backend_oauth2),
-    Config1 = rabbit_ct_helpers:set_config(Config, {env, Env}),
-    rabbit_ct_helpers:run_setup_steps(Config1, []).
+    lists:foreach(fun({K, _V}) -> unset_env(K) end, Env),
+    rabbit_ct_helpers:run_setup_steps(Config, []).
 
 end_per_suite(Config) ->
-    Env = ?config(env, Config),
-    lists:foreach(
-        fun({K, V}) ->
-            set_env(K, V)
-        end,
-        Env),
     rabbit_ct_helpers:run_teardown_steps(Config).
 
 init_per_group(with_rabbitmq_node, Config) ->

--- a/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/unit_SUITE.erl
@@ -1105,8 +1105,8 @@ test_incorrect_kid(_) ->
     AltKid   = <<"other-token-key">>,
     Username = <<"username">>,
     Jwk      = ?UTIL_MOD:fixture_jwk(),
-    set_env(resource_server_id, 
-        <<"rabbitmq">>),
+    unset_env(key_config),
+    set_env(resource_server_id, <<"rabbitmq">>),
     Token = ?UTIL_MOD:sign_token_hs(
         ?UTIL_MOD:token_with_sub(?UTIL_MOD:fixture_token(), Username), Jwk, 
             AltKid, true),
@@ -1298,6 +1298,8 @@ normalize_token_scope_without_scope_claim(_) ->
 
 set_env(Par, Var) ->
     application:set_env(rabbitmq_auth_backend_oauth2, Par, Var).
+unset_env(Par) ->
+    application:unset_env(rabbitmq_auth_backend_oauth2, Par).
 
 assert_vhost_access_granted(AuthUser, VHost) ->
     assert_vhost_access_response(true, AuthUser, VHost).

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -472,6 +472,13 @@ end}.
 {mapping, "management.oauth_response_type", "rabbitmq_management.oauth_response_type",
     [{datatype, string}]}.
 
+%% THIS VARIABLE IS DEPRECATED. CHECKOUT auth_oauth2.discovery_endpoint_path VARIABLE.
+%% The URL of the OIDC discovery url where the provider is listening on
+%% by default it is <oauth_provider_url>/.well-known/openid-configuration which is the
+%% default OIDC discovery endpoint
+{mapping, "management.oauth_metadata_url", "rabbitmq_management.oauth_metadata_url",
+      [{datatype, string}]}.
+
 %% Configure OAuth2 authorization_endpoint additional request parameters
 {mapping, "management.oauth_authorization_endpoint_params.$name",
     "rabbitmq_management.oauth_authorization_endpoint_params",
@@ -548,6 +555,12 @@ end}.
 
 {mapping,
   "management.oauth_resource_servers.$name.oauth_scopes",
+  "rabbitmq_management.oauth_resource_servers",
+  [{datatype, string}]
+}.
+
+{mapping,
+  "management.oauth_resource_servers.$name.oauth_metadata_url",
   "rabbitmq_management.oauth_resource_servers",
   [{datatype, string}]
 }.

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -496,11 +496,6 @@ end}.
 {mapping, "management.oauth_scopes", "rabbitmq_management.oauth_scopes",
       [{datatype, string}]}.
 
-%% The URL of the OIDC discovery url where the provider is listening on
-%% by default it is <oauth_provider_url>/.well-known/openid-configuration which is the
-%% default OIDC discovery endpoint
-{mapping, "management.oauth_metadata_url", "rabbitmq_management.oauth_metadata_url",
-      [{datatype, string}]}.
 
 %% Configure the OAuth 2 type allowed for the end users to logon to the management UI
 %% Default type is sp_initiated meaning the standard OAuth 2.0 mode where users come without any token
@@ -553,12 +548,6 @@ end}.
 
 {mapping,
   "management.oauth_resource_servers.$name.oauth_scopes",
-  "rabbitmq_management.oauth_resource_servers",
-  [{datatype, string}]
-}.
-
-{mapping,
-  "management.oauth_resource_servers.$name.oauth_metadata_url",
   "rabbitmq_management.oauth_resource_servers",
   [{datatype, string}]
 }.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
@@ -34,7 +34,7 @@ merge_property(Key, List, MapIn) ->
 extract_oauth_provider_info_props_as_map(ManagementProps) ->
   lists:foldl(fun(K, Acc) ->
     merge_property(K, ManagementProps, Acc) end, #{}, [oauth_provider_url,
-      oauth_metadata_url, oauth_authorization_endpoint_params,
+      oauth_authorization_endpoint_params,
       oauth_token_endpoint_params]).
 
 merge_oauth_provider_info(OAuthResourceServer, MgtResourceServer, ManagementProps) ->
@@ -55,8 +55,8 @@ oauth_provider_to_map(OAuthProvider) ->
   Map0 = case OAuthProvider#oauth_provider.issuer of
     undefined -> #{};
     Issuer -> #{ oauth_provider_url => Issuer,
-                oauth_metadata_url => OAuthProvider#oauth_provider.discovery_endpoint
-              }
+                 oauth_metadata_url => OAuthProvider#oauth_provider.discovery_endpoint
+               }
   end,
   case OAuthProvider#oauth_provider.end_session_endpoint of
     undefined -> Map0;

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
@@ -23,162 +23,199 @@ variances(Req, Context) ->
     {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
 
 content_types_provided(ReqData, Context) ->
-   {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 merge_property(Key, List, MapIn) ->
-  case proplists:get_value(Key, List) of
-    undefined -> MapIn;
-    V0 -> MapIn#{Key => V0}
-  end.
+    case proplists:get_value(Key, List) of
+        undefined -> MapIn;
+        V0 -> MapIn#{Key => V0}
+    end.
 
 extract_oauth_provider_info_props_as_map(ManagementProps) ->
-  lists:foldl(fun(K, Acc) ->
-    merge_property(K, ManagementProps, Acc) end, #{}, [oauth_provider_url,
-      oauth_authorization_endpoint_params,
-      oauth_token_endpoint_params]).
+    lists:foldl(fun(K, Acc) ->
+        merge_property(K, ManagementProps, Acc) end, #{}, 
+        [oauth_provider_url,
+         oauth_metadata_url,
+         oauth_authorization_endpoint_params,
+         oauth_token_endpoint_params]).
 
-merge_oauth_provider_info(OAuthResourceServer, MgtResourceServer, ManagementProps) ->
-  OAuthProviderResult = case proplists:get_value(oauth_provider_id, OAuthResourceServer) of
-    undefined -> oauth2_client:get_oauth_provider([issuer]);
-    OauthProviderId -> oauth2_client:get_oauth_provider(OauthProviderId, [issuer])
-  end,
-  OAuthProviderInfo0 = case OAuthProviderResult of
-    {ok, OAuthProvider} -> oauth_provider_to_map(OAuthProvider);
-    {error, _} -> #{}
-  end,
-  OAuthProviderInfo1 = maps:merge(OAuthProviderInfo0,
-    extract_oauth_provider_info_props_as_map(ManagementProps)),
-  maps:merge(OAuthProviderInfo1, proplists:to_map(MgtResourceServer)).
+merge_oauth_provider_info(OAuthResourceServer, MgtResourceServer, 
+        ManagementProps) ->
+    OAuthProviderResult = 
+        case proplists:get_value(oauth_provider_id, OAuthResourceServer) of
+            undefined -> 
+                oauth2_client:get_oauth_provider([issuer]);
+            OauthProviderId -> 
+                oauth2_client:get_oauth_provider(OauthProviderId, [issuer])
+        end,
+    OAuthProviderInfo0 = 
+        case OAuthProviderResult of
+            {ok, OAuthProvider} -> oauth_provider_to_map(OAuthProvider);
+            {error, _} -> #{}
+        end,
+    OAuthProviderInfo1 = maps:merge(OAuthProviderInfo0,
+        extract_oauth_provider_info_props_as_map(ManagementProps)),
+    maps:merge(OAuthProviderInfo1, proplists:to_map(MgtResourceServer)).
 
 oauth_provider_to_map(OAuthProvider) ->
-  % only include issuer and end_session_endpoint for now. The other endpoints are resolved by oidc-client library
-  Map0 = case OAuthProvider#oauth_provider.issuer of
-    undefined -> #{};
-    Issuer -> #{ oauth_provider_url => Issuer,
-                 oauth_metadata_url => OAuthProvider#oauth_provider.discovery_endpoint
-               }
-  end,
-  case OAuthProvider#oauth_provider.end_session_endpoint of
-    undefined -> Map0;
-    V -> maps:put(end_session_endpoint, V, Map0)
-  end.
+    % only include issuer and end_session_endpoint for now. 
+    % The other endpoints are resolved by oidc-client library
+    Map0 = case OAuthProvider#oauth_provider.issuer of
+        undefined -> 
+            #{};
+        Issuer -> 
+            #{  
+                oauth_provider_url => Issuer,
+                oauth_metadata_url => 
+                    OAuthProvider#oauth_provider.discovery_endpoint
+            }
+    end,
+    case OAuthProvider#oauth_provider.end_session_endpoint of
+        undefined -> Map0;
+        V -> maps:put(end_session_endpoint, V, Map0)
+    end.
 
-skip_unknown_mgt_resource_servers(MgtOauthResources, OAuth2Resources) ->
-  maps:filter(fun(Key, _Value) -> maps:is_key(Key, OAuth2Resources) end, MgtOauthResources).
+skip_unknown_mgt_resource_servers(ManagementProps, OAuth2Resources) ->
+    maps:filter(fun(Key, _Value) -> maps:is_key(Key, OAuth2Resources) end, 
+        proplists:get_value(oauth_resource_servers, ManagementProps, #{})).
 skip_disabled_mgt_resource_servers(MgtOauthResources) ->
-  maps:filter(fun(_Key, Value) -> not proplists:get_value(disabled, Value, false) end, MgtOauthResources).
+    maps:filter(fun(_Key, Value) -> 
+        not proplists:get_value(disabled, Value, false) end, 
+        MgtOauthResources).
 
 extract_oauth2_and_mgt_resources(OAuth2BackendProps, ManagementProps) ->
-  OAuth2Resources = getAllDeclaredOauth2Resources(OAuth2BackendProps),
-  MgtResources0 = skip_unknown_mgt_resource_servers(proplists:get_value(oauth_resource_servers,
-                                                ManagementProps, #{}), OAuth2Resources),
-  MgtResources1 = maps:merge(MgtResources0, maps:filtermap(fun(K,_V) ->
-      case maps:is_key(K, MgtResources0) of
-        true -> false;
-        false -> {true, [{id, K}]}
-      end end, OAuth2Resources)),
-  MgtResources = maps:map(
-    fun(K,V) -> merge_oauth_provider_info(maps:get(K, OAuth2Resources, #{}), V, ManagementProps) end,
-    skip_disabled_mgt_resource_servers(MgtResources1)),
-  case maps:size(MgtResources) of
-    0 -> {};
-    _ -> {MgtResources}
-  end.
+    OAuth2Resources = getAllDeclaredOauth2Resources(OAuth2BackendProps),
+    MgtResources0 = skip_unknown_mgt_resource_servers(ManagementProps,
+        OAuth2Resources),
+    MgtResources1 = maps:merge(maps:filtermap(fun(K,_V) ->
+        case maps:is_key(K, MgtResources0) of
+            true -> false;
+            false -> {true, [{id, K}]}
+        end end, OAuth2Resources), MgtResources0),
+    MgtResources = maps:map(
+        fun(K,V) -> merge_oauth_provider_info(
+            maps:get(K, OAuth2Resources, #{}), V, ManagementProps) end,
+        skip_disabled_mgt_resource_servers(MgtResources1)),
+    case maps:size(MgtResources) of
+        0 -> {};
+        _ -> {MgtResources}
+    end.
 
 getAllDeclaredOauth2Resources(OAuth2BackendProps) ->
-  OAuth2Resources = proplists:get_value(resource_servers, OAuth2BackendProps, #{}),
-  case proplists:get_value(resource_server_id, OAuth2BackendProps) of
-    undefined -> OAuth2Resources;
-    Id -> maps:put(Id, buildRootResourceServerIfAny(Id, OAuth2BackendProps),
-    OAuth2Resources)
-  end.
+    OAuth2Resources = proplists:get_value(resource_servers, OAuth2BackendProps, 
+        #{}),
+    case proplists:get_value(resource_server_id, OAuth2BackendProps) of
+        undefined -> 
+            OAuth2Resources;
+        Id -> 
+            maps:put(Id, buildRootResourceServerIfAny(Id, OAuth2BackendProps),
+                OAuth2Resources)
+    end.
 buildRootResourceServerIfAny(Id, Props) ->
-  [ {id, Id},
-    {oauth_client_id,
-        proplists:get_value(oauth_client_id, Props)},
-    {oauth_client_secret,
-        proplists:get_value(oauth_client_secret, Props)},
-    {oauth_response_type,
-        proplists:get_value(oauth_response_type, Props)},
-    {oauth_authorization_endpoint_params,
-        proplists:get_value(oauth_authorization_endpoint_params, Props)},
-    {oauth_token_endpoint_params,
-        proplists:get_value(oauth_token_endpoint_params, Props)}
-  ].
+    [ 
+        {id, Id},
+        {oauth_provider_id, proplists:get_value(oauth_provider_id, Props)}       
+    ].
 
 authSettings() ->
-  ManagementProps = application:get_all_env(rabbitmq_management),
-  OAuth2BackendProps = application:get_all_env(rabbitmq_auth_backend_oauth2),
-  EnableOAUTH = proplists:get_value(oauth_enabled, ManagementProps, false),
-  case EnableOAUTH of
-    false -> [{oauth_enabled, false}];
-    true ->
-      case extract_oauth2_and_mgt_resources(OAuth2BackendProps, ManagementProps) of
-        {MgtResources} -> produce_auth_settings(MgtResources, ManagementProps);
-        {} -> [{oauth_enabled, false}]
-      end
+    ManagementProps = application:get_all_env(rabbitmq_management),
+    OAuth2BackendProps = application:get_all_env(rabbitmq_auth_backend_oauth2),
+    EnableOAUTH = proplists:get_value(oauth_enabled, ManagementProps, false),
+    case EnableOAUTH of
+        false -> [{oauth_enabled, false}];
+        true ->
+            case extract_oauth2_and_mgt_resources(OAuth2BackendProps,
+                    ManagementProps) of
+                {MgtResources} -> 
+                    produce_auth_settings(MgtResources, ManagementProps);
+                {} -> 
+                    [{oauth_enabled, false}]
+            end
   end.
 
-skip_mgt_resource_servers_without_oauth_client_id_with_sp_initiated_logon(MgtResourceServers, ManagementProps) ->
-  DefaultOauthInitiatedLogonType = proplists:get_value(oauth_initiated_logon_type, ManagementProps, sp_initiated),
-  maps:filter(fun(_K,ResourceServer) ->
-    SpInitiated = case maps:get(oauth_initiated_logon_type, ResourceServer, DefaultOauthInitiatedLogonType) of
-      sp_initiated -> true;
-      _ -> false
-    end,
-    not SpInitiated or
-    not is_invalid([maps:get(oauth_client_id, ResourceServer, undefined)]) end, MgtResourceServers).
+% invalid -> those resources that dont have an oauth_client_id and 
+%            their login_type is sp_initiated
+skip_invalid_mgt_resource_servers(MgtResourceServers, ManagementProps) ->
+    DefaultOauthInitiatedLogonType = proplists:get_value(
+        oauth_initiated_logon_type, ManagementProps, sp_initiated),
+    maps:filter(fun(_K,ResourceServer) ->
+        SpInitiated = 
+            case maps:get(oauth_initiated_logon_type, ResourceServer, 
+                    DefaultOauthInitiatedLogonType) of
+                sp_initiated -> true;
+                _ -> false
+            end,
+        not SpInitiated or not is_invalid([maps:get(oauth_client_id, 
+            ResourceServer, undefined)]) 
+        end, MgtResourceServers).
 
-
-filter_mgt_resource_servers_without_oauth_client_id_for_sp_initiated(MgtResourceServers, ManagementProps) ->
-  case is_invalid([proplists:get_value(oauth_client_id, ManagementProps)]) of
-    true -> skip_mgt_resource_servers_without_oauth_client_id_with_sp_initiated_logon(MgtResourceServers, ManagementProps);
-    false -> MgtResourceServers
-  end.
+% filter -> include only those resources with an oauth_client_id 
+%           or those whose logon type is not sp_initiated 
+filter_out_invalid_mgt_resource_servers(MgtResourceServers, ManagementProps) ->
+    case is_invalid([proplists:get_value(oauth_client_id, ManagementProps)]) of
+        true -> 
+            skip_invalid_mgt_resource_servers(MgtResourceServers, 
+                ManagementProps);
+        false -> 
+            MgtResourceServers
+    end.
 
 filter_mgt_resource_servers_without_oauth_provider_url(MgtResourceServers) ->
-  maps:filter(fun(_K1,V1) -> maps:is_key(oauth_provider_url, V1) end, MgtResourceServers).
+    maps:filter(fun(_K1,V1) -> maps:is_key(oauth_provider_url, V1) end, 
+        MgtResourceServers).
 
 ensure_oauth_resource_server_properties_are_binaries(Key, Value) ->
-  case Key of
-    oauth_authorization_endpoint_params -> Value;
-    oauth_token_endpoint_params -> Value;
-    _ -> to_binary(Value)
-  end.
+    case Key of
+        oauth_authorization_endpoint_params -> Value;
+        oauth_token_endpoint_params -> Value;
+        _ -> to_binary(Value)
+    end.
 
 produce_auth_settings(MgtResourceServers, ManagementProps) ->
-  ConvertValuesToBinary = fun(_K,V) -> [
-    {K1, ensure_oauth_resource_server_properties_are_binaries(K1, V1)} || {K1,V1}
-      <- maps:to_list(V)] end,
-  FilteredMgtResourceServers = filter_mgt_resource_servers_without_oauth_provider_url(
-    filter_mgt_resource_servers_without_oauth_client_id_for_sp_initiated(MgtResourceServers, ManagementProps)),
+    ConvertValuesToBinary = fun(_K,V) -> 
+        [
+            {K1, ensure_oauth_resource_server_properties_are_binaries(K1, V1)} 
+            || {K1,V1} <- maps:to_list(V) 
+        ] end,
+    FilteredMgtResourceServers = 
+        filter_mgt_resource_servers_without_oauth_provider_url(
+            filter_out_invalid_mgt_resource_servers(MgtResourceServers, 
+                ManagementProps)),
 
-  case maps:size(FilteredMgtResourceServers) of
-    0 -> [{oauth_enabled, false}];
-    _ ->
-       filter_empty_properties([
-        {oauth_enabled, true},
-        {oauth_resource_servers, maps:map(ConvertValuesToBinary, FilteredMgtResourceServers)},
-        to_tuple(oauth_disable_basic_auth, ManagementProps, fun to_binary/1, true),
-        to_tuple(oauth_client_id, ManagementProps),
-        to_tuple(oauth_client_secret, ManagementProps),
-        to_tuple(oauth_scopes, ManagementProps),
-        case proplists:get_value(oauth_initiated_logon_type, ManagementProps, sp_initiated) of
-          sp_initiated -> {};
-          idp_initiated -> {oauth_initiated_logon_type, <<"idp_initiated">>}
-        end,
-        to_tuple(oauth_authorization_endpoint_params, ManagementProps, undefined, undefined),
-        to_tuple(oauth_token_endpoint_params, ManagementProps, undefined, undefined)
-      ])
+    case maps:size(FilteredMgtResourceServers) of
+        0 -> 
+            [{oauth_enabled, false}];
+        _ ->
+            filter_empty_properties([
+                {oauth_enabled, true},
+                {oauth_resource_servers, 
+                    maps:map(ConvertValuesToBinary, FilteredMgtResourceServers)},
+                to_tuple(oauth_disable_basic_auth, ManagementProps, 
+                    fun to_binary/1, true),
+                to_tuple(oauth_client_id, ManagementProps),
+                to_tuple(oauth_client_secret, ManagementProps),
+                to_tuple(oauth_scopes, ManagementProps),
+                case proplists:get_value(oauth_initiated_logon_type, 
+                    ManagementProps, sp_initiated) of
+                    sp_initiated -> 
+                        {};
+                    idp_initiated -> 
+                        {oauth_initiated_logon_type, <<"idp_initiated">>}
+                end,
+                to_tuple(oauth_authorization_endpoint_params, ManagementProps, 
+                    undefined, undefined),
+                to_tuple(oauth_token_endpoint_params, ManagementProps, 
+                    undefined, undefined)
+            ])
   end.
 
 filter_empty_properties(ListOfProperties) ->
-  lists:filter(fun(Prop) ->
-      case Prop of
-        {} -> false;
-        _ -> true
-      end
-    end, ListOfProperties).
+    lists:filter(fun(Prop) ->
+            case Prop of
+                {} -> false;
+                _ -> true
+            end
+        end, ListOfProperties).
 
 to_binary(Value) when is_boolean(Value)-> Value;
 to_binary(Value) -> rabbit_data_coercion:to_binary(Value).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_wm_auth_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_wm_auth_SUITE.erl
@@ -96,7 +96,10 @@ groups() ->
                 should_return_mgt_oauth_metadata_url_url1,
                 {with_mgt_oauth_provider_url_url0, [], [
                   should_return_mgt_oauth_provider_url_url0,
-                  should_return_mgt_oauth_metadata_url_url1                  
+                  should_return_mgt_oauth_metadata_url_url1,
+                  {with_mgt_oauth_resource_server_rabbit_with_oauth_metadata_url_url1, [], [
+                    should_return_oauth_resource_server_rabbit_with_oauth_metadata_url_url1
+                  ]}                 
                 ]}
               ]}
             ]}
@@ -215,6 +218,9 @@ groups() ->
                   {with_mgt_oauth_client_id_z, [], [
                     should_return_oauth_resource_server_rabbit_with_oauth_provider_url_idp1_url,
                     should_return_oauth_resource_server_rabbit_with_oauth_metadata_url_idp1_url,
+                    {with_mgt_oauth_resource_server_rabbit_with_oauth_metadata_url_url1, [], [
+                      should_return_oauth_resource_server_rabbit_with_oauth_metadata_url_url1
+                    ]},
                     {with_root_issuer_url1, [], [
                       should_return_oauth_resource_server_rabbit_with_oauth_provider_url_idp1_url
                     ]},
@@ -223,7 +229,10 @@ groups() ->
                       should_return_oauth_resource_server_rabbit_with_oauth_metadata_url_idp1_url,
                       {with_mgt_oauth_resource_server_a_with_oauth_provider_url_url1, [], [
                         should_return_oauth_resource_server_rabbit_with_oauth_provider_url_url0,
-                        should_return_oauth_resource_server_a_with_oauth_provider_url_url1
+                        should_return_oauth_resource_server_a_with_oauth_provider_url_url1,
+                        {with_mgt_oauth_resource_server_a_with_oauth_metadata_url_url1, [], [
+                          should_return_oauth_resource_server_a_with_oauth_metadata_url_url1
+                        ]}
                       ]}
                     ]}
                   ]}
@@ -459,6 +468,9 @@ init_per_group(with_mgt_resource_server_a_with_client_id_x, Config) ->
 init_per_group(with_default_oauth_provider_idp1, Config) ->
   set_env(rabbitmq_auth_backend_oauth2, default_oauth_provider, ?config(idp1, Config)),
   Config;
+init_per_group(with_mgt_oauth_resource_server_rabbit_with_oauth_metadata_url_url1, Config) ->
+  set_env(rabbitmq_management, oauth_metadata_url, ?config(meta_url1, Config)),
+  Config;
 init_per_group(with_default_oauth_provider_idp3, Config) ->
   set_env(rabbitmq_auth_backend_oauth2, default_oauth_provider, ?config(idp3, Config)),
   Config;
@@ -488,6 +500,10 @@ init_per_group(with_token_endpoint_params_0, Config) ->
 init_per_group(with_mgt_resource_server_a_with_authorization_endpoint_params_1, Config) ->
   set_attribute_in_entry_for_env_variable(rabbitmq_management, oauth_resource_servers,
     ?config(a, Config), oauth_authorization_endpoint_params, ?config(authorization_params_1, Config)),
+  Config;
+init_per_group(with_mgt_oauth_resource_server_a_with_oauth_metadata_url_url1, Config) ->
+  set_attribute_in_entry_for_env_variable(rabbitmq_management, oauth_resource_servers,
+    ?config(a, Config), oauth_metadata_url, ?config(meta_url1, Config)),
   Config;
 init_per_group(with_mgt_resource_server_a_with_token_endpoint_params_1, Config) ->
   set_attribute_in_entry_for_env_variable(rabbitmq_management, oauth_resource_servers,
@@ -522,8 +538,14 @@ end_per_group(with_oauth_disable_basic_auth_false, Config) ->
 end_per_group(with_resource_server_id_rabbit, Config) ->
   unset_env(rabbitmq_auth_backend_oauth2, resource_server_id),
   Config;
+end_per_group(with_default_oauth_provider_idp1, Config) ->
+  unset_env(rabbitmq_auth_backend_oauth2, default_oauth_provider),
+  Config;
 end_per_group(with_mgt_oauth_provider_url_url0, Config) ->
   unset_env(rabbitmq_management, oauth_provider_url),
+  Config;
+end_per_group(with_mgt_oauth_resource_server_rabbit_with_oauth_metadata_url_url1, Config) ->
+  unset_env(rabbitmq_management, oauth_metadata_url),
   Config;
 end_per_group(with_root_issuer_url1, Config) ->
   unset_env(rabbitmq_auth_backend_oauth2, issuer),
@@ -557,6 +579,10 @@ end_per_group(with_mgt_resource_server_a_with_scopes_read_write, Config) ->
 end_per_group(with_mgt_oauth_resource_server_a_with_oauth_provider_url_url1, Config) ->
   remove_attribute_from_entry_from_env_variable(rabbitmq_management, oauth_resource_servers,
     ?config(a, Config), oauth_provider_url),
+  Config;
+end_per_group(with_mgt_oauth_resource_server_a_with_oauth_metadata_url_url1, Config) ->
+  remove_attribute_from_entry_from_env_variable(rabbitmq_management, oauth_resource_servers,
+    ?config(a, Config), oauth_metadata_url),
   Config;
 end_per_group(with_mgt_resource_server_a_with_oauth_initiated_logon_type_sp_initiated, Config) ->
   remove_attribute_from_entry_from_env_variable(rabbitmq_management, oauth_resource_servers,

--- a/deps/rabbitmq_management/test/rabbit_mgmt_wm_auth_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_wm_auth_SUITE.erl
@@ -96,10 +96,7 @@ groups() ->
                 should_return_mgt_oauth_metadata_url_url1,
                 {with_mgt_oauth_provider_url_url0, [], [
                   should_return_mgt_oauth_provider_url_url0,
-                  should_return_mgt_oauth_metadata_url_url1,
-                  {with_mgt_oauth_metadata_url_url0, [], [
-                    should_return_mgt_oauth_metadata_url_url0
-                  ]}
+                  should_return_mgt_oauth_metadata_url_url1                  
                 ]}
               ]}
             ]}
@@ -205,10 +202,7 @@ groups() ->
                     should_return_oauth_resource_server_a_with_oauth_metadata_url_url1,
                     {with_mgt_oauth_resource_server_a_with_oauth_provider_url_url1, [], [
                       should_return_oauth_resource_server_rabbit_with_oauth_provider_url_url0,
-                      should_return_oauth_resource_server_a_with_oauth_provider_url_url1,
-                      {with_mgt_oauth_resource_server_a_with_oauth_metadata_url_url0, [], [
-                        should_return_oauth_resource_server_a_with_oauth_metadata_url_url0
-                      ]}
+                      should_return_oauth_resource_server_a_with_oauth_provider_url_url1                      
                     ]}
                   ]}
                 ]}
@@ -409,9 +403,6 @@ init_per_group(with_mgt_oauth_client_secret_q, Config) ->
 init_per_group(with_mgt_oauth_provider_url_url0, Config) ->
   set_env(rabbitmq_management, oauth_provider_url, ?config(url0, Config)),
   Config;
-init_per_group(with_mgt_oauth_metadata_url_url0, Config) ->
-  set_env(rabbitmq_management, oauth_metadata_url, ?config(meta_url0, Config)),
-  Config;
 init_per_group(with_root_issuer_url1, Config) ->
   set_env(rabbitmq_auth_backend_oauth2, issuer, ?config(url1, Config)),
   Config;
@@ -459,10 +450,6 @@ init_per_group(with_mgt_resource_server_a_with_scopes_read_write, Config) ->
 init_per_group(with_mgt_oauth_resource_server_a_with_oauth_provider_url_url1, Config) ->
   set_attribute_in_entry_for_env_variable(rabbitmq_management, oauth_resource_servers,
     ?config(a, Config), oauth_provider_url, ?config(url1, Config)),
-  Config;
-init_per_group(with_mgt_oauth_resource_server_a_with_oauth_metadata_url_url0, Config) ->
-  set_attribute_in_entry_for_env_variable(rabbitmq_management, oauth_resource_servers,
-    ?config(a, Config), oauth_metadata_url, ?config(meta_url0, Config)),
   Config;
 init_per_group(with_mgt_resource_server_a_with_client_id_x, Config) ->
   set_attribute_in_entry_for_env_variable(rabbitmq_management, oauth_resource_servers,
@@ -538,9 +525,6 @@ end_per_group(with_resource_server_id_rabbit, Config) ->
 end_per_group(with_mgt_oauth_provider_url_url0, Config) ->
   unset_env(rabbitmq_management, oauth_provider_url),
   Config;
-end_per_group(with_mgt_oauth_metadata_url_url0, Config) ->
-  unset_env(rabbitmq_management, oauth_metadata_url),
-  Config;
 end_per_group(with_root_issuer_url1, Config) ->
   unset_env(rabbitmq_auth_backend_oauth2, issuer),
   unset_env(rabbitmq_auth_backend_oauth2, discovery_endpoint),
@@ -573,10 +557,6 @@ end_per_group(with_mgt_resource_server_a_with_scopes_read_write, Config) ->
 end_per_group(with_mgt_oauth_resource_server_a_with_oauth_provider_url_url1, Config) ->
   remove_attribute_from_entry_from_env_variable(rabbitmq_management, oauth_resource_servers,
     ?config(a, Config), oauth_provider_url),
-  Config;
-end_per_group(with_mgt_oauth_resource_server_a_with_oauth_metadata_url_url0, Config) ->
-  remove_attribute_from_entry_from_env_variable(rabbitmq_management, oauth_resource_servers,
-    ?config(a, Config), oauth_metadata_url),
   Config;
 end_per_group(with_mgt_resource_server_a_with_oauth_initiated_logon_type_sp_initiated, Config) ->
   remove_attribute_from_entry_from_env_variable(rabbitmq_management, oauth_resource_servers,
@@ -704,10 +684,6 @@ should_return_oauth_resource_server_a_with_oauth_provider_url_url1(Config) ->
 should_return_oauth_resource_server_a_with_oauth_metadata_url_url1(Config) ->
   assertEqual_on_attribute_for_oauth_resource_server(authSettings(),
     Config, a, oauth_metadata_url, meta_url1).
-
-should_return_oauth_resource_server_a_with_oauth_metadata_url_url0(Config) ->
-  assertEqual_on_attribute_for_oauth_resource_server(authSettings(),
-    Config, a, oauth_metadata_url, meta_url0).
 
 should_return_oauth_resource_server_a_with_oauth_provider_url_url0(Config) ->
   assertEqual_on_attribute_for_oauth_resource_server(authSettings(),


### PR DESCRIPTION
## Proposed Changes

Implements these 2 features which essentially deprecate two settings:
- https://github.com/rabbitmq/rabbitmq-server/issues/12239
- https://github.com/rabbitmq/rabbitmq-server/issues/12237

This PR adds two new settings while keeping the old ones until 4.2.x when they will be removed. 
If the user configures the legacy `management.oauth_metadata_url` or `management.oauth_resource_server.$name.oauth_metadata_url` variables, RabbitMQ uses it. Else, the RabbitMQ uses the calculated discover endpoint url which uses `issuer` and `discovery_endpoint_path` and `discovery_endpoint_params`. 

RabbitMQ will use the legacy `auth_oauth2.jwks_url` variable unless `auth_oauth2.jwks_uri` is not set.
If both are set, RabbitMQ favours the new setting, `auth_oauth2.jwks_uri`.

**IMPORTANT NOTE**: This PR depends on https://github.com/rabbitmq/rabbitmq-server/pull/12258. Once that PR is merged, this PR should be rebased and then merged.

This PR is accompanied by a docs PR https://github.com/rabbitmq/rabbitmq-website/pull/2084.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Release note 

It should be mentioned in the release notes that `auth_oauth2.jwks_url` and `management.oauth_metadata_url` are deprecated and in 4.2.0 they will be removed.
Any reference to `auth_oauth2.jwks_url` should be renamed to `auth_oauth2.jwks_uri`. 
Any reference in the legacy schema to `rabbitmq_auth_backend_oauth2.key_config.jwks_url` should be replaced  by `rabbitmq_auth_backend_oauth2.jwks_uri`.
Any reference to `management.oauth_metadata_url` should be removed and instead configure the `auth_oauth2.discovery_endpoint_path` accordingly. There is a section in the docs that cover this in detail. Likewise with 
`management.oauth_resource_servers.$name.oauth_metadata_url`.

cc @pstack2021 