### PR TITLE
Fix function_clause

### DIFF
--- a/deps/rabbit/src/mc_compat.erl
+++ b/deps/rabbit/src/mc_compat.erl
@@ -94,7 +94,11 @@ set_annotation(?ANN_TIMESTAMP, Millis,
                #basic_message{content = #content{properties = B} = C0} = Msg) ->
     C = C0#content{properties = B#'P_basic'{timestamp = Millis div 1000},
                    properties_bin = none},
-    Msg#basic_message{content = C}.
+    Msg#basic_message{content = C};
+set_annotation(delivery_count, _Value, #basic_message{} = Msg) ->
+    %% Ignore AMQP 1.0 specific delivery-count.
+    %% https://github.com/rabbitmq/rabbitmq-server/issues/12398
+    Msg.
 
 is_persistent(#basic_message{content = Content}) ->
     get_property(durable, Content).

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -100,7 +100,14 @@ amqpl_compat(_Config) ->
 
     XName= <<"exch">>,
     RoutingKey = <<"apple">>,
-    {ok, Msg} = rabbit_basic:message_no_id(XName, RoutingKey, Content),
+    {ok, Msg00} = rabbit_basic:message_no_id(XName, RoutingKey, Content),
+
+    %% Quorum queues set the AMQP 1.0 specific annotation delivery_count.
+    %% This should be a no-op for mc_compat.
+    Msg0 = mc:set_annotation(delivery_count, 1, Msg00),
+    %% However, annotation x-delivery-count has a meaning for mc_compat messages.
+    Msg = mc:set_annotation(<<"x-delivery-count">>, 2, Msg0),
+    ?assertEqual({long, 2}, mc:x_header(<<"x-delivery-count">>, Msg)),
 
     ?assertEqual(98, mc:priority(Msg)),
     ?assertEqual(false, mc:is_persistent(Msg)),


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/12398

The mc annotation `delivery_count` is a new mc annotation specifically used in the header section of AMQP 1.0 messages:
https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header

Hence, we can ignore this annotation for the old `#basic_message{}`.

I manually checked that this fixes the crash as described in https://github.com/rabbitmq/rabbitmq-server/issues/12398#issuecomment-2382317937

It's hard to write an integration test since even mixed version testing won't provide any help here given that feature flag `message_containers` is required starting with `v4.0.0`.