### PR TITLE
Represent `rabbit_binding:deletions()` with a map instead of dict

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1818,8 +1818,8 @@ internal_delete(Queue, ActingUser, Reason) ->
         {error, timeout} = Err ->
             Err;
         Deletions ->
-            _ = rabbit_binding:process_deletions(Deletions),
-            rabbit_binding:notify_deletions(Deletions, ?INTERNAL_USER),
+            ok = rabbit_binding:process_deletions(Deletions),
+            ok = rabbit_binding:notify_deletions(Deletions, ?INTERNAL_USER),
             rabbit_core_metrics:queue_deleted(QueueName),
             ok = rabbit_event:notify(queue_deleted,
                                      [{name, QueueName},
@@ -1942,14 +1942,14 @@ filter_transient_queues_to_delete(Node) ->
     end.
 
 notify_queue_binding_deletions(QueueDeletions) when is_list(QueueDeletions) ->
-    Deletions = rabbit_binding:process_deletions(
-                  lists:foldl(fun rabbit_binding:combine_deletions/2,
-                              rabbit_binding:new_deletions(),
-                              QueueDeletions)),
+    Deletions = lists:foldl(
+                  fun rabbit_binding:combine_deletions/2,
+                  rabbit_binding:new_deletions(), QueueDeletions),
+    ok = rabbit_binding:process_deletions(Deletions),
     rabbit_binding:notify_deletions(Deletions, ?INTERNAL_USER);
 notify_queue_binding_deletions(QueueDeletions) ->
-    Deletions = rabbit_binding:process_deletions(QueueDeletions),
-    rabbit_binding:notify_deletions(Deletions, ?INTERNAL_USER).
+    ok = rabbit_binding:process_deletions(QueueDeletions),
+    rabbit_binding:notify_deletions(QueueDeletions, ?INTERNAL_USER).
 
 notify_transient_queues_deleted(QueueDeletions) ->
     lists:foreach(

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -302,7 +302,10 @@ delete_in_mnesia(Src, Dst, B) ->
                     should_index_table(Src), fun delete/3),
     Deletions0 = maybe_auto_delete_exchange_in_mnesia(
                    B#binding.source, [B], rabbit_binding:new_deletions(), false),
-    fun() -> {ok, rabbit_binding:process_deletions(Deletions0)} end.
+    fun() ->
+            ok = rabbit_binding:process_deletions(Deletions0),
+            {ok, Deletions0}
+    end.
 
 absent_errs_only_in_mnesia(Names) ->
     Errs = [E || Name <- Names,
@@ -352,7 +355,8 @@ delete_in_khepri(#binding{source = SrcName,
         {error, _} = Err ->
             Err;
         Deletions ->
-            {ok, rabbit_binding:process_deletions(Deletions)}
+            ok = rabbit_binding:process_deletions(Deletions),
+            {ok, Deletions}
     end.
 
 exists_in_khepri(Path, Binding) ->
@@ -379,15 +383,18 @@ delete_in_khepri(Binding) ->
     end.
 
 maybe_auto_delete_exchange_in_khepri(XName, Bindings, Deletions, OnlyDurable) ->
-    {Entry, Deletions1} =
-        case rabbit_db_exchange:maybe_auto_delete_in_khepri(XName, OnlyDurable) of
-            {not_deleted, X} ->
-                {{X, not_deleted, Bindings}, Deletions};
-            {deleted, X, Deletions2} ->
-                {{X, deleted, Bindings},
-                 rabbit_binding:combine_deletions(Deletions, Deletions2)}
-        end,
-    rabbit_binding:add_deletion(XName, Entry, Deletions1).
+    case rabbit_db_exchange:maybe_auto_delete_in_khepri(XName, OnlyDurable) of
+        {not_deleted, undefined} ->
+            Deletions;
+        {not_deleted, X} ->
+            rabbit_binding:add_deletion(
+              XName, X, not_deleted, Bindings, Deletions);
+        {deleted, X, Deletions1} ->
+            Deletions2 = rabbit_binding:combine_deletions(
+                           Deletions, Deletions1),
+            rabbit_binding:add_deletion(
+              XName, X, deleted, Bindings, Deletions2)
+    end.
 
 %% -------------------------------------------------------------------
 %% get_all().
@@ -1152,15 +1159,18 @@ sync_index_route(_, _, _) ->
       OnlyDurable :: boolean(),
       Ret :: rabbit_binding:deletions().
 maybe_auto_delete_exchange_in_mnesia(XName, Bindings, Deletions, OnlyDurable) ->
-    {Entry, Deletions1} =
-        case rabbit_db_exchange:maybe_auto_delete_in_mnesia(XName, OnlyDurable) of
-            {not_deleted, X} ->
-                {{X, not_deleted, Bindings}, Deletions};
-            {deleted, X, Deletions2} ->
-                {{X, deleted, Bindings},
-                 rabbit_binding:combine_deletions(Deletions, Deletions2)}
-        end,
-    rabbit_binding:add_deletion(XName, Entry, Deletions1).
+    case rabbit_db_exchange:maybe_auto_delete_in_mnesia(XName, OnlyDurable) of
+        {not_deleted, undefined} ->
+            Deletions;
+        {not_deleted, X} ->
+            rabbit_binding:add_deletion(
+              XName, X, not_deleted, Bindings, Deletions);
+        {deleted, X, Deletions1} ->
+            Deletions2 = rabbit_binding:combine_deletions(
+                           Deletions, Deletions1),
+            rabbit_binding:add_deletion(
+              XName, X, deleted, Bindings, Deletions2)
+    end.
 
 %% Instead of locking entire table on remove operations we can lock the
 %% affected resource only.

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -573,7 +573,7 @@ next_serial_in_khepri_tx(#exchange{name = XName}) ->
       IfUnused :: boolean(),
       Exchange :: rabbit_types:exchange(),
       Binding :: rabbit_types:binding(),
-      Deletions :: dict:dict(),
+      Deletions :: rabbit_binding:deletions(),
       Ret :: {deleted, Exchange, [Binding], Deletions} |
              {error, not_found} |
              {error, in_use} |
@@ -624,7 +624,7 @@ unconditional_delete_in_mnesia(X, OnlyDurable) ->
       RemoveBindingsForSource :: boolean(),
       Exchange :: rabbit_types:exchange(),
       Binding :: rabbit_types:binding(),
-      Deletions :: dict:dict(),
+      Deletions :: rabbit_binding:deletions(),
       Ret :: {error, not_found} | {error, in_use} | {deleted, Exchange, [Binding], Deletions}.
 delete_in_mnesia(X = #exchange{name = XName}, OnlyDurable, RemoveBindingsForSource) ->
     ok = mnesia:delete({?MNESIA_TABLE, XName}),
@@ -695,7 +695,7 @@ delete_all_in_mnesia_tx(VHostName) ->
               {deleted, #exchange{name = XName}, Bindings, XDeletions} =
               unconditional_delete_in_mnesia( X, false),
               XDeletions1 = rabbit_binding:add_deletion(
-                              XName, {X, deleted, Bindings}, XDeletions),
+                              XName, X, deleted, Bindings, XDeletions),
               rabbit_binding:combine_deletions(Acc, XDeletions1)
       end, rabbit_binding:new_deletions(), Xs),
     {ok, Deletions}.
@@ -716,7 +716,7 @@ delete_all_in_khepri_tx(VHostName) ->
                 rabbit_db_binding:delete_all_for_exchange_in_khepri(
                   X, false, true),
               Deletions1 = rabbit_binding:add_deletion(
-                             XName, {X, deleted, Bindings}, XDeletions),
+                             XName, X, deleted, Bindings, XDeletions),
               rabbit_binding:combine_deletions(Deletions, Deletions1)
       end, rabbit_binding:new_deletions(), NodeProps),
     {ok, Deletions}.

--- a/deps/rabbit/test/rabbit_db_binding_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_binding_SUITE.erl
@@ -131,8 +131,8 @@ delete1(_Config) ->
     Ret = rabbit_db_binding:delete(Binding, fun(_, _) -> ok end),
     ?assertMatch({ok, _}, Ret),
     {ok, Deletions} = Ret,
-    ?assertMatch({#exchange{}, not_deleted, [#binding{}], none},
-                 dict:fetch(XName1, Deletions)),
+    ?assertMatch({#exchange{}, not_deleted, [#binding{}]},
+                 rabbit_binding:fetch_deletion(XName1, Deletions)),
     ?assertEqual(false, rabbit_db_binding:exists(Binding)),
     passed.
 
@@ -152,8 +152,8 @@ auto_delete1(_Config) ->
     Ret = rabbit_db_binding:delete(Binding, fun(_, _) -> ok end),
     ?assertMatch({ok, _}, Ret),
     {ok, Deletions} = Ret,
-    ?assertMatch({#exchange{}, deleted, [#binding{}], none},
-                 dict:fetch(XName1, Deletions)),
+    ?assertMatch({#exchange{}, not_deleted, [#binding{}]},
+                 rabbit_binding:fetch_deletion(XName1, Deletions)),
     ?assertEqual(false, rabbit_db_binding:exists(Binding)),
     passed.
 

--- a/deps/rabbit/test/rabbit_db_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_queue_SUITE.erl
@@ -292,8 +292,8 @@ delete1(_Config) ->
     ?assertEqual({ok, Q}, rabbit_db_queue:get(QName)),
     %% TODO Can we handle the deletions outside of rabbit_db_queue? Probably not because
     %% they should be done in a single transaction, but what a horrid API to have!
-    Dict = rabbit_db_queue:delete(QName, normal),
-    ?assertEqual(0, dict:size(Dict)),
+    Deletions = rabbit_db_queue:delete(QName, normal),
+    ?assertEqual(rabbit_binding:new_deletions(), Deletions),
     ?assertEqual(ok, rabbit_db_queue:delete(QName, normal)),
     ?assertEqual({error, not_found}, rabbit_db_queue:get(QName)),
     passed.


### PR DESCRIPTION
This is a mainly cosmetic refactor that makes the types of `rabbit_binding:deletions()` clearer and easier to work with.

The `dict:dict()` typing of `rabbit_binding` appears to be a historical artifact. `dict` has been superseded by `maps`. Switching to a map makes deletions easier to inspect manually and faster. Though if deletions grow so large that the map representation is important, manipulation of the deletions is unlikely to be expensive compared to any other operations that produced them, so performance is probably irrelevant.

This commit refactors the bottom section of the `rabbit_binding` module to switch to a map, switch the `deletions()` type to an opaque, eliminating a TODO created when using Erlang/OTP 17.1, and the deletion value to a record. We eliminate some historical artifacts and "cruft":

* Deletions taking multiple forms needlessly, specifically the shape `{X, deleted | not_deleted, Bindings, none}` no longer being handled. `process_deletions/2` was responsible for creating this shape. Instead we now use a record to clearly define the fields.
* Clauses to catch `{error, not_found}` are unnecessary after minor refactors of the callers. Removing them makes the type specs cleaner.
* `rabbit_binding:process_deletions/1` has no need to update or change the deletions. This function uses `maps:foreach/2` instead and returns `ok` instead of mapped deletions.
* Remove `undefined` from the typespec of deletions. This value is no longer possible with a refactor to `maybe_auto_delete_exchange_in_*` functions for Mnesia and Khepri. The value was nonsensical since you cannot delete bindings for an exchange that does not exist.