### PR TITLE
Add a rabbit.license_line default

### DIFF
--- a/deps/rabbit/BUILD.bazel
+++ b/deps/rabbit/BUILD.bazel
@@ -132,13 +132,10 @@ _APP_ENV = """[
         {credentials_obfuscation_fallback_secret, <<"nocookie">>},
         {dead_letter_worker_consumer_prefetch, 32},
         {dead_letter_worker_publisher_confirm_timeout, 180000},
-
-        %% EOL date for the current release series, if known/announced
-		{release_series_eol_date, none},
-
 		{vhost_process_reconciliation_run_interval, 30},
         %% for testing
-        {vhost_process_reconciliation_enabled, true}
+        {vhost_process_reconciliation_enabled, true},
+        {license_line, "Licensed under the MPL 2.0. Website: https://rabbitmq.com"}
 	  ]
 """
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -118,11 +118,10 @@ define PROJECT_ENV
 		{credentials_obfuscation_fallback_secret, <<"nocookie">>},
       	{dead_letter_worker_consumer_prefetch, 32},
       	{dead_letter_worker_publisher_confirm_timeout, 180000},
-		%% EOL date for the current release series, if known/announced
-		{release_series_eol_date, none},
 		{vhost_process_reconciliation_run_interval, 30},
 		%% for testing
-		{vhost_process_reconciliation_enabled, true}
+		{vhost_process_reconciliation_enabled, true},
+		{license_line, "Licensed under the MPL 2.0. Website: https://rabbitmq.com"}
 	  ]
 endef
 


### PR DESCRIPTION
so that products that build on top could adjust
what's printed in the standard banner.

References #12390
