### PR TITLE
Shutdown QQ peer members on force-shrink-to-single-member execution to allow restoring QQ clusters on healthy nodes

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -74,6 +74,7 @@
 -export([validate_policy/1, merge_policy_value/3]).
 
 -export([force_shrink_member_to_current_member/2,
+         force_vhost_queues_shrink_member_to_current_member/1,
          force_all_queues_shrink_member_to_current_member/0]).
 
 %% for backwards compatibility
@@ -1973,8 +1974,17 @@ force_shrink_member_to_current_member(VHost, Name) ->
             {error, not_found}
     end.
 
+force_vhost_queues_shrink_member_to_current_member(VHost) when is_binary(VHost) ->
+    rabbit_log:warning("Disaster recovery procedure: shrinking all quorum queues in vhost ~tp to a single node cluster", [VHost]),
+    ListQQs = fun() -> rabbit_amqqueue:list(VHost) end,
+    force_all_queues_shrink_member_to_current_member(ListQQs).
+
 force_all_queues_shrink_member_to_current_member() ->
     rabbit_log:warning("Disaster recovery procedure: shrinking all quorum queues to a single node cluster"),
+    ListQQs = fun() -> rabbit_amqqueue:list() end,
+    force_all_queues_shrink_member_to_current_member(ListQQs).
+
+force_all_queues_shrink_member_to_current_member(ListQQFun) when is_function(ListQQFun) ->
     Node = node(),
     _ = [begin
              QName = amqqueue:get_name(Q),
@@ -1989,7 +1999,7 @@ force_all_queues_shrink_member_to_current_member() ->
                    end,
              _ = rabbit_amqqueue:update(QName, Fun),
              _ = [ra:force_delete_server(?RA_SYSTEM, {RaName, N}) || N <- OtherNodes]
-         end || Q <- rabbit_amqqueue:list(), amqqueue:get_type(Q) == ?MODULE],
+         end || Q <- ListQQFun(), amqqueue:get_type(Q) == ?MODULE],
     rabbit_log:warning("Disaster recovery procedure: shrinking finished"),
     ok.
 

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -92,7 +92,9 @@ groups() ->
                                             format,
                                             add_member_2,
                                             single_active_consumer_priority_take_over,
-                                            single_active_consumer_priority
+                                            single_active_consumer_priority,
+                                            force_shrink_member_to_current_member,
+                                            force_all_queues_shrink_member_to_current_member
                                            ]
                        ++ all_tests()},
                       {cluster_size_5, [], [start_queue,
@@ -1150,6 +1152,85 @@ single_active_consumer_priority(Config) ->
     ?assertMatch({ok, {_, {value, {<<"ch1-ctag3">>, _}}}, _},
                 rpc:call(Server0, ra, local_query, [RaNameQ3, QueryFun])),
     ok.
+
+force_shrink_member_to_current_member(Config) ->
+    [Server0, Server1, Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    RaName = ra_name(QQ),
+    rabbit_ct_client_helpers:publish(Ch, QQ, 3),
+    wait_for_messages_ready([Server0], RaName, 3),
+
+    {ok, Q0} = rpc:call(Server0, rabbit_amqqueue, lookup, [QQ, <<"/">>]),
+    #{nodes := Nodes0} = amqqueue:get_type_state(Q0),
+    ?assertEqual(3, length(Nodes0)),
+
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_shrink_member_to_current_member, [<<"/">>, QQ]),
+
+    wait_for_messages_ready([Server0], RaName, 3),
+
+    {ok, Q1} = rpc:call(Server0, rabbit_amqqueue, lookup, [QQ, <<"/">>]),
+    #{nodes := Nodes1} = amqqueue:get_type_state(Q1),
+    ?assertEqual(1, length(Nodes1)),
+
+    %% grow queues back to all nodes
+    [rpc:call(Server0, rabbit_quorum_queue, grow, [S, <<"/">>, <<".*">>, all]) || S <- [Server1, Server2]],
+
+    wait_for_messages_ready([Server0], RaName, 3),
+    {ok, Q2} = rpc:call(Server0, rabbit_amqqueue, lookup, [QQ, <<"/">>]),
+    #{nodes := Nodes2} = amqqueue:get_type_state(Q2),
+    ?assertEqual(3, length(Nodes2)).
+
+force_all_queues_shrink_member_to_current_member(Config) ->
+    [Server0, Server1, Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    AQ = ?config(alt_queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+    ?assertEqual({'queue.declare_ok', AQ, 0, 0},
+                 declare(Ch, AQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    QQs = [QQ, AQ],
+
+    [begin
+        RaName = ra_name(Q),
+        rabbit_ct_client_helpers:publish(Ch, Q, 3),
+        wait_for_messages_ready([Server0], RaName, 3),
+        {ok, Q0} = rpc:call(Server0, rabbit_amqqueue, lookup, [Q, <<"/">>]),
+        #{nodes := Nodes0} = amqqueue:get_type_state(Q0),
+        ?assertEqual(3, length(Nodes0))
+    end || Q <- QQs],
+
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_all_queues_shrink_member_to_current_member, []),
+
+    [begin
+        RaName = ra_name(Q),
+        wait_for_messages_ready([Server0], RaName, 3),
+        {ok, Q0} = rpc:call(Server0, rabbit_amqqueue, lookup, [Q, <<"/">>]),
+        #{nodes := Nodes0} = amqqueue:get_type_state(Q0),
+        ?assertEqual(1, length(Nodes0))
+    end || Q <- QQs],
+
+    %% grow queues back to all nodes
+    [rpc:call(Server0, rabbit_quorum_queue, grow, [S, <<"/">>, <<".*">>, all]) || S <- [Server1, Server2]],
+
+    [begin
+        RaName = ra_name(Q),
+        wait_for_messages_ready([Server0], RaName, 3),
+        {ok, Q0} = rpc:call(Server0, rabbit_amqqueue, lookup, [Q, <<"/">>]),
+        #{nodes := Nodes0} = amqqueue:get_type_state(Q0),
+        ?assertEqual(3, length(Nodes0))
+    end || Q <- QQs].
 
 priority_queue_fifo(Config) ->
     %% testing: if hi priority messages are published before lo priority


### PR DESCRIPTION
## Proposed Changes

Hi 

This is a follow up to #12344 (bouncing off part of our approach to some DR scenarios in case of any unforeseen issues).

We rely on force-shrink commands to rescue QQ nodes in extreme disaster scenarios. Current behavior, when QQs are shrunk to a single node, connected peers keep their local FSMs running, which prevents re-growing the shrunk queues back onto connected nodes which would/could be in a healthy state. We expect peers to update their log to that of the leader on `grow` and/or the next received `#append_entries_rpc{}`.

Example, doing `force_all_queues_shrink_member_to_current_member/0`.

```
$> rabbitmq-queues quorum_status Q1
Status of quorum queue Q1 on node rabbit@host ...
┌─────────────────────┬────────────┬───────────┬──────────────┬────────────────┬──────┬─────────────────┐
│ Node Name           │ Raft State │ Log Index │ Commit Index │ Snapshot Index │ Term │ Machine Version │
├─────────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit_2@host │ follower   │ 233       │ 233          │ undefined      │ 16   │ 3               │
├─────────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit_1@host │ follower   │ 233       │ 233          │ undefined      │ 16   │ 3               │
├─────────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit@host   │ leader     │ 233       │ 233          │ undefined      │ 16   │ 3               │
└─────────────────────┴────────────┴───────────┴──────────────┴────────────────┴──────┴─────────────────┘


$> rabbitmqctl eval 'rabbit_quorum_queue:force_all_queues_shrink_member_to_current_member().'
ok


$> rabbitmq-queues quorum_status Q1
Status of quorum queue Q1 on node rabbit@host ...
┌───────────────────┬────────────┬───────────┬──────────────┬────────────────┬──────┬─────────────────┐
│ Node Name         │ Raft State │ Log Index │ Commit Index │ Snapshot Index │ Term │ Machine Version │
├───────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit@host │ leader     │ 235       │ 235          │ undefined      │ 17   │ 3               │
└───────────────────┴────────────┴───────────┴──────────────┴────────────────┴──────┴─────────────────┘

```

At this point, the cluster can't be restored. i.e. queues cant regrow back to the rest of the cluster (even if they're healthy).

With this patch, if after disaster scenario, part of the cluster nodes are reachable and healthy, we are able to proceed with the re-growing the QQs back to healthy nodes without undergoing major recovery procedures, as follows:

```
$> rabbitmq-queues grow 'rabbit_1@host' all --queue-pattern Q1
Growing all quorum queues on rabbit_1@host...
vhost	name	size	result
/	Q1	2	ok

$> rabbitmq-queues grow 'rabbit_2@host' all --queue-pattern Q1
Growing all quorum queues on rabbit_2@host...
vhost	name	size	result
/	Q1	3	ok


$> rabbitmq-queues quorum_status Q1
Status of quorum queue Q1 on node rabbit@host ...
┌─────────────────────┬────────────┬───────────┬──────────────┬────────────────┬──────┬─────────────────┐
│ Node Name           │ Raft State │ Log Index │ Commit Index │ Snapshot Index │ Term │ Machine Version │
├─────────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit_2@host │ follower   │ 237       │ 237          │ undefined      │ 17   │ 3               │
├─────────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit_1@host │ follower   │ 237       │ 237          │ undefined      │ 17   │ 3               │
├─────────────────────┼────────────┼───────────┼──────────────┼────────────────┼──────┼─────────────────┤
│ rabbit@host   │ leader     │ 237       │ 237          │ undefined      │ 17   │ 3               │
└─────────────────────┴────────────┴───────────┴──────────────┴────────────────┴──────┴─────────────────┘
```


This allows us to avoid unnecessarily doing major recovery procedures like complete wipe out of peers node and/or migrations and queue deletions/re-creation, etc, to restore the cluster. At this point of the cluster, the only other option is a complete re-deploy. 

As part of this PR/proposal, we also introduce `force_vhost_queues_shrink_member_to_current_member/1` which allows us to force-shink all QQs on a per-vhost basis (which we need/use for some our shared cluster environments).

Please take a look 😬 


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
