### PR TITLE
By @ayanda-D: make sure (non-replicated) CQs (classic queues) emit leader and members metrics, just like replicated QQs

### DIFF
--- a/.github/workflows/templates/test-mixed-versions.template.yaml
+++ b/.github/workflows/templates/test-mixed-versions.template.yaml
@@ -96,7 +96,7 @@ jobs:
           https://builds.hex.pm
           https://cdn.jsdelivr.net/hex
     - name: AUTHENTICATE TO GOOGLE CLOUD
-      uses: google-github-actions/auth@v2.1.5
+      uses: google-github-actions/auth@v2.1.6
       with:
         credentials_json: ${{ secrets.REMOTE_CACHE_CREDENTIALS_JSON }}
     - name: BUILD SECONDARY UMBRELLA ARCHIVE

--- a/.github/workflows/templates/test.template.yaml
+++ b/.github/workflows/templates/test.template.yaml
@@ -73,7 +73,7 @@ jobs:
       run: |
         echo "value=bazel-repo-cache-${{ hashFiles('MODULE.bazel') }}" | tee -a $GITHUB_OUTPUT
     - name: AUTHENTICATE TO GOOGLE CLOUD
-      uses: google-github-actions/auth@v2.1.5
+      uses: google-github-actions/auth@v2.1.6
       with:
         credentials_json: ${{ secrets.REMOTE_CACHE_CREDENTIALS_JSON }}
     - name: REPO CACHE

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -119,7 +119,8 @@
          arguments,
          owner_pid,
          exclusive,
-         user_who_performed_action
+         user_who_performed_action,
+         leader
         ]).
 
 -define(INFO_KEYS, [pid | ?CREATION_EVENT_KEYS ++ ?STATISTICS_KEYS -- [name, type]]).
@@ -1083,6 +1084,7 @@ i(auto_delete, #q{q = Q}) -> amqqueue:is_auto_delete(Q);
 i(arguments,   #q{q = Q}) -> amqqueue:get_arguments(Q);
 i(pid, _) ->
     self();
+i(leader, State) -> node(i(pid, State));
 i(owner_pid, #q{q = Q}) when ?amqqueue_exclusive_owner_is(Q, none) ->
     '';
 i(owner_pid, #q{q = Q}) ->

--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -120,7 +120,8 @@
          owner_pid,
          exclusive,
          user_who_performed_action,
-         leader
+         leader,
+         members
         ]).
 
 -define(INFO_KEYS, [pid | ?CREATION_EVENT_KEYS ++ ?STATISTICS_KEYS -- [name, type]]).
@@ -1085,6 +1086,7 @@ i(arguments,   #q{q = Q}) -> amqqueue:get_arguments(Q);
 i(pid, _) ->
     self();
 i(leader, State) -> node(i(pid, State));
+i(members, State) -> [i(leader, State)];
 i(owner_pid, #q{q = Q}) when ?amqqueue_exclusive_owner_is(Q, none) ->
     '';
 i(owner_pid, #q{q = Q}) ->

--- a/deps/rabbit/test/classic_queue_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_SUITE.erl
@@ -83,7 +83,8 @@ leader_locator_client_local(Config) ->
                                       {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
          {ok, Leader0} = rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, lookup, [rabbit_misc:r(<<"/">>, queue, Q)]),
          Leader = amqqueue:qnode(Leader0),
-         ?assertEqual([{leader, Leader}], rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, info, [Leader0, [leader]])),
+         ?assertEqual([{leader, Leader}, {members, [Leader]}],
+            rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, info, [Leader0, [leader, members]])),
          ?assertEqual(Server, Leader),
          ?assertMatch(#'queue.delete_ok'{},
                       amqp_channel:call(Ch, #'queue.delete'{queue = Q}))

--- a/deps/rabbit/test/classic_queue_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_SUITE.erl
@@ -83,6 +83,7 @@ leader_locator_client_local(Config) ->
                                       {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
          {ok, Leader0} = rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, lookup, [rabbit_misc:r(<<"/">>, queue, Q)]),
          Leader = amqqueue:qnode(Leader0),
+         ?assertEqual([{leader, Leader}], rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, info, [Leader0, [leader]])),
          ?assertEqual(Server, Leader),
          ?assertMatch(#'queue.delete_ok'{},
                       amqp_channel:call(Ch, #'queue.delete'{queue = Q}))

--- a/deps/rabbit/test/classic_queue_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_SUITE.erl
@@ -83,8 +83,6 @@ leader_locator_client_local(Config) ->
                                       {<<"x-queue-leader-locator">>, longstr, <<"client-local">>}])),
          {ok, Leader0} = rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, lookup, [rabbit_misc:r(<<"/">>, queue, Q)]),
          Leader = amqqueue:qnode(Leader0),
-         ?assertEqual([{leader, Leader}, {members, [Leader]}],
-            rabbit_ct_broker_helpers:rpc(Config, Server, rabbit_amqqueue, info, [Leader0, [leader, members]])),
          ?assertEqual(Server, Leader),
          ?assertMatch(#'queue.delete_ok'{},
                       amqp_channel:call(Ch, #'queue.delete'{queue = Q}))


### PR DESCRIPTION
This is #12422 by @Ayanda-D with a different title and a slightly different explanation from me.

This change may seem controversial at first given the removal of classic queue mirroring starting with 4.0 but this is just a matter of unifying metric keys between non-replicated CQs and replicated QQs.

So with this change, CQs will report a leader and a list of members (of one node, just the leader) as stats keys. For `v4.0.x`, this seems perfectly fine.

In fact, this will help improve https://github.com/rabbitmq/rabbitmqadmin-ng with its stricter JSON deserializer (compared to the original Python script).