### PR TITLE
rabbit_feature_flags: Improve logging

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -744,7 +744,7 @@ get_stability(FeatureName) when is_atom(FeatureName) ->
         undefined    -> undefined;
         FeatureProps -> get_stability(FeatureProps)
     end;
-get_stability(FeatureProps) when  ?IS_FEATURE_FLAG(FeatureProps) ->
+get_stability(FeatureProps) when ?IS_FEATURE_FLAG(FeatureProps) ->
     maps:get(stability, FeatureProps, stable);
 get_stability(FeatureProps) when ?IS_DEPRECATION(FeatureProps) ->
     Phase = rabbit_deprecated_features:get_phase(FeatureProps),

--- a/deps/rabbit/src/rabbit_ff_controller.erl
+++ b/deps/rabbit/src/rabbit_ff_controller.erl
@@ -888,12 +888,14 @@ enable_many(#{states_per_node := _} = Inventory, FeatureNames) ->
       Ret :: ok | {error, Reason},
       Reason :: term().
 
-enable_many_locked(#{states_per_node := _} = Inventory, [FeatureName | Rest]) ->
+enable_many_locked(
+  #{states_per_node := _} = Inventory, [FeatureName | Rest]) ->
     case enable_if_supported(Inventory, FeatureName) of
         {ok, Inventory1} -> enable_many_locked(Inventory1, Rest);
         Error            -> Error
     end;
-enable_many_locked(_Inventory, []) ->
+enable_many_locked(
+  _Inventory, []) ->
     ok.
 
 -spec enable_if_supported(Inventory, FeatureName) -> Ret when


### PR DESCRIPTION
Here are the changes to the logging in the Feature flags subsystem:

*   Showing that required feature flags are enabled over and over is not useful and only adds noise to the logs. Required feature flags and removed deprecated features are not lists explicitly anymore. We just log their respective numbers to still be clear that they exist.

    Before:
    ```
    list of feature flags found:
      [x] classic_mirrored_queue_version
      [x] classic_queue_type_delivery_support
      [x] direct_exchange_routing_v2
      [x] feature_flags_v2
      [x] implicit_default_bindings
      [ ] khepri_db
      [x] message_containers_deaths_v2
      [x] quorum_queue_non_voters
      [~] rabbit_exchange_type_local_random
      [x] rabbitmq_4.0.0
      ...
    list of deprecated features found:
      [ ] amqp_address_v1
      [x] classic_queue_mirroring
      [ ] global_qos
      [ ] queue_master_locator
      [ ] ram_node_type
      [ ] transient_nonexcl_queues
    ```

    After:
    ```
    list of feature flags found:
      [ ] khepri_db
      [x] message_containers_deaths_v2
      [x] quorum_queue_non_voters
      [~] rabbit_exchange_type_local_random
      [x] rabbitmq_4.0.0
    list of deprecated features found:
      [ ] amqp_address_v1
      [ ] global_qos
      [ ] queue_master_locator
      [ ] ram_node_type
      [ ] transient_nonexcl_queues
    required feature flags not listed above: 18
    removed deprecated features not listed above: 1
    ```

*   The inventory map is huge and difficult to read when it is logged as is. Logging a matrix is much more compact and to the point.

    Before:
    ```
    inventory of node `rabbit-1@giotto`:
    #{feature_flags =>
          #{rabbit_exchange_type_local_random =>
                #{name => rabbit_exchange_type_local_random,
                  desc => "Local random exchange",stability => stable,
                  provided_by => rabbit},
            message_containers_deaths_v2 =>
                #{name => message_containers_deaths_v2,
                  desc => "Bug fix for dead letter cycle detection",
    ...
    ```

    After:
    ```
    inventory queried from node `rabbit-1@giotto`:
                                           ,-- rabbit-1@giotto
                                           |  ,-- rabbit-2@giotto
                                           |  |
                         amqp_address_v1:
          classic_mirrored_queue_version:  x  x
                 classic_queue_mirroring:  x  x
     classic_queue_type_delivery_support:  x  x
    ...
    ```