### PR TITLE
Don't start invalid but enabled plugins at startup

### DIFF
--- a/deps/rabbit/src/rabbit_plugins.erl
+++ b/deps/rabbit/src/rabbit_plugins.erl
@@ -265,7 +265,7 @@ prepare_plugins(Enabled) ->
                                       [ExpandDir, E2]}})
     end,
     [prepare_plugin(Plugin, ExpandDir) || Plugin <- ValidPlugins],
-    Wanted.
+    [P#plugin.name || P <- ValidPlugins].
 
 maybe_warn_about_invalid_plugins([]) ->
     ok;


### PR DESCRIPTION
## Proposed Changes

For example during the startup after RabbitMQ was upgraded but an enabled community plugin wasn't, and the plugin's broker version requirement isn't met any more, RabbitMQ still started the plugin after logging an error.

This was also reported by a message deduplication plugin user https://github.com/noxdafox/rabbitmq-message-deduplication/issues/112#issuecomment-2380848771. In that plugin's case it causes issues because in its boot step the plugin registers a queue decorator which is not compatible with 4.0 (and causes undef crashes)

This patch modifies `rabbit_plugins:setup/0` to only return valid plugins. That list is used by `rabbit:start/2` to load and start the plugin apps and run their boot steps. 

I tested this manually using the delayed message exchange plugin.

manual test steps in a rabbitmq-server repo (using MacOS sed):
```
make run-broker TEST_TMPDIR="/tmp/rabbitmq/"
cp rabbitmq_delayed_message_exchange-3.13.0.ez ./plugins/
sbin/rabbitmqctl stop_app
sed -i "" "s/\]\.$/\,rabbitmq_delayed_message_exchange\]\./" /tmp/rabbitmq/rabbit@<hostname>/enabled_plugins
sbin/rabbitmqctl start_app
```
with this patch both of the bellow should return false
```
sbin/rabbitmqctl eval 'lists:keyfind(rabbitmq_delayed_message_exchange, 1, application:which_applications()).'
false
sbin/rabbitmqctl eval 'lists:keyfind(rabbitmq_delayed_message_exchange, 1, application:loaded_applications()).'
false
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
