### PR TITLE
Remove mention of global prefetch

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -305,15 +305,12 @@ var HELP = {
       </dl>',
 
     'channel-prefetch':
-      'Channel prefetch counts. \
+      'Channel prefetch count.\
        <p> \
-         Each channel can have two prefetch counts: A per-consumer count, which \
-         will limit each new consumer created on the channel, and a global \
-         count, which is shared between all consumers on the channel.\
+         Each channel can have a prefetch count. The prefetch is the number of messages that will be held \
+         by the client. Setting a value of 0 will result in an unlimited prefetch. \
        </p> \
-       <p> \
-         This column shows one, the other, or both limits if they are set. \
-       </p>',
+       ',
 
     'file-descriptors':
       '<p>File descriptor count and limit, as reported by the operating \


### PR DESCRIPTION
## Proposed Changes

RabbitMQ 4.0 removes Global prefetch (https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements#removal-of-global-qos). This is a step to remove mentions of global prefetch in the in-product docs.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

https://www.rabbitmq.com/docs/consumer-prefetch would need more in-depth changes.
