### PR TITLE
Remove multiple mentions of global prefetch from management UI, CLI, man pages

### DIFF
--- a/deps/rabbit/docs/rabbitmqctl.8
+++ b/deps/rabbit/docs/rabbitmqctl.8
@@ -942,8 +942,6 @@ The number of not yet confirmed published messages.
 On channels not in confirm mode, this remains 0.
 .It Cm prefetch_count
 QoS prefetch limit for new consumers, 0 if unlimited.
-.It Cm global_prefetch_count
-QoS prefetch limit for the entire channel, 0 if unlimited.
 .El
 .Pp
 If no

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -184,7 +184,6 @@
          acks_uncommitted,
          pending_raft_commands,
          prefetch_count,
-         global_prefetch_count,
          state,
          garbage_collection]).
 
@@ -2272,6 +2271,8 @@ i(pending_raft_commands,   #ch{queue_states = QS}) ->
 i(state,                   #ch{cfg = #conf{state = running}}) -> credit_flow:state();
 i(state,                   #ch{cfg = #conf{state = State}}) -> State;
 i(prefetch_count,          #ch{cfg = #conf{consumer_prefetch = C}})    -> C;
+%% Retained for backwards compatibility e.g. in mixed version clusters,
+%% can be removed starting with 4.2. MK.
 i(global_prefetch_count, #ch{limiter = Limiter}) ->
     rabbit_limiter:get_prefetch_limit(Limiter);
 i(interceptors, #ch{interceptor_state = IState}) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
@@ -16,7 +16,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
   @info_keys ~w(pid connection name number user vhost transactional
                 confirm consumer_count messages_unacknowledged
                 messages_uncommitted acks_uncommitted messages_unconfirmed
-                prefetch_count global_prefetch_count)a
+                prefetch_count)a
 
   def info_keys(), do: @info_keys
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -305,15 +305,12 @@ var HELP = {
       </dl>',
 
     'channel-prefetch':
-      'Channel prefetch counts. \
+      'Channel prefetch count.\
        <p> \
-         Each channel can have two prefetch counts: A per-consumer count, which \
-         will limit each new consumer created on the channel, and a global \
-         count, which is shared between all consumers on the channel.\
+         Each channel can have a prefetch count. The prefetch is the number of messages that will be held \
+         by the client. Setting a value of 0 will result in an unlimited prefetch. \
        </p> \
-       <p> \
-         This column shows one, the other, or both limits if they are set. \
-       </p>',
+       ',
 
     'file-descriptors':
       '<p>File descriptor count and limit, as reported by the operating \

--- a/deps/rabbitmq_management/priv/www/js/tmpl/channel.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/channel.ejs
@@ -38,10 +38,6 @@
     <th>Prefetch count</th>
     <td><%= channel.prefetch_count %></td>
   </tr>
-  <tr>
-    <th>Global prefetch count</th>
-    <td><%= channel.global_prefetch_count %></td>
-  </tr>
 </table>
 
 <table class="facts">

--- a/deps/rabbitmq_management/priv/www/js/tmpl/channels-list.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/channels-list.ejs
@@ -157,9 +157,6 @@
       <% if (channel.prefetch_count != 0) { %>
         <%= channel.prefetch_count %><br/>
       <% } %>
-      <% if (channel.global_prefetch_count != 0) { %>
-        <%= channel.global_prefetch_count %> (global)
-      <% } %>
     </td>
 <% } %>
 <% if (show_column('channels', 'msgs-unacked')) { %>

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -170,7 +170,7 @@
         {2, undefined, channel_messages_uncommitted, gauge, "Messages received in a transaction but not yet committed", messages_uncommitted},
         {2, undefined, channel_acks_uncommitted, gauge, "Message acknowledgements in a transaction not yet committed", acks_uncommitted},
         {2, undefined, consumer_prefetch, gauge, "Limit of unacknowledged messages for each consumer", prefetch_count},
-        {2, undefined, channel_prefetch, gauge, "Total limit of unacknowledged messages for all consumers on a channel", global_prefetch_count}
+        {2, undefined, channel_prefetch, gauge, "Deprecated and will be removed in a future version", global_prefetch_count}
     ]},
 
     {channel_exchange_metrics, [


### PR DESCRIPTION
As suggested by @johanrhodin in https://github.com/rabbitmq/rabbitmq-server/pull/12454.

This keeps the Prometheus plugin part but
marks it as deprecated. We can remove it in
4.1.