### PR TITLE
By @gomoripeti: Don't start invalid but enabled plugins at startup

### DIFF
--- a/deps/rabbit/src/rabbit_plugins.erl
+++ b/deps/rabbit/src/rabbit_plugins.erl
@@ -265,7 +265,7 @@ prepare_plugins(Enabled) ->
                                       [ExpandDir, E2]}})
     end,
     [prepare_plugin(Plugin, ExpandDir) || Plugin <- ValidPlugins],
-    Wanted.
+    [P#plugin.name || P <- ValidPlugins].
 
 maybe_warn_about_invalid_plugins([]) ->
     ok;


### PR DESCRIPTION
This is #12449 by @gomoripeti.