### PR TITLE
4.0.x: Dependency CSV updated from 3.2.0 to 3.2.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -140,8 +140,8 @@ erlang_package.hex_package(
 erlang_package.hex_package(
     name = "csv",
     build_file = "@rabbitmq-server//bazel:BUILD.csv",
-    sha256 = "f5ee7299a55ff84fbe623d9aea7218b800d19ecccb2b3eac2bcb327d644365ea",
-    version = "3.2.0",
+    sha256 = "8f55a0524923ae49e97ff2642122a2ce7c61e159e7fe1184670b2ce847aee6c8",
+    version = "3.2.1",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -5,7 +5,7 @@ DEPS = csv json observer_cli stdout_formatter
 TEST_DEPS = amqp amqp_client temp x509 rabbit
 
 dep_amqp = hex 3.3.0
-dep_csv = hex 3.2.0
+dep_csv = hex 3.2.1
 dep_json = hex 1.4.1
 dep_temp = hex 0.4.7
 dep_x509 = hex 0.8.8


### PR DESCRIPTION
This is https://github.com/rabbitmq/rabbitmq-server/pull/12470 by @SimonUnge submitted against the `v4.0.x` branch. 

Submitting because access to GH secrets has broken again for external contributors and #12473 is not yet ready to be merged for reasons that have nothing to do with the change itself.