### PR TITLE
4.1/main: Make CI: Temporarily disable tests with OTP-27

### DIFF
--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         erlang_version:
         - '26'
-        - '27'
+#        - '27'
         elixir_version:
         - '1.17'
         metadata_store:


### PR DESCRIPTION
There are two known OTP-27 bugs making tests fail. Until they are fixed (OTP-27.1.2 most likely) we
disable OTP-27 for tests.