### PR TITLE
Actions: try disabling AppArmor

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -52,11 +52,10 @@ jobs:
       run: |
         sudo apt-get update && \
         sudo apt-get install -y \
-          apparmor-utils \
           ldap-utils \
           slapd
 
-        sudo aa-complain `which slapd`
+        sudo service apparmor stop
 
     - name: RUN TESTS
       if: inputs.plugin != 'rabbitmq_cli'

--- a/.github/workflows/test-plugin-mixed.yaml
+++ b/.github/workflows/test-plugin-mixed.yaml
@@ -95,11 +95,10 @@ jobs:
       run: |
         sudo apt-get update && \
         sudo apt-get install -y \
-          apparmor-utils \
           ldap-utils \
           slapd
 
-        sudo aa-complain `which slapd`
+        sudo service apparmor stop
 
         cat << EOF >> user.bazelrc
           build --strategy=TestRunner=local

--- a/.github/workflows/test-plugin.yaml
+++ b/.github/workflows/test-plugin.yaml
@@ -95,11 +95,10 @@ jobs:
       run: |
         sudo apt-get update && \
         sudo apt-get install -y \
-          apparmor-utils \
           ldap-utils \
           slapd
 
-        sudo aa-complain `which slapd`
+        sudo service apparmor stop
 
         cat << EOF >> user.bazelrc
           build --strategy=TestRunner=local


### PR DESCRIPTION
To avoid running into [this error](https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg6062316.html):

```
ERROR: Operation {'runbindable'} cannot have a source. Source = AARE('/')
```

Relevant: https://github.com/actions/runner-images/pull/10024.