### PR TITLE
AMQP filter expressions: handle invalid filters

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_filtex.erl
+++ b/deps/rabbit/src/rabbit_amqp_filtex.erl
@@ -119,9 +119,16 @@ validate0(Descriptor, KVList0) when
     KVList = lists:map(fun({{utf8, Key}, {utf8, String}}) ->
                                {Key, parse_string_modifier_prefix(String)};
                           ({{utf8, Key}, TaggedVal}) ->
-                               {Key, unwrap(TaggedVal)}
+                               {Key, unwrap(TaggedVal)};
+                          (_) ->
+                               invalid_filter
                        end, KVList0),
-    {ok, {application_properties, KVList}};
+    case lists:member(invalid_filter, KVList) of
+        false ->
+            {ok, {application_properties, KVList}};
+        true ->
+            error
+    end;
 validate0(_, _) ->
     error.
 


### PR DESCRIPTION
An invalid application property filter could cause a function_clause that was returned to the client, eg `omq` output looked like this:
```
2024/10/15 13:10:55 ERRO consumer failed to create a receiver id=1
  error=
  │ *Error{Condition: amqp:internal-error, Description: Session error: function_clause
  │ [{rabbit_amqp_filtex,'-validate0/2-fun-0-',
  │                      [{{symbol,<<"subject">>},{utf8,<<"var">>}}],
  │                      [{file,"rabbit_amqp_filtex.erl"},{line,119}]},
  │  {lists,map,2,[{file,"lists.erl"},{line,2077}]},
  │  {rabbit_amqp_filtex,validate0,2,[{file,"rabbit_amqp_filtex.erl"},{line,119}]},
  │  {rabbit_amqp_filtex,validate,1,[{file,"rabbit_amqp_filtex.erl"},{line,28}]},
  │  {rabbit_amqp_session,parse_filters,2,
  │                       [{file,"rabbit_amqp_session.erl"},{line,3068}]},
  │  {rabbit_amqp_session,parse_filter,1,
  │                       [{file,"rabbit_amqp_session.erl"},{line,3014}]},
  │  {rabbit_amqp_session,'-handle_attach/2-fun-0-',21,
  │                       [{file,"rabbit_amqp_session.erl"},{line,1371}]},
  │
  {rabbit_misc,with_exit_handler,2,[{file,"rabbit_misc.erl"},{line,465}]}],
  Info: map[]}
```

Now such filters are ignored.