### PR TITLE
QQ: improve `rabbit_quorum_queue:status/2` efficiency by allowing it to use `ra:key_metrics/1`

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1160,7 +1160,7 @@ cluster_state(Name) ->
 
 key_metrics_rpc(ServerId) ->
     Metrics = ra:key_metrics(ServerId),
-    Metrics#{machine_version := rabbit_fifo:version()}.
+    Metrics#{machine_version => rabbit_fifo:version()}.
 
 -spec status(rabbit_types:vhost(), Name :: rabbit_misc:resource_name()) ->
     [[{binary(), term()}]] | {error, term()}.


### PR DESCRIPTION
Currently the `rabbit_quorum_queue:status/2` function always falls back to the (slower) compatibility code and never gets the benefit of using `ra:key_metrics/1` due to incorrect use of the map update operatior `:=` instead of the insert operator `=>`.

