### PR TITLE
Make CI: Use ubuntu-22.04 for the time being

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   test:
     name: ${{ inputs.plugin }} (${{ inputs.make_target }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
     - name: CHECKOUT REPOSITORY


### PR DESCRIPTION
There are .NET related issues in 24 that we don't
want to look at right now.
