### PR TITLE
Fix error message

### DIFF
--- a/deps/rabbit/test/amqp_system_SUITE.erl
+++ b/deps/rabbit/test/amqp_system_SUITE.erl
@@ -98,19 +98,19 @@ build_dotnet_test_project(Config) ->
             rabbit_ct_helpers:set_config(
               Config, {dotnet_test_project_dir, TestProjectDir});
         _ ->
-            {skip, "Failed to fetch .NET Core test project dependencies"}
+            ct:fail({"'dotnet restore' failed", Ret})
     end.
 
 build_maven_test_project(Config) ->
     TestProjectDir = filename:join([?config(data_dir, Config), "java-tests"]),
     Ret = rabbit_ct_helpers:exec([TestProjectDir ++ "/mvnw", "test-compile"],
-      [{cd, TestProjectDir}]),
+                                 [{cd, TestProjectDir}]),
     case Ret of
         {ok, _} ->
             rabbit_ct_helpers:set_config(Config,
-              {maven_test_project_dir, TestProjectDir});
+                                         {maven_test_project_dir, TestProjectDir});
         _ ->
-            {skip, "Failed to build Maven test project"}
+            ct:fail({"'mvnw test-compile' failed", Ret})
     end.
 
 %% -------------------------------------------------------------------


### PR DESCRIPTION
Prior to this commit if dotnet or mvnw failed to fetch test dependencies, for example because dotnet isn't installed, the test setup crashed in an unexpected way:
```
amqp_system_SUITE > dotnet
    {'EXIT',
        {badarg,
            [{lists,keysearch,
                 [rmq_nodes,1,
                  {skip,
                      "Failed to fetch .NET Core test project dependencies"}],
                 [{error_info,#{module => erl_stdlib_errors}}]},
             {test_server,lookup_config,2,
                 [{file,"test_server.erl"},{line,1779}]},
             {rabbit_ct_broker_helpers,get_node_configs,2,
                 [{file,"rabbit_ct_broker_helpers.erl"},{line,1411}]},
             {rabbit_ct_broker_helpers,enable_feature_flag,2,
                 [{file,"rabbit_ct_broker_helpers.erl"},{line,1999}]},
             {amqp_system_SUITE,init_per_group,2,
                 [{file,"amqp_system_SUITE.erl"},{line,77}]},
             {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
             {test_server,run_test_case_eval1,6,
                 [{file,"test_server.erl"},{line,1391}]},
             {test_server,run_test_case_eval,9,
                 [{file,"test_server.erl"},{line,1235}]}]}}
```

This commit improves the error message instead of failing with `badarg`.

This commit also decides to fail the test setup instead of skipping the suite because we always want CI to execute this test and be notified instead of silently skipping if the test can't be run.