### PR TITLE
Make CI: Check that CI knows about all CT_SUITES in CI

### DIFF
--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -44,6 +44,12 @@ jobs:
           https://builds.hex.pm
           https://cdn.jsdelivr.net/hex
 
+    - name: SANITY CHECK (rabbit)
+      run: make -C deps/rabbit parallel-ct-sanity-check
+
+    - name: SANITY CHECK (rabbitmq_mqtt)
+      run: make -C deps/rabbitmq_mqtt parallel-ct-sanity-check
+
     - name: BUILD
       run: make
 

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -279,8 +279,18 @@ PARALLEL_CT_SET_4 = $(sort $(PARALLEL_CT_SET_4_A) $(PARALLEL_CT_SET_4_B) $(PARAL
 SEQUENTIAL_CT_SUITES = clustering_management dead_lettering feature_flags metadata_store_clustering quorum_queue rabbit_stream_queue
 PARALLEL_CT_SUITES = $(PARALLEL_CT_SET_1) $(PARALLEL_CT_SET_2) $(PARALLEL_CT_SET_3) $(PARALLEL_CT_SET_4)
 
-ifneq ($(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES)),)
-$(error Some test suites in CT_SUITES but not configured for CI: $(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES)))
+ifeq ($(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES)),)
+parallel-ct-sanity-check:
+	$(verbose) :
+else
+parallel-ct-sanity-check:
+	$(verbose) printf "%s\n" \
+		"In order for new test suites to be run in CI, the test suites" \
+		"must be added to one of the PARALLEL_CT_SET_<N>_<M> variables." \
+		"" \
+		"The following test suites are missing:" \
+		"$(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES))"
+	$(verbose) exit 1
 endif
 
 define tpl_parallel_ct_test_spec

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -102,8 +102,18 @@ PARALLEL_CT_SET_1_D = mqtt_shared
 
 PARALLEL_CT_SUITES = $(PARALLEL_CT_SET_1_A) $(PARALLEL_CT_SET_1_B) $(PARALLEL_CT_SET_1_C) $(PARALLEL_CT_SET_1_D)
 
-ifneq ($(filter-out $(PARALLEL_CT_SUITES),$(CT_SUITES)),)
-$(error Some test suites in CT_SUITES but not configured for CI: $(filter-out $(PARALLEL_CT_SUITES),$(CT_SUITES)))
+ifeq ($(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES)),)
+parallel-ct-sanity-check:
+	$(verbose) :
+else
+parallel-ct-sanity-check:
+	$(verbose) printf "%s\n" \
+		"In order for new test suites to be run in CI, the test suites" \
+		"must be added to one of the PARALLEL_CT_SET_<N>_<M> variables." \
+		"" \
+		"The following test suites are missing:" \
+		"$(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES))"
+	$(verbose) exit 1
 endif
 
 define tpl_parallel_ct_test_spec


### PR DESCRIPTION
Instead of every time we run Make for these applications.

This means that during development we are free to modify these values or create new test suites without having to worry about the check. If we forget to then add the test suites in PARALLEL_CT the workflow will tell us.
