### PR TITLE
Make CI: Upload CT's log_private for failed runs

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -77,5 +77,5 @@ jobs:
         name: CT logs (${{ inputs.plugin }} ${{ inputs.make_target }} OTP-${{ inputs.erlang_version }} ${{ inputs.metadata_store }})
         path: |
           logs/
-          !logs/**/log_private
+#          !logs/**/log_private
         if-no-files-found: ignore


### PR DESCRIPTION
All test runs produce artifacts of less than 12MB in size which
is acceptable as it is fast to produce, upload and download.
Most test runs are actually below 1MB.