### PR TITLE
Optionally notify client app with AMQP performative

### DIFF
--- a/deps/amqp10_client/src/amqp10_client.erl
+++ b/deps/amqp10_client/src/amqp10_client.erl
@@ -144,6 +144,8 @@ begin_session_sync(Connection, Timeout) when is_pid(Connection) ->
             receive
                 {amqp10_event, {session, Session, begun}} ->
                     {ok, Session};
+                {amqp10_event, {session, Session, {begun, #'v1_0.begin'{}}}} ->
+                    {ok, Session};
                 {amqp10_event, {session, Session, {ended, Err}}} ->
                     {error, Err}
             after Timeout -> session_timeout
@@ -185,6 +187,8 @@ attach_sender_link_sync(Session, Name, Target, SettleMode, Durability) ->
                                    Durability),
     receive
         {amqp10_event, {link, Ref, attached}} ->
+            {ok, Ref};
+        {amqp10_event, {link, Ref, {attached, #'v1_0.attach'{}}}} ->
             {ok, Ref};
         {amqp10_event, {link, Ref, {detached, Err}}} ->
             {error, Err}

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -4611,9 +4611,7 @@ idle_time_out_on_client(Config) ->
     receive
         {amqp10_event,
          {connection, Connection,
-          {closed,
-           {resource_limit_exceeded,
-            <<"remote idle-time-out">>}}}} -> ok
+          {closed, _}}} -> ok
     after 5000 ->
               ct:fail({missing_event, ?LINE})
     end,

--- a/deps/rabbit/test/amqp_system_SUITE.erl
+++ b/deps/rabbit/test/amqp_system_SUITE.erl
@@ -52,6 +52,11 @@ groups() ->
 %% Testsuite setup/teardown.
 %% -------------------------------------------------------------------
 
+suite() ->
+    [
+      {timetrap, {minutes, 3}}
+    ].
+
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
     Config.

--- a/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl
+++ b/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl
@@ -97,6 +97,8 @@ await_attached(Ref) ->
     receive
         {amqp10_event, {link, Ref, attached}} ->
             ok;
+        {amqp10_event, {link, Ref, {attached, #'v1_0.attach'{}}}} ->
+            ok;
         {amqp10_event, {link, Ref, {detached, Err}}} ->
             {error, Err}
     after ?TIMEOUT ->
@@ -128,6 +130,8 @@ detach(Ref) ->
 await_detached(Ref) ->
     receive
         {amqp10_event, {link, Ref, {detached, normal}}} ->
+            ok;
+        {amqp10_event, {link, Ref, {detached, #'v1_0.detach'{}}}} ->
             ok;
         {amqp10_event, {link, Ref, {detached, Err}}} ->
             {error, Err}


### PR DESCRIPTION
This commit notifies the client app with the AMQP performatives open, begin, attach, detach, end, and close if connection config `notify_with_performative` is set to `true`.

This allows the client app to learn about all fields including properties and capabilities returned by the AMQP server and helps in writing RabbiMQ integration tests.
