### PR TITLE
Try running test suites on Ubuntu 24.04

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   test:
     name: ${{ inputs.plugin }} (${{ inputs.make_target }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
     - name: CHECKOUT REPOSITORY

--- a/.github/workflows/test-plugin-mixed.yaml
+++ b/.github/workflows/test-plugin-mixed.yaml
@@ -21,7 +21,7 @@ on:
         required: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
to avoid slapd(8) segfaulting on Ubuntu 22.04,
which "ubuntu-latest" uses despite [1].

Per discussion with @lukebakken.

1. https://github.com/actions/runner-images/issues/9848
