### PR TITLE
Use OS trusted CA certs if not provided by the user

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_frame_reader.erl
+++ b/deps/amqp10_client/src/amqp10_client_frame_reader.erl
@@ -105,7 +105,8 @@ init([Sup, ConnConfig]) when is_map(ConnConfig) ->
             {ok, expecting_connection_pid, State}
     end.
 
-connect(Address, Port, #{tls_opts := {secure_port, Opts}}) ->
+connect(Address, Port, #{tls_opts := {secure_port, Opts0}}) ->
+    Opts = rabbit_ssl_options:fix_client(Opts0),
     case ssl:connect(Address, Port, ?RABBIT_TCP_OPTS ++ Opts) of
       {ok, S} ->
           {ssl, S};

--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -137,7 +137,7 @@ do_connect({Addr, Family},
                          [Family | ?RABBIT_TCP_OPTS] ++ ExtraOpts,
                          Timeout) of
         {ok, Sock} ->
-            SslOpts = rabbit_ssl_options:fix(
+            SslOpts = rabbit_ssl_options:fix_client(
                         orddict:to_list(
                           orddict:merge(fun (_, _A, B) -> B end,
                                         orddict:from_list(GlobalSslOpts),

--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -205,7 +205,7 @@ do_http_req(Path0, Query) ->
 ssl_options() ->
     case application:get_env(rabbitmq_auth_backend_http, ssl_options) of
         {ok, Opts0} when is_list(Opts0) ->
-            Opts1 = [{ssl, rabbit_networking:fix_ssl_options(Opts0)}],            
+            Opts1 = [{ssl, rabbit_ssl_options:fix_client(Opts0)}],            
             case application:get_env(rabbitmq_auth_backend_http, ssl_hostname_verification) of
                 {ok, wildcard} ->
                     rabbit_log:debug("Enabling wildcard-aware hostname verification for HTTP client connections"),

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -761,7 +761,7 @@ ssl_conf() ->
     end.
 
 ssl_options() ->
-    Opts0 = rabbit_networking:fix_ssl_options(env(ssl_options)),
+    Opts0 = rabbit_ssl_options:fix_client(env(ssl_options)),
     case env(ssl_hostname_verification, undefined) of
         wildcard ->
             rabbit_log_ldap:debug("Enabling wildcard-aware hostname verification for LDAP client connections"),


### PR DESCRIPTION
## Proposed Changes
Provides a specific function to fix client ssl options, i.e.: apply all fixes that are applied for TLS listeneres and clients on previous versions but also sets `cacerts` option to CA certificates obtained by `public_key:cacerts_get/0`, only when no `cacertfile` or `cacerts` are provided.

Addressing #10519 


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Should we also apply this fix for TLS server options? Or is it fine if we only use OS trusted CA certs for TLS client options, as done in the provided changes?
