### PR TITLE
#12557: fall back to system-wide CA certificates (if available) when none are configured for AMQP 1.0 and AMQP 0-9-1 clients such as shovels

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_frame_reader.erl
+++ b/deps/amqp10_client/src/amqp10_client_frame_reader.erl
@@ -105,7 +105,8 @@ init([Sup, ConnConfig]) when is_map(ConnConfig) ->
             {ok, expecting_connection_pid, State}
     end.
 
-connect(Address, Port, #{tls_opts := {secure_port, Opts}}) ->
+connect(Address, Port, #{tls_opts := {secure_port, Opts0}}) ->
+    Opts = rabbit_ssl_options:fix_client(Opts0),
     case ssl:connect(Address, Port, ?RABBIT_TCP_OPTS ++ Opts) of
       {ok, S} ->
           {ssl, S};

--- a/deps/amqp_client/src/amqp_network_connection.erl
+++ b/deps/amqp_client/src/amqp_network_connection.erl
@@ -137,7 +137,7 @@ do_connect({Addr, Family},
                          [Family | ?RABBIT_TCP_OPTS] ++ ExtraOpts,
                          Timeout) of
         {ok, Sock} ->
-            SslOpts = rabbit_ssl_options:fix(
+            SslOpts = rabbit_ssl_options:fix_client(
                         orddict:to_list(
                           orddict:merge(fun (_, _A, B) -> B end,
                                         orddict:from_list(GlobalSslOpts),

--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -205,7 +205,7 @@ do_http_req(Path0, Query) ->
 ssl_options() ->
     case application:get_env(rabbitmq_auth_backend_http, ssl_options) of
         {ok, Opts0} when is_list(Opts0) ->
-            Opts1 = [{ssl, rabbit_networking:fix_ssl_options(Opts0)}],            
+            Opts1 = [{ssl, rabbit_ssl_options:fix_client(Opts0)}],            
             case application:get_env(rabbitmq_auth_backend_http, ssl_hostname_verification) of
                 {ok, wildcard} ->
                     rabbit_log:debug("Enabling wildcard-aware hostname verification for HTTP client connections"),

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -761,7 +761,7 @@ ssl_conf() ->
     end.
 
 ssl_options() ->
-    Opts0 = rabbit_networking:fix_ssl_options(env(ssl_options)),
+    Opts0 = rabbit_ssl_options:fix_client(env(ssl_options)),
     case env(ssl_hostname_verification, undefined) of
         wildcard ->
             rabbit_log_ldap:debug("Enabling wildcard-aware hostname verification for LDAP client connections"),


### PR DESCRIPTION
This is #12557 by @LoisSotoLopez.