### PR TITLE
Bump IBM MQ image used for interoperability testing to 9.4.0

### DIFF
--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
   IBM_MQ_REPOSITORY: ibm-messaging/mq-container
   IBM_MQ_BRANCH_NAME: 9.4.0
-  IMAGE_TAG: 9.4.0-amd64
+  IMAGE_TAG: 9.4.0.5-amd64
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -13,7 +13,7 @@ on:
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
   IBM_MQ_REPOSITORY: ibm-messaging/mq-container
-  IBM_MQ_BRANCH_NAME: 9.4.0.5
+  IBM_MQ_BRANCH_NAME: 9.4.0
   IMAGE_TAG: 9.4.0.5-amd64
 jobs:
   docker:

--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
   IBM_MQ_REPOSITORY: ibm-messaging/mq-container
   IBM_MQ_BRANCH_NAME: 9.4.0
-  IMAGE_TAG: 9.4.0.5-amd64
+  IMAGE_TAG: 9.4.0-amd64
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ibm-mq-make.yaml
+++ b/.github/workflows/ibm-mq-make.yaml
@@ -13,8 +13,8 @@ on:
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/ibm-mqadvanced-server-dev
   IBM_MQ_REPOSITORY: ibm-messaging/mq-container
-  IBM_MQ_BRANCH_NAME: 9.3.5
-  IMAGE_TAG: 9.3.5.1-amd64
+  IBM_MQ_BRANCH_NAME: 9.4.0.5
+  IMAGE_TAG: 9.4.0.5-amd64
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is the image Team RabbitMQ builds internally for interop testing. It has AMQP 1.0 protocol enabled.