### PR TITLE
QQ periodic membership reconciliation: correctly return a `ra:members/2` error in case of a timeout

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue_periodic_membership_reconciliation.erl
@@ -143,7 +143,7 @@ reconciliate_quorum_members(ExpectedNodes, Running, [Q | LocalLeaders],
                              OldResult) ->
     Result =
         maybe
-            {ok, Members, {_, LeaderNode}} = ra:members(amqqueue:get_pid(Q), 500),
+            {ok, Members, {_, LeaderNode}} ?= ra:members(amqqueue:get_pid(Q), 500),
             %% Check if Leader is indeed this node
             LeaderNode ?= node(),
             %% And that this not is not in maintenance mode


### PR DESCRIPTION
## Proposed Changes
Minor type-O that causes a timeout return to not be caught.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
