### PR TITLE
Delete test access_failure

### DIFF
--- a/deps/rabbit/test/amqp_system_SUITE.erl
+++ b/deps/rabbit/test/amqp_system_SUITE.erl
@@ -38,7 +38,6 @@ groups() ->
           routing,
           invalid_routes,
           auth_failure,
-          access_failure,
           access_failure_not_allowed,
           access_failure_send,
           streams
@@ -216,18 +215,6 @@ invalid_routes(Config) ->
 
 auth_failure(Config) ->
     run(Config, [ {dotnet, "auth_failure"} ]).
-
-access_failure(Config) ->
-    User = atom_to_binary(?FUNCTION_NAME),
-    ok = rabbit_ct_broker_helpers:add_user(Config, User, <<"boo">>),
-    ok = rabbit_ct_broker_helpers:set_permissions(Config, User, <<"/">>,
-                                                  <<".*">>, %% configure
-                                                  <<"^banana.*">>, %% write
-                                                  <<"^banana.*">>  %% read
-                                                 ),
-    run(Config, [ {dotnet, "access_failure"} ]),
-    ok = rabbit_ct_broker_helpers:delete_user(Config, User).
-
 
 access_failure_not_allowed(Config) ->
     User = atom_to_binary(?FUNCTION_NAME),

--- a/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs
+++ b/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs
@@ -466,20 +466,6 @@ module Test =
             printfn "Exception %A" ex
             ()
 
-    let accessFailure uri =
-        try
-            let u = Uri uri
-            let uri = sprintf "amqp://access_failure:boo@%s:%i" u.Host u.Port
-            use ac = connect uri
-            let src = "/queues/test"
-            let receiver = ReceiverLink(ac.Session, "test-receiver", src)
-            receiver.Close()
-            failwith "expected exception not received"
-        with
-        | :? Amqp.AmqpException as ex ->
-            printfn "Exception %A" ex
-            ()
-
     let accessFailureNotAllowed uri =
         try
             let u = Uri uri
@@ -504,9 +490,6 @@ let main argv =
     match List.ofArray argv with
     | [AsLower "auth_failure"; uri] ->
         authFailure uri
-        0
-    | [AsLower "access_failure"; uri] ->
-        accessFailure uri
         0
     | [AsLower "access_failure_not_allowed"; uri] ->
         accessFailureNotAllowed uri


### PR DESCRIPTION
This test flakes in CI as described in
https://github.com/rabbitmq/rabbitmq-server/issues/12413#issuecomment-2419293869

The test case fails with
```
Node: rabbit_shard2@localhost
Case: amqp_system_SUITE:access_failure
Reason: {error,{{badmatch,{error,134,
                                 "Unhandled exception. System.Exception: expected exception not received
                                 at Program.Test.accessFailure(String uri) in /home/runner/work/rabbitmq-server/rabbitmq-server/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs:line 477
                                 at Program.main(String[] argv) in /home/runner/work/rabbitmq-server/rabbitmq-server/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/Program.fs:line 509\n"}},
                [{amqp_system_SUITE,run_dotnet_test,2,
                                    [{file,"amqp_system_SUITE.erl"},
                                     {line,257}]},
```

However, RabbitMQ closes the session as expected due to the missing read permissions to the queue as shown in the RabbitMQ logs:
```
[debug] <0.1321.0> Asked to create a new user 'access_failure', password length in bytes: 24
[info] <0.1321.0> Created user 'access_failure'
[debug] <0.1324.0> Asked to set permissions for user 'access_failure' in virtual host '/' to '.*', '^banana.*', '^banana.*'
[info] <0.1324.0> Successfully set permissions for user 'access_failure' in virtual host '/' to '.*', '^banana.*', '^banana.*'
[info] <0.1333.0> accepting AMQP connection 127.0.0.1:36248 -> 127.0.0.1:25000
[debug] <0.1333.0> User 'access_failure' authenticated successfully by backend rabbit_auth_backend_internal
[info] <0.1333.0> Connection from AMQP 1.0 container 'AMQPNetLite-101d7d51': user 'access_failure' authenticated using SASL mechanism PLAIN and granted access to vhost '/'
[debug] <0.1333.0> AMQP 1.0 connection.open frame: hostname = 127.0.0.1, extracted vhost = /, idle-time-out = undefined
[debug] <0.1333.0> AMQP 1.0 created session process <0.1338.0> for channel number 0
[warning] <0.1338.0> Closing session for connection <0.1333.0>: {'v1_0.error',
[warning] <0.1338.0>                                             {symbol,
[warning] <0.1338.0>                                              <<"amqp:unauthorized-access">>},
[warning] <0.1338.0>                                             {utf8,
[warning] <0.1338.0>                                              <<"read access to queue 'test' in vhost '/' refused for user 'access_failure'">>},
[warning] <0.1338.0>                                             undefined}
[debug] <0.1333.0> AMQP 1.0 closed session process <0.1338.0> with channel number 0
[warning] <0.1333.0> closing AMQP connection <0.1333.0> (127.0.0.1:36248 -> 127.0.0.1:25000, duration: '269ms'):
[warning] <0.1333.0> client unexpectedly closed TCP connection
```

```
let receiver = ReceiverLink(ac.Session, "test-receiver", src)
```
uses a null constructur for the onAttached callback. ReceiverLink doesn't seem to block.

Given that the exact same authorization error is already tested in test case attach_source_queue of amqp_auth_SUITE, it's safe to delete this F# test.