### PR TITLE
Fix metrics_SUITE connection_metrics flake

### DIFF
--- a/deps/rabbit/test/metrics_SUITE.erl
+++ b/deps/rabbit/test/metrics_SUITE.erl
@@ -208,9 +208,11 @@ connection_metric_count(Config, Ops) ->
                      fun(Cfg) ->
                              rabbit_ct_client_helpers:close_connection(Cfg)
                      end},
-                   [ connection_created,
-                     connection_metrics,
-                     connection_coarse_metrics ]).
+                    %% connection_metrics are asynchronous,
+                    %% emitted on a timer. These have been removed
+                    %% from here as they're already tested on another
+                    %% testcases
+                    [ connection_created ]).
 
 channel_metric_count(Config, Ops) ->
     Conn =  rabbit_ct_client_helpers:open_unmanaged_connection(Config),


### PR DESCRIPTION
connection_metrics and connection_coarse_metrics are asynchronous to opening a connection, and checking them is not the most suitable for the proper testcase (we would need to introduce a wait for condition). As they're tested in other cases, we can remove them from here as this often flakes on CI