### PR TITLE
MQTT, x.509 certificate-based authentication: use the correct key name for the TLS SAN type configuration parameter

### DIFF
--- a/deps/rabbitmq_ct_helpers/tools/tls-certs/openssl.cnf.in
+++ b/deps/rabbitmq_ct_helpers/tools/tls-certs/openssl.cnf.in
@@ -63,3 +63,6 @@ DNS.2 = localhost
 
 [ client_alt_names ]
 DNS.1 = rabbit_client_id
+DNS.2 = rabbit_client_id_ext
+email.1 = rabbit_client@localhost
+URI.1 = rabbit_client_id_uri

--- a/deps/rabbitmq_mqtt/BUILD.bazel
+++ b/deps/rabbitmq_mqtt/BUILD.bazel
@@ -136,7 +136,7 @@ rabbitmq_integration_suite(
         "test/rabbit_auth_backend_mqtt_mock.beam",
         "test/util.beam",
     ],
-    shard_count = 18,
+    shard_count = 22,
     runtime_deps = [
         "@emqtt//:erlang_app",
         "@meck//:erlang_app",

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -2331,8 +2331,8 @@ extract_ssl_cert_client_id_settings() ->
 
 extract_client_id_san_type(Mode) ->
     {Mode,
-        application:get_env(?APP_NAME, ssl_cert_client_id_san_type, dns),
-        application:get_env(?APP_NAME, ssl_cert_client_id_san_index, 0)
+        application:get_env(?APP_NAME, ssl_cert_login_san_type, dns),
+        application:get_env(?APP_NAME, ssl_cert_login_san_index, 0)
     }.
 
 

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -205,7 +205,7 @@ mqtt_config(ssl_user_with_client_id_in_cert_san_dns) ->
     {rabbitmq_mqtt, [{ssl_cert_login,  true},
                      {allow_anonymous, false}, 
                      {ssl_cert_client_id_from, subject_alternative_name},
-                     {ssl_cert_client_id_san_type, dns}]};
+                     {ssl_cert_login_san_type, dns}]};
 mqtt_config(ssl_user_with_client_id_in_cert_dn) ->
     {rabbitmq_mqtt, [{ssl_cert_login,  true},
                      {allow_anonymous, false}, 

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -72,6 +72,12 @@ sub_groups() ->
        [client_id_from_cert_san_dns,
         invalid_client_id_from_cert_san_dns
        ]},
+     {ssl_user_with_client_id_in_cert_san_dns_1, [], 
+       [client_id_from_cert_san_dns_1        
+       ]},
+     {ssl_user_with_client_id_in_cert_san_email, [], 
+       [client_id_from_cert_san_email     
+       ]},            
      {ssl_user_with_client_id_in_cert_dn, [], 
        [client_id_from_cert_dn
        ]},  
@@ -206,6 +212,17 @@ mqtt_config(ssl_user_with_client_id_in_cert_san_dns) ->
                      {allow_anonymous, false}, 
                      {ssl_cert_client_id_from, subject_alternative_name},
                      {ssl_cert_login_san_type, dns}]};
+mqtt_config(ssl_user_with_client_id_in_cert_san_dns_1) ->
+    {rabbitmq_mqtt, [{ssl_cert_login,  true},
+                     {allow_anonymous, false}, 
+                     {ssl_cert_client_id_from, subject_alternative_name},
+                     {ssl_cert_login_san_type, dns},
+                     {ssl_cert_login_san_index, 1}]}; 
+mqtt_config(ssl_user_with_client_id_in_cert_san_email) ->
+    {rabbitmq_mqtt, [{ssl_cert_login,  true},
+                     {allow_anonymous, false}, 
+                     {ssl_cert_client_id_from, subject_alternative_name},
+                     {ssl_cert_login_san_type, email}]};                                       
 mqtt_config(ssl_user_with_client_id_in_cert_dn) ->
     {rabbitmq_mqtt, [{ssl_cert_login,  true},
                      {allow_anonymous, false}, 
@@ -216,6 +233,8 @@ mqtt_config(_) ->
 
 auth_config(T) when T == client_id_propagation; 
                     T == ssl_user_with_client_id_in_cert_san_dns;
+                    T == ssl_user_with_client_id_in_cert_san_dns_1;
+                    T == ssl_user_with_client_id_in_cert_san_email;
                     T == ssl_user_with_client_id_in_cert_dn ->
     {rabbit, [
             {auth_backends, [rabbit_auth_backend_mqtt_mock]}
@@ -316,6 +335,8 @@ init_per_testcase(T, Config)
   when T =:= client_id_propagation;
        T =:= invalid_client_id_from_cert_san_dns;
        T =:= client_id_from_cert_san_dns;
+       T =:= client_id_from_cert_san_dns_1;
+       T =:= client_id_from_cert_san_email;
        T =:= client_id_from_cert_dn ->
     SetupProcess = setup_rabbit_auth_backend_mqtt_mock(Config),
     rabbit_ct_helpers:set_config(Config, {mock_setup_process, SetupProcess});
@@ -444,6 +465,8 @@ end_per_testcase(T, Config)
    when T =:= client_id_propagation;
        T =:= invalid_client_id_from_cert_san_dns;
        T =:= client_id_from_cert_san_dns;
+       T =:= client_id_from_cert_san_dns_1;
+       T =:= client_id_from_cert_san_email;
        T =:= client_id_from_cert_dn ->
     SetupProcess = ?config(mock_setup_process, Config),
     SetupProcess ! stop;
@@ -500,7 +523,31 @@ user_credentials_auth(Config) ->
         Config).
 
 client_id_from_cert_san_dns(Config) ->    
-    ExpectedClientId = <<"rabbit_client_id">>, % Found in the client's certificate as SAN type CLIENT_ID 
+    ExpectedClientId = <<"rabbit_client_id">>, % Found in the client's certificate as SAN type DNS 
+    MqttClientId = ExpectedClientId,
+    {ok, C} = connect_ssl(MqttClientId, Config),
+    {ok, _} = emqtt:connect(C),
+    [{authentication, AuthProps}] = rpc(Config, 0,
+                                        rabbit_auth_backend_mqtt_mock,
+                                        get,
+                                        [authentication]),
+    ?assertEqual(ExpectedClientId, proplists:get_value(client_id, AuthProps)),
+    ok = emqtt:disconnect(C).
+
+client_id_from_cert_san_dns_1(Config) ->    
+    ExpectedClientId = <<"rabbit_client_id_ext">>, % Found in the client's certificate as SAN type DNS
+    MqttClientId = ExpectedClientId,
+    {ok, C} = connect_ssl(MqttClientId, Config),
+    {ok, _} = emqtt:connect(C),
+    [{authentication, AuthProps}] = rpc(Config, 0,
+                                        rabbit_auth_backend_mqtt_mock,
+                                        get,
+                                        [authentication]),
+    ?assertEqual(ExpectedClientId, proplists:get_value(client_id, AuthProps)),
+    ok = emqtt:disconnect(C).
+
+client_id_from_cert_san_email(Config) ->    
+    ExpectedClientId = <<"rabbit_client@localhost">>, % Found in the client's certificate as SAN type email
     MqttClientId = ExpectedClientId,
     {ok, C} = connect_ssl(MqttClientId, Config),
     {ok, _} = emqtt:connect(C),


### PR DESCRIPTION
## Proposed Changes

It fixes an issue caused when the `mqtt.ssl_cert_client_id_san_type` was renamed in the schema to 'mqtt.ssl_cert_login_san_type` to keep it consistent with how the username is determined. But one part of the code was not updated accordingly. 

Adding a selenium end-2-end test so that this kind of issues are spotted earlier. 

References https://github.com/rabbitmq/rabbitmq-server/discussions/12595.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #12595)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

