### PR TITLE
Fix rabbitmq_federation queue_SUITE flake

### DIFF
--- a/deps/rabbitmq_federation/test/federation_status_command_SUITE.erl
+++ b/deps/rabbitmq_federation/test/federation_status_command_SUITE.erl
@@ -95,12 +95,12 @@ run_federated(Config) ->
               timer:sleep(3000),
               {stream, [Props]} = ?CMD:run([], Opts#{only_down => false}),
               <<"upstream">> = proplists:get_value(upstream_queue, Props),
-              <<"fed.downstream">> = proplists:get_value(queue, Props),
+              <<"fed1.downstream">> = proplists:get_value(queue, Props),
               <<"fed.tag">> = proplists:get_value(consumer_tag, Props),
               running = proplists:get_value(status, Props)
       end,
       [rabbit_federation_test_util:q(<<"upstream">>),
-       rabbit_federation_test_util:q(<<"fed.downstream">>)]),
+       rabbit_federation_test_util:q(<<"fed1.downstream">>)]),
     %% Down
     rabbit_federation_test_util:with_ch(
       Config,
@@ -108,7 +108,7 @@ run_federated(Config) ->
               {stream, []} = ?CMD:run([], Opts#{only_down => true})
       end,
       [rabbit_federation_test_util:q(<<"upstream">>),
-       rabbit_federation_test_util:q(<<"fed.downstream">>)]).
+       rabbit_federation_test_util:q(<<"fed1.downstream">>)]).
 
 run_down_federated(Config) ->
     [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
@@ -128,7 +128,7 @@ run_down_federated(Config) ->
                 end, 15000)
       end,
       [rabbit_federation_test_util:q(<<"upstream">>),
-       rabbit_federation_test_util:q(<<"fed.downstream">>)]),
+       rabbit_federation_test_util:q(<<"fed1.downstream">>)]),
     %% Down
     rabbit_federation_test_util:with_ch(
       Config,
@@ -142,12 +142,12 @@ run_down_federated(Config) ->
                 end, 15000)
       end,
       [rabbit_federation_test_util:q(<<"upstream">>),
-       rabbit_federation_test_util:q(<<"fed.downstream">>)]).
+       rabbit_federation_test_util:q(<<"fed1.downstream">>)]).
 
 output_federated(Config) ->
     [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Opts = #{node => A},
-    Input = {stream,[[{queue, <<"fed.downstream">>},
+    Input = {stream,[[{queue, <<"fed1.downstream">>},
                       {consumer_tag, <<"fed.tag">>},
                       {upstream_queue, <<"upstream">>},
                       {type, queue},
@@ -157,7 +157,7 @@ output_federated(Config) ->
                       {local_connection, <<"<rmq-ct-federation_status_command_SUITE-1-21000@localhost.1.563.0>">>},
                       {uri, <<"amqp://localhost:21000">>},
                       {timestamp, {{2016,11,21},{8,51,19}}}]]},
-    {stream, [#{queue := <<"fed.downstream">>,
+    {stream, [#{queue := <<"fed1.downstream">>,
                 upstream_queue := <<"upstream">>,
                 type := queue,
                 vhost := <<"/">>,

--- a/deps/rabbitmq_federation/test/rabbit_federation_test_util.erl
+++ b/deps/rabbitmq_federation/test/rabbit_federation_test_util.erl
@@ -96,12 +96,17 @@ setup_federation_with_upstream_params(Config, ExtraParams) ->
 
     rabbit_ct_broker_helpers:rpc(
       Config, 0, rabbit_policy, set,
-      [<<"/">>, <<"fed">>, <<"^fed\.">>, [{<<"federation-upstream-set">>, <<"upstream">>}],
+      [<<"/">>, <<"fed">>, <<"^fed1\.">>, [{<<"federation-upstream-set">>, <<"upstream">>}],
        0, <<"all">>, <<"acting-user">>]),
 
     rabbit_ct_broker_helpers:rpc(
       Config, 0, rabbit_policy, set,
-      [<<"/">>, <<"fed12">>, <<"^fed12\.">>, [{<<"federation-upstream-set">>, <<"upstream12">>}],
+      [<<"/">>, <<"fed2">>, <<"^fed2\.">>, [{<<"federation-upstream-set">>, <<"upstream2">>}],
+       0, <<"all">>, <<"acting-user">>]),
+
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0, rabbit_policy, set,
+      [<<"/">>, <<"fed12">>, <<"^fed3\.">>, [{<<"federation-upstream-set">>, <<"upstream12">>}],
        2, <<"all">>, <<"acting-user">>]),
 
     rabbit_ct_broker_helpers:set_policy(Config, 0,
@@ -144,10 +149,10 @@ setup_down_federation(Config) ->
         {<<"queue">>, <<"upstream">>}]]),
     rabbit_ct_broker_helpers:set_policy(
       Config, 0,
-      <<"fed">>, <<"^fed\.">>, <<"all">>, [{<<"federation-upstream-set">>, <<"upstream">>}]),
+      <<"fed">>, <<"^fed1\.">>, <<"all">>, [{<<"federation-upstream-set">>, <<"upstream">>}]),
     rabbit_ct_broker_helpers:set_policy(
       Config, 0,
-      <<"fed">>, <<"^fed\.">>, <<"all">>, [{<<"federation-upstream-set">>, <<"upstream">>}]),
+      <<"fed">>, <<"^fed1\.">>, <<"all">>, [{<<"federation-upstream-set">>, <<"upstream">>}]),
     Config.
 
 wait_for_federation(Retries, Fun) ->

--- a/deps/rabbitmq_federation/test/restart_federation_link_command_SUITE.erl
+++ b/deps/rabbitmq_federation/test/restart_federation_link_command_SUITE.erl
@@ -87,7 +87,7 @@ run(Config) ->
               ok = ?CMD:run([Id], Opts)
       end,
       [rabbit_federation_test_util:q(<<"upstream">>),
-       rabbit_federation_test_util:q(<<"fed.downstream">>)]).
+       rabbit_federation_test_util:q(<<"fed1.downstream">>)]).
 
 run_not_found(Config) ->
     [A] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
queue_SUITE: use a different upstream for each queue on multi-federation tests
