### PR TITLE
rabbit_prometheus_http_SUITE: Start broker once in `special_chars` group

### DIFF
--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -248,7 +248,7 @@ init_per_group(special_chars, Config0) ->
                {connection, VHostConn},
                {channel, VHostCh}
                |Config1],
-    init_per_group(special_chars, Config2, []);
+    Config2;
 
 init_per_group(authentication, Config) ->
     Config1 = rabbit_ct_helpers:merge_app_env(


### PR DESCRIPTION
`init_per_group/3`, which starts the broker, was already called earlier in the function.

This fixes a bug where the node can't be stopped in `end_per_group/2`, attecting the next group ability to start one.