### PR TITLE
Make (rabbitmq-run.mk): abort restart-cluster if something goes wrong

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -423,6 +423,7 @@ restart-cluster:
 		  -rabbitmq_prometheus tcp_config [{port,$$((15692 + $$n - 1))}] \
 		  -rabbitmq_stream tcp_listeners [$$((5552 + $$n - 1))] \
 		  "; \
+		  $(RABBITMQCTL) -n "$$nodename" await_online_nodes $(NODES) || exit 1; \
 	done; \
 	wait
 


### PR DESCRIPTION
For example, if the first restarted node doesn't start, don't try to restart the other nodes. This mimics what orchestrators such as Kubernetes or BOSH would do (although they perform this check differently)