### PR TITLE
Fixes for CI flakes

### DIFF
--- a/deps/rabbit/test/metrics_SUITE.erl
+++ b/deps/rabbit/test/metrics_SUITE.erl
@@ -46,7 +46,8 @@ merge_app_env(Config) ->
     rabbit_ct_helpers:merge_app_env(Config,
                                     {rabbit, [
                                               {collect_statistics, fine},
-                                              {collect_statistics_interval, 500}
+                                              {collect_statistics_interval, 500},
+                                              {core_metrics_gc_interval, 5000}
                                              ]}).
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -295,9 +296,12 @@ connection(Config) ->
     [_] = read_table_rpc(Config, connection_coarse_metrics),
     ok = rabbit_ct_client_helpers:close_connection(Conn),
     force_metric_gc(Config),
-    [] = read_table_rpc(Config, connection_created),
-    [] = read_table_rpc(Config, connection_metrics),
-    [] = read_table_rpc(Config, connection_coarse_metrics),
+    ?awaitMatch([], read_table_rpc(Config, connection_created),
+                30000),
+    ?awaitMatch([], read_table_rpc(Config, connection_metrics),
+                30000),
+    ?awaitMatch([], read_table_rpc(Config, connection_coarse_metrics),
+                30000),
     ok.
 
 channel(Config) ->

--- a/deps/rabbitmq_federation_prometheus/test/prometheus_rabbitmq_federation_collector_SUITE.erl
+++ b/deps/rabbitmq_federation_prometheus/test/prometheus_rabbitmq_federation_collector_SUITE.erl
@@ -94,8 +94,10 @@ single_link_then_second_added(Config) ->
               timer:sleep(3000),
               [_L1] = rabbit_ct_broker_helpers:rpc(Config, 0,
                                                    rabbit_federation_status, status, []),
-              MFs = get_metrics(Config),
-              [?ONE_RUNNING_METRIC] = MFs,
+              rabbit_ct_helpers:eventually(?_assertEqual([?ONE_RUNNING_METRIC],
+                                                         get_metrics(Config)),
+                                           500,
+                                           5),
               maybe_declare_queue(Config, Ch, q(<<"fed.downstream2">>, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
               %% here we race against queue.declare... most of the times there is going to be
               %% new status=starting metric. In this case we wait a bit more for running=2.


### PR DESCRIPTION
Many metrics are asynchronous or depend on different events. On slow runs (CI), these suites fail often.

Let's try to address them by waiting a reasonable time for them to be ready.