### PR TITLE
Reduce AWS peer discovery workflow run rate

### DIFF
--- a/.github/workflows/rabbitmq_peer_discovery_aws.yaml
+++ b/.github/workflows/rabbitmq_peer_discovery_aws.yaml
@@ -1,10 +1,12 @@
 name: Peer Discovery AWS Integration Test
 on:
   push:
-    paths-ignore:
-      - '.github/workflows/secondary-umbrella.yaml'
-      - '.github/workflows/update-elixir-patches.yaml'
-      - '.github/workflows/update-otp-patches.yaml'
+    paths:
+      - "deps/rabbitmq_peer_discovery_aws/**"
+      - "deps/rabbitmq_peer_discovery_common/**"
+      - "deps/rabbit/src/rabbit_peer_discovery.erl"
+  schedule:
+    - cron: "4 0 * * MON"
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
By running it

 * On push, when relevant code paths change
 * Every Monday morning

The peer discovery subsystem does not change
particularly often, and this plugin in particular
does not. Nonetheless, we currently run it for
every push unconditionally.
