### PR TITLE
Expose AMQP connection metrics

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_reader.hrl
+++ b/deps/rabbit/src/rabbit_amqp_reader.hrl
@@ -1,0 +1,17 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+-define(SIMPLE_METRICS, [pid,
+                         recv_oct,
+                         send_oct,
+                         reductions]).
+
+-define(OTHER_METRICS, [recv_cnt,
+                        send_cnt,
+                        send_pend,
+                        state,
+                        channels,
+                        garbage_collection]).

--- a/deps/rabbit_common/src/rabbit_core_metrics.erl
+++ b/deps/rabbit_common/src/rabbit_core_metrics.erl
@@ -141,9 +141,9 @@ connection_stats(Pid, Infos) ->
     ets:insert(connection_metrics, {Pid, Infos}),
     ok.
 
-connection_stats(Pid, Recv_oct, Send_oct, Reductions) ->
+connection_stats(Pid, RecvOct, SendOct, Reductions) ->
     %% Includes delete marker
-    ets:insert(connection_coarse_metrics, {Pid, Recv_oct, Send_oct, Reductions, 0}),
+    ets:insert(connection_coarse_metrics, {Pid, RecvOct, SendOct, Reductions, 0}),
     ok.
 
 channel_created(Pid, Infos) ->

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -42,7 +42,7 @@
           stats_timer :: option(rabbit_event:state()),
           keepalive = rabbit_mqtt_keepalive:init() :: rabbit_mqtt_keepalive:state(),
           conn_name :: option(binary())
-        }).
+         }).
 
 -type state() :: #state{}.
 
@@ -79,13 +79,12 @@ init(Req, Opts) ->
                 false ->
                     no_supported_sub_protocol(Protocol, Req);
                 true ->
+                    Req1 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, <<"mqtt">>, Req),
+                    State = #state{socket = maps:get(proxy_header, Req, undefined),
+                                   stats_timer = rabbit_event:init_stats_timer()},
                     WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
                     WsOpts  = maps:merge(#{compress => true}, WsOpts0),
-
-                    {?MODULE,
-                     cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, <<"mqtt">>, Req),
-                     #state{socket = maps:get(proxy_header, Req, undefined)},
-                     WsOpts}
+                    {?MODULE, Req1, State, WsOpts}
             end
     end.
 
@@ -112,8 +111,7 @@ websocket_init(State0 = #state{socket = Sock}) ->
             ConnName = rabbit_data_coercion:to_binary(ConnStr),
             ?LOG_INFO("Accepting Web MQTT connection ~s", [ConnName]),
             _ = rabbit_alarm:register(self(), {?MODULE, conserve_resources, []}),
-            State1 = State0#state{conn_name = ConnName},
-            State = rabbit_event:init_stats_timer(State1, #state.stats_timer),
+            State = State0#state{conn_name = ConnName},
             process_flag(trap_exit, true),
             {[], State, hibernate};
         {error, Reason} ->

--- a/release-notes/4.1.0.md
+++ b/release-notes/4.1.0.md
@@ -29,6 +29,15 @@ This annotation allows publishers to specify a [list](https://docs.oasis-open.or
 This feature allows clients to set a new token proactively before the current one [expires](/docs/oauth2#token-expiration), ensuring uninterrupted connectivity.
 If a client does not set a new token before the existing one expires, RabbitMQ will automatically close the AMQP 1.0 connection.
 
+### Metrics for AMQP 1.0 Connections
+[PR #12638](https://github.com/rabbitmq/rabbitmq-server/pull/12638) exposes the following AMQP 1.0 connection metrics in the RabbitMQ Management UI and the [/metrics/per-object](https://www.rabbitmq.com/docs/prometheus#per-object-endpoint) Prometheus endpoint:
+* Bytes received and sent
+* Reductions
+* Garbage collections
+* Number of channels/sessions
+
+These metrics have already been emitted for AMQP 0.9.1 connections prior to RabbitMQ 4.1.
+
 ## Potential incompatibilities
 
 * The default MQTT [Maximum Packet Size](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901086) changed from 256 MiB to 16 MiB. This default can be overridden by [configuring](https://www.rabbitmq.com/docs/configure#config-file) `mqtt.max_packet_size_authenticated`. Note that this value must not be greater than `max_message_size` (which also defaults to 16 MiB).


### PR DESCRIPTION
Expose the same metrics for AMQP 1.0 connections as for AMQP 0.9.1 connections.

Display the following AMQP 1.0 metrics on the Management UI. The metrics in the red rectangles are new with this PR:
* Network bytes per second from/to client on connections page
* Number of sessions/channels on connections page

<img width="1650" alt="Screenshot 2024-11-04 at 14 41 29" src="https://github.com/user-attachments/assets/af7270d6-c2ef-4a9b-8ff9-8a23d976086f">

* Network bytes per second from/to client graph on connection page
* Reductions graph on connection page
* Garbage colletion info on connection page

<img width="1239" alt="Screenshot 2024-11-04 at 14 41 55" src="https://github.com/user-attachments/assets/d5afd236-dfbb-4083-af8c-fd56682711b3">

Expose the following AMQP 1.0 per-object Prometheus metrics:
* rabbitmq_connection_incoming_bytes_total
* rabbitmq_connection_outgoing_bytes_total
* rabbitmq_connection_process_reductions_total
* rabbitmq_connection_incoming_packets_total
* rabbitmq_connection_outgoing_packets_total
* rabbitmq_connection_pending_packets
* rabbitmq_connection_channels

The rabbit_amqp_writer proc:
* notifies the rabbit_amqp_reader proc if it sent frames
* hibernates eventually if it doesn't send any frames

The rabbit_amqp_reader proc:
* does not emit stats (update ETS tables) if no frames are received or sent to save resources when there are many idle connections.