### PR TITLE
4.1.x: new Actions workflow for triggering alpha releases

### DIFF
--- a/.github/workflows/alpha-build.yaml
+++ b/.github/workflows/alpha-build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "v4.0.x"
       - "mk-actions-notify-server-trigger-packages-workflow"
     paths:
       - "deps/**"
@@ -22,4 +21,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.RABBITMQCI_BOT_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/rabbitmq/server-packages/dispatches \
-            -d '{"event_type": "trigger-workflow", "client_payload": {"prerelease": true, "prerelease_kind": "alpha", "prerelease_identifier": "${{ github.ref }}", "base_version": "4.1.0"}}'
+            -d '{"event_type": "new_4.1.x_alpha", "client_payload": {"prerelease": true, "prerelease_kind": "alpha", "prerelease_identifier": "${{ github.ref }}", "base_version": "4.1.0"}}'

--- a/.github/workflows/alpha-build.yaml
+++ b/.github/workflows/alpha-build.yaml
@@ -1,0 +1,25 @@
+name: Trigger an alpha release build
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "v4.0.x"
+      - "mk-actions-notify-server-trigger-packages-workflow"
+    paths:
+      - "deps/**"
+      - ".github/workflows/**"
+
+jobs:
+  trigger_alpha_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger an alpha build in rabbitmq/server-packages
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RABBITMQCI_BOT_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/rabbitmq/server-packages/dispatches \
+            -d '{"event_type": "trigger-workflow", "client_payload": {"prerelease": true, "prerelease_kind": "alpha", "prerelease_identifier": "${{ github.ref }}", "base_version": "4.1.0"}}'


### PR DESCRIPTION
in [`rabbitmq/server-packages`](https://github.com/rabbitmq/server-packages), an Actions-only
repo dedicated to open source RabbitMQ release automation.
