### PR TITLE
Selenium suite workflow: updates for 2024

### DIFF
--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -10,6 +10,7 @@ on:
       - 'deps/rabbitmq_auth_**'
       - 'deps/rabbitmq_management/src/**'
       - 'deps/rabbitmq_management/priv/**'
+      - 'deps/rabbitmq_management/selenium/**'
       - 'scripts/**'
       - .bazelrc
       - .bazelversion

--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -3,12 +3,13 @@ on:
   push:
     branches:
       - main
-      - v3.12.x
-      - v3.11.x
+      - v4.0.x
     paths:
-      - 'deps/rabbit/**'
+      - 'deps/rabbit/src/rabbit_auth**'
+      - 'deps/rabbit/src/rabbit_access_control**'
       - 'deps/rabbitmq_auth_**'
-      - 'deps/rabbitmq_management/selenium/**'
+      - 'deps/rabbitmq_management/src/**'
+      - 'deps/rabbitmq_management/priv/**'
       - 'scripts/**'
       - .bazelrc
       - .bazelversion
@@ -40,7 +41,7 @@ jobs:
         - chrome
         include:
         - erlang_version: "26.2"
-          elixir_version: 1.15.7
+          elixir_version: 1.17.3
     env:
       SELENIUM_DIR: selenium
       DOCKER_NETWORK: rabbitmq_net


### PR DESCRIPTION
1. Use Elixir 1.17.x
2. Run only when several relevant code paths change
3. Do not run when unrelated core server tests change
