### PR TITLE
rabbitmq_management: Link from the deprecated features panel to docs

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/deprecated-features.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/deprecated-features.ejs
@@ -56,6 +56,9 @@
 <% } else { %>
     <p>... no deprecated features ...</p>
 <% } %>
+  <p>
+  See the <a href="https://www.rabbitmq.com/docs/deprecated-features" target="_blank">Deprecated features documentation</a> for more information.
+  </p>
   </div>
   </div>
 </div>


### PR DESCRIPTION
The docs were added to the website in rabbitmq/rabbitmq-website#2122.