### PR TITLE
Make sure Management UI JavaScript files are forced to reload after an upgrade

### DIFF
--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -45,3 +45,6 @@ list-dist-deps::
 prepare-dist::
 	$(verbose) sed 's/%%VSN%%/$(PROJECT_VERSION)/' bin/rabbitmqadmin \
 		> $(EZ_DIR)/priv/www/cli/rabbitmqadmin
+	mv $(EZ_DIR)/priv/www/css/main.css $(EZ_DIR)/priv/www/css/main-$(PROJECT_VERSION).css
+	$(verbose) sed "s#css/main.css#css/main-$(PROJECT_VERSION).css#" priv/www/index.html \
+		> $(EZ_DIR)/priv/www/index.html

--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -45,7 +45,5 @@ list-dist-deps::
 prepare-dist::
 	$(verbose) sed 's/%%VSN%%/$(PROJECT_VERSION)/' bin/rabbitmqadmin \
 		> $(EZ_DIR)/priv/www/cli/rabbitmqadmin
-	mv $(EZ_DIR)/priv/www/css/main.css $(EZ_DIR)/priv/www/css/main-$(PROJECT_VERSION).css
-	$(verbose) sed "s#css/main.css#css/main-$(PROJECT_VERSION).css#" priv/www/index.html \
+	$(verbose) sed "s/%%VSN%%/$(PROJECT_VERSION)/" priv/www/index.html \
 		> $(EZ_DIR)/priv/www/index.html
-	echo "management_version = \"$(PROJECT_VERSION)\";" >> $(EZ_DIR)/priv/www/js/global.js

--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -48,3 +48,4 @@ prepare-dist::
 	mv $(EZ_DIR)/priv/www/css/main.css $(EZ_DIR)/priv/www/css/main-$(PROJECT_VERSION).css
 	$(verbose) sed "s#css/main.css#css/main-$(PROJECT_VERSION).css#" priv/www/index.html \
 		> $(EZ_DIR)/priv/www/index.html
+	echo "management_version = \"$(PROJECT_VERSION)\";" >> $(EZ_DIR)/priv/www/js/global.js

--- a/deps/rabbitmq_management/app.bzl
+++ b/deps/rabbitmq_management/app.bzl
@@ -285,7 +285,6 @@ def all_srcs(name = "all_srcs"):
             "priv/www/api/index.html",
             "priv/www/cli/index.html",
             "priv/www/cli/rabbitmqadmin",
-            "priv/www/css/evil.css",
             "priv/www/css/main.css",
             "priv/www/favicon.ico",
             "priv/www/img/bg-binary.png",

--- a/deps/rabbitmq_management/priv/www/css/evil.css
+++ b/deps/rabbitmq_management/priv/www/css/evil.css
@@ -1,1 +1,0 @@
-#login { text-align: center; }

--- a/deps/rabbitmq_management/priv/www/index.html
+++ b/deps/rabbitmq_management/priv/www/index.html
@@ -11,14 +11,25 @@
     <script src="js/sammy-0.7.6.min.js" type="text/javascript"></script>
     <script src="js/json2-2016.10.28.js" type="text/javascript"></script>
     <script src="js/base64.js" type="text/javascript"></script>
-    <script src="js/global.js" type="text/javascript"></script>
-    <script src="js/main.js" type="text/javascript"></script>
-    <script src="js/prefs.js" type="text/javascript"></script>
-    <script src="js/formatters.js" type="text/javascript"></script>
-    <script src="js/charts.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+      management_version = "%%VSN%%";
+      const scripts = ["global.js", "main.js", "prefs.js", "formatters.js", "charts.js"];
+      scripts.forEach((script) => {
+        tag = document.createElement('script');
+        tag.src = 'js/' + script + '?v=' + management_version;
+        document.head.appendChild(tag);
+      });
+
+      tag = document.createElement('link');
+      tag.rel = 'stylesheet';
+      tag.type = 'text/css';
+      tag.href = 'css/main.css?v=' + management_version;
+      document.head.appendChild(tag);
+    </script>
+
     <script src="js/oidc-oauth/bootstrap.js" type="module"></script>
     
-    <link href="css/main.css" rel="stylesheet" type="text/css"/>
     <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>    
     
     <script type="module">

--- a/deps/rabbitmq_management/priv/www/index.html
+++ b/deps/rabbitmq_management/priv/www/index.html
@@ -25,12 +25,6 @@
       window.oauth = oauth_initialize_if_required();
       
     </script>
-    
-
-<!--[if lte IE 8]>
-    <script src="js/excanvas.min.js" type="text/javascript"></script>
-    <link href="css/evil.css" rel="stylesheet" type="text/css"/>
-<![endif]-->
   </head>
 
   <body>

--- a/deps/rabbitmq_management/priv/www/index.html
+++ b/deps/rabbitmq_management/priv/www/index.html
@@ -29,12 +29,11 @@
     </script>
 
     <script src="js/oidc-oauth/bootstrap.js" type="module"></script>
-    
-    <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>    
-    
+
+    <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
     <script type="module">
       window.oauth = oauth_initialize_if_required();
-      
     </script>
   </head>
 

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -872,6 +872,9 @@ var timer_interval;
 // When did we last connect successfully (for the "could not connect" error)
 var last_successful_connect;
 
+// we want a full page refresh after we were disconnected or if the RabbitMQ version changed
+var needs_full_refresh = false;
+
 // Every 200 updates without user interaction we do a full refresh, to
 // work around memory leaks in browser DOM implementations.
 // TODO: maybe we don't need this any more?
@@ -886,3 +889,6 @@ var chart_data = {};
 var last_page_out_of_range_error = 0;
 
 var oauth;
+
+// version of RabbitMQ we connected to; used to detect version changes
+var management_version = "";

--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -889,6 +889,3 @@ var chart_data = {};
 var last_page_out_of_range_error = 0;
 
 var oauth;
-
-// version of RabbitMQ we connected to; used to detect version changes
-var management_version = "";

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1306,7 +1306,11 @@ function maybe_format_extra_queue_content(queue, extraContent) {
 
 function update_status(status) {
     var text;
-    if (status == 'ok')
+    if (status == 'ok' && needs_full_refresh) {
+        // connection was restored, get the latest CSS/JS
+        needs_full_refresh = false;
+        full_refresh();
+    } else if (status == 'ok')
         text = "Refreshed " + fmt_date(new Date());
     else if (status == 'error') {
         var next_try = new Date(new Date().getTime() + timer_interval);
@@ -1496,6 +1500,7 @@ function check_bad_response(req, full_page_404) {
         clearInterval(timer);
     }
 
+    needs_full_refresh = true;
     return false;
 }
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
@@ -1,3 +1,10 @@
+<%
+   if(management_version != overview.management_version) {
+     // RabbitMQ was upgraded
+     // full reload to get the latest CSS and JavaScript files
+     needs_full_refresh = true;
+   }
+%>
 <% if(disable_stats) { %>
    <h1>Overview: Management only mode</h1>
 <% } else { %>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
@@ -1,5 +1,5 @@
 <%
-   if(management_version != overview.management_version) {
+   if(management_version != undefined && management_version != '%%VSN%%' && management_version != overview.management_version) {
      // RabbitMQ was upgraded
      // full reload to get the latest CSS and JavaScript files
      needs_full_refresh = true;


### PR DESCRIPTION
## What

Users should no longer run into issues with the Management UI when upgrading RabbitMQ. There are numerous reports
of JavaScript errors, blank pages, or just header+footer pages (without the main content).

## How?

1. When build RMQ, a version is injected into index.html
2. `index.html` refers to all our JS and CSS files with query string `v=$VERSION` and therefore the URL changes from version to version
3. If Management UI is disconnected from the server (red error at the top) and then reconnects, it'll trigger a full reload (likely we are now connected to a different node and/or different server version)
4. If the Management UI is open on the main page, it checks the `management_version` returned by the `/api/overview` endpoint and compares it with its own version (defined in index.html). If there's a difference - a full page reload is performed (this is clearly an upgrade)

Breaking change: we no longer support MSIE 8 :)  (`evil.css` was a piece of history: https://github.com/rabbitmq/rabbitmq-server/commits/v4.0.x/deps/rabbitmq_management/priv/www/css/evil.css)