### PR TITLE
Fix MQTT test flake management_plugin_connection

### DIFF
--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -1214,7 +1214,7 @@ management_plugin_connection(Config) ->
                 "/connections/" ++ binary_to_list(uri_string:quote(ConnectionName)),
                 ?NO_CONTENT),
     await_exit(C1),
-    ?assertEqual([], http_get(Config, "/connections")),
+    eventually(?_assertEqual([], http_get(Config, "/connections"))),
     eventually(?_assertEqual([], all_connection_pids(Config)), 500, 3),
 
     C2 = connect(ClientId, Config, [{keepalive, KeepaliveSecs}]),
@@ -1223,7 +1223,7 @@ management_plugin_connection(Config) ->
                 "/connections/username/guest",
                 ?NO_CONTENT),
     await_exit(C2),
-    ?assertEqual([], http_get(Config, "/connections")),
+    eventually(?_assertEqual([], http_get(Config, "/connections"))),
     eventually(?_assertEqual([], all_connection_pids(Config)), 500, 3).
 
 management_plugin_enable(Config) ->


### PR DESCRIPTION
Prior to this commit this test flaked in CI:
```
=== === Reason: {assertEqual,
                     [{module,mqtt_shared_SUITE},
                      {line,1222},
                      {expression,"http_get ( Config , \"/connections\" )"},
                      {expected,[]},
                      {value,
                          [#{timeout => 99,
                             name => <<"127.0.0.1:58712 -> 127.0.0.1:29005">>,
                             node =>
                                 <<"rmq-ct-mqtt-cluster_size_1-1-29000@localhost">>,
                             port => 29005,user => <<"guest">>,ssl => false,
                             protocol => <<"MQTT 5-0">>,
                             host => <<"127.0.0.1">>,
                             client_properties =>
                                 #{client_id =>
                                       <<"management_plugin_connection">>},
                             vhost => <<"/">>,peer_host => <<"127.0.0.1">>,
                             peer_port => 58712,frame_max => 0,
                             channel_max => 0,auth_mechanism => <<"none">>,
                             connected_at => 1730797370048,
                             ssl_protocol => null,ssl_key_exchange => null,
                             ssl_cipher => null,ssl_hash => null,
                             peer_cert_issuer => null,
                             peer_cert_subject => null,
                             peer_cert_validity => null,
                             user_who_performed_action => <<"guest">>}]}]}
  in function  mqtt_shared_SUITE:management_plugin_connection/1 (mqtt_shared_SUITE.erl, line 1222)
  in call from test_server:ts_tc/3 (test_server.erl, line 1793)
  in call from test_server:run_test_case_eval1/6 (test_server.erl, line 1302)
  in call from test_server:run_test_case_eval/9 (test_server.erl, line 1234)
```
