### PR TITLE
HTTP API: reduce body size limit for the endpoint used to bind queues/streams/exchanges

### DIFF
--- a/deps/rabbitmq_amqp1_0/BUILD.bazel
+++ b/deps/rabbitmq_amqp1_0/BUILD.bazel
@@ -30,6 +30,7 @@ rabbitmq_app(
     app_description = APP_DESCRIPTION,
     app_name = APP_NAME,
     beam_files = [":beam_files"],
+    extra_apps = ["rabbit"],
     license_files = [":license_files"],
     priv = [":priv"],
     deps = [

--- a/deps/rabbitmq_ct_client_helpers/BUILD.bazel
+++ b/deps/rabbitmq_ct_client_helpers/BUILD.bazel
@@ -33,6 +33,7 @@ rabbitmq_app(
     hdrs = [":public_hdrs"],
     app_name = "rabbitmq_ct_client_helpers",
     beam_files = [":beam_files"],
+    extra_apps = ["rabbit_common"],
     license_files = [":license_files"],
     priv = [":priv"],
     deps = [

--- a/deps/rabbitmq_ct_helpers/BUILD.bazel
+++ b/deps/rabbitmq_ct_helpers/BUILD.bazel
@@ -39,6 +39,7 @@ rabbitmq_app(
     hdrs = [":public_hdrs"],
     app_name = "rabbitmq_ct_helpers",
     beam_files = [":beam_files"],
+    extra_apps = ["inet_tcp_proxy"],
     license_files = [":license_files"],
     priv = [":priv"],
     deps = [

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -30,7 +30,7 @@
          list_login_vhosts_names/2]).
 -export([filter_tracked_conn_list/3]).
 -export([with_decode/5, decode/1, decode/2, set_resp_header/3,
-         args/1, read_complete_body/1]).
+         args/1, read_complete_body/1, read_complete_body_with_limit/2]).
 -export([reply_list/3, reply_list/5, reply_list/4,
          sort_list/2, destination_type/1, reply_list_or_paginate/3
          ]).
@@ -703,19 +703,46 @@ halt_response(Code, Type, Reason, ReqData, Context) ->
 id(Key, ReqData) ->
     rabbit_web_dispatch_access_control:id(Key, ReqData).
 
+%% IMPORTANT:
+%% Prefer read_complete_body_with_limit/2 with an explicit limit to make it easier
+%% to reason about what limit will be used.
 read_complete_body(Req) ->
     read_complete_body(Req, <<"">>).
 read_complete_body(Req, Acc) ->
     BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
     read_complete_body(Req, Acc, BodySizeLimit).
 read_complete_body(Req0, Acc, BodySizeLimit) ->
-    case bit_size(Acc) > BodySizeLimit of
+    case byte_size(Acc) > BodySizeLimit of
         true ->
-            {error, "Exceeded HTTP request body size limit"};
+            {error, http_body_limit_exceeded};
         false ->
             case cowboy_req:read_body(Req0) of
                 {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};
                 {more, Data, Req} -> read_complete_body(Req, <<Acc/binary, Data/binary>>)
+            end
+    end.
+
+read_complete_body_with_limit(Req, BodySizeLimit) when is_integer(BodySizeLimit) ->
+    case cowboy_req:body_length(Req) of
+        N when is_integer(N) ->
+            case N > BodySizeLimit of
+                true ->
+                    {error, http_body_limit_exceeded, BodySizeLimit, N};
+                false ->
+                    do_read_complete_body_with_limit(Req, <<"">>, BodySizeLimit)
+            end;
+        undefined ->
+            do_read_complete_body_with_limit(Req, <<"">>, BodySizeLimit)
+    end.
+
+do_read_complete_body_with_limit(Req0, Acc, BodySizeLimit) ->
+    case byte_size(Acc) > BodySizeLimit of
+        true ->
+            {error, http_body_limit_exceeded, BodySizeLimit, byte_size(Acc)};
+        false ->
+            case cowboy_req:read_body(Req0, #{length => BodySizeLimit, period => 30000}) of
+                {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};
+                {more, Data, Req} -> do_read_complete_body_with_limit(Req, <<Acc/binary, Data/binary>>, BodySizeLimit)
             end
     end.
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -750,8 +750,9 @@ do_read_complete_body_with_limit(Req0, Acc, BodySizeLimit) ->
 
 with_decode(Keys, ReqData, Context, Fun) ->
     case read_complete_body(ReqData) of
-        {error, Reason} ->
-            bad_request(Reason, ReqData, Context);
+        {error, http_body_limit_exceeded, LimitApplied, BytesRead} ->
+            rabbit_log:warning("HTTP API: request exceeded maximum allowed payload size (limit: ~tp bytes, payload size: ~tp bytes)", [LimitApplied, BytesRead]),
+            bad_request("Exceeded HTTP request body size limit", ReqData, Context);
         {ok, Body, ReqData1} ->
             with_decode(Keys, Body, ReqData1, Context, Fun)
     end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -712,9 +712,10 @@ read_complete_body(Req, Acc) ->
     BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
     read_complete_body(Req, Acc, BodySizeLimit).
 read_complete_body(Req0, Acc, BodySizeLimit) ->
-    case byte_size(Acc) > BodySizeLimit of
+    N = byte_size(Acc),
+    case N > BodySizeLimit of
         true ->
-            {error, http_body_limit_exceeded};
+            {error, http_body_limit_exceeded, BodySizeLimit, N};
         false ->
             case cowboy_req:read_body(Req0) of
                 {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};
@@ -736,9 +737,10 @@ read_complete_body_with_limit(Req, BodySizeLimit) when is_integer(BodySizeLimit)
     end.
 
 do_read_complete_body_with_limit(Req0, Acc, BodySizeLimit) ->
-    case byte_size(Acc) > BodySizeLimit of
+    N = byte_size(Acc),
+    case N > BodySizeLimit of
         true ->
-            {error, http_body_limit_exceeded, BodySizeLimit, byte_size(Acc)};
+            {error, http_body_limit_exceeded, BodySizeLimit, N};
         false ->
             case cowboy_req:read_body(Req0, #{length => BodySizeLimit, period => 30000}) of
                 {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -86,10 +86,10 @@ all_definitions(ReqData, Context) ->
 accept_json(ReqData0, Context) ->
     BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
     case rabbit_mgmt_util:read_complete_body_with_limit(ReqData0, BodySizeLimit) of
-        {error, Reason} ->
-            _ = rabbit_log:warning("HTTP API: uploaded definition file exceeded the maximum request body limit of ~p bytes. "
-                                   "Use the 'management.http.max_body_size' key in rabbitmq.conf to increase the limit if necessary", [BodySizeLimit]),
-            rabbit_mgmt_util:bad_request(Reason, ReqData0, Context);
+        {error, http_body_limit_exceeded, LimitApplied, BytesRead} ->
+            _ = rabbit_log:warning("HTTP API: uploaded definition file size (~tp) exceeded the maximum request body limit of ~tp bytes. "
+                                   "Use the 'management.http.max_body_size' key in rabbitmq.conf to increase the limit if necessary", [BytesRead, LimitApplied]),
+            rabbit_mgmt_util:bad_request("Exceeded HTTP request body size limit", ReqData0, Context);
         {ok, Body, ReqData} ->
             accept(Body, ReqData, Context)
     end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -84,9 +84,9 @@ all_definitions(ReqData, Context) ->
       Context).
 
 accept_json(ReqData0, Context) ->
-    case rabbit_mgmt_util:read_complete_body(ReqData0) of
+    BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
+    case rabbit_mgmt_util:read_complete_body_with_limit(ReqData0, BodySizeLimit) of
         {error, Reason} ->
-            BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
             _ = rabbit_log:warning("HTTP API: uploaded definition file exceeded the maximum request body limit of ~p bytes. "
                                    "Use the 'management.http.max_body_size' key in rabbitmq.conf to increase the limit if necessary", [BodySizeLimit]),
             rabbit_mgmt_util:bad_request(Reason, ReqData0, Context);


### PR DESCRIPTION
It does not need to use the "worst case scenario"
default HTTP request body size limit that
is primarily necessary because definition imports
can be large (MiBs in size, for example).

Since exchange, queue names and routing key
have limits of 255 bytes and optional arguments
can practically be expected to be short, we
can lower the limit to < 10 KiB.
