### PR TITLE
Added checkbox "Reverse order" in "Get Messages" section

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -338,6 +338,10 @@
           <th><label>Messages:</label></th>
           <td><input type="text" name="count" value="1"/></td>
         </tr>
+        <tr>
+          <th><label>Reverse order:</label></th>
+          <td><input type="checkbox" name="reversed" /></td>
+        </tr>
       </table>
       <input type="submit" value="Get Message(s)" />
     </form>


### PR DESCRIPTION
## Proposed Changes

This PR introduces a new UI feature: a "Reverse order" checkbox in the queue page that allows users to reverse the order of retrieved messages. 

Additionally, server-side handling for the 'reversed' parameter has been added in rabbit_mgmt_
wm_queue_get.erl to process this option and return the message list in reversed order when requested.

<img 
  width="1224" 
  alt="Usage example" 
  src="https://github.com/user-attachments/assets/d3f8d85e-cb92-490b-973c-16fa4969f2da"
/>

This feature was implemented to improve the user experience by providing more flexibility in how message lists are viewed and managed directly from the UI.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
