### PR TITLE
Fix crashes in connection tracking

### DIFF
--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -35,7 +35,7 @@
          list/0, list/1, list_on_node/1, list_on_node/2, list_of_user/1,
          tracked_connection_from_connection_created/1,
          tracked_connection_from_connection_state/1,
-         lookup/1, count/0]).
+         lookup/1, lookup/2, count/0]).
 
 -export([count_local_tracked_items_in_vhost/1,
          count_local_tracked_items_of_user/1]).
@@ -233,8 +233,8 @@ lookup(Name, [Node | Nodes]) when Node == node() ->
     end;
 lookup(Name, [Node | Nodes]) ->
     case rabbit_misc:rpc_call(Node, ?MODULE, lookup, [Name, [Node]]) of
-        [] -> lookup(Name, Nodes);
-        [Row] -> Row
+        not_found -> lookup(Name, Nodes);
+        Row = #tracked_connection{} -> Row
     end.
 
 lookup_internal(Name, Node) ->


### PR DESCRIPTION
This commit fixes two different bugs/crashes.

To repro, prior to this commit on `main`:
1. Create an AMQP 1.0 connection on node-1.
2. Open the Management UI on node-2 and open the connection page of this single AMQP 1.0 connection.

The first crash was the following:
```
[error] <0.1297.0>   crasher:
[error] <0.1297.0>     initial call: cowboy_stream_h:request_process/3
[error] <0.1297.0>     pid: <0.1297.0>
[error] <0.1297.0>     registered_name: []
[error] <0.1297.0>     exception error: no case clause matching
[error] <0.1297.0>                      {badrpc,
[error] <0.1297.0>                          {'EXIT',
[error] <0.1297.0>                              {undef,
[error] <0.1297.0>                                  [{rabbit_connection_tracking,lookup,
[error] <0.1297.0>                                       [<<"[::1]:51729 -> [::1]:5672">>,
[error] <0.1297.0>                                        ['rabbit-1@ABCDDDEEAA']],
[error] <0.1297.0>                                       []}]}}}
[error] <0.1297.0>       in function  rabbit_connection_tracking:lookup/2 (rabbit_connection_tracking.erl, line 235)
[error] <0.1297.0>       in call from rabbit_mgmt_wm_connection_sessions:conn/1 (rabbit_mgmt_wm_connection_sessions.erl, line 72)
[error] <0.1297.0>       in call from rabbit_mgmt_wm_connection_sessions:is_authorized/2 (rabbit_mgmt_wm_connection_sessions.erl, line 63)
[error] <0.1297.0>       in call from cowboy_rest:call/3 (src/cowboy_rest.erl, line 1590)
[error] <0.1297.0>       in call from cowboy_rest:is_authorized/2 (src/cowboy_rest.erl, line 368)
[error] <0.1297.0>       in call from cowboy_rest:upgrade/4 (src/cowboy_rest.erl, line 284)
[error] <0.1297.0>       in call from cowboy_stream_h:execute/3 (src/cowboy_stream_h.erl, line 306)
[error] <0.1297.0>       in call from cowboy_stream_h:request_process/3 (src/cowboy_stream_h.erl, line 295)
```

The second crash was the following:
```
[error] <0.1132.0>   crasher:
[error] <0.1132.0>     initial call: cowboy_stream_h:request_process/3
[error] <0.1132.0>     pid: <0.1132.0>
[error] <0.1132.0>     registered_name: []
[error] <0.1132.0>     exception error: no case clause matching
[error] <0.1132.0>                      {tracked_connection,
[error] <0.1132.0>                          {'rabbit-1@ABCDDDEEAA',
[error] <0.1132.0>                              <<"[::1]:65505 -> [::1]:5672">>},
[error] <0.1132.0>                          'rabbit-1@ABCDDDEEAA',<<"/">>,
[error] <0.1132.0>                          <<"[::1]:65505 -> [::1]:5672">>,<13661.1110.0>,
[error] <0.1132.0>                          {1,0},
[error] <0.1132.0>                          network,
[error] <0.1132.0>                          {0,0,0,0,0,0,0,1},
[error] <0.1132.0>                          65505,<<"guest">>,1730908606089}
[error] <0.1132.0>       in function  rabbit_connection_tracking:lookup/2 (rabbit_connection_tracking.erl, line 235)
[error] <0.1132.0>       in call from rabbit_mgmt_wm_connection_sessions:conn/1 (rabbit_mgmt_wm_connection_sessions.erl, line 72)
[error] <0.1132.0>       in call from rabbit_mgmt_wm_connection_sessions:is_authorized/2 (rabbit_mgmt_wm_connection_sessions.erl, line 63)
[error] <0.1132.0>       in call from cowboy_rest:call/3 (src/cowboy_rest.erl, line 1590)
[error] <0.1132.0>       in call from cowboy_rest:is_authorized/2 (src/cowboy_rest.erl, line 368)
[error] <0.1132.0>       in call from cowboy_rest:upgrade/4 (src/cowboy_rest.erl, line 284)
[error] <0.1132.0>       in call from cowboy_stream_h:execute/3 (src/cowboy_stream_h.erl, line 306)
[error] <0.1132.0>       in call from cowboy_stream_h:request_process/3 (src/cowboy_stream_h.erl, line 295)
```

This commit is a partial backport of https://github.com/rabbitmq/rabbitmq-server/pull/12670

(cherry picked from commit 124ef694bc74041c22efb81704cbcbc03cd3dbbb)