### PR TITLE
4.0.x: Avoid an exception when an AMQP 0-9-1-originating message with expiration set is converted for an MQTT consumer

### DIFF
--- a/deps/rabbitmq_mqtt/src/mc_mqtt.erl
+++ b/deps/rabbitmq_mqtt/src/mc_mqtt.erl
@@ -426,7 +426,7 @@ protocol_state(Msg = #mqtt_msg{props = Props0,
                 undefined ->
                     Props2;
                 Ttl ->
-                    case maps:get(?ANN_TIMESTAMP, Anns) of
+                    case maps:get(?ANN_TIMESTAMP, Anns, undefined) of
                         undefined ->
                             Props2;
                         Timestamp ->

--- a/deps/rabbitmq_mqtt/test/mc_mqtt_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mc_mqtt_SUITE.erl
@@ -33,7 +33,8 @@ groups() ->
        mqtt_amqp,
        mqtt_amqp_alt,
        amqp_mqtt,
-       is_persistent
+       is_persistent,
+       amqpl_to_mqtt_gh_12707
       ]}
     ].
 
@@ -155,6 +156,34 @@ roundtrip_amqpl(_Config) ->
     %% We expect order to not be maintained since AMQP 0.9.1 sorts by key.
     ExpectedUserProperty = lists:keysort(1, UserProperty),
     ?assertMatch(#{'User-Property' := ExpectedUserProperty}, Props).
+
+amqpl_to_mqtt_gh_12707(_Config) ->
+    Props = #'P_basic'{content_type = <<"text/plain">>,
+                        content_encoding = <<"gzip">>,
+                        headers = [],
+                        delivery_mode = 1,
+                        priority = 7,
+                        correlation_id = <<"gh_12707-corr">> ,
+                        reply_to = <<"reply-to">>,
+                        expiration = <<"12707">>,
+                        message_id = <<"msg-id">>,
+                        timestamp = 99,
+                        type = <<"45">>,
+                        user_id = <<"gh_12707">>,
+                        app_id = <<"rmq">>
+                        },
+    Payload = [<<"gh_12707">>],
+    Content = #content{properties = Props,
+                        payload_fragments_rev = Payload},
+    Content = #content{properties = Props,
+                        payload_fragments_rev = Payload},
+    Anns = #{
+        ?ANN_EXCHANGE => <<"amq.topic">>,
+        ?ANN_ROUTING_KEYS => [<<"dummy">>]
+    },
+    OriginalMsg = mc:init(mc_amqpl, Content, Anns),
+    Converted = mc:convert(mc_mqtt, OriginalMsg),
+    ?assertEqual(12707, mc:get_annotation(ttl, Converted)).
 
 %% Non-UTF-8 Correlation Data should also be converted (via AMQP 0.9.1 header x-correlation-id).
 roundtrip_amqpl_correlation(_Config) ->


### PR DESCRIPTION
Note: this is submitted directly against `v4.0.x` because the [`mc_mqtt` module](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_mqtt/src/mc_mqtt.erl) in `main` is different and an equivalent line must be located first, so there might be a separate future PR for that.

See https://github.com/rabbitmq/rabbitmq-server/discussions/12707.

Version for `main`: https://github.com/rabbitmq/rabbitmq-server/pull/12710.

To reproduce the exception:

1. Start a node with `rabbitmq_mqtt` enabled
2. Tail its logs
3. Install `github.com/rabbitmq/omq`
4. `omq amqp-mqtt --message-ttl 10s -t /topic/my_topic -T my_topic -C 1`
