### PR TITLE
feat/get-messages-reversed: updated UI for "Get Messages" in Queue tab 

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -652,6 +652,9 @@ var user;
 var ac = new AccessControl();
 var display = new DisplayControl();
 
+// Reverse order of rendered messages - checkbox value
+var reversed_messages_order;   
+
 var ui_data_model = {
   vhosts: [],
   nodes: [],
@@ -771,7 +774,9 @@ function setup_global_vars(overview) {
 
     disable_stats = overview.disable_stats;
     enable_queue_totals = overview.enable_queue_totals;
-    COLUMNS = disable_stats?DISABLED_STATS_COLUMNS:ALL_COLUMNS;
+    COLUMNS = disable_stats ? DISABLED_STATS_COLUMNS : ALL_COLUMNS;
+  
+    reversed_messages_order = false;
 
     setup_chart_ranges(overview.sample_retention_policies);
 }

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1244,7 +1244,7 @@ function get_msgs(params) {
                 show_popup('info', 'Queue is empty');
             } else {
                 $('#msg-wrapper').slideUp(200);
-                replace_content('msg-wrapper', format('messages', {'msgs': msgs}));
+                replace_content('msg-wrapper', format('messages', {'msgs': msgs, 'reversed_messages_order': reversed_messages_order }));
                 $('#msg-wrapper').slideDown(200);
             }
         });
@@ -1761,6 +1761,10 @@ function rename_multifield(params, from, to) {
         }
     }
     return new_params;
+}
+
+function toggle_reversed_messages_order () {
+    reversed_messages_order = event.target.checked;
 }
 
 function select_queue_type(queuetype) {

--- a/deps/rabbitmq_management/priv/www/js/tmpl/messages.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/messages.ejs
@@ -1,6 +1,7 @@
 <%
    for (var i = 0; i < msgs.length; i++) {
-   var msg = msgs[i];
+   var index = reversed_messages_order ? (msgs.length - 1) - i : i;
+   var msg = msgs[index];
 %>
 <div class="box">
 <h3>Message <%= i+1 %></h3>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -338,6 +338,13 @@
           <th><label>Messages:</label></th>
           <td><input type="text" name="count" value="1"/></td>
         </tr>
+        <tr>
+          <th><label>Reverse order:</label></th>
+          <td>
+            <input type="checkbox" name="reversed_messages_order" onchange="toggle_reversed_messages_order()"
+              <%=reversed_messages_order ? "checked" : "" %> />
+          </td>
+        </tr>
       </table>
       <input type="submit" value="Get Message(s)" />
     </form>


### PR DESCRIPTION
Hello, @michaelklishin!

This PR is related to my previous [#12698](https://github.com/rabbitmq/rabbitmq-server/pull/12698) 
where I tried to implement similar functionality, but in a different way.

I would be glad to hear your opinion and feedback on the new implementation.

## Proposed Changes

I've updated the [#12698](https://github.com/rabbitmq/rabbitmq-server/pull/12698) implementation away from using `basic.get`. 

## Types of Changes

- [ ] Bug fix 
- [x] New feature
- [ ] Breaking change 
- [ ] Documentation improvements
- [ ] Cosmetic change 
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
