### PR TITLE
Grafana Dashboards: Fix Query Errors and Improve Instance Filtering in Erlang Distribution and BEAM Dashboards

### DIFF
--- a/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-BEAM.json
+++ b/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-BEAM.json
@@ -140,7 +140,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "erlang_vm_statistics_run_queues_length",
+          "expr": "erlang_vm_statistics_run_queues_length{instance=\"$node\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -156,7 +156,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "erlang_vm_statistics_dirty_io_run_queue_length",
+          "expr": "erlang_vm_statistics_dirty_io_run_queue_length{instance=\"$node\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -173,7 +173,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "erlang_vm_statistics_dirty_cpu_run_queue_length",
+          "expr": "erlang_vm_statistics_dirty_cpu_run_queue_length{instance=\"$node\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1165,6 +1165,20 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "current": {},
         "datasource": {

--- a/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-Distribution.json
+++ b/deps/rabbitmq_prometheus/docker/grafana/dashboards/Erlang-Distribution.json
@@ -542,10 +542,10 @@
           "displayType": "Regular",
           "displayValueWithAlias": "Never",
           "editorMode": "code",
-          "expr": "erlang_vm_dist_node_state{peer!~\"rabbitmqcli.*\"} * on(rabbitmq_instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\"}",
+          "expr": "erlang_vm_dist_node_state{peer!~\"rabbitmqcli.*\"} * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{rabbitmq_instance}} -> {{ peer }}",
+          "legendFormat": "{{rabbitmq_node}} -> {{ peer }}",
           "range": true,
           "refId": "A",
           "units": "none",
@@ -2902,7 +2902,7 @@
         "showExtraInfo": false,
         "showItems": false
       },
-      "type": "flant-statusmap-panel",
+      "type": "status-history",
       "useMax": true,
       "usingPagination": false,
       "xAxis": {


### PR DESCRIPTION
## Proposed Changes
Hi,

During the testing with Grafana 11.3.0 and RabbitMQ 3.13.7, deployed on Kubernetes, we noticed several issues with the Erlang Distribution and Erlang BEAM dashboards.

Erlang Distribution dashboard:

- The "State of distribution links" panel on the Erlang Distribution dashboard was failing due to a query error caused by duplicate series in the match group, resulting in many-to-many matching conflicts.
![Screenshot_14-11-2024_142747_a4076d80e635246b6a27df68356a7971-1747288694 eu-central-1 elb amazonaws com](https://github.com/user-attachments/assets/f5107bef-d44f-45e3-9d4f-fcfc7c4f7c52)
![Screenshot_14-11-2024_151510_a4076d80e635246b6a27df68356a7971-1747288694 eu-central-1 elb amazonaws](https://github.com/user-attachments/assets/9ebcef70-836e-4f85-9fde-95ae57799e48)

- The "Process state" panel was unable to display correctly due to the flant status map being deprecated.
![Screenshot_14-11-2024_142845_a4076d80e635246b6a27df68356a7971-1747288694 eu-central-1 elb amazonaws com](https://github.com/user-attachments/assets/7de8b25f-73f7-4549-bb0d-af92a6266611)


Erlang-BEAM dashboard:
- Data was unable to be retrieved due to the missing DS_Prometheus variable, which was not defined as a datasource.
![Screenshot_14-11-2024_142926_a4076d80e635246b6a27df68356a7971-1747288694 eu-central-1 elb amazonaws](https://github.com/user-attachments/assets/0bb65a47-3cb2-41d2-9324-3f4e76f94c5f)

- The "Erlang VM Run Queue Length" panel displayed data for all nodes in the cluster rather than filtering to show data only for the selected node.
![Screenshot_14-11-2024_1755_3 70 218 181](https://github.com/user-attachments/assets/cc8eed71-35bf-44e9-8817-ac28030049a6)


**Changes:**

- Updated the Erlang Distribution dashboard to refine instance filtering, preventing many-to-many matching errors.
- Replaced the deprecated flant status map of "Process state" panel to status map.
- On the Erlang-BEAM dashboard, defined the DS_Prometheus variable as a datasource to ensure accurate data retrieval.
- Enhanced the "Erlang VM Run Queue Length" panel to filter data by the currently selected node.



## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
