### PR TITLE
CQ: Fix flakes in the store file scan test

### DIFF
--- a/deps/rabbit/test/backing_queue_SUITE.erl
+++ b/deps/rabbit/test/backing_queue_SUITE.erl
@@ -656,9 +656,11 @@ gen_msg() ->
     gen_msg(1024 * 1024).
 
 gen_msg(MaxSize) ->
-    %% This might generate false positives but very rarely
-    %% so we don't do anything to prevent them.
-    rand:bytes(rand:uniform(MaxSize)).
+    Bytes = rand:bytes(rand:uniform(MaxSize)),
+    %% We remove 255 to avoid false positives. In a running
+    %% rabbit node we will not get false positives because
+    %% we also check messages against the index.
+    << <<case B of 255 -> 254; _ -> B end>> || <<B>> <= Bytes >>.
 
 gen_msg_file(Config, Blocks) ->
     PrivDir = ?config(priv_dir, Config),
@@ -668,8 +670,8 @@ gen_msg_file(Config, Blocks) ->
         {bin, Bin} ->
             Bin;
         {pad, Size} ->
-            %% This might generate false positives although very unlikely.
-            rand:bytes(Size);
+            %% Empty space between messages is expected to be zeroes.
+            <<0:Size/unit:8>>;
         {msg, MsgId, Msg} ->
             Size = 16 + byte_size(Msg),
             [<<Size:64>>, MsgId, Msg, <<255>>]


### PR DESCRIPTION
We don't expect random bytes to be there in the current version of the message store as we overwrite empty spaces with zeroes when moving messages around.

This fixes a very rare flake.