### PR TITLE
rabbitmq_ct_helpers: Change how Mnesia/Khepri is selected

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: dsaltares/fetch-gh-release-asset@master
       if: inputs.mixed_clusters
       with:
-        version: 'tags/v4.0.3'
+        version: 'tags/v4.0.5'
         regex: true
         file: "rabbitmq-server-generic-unix-\\d.+\\.tar\\.xz"
         target: ./

--- a/deps/rabbit/test/bindings_SUITE.erl
+++ b/deps/rabbit/test/bindings_SUITE.erl
@@ -72,7 +72,7 @@ end_per_suite(Config) ->
 %     init_per_group_common(Group, Config, 1);
 init_per_group(khepri_migration = Group, Config) ->
     case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
-        {khepri, _} ->
+        khepri ->
             {skip, "skip khepri migration test when khepri already configured"};
         mnesia ->
             init_per_group_common(Group, Config, 1)

--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -138,7 +138,7 @@ init_per_group(khepri_store, Config) ->
     end;
 init_per_group(mnesia_store, Config) ->
     case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
-        {khepri, _} ->
+        khepri ->
             {skip, "These tests target mnesia"};
         _ ->
             Config

--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -80,7 +80,7 @@ init_per_group(khepri_store, Config) ->
     end;
 init_per_group(mnesia_store, Config) ->
     case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
-        {khepri, _} ->
+        khepri ->
             {skip, "These tests target mnesia"};
         _ ->
             Config

--- a/deps/rabbitmq_jms_topic_exchange/test/rjms_topic_selector_SUITE.erl
+++ b/deps/rabbitmq_jms_topic_exchange/test/rjms_topic_selector_SUITE.erl
@@ -56,7 +56,7 @@ init_per_group(mnesia_store = Group, Config0) ->
 init_per_group(khepri_store = Group, Config0) ->
     Config = rabbit_ct_helpers:set_config(
                Config0,
-               [{metadata_store, {khepri, [khepri_db]}}]),
+               [{metadata_store, khepri}]),
     init_per_group_common(Group, Config);
 init_per_group(khepri_migration = Group, Config0) ->
     Config = rabbit_ct_helpers:set_config(Config0, [{metadata_store, mnesia}]),

--- a/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
+++ b/deps/rabbitmq_recent_history_exchange/test/system_SUITE.erl
@@ -59,8 +59,8 @@ end_per_suite(Config) ->
 
 init_per_group(mnesia_store, Config) ->
     case rabbit_ct_broker_helpers:configured_metadata_store(Config) of
-        {khepri, _} -> {skip, "These tests target Mnesia"};
-        _           -> Config
+        khepri -> {skip, "These tests target Mnesia"};
+        _      -> Config
     end;
 init_per_group(khepri_store, Config) ->
     case rabbit_ct_broker_helpers:configured_metadata_store(Config) of


### PR DESCRIPTION
## Why

Once `khepr_db` is enabled by default, we need another way to disable it to select Mnesia instead.

## How

We use the new relative forced feature flags mechanism to indicate if we want to explicitly enable or disable `khepri_db`. This way, we don't touch other stable feature flags and only mess with Khepri.

However, this mechanism is not supported by RabbitMQ 4.0.x and older. They will ignore the setting. Therefore, to make this work in mixed-version testing, after a node has been started, we try to enable `khepri_db` if we detect that it doesn't support this mechanism.

At the end, we compare the effective metadata store to the expected one. If they don't match, we skip the test.

While here, change `rjms_topic_selector_SUITE` to only choose Khepri without specifying any feature flags.