### PR TITLE
Revival of #9620 Pass the message to `rabbit_backing_queue:discard` callback

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -648,7 +648,7 @@ discard(#delivery{confirm = Confirm,
                true  -> confirm_messages([MsgId], MTC, QName);
                false -> MTC
            end,
-    BQS1 = BQ:discard(MsgId, SenderPid, BQS),
+    BQS1 = BQ:discard(Msg, SenderPid, BQS),
     {BQS1, MTC1}.
 
 run_message_queue(ActiveConsumersChanged, State) ->
@@ -815,7 +815,7 @@ send_reject_publish(#delivery{confirm = true,
                                              amqqueue:get_name(Q), MsgSeqNo),
 
     MTC1 = maps:remove(MsgId, MTC),
-    BQS1 = BQ:discard(MsgId, SenderPid, BQS),
+    BQS1 = BQ:discard(Msg, SenderPid, BQS),
     State#q{ backing_queue_state = BQS1, msg_id_to_channel = MTC1 };
 send_reject_publish(#delivery{confirm = false}, State) ->
     State.

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -105,7 +105,7 @@
 
 %% Called to inform the BQ about messages which have reached the
 %% queue, but are not going to be further passed to BQ.
--callback discard(rabbit_types:msg_id(), pid(), state()) -> state().
+-callback discard(rabbit_types:basic_message(), pid(), state()) -> state().
 
 %% Return ids of messages which have been confirmed since the last
 %% invocation of this function (or initialisation).

--- a/deps/rabbit/src/rabbit_variable_queue.erl
+++ b/deps/rabbit/src/rabbit_variable_queue.erl
@@ -544,7 +544,7 @@ publish_delivered(Msg, MsgProps, ChPid, State) ->
                            State),
     {SeqId, a(maybe_update_rates(State1))}.
 
-discard(_MsgId, _ChPid, State) -> State.
+discard(_Msg, _ChPid, State) -> State.
 
 drain_confirmed(State = #vqstate { confirmed = C }) ->
     case sets:is_empty(C) of


### PR DESCRIPTION
## Proposed Changes

This is a refresher of PR #9620. It was requested to come back with these changes after HA/Mirroring queues were deprecated.

Here I include the previous PR description:

The `rabbit_backing_queue:discard` callback is passing the message ID to the implementer. This is often not enough to carry on some necessary work as it's seen in the rabbit_priority_queue [comment](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_priority_queue.erl#L252).

In my particular case, this makes it hard to fix the following issue:
https://github.com/noxdafox/rabbitmq-message-deduplication/issues/96

In the above issue a consumer starts consuming with noAck over an empty queue. A publisher publishes a single message which gets forwarded directly to the consumer. In this case, the discard callback is invoked instead of publish_delivered and therefore it's header is not removed from the deduplication cache.

Problem is the discard callback only forwards the message ID and not the whole message not providing enough context for the implementer.

This patch adjust the rabbit_backing_queue behaviour passing the whole message to the discard callback instead of its sole ID.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
