### PR TITLE
rabbitmq-auth-backend-oauth2: correctly map additional_scopes_key

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_schema.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_schema.erl
@@ -25,6 +25,15 @@
     translate_scope_aliases/1
 ]).
 
+-define(RESOURCE_SERVERS_SYNONYMS, #{
+  "additional_scopes_key" => "extra_scopes_source"
+}).
+
+resource_servers_key_synonym(Name) ->
+  case maps:find(Name, ?RESOURCE_SERVERS_SYNONYMS) of {ok, Synonym} -> Synonym;
+    error -> Name
+  end.
+
 extract_key_as_binary({Name,_}) -> list_to_binary(Name).
 extract_value({_Name,V}) -> V.
 
@@ -240,7 +249,7 @@ extract_resource_server_properties(Settings) ->
     KeyFun = fun extract_key_as_binary/1,
     ValueFun = fun extract_value/1,
 
-    OAuthProviders = [{Name, {list_to_atom(Key), list_to_binary(V)}}
+    OAuthProviders = [{Name, {list_to_atom(resource_servers_key_synonym(Key)), list_to_binary(V)}}
         || {[?AUTH_OAUTH2, ?RESOURCE_SERVERS, Name, Key], V} <- Settings ],
     maps:groups_from_list(KeyFun, ValueFun, OAuthProviders).
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_schema.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_schema.erl
@@ -16,6 +16,9 @@
 -define(AUTH_OAUTH2_RESOURCE_SERVERS, ?AUTH_OAUTH2 ++ "." ++ ?RESOURCE_SERVERS).
 -define(AUTH_OAUTH2_OAUTH_PROVIDERS, ?AUTH_OAUTH2 ++ "." ++ ?OAUTH_PROVIDERS).
 -define(AUTH_OAUTH2_SIGNING_KEYS, ?AUTH_OAUTH2 ++ "." ++ ?SIGNING_KEYS).
+-define(RESOURCE_SERVERS_SYNONYMS, #{
+  "additional_scopes_key" => "extra_scopes_source"
+}).
 
 -export([
     translate_oauth_providers/1,
@@ -25,14 +28,7 @@
     translate_scope_aliases/1
 ]).
 
--define(RESOURCE_SERVERS_SYNONYMS, #{
-  "additional_scopes_key" => "extra_scopes_source"
-}).
-
-resource_servers_key_synonym(Name) ->
-  case maps:find(Name, ?RESOURCE_SERVERS_SYNONYMS) of {ok, Synonym} -> Synonym;
-    error -> Name
-  end.
+resource_servers_key_synonym(Key) -> maps:get(Key, ?RESOURCE_SERVERS_SYNONYMS, Key).
 
 extract_key_as_binary({Name,_}) -> list_to_binary(Name).
 extract_value({_Name,V}) -> V.

--- a/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
+++ b/deps/rabbitmq_auth_backend_oauth2/test/config_schema_SUITE_data/rabbitmq_auth_backend_oauth2.snippets
@@ -101,7 +101,7 @@
                   {id, <<"rabbitmq-operations">>}
                 ],
                 <<"rabbitmq-customers">> => [
-                  {additional_scopes_key, <<"roles">>},
+                  {extra_scopes_source, <<"roles">>},
                   {id, <<"rabbitmq-customers">>}
                 ]
               }

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_schema_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_schema_SUITE.erl
@@ -169,7 +169,7 @@ test_resource_servers_attributes(_) ->
         {["auth_oauth2","resource_servers","rabbitmq1","preferred_username_claims","2"],
             "groupid"}
     ],
-    #{<<"rabbitmq1xxx">> := [{additional_scopes_key, <<"roles">>},
+    #{<<"rabbitmq1xxx">> := [{extra_scopes_source, <<"roles">>},
                           {id, <<"rabbitmq1xxx">>},
                           {preferred_username_claims, [<<"userid">>, <<"groupid">>]},
                           {scope_prefix, <<"somescope.">>}
@@ -186,7 +186,7 @@ test_resource_servers_attributes(_) ->
         {["auth_oauth2","resource_servers","rabbitmq1","preferred_username_claims","2"],
             "groupid"}
     ],
-    #{<<"rabbitmq1">> := [{additional_scopes_key, <<"roles">>},
+    #{<<"rabbitmq1">> := [{extra_scopes_source, <<"roles">>},
                           {id, <<"rabbitmq1">>},
                           {preferred_username_claims, [<<"userid">>, <<"groupid">>]},
                           {scope_prefix, <<"somescope.">>}


### PR DESCRIPTION
## Proposed Changes

Fix #12750 by introducing a synonyms map that will map `additional_scopes_key` to `extra_scopes_source`, instead of replacing `extra_scopes_source` in the schema which will be a breaking change.

There's probably a better way to handle this, as this is my first time writing erlang code, let me know what you think.


## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #12750 )

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes (tested only `rabbitmq-auth-backend-oauth2`)
