### PR TITLE
GitHub Actions: Run mixed-version testing against 4.0.3 explicitly

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -65,11 +65,16 @@ jobs:
     - name: MIXED CLUSTERS - SETUP SECONDARY_DIST
       if: inputs.mixed_clusters
       run: |
-        gpg --import rabbitmq-release-signing-key.asc
-        gpg --verify rabbitmq-server-generic-unix-*.asc rabbitmq-server-generic-unix-*.tar.xz
-        tar xf rabbitmq-server-generic-unix-*.tar.xz
+        ls -l rabbitmq-server-generic-unix-*.tar.xz*
 
-        echo "SECONDARY_DIST=${GITHUB_WORKSPACE}/rabbitmq_server-`echo -n ${{ steps.fetch_secondary_dist.outputs.version }} | sed s/v//`" >> $GITHUB_ENV
+        archive_name=$(echo rabbitmq-server-generic-unix-*.tar.xz)
+        archive_version=$(echo $archive_name | sed -E -e 's/^rabbitmq-server-generic-unix-//' -e 's/\.tar\.xz$//')
+
+        gpg --import rabbitmq-release-signing-key.asc
+        gpg --verify $archive_name.asc $archive_name
+        tar xf $archive_name
+
+        echo "SECONDARY_DIST=${GITHUB_WORKSPACE}/rabbitmq_server-$archive_version" >> $GITHUB_ENV
 
     - name: SETUP DOTNET (rabbit)
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -57,8 +57,9 @@ jobs:
       uses: dsaltares/fetch-gh-release-asset@master
       if: inputs.mixed_clusters
       with:
+        version: 'tags/v4.0.3'
         regex: true
-        file: "rabbitmq-server-generic-unix-[\\d.]*\\.tar.xz"
+        file: "rabbitmq-server-generic-unix-[\\d.]*\\.tar\\.xz"
         target: ./
 
     - name: MIXED CLUSTERS - SETUP SECONDARY_DIST

--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -59,7 +59,7 @@ jobs:
       with:
         version: 'tags/v4.0.3'
         regex: true
-        file: "rabbitmq-server-generic-unix-[\\d.]*\\.tar\\.xz"
+        file: "rabbitmq-server-generic-unix-\\d.+\\.tar\\.xz"
         target: ./
 
     - name: MIXED CLUSTERS - SETUP SECONDARY_DIST


### PR DESCRIPTION
… not any release.

## Why

Once we release RabbitMQ 4.1.0, it means that the `v4.1.x` branch would be tested against 4.1.x, i.e. itself.

Note that we will have to update this pinned version from time to time if needed.