### PR TITLE
Drop release_series_support_status from GET /api/overview and 'rabbitmq-diagnostics status'

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -262,7 +262,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
       rabbitmq_version: Keyword.get(result, :rabbitmq_version) |> to_string,
       erlang_version: Keyword.get(result, :erlang_version) |> to_string |> String.trim_trailing(),
       crypto_lib_version: crypto_lib_version,
-      release_series_support_status: Keyword.get(result, :release_series_support_status, true),
       uptime: Keyword.get(result, :uptime),
       is_under_maintenance: Keyword.get(result, :is_under_maintenance, false),
       processes: Enum.into(Keyword.get(result, :processes), %{}),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -51,7 +51,6 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {node_tags,                 node_tags()},
                  {erlang_version,            erlang_version()},
                  {erlang_full_version,       erlang_full_version()},
-                 {release_series_support_status, rabbit_release_series:readable_support_status()},
                  {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
                  {is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},
                  {enable_queue_totals,           rabbit_mgmt_util:enable_queue_totals(ReqData)}],


### PR DESCRIPTION
This undocumented key used to use a simple date-based formula and used to help support and the core team.

Nodes no longer have the context to return a correct response, so all we can do is drop this key.
