### PR TITLE
rabbit_vhosts: Don't reconcile vhosts if `rabbit` is stopped

### DIFF
--- a/deps/rabbit/src/rabbit_vhosts.erl
+++ b/deps/rabbit/src/rabbit_vhosts.erl
@@ -51,7 +51,7 @@ boot() ->
 %% See start_processes_for_all/1.
 -spec reconcile() -> 'ok'.
 reconcile() ->
-    case is_reconciliation_enabled() of
+    case rabbit:is_running() andalso is_reconciliation_enabled() of
         false -> ok;
         true  ->
             _ = reconcile_once(),

--- a/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_member_reconciliation_SUITE.erl
@@ -91,7 +91,10 @@ reset_nodes([], _Leader) ->
     ok;
 reset_nodes([Node| Nodes], Leader) ->
     ok = rabbit_control_helper:command(stop_app, Node),
-    ok = rabbit_control_helper:command(forget_cluster_node, Leader, [atom_to_list(Node)]),
+    case rabbit_control_helper:command(forget_cluster_node, Leader, [atom_to_list(Node)]) of
+        ok -> ok;
+        {error, _, <<"Error:\n{:not_a_cluster_node, ~c\"The node selected is not in the cluster.\"}">>} -> ok
+    end,
     ok = rabbit_control_helper:command(reset, Node),
     ok = rabbit_control_helper:command(start_app, Node),
     reset_nodes(Nodes, Leader).


### PR DESCRIPTION
## Why

That timer was started during boot and continued regardless if `rabbit` was running or stopped.

This caused the reconsiliation to crash if the `rabbit` app was stopped before the it ended because it tried to access the database even though it was stopped or even reset.

## How

We just check if `rabbit` is running before running one reconciliation and scheduling a new one.