### PR TITLE
Peer discovery cleanup: be more defensive

### DIFF
--- a/deps/rabbit_common/src/rabbit_data_coercion.erl
+++ b/deps/rabbit_common/src/rabbit_data_coercion.erl
@@ -10,6 +10,7 @@
 -export([to_binary/1, to_list/1, to_atom/1, to_integer/1, to_proplist/1, to_map/1]).
 -export([to_atom/2, atomize_keys/1, to_list_of_binaries/1]).
 -export([to_utf8_binary/1, to_unicode_charlist/1]).
+-export([as_list/1]).
 
 -spec to_binary(Val :: binary() | list() | atom() | integer() | function()) -> binary().
 to_binary(Val) when is_list(Val)     -> list_to_binary(Val);
@@ -109,3 +110,9 @@ to_unicode_charlist(Val) ->
         UnicodeValue ->
             UnicodeValue
     end.
+
+-spec as_list(list() | any()) -> [any()].
+as_list(Nodes) when is_list(Nodes) ->
+    Nodes;
+as_list(Other) ->
+    [Other].

--- a/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_cleanup.erl
+++ b/deps/rabbitmq_peer_discovery_common/src/rabbit_peer_discovery_cleanup.erl
@@ -28,6 +28,8 @@
 -compile(export_all).
 -endif.
 
+-import(rabbit_data_coercion, [as_list/1]).
+
 -define(CONFIG_MODULE, rabbit_peer_discovery_config).
 -define(CONFIG_KEY, node_cleanup).
 
@@ -318,9 +320,3 @@ service_discovery_nodes() ->
                #{domain => ?RMQLOG_DOMAIN_PEER_DIS}),
             []
     end.
-
--spec as_list(list() | any()) -> [any()].
-as_list(Nodes) when is_list(Nodes) ->
-    Nodes;
-as_list(Other) ->
-    [Other].


### PR DESCRIPTION
See discussion #12807 for details. This is to avoid an exception when
the cleanup functions perform peer discovery and may get a single node back
instead of a list.

`rabbit_peer_discovery:normalize/1` can be
changed to only return lists of nodes but then
there is a number of core code paths that
treat a single node as a special "preselected" value.

So let's keep that part and convert both
sets of nodes to lists before computing the
difference.
