### PR TITLE
Definition export: inject default queue type into virtual host metadata

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -1071,10 +1071,13 @@ list_vhosts() ->
     [vhost_definition(V) || V <- rabbit_vhost:all()].
 
 vhost_definition(VHost) ->
+    Name = vhost:get_name(VHost),
+    DQT = rabbit_queue_type:short_alias_of(rabbit_vhost:default_queue_type(Name)),
     #{
-        <<"name">> => vhost:get_name(VHost),
+        <<"name">> => Name,
         <<"limits">> => vhost:get_limits(VHost),
-        <<"metadata">> => vhost:get_metadata(VHost)
+        <<"metadata">> => vhost:get_metadata(VHost),
+        <<"default_queue_type">> => DQT
     }.
 
 list_users() ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -23,6 +23,7 @@
          feature_flag_name/1,
          to_binary/1,
          default/0,
+         default_alias/0,
          fallback/0,
          inject_dqt/1,
          vhosts_with_dqt/1,
@@ -356,6 +357,10 @@ default() ->
                             default_queue_type,
                             fallback()),
     rabbit_data_coercion:to_atom(V).
+
+-spec default_alias() -> binary().
+default_alias() ->
+    short_alias_of(default()).
 
 -spec to_binary(module()) -> binary().
 to_binary(rabbit_classic_queue) ->

--- a/deps/rabbit/src/vhost.erl
+++ b/deps/rabbit/src/vhost.erl
@@ -26,11 +26,14 @@
   get_description/1,
   get_tags/1,
   get_default_queue_type/1,
+
   set_limits/2,
   set_metadata/2,
   merge_metadata/2,
   new_metadata/3,
-  is_tagged_with/2
+  is_tagged_with/2,
+
+  to_map/1
 ]).
 
 -define(record_version, vhost_v2).
@@ -196,3 +199,13 @@ new_metadata(Description, Tags, DefaultQueueType) ->
 -spec is_tagged_with(vhost(), tag()) -> boolean().
 is_tagged_with(VHost, Tag) ->
     lists:member(Tag, get_tags(VHost)).
+
+-spec to_map(vhost()) -> map().
+to_map(VHost) ->
+    #{
+        name               => get_name(VHost),
+        description        => get_description(VHost),
+        tags               => get_tags(VHost),
+        default_queue_type => get_default_queue_type(VHost),
+        metadata           => get_metadata(VHost)
+    }.

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -2,7 +2,7 @@
 ## License, v. 2.0. If a copy of the MPL was not distributed with this
 ## file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ##
-## Copyright (c) 2007-2023 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+## Copyright (c) 2007-2024 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
   alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers}

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -19,6 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
   use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
 
   def merge_defaults([], opts) do
+    # this default historically benefits those who script using 'rabbitmqctl list_vhosts',
+    # adding more fields here would break scripts but be more useful to a human reader. MK.
     merge_defaults(["name"], opts)
   end
 

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -111,6 +111,7 @@
     add_vhost/2,
     add_vhost/3,
     add_vhost/4,
+    update_vhost_metadata/3,
     delete_vhost/2,
     delete_vhost/3,
     delete_vhost/4,
@@ -1601,6 +1602,9 @@ add_vhost(Config, Node, VHost) ->
 
 add_vhost(Config, Node, VHost, Username) ->
     catch rpc(Config, Node, rabbit_vhost, add, [VHost, Username]).
+
+update_vhost_metadata(Config, VHost, Meta) ->
+    catch rpc(Config, 0, rabbit_vhost, update_metadata, [VHost, Meta, <<"acting-user">>]).
 
 delete_vhost(Config, VHost) ->
     delete_vhost(Config, 0, VHost).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -271,7 +271,12 @@ retain_whitelisted(Items) ->
 retain_whitelisted_items(Name, List, Allowed) ->
     {Name, [only_whitelisted_for_item(I, Allowed) || I <- List]}.
 
-only_whitelisted_for_item(Item, Allowed) ->
+only_whitelisted_for_item(Item, Allowed) when is_map(Item) ->
+    Map1 = maps:with(Allowed, Item),
+    maps:filter(fun(_Key, Val) ->
+                    Val =/= undefined
+                end, Map1);
+only_whitelisted_for_item(Item, Allowed) when is_list(Item) ->
     [{K, Fact} || {K, Fact} <- Item, lists:member(K, Allowed), Fact =/= undefined].
 
 strip_vhost(Item) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -132,6 +132,11 @@ vhost_definitions(ReqData, VHostName, Context) ->
     ProductName = rabbit:product_name(),
     ProductVersion = rabbit:product_version(),
 
+    DQT = rabbit_queue_type:short_alias_of(rabbit_vhost:default_queue_type(VHostName)),
+    %% note: the type changes to a map
+    VHost1 = rabbit_queue_type:inject_dqt(VHost),
+    Metadata = maps:get(metadata, VHost1),
+
     TopLevelDefsAndMetadata = [
         {rabbit_version, rabbit_data_coercion:to_binary(Vsn)},
         {rabbitmq_version, rabbit_data_coercion:to_binary(Vsn)},
@@ -140,8 +145,9 @@ vhost_definitions(ReqData, VHostName, Context) ->
         {rabbitmq_definition_format, <<"single_virtual_host">>},
         {original_vhost_name, VHostName},
         {explanation, rabbit_data_coercion:to_binary(io_lib:format("Definitions of virtual host '~ts'", [VHostName]))},
+        {metadata, Metadata},
         {description, vhost:get_description(VHost)},
-        {default_queue_type, rabbit_queue_type:short_alias_of(rabbit_vhost:default_queue_type(VHostName))}
+        {default_queue_type, DQT}
     ],
     Result = TopLevelDefsAndMetadata ++ retain_whitelisted(Contents),
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -58,30 +58,39 @@ all_definitions(ReqData, Context) ->
     Vsn = rabbit:base_product_version(),
     ProductName = rabbit:product_name(),
     ProductVersion = rabbit:product_version(),
-    rabbit_mgmt_util:reply(
-      [{rabbit_version, rabbit_data_coercion:to_binary(Vsn)},
-       {rabbitmq_version, rabbit_data_coercion:to_binary(Vsn)},
-       {product_name, rabbit_data_coercion:to_binary(ProductName)},
-       {product_version, rabbit_data_coercion:to_binary(ProductVersion)}] ++
-      retain_whitelisted(
-        [{users,             rabbit_mgmt_wm_users:users(all)},
-         {vhosts,            rabbit_mgmt_wm_vhosts:basic()},
-         {permissions,       rabbit_mgmt_wm_permissions:permissions()},
-         {topic_permissions, rabbit_mgmt_wm_topic_permissions:topic_permissions()},
-         {parameters,        rabbit_mgmt_wm_parameters:basic(ReqData)},
-         {global_parameters, rabbit_mgmt_wm_global_parameters:basic()},
-         {policies,          rabbit_mgmt_wm_policies:basic(ReqData)},
-         {queues,            Qs},
-         {exchanges,         Xs},
-         {bindings,          Bs}]),
-      case rabbit_mgmt_util:qs_val(<<"download">>, ReqData) of
-          undefined -> ReqData;
-          Filename  -> rabbit_mgmt_util:set_resp_header(
-                         <<"Content-Disposition">>,
-                         "attachment; filename=" ++
-                             binary_to_list(Filename), ReqData)
-      end,
-      Context).
+
+    Contents = [
+        {users,             rabbit_mgmt_wm_users:users(all)},
+        {vhosts,            rabbit_mgmt_wm_vhosts:basic()},
+        {permissions,       rabbit_mgmt_wm_permissions:permissions()},
+        {topic_permissions, rabbit_mgmt_wm_topic_permissions:topic_permissions()},
+        {parameters,        rabbit_mgmt_wm_parameters:basic(ReqData)},
+        {global_parameters, rabbit_mgmt_wm_global_parameters:basic()},
+        {policies,          rabbit_mgmt_wm_policies:basic(ReqData)},
+        {queues,            Qs},
+        {exchanges,         Xs},
+        {bindings,          Bs}
+    ],
+
+    TopLevelDefsAndMetadata = [
+        {rabbit_version, rabbit_data_coercion:to_binary(Vsn)},
+        {rabbitmq_version, rabbit_data_coercion:to_binary(Vsn)},
+        {product_name, rabbit_data_coercion:to_binary(ProductName)},
+        {product_version, rabbit_data_coercion:to_binary(ProductVersion)},
+        {rabbitmq_definition_format, <<"cluster">>},
+        {original_cluster_name, rabbit_nodes:cluster_name()},
+        {explanation, rabbit_data_coercion:to_binary(io_lib:format("Definitions of cluster '~ts'", [rabbit_nodes:cluster_name()]))}
+    ],
+    Result = TopLevelDefsAndMetadata ++ retain_whitelisted(Contents),
+    ReqData1 = case rabbit_mgmt_util:qs_val(<<"download">>, ReqData) of
+                   undefined -> ReqData;
+                   Filename  -> rabbit_mgmt_util:set_resp_header(
+                       <<"Content-Disposition">>,
+                       "attachment; filename=" ++
+                       binary_to_list(Filename), ReqData)
+               end,
+
+    rabbit_mgmt_util:reply(Result, ReqData1, Context).
 
 accept_json(ReqData0, Context) ->
     BodySizeLimit = application:get_env(rabbitmq_management, max_http_body_size, ?MANAGEMENT_DEFAULT_HTTP_MAX_BODY_SIZE),
@@ -94,7 +103,10 @@ accept_json(ReqData0, Context) ->
             accept(Body, ReqData, Context)
     end.
 
-vhost_definitions(ReqData, VHost, Context) ->
+vhost_definitions(ReqData, VHostName, Context) ->
+    %% the existence of this virtual host is verified in the called, 'to_json/2'
+    VHost = rabbit_vhost:lookup(VHostName),
+
     %% rabbit_mgmt_wm_<>:basic/1 filters by VHost if it is available.
     %% TODO: should we stop stripping virtual host? Such files cannot be imported on boot, for example.
     Xs = [strip_vhost(X) || X <- rabbit_mgmt_wm_exchanges:basic(ReqData),
@@ -105,25 +117,41 @@ vhost_definitions(ReqData, VHost, Context) ->
     %% TODO: should we stop stripping virtual host? Such files cannot be imported on boot, for example.
     Bs = [strip_vhost(B) || B <- rabbit_mgmt_wm_bindings:basic(ReqData),
                             export_binding(B, QNames)],
-    {ok, Vsn} = application:get_key(rabbit, vsn),
     Parameters = [strip_vhost(
                     rabbit_mgmt_format:parameter(P))
-                  || P <- rabbit_runtime_parameters:list(VHost)],
-    rabbit_mgmt_util:reply(
-      [{rabbit_version, rabbit_data_coercion:to_binary(Vsn)}] ++
-          retain_whitelisted(
-            [{parameters,  Parameters},
-             {policies,    [strip_vhost(P) || P <- rabbit_mgmt_wm_policies:basic(ReqData)]},
-             {queues,      Qs},
-             {exchanges,   Xs},
-             {bindings,    Bs}]),
-      case rabbit_mgmt_util:qs_val(<<"download">>, ReqData) of
-          undefined -> ReqData;
-          Filename  ->
-              HeaderVal = "attachment; filename=" ++ binary_to_list(Filename),
-              rabbit_mgmt_util:set_resp_header(<<"Content-Disposition">>, HeaderVal, ReqData)
-      end,
-      Context).
+                  || P <- rabbit_runtime_parameters:list(VHostName)],
+    Contents = [
+        {parameters,  Parameters},
+        {policies,    [strip_vhost(P) || P <- rabbit_mgmt_wm_policies:basic(ReqData)]},
+        {queues,      Qs},
+        {exchanges,   Xs},
+        {bindings,    Bs}
+    ],
+
+    Vsn = rabbit:base_product_version(),
+    ProductName = rabbit:product_name(),
+    ProductVersion = rabbit:product_version(),
+
+    TopLevelDefsAndMetadata = [
+        {rabbit_version, rabbit_data_coercion:to_binary(Vsn)},
+        {rabbitmq_version, rabbit_data_coercion:to_binary(Vsn)},
+        {product_name, rabbit_data_coercion:to_binary(ProductName)},
+        {product_version, rabbit_data_coercion:to_binary(ProductVersion)},
+        {rabbitmq_definition_format, <<"single_virtual_host">>},
+        {original_vhost_name, VHostName},
+        {explanation, rabbit_data_coercion:to_binary(io_lib:format("Definitions of virtual host '~ts'", [VHostName]))},
+        {description, vhost:get_description(VHost)},
+        {default_queue_type, rabbit_queue_type:short_alias_of(rabbit_vhost:default_queue_type(VHostName))}
+    ],
+    Result = TopLevelDefsAndMetadata ++ retain_whitelisted(Contents),
+
+    ReqData1 = case rabbit_mgmt_util:qs_val(<<"download">>, ReqData) of
+                   undefined -> ReqData;
+                   Filename  ->
+                       HeaderVal = "attachment; filename=" ++ binary_to_list(Filename),
+                       rabbit_mgmt_util:set_resp_header(<<"Content-Disposition">>, HeaderVal, ReqData)
+               end,
+    rabbit_mgmt_util:reply(Result, ReqData1, Context).
 
 accept_multipart(ReqData0, Context) ->
     {Parts, ReqData} = get_all_parts(ReqData0),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -147,7 +147,8 @@ vhost_definitions(ReqData, VHostName, Context) ->
         {explanation, rabbit_data_coercion:to_binary(io_lib:format("Definitions of virtual host '~ts'", [VHostName]))},
         {metadata, Metadata},
         {description, vhost:get_description(VHost)},
-        {default_queue_type, DQT}
+        {default_queue_type, DQT},
+        {limits, vhost:get_limits(VHost)}
     ],
     Result = TopLevelDefsAndMetadata ++ retain_whitelisted(Contents),
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -53,6 +53,7 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {erlang_full_version,       erlang_full_version()},
                  {release_series_support_status, rabbit_release_series:readable_support_status()},
                  {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
+                 {default_queue_type,            rabbit_queue_type:default_alias()},
                  {is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},
                  {enable_queue_totals,           rabbit_mgmt_util:enable_queue_totals(ReqData)}],
     try

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -52,7 +52,8 @@ all() ->
         {group, definitions_group1_without_prefix},
         {group, definitions_group2_without_prefix},
         {group, definitions_group3_without_prefix},
-        {group, definitions_group4_without_prefix}
+        {group, definitions_group4_without_prefix},
+        {group, default_queue_type_without_prefix}
     ].
 
 groups() ->
@@ -66,7 +67,8 @@ groups() ->
         {definitions_group1_without_prefix, [], definitions_group1_tests()},
         {definitions_group2_without_prefix, [], definitions_group2_tests()},
         {definitions_group3_without_prefix, [], definitions_group3_tests()},
-        {definitions_group4_without_prefix, [], definitions_group4_tests()}
+        {definitions_group4_without_prefix, [], definitions_group4_tests()},
+        {default_queue_type_without_prefix, [], default_queue_type_group_tests()}
     ].
 
 some_tests() ->
@@ -102,6 +104,14 @@ definitions_group3_tests() ->
 definitions_group4_tests() ->
     [
         definitions_vhost_test
+    ].
+
+default_queue_type_group_tests() ->
+    [
+        default_queue_type_fallback_in_overview_test,
+        default_queue_type_with_value_configured_in_overview_test,
+        default_queue_types_in_vhost_list_test,
+        default_queue_type_of_one_vhost_test
     ].
 
 all_tests() -> [
@@ -4118,9 +4128,123 @@ cluster_and_node_tags_test(Config) ->
     ?assertEqual(ExpectedTags, NodeTags),
     passed.
 
+default_queue_type_fallback_in_overview_test(Config) ->
+    Overview = http_get(Config, "/overview"),
+    DQT = maps:get(default_queue_type, Overview),
+    ?assertEqual(<<"classic">>, DQT).
+
+default_queue_type_with_value_configured_in_overview_test(Config) ->
+    Overview = with_default_queue_type(Config, rabbit_quorum_queue,
+        fun(Cfg) ->
+            http_get(Cfg, "/overview")
+        end),
+
+    DQT = maps:get(default_queue_type, Overview),
+    ?assertEqual(<<"quorum">>, DQT).
+
+default_queue_types_in_vhost_list_test(Config) ->
+    TestName = rabbit_data_coercion:to_binary(?FUNCTION_NAME),
+    VHost1 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 1])),
+    VHost2 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 2])),
+    VHost3 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 3])),
+    VHost4 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 4])),
+
+    VHosts = #{
+        VHost1 => undefined,
+        VHost2 => <<"classic">>,
+        VHost3 => <<"quorum">>,
+        VHost4 => <<"stream">>
+    },
+
+    try
+        begin
+            lists:foreach(
+                fun({V, QT}) ->
+                    rabbit_ct_broker_helpers:add_vhost(Config, V),
+                    rabbit_ct_broker_helpers:set_full_permissions(Config, V),
+                    rabbit_ct_broker_helpers:update_vhost_metadata(Config, V, #{
+                        default_queue_type => QT
+                    })
+                end, maps:to_list(VHosts)),
+
+            List = http_get(Config, "/vhosts"),
+            ct:pal("GET /api/vhosts returned: ~tp", [List]),
+            VH1 = find_map_by_name(VHost1, List),
+            ?assertEqual(<<"classic">>, maps:get(default_queue_type, VH1)),
+
+            VH2 = find_map_by_name(VHost2, List),
+            ?assertEqual(<<"classic">>, maps:get(default_queue_type, VH2)),
+
+            VH3 = find_map_by_name(VHost3, List),
+            ?assertEqual(<<"quorum">>, maps:get(default_queue_type, VH3)),
+
+            VH4 = find_map_by_name(VHost4, List),
+            ?assertEqual(<<"stream">>, maps:get(default_queue_type, VH4))
+        end
+    after
+        lists:foreach(
+            fun(V) ->
+                rabbit_ct_broker_helpers:delete_vhost(Config, V)
+            end, maps:keys(VHosts))
+    end.
+
+default_queue_type_of_one_vhost_test(Config) ->
+    TestName = rabbit_data_coercion:to_binary(?FUNCTION_NAME),
+    VHost1 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 1])),
+    VHost2 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 2])),
+    VHost3 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 3])),
+    VHost4 = rabbit_data_coercion:to_binary(io_lib:format("~ts-~b", [TestName, 4])),
+
+    VHosts = #{
+        VHost1 => undefined,
+        VHost2 => <<"classic">>,
+        VHost3 => <<"quorum">>,
+        VHost4 => <<"stream">>
+    },
+
+    try
+        begin
+            lists:foreach(
+                fun({V, QT}) ->
+                    rabbit_ct_broker_helpers:add_vhost(Config, V),
+                    rabbit_ct_broker_helpers:set_full_permissions(Config, V),
+                    rabbit_ct_broker_helpers:update_vhost_metadata(Config, V, #{
+                        default_queue_type => QT
+                    })
+                end, maps:to_list(VHosts)),
+
+            VH1 = http_get(Config, io_lib:format("/vhosts/~ts", [VHost1])),
+            ?assertEqual(<<"classic">>, maps:get(default_queue_type, VH1)),
+
+            VH2 = http_get(Config, io_lib:format("/vhosts/~ts", [VHost2])),
+            ?assertEqual(<<"classic">>, maps:get(default_queue_type, VH2)),
+
+            VH3 = http_get(Config, io_lib:format("/vhosts/~ts", [VHost3])),
+            ?assertEqual(<<"quorum">>, maps:get(default_queue_type, VH3)),
+
+            VH4 = http_get(Config, io_lib:format("/vhosts/~ts", [VHost4])),
+            ?assertEqual(<<"stream">>, maps:get(default_queue_type, VH4))
+        end
+    after
+        lists:foreach(
+            fun(V) ->
+                rabbit_ct_broker_helpers:delete_vhost(Config, V)
+            end, maps:keys(VHosts))
+    end.
+
 %% -------------------------------------------------------------------
 %% Helpers.
 %% -------------------------------------------------------------------
+
+%% Finds a map by its <<"name">> key in an HTTP API response.
+-spec find_map_by_name(binary(), [#{binary() => any()}]) -> #{binary() => any()} | undefined.
+find_map_by_name(NameToFind, List) ->
+    case lists:filter(fun(#{name := Name}) ->
+                        Name =:= NameToFind
+                      end, List) of
+        []    -> undefined;
+        [Val] -> Val
+    end.
 
 msg(Key, Headers, Body) ->
     msg(Key, Headers, Body, <<"string">>).
@@ -4214,3 +4338,13 @@ await_condition(Fun) ->
                         false
               end
       end, ?COLLECT_INTERVAL * 100).
+
+
+clear_default_queue_type(Config) ->
+    rpc(Config, application, unset_env, [rabbit, default_queue_type]).
+
+with_default_queue_type(Config, DQT, Fun) ->
+    rpc(Config, application, set_env, [rabbit, default_queue_type, DQT]),
+    ToReturn = Fun(Config),
+    rpc(Config, application, unset_env, [rabbit, default_queue_type]),
+    ToReturn.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -2156,6 +2156,7 @@ definitions_file_metadata_test(Config) ->
     %% verify definitions file metadata
     ?assertEqual(<<"single_virtual_host">>, maps:get(rabbitmq_definition_format, VHDefinitions)),
     ?assertEqual(VHostName, (maps:get(original_vhost_name, VHDefinitions))),
+    ?assert(is_map_key(default_queue_type, maps:get(metadata, VHDefinitions))),
 
     %% Remove the test vhost
     http_delete(Config, io_lib:format("/vhosts/~ts", [VHostName]), {group, '2xx'}),

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -548,6 +548,8 @@ vhosts_description_test(Config) ->
     Expected = #{name => <<"myvhost">>,
                  metadata => #{
                                description => <<"vhost description">>,
+                               %% this is an injected DQT
+                               default_queue_type => <<"classic">>,
                                tags => [<<"tag1">>, <<"tag2">>]
                               }},
     assert_item(Expected, http_get(Config, "/vhosts/myvhost")),


### PR DESCRIPTION
With this change, `GET /api/definitions` and `GET /api/vhosts` will inject a default queue type (DQT) into virtual host metadata when `default_queue_type` is set in `rabbitmq.conf` (`v4.0.x`-only) and the virtual host in question does not have [DQT defined for it](https://www.rabbitmq.com/docs/vhosts):

``` ini
default_queue_type = quorum
```

Closes #12776.
Closes #12835.