### PR TITLE
Update rabbitmq_auth_mechanism_ssl/README.md so openssl command is easier to change after pasting.

### DIFF
--- a/deps/rabbitmq_auth_mechanism_ssl/README.md
+++ b/deps/rabbitmq_auth_mechanism_ssl/README.md
@@ -54,7 +54,7 @@ produced by OpenSSL's "-nameopt [RFC 2253"](https://tools.ietf.org/html/rfc2253)
 You can obtain this string form from a certificate with a command like:
 
 ```
-openssl x509 -in path/to/cert.pem -nameopt RFC2253 -subject -noout
+openssl x509 -nameopt RFC2253 -subject -noout -in path/to/cert.pem
 ```
 
 or from an existing amqps connection with commands like:


### PR DESCRIPTION
## Proposed Changes

This changes the line `openssl x509 -in path/to/cert.pem -nameopt RFC2253 -subject -noout` to put the `-in` parameter at the end of the line, so that it's easier to ^W the path and replace it with another path.

Tested that this works with OpenSSL 3.1.6 4 Jun 2024 (Library: OpenSSL 3.1.6 4 Jun 2024) and OpenSSL 3.3.0 9 Apr 2024 (Library: OpenSSL 3.3.0 9 Apr 2024) on an Ubuntu 22.04.4 container and MacOS 14.7.1

## Types of Changes

This is a single line documentation change to `deps/rabbitmq_auth_mechanism_ssl/README.md`

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This is a trivial commit that I hope will be accepted for convenience. Thank you!