### PR TITLE
Fix transient queue detection

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -118,12 +118,19 @@
      }}).
 
 are_transient_nonexcl_used(_) ->
-    case rabbit_db_queue:list_transient() of
-        {ok, Queues} ->
-            NonExclQueues = [Q || Q <- Queues, not is_exclusive(Q)],
-            length(NonExclQueues) > 0;
-        {error, _} ->
-            undefined
+    case rabbit_db:is_virgin_node() of
+        true ->
+            %% a virgin node can't have any queues and the check is performed before
+            %% metadata store is ready, so skip the query
+            false;
+        false ->
+            case rabbit_db_queue:list_transient() of
+                {ok, Queues} ->
+                    NonExclQueues = [Q || Q <- Queues, not is_exclusive(Q)],
+                    length(NonExclQueues) > 0;
+                {error, _} ->
+                    undefined
+            end
     end.
 
 -define(CONSUMER_INFO_KEYS,

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -985,7 +985,7 @@ list_transient() ->
        }).
 
 list_transient_in_mnesia() ->
-    Pattern = amqqueue:pattern_match_all(),
+    Pattern = amqqueue:pattern_match_on_durable(false),
     AllQueues = mnesia:dirty_match_object(
                   ?MNESIA_TABLE,
                   Pattern),


### PR DESCRIPTION
This fixes two separate issues in the same area:

1. Invalid pattern leading to an incorrect warning about transient queues being used (because all durable queues were counted).
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/12802

2. A fresh deployment wouldn't boot with `deprecated_features.permit.transient_nonexcl_queues = false`
Fixes https://github.com/rabbitmq/rabbitmq-server/discussions/12793