### PR TITLE
Pin Horus to 0.3.1 temporarily

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -189,8 +189,8 @@ erlang_package.hex_package(
 erlang_package.hex_package(
     name = "horus",
     build_file = "@rabbitmq-server//bazel:BUILD.horus",
-    sha256 = "4ebcb0ce86c8ee411d24b289c504b14431ee004d9f2c48e6f88d4128ded33a2e",
-    version = "0.2.6",
+    sha256 = "d564d30ebc274f0d92c3d44a336d0b892f000be159912ae4e6838701e85495ec",
+    version = "0.3.1",
 )
 
 erlang_package.hex_package(

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -128,8 +128,14 @@ endef
 LOCAL_DEPS = sasl os_mon inets compiler public_key crypto ssl syntax_tools xmerl
 
 BUILD_DEPS = rabbitmq_cli
-DEPS = ranch rabbit_common amqp10_common rabbitmq_prelaunch ra sysmon_handler stdout_formatter recon redbug observer_cli osiris syslog systemd seshat khepri khepri_mnesia_migration cuttlefish gen_batch_server
+DEPS = ranch rabbit_common amqp10_common rabbitmq_prelaunch ra sysmon_handler stdout_formatter recon redbug observer_cli osiris syslog systemd seshat horus khepri khepri_mnesia_migration cuttlefish gen_batch_server
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers meck proper amqp_client rabbitmq_amqp_client rabbitmq_amqp1_0
+
+# We pin a version of Horus even if we don't use it directly (it is a
+# dependency of Khepri). But currently, we can't update Khepri while still
+# needing the fix in Horus 0.3.1. This line and the mention of `horus` above
+# should be removed with the next update of Khepri.
+dep_horus = hex 0.3.1
 
 PLT_APPS += mnesia runtime_tools
 


### PR DESCRIPTION
## Why

We pin a version of Horus even if we don't use it directly (it is a dependency of Khepri). But currently, we can't update Khepri while still needing the fix in Horus 0.3.1.

Horus 0.3.1 works around a crash in `cover` that mostly affects CI for now.

This pinning will have to go away with the next update of Khepri.