### PR TITLE
mirrored_supervisor: Catch timeout from Khepri in `hanlde_info/2`

### DIFF
--- a/deps/rabbit/src/rabbit_db_msup.erl
+++ b/deps/rabbit/src/rabbit_db_msup.erl
@@ -226,9 +226,10 @@ find_mirror_in_khepri(Group, Id) ->
 %% update_all().
 %% -------------------------------------------------------------------
 
--spec update_all(Overall, Overall) -> [ChildSpec] when
+-spec update_all(Overall, Overall) -> [ChildSpec] | Error when
       Overall :: pid(),
-      ChildSpec :: supervisor2:child_spec().
+      ChildSpec :: supervisor2:child_spec(),
+      Error :: {error, any()}.
 
 update_all(Overall, OldOverall) ->
     rabbit_khepri:handle_fallback(


### PR DESCRIPTION
## Why

The code assumed that the transaction would always succeed. It was kind of the case with Mnesia because it would throw an exception if it failed.

Khepri returns an error instead. The code has to handle it. In particular, we see timeouts in CI and before this patch, they caused a crash because the list comprehension was asked to work on a tuple.

## How

We now retry a few times for 10 seconds.