### PR TITLE
rabbitmq_peer_discovery_consul: Set `bind_addr` to 127.0.0.1 in test config

### DIFF
--- a/deps/rabbitmq_peer_discovery_consul/test/system_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_consul/test/system_SUITE.erl
@@ -197,7 +197,11 @@ start_consul(Config) ->
     ct:pal("Starting Consul daemon"),
     ConsulBin = ?config(consul_bin, Config),
     ConsulConfDir = ?config(consul_conf_dir, Config),
-    Cmd = [ConsulBin, "agent", "-config-dir", ConsulConfDir],
+    PrivDir = ?config(priv_dir, Config),
+    LogFile = filename:join(PrivDir, "consul.log"),
+    Cmd = [ConsulBin, "agent",
+           "-config-dir", ConsulConfDir,
+           "-log-file", LogFile],
     ConsulPid = spawn(fun() -> rabbit_ct_helpers:exec(Cmd) end),
     rabbit_ct_helpers:set_config(Config, {consul_pid, ConsulPid}).
 

--- a/deps/rabbitmq_peer_discovery_consul/test/system_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_consul/test/system_SUITE.erl
@@ -202,8 +202,18 @@ start_consul(Config) ->
     Cmd = [ConsulBin, "agent",
            "-config-dir", ConsulConfDir,
            "-log-file", LogFile],
-    ConsulPid = spawn(fun() -> rabbit_ct_helpers:exec(Cmd) end),
+    ConsulPid = spawn(fun() -> do_start_consul(Cmd) end),
     rabbit_ct_helpers:set_config(Config, {consul_pid, ConsulPid}).
+
+do_start_consul(Cmd) ->
+    case rabbit_ct_helpers:exec(Cmd) of
+        {ok, Stdout} ->
+            ct:pal("Consul daemon exited:~n~s", [Stdout]);
+        {error, Reason, Stdout} ->
+            ct:pal(
+               "Consul daemon exited with error ~0p:~n~s",
+               [Reason, Stdout])
+    end.
 
 stop_consul(Config) ->
     case rabbit_ct_helpers:get_config(Config, consul_pid) of

--- a/deps/rabbitmq_peer_discovery_consul/test/system_SUITE_data/consul.hcl
+++ b/deps/rabbitmq_peer_discovery_consul/test/system_SUITE_data/consul.hcl
@@ -23,7 +23,7 @@ connect {
 
 # Addresses and ports
 client_addr = "0.0.0.0"
-bind_addr = "{{ GetInterfaceIP \"eth0\" }}"
+bind_addr = "127.0.0.1"
 
 addresses {
   grpc = "0.0.0.0"


### PR DESCRIPTION
## Why

The test configuration was querying a network interface IP address based on its name. However, the name, "eth0", is very specific to Linux. This broke the test on other systems.

## How

We still have to set an explicit `bind_addr` because Consul refuses to start if the host has multiple private IPv4 addresses, as it is the case in CI.

Therefore, we hard-code 127.0.0.1 as the IPv4 address to use because it has a great chance to exist about anywhere.

**V2**: We abandon the idea of not setting `bind_addr` because GitHub Actions default hosts have several private IPv4 addresses configured.