### PR TITLE
rabbitmq_cli: Improve test node start

### DIFF
--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -116,8 +116,12 @@ rel:: $(ESCRIPTS)
 
 tests:: $(ESCRIPTS)
 	$(verbose) $(MAKE) -C ../../ install-cli
-	$(verbose) $(MAKE) -C ../../ start-background-broker PLUGINS="rabbit rabbitmq_federation rabbitmq_stomp rabbitmq_stream_management amqp_client"
-	$(gen_verbose) $(MIX_TEST) $(TEST_FILE); \
+	$(verbose) $(MAKE) -C ../../ start-background-broker \
+		PLUGINS="rabbit rabbitmq_federation rabbitmq_stomp rabbitmq_stream_management amqp_client" \
+		$(if $(filter khepri,$(RABBITMQ_METADATA_STORE)),,RABBITMQ_FEATURE_FLAGS="-khepri_db")
+	$(gen_verbose) $(MIX_TEST) \
+		$(if $(RABBITMQ_METADATA_STORE),--exclude $(filter-out $(RABBITMQ_METADATA_STORE),khepri mnesia),) \
+		$(TEST_FILE); \
 		RES=$$?; \
 		$(MAKE) -C ../../ stop-node; \
 		exit $$RES

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -27,6 +27,8 @@ ifeq ($(VERBOSE_TEST),true)
 MIX_TEST := $(MIX_TEST) --trace
 endif
 
+export MAKE
+
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 
@@ -114,7 +116,7 @@ rel:: $(ESCRIPTS)
 
 tests:: $(ESCRIPTS)
 	$(verbose) $(MAKE) -C ../../ install-cli
-	$(verbose) $(MAKE) -C ../../ run-background-broker PLUGINS="rabbit rabbitmq_federation rabbitmq_stomp rabbitmq_stream_management amqp_client"
+	$(verbose) $(MAKE) -C ../../ start-background-broker PLUGINS="rabbit rabbitmq_federation rabbitmq_stomp rabbitmq_stream_management amqp_client"
 	$(gen_verbose) $(MIX_TEST) $(TEST_FILE); \
 		RES=$$?; \
 		$(MAKE) -C ../../ stop-node; \


### PR DESCRIPTION
Make several improvements to the way the RabbitMQ test node is started:
* Wait for the node to be ready befor proceeding with the tests
* Export the value of `$(MAKE)` to make sure the correct make command is used by nested instances
* Honor `$RABBITMQ_METADATA_STORE` when starting the test node

See individual commits.