### PR TITLE
Selenium suites: fix a flake in an AMQP 1.0 test suite

### DIFF
--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -10,7 +10,7 @@ on:
       - 'deps/rabbitmq_auth_**'
       - 'deps/rabbitmq_management/src/**'
       - 'deps/rabbitmq_management/priv/**'
-      - 'deps/rabbitmq_management/selenium/**'
+      - 'selenium/**'
       - 'scripts/**'
       - .bazelrc
       - .bazelversion
@@ -23,9 +23,9 @@ on:
       - 'deps/rabbit/**'
       - 'deps/rabbitmq_auth_/**'
       - 'deps/rabbitmq_mqtt/**'
-      - 'deps/rabbitmq_management/selenium/full-suite-authnz-messaging'
-      - 'deps/rabbitmq_management/selenium/suites/authnz-messaging'
-      - 'deps/rabbitmq_management/selenium/test/authnz-msg-protocols'
+      - 'selenium/full-suite-authnz-messaging'
+      - 'selenium/suites/authnz-messaging'
+      - 'selenium/test/authnz-msg-protocols'
       - .github/workflows/test-authnz.yaml
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/selenium/test/authnz-msg-protocols/amqp10.js
+++ b/selenium/test/authnz-msg-protocols/amqp10.js
@@ -10,9 +10,7 @@ var untilConnectionEstablished = new Promise((resolve, reject) => {
   })
 })
 
-onAmqp('message', function (context) {
-    receivedAmqpMessageCount++
-})
+
 onceAmqp('sendable', function (context) {
     context.sender.send({body:'first message'})    
 })
@@ -52,16 +50,21 @@ describe('Having AMQP 1.0 protocol enabled and the following auth_backends: ' + 
   })
 
   it('can open an AMQP 1.0 connection', async function () {     
+    var untilFirstMessageReceived = new Promise((resolve, reject) => {
+      onAmqp('message', function(context) {
+        resolve()
+      })
+    })
     amqp = openAmqp()
     await untilConnectionEstablished
-    var untilMessageReceived = new Promise((resolve, reject) => {
+    await untilFirstMessageReceived
+    var untilSecondMessageReceived = new Promise((resolve, reject) => {
       onAmqp('message', function(context) {
         resolve()
       })
     })
     amqp.sender.send({body:'second message'})    
-    await untilMessageReceived
-    assert.equal(2, receivedAmqpMessageCount)
+    await untilSecondMessageReceived    
   })
 
   after(function () {


### PR DESCRIPTION
## Proposed Changes

Fix flake due to a timing issue. Rather than checking against a counter updated by one callback, we check against two separate callbacks being called.

