### PR TITLE
Fixes an exception in AMQP 0-9-1 exception (error) generator when input data includes non-ASCII characters

### DIFF
--- a/deps/rabbit_common/src/rabbit_binary_generator.erl
+++ b/deps/rabbit_common/src/rabbit_binary_generator.erl
@@ -228,8 +228,5 @@ lookup_amqp_exception(Other, Protocol) ->
     {ShouldClose, Code, Text, none}.
 
 amqp_exception_explanation(Text, Expl) ->
-    ExplBin = list_to_binary(Expl),
-    CompleteTextBin = <<Text/binary, " - ", ExplBin/binary>>,
-    if size(CompleteTextBin) > 255 -> <<CompleteTextBin:252/binary, "...">>;
-       true                        -> CompleteTextBin
-    end.
+    LimitedText = io_lib:format("~ts - ~ts", [Text, Expl], [{chars_limit, 255}]),
+    unicode:characters_to_binary(LimitedText).

--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -46,6 +46,7 @@ groups() ->
             pid_decompose_compose,
             platform_and_version,
             frame_encoding_does_not_fail_with_empty_binary_payload,
+            map_exception_does_not_fail_with_unicode_explaination,
             amqp_table_conversion,
             name_type,
             get_erl_path,
@@ -413,6 +414,13 @@ frame_encoding_does_not_fail_with_empty_binary_payload(_Config) ->
                     {[<<"payload">>], [[<<2,0,1,0,0,0,14>>,[<<0,60,0,0,0,0,0,0,0,0,0,7>>,<<0,0>>],206],
                                        [<<3,0,1,0,0,0,7>>,[<<"payload">>],206]]}
                     ]],
+    ok.
+
+map_exception_does_not_fail_with_unicode_explaination(_Config) ->
+    NonAsciiExplaination = "no queue 'non_ascii_name_😍_你好' in vhost '/'",
+    rabbit_binary_generator:map_exception(0,
+        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'},
+        rabbit_framing_amqp_0_9_1),
     ok.
 
 amqp_table_conversion(_Config) ->


### PR DESCRIPTION
## Proposed Changes

`rabbit_binary_generator:map_exception/3` will crash when there are unicode characters in the `explanation` field of `Reason#amqp_error` parameter. The explanation string (list) is assumed to be ascii, with each character/member in the range of a byte. Any unicode characters in the string will trigger `badarg` crash of `list_to_binary/1` in `rabbit_binary_generator:amqp_exception_explanation/2`.

Amqp091 shovel crash due to this is reported, <https://github.com/rabbitmq/rabbitmq-server/discussions/12874>
When a queue as shovel source/destination does not exist, and its name contains non-ascii characters, the explanation of amqp_error will be like `no queue non_ascii_name_😍 in vhost /`. It will subsequently crash and even affect management console.

To fix this, `unicode:characters_to_binary/1` is used instead of `list_to_binary/1`, and unicode-safe truncation of long explanation with `io_lib:format/3` chars_limit replaces direct bytes truncation.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes issue <https://github.com/rabbitmq/rabbitmq-server/discussions/12874>)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
