### PR TITLE
By @bpint: Fixes an exception in AMQP 0-9-1 exception (error) generator when input data includes non-ASCII characters

### DIFF
--- a/deps/rabbit_common/src/rabbit_binary_generator.erl
+++ b/deps/rabbit_common/src/rabbit_binary_generator.erl
@@ -228,8 +228,5 @@ lookup_amqp_exception(Other, Protocol) ->
     {ShouldClose, Code, Text, none}.
 
 amqp_exception_explanation(Text, Expl) ->
-    ExplBin = list_to_binary(Expl),
-    CompleteTextBin = <<Text/binary, " - ", ExplBin/binary>>,
-    if size(CompleteTextBin) > 255 -> <<CompleteTextBin:252/binary, "...">>;
-       true                        -> CompleteTextBin
-    end.
+    LimitedText = io_lib:format("~ts - ~ts", [Text, Expl], [{chars_limit, 255}]),
+    unicode:characters_to_binary(LimitedText).

--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -46,6 +46,7 @@ groups() ->
             pid_decompose_compose,
             platform_and_version,
             frame_encoding_does_not_fail_with_empty_binary_payload,
+            map_exception_does_not_fail_with_unicode_explaination,
             amqp_table_conversion,
             name_type,
             get_erl_path,
@@ -413,6 +414,13 @@ frame_encoding_does_not_fail_with_empty_binary_payload(_Config) ->
                     {[<<"payload">>], [[<<2,0,1,0,0,0,14>>,[<<0,60,0,0,0,0,0,0,0,0,0,7>>,<<0,0>>],206],
                                        [<<3,0,1,0,0,0,7>>,[<<"payload">>],206]]}
                     ]],
+    ok.
+
+map_exception_does_not_fail_with_unicode_explaination(_Config) ->
+    NonAsciiExplaination = "no queue 'non_ascii_name_😍_你好' in vhost '/'",
+    rabbit_binary_generator:map_exception(0,
+        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'},
+        rabbit_framing_amqp_0_9_1),
     ok.
 
 amqp_table_conversion(_Config) ->

--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -46,7 +46,8 @@ groups() ->
             pid_decompose_compose,
             platform_and_version,
             frame_encoding_does_not_fail_with_empty_binary_payload,
-            map_exception_does_not_fail_with_unicode_explaination,
+            map_exception_does_not_fail_with_unicode_explaination_case1,
+            map_exception_does_not_fail_with_unicode_explaination_case2,
             amqp_table_conversion,
             name_type,
             get_erl_path,
@@ -416,8 +417,15 @@ frame_encoding_does_not_fail_with_empty_binary_payload(_Config) ->
                     ]],
     ok.
 
-map_exception_does_not_fail_with_unicode_explaination(_Config) ->
+map_exception_does_not_fail_with_unicode_explaination_case1(_Config) ->
     NonAsciiExplaination = "no queue 'non_ascii_name_😍_你好' in vhost '/'",
+    rabbit_binary_generator:map_exception(0,
+        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'},
+        rabbit_framing_amqp_0_9_1),
+    ok.
+
+map_exception_does_not_fail_with_unicode_explaination_case2(_Config) ->
+    NonAsciiExplaination = "no queue 'кролик 🐰' in vhost '/'",
     rabbit_binary_generator:map_exception(0,
         #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'},
         rabbit_framing_amqp_0_9_1),


### PR DESCRIPTION
This is #12888 re-submitted by me so that the PR has access to relevant GH secrets.

I've also added one more test case with a different character range.