### PR TITLE
CLI: Error on compiler warnings in tests

### DIFF
--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -17,7 +17,7 @@ VERBOSE_TEST ?= true
 MAX_CASES ?= 1
 
 MIX_TEST_OPTS ?= ""
-MIX_TEST = ERL_COMPILER_OPTIONS=deterministic mix test --max-cases=$(MAX_CASES)
+MIX_TEST = ERL_COMPILER_OPTIONS=deterministic MIX_ENV=test mix do compile --warnings-as-errors, test --max-cases=$(MAX_CASES) --warnings-as-errors
 
 ifneq ("",$(MIX_TEST_OPTS))
 MIX_TEST := $(MIX_TEST) $(MIX_TEST_OPTS)

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/auto_complete.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/auto_complete.ex
@@ -94,7 +94,7 @@ defmodule RabbitMQ.CLI.AutoComplete do
 
   defp complete_command_opts(command, <<"-", _::binary>> = opt) do
     switches =
-      command.switches
+      command.switches()
       |> Keyword.keys()
       |> Enum.map(fn sw -> "--" <> to_string(sw) end)
 

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_any_deprecated_features_are_used_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_any_deprecated_features_are_used_command_test.exs
@@ -10,7 +10,6 @@ defmodule CheckIfAnyDeprecatedFeaturesAreUsedCommandTest do
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedCommand
   @policy_name "cmq-policy-8373"
-  # @policy_value "{\"ha-mode\":\"all\"}"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_any_deprecated_features_are_used_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_any_deprecated_features_are_used_command_test.exs
@@ -10,7 +10,7 @@ defmodule CheckIfAnyDeprecatedFeaturesAreUsedCommandTest do
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfAnyDeprecatedFeaturesAreUsedCommand
   @policy_name "cmq-policy-8373"
-  @policy_value "{\"ha-mode\":\"all\"}"
+  # @policy_value "{\"ha-mode\":\"all\"}"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_cluster_has_classic_queue_mirroring_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_cluster_has_classic_queue_mirroring_policy_command_test.exs
@@ -10,7 +10,6 @@ defmodule CheckIfClusterHasClassicQueueMirroringPolicyCommandTest do
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfClusterHasClassicQueueMirroringPolicyCommand
   @policy_name "cmq-policy-8373"
-  # @policy_value "{\"ha-mode\":\"all\"}"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_cluster_has_classic_queue_mirroring_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_cluster_has_classic_queue_mirroring_policy_command_test.exs
@@ -10,7 +10,7 @@ defmodule CheckIfClusterHasClassicQueueMirroringPolicyCommandTest do
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfClusterHasClassicQueueMirroringPolicyCommand
   @policy_name "cmq-policy-8373"
-  @policy_value "{\"ha-mode\":\"all\"}"
+  # @policy_value "{\"ha-mode\":\"all\"}"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()

--- a/deps/rabbitmq_cli/test/diagnostics/discover_peers_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/discover_peers_command_test.exs
@@ -37,7 +37,7 @@ defmodule DiscoverPeersCommandTest do
 
   @tag test_timeout: 15000
   test "run: returns a list of nodes when the backend isn't configured", context do
-    this_node = node()
-    assert match?({:ok, {[this_node], _}}, @command.run([], context[:opts]))
+    this_node = context.opts.node
+    assert match?({:ok, {[^this_node], _}}, @command.run([], context[:opts]))
   end
 end

--- a/deps/rabbitmq_cli/test/rabbitmqctl_test.exs
+++ b/deps/rabbitmq_cli/test/rabbitmqctl_test.exs
@@ -121,7 +121,7 @@ defmodule RabbitMQCtlTest do
 
   test "short node name without the host part connects properly" do
     command = ["status", "-n", "rabbit"]
-    capture_io(:stderr, fn -> error_check(command, exit_ok()) end)
+    capture_io(:stdio, fn -> error_check(command, exit_ok()) end)
   end
 
   test "a non-existent command results in help message displayed" do


### PR DESCRIPTION
This is similar to https://github.com/rabbitmq/rabbitmq-server/pull/10459 but focused on `make` instead. #10459 also only focused on warnings in `lib/` files while this change causes CLI tests to fail when the test modules contain warnings. We need to add the `--warnings-as-errors` flag to `mix test` (added in Elixir 1.12). We can at the same time check that the `lib/` files compile without warning by compiling with `--warnings-as-errors` as well.

Most compiler warnings fixed were benign. The shadowing diagnostics like unused bindings are useful though - one fix covered an unused binding that should've been a match (i.e. needed the pin operator `^`).