### PR TITLE
Improve rabbit_backing_queue:is_duplicate behaviour

### DIFF
--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -220,9 +220,8 @@
 
 %% Called prior to a publish or publish_delivered call. Allows the BQ
 %% to signal that it's already seen this message, (e.g. it was published
-%% or discarded previously) specifying whether to drop the message or reject it.
--callback is_duplicate(mc:state(), state())
-                      -> {{true, drop} | {true, reject} | boolean(), state()}.
+%% or discarded previously).
+-callback is_duplicate(mc:state(), state()) -> {boolean(), state()}.
 
 -callback set_queue_mode(queue_mode(), state()) -> state().
 


### PR DESCRIPTION
## Proposed Changes

The `rabbit_backing_queue:is_duplicate` callback was modified in [PR 1774](https://github.com/rabbitmq/rabbitmq-server/pull/1774) in order to support both the de-duplication plugin and the mirroring queues.

Since implementation of mirroring queues has been removed, the only user for the `is_duplicate` callback remains the de-duplication plugin. Hence, this PR simplifies the callback signature removing dead code.

Neither the classic variable nor the priority queues are making use of the `is_duplicate` callback.

On top of that, in the event the message is deemed duplicated, it is re-routed to DLX if present. This would satisfy issue https://github.com/noxdafox/rabbitmq-message-deduplication/issues/106 on the plugin itself.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

