### PR TITLE
By @noxdafox: Improve rabbit_backing_queue:is_duplicate behaviour (#12913)

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -722,16 +722,27 @@ maybe_deliver_or_enqueue(Delivery = #delivery{message = Message},
             %% Drop publish and nack to publisher
             send_reject_publish(Delivery, State);
         _ ->
-            {IsDuplicate, BQS1} = BQ:is_duplicate(Message, BQS),
-            State1 = State#q{backing_queue_state = BQS1},
-            case IsDuplicate of
-                true -> State1;
-                {true, drop} -> State1;
-                %% Drop publish and nack to publisher
-                {true, reject} ->
+            case BQ:is_duplicate(Message, BQS) of
+                {true, State1} ->
+                    %% Publish to DLX
+                    _ = with_dlx(
+                          DLX,
+                          fun (X) ->
+                                  rabbit_global_counters:messages_dead_lettered(maxlen,
+                                                                                rabbit_classic_queue,
+                                                                                at_most_once, 1),
+                                  QName = qname(State1),
+                                  rabbit_dead_letter:publish(Message, maxlen, X, RK, QName)
+                          end,
+                          fun () ->
+                                  rabbit_global_counters:messages_dead_lettered(maxlen,
+                                                                                rabbit_classic_queue,
+                                                                                disabled, 1)
+                          end),
+                    %% Drop publish and nack to publisher
                     send_reject_publish(Delivery, State1);
                 %% Enqueue and maybe drop head later
-                false ->
+                {false, State1} ->
                     deliver_or_enqueue(Delivery, Delivered, State1)
             end
     end.

--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -220,9 +220,8 @@
 
 %% Called prior to a publish or publish_delivered call. Allows the BQ
 %% to signal that it's already seen this message, (e.g. it was published
-%% or discarded previously) specifying whether to drop the message or reject it.
--callback is_duplicate(mc:state(), state())
-                      -> {{true, drop} | {true, reject} | boolean(), state()}.
+%% or discarded previously).
+-callback is_duplicate(mc:state(), state()) -> {boolean(), state()}.
 
 -callback set_queue_mode(queue_mode(), state()) -> state().
 


### PR DESCRIPTION
This is #12913 by @noxdafox re-submitted so that Actions have access to all the secrets.