### PR TITLE
By @noxdafox: Improve rabbit_backing_queue:is_duplicate behaviour (#12913), take 2

### DIFF
--- a/deps/rabbit/src/rabbit_backing_queue.erl
+++ b/deps/rabbit/src/rabbit_backing_queue.erl
@@ -220,9 +220,8 @@
 
 %% Called prior to a publish or publish_delivered call. Allows the BQ
 %% to signal that it's already seen this message, (e.g. it was published
-%% or discarded previously) specifying whether to drop the message or reject it.
--callback is_duplicate(mc:state(), state())
-                      -> {{true, drop} | {true, reject} | boolean(), state()}.
+%% or discarded previously).
+-callback is_duplicate(mc:state(), state()) -> {boolean(), state()}.
 
 -callback set_queue_mode(queue_mode(), state()) -> state().
 


### PR DESCRIPTION
This is #12913 by @noxdafox, take 2, re-submitted so that Actions have access to all the secrets.