### PR TITLE
Disallow transient entities in RabbitMQ AMQP 1.0 Erlang client

### DIFF
--- a/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl
+++ b/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl
@@ -50,13 +50,11 @@
                         replicas => [binary()],
                         leader => binary()}.
 
--type queue_properties() :: #{durable => boolean(),
-                              exclusive => boolean(),
+-type queue_properties() :: #{exclusive => boolean(),
                               auto_delete => boolean(),
                               arguments => arguments()}.
 
 -type exchange_properties() :: #{type => binary(),
-                                 durable => boolean(),
                                  auto_delete => boolean(),
                                  internal => boolean(),
                                  arguments => arguments()}.
@@ -161,9 +159,7 @@ get_queue(LinkPair, QueueName) ->
     {ok, queue_info()} | {error, term()}.
 declare_queue(LinkPair, QueueName, QueueProperties) ->
     Body0 = maps:fold(
-              fun(durable, V, L) when is_boolean(V) ->
-                      [{{utf8, <<"durable">>}, {boolean, V}} | L];
-                 (exclusive, V, L) when is_boolean(V) ->
+              fun(exclusive, V, L) when is_boolean(V) ->
                       [{{utf8, <<"exclusive">>}, {boolean, V}} | L];
                  (auto_delete, V, L) when is_boolean(V) ->
                       [{{utf8, <<"auto_delete">>}, {boolean, V}} | L];
@@ -341,8 +337,6 @@ declare_exchange(LinkPair, ExchangeName, ExchangeProperties) ->
     Body0 = maps:fold(
               fun(type, V, L) when is_binary(V) ->
                       [{{utf8, <<"type">>}, {utf8, V}} | L];
-                 (durable, V, L) when is_boolean(V) ->
-                      [{{utf8, <<"durable">>}, {boolean, V}} | L];
                  (auto_delete, V, L) when is_boolean(V) ->
                       [{{utf8, <<"auto_delete">>}, {boolean, V}} | L];
                  (internal, V, L) when is_boolean(V) ->

--- a/deps/rabbitmq_consistent_hash_exchange/test/rabbit_exchange_type_consistent_hash_SUITE.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/test/rabbit_exchange_type_consistent_hash_SUITE.erl
@@ -204,7 +204,6 @@ amqp_dead_letter(Config) ->
 
     ok = rabbitmq_amqp_client:declare_exchange(
            LinkPair, XName, #{type => <<"x-consistent-hash">>,
-                              durable => true,
                               auto_delete => true,
                               arguments => #{<<"hash-property">> => {utf8, <<"correlation_id">>}}}),
     {ok, #{type := <<"quorum">>}} = rabbitmq_amqp_client:declare_queue(


### PR DESCRIPTION
Transient (i.e. `durable=false`) exchanges and queues are deprecated.

Khepri will store all entities durably.
(Even exclusive queues will be stored durably. Exclusive queues are still deleted when the declaring connection is closed.)

Similar to how the RabbitMQ AMQP 1.0 Java client already disallows the creation of transient exchanges and queues, this commit will prohibit the declaration of transient exchanges and queues in the RabbitMQ AMQP 1.0 Erlang client starting with RabbitMQ 4.1.