### PR TITLE
Quorum queues: ignore handle_tick with an old overview format

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -655,7 +655,10 @@ handle_tick(QName,
                                        [rabbit_misc:rs(QName), Err]),
                       ok
               end
-      end).
+      end);
+handle_tick(QName, Config, _Nodes) ->
+    rabbit_log:debug("~ts: handle tick received unexpected config format ~tp",
+                     [rabbit_misc:rs(QName), Config]).
 
 repair_leader_record(Q, Self) ->
     Node = node(),


### PR DESCRIPTION
If handle_tick is called before the machine has finished the upgrade process, it could receive an old overview format (stats tuple vs map). Let's ignore it and the next handle tick should be fine.

Unlikely to happen in production, detected on CI with a very low tick timeout

