### PR TITLE
WIP Fix v4.0.x CI

### DIFF
--- a/.github/workflows/test-make-tests.yaml
+++ b/.github/workflows/test-make-tests.yaml
@@ -17,8 +17,6 @@ on:
 jobs:
   test-rabbit:
     name: Test rabbit
-    env:
-      DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -10,7 +10,7 @@ on:
     - Makefile
     - plugins.mk
     - rabbitmq-components.mk
-    - .github/workflows/test-make.yaml
+    - .github/workflows/test-make*.yaml
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This reverts commit bdce755c4ef42434f97459a23855e11d7244d0ef because it broke CI. `make` tests are not run anymore.
