### PR TITLE
v4.0.x: AMQP 1.0 .NET-based integration suite: an attempt to fix 'dotnet restore'

### DIFF
--- a/deps/rabbit/test/amqp_system_SUITE.erl
+++ b/deps/rabbit/test/amqp_system_SUITE.erl
@@ -90,8 +90,14 @@ end_per_testcase(Testcase, Config) ->
 build_dotnet_test_project(Config) ->
     TestProjectDir = filename:join(
                        [?config(data_dir, Config), "fsharp-tests"]),
+    Env = [
+        %% https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization
+        %% https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md
+        {"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"}
+    ],
     Ret = rabbit_ct_helpers:exec(["dotnet", "restore"],
-                                 [{cd, TestProjectDir}]),
+                                 [{cd, TestProjectDir},
+                                  {env, Env}]),
     case Ret of
         {ok, _} ->
             rabbit_ct_helpers:set_config(

--- a/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/fsharp-tests.fsproj
+++ b/deps/rabbit/test/amqp_system_SUITE_data/fsharp-tests/fsharp-tests.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
As a result recent Actions environment upgrade, `dotnet restore` currently throws

```
Process terminated. Couldn't find a valid ICU package installed on the system.
Set the configuration flag System.Globalization.Invariant to true if you want
to run with no globalization support.
```

on `v4.0.x`.