### PR TITLE
v4.0.x: Bump .NET version used by some AMQP 1.0 integration suites

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -74,7 +74,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       if: inputs.plugin == 'rabbit'
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '8.0'
 
     - name: SETUP SLAPD (rabbitmq_auth_backend_ldap)
       if: inputs.plugin == 'rabbitmq_auth_backend_ldap'


### PR DESCRIPTION
This is a continuation to https://github.com/rabbitmq/rabbitmq-server/pull/12954.

As a result recent Actions environment upgrade, `dotnet restore` currently throws

```
Process terminated. Couldn't find a valid ICU package installed on the system.
Set the configuration flag System.Globalization.Invariant to true if you want
to run with no globalization support.
```

on `v4.0.x`.

This backports https://github.com/rabbitmq/rabbitmq-server/commit/8c0cd1b78c7736dc64a66c2f1d3923ee192847d2 to `v4.0.x`.