### PR TITLE
Remove actions/setup-dotnet

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -76,12 +76,6 @@ jobs:
 
         echo "SECONDARY_DIST=${GITHUB_WORKSPACE}/rabbitmq_server-$archive_version" >> $GITHUB_ENV
 
-    - name: SETUP DOTNET (rabbit)
-      uses: actions/setup-dotnet@v4
-      if: inputs.plugin == 'rabbit'
-      with:
-        dotnet-version: '8.0'
-
     - name: SETUP SLAPD (rabbitmq_auth_backend_ldap)
       if: inputs.plugin == 'rabbitmq_auth_backend_ldap'
       run: |

--- a/.github/workflows/test-plugin-mixed.yaml
+++ b/.github/workflows/test-plugin-mixed.yaml
@@ -72,10 +72,6 @@ jobs:
         bazelisk info release
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
-    - uses: actions/setup-dotnet@v4
-      if: inputs.plugin == 'rabbit'
-      with:
-        dotnet-version: '8.0'
     - name: deps/amqp10_client SETUP
       if: inputs.plugin == 'amqp10_client'
       run: |

--- a/.github/workflows/test-plugin.yaml
+++ b/.github/workflows/test-plugin.yaml
@@ -72,10 +72,6 @@ jobs:
         bazelisk info release
     #! - name: Setup tmate session
     #!   uses: mxschmitt/action-tmate@v3
-    - uses: actions/setup-dotnet@v4
-      if: inputs.plugin == 'rabbit'
-      with:
-        dotnet-version: '8.0'
     - name: deps/amqp10_client SETUP
       if: inputs.plugin == 'amqp10_client'
       run: |


### PR DESCRIPTION
According to https://github.com/rabbitmq/rabbitmq-server/pull/12955#pullrequestreview-2506932356 and https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#net-tools dotnet 8.0 is already installed on Ubuntu 24.04.