### PR TITLE
Upgrade eetcd and gun

### DIFF
--- a/deps/rabbitmq_peer_discovery_etcd/Makefile
+++ b/deps/rabbitmq_peer_discovery_etcd/Makefile
@@ -5,8 +5,8 @@ PROJECT_MOD = rabbitmq_peer_discovery_etcd_app
 DEPS = rabbit_common rabbitmq_peer_discovery_common rabbit eetcd gun
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers ct_helper meck
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_gun = hex 1.3.3
-dep_eetcd = hex 0.3.6
+dep_gun = hex 2.1.0
+dep_eetcd = hex 0.4.0
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/deps/rabbitmq_peer_discovery_etcd/priv/schema/rabbitmq_peer_discovery_etcd.schema
+++ b/deps/rabbitmq_peer_discovery_etcd/priv/schema/rabbitmq_peer_discovery_etcd.schema
@@ -182,9 +182,6 @@ end}.
 {mapping, "cluster_formation.etcd.ssl_options.verify", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.verify", [
     {datatype, {enum, [verify_peer, verify_none]}}]}.
 
-{mapping, "cluster_formation.etcd.ssl_options.fail_if_no_peer_cert", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.fail_if_no_peer_cert", [
-    {datatype, {enum, [true, false]}}]}.
-
 {mapping, "cluster_formation.etcd.ssl_options.cacertfile", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.cacertfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 
@@ -213,17 +210,6 @@ end}.
 
 {mapping, "cluster_formation.etcd.ssl_options.depth", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.depth",
     [{datatype, integer}, {validators, ["byte"]}]}.
-
-{mapping, "cluster_formation.etcd.ssl_options.dh", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.dh",
-    [{datatype, string}]}.
-
-{translation, "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.dh",
-fun(Conf) ->
-    list_to_binary(cuttlefish:conf_get("cluster_formation.etcd.ssl_options.dh", Conf))
-end}.
-
-{mapping, "cluster_formation.etcd.ssl_options.dhfile", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.dhfile",
-    [{datatype, string}, {validators, ["file_accessible"]}]}.
 
 {mapping, "cluster_formation.etcd.ssl_options.key.RSAPrivateKey", "rabbit.cluster_formation.peer_discovery_etcd.ssl_options.key",
     [{datatype, string}]}.

--- a/release-notes/4.1.0.md
+++ b/release-notes/4.1.0.md
@@ -32,6 +32,12 @@ for the complete list of related changes.
    This default can be overridden by [configuring](https://www.rabbitmq.com/docs/configure#config-file) `mqtt.max_packet_size_authenticated`.
    Note that this value must not be greater than `max_message_size` (which also defaults to 16 MiB).
 
+### etcd Peer Discovery
+
+The following `rabbitmq.conf` settings are unsupported:
+* `cluster_formation.etcd.ssl_options.fail_if_no_peer_cert`
+* `cluster_formation.etcd.ssl_options.dh`
+* `cluster_formation.etcd.ssl_options.dhfile`
 
 ## Erlang/OTP Compatibility Notes
 


### PR DESCRIPTION
## Why?

To introduce AMQP over WebSocket, we will add gun to the Erlang AMQP
1.0 client. We want to add the latest version of gun for this new
feature. Since rabbitmq_peer_discovery_etcd depends on the outdated
eetcd 0.3.6 which in turn depends on the outdated gun 1.3.3, this commit
first upgrades eetcd and gun.

## How?
See https://github.com/zhongwencool/eetcd?tab=readme-ov-file#migration-from-eetcd-03x-to-04x

## Breaking Changes

This commit causes the following breaking change:
`rabbitmq.conf` settings
* `cluster_formation.etcd.ssl_options.fail_if_no_peer_cert`
* `cluster_formation.etcd.ssl_options.dh`
* `cluster_formation.etcd.ssl_options.dhfile`

are unsupported because they are not valid `ssl:tls_client_option()`.

See https://github.com/erlang/otp/issues/7497#issuecomment-1636012198
