### PR TITLE
Remove rabbit_common from MQTT dependencies

### DIFF
--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -42,7 +42,7 @@ BUILD_WITHOUT_QUIC=1
 export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = ssl
-DEPS = ranch rabbit_common rabbit amqp10_common
+DEPS = ranch rabbit amqp10_common
 TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management amqp_client rabbitmq_consistent_hash_exchange rabbitmq_amqp_client rabbitmq_stomp rabbitmq_stream
 
 PLT_APPS += rabbitmqctl elixir

--- a/deps/rabbitmq_web_mqtt/Makefile
+++ b/deps/rabbitmq_web_mqtt/Makefile
@@ -18,7 +18,7 @@ BUILD_WITHOUT_QUIC=1
 export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = ssl
-DEPS = rabbit_common rabbit cowboy rabbitmq_mqtt
+DEPS = rabbit cowboy rabbitmq_mqtt
 TEST_DEPS = emqtt rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management rabbitmq_stomp rabbitmq_consistent_hash_exchange
 
 PLT_APPS += rabbitmqctl elixir cowlib


### PR DESCRIPTION
`rabbit_common` is a relict from the pre native MQTT era.