### PR TITLE
Upgrade eetcd to v0.5.0

### DIFF
--- a/deps/rabbitmq_peer_discovery_etcd/Makefile
+++ b/deps/rabbitmq_peer_discovery_etcd/Makefile
@@ -5,8 +5,7 @@ PROJECT_MOD = rabbitmq_peer_discovery_etcd_app
 DEPS = rabbit_common rabbitmq_peer_discovery_common rabbit eetcd gun
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers ct_helper meck
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
-dep_gun = hex 2.1.0
-dep_eetcd = hex 0.4.0
+dep_eetcd = hex 0.5.0
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk


### PR DESCRIPTION
eetcd v0.5.0 is compatible with OTP 27 and depends on gun 2.1.0