### PR TITLE
Speed up tests

### DIFF
--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -6249,7 +6249,7 @@ receive_all_messages0(Receiver, Accept, Acc) ->
                     false -> ok
                 end,
                 receive_all_messages0(Receiver, Accept, [Msg | Acc])
-    after 5000 ->
+    after 2000 ->
               lists:reverse(Acc)
     end.
 
@@ -6319,7 +6319,7 @@ count_received_messages0(Receiver, Count) ->
     receive
         {amqp10_msg, Receiver, _Msg} ->
             count_received_messages0(Receiver, Count + 1)
-    after 5000 ->
+    after 2000 ->
               Count
     end.
 
@@ -6357,7 +6357,7 @@ assert_link_credit_runs_out(Sender, Left) ->
             receive {amqp10_event, {link, Sender, credited}} ->
                         ct:pal("credited with ~b messages left", [Left]),
                         assert_link_credit_runs_out(Sender, Left - 1)
-            after 30000 ->
+            after 1000 ->
                       ct:pal("insufficient link credit with ~b messages left", [Left]),
                       ok
             end

--- a/deps/rabbitmq_mqtt/test/util.erl
+++ b/deps/rabbitmq_mqtt/test/util.erl
@@ -65,7 +65,7 @@ expect_publishes(Client, Topic, [Payload|Rest])
                     payload := Other}} ->
             ct:fail("Received unexpected PUBLISH payload. Expected: ~p Got: ~p",
                     [Payload, Other])
-    after 30_000 ->
+    after 5000 ->
               {publish_not_received, Payload}
     end.
 


### PR DESCRIPTION
Multiple test cases were recently slowed down by up to 30 seconds. This commit reverts these changes.