### PR TITLE
Prevent node from booting if credit_flow_default_credit is not valid

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -300,8 +300,6 @@
 %% 100 ms
 -define(BOOT_STATUS_CHECK_INTERVAL, 100).
 
--define(DEFAULT_CREDIT, {400, 200}).
-
 %%----------------------------------------------------------------------------
 
 -type restart_type() :: 'permanent' | 'transient' | 'temporary'.
@@ -1767,8 +1765,8 @@ persist_static_configuration() ->
                        MoreCreditAfter < InitialCredit ->
                          {InitialCredit, MoreCreditAfter};
                      _ ->
-                       rabbit_log:warning("Invalid value for credit_flow_default_credit, changing to the default value."),
-                       ?DEFAULT_CREDIT
+                       rabbit_log:error("Failed to boot due to invalid setting of credit_flow_default_credit."),
+                       throw({error,invalid_credit_flow_default_credit_value})
                end,
     ok = persistent_term:put(credit_flow_default_credit, CREDIT_FLOW_DEFAULT_CREDIT),
 

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1751,8 +1751,7 @@ persist_static_configuration() ->
       [classic_queue_index_v2_segment_entry_count,
        classic_queue_store_v2_max_cache_size,
        classic_queue_store_v2_check_crc32,
-       incoming_message_interceptors,
-       credit_flow_default_credit
+       incoming_message_interceptors
       ]),
 
     %% Disallow the following two cases:

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1757,7 +1757,7 @@ persist_static_configuration() ->
     %% Disallow the following two cases:
     %% 1. Negative value
     %% 2. MoreCreditAfter larger than InitialCredit.
-    CREDIT_FLOW_DEFAULT_CREDIT = case application:get_env(?MODULE, credit_flow_default_credit) of
+    CreditFlowDefaultCredit = case application:get_env(?MODULE, credit_flow_default_credit) of
                      {ok, {InitialCredit, MoreCreditAfter}}
                        when is_integer(InitialCredit) andalso
                        is_integer(MoreCreditAfter) andalso
@@ -1767,7 +1767,7 @@ persist_static_configuration() ->
                        rabbit_log:error("Failed to start due to invalid value of credit_flow_default_credit."),
                        throw({error, invalid_credit_flow_default_credit_value})
                end,
-    ok = persistent_term:put(credit_flow_default_credit, CREDIT_FLOW_DEFAULT_CREDIT),
+    ok = persistent_term:put(credit_flow_default_credit, CreditFlowDefaultCredit),
 
     %% Disallow 0 as it means unlimited:
     %% "If this field is zero or unset, there is no maximum

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1761,11 +1761,11 @@ persist_static_configuration() ->
     %% 1. Negative value
     %% 2. MoreCreditAfter larger than InitialCredit.
     CREDIT_FLOW_DEFAULT_CREDIT = case application:get_env(?MODULE, credit_flow_default_credit) of
-                     {ok, {InitialCredit, _MoreCreditAfter}}
+                     {ok, {InitialCredit, MoreCreditAfter}}
                        when is_integer(InitialCredit) andalso
-                       is_integer(_MoreCreditAfter) andalso
-                       _MoreCreditAfter < InitialCredit ->
-                         {InitialCredit, _MoreCreditAfter};
+                       is_integer(MoreCreditAfter) andalso
+                       MoreCreditAfter < InitialCredit ->
+                         {InitialCredit, MoreCreditAfter};
                      _ ->
                        rabbit_log:warning("Invalid value for credit_flow_default_credit, changing to the default value."),
                        ?DEFAULT_CREDIT

--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1764,8 +1764,8 @@ persist_static_configuration() ->
                        MoreCreditAfter < InitialCredit ->
                          {InitialCredit, MoreCreditAfter};
                      _ ->
-                       rabbit_log:error("Failed to boot due to invalid setting of credit_flow_default_credit."),
-                       throw({error,invalid_credit_flow_default_credit_value})
+                       rabbit_log:error("Failed to start due to invalid value of credit_flow_default_credit."),
+                       throw({error, invalid_credit_flow_default_credit_value})
                end,
     ok = persistent_term:put(credit_flow_default_credit, CREDIT_FLOW_DEFAULT_CREDIT),
 


### PR DESCRIPTION
## Proposed Changes
As mention in previous [discussion](https://github.com/rabbitmq/rabbitmq-server/discussions/13041) thread, this PR add adds validation for
param `credit_flow_default_credit`, and change it to default value for the following two cases:
1. MoreCreditAfter larger than InitialCredit
2. Negative value

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
