### PR TITLE
Stream queue: consumers are active by default

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -329,7 +329,7 @@ consume(Q, Spec, #stream_client{} = QState0)
                     AckRequired = not NoAck,
                     rabbit_core_metrics:consumer_created(
                       ChPid, ConsumerTag, ExclusiveConsume, AckRequired,
-                      QName, ConsumerPrefetchCount, false, up, Args),
+                      QName, ConsumerPrefetchCount, true, up, Args),
                     %% reply needs to be sent before the stream
                     %% begins sending
                     maybe_send_reply(ChPid, OkMsg),


### PR DESCRIPTION
Without this change, consumers using protocols other than the stream protocol would display as inactive in the Management UI/API and CLI commands, even though they were receiving messages.

Here's a screenshot before, with 2 stream-perf-test (one using SAC, the other not) and 1 consumer for AMQP 0.9.1, AMQP 1.0 and STOMP. You can see that only 2 consumers appear to be active, while in fact 5 were receiving messages (all except 2 non-active SAC consumers).
<img width="1213" alt="before" src="https://github.com/user-attachments/assets/04c9d051-c2a0-4e1b-9b30-0c5a3c3f0562" />

With this change and with the same clients running, we can indeed see 5 active consumers:
<img width="1218" alt="after" src="https://github.com/user-attachments/assets/778df76e-06da-47bb-a3b3-cbb976c88624" />
