### PR TITLE
Allow InitialCredit/MoreCreditAfter of zero

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1761,8 +1761,8 @@ persist_static_configuration() ->
                      {ok, {InitialCredit, MoreCreditAfter}}
                        when is_integer(InitialCredit) andalso
                             is_integer(MoreCreditAfter) andalso
-                            InitialCredit > 0 andalso
-                            MoreCreditAfter > 0 andalso
+                            InitialCredit >= 0 andalso
+                            MoreCreditAfter >= 0 andalso
                             MoreCreditAfter =< InitialCredit ->
                          {InitialCredit, MoreCreditAfter};
                      Other ->


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-server/pull/13046 introduced additional checks which prevent setting `{credit_flow_default_credit,{0,0}}`.

Setting credits to zero allows disabling the credit flow mechanism (we use it in our benchmarks and mention for example in https://www.rabbitmq.com/blog/2023/03/21/native-mqtt)