### PR TITLE
Test feature flag

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -205,3 +205,10 @@
       stability     => stable,
       depends_on    => [message_containers]
      }}).
+
+-rabbit_feature_flag(
+   {'rabbitmq_4.1.0',
+    #{desc          => "just a test",
+      stability     => stable,
+      depends_on    => ['rabbitmq_4.0.0']
+     }}).


### PR DESCRIPTION
Adding a new feature flag to `main` branch leads currently to `feature_flags_SUITE` in mixed version mode to fail.