### PR TITLE
Delete stream consumer metrics when AMQP 091 connection closes

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -972,9 +972,15 @@ init(Q) when ?is_amqqueue(Q) ->
             E
     end.
 
-close(#stream_client{readers = Readers}) ->
-    maps:foreach(fun (_, #stream{log = Log}) ->
-                         osiris_log:close(Log)
+close(#stream_client{readers = Readers,
+                     name = QName}) ->
+    maps:foreach(fun (CTag, #stream{log = Log}) ->
+                         close_log(Log),
+                         rabbit_core_metrics:consumer_deleted(self(), CTag, QName),
+                         rabbit_event:notify(consumer_deleted,
+                                             [{consumer_tag, CTag},
+                                              {channel, self()},
+                                              {queue, QName}])
                  end, Readers).
 
 update(Q, State)


### PR DESCRIPTION
To avoid rogue consumer records.
