### PR TITLE
Fix return value of `rabbit_priority_queue:delete_crashed/1`

### DIFF
--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -187,7 +187,9 @@ delete_crashed(Q) ->
     BQ = bq(),
     case priorities(Q) of
         none -> BQ:delete_crashed(Q);
-        Ps   -> [BQ:delete_crashed(mutate_name(P, Q)) || P <- Ps]
+        Ps   ->
+            [ok = BQ:delete_crashed(mutate_name(P, Q)) || P <- Ps],
+            ok
     end.
 
 purge(State = #state{bq = BQ}) ->


### PR DESCRIPTION
## Proposed Changes

According to the `rabbit_backing_queue` behavious it must always return `ok`, but it used to return a list of results one for each priority. That caused the below crash further up the call chain.

```
> rabbit_classic_queue:delete_crashed(Q)
** exception error: no case clause matching [ok,ok,ok,ok,ok,ok,ok,ok,ok,ok,ok]
     in function  rabbit_classic_queue:delete_crashed/2 (rabbit_classic_queue.erl, line 516)
```

Other backing_queue implementations (`rabbit_variable_queue`) just exit with a badmatch upon error.

This (very minor) issue is present since 3.13.0 when `rabbit_classic_queue:delete_crashed_in_backing_queue/1` was introduced with Khepri in commit 5f0981c5. Before that the result of `BQ:delete_crashed/1` was simply ignored.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
