### PR TITLE
Highlight busy incoming links

### DIFF
--- a/deps/rabbitmq_management/priv/www/css/main.css
+++ b/deps/rabbitmq_management/priv/www/css/main.css
@@ -420,3 +420,11 @@ input.toggle:checked + label.toggle:after {
     left: calc(100% - 2px);
     transform: translateX(-100%);
 }
+
+.grey-background {
+  background-color: #f0f0f0;
+}
+
+.yellow-background {
+  background-color: #ffff7b;
+}

--- a/deps/rabbitmq_management/priv/www/js/tmpl/sessions-list.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/sessions-list.ejs
@@ -1,3 +1,13 @@
+<%
+function getAddressClass(address) {
+  return address === '/management' ? 'grey-background' : '';
+}
+
+function getCreditClass(credit) {
+  return credit === 0 || credit === '0' ? 'yellow-background' : '';
+}
+%>
+
 <% if (sessions.length > 0) { %>
 <table class="list" id="sessions">
  <thead>
@@ -22,9 +32,9 @@
    <td class="c"><%= fmt_string(session.channel_number) %></td>
    <td class="c"><%= fmt_string(session.handle_max) %></td>
    <td class="c"><%= fmt_string(session.next_incoming_id) %></td>
-   <td class="c"><%= fmt_string(session.incoming_window) %></td>
+   <td class="c <%= getCreditClass(session.incoming_window) %>"><%= fmt_string(session.incoming_window) %></td>
    <td class="c"><%= fmt_string(session.next_outgoing_id) %></td>
-   <td class="c"><%= fmt_string(session.remote_incoming_window) %></td>
+   <td class="c <%= getCreditClass(session.remote_incoming_window) %>"><%= fmt_string(session.remote_incoming_window) %></td>
    <td class="c"><%= fmt_string(session.remote_outgoing_window) %></td>
    <td class="c"><%= fmt_string(session.outgoing_unsettled_deliveries) %></td>
   </tr>
@@ -53,11 +63,11 @@
      <tr class="link">
       <td class="c"><%= fmt_string(in_link.handle) %></td>
       <td class="c"><%= fmt_string(in_link.link_name) %></td>
-      <td class="c"><%= fmt_string(in_link.target_address) %></td>
+      <td class="c <%= getAddressClass(in_link.target_address) %>"><%= fmt_string(in_link.target_address) %></td>
       <td class="c"><%= fmt_string(in_link.snd_settle_mode) %></td>
       <td class="c"><%= fmt_string(in_link.max_message_size) %></td>
       <td class="c"><%= fmt_string(in_link.delivery_count) %></td>
-      <td class="c"><%= fmt_string(in_link.credit) %></td>
+      <td class="c <%= getCreditClass(in_link.credit) %>"><%= fmt_string(in_link.credit) %></td>
       <td class="c"><%= fmt_string(in_link.unconfirmed_messages) %></td>
      </tr>
 <% } %>
@@ -91,7 +101,7 @@
      <tr class="link">
       <td class="c"><%= fmt_string(out_link.handle) %></td>
       <td class="c"><%= fmt_string(out_link.link_name) %></td>
-      <td class="c"><%= fmt_string(out_link.source_address) %></td>
+      <td class="c <%= getAddressClass(out_link.source_address) %>"><%= fmt_string(out_link.source_address) %></td>
       <td class="c"><%= fmt_string(out_link.queue_name) %></td>
       <td class="c"><%= fmt_boolean(out_link.send_settled) %></td>
       <td class="c"><%= fmt_string(out_link.max_message_size) %></td>


### PR DESCRIPTION
Visualise busy links from publisher to RabbitMQ. If the link credit reaches 0, we set a yellow background colour in the cell. Note that these credit values can change many times per second while the management UI refreshes only every few seconds. However, it may still give a user an idea of what links are currently busy.

We use yellow since that's consistent with the `flow` state in AMQP 0.9.1, which is also set to yellow.

We do not want want to highlight **outgoing** links with credit 0 as that might be a paused consumer, and therefore not a busy link.

We also use yellow background color if incoming-window is 0 (in case of a cluster wider memory or disk alarm) or if remote-incoming-window is 0 as consumers should try to keep their incoming-window open and instead use link credit if they want to pause consumption.

Additionally we set a grey background colour for the `/management` address just to highlight them slightly since these are "special" link pairs.

 ## Example 1
1. Start RabbitMQ server on Ubuntu.
2. Declare a quorum queue:
```
deps/rabbitmq_management/bin/rabbitmqadmin declare queue name=my-quorum-queue queue_type=quorum durable=true
```
3. Send and receive large messages as fast as possible:
```
quiver //host.docker.internal//queues/my-quorum-queue \
    --durable --count 1m --duration 10m --body-size 10000 --credit 5000
```

The management UI will show the link from client to RabbitMQ as busy sometimes when it auto-refreshes every 5 seconds:
<img width="1439" alt="Screenshot 2025-01-17 at 11 10 25" src="https://github.com/user-attachments/assets/9e10d8fe-d7bb-44be-92ea-4be621d5de42" />

 ## Example 2
Trigger a memory alarm:
```
./sbin/rabbitmqctl set_vm_memory_high_watermark absolute 1MB
```
The incoming-window of sessions will be closed. Also you see here the grey background of the management link pair:
<img width="1306" alt="Screenshot 2025-01-17 at 10 51 12" src="https://github.com/user-attachments/assets/ef0203c1-b4f8-4b4b-8da6-6791a07015a6" />