### PR TITLE
rabbitmq_ct_helpers: Use node 2 as the cluster seed node

### DIFF
--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -133,7 +133,9 @@ init_per_group(Group, Config0) ->
                                                     {rmq_nodes_clustered, false},
                                                     {tcp_ports_base},
                                                     {net_ticktime, 5}]),
-    rabbit_ct_helpers:run_steps(Config,
+    Config1 = rabbit_ct_helpers:merge_app_env(
+                Config, {rabbit, [{forced_feature_flags_on_init, []}]}),
+    rabbit_ct_helpers:run_steps(Config1,
                                 rabbit_ct_broker_helpers:setup_steps() ++
                                     rabbit_ct_client_helpers:setup_steps()).
 

--- a/deps/rabbit/test/clustering_events_SUITE.erl
+++ b/deps/rabbit/test/clustering_events_SUITE.erl
@@ -87,10 +87,10 @@ configure_cluster_essentials(Config, Group, Clustered) ->
 
 node_added_event(Config) ->
     [Server1, Server2, _Server3] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
-    ok = event_recorder:start(Config),
-    join_cluster(Server2, Server1),
-    E = event_recorder:get_events(Config),
-    ok = event_recorder:stop(Config),
+    ok = event_recorder:start(Config, Server2),
+    join_cluster(Server1, Server2),
+    E = event_recorder:get_events(Config, Server2),
+    ok = event_recorder:stop(Config, Server2),
     ?assert(lists:any(fun(#event{type = node_added}) ->
                               true;
                          (_) ->

--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -144,9 +144,15 @@ init_per_group(mnesia_store, Config) ->
             Config
     end;
 init_per_group(unclustered_2_nodes, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, false}]);
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [{rmq_nodes_clustered, false}]),
+    rabbit_ct_helpers:merge_app_env(
+      Config1, {rabbit, [{forced_feature_flags_on_init, []}]});
 init_per_group(unclustered_3_nodes, Config) ->
-    rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, false}]);
+    Config1 = rabbit_ct_helpers:set_config(
+                Config, [{rmq_nodes_clustered, false}]),
+    rabbit_ct_helpers:merge_app_env(
+      Config1, {rabbit, [{forced_feature_flags_on_init, []}]});
 init_per_group(clustered_2_nodes, Config) ->
     rabbit_ct_helpers:set_config(Config, [{rmq_nodes_clustered, true}]);
 init_per_group(clustered_3_nodes, Config) ->

--- a/deps/rabbit/test/feature_flags_SUITE.erl
+++ b/deps/rabbit/test/feature_flags_SUITE.erl
@@ -119,9 +119,7 @@ groups() ->
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
-    Config1 = rabbit_ct_helpers:set_config(
-                Config, {skip_metadata_store_configuration, true}),
-    rabbit_ct_helpers:run_setup_steps(Config1, [
+    rabbit_ct_helpers:run_setup_steps(Config, [
       fun rabbit_ct_broker_helpers:configure_dist_proxy/1
     ]).
 
@@ -198,7 +196,9 @@ init_per_group(clustering, Config) ->
                 [{rmq_nodes_count, 2},
                  {rmq_nodes_clustered, false},
                  {start_rmq_with_plugins_disabled, true}]),
-    rabbit_ct_helpers:run_setup_steps(Config1, [fun prepare_my_plugin/1]);
+    Config2 = rabbit_ct_helpers:merge_app_env(
+                Config1, {rabbit, [{forced_feature_flags_on_init, []}]}),
+    rabbit_ct_helpers:run_setup_steps(Config2, [fun prepare_my_plugin/1]);
 init_per_group(activating_plugin, Config) ->
     Config1 = rabbit_ct_helpers:set_config(
                 Config,
@@ -212,7 +212,17 @@ init_per_group(_, Config) ->
 end_per_group(_, Config) ->
     Config.
 
+init_per_testcase(enable_feature_flag_when_ff_file_is_unwritable = Testcase, Config) ->
+    case erlang:system_info(otp_release) of
+        "26" ->
+            {skip, "Hits a crash in Mnesia fairly frequently"};
+        _ ->
+            do_init_per_testcase(Testcase, Config)
+    end;
 init_per_testcase(Testcase, Config) ->
+    do_init_per_testcase(Testcase, Config).
+
+do_init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
     TestNumber = rabbit_ct_helpers:testcase_number(Config, ?MODULE, Testcase),
     Config1 = case Testcase of
@@ -891,7 +901,7 @@ clustering_ok_with_ff_enabled_on_some_nodes(Config) ->
             ok
     end,
 
-    ?assertEqual(Config, rabbit_ct_broker_helpers:cluster_nodes(Config)),
+    ?assertEqual(Config, rabbit_ct_broker_helpers:cluster_nodes(Config, 0)),
 
     log_feature_flags_of_all_nodes(Config),
     case FFSubsysOk of
@@ -987,7 +997,7 @@ clustering_denied_with_new_ff_enabled(Config) ->
         false -> ok
     end,
 
-    ?assertMatch({skip, _}, rabbit_ct_broker_helpers:cluster_nodes(Config)),
+    ?assertMatch({skip, _}, rabbit_ct_broker_helpers:cluster_nodes(Config, 0)),
 
     log_feature_flags_of_all_nodes(Config),
     case FFSubsysOk of
@@ -1049,7 +1059,7 @@ clustering_ok_with_new_ff_enabled_from_plugin_on_some_nodes(Config) ->
         false -> ok
     end,
 
-    ?assertEqual(Config, rabbit_ct_broker_helpers:cluster_nodes(Config)),
+    ?assertEqual(Config, rabbit_ct_broker_helpers:cluster_nodes(Config, 0)),
 
     log_feature_flags_of_all_nodes(Config),
     case FFSubsysOk of

--- a/deps/rabbit/test/peer_discovery_classic_config_SUITE.erl
+++ b/deps/rabbit/test/peer_discovery_classic_config_SUITE.erl
@@ -91,6 +91,7 @@ init_per_testcase(successful_discovery = Testcase, Config) ->
     NodeNamesWithHostname = [rabbit_nodes:make({Name, "localhost"}) || Name <- NodeNames],
     Config3 = rabbit_ct_helpers:merge_app_env(Config2,
       {rabbit, [
+          {forced_feature_flags_on_init, []},
           {cluster_nodes, {NodeNamesWithHostname, disc}},
           {cluster_formation, [
               {internal_lock_retries, 10}
@@ -124,6 +125,7 @@ init_per_testcase(successful_discovery_with_a_subset_of_nodes_coming_online = Te
     %% unreachable nodes vs ~6min without them
     Config3 = rabbit_ct_helpers:merge_app_env(Config2,
       {rabbit, [
+          {forced_feature_flags_on_init, []},
           {cluster_nodes, {NodeNamesWithHostname, disc}},
           {cluster_formation, [
               {internal_lock_retries, 10}
@@ -141,6 +143,7 @@ init_per_testcase(no_nodes_configured = Testcase, Config) ->
       ]),
     Config3 = rabbit_ct_helpers:merge_app_env(Config2,
       {rabbit, [
+          {forced_feature_flags_on_init, []},
           {cluster_nodes, {[], disc}},
           {cluster_formation, [
               {internal_lock_retries, 10}

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -237,7 +237,9 @@ init_per_group1(Group, Config) ->
                    _ ->
                        Config1
                end,
-    Ret = rabbit_ct_helpers:run_steps(Config1b,
+    Config1c = rabbit_ct_helpers:merge_app_env(
+                 Config1b, {rabbit, [{forced_feature_flags_on_init, []}]}),
+    Ret = rabbit_ct_helpers:run_steps(Config1c,
                                       [fun merge_app_env/1 ] ++
                                       rabbit_ct_broker_helpers:setup_steps()),
     case Ret of

--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -159,7 +159,8 @@ init_per_suite(Config) ->
     Config1 = rabbit_ct_helpers:merge_app_env(
                 Config, {rabbit, [
                                   {quorum_tick_interval, 1000},
-                                  {stream_tick_interval, 1000}
+                                  {stream_tick_interval, 1000},
+                                  {forced_feature_flags_on_init, []}
                                  ]}),
     rabbit_ct_helpers:run_setup_steps(Config1).
 

--- a/deps/rabbitmq_peer_discovery_consul/test/system_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_consul/test/system_SUITE.erl
@@ -50,10 +50,12 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config, [fun stop_consul/1]).
 
 init_per_group(clustering, Config) ->
-    rabbit_ct_helpers:set_config(
-      Config,
-      [{rmq_nodes_count, 3},
-       {rmq_nodes_clustered, false}]);
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{rmq_nodes_count, 3},
+                 {rmq_nodes_clustered, false}]),
+    rabbit_ct_helpers:merge_app_env(
+      Config1, {rabbit, [{forced_feature_flags_on_init, []}]});
 init_per_group(_Group, Config) ->
     Config.
 

--- a/deps/rabbitmq_peer_discovery_etcd/test/system_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_etcd/test/system_SUITE.erl
@@ -59,10 +59,12 @@ end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config, [fun stop_etcd/1]).
 
 init_per_group(clustering, Config) ->
-    rabbit_ct_helpers:set_config(
-      Config,
-      [{rmq_nodes_count, 3},
-       {rmq_nodes_clustered, false}]);
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{rmq_nodes_count, 3},
+                 {rmq_nodes_clustered, false}]),
+    rabbit_ct_helpers:merge_app_env(
+      Config1, {rabbit, [{forced_feature_flags_on_init, []}]});
 init_per_group(_Group, Config) ->
     Config.
 


### PR DESCRIPTION
## Why

When running mixed-version tests, nodes 1/3/5/... are using the primary umbrella, so usually the newest version. Nodes 2/4/6/... are using the secondary umbrella, thus the old version.

When clustering, we used to use node 1 (running a new version) as the seed node, meaning other nodes would join it.

This complicates things with feature flags because we have to make sure that we start node 1 with new stable feature flags disabled to allow old nodes to join.

This is also a problem with Khepri machine versions because the cluster would start with the latest version, which old nodes might not have.

## How

This patch changes the logic to use a node running the secondary umbrella as the seed node instead. If there is no node running it, we pick the first node as before.

**V2**: Revert part of "rabbitmq_ct_helpers: Fix how we set `$RABBITMQ_FEATURE_FLAGS` in tests" (commit 57ed962ef69669cb72c5dd7be93cb7fbf3ca4c0c from #13077). These changes are no longer needed with the new logic.

**V3**: The check that verifies that the correct metadata store is used has a special case for nodes that use the secondary umbrella: if Khepri is supposed to be used but it's not, the feature flag is enabled. The reason is that the `v4.0.x` branch doesn't know about the `rel` configuration of `forced_feature_flags_on_init`. The nodes will have ignored this parameter and booted with the stable feature flags only.

Many testsuites are adapted to the new clustering order. If they manage which node joins which node, either the order is changed in the testcases, or nodes are started with only required feature flags. For testsuites that rely on peer discovery where the order is unknown, nodes are started with only required feature flags.