### PR TITLE
Support exchange federation with MQTT 5.0 subscribers

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -205,3 +205,10 @@
       stability     => stable,
       depends_on    => [message_containers]
      }}).
+
+-rabbit_feature_flag(
+   {'rabbitmq_4.1.0',
+    #{desc          => "Allows rolling upgrades to 4.1.x",
+      stability     => stable,
+      depends_on    => ['rabbitmq_4.0.0']
+     }}).

--- a/deps/rabbitmq_mqtt/Makefile
+++ b/deps/rabbitmq_mqtt/Makefile
@@ -43,7 +43,7 @@ export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = ssl
 DEPS = ranch rabbit amqp10_common
-TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management amqp_client rabbitmq_consistent_hash_exchange rabbitmq_amqp_client rabbitmq_stomp rabbitmq_stream
+TEST_DEPS = emqtt ct_helper rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management amqp_client rabbitmq_consistent_hash_exchange rabbitmq_amqp_client rabbitmq_stomp rabbitmq_stream rabbitmq_federation
 
 PLT_APPS += rabbitmqctl elixir
 
@@ -94,7 +94,7 @@ define ct_master.erl
 	halt(0)
 endef
 
-PARALLEL_CT_SET_1_A = auth retainer
+PARALLEL_CT_SET_1_A = auth retainer federation feature_flag
 PARALLEL_CT_SET_1_B = cluster command config config_schema mc_mqtt packet_prop \
     processor protocol_interop proxy_protocol rabbit_mqtt_confirms reader util
 PARALLEL_CT_SET_1_C = java v5

--- a/deps/rabbitmq_mqtt/test/feature_flag_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/feature_flag_SUITE.erl
@@ -1,0 +1,111 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+%% This suite should be deleted when feature flag 'rabbitmq_4.1.0' becomes required.
+-module(feature_flag_SUITE).
+-compile([export_all,
+          nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(util,
+        [connect/2,
+         connect/3,
+         non_clean_sess_opts/0
+        ]).
+
+-define(RC_SESSION_TAKEN_OVER, 16#8E).
+
+all() ->
+    [migrate_binding_args].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{mqtt_version, v5},
+                 {rmq_nodename_suffix, ?MODULE}]),
+    Config2 = rabbit_ct_helpers:merge_app_env(
+                Config1,
+                {rabbit, [{forced_feature_flags_on_init, []}]}),
+    rabbit_ct_helpers:run_setup_steps(
+      Config2,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+migrate_binding_args(Config) ->
+    %% Feature flag rabbitmq_4.1.0 enables binding arguments v2.
+    FeatureFlag = 'rabbitmq_4.1.0',
+    ?assertNot(rabbit_ct_broker_helpers:is_feature_flag_enabled(Config, FeatureFlag)),
+
+    Sub1a = connect(<<"sub 1">>, Config, non_clean_sess_opts()),
+    {ok, _, [0]} = emqtt:subscribe(Sub1a, <<"x/+">>, qos0),
+    ok = emqtt:disconnect(Sub1a),
+
+    Sub2a = connect(<<"sub 2">>, Config,non_clean_sess_opts()),
+    {ok, _, [0, 1]} = emqtt:subscribe(
+                        Sub2a,
+                        #{'Subscription-Identifier' => 9},
+                        [{<<"x/y">>, [{nl, false}, {rap, false}, {qos, qos0}]},
+                         {<<"z">>, [{nl, true}, {rap, true}, {qos, qos1}]}]),
+
+    Pub = connect(<<"pub">>, Config),
+    {ok, _} = emqtt:publish(Pub, <<"x/y">>, <<"m1">>, [{retain, true}, {qos, 1}]),
+    receive {publish, #{client_pid := Sub2a,
+                        qos := 0,
+                        topic := <<"x/y">>,
+                        payload := <<"m1">>,
+                        retain := false}} -> ok
+    after 10_000 -> ct:fail({missing_publish, ?LINE})
+    end,
+
+    ?assertEqual(ok, rabbit_ct_broker_helpers:enable_feature_flag(Config, FeatureFlag)),
+
+    %% Connecting causes binding args to be migrated from v1 to v2.
+    Sub1b = connect(<<"sub 1">>, Config, [{clean_start, false}]),
+    receive {publish, #{client_pid := Sub1b,
+                        qos := 0,
+                        topic := <<"x/y">>,
+                        payload := <<"m1">>}} -> ok
+    after 10_000 -> ct:fail({missing_publish, ?LINE})
+    end,
+
+    unlink(Sub2a),
+    %% Connecting causes binding args to be migrated from v1 to v2.
+    Sub2b = connect(<<"sub 2">>, Config, [{clean_start, false}]),
+    receive {disconnected, ?RC_SESSION_TAKEN_OVER, #{}} -> ok
+    after 10_000 -> ct:fail({missing_disconnected, ?LINE})
+    end,
+
+    {ok, _} = emqtt:publish(Sub2b, <<"z">>, <<"m2">>, qos1),
+    %% We should not receive m2 since it's a local publish.
+    {ok, _} = emqtt:publish(Pub, <<"z">>, <<"m3">>, [{retain, true}, {qos, qos1}]),
+    receive {publish, Publish} ->
+                ?assertMatch(#{client_pid := Sub2b,
+                               qos := 1,
+                               topic := <<"z">>,
+                               payload := <<"m3">>,
+                               properties := #{'Subscription-Identifier' := 9},
+                               retain := true},
+                             Publish)
+    after 10_000 -> ct:fail({missing_publish, ?LINE})
+    end,
+
+    ok = emqtt:disconnect(Sub1b),
+    ok = emqtt:disconnect(Sub2b),
+    ok = emqtt:disconnect(Pub).

--- a/deps/rabbitmq_mqtt/test/federation_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/federation_SUITE.erl
@@ -1,0 +1,102 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+-module(federation_SUITE).
+-compile([export_all,
+          nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(rabbit_ct_helpers,
+        [eventually/3]).
+
+all() ->
+    [exchange_federation].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{rmq_nodename_suffix, ?MODULE},
+                 {rmq_nodes_count, 2},
+                 {rmq_nodes_clustered, false}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, 'rabbitmq_4.1.0') of
+        ok ->
+            rabbit_ct_helpers:testcase_started(Config, Testcase);
+        Skip = {skip, _Reason} ->
+            Skip
+    end.
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% Test that exchange federation works for MQTT clients.
+%% https://github.com/rabbitmq/rabbitmq-server/issues/13040
+exchange_federation(Config) ->
+    Upstream = 0,
+    Downstream = 1,
+    ok = rabbit_ct_broker_helpers:set_parameter(
+           Config, Downstream, <<"federation-upstream">>, <<"origin">>,
+           [
+            {<<"uri">>, rabbit_ct_broker_helpers:node_uri(Config, Upstream)}
+           ]),
+    ok = rabbit_ct_broker_helpers:set_policy(
+           Config, Downstream, <<"my policy">>, <<"^amq\.topic$">>, <<"exchanges">>,
+           [
+            {<<"federation-upstream-set">>, <<"all">>}
+           ]),
+
+    %% Subscribe on the downstream.
+    SubV4 = util:connect(<<"v4 client">>, Config, Downstream, [{proto_ver, v4}]),
+    SubV5 = util:connect(<<"v5 client">>, Config, Downstream, [{proto_ver, v5}]),
+    {ok, _, [1]} = emqtt:subscribe(SubV4, <<"vsn/4">>, qos1),
+    {ok, _, [1]} = emqtt:subscribe(SubV5, #{'Subscription-Identifier' => 500}, <<"vsn/5">>, qos1),
+
+    %% "The bindings are replicated with the upstream asynchronously so the effect of
+    %% adding or removing a binding is only guaranteed to be seen eventually."
+    %% https://www.rabbitmq.com/docs/federated-exchanges#details
+    eventually(
+      ?_assertMatch(
+         [_V4, _V5],
+         rabbit_ct_broker_helpers:rpc(
+           Config, Upstream, rabbit_binding, list_for_source,
+           [rabbit_misc:r(<<"/">>, exchange, <<"amq.topic">>)])),
+      1000, 10),
+
+    %% Publish on the upstream.
+    Pub = util:connect(<<"v3 client">>, Config, Upstream, [{proto_ver, v3}]),
+    {ok, #{reason_code_name := success}} = emqtt:publish(Pub, <<"vsn/4">>, <<"m1">>, qos1),
+    {ok, #{reason_code_name := success}} = emqtt:publish(Pub, <<"vsn/5">>, <<"m2">>, qos1),
+
+    receive {publish, #{client_pid := SubV4,
+                        qos := 1,
+                        topic := <<"vsn/4">>,
+                        payload := <<"m1">>}} -> ok
+    after 10_000 -> ct:fail({missing_publish, ?LINE})
+    end,
+    receive {publish, #{client_pid := SubV5,
+                        qos := 1,
+                        topic := <<"vsn/5">>,
+                        payload := <<"m2">>,
+                        properties := #{'Subscription-Identifier' := 500}}} -> ok
+    after 10_000 -> ct:fail({missing_publish, ?LINE})
+    end,
+
+    ok = emqtt:disconnect(SubV4),
+    ok = emqtt:disconnect(SubV5),
+    ok = emqtt:disconnect(Pub).


### PR DESCRIPTION
 ## What?
This commit fixes #13040.

Prior to this commit, exchange federation crashed if the MQTT topic exchange
(`amq.topic` by default) got federated and MQTT 5.0 clients subscribed on the
downstream. That's because the federation plugin sends bindings from downstream
to upstream via AMQP 0.9.1. However, binding arguments containing Erlang record
`mqtt_subscription_opts` (henceforth binding args v1) cannot be encoded in AMQP 0.9.1.

 ## Why?
Federating the MQTT topic exchange could be useful for warm standby use cases.

 ## How?
This commit makes binding arguments a valid AMQP 0.9.1 table (henceforth
binding args v2).

Binding args v2 can only be used if all nodes support it. Hence binding
args v2 comes with feature flag `rabbitmq_4.1.0`. Note that the AMQP
over WebSocket
[PR](https://github.com/rabbitmq/rabbitmq-server/pull/13071) already
introduces this same feature flag. Although the feature flag subsystem
supports plugins to define their own feature flags, and the MQTT plugin
defined its own feature flags in the past, reusing feature flag
`rabbitmq_4.1.0` is simpler.

This commit also avoids database migrations for both Mnesia and Khepri
if feature flag `rabbitmq_4.1.0` gets enabled. Instead, it's simpler to
migrate binding args v1 to binding args v2 at MQTT connection establishment
time if the feature flag is enabled. (If the feature flag is disabled at
connection etablishment time, but gets enabled during the connection
lifetime, the connection keeps using bindings args v1.)

This commit adds two new suites:
1. `federation_SUITE` which tests that federating the MQTT topic
   exchange works, and
2. `feature_flag_SUITE` which tests the binding args migration from v1 to v2