### PR TITLE
Test helpers: add `** killed` to the default find crashes ignore list

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -1206,7 +1206,7 @@ stop_rabbitmq_nodes(Config) ->
     case FindCrashes of
         true ->
             %% TODO: Make the ignore list configurable.
-            IgnoredCrashes0 = ["** force_vhost_failure"],
+            IgnoredCrashes0 = ["** force_vhost_failure", "** killed"],
             case rabbit_ct_helpers:get_config(Config, ignored_crashes) of
                 undefined ->
                     find_crashes_in_logs(NodeConfigs, IgnoredCrashes0);


### PR DESCRIPTION
Exits the with reason "killed" only occurs "naturally" in OTP when a supervisor tries to shut a child down and it times out.

It is used for failure simulation in tests quite frequently however.
