### PR TITLE
Simplify Direct Reply-To

### DIFF
--- a/deps/rabbit/src/rabbit_direct_reply_to.erl
+++ b/deps/rabbit/src/rabbit_direct_reply_to.erl
@@ -7,45 +7,14 @@
 
 -module(rabbit_direct_reply_to).
 
-%% API
--export([
-    %% Original amq.rabbitmq.reply-to target channel encoding
-    compute_key_and_suffix_v1/1,
-    decode_reply_to_v1/1,
+-export([compute_key_and_suffix/1,
+         decode_reply_to/2]).
 
-    %% v2 amq.rabbitmq.reply-to target channel encoding
-    compute_key_and_suffix_v2/1,
-    decode_reply_to_v2/2
-]).
-
-%%
-%% API
-%%
-
--type decoded_pid_and_key() :: {ok, pid(), binary()}.
-
--spec compute_key_and_suffix_v1(pid()) -> {binary(), binary()}.
-%% This original pid encoding function produces values that exceed routing key length limit
-%% on nodes with long (say, 130+ characters) node names.
-compute_key_and_suffix_v1(Pid) ->
-    Key = base64:encode(rabbit_guid:gen()),
-    PidEnc = base64:encode(term_to_binary(Pid)),
-    Suffix = <<PidEnc/binary, ".", Key/binary>>,
-    {Key, Suffix}.
-
--spec decode_reply_to_v1(binary()) -> decoded_pid_and_key() | {error, any()}.
-decode_reply_to_v1(Bin) ->
-    case string:lexemes(Bin, ".") of
-        [PidEnc, Key] -> Pid = binary_to_term(base64:decode(PidEnc)),
-                         {ok, Pid, unicode:characters_to_binary(Key)};
-        _             -> {error, unrecognized_format}
-    end.
-
-
--spec compute_key_and_suffix_v2(pid()) -> {binary(), binary()}.
 %% This pid encoding function produces values that are of mostly fixed size
 %% regardless of the node name length.
-compute_key_and_suffix_v2(Pid) ->
+-spec compute_key_and_suffix(pid()) ->
+    {binary(), binary()}.
+compute_key_and_suffix(Pid) ->
     Key = base64:encode(rabbit_guid:gen()),
 
     PidParts0 = #{node := Node} = pid_recomposition:decompose(Pid),
@@ -61,19 +30,22 @@ compute_key_and_suffix_v2(Pid) ->
     Suffix = <<RecomposedEncoded/binary, ".", Key/binary>>,
     {Key, Suffix}.
 
--spec decode_reply_to_v2(binary(), #{non_neg_integer() => node()}) -> decoded_pid_and_key() | {error, any()}.
-decode_reply_to_v2(Bin, CandidateNodes) ->
+-spec decode_reply_to(binary(), #{non_neg_integer() => node()}) ->
+    {ok, pid(), binary()} | {error, any()}.
+decode_reply_to(Bin, CandidateNodes) ->
     try
         [PidEnc, Key] = binary:split(Bin, <<".">>),
         RawPidBin = base64:decode(PidEnc),
         PidParts0 = #{node := ShortenedNodename} = pid_recomposition:from_binary(RawPidBin),
         {_, NodeHash} = rabbit_nodes_common:parts(ShortenedNodename),
         case maps:get(list_to_integer(NodeHash), CandidateNodes, undefined) of
-            undefined -> {error, target_node_not_found};
+            undefined ->
+                {error, target_node_not_found};
             Candidate ->
                 PidParts = maps:update(node, Candidate, PidParts0),
                 {ok, pid_recomposition:recompose(PidParts), Key}
         end
     catch
-        error:_ -> {error, unrecognized_format}
+        error:_ ->
+            {error, unrecognized_format}
     end.

--- a/deps/rabbit/test/rabbit_direct_reply_to_prop_SUITE.erl
+++ b/deps/rabbit/test/rabbit_direct_reply_to_prop_SUITE.erl
@@ -8,7 +8,7 @@
 
 all() ->
     [
-     decode_reply_to_v2
+     decode_reply_to
     ].
 
 init_per_suite(Config) ->
@@ -32,7 +32,7 @@ end_per_testcase(_TestCase, _Config) ->
 %%% Tests %%%
 
 
-decode_reply_to_v2(Config) ->
+decode_reply_to(Config) ->
     rabbit_ct_proper_helpers:run_proper(
       fun() -> prop_decode_reply_to(Config) end,
       [],
@@ -61,9 +61,9 @@ prop_decode_reply_to(_) ->
             NonB64 = <<0, Random/binary>>, 
 
             {ok, pid_recomposition:recompose(PidParts), Key} =:=
-                rabbit_direct_reply_to:decode_reply_to_v2(IxBin, NodeMap)
+                rabbit_direct_reply_to:decode_reply_to(IxBin, NodeMap)
             andalso {error, target_node_not_found} =:=
-                rabbit_direct_reply_to:decode_reply_to_v2(IxBin, NoNodeMap)
+                rabbit_direct_reply_to:decode_reply_to(IxBin, NoNodeMap)
             andalso {error, unrecognized_format} =:=
-                rabbit_direct_reply_to:decode_reply_to_v2(NonB64, NodeMap)
+                rabbit_direct_reply_to:decode_reply_to(NonB64, NodeMap)
         end).


### PR DESCRIPTION
This commit is no change in functionality and mostly deletes dead code.

1. Code targeting Erlang 22 and below is deleted since the mininmum required Erlang version is higher nowadays. "In OTP 23 distribution flag DFLAG_BIG_CREATION became mandatory. All pids are now encoded using NEW_PID_EXT, even external pids received as PID_EXT from older nodes." https://www.erlang.org/doc/apps/erts/erl_ext_dist.html#new_pid_ext
2. All v1 encoding and decoding of the Pid is deleted since the lower version RabbitMQ node supports the v2 encoding nowadays.
