### PR TITLE
Log incorrectly claims the limit is per node,

### DIFF
--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -166,10 +166,10 @@ is_within_limit(Component) ->
     case Limit < 0 orelse count_component(Component) < Limit of
        true -> ok;
        false ->
-            ErrorMsg = "Limit reached: component ~ts is limited to ~tp per node",
+            ErrorMsg = "Limit reached: component ~ts is limited to ~tp",
             ErrorArgs = [Component, Limit],
             rabbit_log:error(ErrorMsg, ErrorArgs),
-            {errors, [{"component ~ts is limited to ~tp per node", [Component, Limit]}]}
+            {errors, [{"component ~ts is limited to ~tp", [Component, Limit]}]}
     end.
 
 count_component(Component) -> length(list_component(Component)).


### PR DESCRIPTION
 but the component count is over all vhost in the cluster.
Very minor fix.

## Proposed Changes

Remove the mention of 'per node' in the log msg as it is not correct, its per cluster.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
