### PR TITLE
Revert "Log incorrectly claims the limit is per node,"

### DIFF
--- a/deps/rabbit/src/rabbit_runtime_parameters.erl
+++ b/deps/rabbit/src/rabbit_runtime_parameters.erl
@@ -166,10 +166,10 @@ is_within_limit(Component) ->
     case Limit < 0 orelse count_component(Component) < Limit of
        true -> ok;
        false ->
-            ErrorMsg = "Limit reached: component ~ts is limited to ~tp",
+            ErrorMsg = "Limit reached: component ~ts is limited to ~tp per node",
             ErrorArgs = [Component, Limit],
             rabbit_log:error(ErrorMsg, ErrorArgs),
-            {errors, [{"component ~ts is limited to ~tp", [Component, Limit]}]}
+            {errors, [{"component ~ts is limited to ~tp per node", [Component, Limit]}]}
     end.
 
 count_component(Component) -> length(list_component(Component)).


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-server#13149.

```
cd deps/rabbit
gmake ct-runtime_parameters
```

repeatedly fails in multiple environments.