### PR TITLE
QQ: make sure there are no duplicates on the list of nodes

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1373,7 +1373,7 @@ do_add_member(Q, Node, Membership, Timeout)
                     Fun = fun(Q1) ->
                                   Q2 = update_type_state(
                                          Q1, fun(#{nodes := Nodes} = Ts) ->
-                                                     Ts#{nodes => [Node | Nodes]}
+                                                     Ts#{nodes => lists:usort([Node | Nodes])}
                                              end),
                                   amqqueue:set_pid(Q2, Leader)
                           end,


### PR DESCRIPTION
Make sure there are no duplicates on the nodes list.

Trying to address the following failure:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/13013004042/job/36295172214?pr=13050