### PR TITLE
New health checks for metadata store initialization

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_command.ex
@@ -1,0 +1,47 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfMetadataStoreIsInitializedCommand do
+  @moduledoc """
+  Exits with a non-zero code if the node reports that its metadata store
+  has finished its initialization procedure.
+
+  This command is meant to be used in health checks.
+  """
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    :rabbit_misc.rpc_call(node_name, :rabbit_db, :is_init_finished, [], timeout)
+  end
+
+  def output(true, %{node: node_name} = _options) do
+    {:ok, "Metadata store on node #{node_name} has completed its initialization"}
+  end
+
+  def output(false, %{node: node_name} = _options) do
+    {:error,
+     "Metadata store on node #{node_name} reports to not yet have finished initialization"}
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if the metadata store on target node has not yet finished initializing"
+
+  def usage, do: "check_if_metadata_store_initialized"
+
+  def banner([], %{node: node_name}) do
+    "Checking if metadata store on node #{node_name} has finished initializing ..."
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_command.ex
@@ -22,13 +22,30 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfMetadataStoreIsInitializedCom
     :rabbit_misc.rpc_call(node_name, :rabbit_db, :is_init_finished, [], timeout)
   end
 
+
+  def output(true, %{silent: true}) do
+    {:ok, :check_passed}
+  end
+  def output(true, %{formatter: "json"}) do
+    {:ok, %{"result" => "ok"}}
+  end
   def output(true, %{node: node_name} = _options) do
     {:ok, "Metadata store on node #{node_name} has completed its initialization"}
   end
 
+  def output(false, %{silent: true}) do
+    {:error, :check_failed}
+  end
+  def output(false, %{node: node_name, formatter: "json"}) do
+    {:error, :check_failed,
+      %{
+        "result"  => "error",
+        "message" => "Metadata store on node #{node_name} reports to not yet have finished initialization"
+      }}
+  end
   def output(false, %{node: node_name} = _options) do
     {:error,
-     "Metadata store on node #{node_name} reports to not yet have finished initialization"}
+      "Metadata store on node #{node_name} reports to not yet have finished initialization"}
   end
 
   use RabbitMQ.CLI.DefaultOutput

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_with_data_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_with_data_command.ex
@@ -1,0 +1,67 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfMetadataStoreIsInitializedWithDataCommand do
+  @moduledoc """
+  Exits with a non-zero code if the node reports that its metadata store
+  has finished its initialization procedure.
+
+  This command is meant to be used in health checks.
+  """
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_db, :is_init_finished, [], timeout) do
+      {:badrpc, _} = err ->
+        err
+
+      {:error, _} = err ->
+        err
+
+      {:error, _, _} = err ->
+        err
+
+      false -> false
+
+      true ->
+        case :rabbit_misc.rpc_call(node_name, :rabbit_db_vhost, :count_all, [], timeout) do
+          {:error, _} = err ->
+            err
+
+          {:ok, n} ->
+            (n > 0)
+        end
+    end
+  end
+
+  def output(true, %{node: node_name} = _options) do
+    {:ok, "Metadata store on node #{node_name} has completed its initialization"}
+  end
+
+  def output(false, %{node: node_name} = _options) do
+    {:error,
+     "Metadata store on node #{node_name} reports to not yet have finished initialization"}
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if the metadata store on target node has not yet finished initializing"
+
+  def usage, do: "check_if_metadata_store_initialized"
+
+  def banner([], %{node: node_name}) do
+    "Checking if metadata store on node #{node_name} has finished initializing ..."
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_with_data_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/check_if_metadata_store_is_initialized_with_data_command.ex
@@ -42,13 +42,29 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckIfMetadataStoreIsInitializedWit
     end
   end
 
+  def output(true, %{silent: true}) do
+    {:ok, :check_passed}
+  end
+  def output(true, %{formatter: "json"}) do
+    {:ok, %{"result" => "ok"}}
+  end
   def output(true, %{node: node_name} = _options) do
     {:ok, "Metadata store on node #{node_name} has completed its initialization"}
   end
 
+  def output(false, %{silent: true}) do
+    {:error, :check_failed}
+  end
+  def output(false, %{node: node_name, formatter: "json"}) do
+    {:error, :check_failed,
+      %{
+        "result"  => "error",
+        "message" => "Metadata store on node #{node_name} reports to not yet have finished initialization"
+      }}
+  end
   def output(false, %{node: node_name} = _options) do
     {:error,
-     "Metadata store on node #{node_name} reports to not yet have finished initialization"}
+      "Metadata store on node #{node_name} reports to not yet have finished initialization"}
   end
 
   use RabbitMQ.CLI.DefaultOutput

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_metadata_store_is_initialized_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_metadata_store_is_initialized_command_test.exs
@@ -1,0 +1,67 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule CheckIfMetadataStoreIsInitializedCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfMetadataStoreIsInitializedCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
+  end
+
+  test "run: when the RabbitMQ app is booted and started, returns true", context do
+    await_rabbitmq_startup()
+
+    assert @command.run([], context[:opts])
+  end
+
+  test "output: when the result is true, returns successfully", context do
+    assert match?({:ok, _}, @command.output(true, context[:opts]))
+  end
+
+  # this is a check command
+  test "output: when the result is false, returns an error", context do
+    assert match?({:error, _}, @command.output(false, context[:opts]))
+  end
+end

--- a/deps/rabbitmq_cli/test/diagnostics/check_if_metadata_store_is_initialized_with_data_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/check_if_metadata_store_is_initialized_with_data_command_test.exs
@@ -1,0 +1,67 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule CheckIfMetadataStoreIsInitializedWithDataCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckIfMetadataStoreIsInitializedWithDataCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
+  end
+
+  test "run: when the RabbitMQ app is booted and started, returns true", context do
+    await_rabbitmq_startup()
+
+    assert @command.run([], context[:opts])
+  end
+
+  test "output: when the result is true, returns successfully", context do
+    assert match?({:ok, _}, @command.output(true, context[:opts]))
+  end
+
+  # this is a check command
+  test "output: when the result is false, returns an error", context do
+    assert match?({:error, _}, @command.output(false, context[:opts]))
+  end
+end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -196,6 +196,8 @@ dispatcher() ->
      %% modern generation of fine-grained health checks
      {"/health/checks/alarms",                                 rabbit_mgmt_wm_health_check_alarms, []},
      {"/health/checks/local-alarms",                           rabbit_mgmt_wm_health_check_local_alarms, []},
+     {"/health/checks/metadata-store/initialized",             rabbit_mgmt_wm_health_check_metadata_store_initialized, []},
+     {"/health/checks/metadata-store/initialized/with-data",   rabbit_mgmt_wm_health_check_metadata_store_initialized_with_data, []},
      {"/health/checks/certificate-expiration/:within/:unit",   rabbit_mgmt_wm_health_check_certificate_expiration, []},
      {"/health/checks/port-listener/:port",                    rabbit_mgmt_wm_health_check_port_listener, []},
      {"/health/checks/protocol-listener/:protocol",            rabbit_mgmt_wm_health_check_protocol_listener, []},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_aliveness_test.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_aliveness_test.erl
@@ -42,7 +42,7 @@ to_json(ReqData, Context) ->
         rabbit_mgmt_util:vhost(ReqData),
         ReqData,
         Context,
-        fun(_Ch) -> rabbit_mgmt_util:reply([{status, ok}], ReqData, Context) end
+        fun(_Ch) -> rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context) end
     ).
 
 is_authorized(ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_alarms.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_alarms.erl
@@ -36,7 +36,7 @@ to_json(ReqData, Context) ->
               end,
     case rabbit_alarm:get_alarms(Timeout) of
         [] ->
-            rabbit_mgmt_util:reply([{status, ok}], ReqData, Context);
+            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
         Xs when length(Xs) > 0 ->
             Msg = "There are alarms in effect in the cluster",
             failure(Msg, Xs, ReqData, Context)

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_certificate_expiration.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_certificate_expiration.erl
@@ -50,7 +50,7 @@ to_json(ReqData, Context) ->
                                             end, [], Local),
             case ExpiringListeners of
                 [] ->
-                    rabbit_mgmt_util:reply([{status, ok}], ReqData, Context);
+                    rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
                 _ ->
                     Msg = <<"Certificates expiring">>,
                     failure(Msg, ExpiringListeners, ReqData, Context)
@@ -58,10 +58,12 @@ to_json(ReqData, Context) ->
     end.
 
 failure(Message, Listeners, ReqData, Context) ->
-    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply([{status, failed},
-                                                             {reason, Message},
-                                                             {expired, Listeners}],
-                                                            ReqData, Context),
+    Body = #{
+        status  => failed,
+        reason  => Message,
+        expired => Listeners
+    },
+    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body, ReqData, Context),
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_metadata_store_initialized.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_metadata_store_initialized.erl
@@ -6,7 +6,7 @@
 %%
 
 %% An HTTP API counterpart of 'rabbitmq-dignoastics check_local_alarms'
--module(rabbit_mgmt_wm_health_check_local_alarms).
+-module(rabbit_mgmt_wm_health_check_metadata_store_initialized).
 
 -export([init/2, to_json/2, content_types_provided/2, is_authorized/2]).
 -export([resource_exists/2]).
@@ -30,24 +30,19 @@ resource_exists(ReqData, Context) ->
     {true, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    Timeout = case cowboy_req:header(<<"timeout">>, ReqData) of
-                  undefined -> 70000;
-                  Val       -> list_to_integer(binary_to_list(Val))
-              end,
-    case rabbit_alarm:get_local_alarms(Timeout) of
-        [] ->
+    Result = rabbit_db:is_init_finished(),
+    case Result of
+        true ->
             rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
-        Xs when length(Xs) > 0 ->
-            Msg = "There are alarms in effect on the node",
-            failure(Msg, Xs, ReqData, Context)
+        false ->
+            Msg = "Metadata store has not yet reported as initialized",
+            failure(Msg, ReqData, Context)
     end.
 
-failure(Message, Alarms0, ReqData, Context) ->
-    Alarms = rabbit_alarm:format_as_maps(Alarms0),
+failure(Message, ReqData, Context) ->
     Body = #{
         status => failed,
-        reason => rabbit_data_coercion:to_binary(Message),
-        alarms => Alarms
+        reason => rabbit_data_coercion:to_binary(Message)
     },
     {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body, ReqData, Context),
     {stop, cowboy_req:reply(?HEALTH_CHECK_FAILURE_STATUS, #{}, Response, ReqData1), Context1}.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_port_listener.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_port_listener.erl
@@ -43,8 +43,9 @@ to_json(ReqData, Context) ->
                 Msg = <<"No active listener">>,
                 failure(Msg, Port, [P || #listener{port = P} <- Local], ReqData, Context);
             _ ->
-                rabbit_mgmt_util:reply([{status, ok},
-                                        {port, Port}], ReqData, Context)
+                Body = #{status => ok,
+                         port => Port},
+                rabbit_mgmt_util:reply(Body, ReqData, Context)
         end
     catch
         error:badarg ->
@@ -52,10 +53,11 @@ to_json(ReqData, Context) ->
     end.
 
 failure(Message, Missing, Ports, ReqData, Context) ->
-    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply([{status, failed},
-                                                             {reason, Message},
-                                                             {missing, Missing},
-                                                             {ports, Ports}],
+    Body = #{status  => failed,
+             reason  => Message,
+             missing => Missing,
+             ports   => Ports},
+    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body,
                                                             ReqData, Context),
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
@@ -42,16 +42,19 @@ to_json(ReqData, Context) ->
             Msg = <<"No active listener">>,
             failure(Msg, Protocol, [P || #listener{protocol = P} <- Local], ReqData, Context);
         _ ->
-            rabbit_mgmt_util:reply([{status, ok},
-                                    {protocol, list_to_binary(Protocol)}], ReqData, Context)
+            Body = #{status   => ok,
+                     protocol => list_to_binary(Protocol)},
+            rabbit_mgmt_util:reply(Body, ReqData, Context)
     end.
 
 failure(Message, Missing, Protocols, ReqData, Context) ->
-    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply([{status, failed},
-                                                             {reason, Message},
-                                                             {missing, list_to_binary(Missing)},
-                                                             {protocols, Protocols}],
-                                                            ReqData, Context),
+    Body = #{
+        status    => failed,
+        reason    => Message,
+        missing   => list_to_binary(Missing),
+        protocols => Protocols
+    },
+    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body, ReqData, Context),
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
 
 is_authorized(ReqData, Context) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_virtual_hosts.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_virtual_hosts.erl
@@ -31,7 +31,7 @@ resource_exists(ReqData, Context) ->
 to_json(ReqData, Context) ->
     case rabbit_vhost_sup_sup:check() of
         [] ->
-            rabbit_mgmt_util:reply([{status, ok}], ReqData, Context);
+            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
         Vs when length(Vs) > 0 ->
             Msg = <<"Some virtual hosts are down">>,
             failure(Msg, Vs, ReqData, Context)

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
@@ -41,7 +41,7 @@ to_json(ReqData, Context) ->
               end,
     case rabbit_health_check:node(Node, Timeout) of
         ok ->
-            rabbit_mgmt_util:reply([{status, ok}], ReqData, Context);
+            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
         {badrpc, timeout} ->
             ErrMsg = rabbit_mgmt_format:print("node ~tp health check timed out", [Node]),
             failure(ErrMsg, ReqData, Context);

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -35,12 +35,16 @@ groups() ->
      {single_node, [], [
                         alarms_test,
                         local_alarms_test,
+                        metadata_store_initialized_test,
+                        metadata_store_initialized_with_data_test,
                         is_quorum_critical_single_node_test]}
     ].
 
 all_tests() -> [
                 health_checks_test,
                 virtual_hosts_test,
+                metadata_store_initialized_test,
+                metadata_store_initialized_with_data_test,
                 protocol_listener_test,
                 port_listener_test,
                 certificate_expiration_test
@@ -100,6 +104,14 @@ health_checks_test(Config) ->
     http_get(Config, "/health/checks/protocol-listener/http", ?OK),
     http_get(Config, "/health/checks/virtual-hosts", ?OK),
     http_get(Config, "/health/checks/node-is-quorum-critical", ?OK),
+    passed.
+
+metadata_store_initialized_test(Config) ->
+    http_get(Config, "/health/checks/metadata-store/initialized", ?OK),
+    passed.
+
+metadata_store_initialized_with_data_test(Config) ->
+    http_get(Config, "/health/checks/metadata-store/initialized/with-data", ?OK),
     passed.
 
 alarms_test(Config) ->


### PR DESCRIPTION
This introduces two new health checks

 * `rabbitmq-diagnostics check_if_metadata_store_is_initialized`
 * `rabbitmq-diagnostics check_if_metadata_store_is_initialized_with_data`

and their HTTP API counterparts:

 * `GET {prefix}/health/checks/metadata-store/initialized`
 * `GET {prefix}/health/checks/metadata-store/initialized/with-data`

The first one relies on `rabbit_db:is_init_completed/0`, which is already used by a few
code paths, namely peer discovery, to detect when the metadata store initialization has
completed.

The second check is more opinionated: it assumes that a cluster will always have
at least one virtual host. Technically you can delete the only virtual host in the system
but then the cluster would not be practically useful.

So let's use this clue, at least one virtual host that the metadata store contains,
as a good enough indication that the metadata store has synced "just enough" for client
connections to have a chance of succeeding.

Note that these checks cannot be 100% accurate in the case of Mnesia because some data may still be in flight but should be pretty accurate in the case of Khepri, which is
the future of RabbitMQ in any case.

In any case, we currently do not provide a health check like this, which makes the problem
outlined in #13153 harder to spot and comprehend.

References #13153.