### PR TITLE
Set RABBITMQ_VERSION in the OCI image

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -25,6 +25,7 @@ on:
         default: false
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/rabbitmq
+  VERSION: 4.1.0+${{ github.sha }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -58,7 +59,7 @@ jobs:
       - name: make package-generic-unix
         if: steps.authorized.outputs.authorized == 'true'
         run: |
-          make package-generic-unix PROJECT_VERSION=4.1.0-alpha.1
+          make package-generic-unix PROJECT_VERSION=${{ env.VERSION }}
       - name: Upload package-generic-unix
         if: steps.authorized.outputs.authorized == 'true'
         uses: actions/upload-artifact@v4
@@ -118,5 +119,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-to: type=gha,mode=max,scope=${{ matrix.otp_version }}
           cache-from: type=gha,scope=${{ matrix.otp_version }}
-          build-args:
+          build-args: |
             OTP_VERSION=${{ matrix.otp_version }}
+            RABBITMQ_VERSION=${{ env.VERSION }}


### PR DESCRIPTION
A small follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/13160

Without this change, all images built with the new workflow would report the version as `4.1.0-alpha.1`.
Now, it's `4.1.0+SHA` (the commit SHA).