### PR TITLE
Depends on #12753: Use local read to check node is in maintenance

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -2417,12 +2417,10 @@ handle_frame_post_auth(Transport,
         lists:sort(
             maps:keys(NodesMap)),
     %% filter out nodes in maintenance
-    Nodes =
-        lists:filter(fun(N) ->
-                        rabbit_maintenance:is_being_drained_consistent_read(N)
-                        =:= false
-                     end,
-                     Nodes0),
+        Nodes = lists:filter(fun(N) ->
+                                     rabbit_maintenance:is_being_drained_local_read(N) =:= false
+                             end,
+                             Nodes0),
     NodeEndpoints =
         lists:foldr(fun(Node, Acc) ->
                        PortFunction =


### PR DESCRIPTION
In stream reader. The consistent read may cause some timeout for the metadata frame (when Khepri is used as the data store).

Depends on #12753.