### PR TITLE
Add force checkpoint functions for quorum queues and command line tool

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -925,26 +925,6 @@ which_module(3) -> rabbit_fifo_v3;
 which_module(4) -> ?MODULE;
 which_module(5) -> ?MODULE.
 
--define(AUX, aux_v3).
-
--record(checkpoint, {index :: ra:index(),
-                     timestamp :: milliseconds(),
-                     smallest_index :: undefined | ra:index(),
-                     messages_total :: non_neg_integer(),
-                     indexes = ?CHECK_MIN_INDEXES :: non_neg_integer(),
-                     unused_1 = ?NIL}).
--record(aux_gc, {last_raft_idx = 0 :: ra:index()}).
--record(aux, {name :: atom(),
-              capacity :: term(),
-              gc = #aux_gc{} :: #aux_gc{}}).
--record(?AUX, {name :: atom(),
-               last_decorators_state :: term(),
-               capacity :: term(),
-               gc = #aux_gc{} :: #aux_gc{},
-               tick_pid :: undefined | pid(),
-               cache = #{} :: map(),
-               last_checkpoint :: #checkpoint{}}).
-
 init_aux(Name) when is_atom(Name) ->
     %% TODO: catch specific exception throw if table already exists
     ok = ra_machine_ets:create_table(rabbit_fifo_usage,

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -227,3 +227,23 @@
                     msg_ttl => non_neg_integer(),
                     created => non_neg_integer()
                    }.
+
+-define(AUX, aux_v3).
+
+-record(checkpoint, {index :: ra:index(),
+                     timestamp :: milliseconds(),
+                     smallest_index :: undefined | ra:index(),
+                     messages_total :: non_neg_integer(),
+                     indexes = ?CHECK_MIN_INDEXES :: non_neg_integer(),
+                     unused_1 = ?NIL}).
+-record(aux_gc, {last_raft_idx = 0 :: ra:index()}).
+-record(aux, {name :: atom(),
+              capacity :: term(),
+              gc = #aux_gc{} :: #aux_gc{}}).
+-record(?AUX, {name :: atom(),
+               last_decorators_state :: term(),
+               capacity :: term(),
+               gc = #aux_gc{} :: #aux_gc{},
+               tick_pid :: undefined | pid(),
+               cache = #{} :: map(),
+               last_checkpoint :: #checkpoint{}}).

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -140,6 +140,7 @@
 -define(RPC_TIMEOUT, 1000).
 -define(START_CLUSTER_TIMEOUT, 5000).
 -define(START_CLUSTER_RPC_TIMEOUT, 60_000). %% needs to be longer than START_CLUSTER_TIMEOUT
+-define(FORCE_CHECKPOINT_RPC_TIMEOUT, 15_000).
 -define(TICK_INTERVAL, 5000). %% the ra server tick time
 -define(DELETE_TIMEOUT, 5000).
 -define(MEMBER_CHANGE_TIMEOUT, 20_000).
@@ -2095,7 +2096,7 @@ force_checkpoint_on_queue(QName) ->
         {ok, Q} when ?amqqueue_is_quorum(Q) ->
             {RaName, _} = amqqueue:get_pid(Q),
             rabbit_log:debug("Sending command to force ~ts to take a checkpoint", [QNameFmt]),
-            rpc:call(Node, ra, cast_aux_command, [{RaName, Node}, force_checkpoint]);
+            rpc:call(Node, ra, cast_aux_command, [{RaName, Node}, force_checkpoint], ?FORCE_CHECKPOINT_RPC_TIMEOUT);
         {ok, _Q} ->
             {error, not_quorum_queue};
         {error, _} = E ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2089,13 +2089,13 @@ force_all_queues_shrink_member_to_current_member(ListQQFun) when is_function(Lis
 force_checkpoint_on_queue(QName) ->
     Node = node(),
     QNameFmt = rabbit_misc:rs(QName),
-    case rabbit_amqqueue:lookup(QName) of
+    case rabbit_db_queue:get_durable(QName) of
         {ok, Q} when ?amqqueue_is_classic(Q) ->
             {error, classic_queue_not_supported};
         {ok, Q} when ?amqqueue_is_quorum(Q) ->
             {RaName, _} = amqqueue:get_pid(Q),
-            rpc:call(Node, ra, cast_aux_command, [{RaName, Node}, force_checkpoint]),
-            rabbit_log:debug("Sent command to force checkpoint ~ts", [QNameFmt]);
+            rabbit_log:debug("Sending command to force ~ts to take a checkpoint", [QNameFmt]),
+            rpc:call(Node, ra, cast_aux_command, [{RaName, Node}, force_checkpoint]);
         {ok, _Q} ->
             {error, not_quorum_queue};
         {error, _} = E ->
@@ -2114,8 +2114,7 @@ force_checkpoint(VhostSpec, QueueSpec) ->
                  {QName, {error, Err}}
          end
      end
-     || Q <- rabbit_amqqueue:list(),
-        amqqueue:get_type(Q) == ?MODULE,
+     || Q <- rabbit_db_queue:get_all_durable_by_type(?MODULE),
         is_match(amqqueue:get_vhost(Q), VhostSpec)
         andalso is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)].
 
@@ -2179,4 +2178,3 @@ file_handle_other_reservation() ->
 
 file_handle_release_reservation() ->
     ok.
-

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -77,6 +77,8 @@
          force_vhost_queues_shrink_member_to_current_member/1,
          force_all_queues_shrink_member_to_current_member/0]).
 
+-export([force_checkpoint/2, force_checkpoint_on_queue/1]).
+
 %% for backwards compatibility
 -export([file_handle_leader_reservation/1,
          file_handle_other_reservation/0,
@@ -2083,6 +2085,39 @@ force_all_queues_shrink_member_to_current_member(ListQQFun) when is_function(Lis
          end || Q <- ListQQFun(), amqqueue:get_type(Q) == ?MODULE],
     rabbit_log:warning("Shrinking finished"),
     ok.
+
+force_checkpoint_on_queue(QName) ->
+    Node = node(),
+    QNameFmt = rabbit_misc:rs(QName),
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} when ?amqqueue_is_classic(Q) ->
+            {error, classic_queue_not_supported};
+        {ok, Q} when ?amqqueue_is_quorum(Q) ->
+            {RaName, _} = amqqueue:get_pid(Q),
+            rpc:call(Node, ra, cast_aux_command, [{RaName, Node}, force_checkpoint]),
+            rabbit_log:debug("Sent command to force checkpoint ~ts", [QNameFmt]);
+        {ok, _Q} ->
+            {error, not_quorum_queue};
+        {error, _} = E ->
+            E
+    end.
+
+force_checkpoint(VhostSpec, QueueSpec) ->
+    [begin
+         QName = amqqueue:get_name(Q),
+         case force_checkpoint_on_queue(QName) of
+             ok ->
+                 {QName, {ok}};
+             {error, Err} ->
+                 rabbit_log:warning("~ts: failed to force checkpoint, error: ~w",
+                                    [rabbit_misc:rs(QName), Err]),
+                 {QName, {error, Err}}
+         end
+     end
+     || Q <- rabbit_amqqueue:list(),
+        amqqueue:get_type(Q) == ?MODULE,
+        is_match(amqqueue:get_vhost(Q), VhostSpec)
+        andalso is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)].
 
 is_minority(All, Up) ->
     MinQuorum = length(All) div 2 + 1,

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -97,6 +97,8 @@ groups() ->
                                             force_shrink_member_to_current_member,
                                             force_all_queues_shrink_member_to_current_member,
                                             force_vhost_queues_shrink_member_to_current_member,
+                                            force_checkpoint_on_queue,
+                                            force_checkpoint,
                                             policy_repair,
                                             gh_12635,
                                             replica_states
@@ -1308,6 +1310,80 @@ force_vhost_queues_shrink_member_to_current_member(Config) ->
         ?assertEqual(3, length(Nodes0))
     end || Q <- QQs, VHost <- VHosts].
 
+force_checkpoint_on_queue(Config) ->
+    [Server0, _Server1, _Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    RaName = ra_name(QQ),
+    QName = rabbit_misc:r(<<"/">>, queue, QQ),
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    rabbit_ct_client_helpers:publish(Ch, QQ, 3),
+    wait_for_messages_ready([Server0], RaName, 3),
+
+    % Wait for initial checkpoint and make sure it's 0; checkpoint hasn't been triggered yet.
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+          {ok, #{aux := Aux1}, _} = rpc:call(Server0, ra, member_overview, [{RaName, Server0}]),
+          {aux_v3, _, _, _, _, _, _, {checkpoint, Index, _, _, _, _, _}} = Aux1,
+          case Index of
+              0 -> true;
+              _ -> false
+          end
+      end),
+
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_checkpoint_on_queue, [QName]),
+
+    % Wait for initial checkpoint and make sure it's not 0
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+          {ok, #{aux := Aux1}, _} = rpc:call(Server0, ra, member_overview, [{RaName, Server0}]),
+          {aux_v3, _, _, _, _, _, _, {checkpoint, Index, _, _, _, _, _}} = Aux1,
+          case Index of
+              0 -> false;
+              _ -> true
+          end
+      end).
+
+force_checkpoint(Config) ->
+    [Server0, _Server1, _Server2] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    CQ = <<"force_checkpoint_cq">>,
+    RaName = ra_name(QQ),
+
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    ?assertEqual({'queue.declare_ok', CQ, 0, 0},
+                 declare(Ch, CQ, [{<<"x-queue-type">>, longstr, <<"classic">>}])),
+
+    rabbit_ct_client_helpers:publish(Ch, QQ, 3),
+    wait_for_messages_ready([Server0], RaName, 3),
+
+    meck:expect(rabbit_quorum_queue, force_checkpoint_on_queue, fun(Q) -> ok end),
+
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_checkpoint, [<<".*">>, <<".*">>]),
+
+    % Waiting here to make sure checkpoint has been forced
+    rabbit_ct_helpers:await_condition(
+      fun() ->
+          {ok, #{aux := Aux1}, _} = rpc:call(Server0, ra, member_overview, [{RaName, Server0}]),
+          {aux_v3, _, _, _, _, _, _, {checkpoint, Index, _, _, _, _, _}} = Aux1,
+          case Index of
+              0 -> false;
+              _ -> true
+          end
+      end),
+
+    % Make sure force_checkpoint_on_queue was only called for the quorun queue
+    ?assertEqual(1, meck:num_calls(rabbit_quorum_queue, force_checkpoint_on_queue, '_')).
 
 % Tests that, if the process of a QQ is dead in the moment of declaring a policy
 % that affects such queue, when the process is made available again, the policy

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/force_checkpoint_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/force_checkpoint_command.ex
@@ -1,0 +1,107 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  defp default_opts,
+    do: %{vhost_pattern: ".*", queue_pattern: ".*", errors_only: false}
+
+  def switches(),
+    do: [
+      vhost_pattern: :string,
+      queue_pattern: :string,
+      errors_only: :boolean
+    ]
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(default_opts(), opts)}
+  end
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{
+        node: node_name,
+        vhost_pattern: vhost_pat,
+        queue_pattern: queue_pat,
+        errors_only: errors_only
+      }) do
+    args = [vhost_pat, queue_pat]
+
+    case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :force_checkpoint, args) do
+      {:error, _} = error ->
+        error
+
+      {:badrpc, _} = error ->
+        error
+
+      results when errors_only ->
+        for {{:resource, vhost, _kind, name}, {:error, _, _} = res} <- results,
+            do: [
+              {:vhost, vhost},
+              {:name, name},
+              {:result, format_result(res)}
+            ]
+
+      results ->
+        for {{:resource, vhost, _kind, name}, res} <- results,
+            do: [
+              {:vhost, vhost},
+              {:name, name},
+              {:result, format_result(res)}
+            ]
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Table
+
+  def usage,
+    do: "force_checkpoint [--vhost-pattern <pattern>] [--queue-pattern <pattern>]"
+
+  def usage_additional do
+    [
+      ["--queue-pattern <pattern>", "regular expression to match queue names"],
+      ["--vhost-pattern <pattern>", "regular expression to match virtual host names"],
+      ["--errors-only", "only list queues which reported an error"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.quorum_queues()
+    ]
+  end
+
+  def help_section, do: :replication
+
+  def description,
+    do: "Forces checkpoints for all matching quorum queues"
+
+  def banner([], _) do
+    "Forcing checkpoint for all matching quorum queues..."
+  end
+
+  #
+  # Implementation
+  #
+
+  defp format_result({:ok}) do
+    "ok"
+  end
+
+  defp format_result({:error, :timeout}) do
+    "error: the operation timed out and may not have been completed"
+  end
+
+  defp format_result({:error, err}) do
+    to_string(:io_lib.format("error: ~W", [err, 10]))
+  end
+end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/force_checkpoint_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/force_checkpoint_command.ex
@@ -35,9 +35,6 @@ defmodule RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommand do
     args = [vhost_pat, queue_pat]
 
     case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :force_checkpoint, args) do
-      {:error, _} = error ->
-        error
-
       {:badrpc, _} = error ->
         error
 
@@ -46,7 +43,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommand do
             do: [
               {:vhost, vhost},
               {:name, name},
-              {:result, format_result(res)}
+              {:result, res}
             ]
 
       results ->
@@ -54,7 +51,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommand do
             do: [
               {:vhost, vhost},
               {:name, name},
-              {:result, format_result(res)}
+              {:result, res}
             ]
     end
   end
@@ -87,21 +84,5 @@ defmodule RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommand do
 
   def banner([], _) do
     "Forcing checkpoint for all matching quorum queues..."
-  end
-
-  #
-  # Implementation
-  #
-
-  defp format_result({:ok}) do
-    "ok"
-  end
-
-  defp format_result({:error, :timeout}) do
-    "error: the operation timed out and may not have been completed"
-  end
-
-  defp format_result({:error, err}) do
-    to_string(:io_lib.format("error: ~W", [err, 10]))
   end
 end

--- a/deps/rabbitmq_cli/test/queues/force_checkpoint_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/force_checkpoint_command_test.exs
@@ -1,0 +1,64 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Queues.Commands.ForceCheckpointCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000,
+       vhost_pattern: ".*",
+       queue_pattern: ".*",
+       errors_only: false
+     }}
+  end
+
+  test "merge_defaults: defaults to reporting complete results" do
+    assert @command.merge_defaults([], %{}) ==
+             {[],
+              %{
+                vhost_pattern: ".*",
+                queue_pattern: ".*",
+                errors_only: false
+              }}
+  end
+
+  test "validate: accepts no positional arguments" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  test "validate: any positional arguments fail validation" do
+    assert @command.validate(["quorum-queue-a"], %{}) == {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "two"], %{}) ==
+             {:validation_failure, :too_many_args}
+
+    assert @command.validate(["quorum-queue-a", "two", "three"], %{}) ==
+             {:validation_failure, :too_many_args}
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?(
+             {:badrpc, _},
+             @command.run(
+               [],
+               Map.merge(context[:opts], %{node: :jake@thedog})
+             )
+           )
+  end
+end


### PR DESCRIPTION
## Proposed Changes

Addresses #13137.

Adds functions to force checkpoint for a quorum queue or for all quorum queues matching a `VhostSpec` and `QueueSpec`.

Also adds a CLI tool to invoke that function.

Hand-in-hand with doc change PR: https://github.com/rabbitmq/rabbitmq-website/pull/2175

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

The test case for `force_checkpoint_on_queue` is a bit sensitive to changes in `rabbit_fifo:aux...` and `rabbit_fifo:checkpoint` records. Please feel free to suggest a different testing approach.

### Some local testing for CLI tool

`gmake run-broker RABBITMQ_NODENAME="force_checkpoint2"`

Create these queues and vhost:

```
aaronseo: ~/workplace/rabbitMq/rabbitmq-server/sbin $ ./rabbitmqctl -n force_checkpoint2 list_queues --vhost test name,type
Timeout: 60.0 seconds ...
Listing queues for vhost test ...
name    type
qwe     quorum
qq1     quorum
qq2     quorum
cq1     classic
aaronseo: ~/workplace/rabbitMq/rabbitmq-server/sbin $ ./rabbitmqctl -n force_checkpoint2 list_queues name,type
Timeout: 60.0 seconds ...
Listing queues for vhost / ...
name    type
qq2     quorum
qwe     quorum
qq1     quorum
cq1     classic
```

```
aaronseo: ~/workplace/rabbitMq/rabbitmq-server/sbin $ ./rabbitmq-queues -n force_checkpoint2 force_checkpoint
Forcing checkpoint for all matching quorum queues...
vhost   name    result
/       qq2     ok
/       qwe     ok
/       qq1     ok
test    qwe     ok
test    qq1     ok
test    qq2     ok

aaronseo: ~/workplace/rabbitMq/rabbitmq-server/sbin $ ./rabbitmq-queues -n force_checkpoint2 force_checkpoint --queue-pattern "qq.*"
Forcing checkpoint for all matching quorum queues...
vhost   name    result
/       qq2     ok
/       qq1     ok
test    qq1     ok
test    qq2     ok

aaronseo: ~/workplace/rabbitMq/rabbitmq-server/sbin $ ./rabbitmq-queues -n force_checkpoint2 force_checkpoint --vhost-pattern "test"
Forcing checkpoint for all matching quorum queues...
vhost   name    result
test    qwe     ok
test    qq1     ok
test    qq2     ok
```

### Some local testing for checkpoint value

- `gmake run-broker RABBITMQ_NODENAME="force_checkpoint2"`
- Create a quorum queue: `testqq`.
- `observer:start()` --> `Applications` --> `ra` --> `%2F_testqq` --> `State` --> 
```
aux =>
           {aux_v3,'%2F_testqq',
               {empty,true},
               {inactive,-576460727567095,1,1.0},
               {aux_gc,0},
               <0.1644.0>,#{},
               {checkpoint,0,1738181974685,2,0,4096,[]}},
```
- Send some messages to `testqq`
- Observe no change in checkpoint.
- Force checkpoints
```
(force_checkpoint2@b0f1d85a952f)2> rabbit_quorum_queue:force_checkpoint(".*", ".*").
[{{resource,<<"/">>,queue,<<"qq2">>},{ok}},
 {{resource,<<"/">>,queue,<<"qwe">>},{ok}},
 {{resource,<<"/">>,queue,<<"testqq">>},{ok}},
 {{resource,<<"/">>,queue,<<"qq1">>},{ok}},
 {{resource,<<"test">>,queue,<<"qwe">>},{ok}},
 {{resource,<<"test">>,queue,<<"qq1">>},{ok}},
 {{resource,<<"test">>,queue,<<"qq2">>},{ok}}]
(force_checkpoint2@b0f1d85a952f)3>
```

-- Observe change in `aux => checkpoint`
```
       aux =>
           {aux_v3,'%2F_testqq',
               {empty,false},
               {inactive,-576460749650951,1,1.0},
               {aux_gc,0},
               <0.1278.0>,#{},
               {checkpoint,15,1738182269854,4,4,4096,[]}},
               ```