### PR TITLE
Switch AWS peer discovery test from Bazel to make

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -115,6 +115,7 @@ jobs:
         with:
           push: true
           context: packaging/docker-image
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ github.event.inputs.build_arm && 'linux/amd64, linux/arm64' || 'linux/amd64' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-to: type=gha,mode=max,scope=${{ matrix.otp_version }}

--- a/.github/workflows/peer-discovery-aws.yaml
+++ b/.github/workflows/peer-discovery-aws.yaml
@@ -12,6 +12,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
+env:
+  OTP_VERSION: "27"
 jobs:
   peer-discovery-aws-integration-test:
     name: Integration Test
@@ -34,6 +36,8 @@ jobs:
       id: metadata
       with:
         images: pivotalrabbitmq/rabbitmq
+        flavor: |
+          suffix=-otp${{ env.OTP_VERSION }}
         tags: |
           type=sha,format=long
     - uses: int128/wait-for-docker-image-action@v1
@@ -42,23 +46,12 @@ jobs:
         tags: ${{ steps.metadata.outputs.tags }}
         timeout-seconds: 3600
         polling-seconds: 60
-    - name: COMPUTE REPO CACHE KEY
-      if: steps.authorized.outputs.authorized == 'true'
-      id: repo-cache-key
-      run: |
-        echo "value=bazel-repo-cache-${{ hashFiles('MODULE.bazel') }}" | tee -a $GITHUB_OUTPUT
-    - name: LOAD REPO CACHE
-      if: steps.authorized.outputs.authorized == 'true'
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ steps.repo-cache-key.outputs.value }}
-        path: /home/runner/repo-cache/
     - name: CONFIGURE OTP & ELIXIR
       if: steps.authorized.outputs.authorized == 'true'
       uses: erlef/setup-beam@v1.17
       with:
-        otp-version: 26
-        elixir-version: 1.15
+        otp-version: ${{ env.OTP_VERSION }}
+        elixir-version: "1.17"
     - name: SETUP ecs-cli
       if: steps.authorized.outputs.authorized == 'true'
       env:
@@ -67,40 +60,20 @@ jobs:
         curl -Lo /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-v${ECS_CLI_VERSION} && \
         chmod +x /usr/local/bin/ecs-cli && \
         ecs-cli --version
-    - name: AUTHENTICATE TO GOOGLE CLOUD
-      if: steps.authorized.outputs.authorized == 'true'
-      uses: google-github-actions/auth@v2.1.7
-      with:
-        credentials_json: ${{ secrets.REMOTE_CACHE_CREDENTIALS_JSON }}
-    - name: CONFIGURE BAZEL
-      if: steps.authorized.outputs.authorized == 'true'
-      run: |
-        if [ -n "${{ secrets.REMOTE_CACHE_BUCKET_NAME }}" ]; then
-        cat << EOF >> user.bazelrc
-          build --remote_cache=https://storage.googleapis.com/${{ secrets.REMOTE_CACHE_BUCKET_NAME }}
-          build --google_default_credentials
-
-          build --experimental_guard_against_concurrent_changes
-        EOF
-        fi
-        cat << EOF >> user.bazelrc
-          build --repository_cache=/home/runner/repo-cache/
-          build --color=yes
-        EOF
-
-        bazelisk info release
-    #! - name: Setup tmate session
-    #!   uses: mxschmitt/action-tmate@v3
     - name: RUN INTEGRATION TESTS
       if: steps.authorized.outputs.authorized == 'true'
+      env:
+        AWS_ACCESS_KEY_ID: "${{ secrets.CONCOURSE_AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "${{ secrets.CONCOURSE_AWS_SECRET_ACCESS_KEY }}"
+        RABBITMQ_IMAGE: "${{ steps.metadata.outputs.tags }}"
       run: |
         branch_or_tag="${GITHUB_REF##*/}"
-        bazelisk test //deps/rabbitmq_peer_discovery_aws:integration_SUITE \
-          --test_tag_filters=aws \
-          --build_tests_only \
-          --test_env AWS_ACCESS_KEY_ID=${{ secrets.CONCOURSE_AWS_ACCESS_KEY_ID }} \
-          --test_env AWS_SECRET_ACCESS_KEY=${{ secrets.CONCOURSE_AWS_SECRET_ACCESS_KEY }} \
-          --test_env RABBITMQ_IMAGE="pivotalrabbitmq/rabbitmq:sha-${{ github.sha }}" \
-          --test_env AWS_ECS_CLUSTER_NAME="rabbitmq-peer-discovery-aws-actions-${branch_or_tag//[._]/-}" \
-          --test_output=streamed \
-          --verbose_failures
+        export AWS_ECS_CLUSTER_NAME="rabbitmq-peer-discovery-aws-actions-${branch_or_tag//[._]/-}"
+        make -C deps/rabbitmq_peer_discovery_aws ct-integration
+    - name: UPLOAD TEST LOGS
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: CT logs
+        path: "logs/"
+        if-no-files-found: ignore

--- a/.github/workflows/peer-discovery-aws.yaml
+++ b/.github/workflows/peer-discovery-aws.yaml
@@ -2,6 +2,7 @@ name: Peer Discovery AWS Integration Test
 on:
   push:
     paths:
+      - ".github/workflows/peer-discovery-aws.yaml"
       - "deps/rabbitmq_peer_discovery_aws/**"
       - "deps/rabbitmq_peer_discovery_common/**"
       - "deps/rabbit/src/rabbit_peer_discovery.erl"

--- a/deps/rabbitmq_mqtt/test/packet_prop_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/packet_prop_SUITE.erl
@@ -103,7 +103,7 @@ publish_packet() ->
                        retain = boolean()},
             variable = #mqtt_packet_publish{
                           packet_id = packet_id(Qos),
-                          topic_name = utf8_string()},
+                          topic_name = mqtt_utf8_string()},
             payload = binary()}).
 
 publish_with_properties_packet() ->
@@ -135,15 +135,15 @@ publish_properties() ->
          list(elements([{'Payload-Format-Indicator', bit()},
                         {'Message-Expiry-Interval', four_byte_integer()},
                         {'Topic-Alias', two_byte_integer()},
-                        {'Response-Topic', utf8_string()},
+                        {'Response-Topic', mqtt_utf8_string()},
                         {'Correlation-Data', binary_data()},
                         user_property(),
-                        {'Content-Type', utf8_string()}])),
+                        {'Content-Type', mqtt_utf8_string()}])),
          maps:from_list(L)).
 
 puback_properties() ->
     ?LET(L,
-         list(elements([{'Reason-String', utf8_string()},
+         list(elements([{'Reason-String', mqtt_utf8_string()},
                         user_property()
                        ])),
          maps:from_list(L)).
@@ -151,7 +151,7 @@ puback_properties() ->
 disconnect_properties() ->
     ?LET(L,
          list(elements([{'Session-Expiry-Interval', four_byte_integer()},
-                        {'Reason-String', utf8_string()},
+                        {'Reason-String', mqtt_utf8_string()},
                         user_property()
                        ])),
          maps:from_list(L)).
@@ -161,7 +161,7 @@ user_property() ->
      non_empty(list(frequency(
                       [{5, utf8_string_pair()},
                        %% "The same name is allowed to appear more than once." [v5 3.3.2.3.7]
-                       {1, {<<"same name">>, utf8_string()}},
+                       {1, {<<"same name">>, mqtt_utf8_string()}},
                        {1, {<<"same name">>, <<"same value">>}}
                       ])))}.
 
@@ -204,11 +204,11 @@ binary_up_to(N) ->
 
 %% v5 1.5.7
 utf8_string_pair() ->
-    {utf8_string(), utf8_string()}.
+    {mqtt_utf8_string(), mqtt_utf8_string()}.
 
 %% "Unless stated otherwise all UTF-8 encoded strings can have any length
 %% in the range 0 to 65,535 bytes." v5 1.5.4
-utf8_string() ->
+mqtt_utf8_string() ->
     %% Defining an upper size other than 'inf' is too slow because the
     %% test ?SIZE is not taken into account anymore.
     MaxCodePointSize = 4,

--- a/erlang.mk
+++ b/erlang.mk
@@ -2680,7 +2680,7 @@ pkg_proper_name = proper
 pkg_proper_description = PropEr: a QuickCheck-inspired property-based testing tool for Erlang.
 pkg_proper_homepage = http://proper.softlab.ntua.gr
 pkg_proper_fetch = git
-pkg_proper_repo = https://github.com/manopapad/proper
+pkg_proper_repo = https://github.com/proper-testing/proper
 pkg_proper_commit = master
 
 PACKAGES += props


### PR DESCRIPTION
This includes some fixes to adapt the workflow to the changes in #13160. The main change is to switch the test from running via `bazel test ...` to `make ... ct-integration`.