### PR TITLE
Bump Khepri cluster formation timeout to the standard 5 minutes

### DIFF
--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -286,7 +286,7 @@ setup(_) ->
 retry_timeout() ->
     case application:get_env(rabbit, khepri_leader_wait_retry_timeout) of
         {ok, T}   -> T;
-        undefined -> 30000
+        undefined -> 300_000
     end.
 
 retry_limit() ->


### PR DESCRIPTION
to match that used with Mnesia.

In the case of Mnesia, there are 10 retries
with a 30 second delay each.

For Khepri, a single timeout is used, so it
must be ten times as long.

Discovered and reported by @evolvedlight.

Per discussion with @dumbbell.