### PR TITLE
Peer discovery: add an option to opt out of registration

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1353,6 +1353,13 @@ end}.
     {datatype, {enum, [disc, disk, ram]}}
 ]}.
 
+%% Register node during cluster formation.
+%%
+
+{mapping, "cluster_formation.registration", "rabbit.cluster_formation.register", [
+    {datatype, {enum, [true, false]}}
+]}.
+
 {translation, "rabbit.cluster_formation.node_type",
 fun(Conf) ->
     %% if peer discovery backend isn't configured, don't generate

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1353,13 +1353,6 @@ end}.
     {datatype, {enum, [disc, disk, ram]}}
 ]}.
 
-%% Register node during cluster formation.
-%%
-
-{mapping, "cluster_formation.registration", "rabbit.cluster_formation.register", [
-    {datatype, {enum, [true, false]}}
-]}.
-
 {translation, "rabbit.cluster_formation.node_type",
 fun(Conf) ->
     %% if peer discovery backend isn't configured, don't generate
@@ -1376,6 +1369,13 @@ fun(Conf) ->
             end
     end
 end}.
+
+%% Register node during cluster formation when backend supports registration.
+%%
+
+{mapping, "cluster_formation.registration", "rabbit.cluster_formation.register", [
+    {datatype, {enum, [true, false]}}
+]}.
 
 %% Cluster formation: lock acquisition retries as passed to https://erlang.org/doc/man/global.html#set_lock-3
 %%


### PR DESCRIPTION
## Proposed Changes

When forming a cluster, registration of the node joining the cluster might be left to (container) orchestration tools like Nomad or Kubernetes. This PR add the config option `cluster_formation.registration` which defaults to `true`. When set to `false` node registration at the backend is disabled.

When using container orchestration - we are using Nomad, it is the orchestrator that deploys containers with all requirements like network, storage, and also the registration in the service registry (Consul) with a per-service health check. There is at least one important advantage using this over the application doing the registration. When the application is not stopped gracefully for whatever reason, e.g. its OOM killed, it cannot deregister the service. This leaves behind an unlinked service entry in the registry. This caused the bug in #11233, also see [my remarks in PR #11045](https://github.com/rabbitmq/rabbitmq-server/pull/11045#issuecomment-2110144234) and [the exchange I had with @dumbbell in this discussion](https://github.com/rabbitmq/rabbitmq-server/discussions/11161#discussioncomment-9307332). When leaving registration and deregistration to the orchestrator, you cannot run in such problems.

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue #11233)
- [X] New feature (non-breaking change which adds functionality)
 
## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [x] If relevant, I have added [necessary documentation in a PR](https://github.com/rabbitmq/rabbitmq-website/pull/2177)
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

When trying to solve #11233 I was looking how I should disable node registration for Consul peer discovery. I found out that the `maybe_register` function inside `rabbit_peer_discovery` was the best option. This does however makes the option to disable registration a global peer discovery option rather specifically for Consul. Before continuing I'd like to know how this direction is perceived.

Please take into account, this is my first code in Erlang. I have additional work to do to make this a complete PR.