### PR TITLE
Show consumer count column on Mgmt UI Channels page

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -96,6 +96,7 @@ var ALL_COLUMNS =
                    ['mode',  'Mode',      true],
                    ['state', 'State',     true]],
       'Details': [['msgs-unconfirmed', 'Unconfirmed', true],
+                  ['consumer-count',   'Consumer count', false],
                   ['prefetch',         'Prefetch',    true],
                   ['msgs-unacked',     'Unacked',     true]],
       'Transactions': [['msgs-uncommitted', 'Msgs uncommitted', false],

--- a/deps/rabbitmq_management/priv/www/js/tmpl/channels-list.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/channels-list.ejs
@@ -35,6 +35,9 @@
 <% if (show_column('channels', 'msgs-unconfirmed')) { %>
     <th><%= fmt_sort('Unconfirmed',     'messages_unconfirmed') %></th>
 <% } %>
+<% if (show_column('channels', 'consumer-count')) { %>
+    <th><%= fmt_sort('Consumer count', 'consumer_count') %></th>
+<% } %>
 <% if (show_column('channels', 'prefetch')) { %>
     <th>Prefetch <span class="help" id="channel-prefetch"></span></th>
 <% } %>
@@ -84,6 +87,9 @@
 <% } %>
 <% if (show_column('channels', 'msgs-unconfirmed')) { %>
     <th>Unconfirmed</th>
+<% } %>
+<% if (show_column('channels', 'consumer-count')) { %>
+    <th>Consumer count</th>
 <% } %>
 <% if (show_column('channels', 'prefetch')) { %>
     <th>Prefetch <span class="help" id="channel-prefetch"></span></th>
@@ -151,6 +157,9 @@
 <% } %>
 <% if (show_column('channels', 'msgs-unconfirmed')) { %>
     <td class="c"><%= channel.messages_unconfirmed %></td>
+<% } %>
+<% if (show_column('channels', 'consumer-count')) { %>
+    <td class="c"><%= channel.consumer_count %></td>
 <% } %>
 <% if (show_column('channels', 'prefetch')) { %>
     <td class="c">


### PR DESCRIPTION
## Proposed Changes

Consumer count is already returned by the /channels API endpoint.
Now the consumer count column can be shown in the channels table but it is hidden by default.

For example in case the global consumer count is unexpectedly high it is useful to see which channels have the most consumers or how (un)evenly they are distributed between channels.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
