### PR TITLE
Peer discovery: disable consul health check helper when registration is disabled

### DIFF
--- a/deps/rabbit/src/rabbit_peer_discovery.erl
+++ b/deps/rabbit/src/rabbit_peer_discovery.erl
@@ -22,6 +22,7 @@
          maybe_unregister/0,
          discover_cluster_nodes/0]).
 -export([backend/0,
+         should_perform_registration/0,
          node_type/0,
          normalize/1,
          append_node_prefix/1,

--- a/deps/rabbitmq_peer_discovery_consul/src/rabbitmq_peer_discovery_consul_health_check_helper.erl
+++ b/deps/rabbitmq_peer_discovery_consul/src/rabbitmq_peer_discovery_consul_health_check_helper.erl
@@ -33,12 +33,17 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 init([]) ->
-    case rabbit_peer_discovery:backend() of
-        rabbit_peer_discovery_consul ->
-            set_up_periodic_health_check();
-        rabbitmq_peer_discovery_consul ->
-            set_up_periodic_health_check();
-        _ ->
+    case rabbit_peer_discovery:should_perform_registration() of
+        true ->
+            case rabbit_peer_discovery:backend() of
+                rabbit_peer_discovery_consul ->
+                    set_up_periodic_health_check();
+                rabbitmq_peer_discovery_consul ->
+                    set_up_periodic_health_check();
+                _ ->
+                    {ok, #state{}}
+            end;
+        false ->
             {ok, #state{}}
     end.
 


### PR DESCRIPTION
## Proposed Changes

This is a follow-up PR for #13201. In that PR a new configuration option was added: `cluster_formation.registration.enabled`. 

For Consul, this does work during boot, but the `rabbitmq_peer_discovery_consul_health_check_helper` keep querying Consul periodically to see whether the node is healthy. If it is not, it will register the node even though the registration was disabled. Since the periodic health check has no other function than to register the node if unhealthy,  the periodic check needs to be disabled when registration is disabled.

I have tested this PR with Consul and Nomad.

## Types of Changes

- [X] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it