### PR TITLE
Set cluster_name to "localhost" when running with make

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -159,7 +159,8 @@ define test_rabbitmq_config
 [
   {rabbit, [
 $(if $(RABBITMQ_NODE_PORT),      {tcp_listeners$(comma) [$(RABBITMQ_NODE_PORT)]}$(comma),)
-      {loopback_users, []}
+      {loopback_users, []},
+      {cluster_name, "localhost"}
     ]},
   {rabbitmq_management, [
 $(if $(RABBITMQ_NODE_PORT),      {listener$(comma) [{port$(comma) $(shell echo "$$(($(RABBITMQ_NODE_PORT) + 10000))")}]},)
@@ -378,6 +379,7 @@ start-brokers start-cluster: $(DIST_TARGET)
 		  RABBITMQ_NODE_PORT="$$((5672 + $$n - 1))" \
 		  RABBITMQ_SERVER_START_ARGS=" \
 		  -rabbit loopback_users [] \
+		  -rabbit cluster_name localhost \
 		  -rabbitmq_management listener [{port,$$((15672 + $$n - 1))}] \
 		  -rabbitmq_mqtt tcp_listeners [$$((1883 + $$n - 1))] \
 		  -rabbitmq_web_mqtt tcp_config [{port,$$((1893 + $$n - 1))}] \


### PR DESCRIPTION
Right now, after `make start-cluster`, each node reports a different cluster name