### PR TITLE
clustering_management_SUITE: Use old node as seed node

### DIFF
--- a/deps/rabbit/test/clustering_management_SUITE.erl
+++ b/deps/rabbit/test/clustering_management_SUITE.erl
@@ -76,7 +76,6 @@ groups() ->
                                                  status_with_alarm,
                                                  pid_file_and_await_node_startup_in_khepri,
                                                  await_running_count_in_khepri,
-                                                 start_with_invalid_schema_in_path,
                                                  persistent_cluster_id,
                                                  stop_start_cluster_node,
                                                  restart_cluster_node,


### PR DESCRIPTION
## Why

During mixed-version testing, the old node might not be able to join or rejoin a cluster if the other nodes run a newer Khepri machine version.

## How

The old node is used as the cluster seed node and is never touched otherwise. Other nodes are restarted or join the cluster later.

While here, skip `start_with_invalid_schema_in_path` with Khepri as it is specific to Mnesia.