### PR TITLE
Trap exit in AMQP 1.0 client proc

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_frame_reader.erl
+++ b/deps/amqp10_client/src/amqp10_client_frame_reader.erl
@@ -80,6 +80,7 @@ callback_mode() ->
     [handle_event_function].
 
 init([Sup, ConnConfig]) when is_map(ConnConfig) ->
+    process_flag(trap_exit, true),
     Port = maps:get(port, ConnConfig, 5672),
     %% combined the list of `addresses' with the value of the original `address' option if provided
     Addresses0 = maps:get(addresses, ConnConfig, []),


### PR DESCRIPTION
Trap exit signal such that terminate/3 gets executed so that the socket is closed cleanly.