### PR TITLE
Fix flake in test consume_from_replica

### DIFF
--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -6669,26 +6669,9 @@ ra_name(Q) ->
 wait_for_local_member(<<"stream">>, QName, Config) ->
     %% If it is a stream we need to wait until there is a local member
     %% on the node we want to subscribe from before proceeding.
-    rabbit_ct_helpers:await_condition(
-      fun() -> rpc(Config, 0, ?MODULE, has_local_member,
-                   [rabbit_misc:r(<<"/">>, queue, QName)])
-      end, 30_000);
+    ok = queue_utils:wait_for_local_stream_member(0, <<"/">>, QName, Config);
 wait_for_local_member(_, _, _) ->
     ok.
-
-has_local_member(QName) ->
-    case rabbit_amqqueue:lookup(QName) of
-        {ok, Q} ->
-            #{name := StreamId} = amqqueue:get_type_state(Q),
-            case rabbit_stream_coordinator:local_pid(StreamId) of
-                {ok, Pid} ->
-                    is_process_alive(Pid);
-                {error, _} ->
-                    false
-            end;
-        {error, _} ->
-            false
-    end.
 
 -spec find_event(Type, Props, Events) -> Ret when
       Type :: atom(),

--- a/deps/rabbit/test/queue_type_SUITE.erl
+++ b/deps/rabbit/test/queue_type_SUITE.erl
@@ -240,11 +240,7 @@ stream(Config) ->
 
     SubCh = rabbit_ct_client_helpers:open_channel(Config, 2),
     qos(SubCh, 10, false),
-    %% wait for local replica
-    rabbit_ct_helpers:await_condition(
-      fun() ->
-              queue_utils:has_local_stream_member(Config, 2, QName, <<"/">>)
-      end, 60000),
+    ok = queue_utils:wait_for_local_stream_member(2, <<"/">>, QName, Config),
 
     try
         amqp_channel:subscribe(

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1734,6 +1734,7 @@ consume_from_replica(Config) ->
     Ch2 = rabbit_ct_client_helpers:open_channel(Config, Server3),
     qos(Ch2, 10, false),
 
+    ok = queue_utils:wait_for_local_stream_member(Server3, <<"/">>, Q, Config),
     subscribe(Ch2, Q, false, 0),
     receive_batch(Ch2, 0, 99),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).


### PR DESCRIPTION
```
make -C deps/rabbit ct-rabbit_stream_queue t=cluster_size_3_parallel_1 RABBITMQ_METADATA_STORE=mnesia
```

flaked prior to this commit locally on Ubuntu with the following error after 11 runs:
```
rabbit_stream_queue_SUITE > cluster_size_3_parallel_1 > consume_from_replica
{error,
    {{shutdown,
         {server_initiated_close,406,
             <<"PRECONDITION_FAILED - stream queue 'consume_from_replica' in vhost '/' does not have a running replica on the local node">>}},
     {gen_server,call,
         [<0.8365.0>,
          {subscribe,
              {'basic.consume',0,<<"consume_from_replica">>,
                  <<"ctag">>,false,false,false,false,
                  [{<<"x-stream-offset">>,long,0}]},
              <0.8151.0>},
          infinity]}}}
```