### PR TITLE
CLI: Don't use regex as module attributes

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/command_modules.ex
@@ -11,7 +11,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
 
   import RabbitMQ.CLI.Core.CodePath
 
-  @commands_ns ~r/RabbitMQ.CLI.(.*).Commands/
+  @commands_ns ~S"RabbitMQ.CLI.(.*).Commands"
 
   def module_map(opts \\ %{}) do
     Application.get_env(:rabbitmqctl, :commands) || load(opts)
@@ -130,7 +130,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
   end
 
   defp make_module_map(modules, scope) when modules != nil do
-    commands_ns = Regex.recompile!(@commands_ns)
+    commands_ns = Regex.compile!(@commands_ns)
 
     modules
     |> Enum.filter(fn mod ->
@@ -212,7 +212,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
   defp command_scopes(cmd) do
     case CommandBehaviour.scopes(cmd) do
       nil ->
-        Regex.recompile!(@commands_ns)
+        Regex.compile!(@commands_ns)
         |> Regex.run(to_string(cmd), capture: :all_but_first)
         |> List.first()
         |> to_snake_case

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/os_pid.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/os_pid.ex
@@ -7,7 +7,7 @@
 defmodule RabbitMQ.CLI.Core.OsPid do
   @external_process_check_interval 1000
 
-  @pid_regex ~r/^\s*(?<pid>\d+)/
+  @pid_regex ~S"^\s*(?<pid>\d+)"
 
   #
   # API
@@ -27,7 +27,7 @@ defmodule RabbitMQ.CLI.Core.OsPid do
   def read_pid_from_file(pidfile_path, should_wait) do
     case {:file.read_file(pidfile_path), should_wait} do
       {{:ok, contents}, _} ->
-        pid_regex = Regex.recompile!(@pid_regex)
+        pid_regex = Regex.compile!(@pid_regex)
 
         case Regex.named_captures(pid_regex, contents)["pid"] do
           # e.g. the file is empty


### PR DESCRIPTION
This is not sufficient to build RabbitMQ on OTP 28.0-rc1 but it fixes the first problem that we hit. It might be that Elixir will support regex module attributes once it supports OTP 28, but we don't have to wait - this minor refactor just makes our code compatible with OTP28 without changing anything of substance.