### PR TITLE
Adding a "source-bundle" target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ endef
 # --------------------------------------------------------------------
 
 .PHONY: source-dist clean-source-dist
-.PHONY: build-dist clean-build-dist
+.PHONY: source-bundle clean-source-bundle
 
 SOURCE_DIST_BASE ?= rabbitmq-server
 SOURCE_DIST_SUFFIXES ?= tar.xz
@@ -151,8 +151,8 @@ SOURCE_DIST_FILES = $(addprefix $(SOURCE_DIST).,$(SOURCE_DIST_SUFFIXES))
 .PHONY: $(SOURCE_DIST_FILES)
 
 # Override rsync flags as a pre-requisite
-build-dist: RSYNC_FLAGS = $(BUILD_DIST_RSYNC_FLAGS)
-build-dist: $(SOURCE_DIST_FILES)
+source-bundle: RSYNC_FLAGS = $(SOURCE_BUNDLE_RSYNC_FLAGS)
+source-bundle: $(SOURCE_DIST_FILES)
 	@:
 
 # Override rsync flags as a pre-requisite
@@ -222,10 +222,10 @@ SOURCE_DIST_RSYNC_FLAGS += $(BASE_RSYNC_FLAGS)          \
 	       --exclude 'packaging'			\
 	       --exclude 'test'
 
-# For build-dist, explicitly include folders that are needed
+# For source-bundle, explicitly include folders that are needed
 # for tests to execute. These are added before excludes from
 # the base flags so rsync honors the first match.
-BUILD_DIST_RSYNC_FLAGS += \
+SOURCE_BUNDLE_RSYNC_FLAGS += \
 	       --include 'rabbit_shovel_test/ebin'      \
 	       --include 'rabbit_shovel_test/ebin/*'    \
 	       --include 'rabbitmq_ct_helpers/tools'    \
@@ -395,7 +395,7 @@ $(SOURCE_DIST).zip: $(SOURCE_DIST).manifest
 
 clean:: clean-source-dist
 
-clean-build-dist:: clean-source-dist
+clean-source-bundle:: clean-source-dist
 
 clean-source-dist:
 	$(gen_verbose) rm -rf -- $(SOURCE_DIST_BASE)-*


### PR DESCRIPTION

## Proposed Changes

This change adds a `source-bundle` build target to the RabbitMQ Makefile. This target is identical to the existing `source-dist` target but it also allows for packaging and testing of the source archive. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it