### PR TITLE
Do not propagate `none` password to http backend

### DIFF
--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -76,8 +76,12 @@ is_internal_property(rabbit_auth_backend_http) -> true;
 is_internal_property(rabbit_auth_backend_cache) -> true;
 is_internal_property(_Other) -> false.
 
+is_internal_none_password(password, none) -> true;
+is_internal_none_password(_, _) -> false.
+
 extract_other_credentials(AuthProps) ->
-  PublicAuthProps = [{K,V} || {K,V} <-AuthProps, not is_internal_property(K)],
+  PublicAuthProps = [{K,V} || {K,V} <-AuthProps, not is_internal_property(K) and 
+                                                  not is_internal_none_password(K, V)],
   case PublicAuthProps of
     [] -> resolve_using_persisted_credentials(AuthProps);
     _ -> PublicAuthProps

--- a/deps/rabbitmq_auth_backend_http/test/auth_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_http/test/auth_SUITE.erl
@@ -18,6 +18,9 @@
                         password => <<"Kocur">>,
                         expected_credentials => [username, password],
                         tags => [policymaker, monitoring]}).
+-define(ALLOWED_USER_2, #{username => <<"Ala3">>,                        
+                        expected_credentials => [username],
+                        tags => [policymaker, monitoring]}).
 -define(ALLOWED_USER_WITH_EXTRA_CREDENTIALS, #{username => <<"Ala2">>,
                                                password => <<"Kocur">>,
                                                client_id => <<"some_id">>,
@@ -46,12 +49,14 @@ shared() ->
         grants_access_to_user_passing_additional_required_authprops,
         grants_access_to_user_skipping_internal_authprops,
         grants_access_to_user_with_credentials_in_rabbit_auth_backend_http,
-        grants_access_to_user_with_credentials_in_rabbit_auth_backend_cache
+        grants_access_to_user_with_credentials_in_rabbit_auth_backend_cache,
+        grants_access_to_ssl_user_with_none_password
     ].
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:run_setup_steps(Config) ++
         [{allowed_user, ?ALLOWED_USER},
+        {allowed_user_2, ?ALLOWED_USER_2},
         {allowed_user_with_extra_credentials, ?ALLOWED_USER_WITH_EXTRA_CREDENTIALS},
         {denied_user, ?DENIED_USER}].
 
@@ -65,13 +70,21 @@ init_per_group(over_http, Config) ->
 init_per_group(over_https, Config) ->
     configure_http_auth_backend("https", Config),
     {User1, Tuple1} = extractUserTuple(?ALLOWED_USER),
-    {User2, Tuple2} = extractUserTuple(?ALLOWED_USER_WITH_EXTRA_CREDENTIALS),
+    {User2, Tuple2} = extractUserTuple(?ALLOWED_USER_2),    
+    {User3, Tuple3} = extractUserTuple(?ALLOWED_USER_WITH_EXTRA_CREDENTIALS),
     CertsDir = ?config(rmq_certsdir, Config),
-    start_https_auth_server(?AUTH_PORT, CertsDir, ?USER_PATH, #{User1 => Tuple1, User2 => Tuple2}),
-    Config.
+    start_https_auth_server(?AUTH_PORT, CertsDir, ?USER_PATH, #{
+        User1 => Tuple1, 
+        User3 => Tuple3, 
+        User2 => Tuple2}),
+    Config ++ [{group, over_https}].
 
 extractUserTuple(User) ->
-    #{username := Username, password := Password, tags := Tags, expected_credentials := ExpectedCredentials} = User,
+    #{username := Username,  tags := Tags, expected_credentials := ExpectedCredentials} = User,
+    Password = case maps:get(password, User, undefined) of
+        undefined -> none;
+        P -> P
+    end,
     {Username, {Password, Tags, ExpectedCredentials}}.
 
 end_per_suite(Config) ->
@@ -91,6 +104,16 @@ grants_access_to_user(Config) ->
     ?assertMatch({U, T, AuthProps},
                  {User#auth_user.username, User#auth_user.tags, (User#auth_user.impl)()}).
 
+grants_access_to_ssl_user_with_none_password(Config) ->
+    case ?config(group, Config) of 
+        over_https -> 
+            #{username := U, tags := T} = ?config(allowed_user_2, Config),
+            {ok, User} = rabbit_auth_backend_http:user_login_authentication(U, []),
+            ?assertMatch({U, T, []},
+                        {User#auth_user.username, User#auth_user.tags, (User#auth_user.impl)()});
+        _ ->{skip, "Requires https"}
+    end.
+ 
 denies_access_to_user(Config) ->
     #{username := U, password := P} = ?config(denied_user, Config),
     ?assertMatch({refused, "Denied by the backing HTTP service", []},

--- a/deps/rabbitmq_auth_backend_http/test/auth_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_http/test/auth_SUITE.erl
@@ -50,7 +50,7 @@ shared() ->
         grants_access_to_user_skipping_internal_authprops,
         grants_access_to_user_with_credentials_in_rabbit_auth_backend_http,
         grants_access_to_user_with_credentials_in_rabbit_auth_backend_cache,
-        grants_access_to_ssl_user_with_none_password
+        grants_access_to_ssl_user_without_a_password
     ].
 
 init_per_suite(Config) ->
@@ -104,7 +104,7 @@ grants_access_to_user(Config) ->
     ?assertMatch({U, T, AuthProps},
                  {User#auth_user.username, User#auth_user.tags, (User#auth_user.impl)()}).
 
-grants_access_to_ssl_user_with_none_password(Config) ->
+grants_access_to_ssl_user_without_a_password(Config) ->
     case ?config(group, Config) of 
         over_https -> 
             #{username := U, tags := T} = ?config(allowed_user_2, Config),

--- a/deps/rabbitmq_auth_backend_http/test/auth_http_mock.erl
+++ b/deps/rabbitmq_auth_backend_http/test/auth_http_mock.erl
@@ -14,8 +14,9 @@ init(Req = #{method := <<"GET">>}, Users) ->
 %%% HELPERS
 
 authenticate(QsVals, Users) ->
+   ct:log("QsVals: ~p Users: ~p", [QsVals, Users]),
    Username = proplists:get_value(<<"username">>, QsVals),
-   Password = proplists:get_value(<<"password">>, QsVals),
+   Password = proplists:get_value(<<"password">>, QsVals, none),
    case maps:get(Username, Users, undefined) of
        {MatchingPassword, Tags, ExpectedCredentials} when Password =:= MatchingPassword ->
             case lists:all(fun(C) -> proplists:is_defined(list_to_binary(rabbit_data_coercion:to_list(C)),QsVals) end, ExpectedCredentials) of

--- a/deps/rabbitmq_mqtt/test/auth_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/auth_SUITE.erl
@@ -72,7 +72,7 @@ sub_groups() ->
        [invalid_client_id_from_cert_san_dns
        ]},
      {ssl_user_with_client_id_in_cert_san_dns, [],
-       [client_id_from_cert_san_dns        
+       [client_id_from_cert_san_dns
        ]},
      {ssl_user_with_client_id_in_cert_san_dns_1, [],
        [client_id_from_cert_san_dns_1

--- a/selenium/full-suite-authnz-messaging
+++ b/selenium/full-suite-authnz-messaging
@@ -1,10 +1,9 @@
 authnz-messaging/auth-cache-http-backends.sh
 authnz-messaging/auth-cache-ldap-backends.sh
-authnz-messaging/auth-http-backend.sh
+authnz-messaging/auth-http-backend-with-mtls.sh
 authnz-messaging/auth-http-internal-backends-with-internal.sh
 authnz-messaging/auth-http-internal-backends.sh
 authnz-messaging/auth-internal-backend.sh
 authnz-messaging/auth-internal-mtls-backend.sh
 authnz-messaging/auth-internal-http-backends.sh
 authnz-messaging/auth-ldap-backend.sh
-authnz-messaging/auth-http-backend.sh

--- a/selenium/suites/authnz-messaging/auth-http-backend-with-mtls.sh
+++ b/selenium/suites/authnz-messaging/auth-http-backend-with-mtls.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEST_CASES_PATH=/authnz-msg-protocols
+PROFILES="internal-user auth-http auth_backends-http auth-mtls"
+# internal-user profile is used because the client certificates to 
+# access rabbitmq are issued with the alt_name = internal-user 
+
+source $SCRIPT/../../bin/suite_template
+runWith mock-auth-backend-http

--- a/selenium/suites/authnz-messaging/auth-http-backend.sh
+++ b/selenium/suites/authnz-messaging/auth-http-backend.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-TEST_CASES_PATH=/authnz-msg-protocols
-PROFILES="http-user auth-http auth_backends-http"
-
-source $SCRIPT/../../bin/suite_template
-runWith mock-auth-backend-http

--- a/selenium/test/amqp.js
+++ b/selenium/test/amqp.js
@@ -28,6 +28,7 @@ function getAmqpsConnectionOptions() {
 }
 function getConnectionOptions() {
   let scheme = process.env.RABBITMQ_AMQP_SCHEME || 'amqp'
+  console.log("Using AMQP protocol: " + scheme)
   switch(scheme){
     case "amqp":
       return getAmqpConnectionOptions()


### PR DESCRIPTION
## Proposed Changes

Do not propagate password if not provided. Internally, when a connection authenticates with a client certificate, the password credentials is set to `none`.  When RabbitMQ delegates the authentication to a http backend, RabbitMQ should not send a password whose value is the Erlang term `none`. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

