### PR TITLE
Configurable management delegate pool size (via management.delegate_count)

### DIFF
--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -13,7 +13,8 @@ define PROJECT_ENV
 	    {cors_allow_origins, []},
 	    {cors_max_age, 1800},
 	    {content_security_policy, "script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'"},
-	    {max_http_body_size, 10000000}
+	    {max_http_body_size, 10000000},
+	    {delegate_count, 5}
 	  ]
 endef
 

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -37,6 +37,15 @@ fun(Conf) ->
 end}.
 
 
+%% Number of delegate processes to use for metrics acquisition intra-cluster
+%% communication. On a machine which has a very large number of cores and is
+%% also part of a cluster, you may wish to increase this value.
+%%
+
+{mapping, "management.delegate_count", "rabbitmq_management.delegate_count", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.
+
 %% HTTP (TCP) listener options ========================================================
 
 %% HTTP listener consistent with Web STOMP and Web MQTT.

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_agent_sup.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_agent_sup.erl
@@ -37,9 +37,10 @@ maybe_enable_metrics_collector() ->
     case rabbit_mgmt_agent_config:is_metrics_collector_enabled() of
         true ->
             ok = pg:join(?MANAGEMENT_PG_SCOPE, ?MANAGEMENT_PG_GROUP, self()),
+            MDC = get_management_delegate_count(),
             ST = {rabbit_mgmt_storage, {rabbit_mgmt_storage, start_link, []},
                   permanent, ?WORKER_WAIT, worker, [rabbit_mgmt_storage]},
-            MD = {delegate_management_sup, {delegate_sup, start_link, [5, ?DELEGATE_PREFIX]},
+            MD = {delegate_management_sup, {delegate_sup, start_link, [MDC, ?DELEGATE_PREFIX]},
                   permanent, ?SUPERVISOR_WAIT, supervisor, [delegate_sup]},
             MC = [{rabbit_mgmt_metrics_collector:name(Table),
                    {rabbit_mgmt_metrics_collector, start_link, [Table]},
@@ -55,3 +56,7 @@ maybe_enable_metrics_collector() ->
         false ->
             []
     end.
+
+get_management_delegate_count() ->
+    {ok, MDC} = application:get_env(rabbitmq_management, delegate_count),
+    MDC.


### PR DESCRIPTION
## Proposed Changes

Hello 👋 

This proposed change introduces a new `delegate_count` config for the Management Plugin, configured via `management.delegate_count` (rabbitmq.conf) or  `rabbitmq_management.delegate_count` (advanced/classic). When nodes are extremely busy aggregating stats, we'd like to have the flexibility to significantly increase the concurrency/available delegate processes (specifically to optimize all the `created_stats_delegated/{1,2}` calls in the `rabbit_mgmt_db` and eliminate blocking from a small pool size), to make better use of available hardware cores for stats acquisition. One general observation on the Management UI (Admin -> Top) when nodes are busy and experience slowness in stats acquisition are the busy management delegate processes,  registered as `delegate_management_[1-5]`, which are currently only limited to the hard-coded pool size of 5. This change allows us to bump this up whenever necessary on heavy deployments.

This changes also retains the current default delegate pool size of 5: `rabbitmq_management.delegate_count = 5`.

Please take a look, keen to have this flexibility available on the Management-Plugin 👍 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
