### PR TITLE
Minor improvement: Remove observer_cli from CLI escritps

### DIFF
--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -1,7 +1,7 @@
 PROJECT = rabbitmq_cli
 
 BUILD_DEPS = rabbit_common
-DEPS = csv json observer_cli stdout_formatter
+DEPS = csv json stdout_formatter
 TEST_DEPS = amqp amqp_client temp x509 rabbit
 
 dep_amqp = hex 3.3.0

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -19,11 +19,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
 
   @dialyzer {:nowarn_function, run: 2}
   def run([], %{node: node_name, interval: interval}) do
-    case :observer_cli.start(node_name, [{:interval, interval * 1000}]) do
-      # See zhongwencool/observer_cli#54
-      {:badrpc, _} = err -> err
-      {:error, _} = err -> err
-      {:error, _, _} = err -> err
+    case :rabbit_misc.rpc_call(node_name, :observer_cli, :start, [interval * 1000], :infinity) do
       :ok -> {:ok, "Disconnected from #{node_name}."}
       :quit -> {:ok, "Disconnected from #{node_name}."}
       other -> other

--- a/deps/rabbitmq_cli/mix.exs
+++ b/deps/rabbitmq_cli/mix.exs
@@ -29,7 +29,6 @@ defmodule RabbitMQCtl.MixfileBase do
           JSON,
           :mnesia,
           :msacc,
-          :observer_cli,
           :public_key,
           :pubkey_cert,
           :rabbit,
@@ -155,11 +154,6 @@ defmodule RabbitMQCtl.MixfileBase do
       {
         :stdout_formatter,
         path: Path.join(deps_dir, "stdout_formatter"),
-        compile: if(is_bazel, do: fake_cmd, else: make_cmd)
-      },
-      {
-        :observer_cli,
-        path: Path.join(deps_dir, "observer_cli"),
         compile: if(is_bazel, do: fake_cmd, else: make_cmd)
       },
       {


### PR DESCRIPTION
## Proposed Changes

observer_cli (and its dependency recon) was declared as a dependency of rabbitmq_cli and as a consequence included in all escritps. However the major part of observer_cli runs in the broker. The cli side only used `observer_cli:rpc_start/2` which is just an rpc call into the target node.

By using common rpc call we can remove observer_cli and recon from the escripts. This can be considered a minor improvement based on the philosophy "simpler is better".

As an additional benefit auto-completing functions of the recon app now works in `rabbitmq-diagnostics remote_shell`.
(eg. `recon:proc_c<TAB>`) This was my main motivation for this change.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
