### PR TITLE
rabbit_peer_discovery: Compute start time once

### DIFF
--- a/deps/rabbit/src/rabbit_peer_discovery.erl
+++ b/deps/rabbit/src/rabbit_peer_discovery.erl
@@ -637,8 +637,7 @@ query_node_props2([{Node, Members} | Rest], NodesAndProps, FromNode) ->
                            ["Peer discovery: temporary hidden node '~ts' "
                             "queries properties from node '~ts'",
                             [node(), Node]], FromNode),
-                         StartTime = get_node_start_time(
-                                       Node, microsecond, FromNode),
+                         StartTime = get_node_start_time(Node, FromNode),
                          IsReady = is_node_db_ready(Node, FromNode),
                          NodeAndProps = {Node, Members, StartTime, IsReady},
                          NodesAndProps1 = [NodeAndProps | NodesAndProps],
@@ -666,9 +665,8 @@ query_node_props2([], NodesAndProps, _FromNode) ->
     ?assert(length(NodesAndProps1) =< length(nodes(hidden))),
     NodesAndProps1.
 
--spec get_node_start_time(Node, Unit, FromNode) -> StartTime when
+-spec get_node_start_time(Node, FromNode) -> StartTime when
       Node :: node(),
-      Unit :: erlang:time_unit(),
       FromNode :: node(),
       StartTime :: non_neg_integer().
 %% @doc Returns the start time of the given `Node' in `Unit'.
@@ -689,15 +687,21 @@ query_node_props2([], NodesAndProps, _FromNode) ->
 %%
 %% @private
 
-get_node_start_time(Node, Unit, FromNode) ->
-    NativeStartTime = erpc_call(
-                        Node, erlang, system_info, [start_time], FromNode),
-    TimeOffset = erpc_call(Node, erlang, time_offset, [], FromNode),
-    SystemStartTime = NativeStartTime + TimeOffset,
-    StartTime = erpc_call(
-                  Node, erlang, convert_time_unit,
-                  [SystemStartTime, native, Unit], FromNode),
-    StartTime.
+get_node_start_time(Node, FromNode) ->
+    try
+        erpc_call(Node,rabbit_boot_state, get_start_time, [], FromNode)
+    catch
+        error:{exception, _, _} ->
+            NativeStartTime = erpc_call(
+                                Node, erlang, system_info, [start_time],
+                                FromNode),
+            TimeOffset = erpc_call(Node, erlang, time_offset, [], FromNode),
+            SystemStartTime = NativeStartTime + TimeOffset,
+            StartTime = erpc_call(
+                          Node, erlang, convert_time_unit,
+                          [SystemStartTime, native, microsecond], FromNode),
+            StartTime
+    end.
 
 -spec is_node_db_ready(Node, FromNode) -> IsReady when
       Node :: node(),

--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch.erl
@@ -48,6 +48,7 @@ run_prelaunch_first_phase() ->
 do_run() ->
     %% Indicate RabbitMQ is booting.
     clear_stop_reason(),
+    rabbit_boot_state:record_start_time(),
     rabbit_boot_state:set(booting),
 
     %% Configure dbg if requested.


### PR DESCRIPTION
… and cache it.

## Why

It happens at least in CI that the computed start time varies by a few seconds. I think this comes from the Erlang time offset which might be adjusted over time.

This affects peer discovery's sorting of RabbitMQ nodes which uses that start time to determine the oldest node. When the start time of a node changes, it could be considered the seed node to join by some nodes but ignored by the other nodes, leading to troubles with cluster formation.