### PR TITLE
By @ikavgo: introduce a deletion protection marker for queues

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -276,7 +276,7 @@ PARALLEL_CT_SET_3_D = metadata_store_phase1 metrics mirrored_supervisor peer_dis
 PARALLEL_CT_SET_4_A = clustering_events rabbit_local_random_exchange rabbit_message_interceptor rabbitmq_4_0_deprecations unit_pg_local unit_plugin_directories unit_plugin_versioning unit_policy_validators unit_priority_queue
 PARALLEL_CT_SET_4_B = per_user_connection_tracking per_vhost_connection_limit rabbit_fifo_dlx_integration rabbit_fifo_int
 PARALLEL_CT_SET_4_C = msg_size_metrics unit_msg_size_metrics per_vhost_msg_store per_vhost_queue_limit priority_queue upgrade_preparation vhost
-PARALLEL_CT_SET_4_D = per_user_connection_channel_tracking product_info publisher_confirms_parallel queue_type rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown routing
+PARALLEL_CT_SET_4_D = per_user_connection_channel_tracking product_info publisher_confirms_parallel queue_type rabbitmq_queues_cli_integration rabbitmqctl_integration rabbitmqctl_shutdown routing rabbit_amqqueue
 
 PARALLEL_CT_SET_1 = $(sort $(PARALLEL_CT_SET_1_A) $(PARALLEL_CT_SET_1_B) $(PARALLEL_CT_SET_1_C) $(PARALLEL_CT_SET_1_D))
 PARALLEL_CT_SET_2 = $(sort $(PARALLEL_CT_SET_2_A) $(PARALLEL_CT_SET_2_B) $(PARALLEL_CT_SET_2_C) $(PARALLEL_CT_SET_2_D))

--- a/deps/rabbit/test/rabbit_amqqueue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_amqqueue_SUITE.erl
@@ -1,0 +1,117 @@
+-module(rabbit_amqqueue_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+%%%===================================================================
+%%% Common Test callbacks
+%%%===================================================================
+
+all() ->
+    [
+     {group, rabbit_amqqueue_tests}
+    ].
+
+
+all_tests() ->
+    [
+     normal_queue_delete_with,
+     internal_queue_delete_with
+    ].
+
+groups() ->
+    [
+     {rabbit_amqqueue_tests, [], all_tests()}
+    ].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_group(_Group, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:testcase_started(Config, Testcase),
+    rabbit_ct_helpers:run_steps(Config1,
+                                rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(
+                Config,
+                rabbit_ct_client_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%%%===================================================================
+%%% Test cases
+%%%===================================================================
+
+normal_queue_delete_with(Config) ->
+    QName = queue_name(Config, <<"normal">>),
+    Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Queue = amqqueue:new(QName,
+                         none, %% pid
+                         true, %% durable
+                         false, %% auto delete
+                         none, %% owner,
+                         [],
+                         <<"/">>,
+                         #{},
+                         rabbit_classic_queue),
+
+    ?assertMatch({new, _Q},  rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_queue_type, declare, [Queue, Node])),
+
+    ?assertMatch({ok, _},  rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, delete_with, [QName, false, false, <<"dummy">>])),
+
+    ?assertMatch({error, not_found}, rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup, [QName])),
+
+    ok.
+
+internal_queue_delete_with(Config) ->
+    QName = queue_name(Config, <<"internal_protected">>),
+    Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Queue = amqqueue:new(QName,
+                         none, %% pid
+                         true, %% durable
+                         false, %% auto delete
+                         none, %% owner,
+                         [],
+                         <<"/">>,
+                         #{},
+                         rabbit_classic_queue),
+    IQueue = amqqueue:make_internal(Queue, rabbit_misc:r(<<"/">>, exchange, <<"amq.default">>)),
+
+    ?assertMatch({new, _Q},  rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_queue_type, declare, [IQueue, Node])),
+
+    ?assertException(exit, {exception,
+                            {amqp_error, resource_locked,
+                             "Cannot delete protected queue 'rabbit_amqqueue_tests/internal_protected' in vhost '/'.",
+                             none}}, rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, delete_with, [QName, false, false, <<"dummy">>])),
+
+    ?assertMatch({ok, _}, rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup, [QName])),
+
+    ?assertMatch({ok, _},  rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, delete_with, [QName, false, false, ?INTERNAL_USER])),
+
+    ?assertMatch({error, not_found}, rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_amqqueue, lookup, [QName])),
+
+    ok.
+
+%% Utility
+
+queue_name(Config, Name) ->
+    Name1 = iolist_to_binary(rabbit_ct_helpers:config_to_testcase_name(Config, Name)),
+    queue_name(Name1).
+
+queue_name(Name) ->
+    rabbit_misc:r(<<"/">>, queue, Name).


### PR DESCRIPTION
This work was originally done by @ikavgo in Tanzu RabbitMQ.

Similarly to internal exchanges, that have restrictions on what applications can do with them,
and virtual hosts that have deletion protection in 4.x, this introduces a deletion protection concept for queues.

This relies on a map property all queues already have, so no schema migrations are necessary.