### PR TITLE
By @ikavgo: add --force to 'rabbitmqctl delete_queue'

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/delete_queue_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/delete_queue_command.ex
@@ -9,13 +9,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: [if_empty: :boolean, if_unused: :boolean, timeout: :integer]
+  def switches(), do: [if_empty: :boolean, if_unused: :boolean, force: :boolean, timeout: :integer]
   def aliases(), do: [e: :if_empty, u: :if_unused, t: :timeout]
 
   def merge_defaults(args, opts) do
     {
       args,
-      Map.merge(%{if_empty: false, if_unused: false, vhost: "/"}, opts)
+      Map.merge(%{if_empty: false, if_unused: false, force: false, vhost: "/"}, opts)
     }
   end
 
@@ -46,37 +46,49 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand do
         vhost: vhost,
         if_empty: if_empty,
         if_unused: if_unused,
+        force: force,
         timeout: timeout
       }) do
     ## Generate queue resource name from queue name and vhost
     queue_resource = :rabbit_misc.r(vhost, :queue, qname)
+    user = if force, do: RabbitMQ.CLI.Common.internal_user, else: "cli_user"
     ## Lookup a queue on broker node using resource name
     case :rabbit_misc.rpc_call(node, :rabbit_amqqueue, :lookup, [queue_resource]) do
       {:ok, queue} ->
         ## Delete queue
-        :rabbit_misc.rpc_call(
-          node,
-          :rabbit_amqqueue,
-          :delete_with,
-          [queue, if_unused, if_empty, "cli_user"],
-          timeout
-        )
+        case :rabbit_misc.rpc_call(node,
+              :rabbit_amqqueue,
+              :delete_with,
+              [queue, if_unused, if_empty, user],
+              timeout
+            ) do
+          {:ok, _} = ok -> ok
+
+          {:badrpc, {:EXIT, {:amqp_error, :resource_locked, _, :none}}} ->
+              {:error, :protected}
+
+          other_error -> other_error
+        end
 
       {:error, _} = error ->
         error
     end
   end
 
+  def output({:error, :protected}, _options) do
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "The queue is locked or protected from deletion"}
+  end
+
   def output({:error, :not_found}, _options) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "Queue not found"}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "No such queue was found"}
   end
 
   def output({:error, :not_empty}, _options) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "Queue is not empty"}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "The queue is not empty"}
   end
 
   def output({:error, :in_use}, _options) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "Queue is in use"}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_usage(), "The queue is in use"}
   end
 
   def output({:ok, qlen}, _options) do
@@ -103,14 +115,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand do
       Enum.join(Enum.concat([if_empty_str, if_unused_str]), "and ") <> "..."
   end
 
-  def usage(), do: "delete_queue [--vhost <vhost>] <queue_name> [--if-empty|-e] [--if-unused|-u]"
+  def usage(), do: "delete_queue [--vhost <vhost>] <queue_name> [--if-empty|-e] [--if-unused|-u] [--force]"
 
   def usage_additional() do
     [
       ["--vhost", "Virtual host name"],
       ["<queue_name>", "name of the queue to delete"],
       ["--if-empty", "delete the queue if it is empty (has no messages ready for delivery)"],
-      ["--if-unused", "delete the queue only if it has no consumers"]
+      ["--if-unused", "delete the queue only if it has no consumers"],
+      ["--force", "delete the queue even if it is protected"]
     ]
   end
 

--- a/deps/rabbitmq_cli/src/Elixir.RabbitMQ.CLI.Common.erl
+++ b/deps/rabbitmq_cli/src/Elixir.RabbitMQ.CLI.Common.erl
@@ -1,0 +1,15 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module('Elixir.RabbitMQ.CLI.Common').
+
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-export([internal_user/0]).
+
+internal_user() ->
+    ?INTERNAL_USER.

--- a/deps/rabbitmq_cli/test/test_helper.exs
+++ b/deps/rabbitmq_cli/test/test_helper.exs
@@ -302,6 +302,34 @@ defmodule TestHelper do
     ])
   end
 
+  def declare_internal_queue(
+        name,
+        vhost,
+        durable \\ false,
+        auto_delete \\ false,
+        args \\ [],
+        owner \\ :none
+      ) do
+    queue_name = :rabbit_misc.r(vhost, :queue, name)
+
+    amqqueue = :amqqueue.new(
+      queue_name,
+      :none,
+      durable,
+      auto_delete,
+      owner,
+      args,
+      vhost,
+      %{})
+
+    internal_amqqueue = :amqqueue.make_internal(amqqueue)
+
+    :rpc.call(get_rabbit_hostname(), :rabbit_queue_type, :declare, [
+      internal_amqqueue,
+      get_rabbit_hostname()
+    ])
+  end
+
   def declare_stream(name, vhost) do
     declare_queue(name, vhost, true, false, [{"x-queue-type", :longstr, "stream"}])
   end


### PR DESCRIPTION
This work was originally done by @ikavgo in Tanzu RabbitMQ.

As a follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/13525, `rabbitmqctl delete_queue` now supports a `--force` flag that can be used to force delete a deletion-protected queue.
