### PR TITLE
Refine CI triggers for building OCI

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -12,6 +12,8 @@ on:
       - Makefile
       - plugins.mk
       - rabbitmq-components.mk
+      - packaging/**
+      - .github/workflows/oci-make.yaml
   workflow_dispatch:
     inputs:
       otp_version:

--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -6,12 +6,12 @@
 name: OCI (make)
 on:
   push:
-    paths-ignore:
-      - '.github/workflows/secondary-umbrella.yaml'
-      - '.github/workflows/update-elixir-patches.yaml'
-      - '.github/workflows/update-otp-patches.yaml'
-      - '.github/workflows/release-alphas.yaml'
-      - '*.md'
+    paths:
+      - deps/**
+      - scripts/**
+      - Makefile
+      - plugins.mk
+      - rabbitmq-components.mk
   workflow_dispatch:
     inputs:
       otp_version:


### PR DESCRIPTION
## Proposed Changes

- Trigger OCI builds only on code changes
- ~~Build OCI only on commits to `main`~~

Right now, we are building a dev OCI on _any_ type of changes. For example, changes to Selenim tests would
trigger a build of the OCI. This doesn't make sense because changes to tests do not alter RabbitMQ functionality.
This PR changes the triggers so that CI builds the OCI when there are changes to RabbitMQ code or its dependencies.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

