### PR TITLE
Increase initial AMQP 0-9-1 connection frame size limit

### DIFF
--- a/deps/rabbit_common/include/rabbit_framing.hrl
+++ b/deps/rabbit_common/include/rabbit_framing.hrl
@@ -11,7 +11,7 @@
 -define(FRAME_HEADER, 2).
 -define(FRAME_BODY, 3).
 -define(FRAME_HEARTBEAT, 8).
--define(FRAME_MIN_SIZE, 4096).
+-define(FRAME_MIN_SIZE, 8192).
 -define(FRAME_END, 206).
 -define(REPLY_SUCCESS, 200).
 -define(CONTENT_TOO_LARGE, 311).


### PR DESCRIPTION
Before the client authenticates, the standard
frame_max is not used. Instead, the initial limit uses a special constant.

This is fine for password or x.509 certificate-based authentication but not for some JWT tokens, which can vary in size, and take multiple kilobytes.

8 kB specifically is the default HTTP header length limit used by Nginx.
Sounds like this value was good enough for a lot of Bearer headers with JWT tokens.

Closes #13541.
