### PR TITLE
Use Erlang 27 in CI for tests

### DIFF
--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -30,11 +30,11 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - "26.2"
+        - "27.3"
         browser:
         - chrome
         include:
-        - erlang_version: "26.2"
+        - erlang_version: "27.3"
           elixir_version: 1.17.3
     env:
       SELENIUM_DIR: selenium

--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -62,8 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - '26'
-##        - '27'
+        - '27'
         elixir_version:
         - '1.17'
         metadata_store:
@@ -82,8 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - '26'
-##        - '27'
+        - '27'
         elixir_version:
         - '1.17'
         metadata_store:

--- a/.github/workflows/test-management-ui-for-pr.yaml
+++ b/.github/workflows/test-management-ui-for-pr.yaml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - "26.2"
+        - "27.3"
         browser:
         - chrome
         include:
-        - erlang_version: "26.2"
+        - erlang_version: "27.3"
           elixir_version: 1.17
     env:
       SELENIUM_DIR: selenium

--- a/.github/workflows/test-management-ui.yaml
+++ b/.github/workflows/test-management-ui.yaml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         erlang_version:
-        - "26.2"
+        - "27.3"
         browser:
         - chrome
         include:
-        - erlang_version: "26.2"
+        - erlang_version: "27.3"
           elixir_version: 1.17.3
     env:
       SELENIUM_DIR: selenium


### PR DESCRIPTION

## Proposed Changes

Run tests with Erlang 27. Erlang 27 is fully supported in main and v4.1.x. Erlang 27 is already used for build and XREF.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Erlang 27 is fully supported in main and v4.1.x. Support for Erlang 26
in v4.1 remains. It's better to "drop" erlang 26 from CI because, at the
moment, our PRs and commits to main trigger about 270 jobs. If we just
add '27' to the matrix, we would spawn ~216 more jobs, totalling around
496 jobs per PR and commit to main. That's simply too much, because it's
reaching the usage limits of Github Actions [1], namely the 256 limit of
matrix jobs.

[1]
https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
