### PR TITLE
Allow the rabbitmq_auth_backend_http plug-in to be used only for user authentication and authorization against the HTTP backend by setting vhost_path, resource_path, and topic_path to 'disabled'

### DIFF
--- a/deps/rabbitmq_auth_backend_http/README.md
+++ b/deps/rabbitmq_auth_backend_http/README.md
@@ -93,7 +93,7 @@ For instance, if the user accessed RabbitMQ via the MQTT protocol, it is expecte
 * `vhost`: the name of the virtual host being accessed
 * `ip`: the client ip address
 
-Note that you cannot create arbitrary virtual hosts using this plugin; you can only determine whether your users can see / access the ones that exist. By setting `vhost_path` to `disabled`, this authentication request is skipped, and  unrestricted access is granted.
+Note that you cannot create arbitrary virtual hosts using this plugin; you can only determine whether your users can see / access the ones that exist. By setting `vhost_path` to `disabled`, this authentication request is skipped, and unrestricted access is granted.
 
 ### resource_path
 
@@ -105,7 +105,7 @@ Note that you cannot create arbitrary virtual hosts using this plugin; you can o
 
 Note: This request may include additional http request parameters in addition to the ones listed above.
 For instance, if the user accessed RabbitMQ via the MQTT protocol, it is expected `client_id` request parameter too.
-By setting `resource_path` to `disabled`, this authentication request is skipped, and  unrestricted access is granted.
+By setting `resource_path` to `disabled`, this authentication request is skipped, and unrestricted access is granted.
 
 ### topic_path
 
@@ -117,7 +117,7 @@ By setting `resource_path` to `disabled`, this authentication request is skipped
 * `routing_key`: the routing key of a published message (when the permission is `write`)
 or routing key of the queue binding (when the permission is `read`)
 
-Note: By setting `topic_path` to `disabled`, this authentication request is skipped, and  unrestricted access is granted.
+Note: By setting `topic_path` to `disabled`, this authentication request is skipped, and unrestricted access is granted.
 
 See [topic authorisation](http://www.rabbitmq.com/access-control.html#topic-authorisation) for more information
 about topic authorisation.

--- a/deps/rabbitmq_auth_backend_http/README.md
+++ b/deps/rabbitmq_auth_backend_http/README.md
@@ -93,7 +93,7 @@ For instance, if the user accessed RabbitMQ via the MQTT protocol, it is expecte
 * `vhost`: the name of the virtual host being accessed
 * `ip`: the client ip address
 
-Note that you cannot create arbitrary virtual hosts using this plugin; you can only determine whether your users can see / access the ones that exist.
+Note that you cannot create arbitrary virtual hosts using this plugin; you can only determine whether your users can see / access the ones that exist. By setting `vhost_path` to `disabled`, this authentication request is skipped, and  unrestricted access is granted.
 
 ### resource_path
 
@@ -105,6 +105,7 @@ Note that you cannot create arbitrary virtual hosts using this plugin; you can o
 
 Note: This request may include additional http request parameters in addition to the ones listed above.
 For instance, if the user accessed RabbitMQ via the MQTT protocol, it is expected `client_id` request parameter too.
+By setting `resource_path` to `disabled`, this authentication request is skipped, and  unrestricted access is granted.
 
 ### topic_path
 
@@ -115,6 +116,8 @@ For instance, if the user accessed RabbitMQ via the MQTT protocol, it is expecte
 * `permission`: the access level to the resource (`write` or `read`)
 * `routing_key`: the routing key of a published message (when the permission is `write`)
 or routing key of the queue binding (when the permission is `read`)
+
+Note: By setting `topic_path` to `disabled`, this authentication request is skipped, and  unrestricted access is granted.
 
 See [topic authorisation](http://www.rabbitmq.com/access-control.html#topic-authorisation) for more information
 about topic authorisation.

--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -148,10 +148,17 @@ context_as_parameters(_) ->
     [].
 
 bool_req(PathName, Props) ->
-    case http_req(p(PathName), q(Props)) of
-        "deny"  -> false;
-        "allow" -> true;
-        E       -> E
+    Authpath = p(PathName),
+    case Authpath of
+        "disabled" ->
+            rabbit_log:debug("auth_backend_http: Skip ~ts!", [PathName]),
+            true;
+        _Else ->
+            case http_req(Authpath, q(Props)) of
+                 "deny"  -> false;
+                 "allow" -> true;
+                 E       -> E
+         end
     end.
 
 http_req(Path, Query) -> http_req(Path, Query, ?RETRY_ON_KEEPALIVE_CLOSED).


### PR DESCRIPTION
## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
