### PR TITLE
Emit queue_info metric

### DIFF
--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -533,19 +533,56 @@ queue_consumer_count_single_vhost_per_object_test(Config) ->
 
     %% There should be exactly 2 metrics returned (2 queues in that vhost, `queue_consumer_count` has only single metric)
     ?assertEqual(#{rabbitmq_detailed_queue_consumers =>
-                       #{#{queue => "vhost-1-queue-with-consumer",vhost => "vhost-1"} => [1],
-                         #{queue => "vhost-1-queue-with-messages",vhost => "vhost-1"} => [0]}},
+                   #{#{queue => "vhost-1-queue-with-consumer",vhost => "vhost-1"} => [1],
+                     #{queue => "vhost-1-queue-with-messages",vhost => "vhost-1"} => [0]},
+                   rabbitmq_detailed_queue_info =>
+                   #{#{queue => "vhost-1-queue-with-consumer",
+                       vhost => "vhost-1",
+                       queue_type => "rabbit_classic_queue",
+                       membership => "leader"} => [1],
+                     #{queue => "vhost-1-queue-with-messages",
+                       vhost => "vhost-1",
+                       queue_type => "rabbit_classic_queue",
+                       membership => "leader"} => [1]}
+                  },
                  parse_response(Body)),
     ok.
 
 queue_consumer_count_all_vhosts_per_object_test(Config) ->
     Expected = #{rabbitmq_detailed_queue_consumers =>
-                     #{#{queue => "vhost-1-queue-with-consumer",vhost => "vhost-1"} => [1],
-                       #{queue => "vhost-1-queue-with-messages",vhost => "vhost-1"} => [0],
-                       #{queue => "vhost-2-queue-with-consumer",vhost => "vhost-2"} => [1],
-                       #{queue => "vhost-2-queue-with-messages",vhost => "vhost-2"} => [0],
-                       #{queue => "default-queue-with-consumer",vhost => "/"} => [1],
-                       #{queue => "default-queue-with-messages",vhost => "/"} => [0]}},
+                 #{#{queue => "vhost-1-queue-with-consumer",vhost => "vhost-1"} => [1],
+                   #{queue => "vhost-1-queue-with-messages",vhost => "vhost-1"} => [0],
+                   #{queue => "vhost-2-queue-with-consumer",vhost => "vhost-2"} => [1],
+                   #{queue => "vhost-2-queue-with-messages",vhost => "vhost-2"} => [0],
+                   #{queue => "default-queue-with-consumer",vhost => "/"} => [1],
+                   #{queue => "default-queue-with-messages",vhost => "/"} => [0]},
+
+                 rabbitmq_detailed_queue_info =>
+                 #{#{queue => "default-queue-with-consumer",
+                     vhost => "/",
+                     queue_type => "rabbit_classic_queue",
+                     membership => "leader"} => [1],
+                   #{queue => "default-queue-with-messages",
+                     vhost => "/",
+                     queue_type => "rabbit_classic_queue",
+                     membership => "leader"} => [1],
+                   #{queue => "vhost-1-queue-with-consumer",
+                     vhost => "vhost-1",
+                     queue_type => "rabbit_classic_queue",
+                     membership => "leader"} => [1],
+                   #{queue => "vhost-1-queue-with-messages",
+                     vhost => "vhost-1",
+                     queue_type => "rabbit_classic_queue",
+                     membership => "leader"} => [1],
+                   #{queue => "vhost-2-queue-with-consumer",
+                     vhost => "vhost-2",
+                     queue_type => "rabbit_classic_queue",
+                     membership => "leader"} => [1],
+                   #{queue => "vhost-2-queue-with-messages",
+                     vhost => "vhost-2",
+                     queue_type => "rabbit_classic_queue",
+                     membership => "leader"} => [1]}
+                },
 
     %% No vhost given, all should be returned
     {_, Body1} = http_get_with_pal(Config, "/metrics/detailed?family=queue_consumer_count&per-object=1", [], 200),


### PR DESCRIPTION
To allow filtering on queue type or membership status, we need an info metric for queues; see
https://grafana.com/blog/2021/08/04/how-to-use-promql-joins-for-more-effective-queries-of-prometheus-metrics-at-scale/#info-metrics

With this change, per-object metrics and the detailed metrics (if queue-related families are requested) will contain rabbitmq_queue_info / rabbitmq_detailed_queue_info with a value of 1 and labels including the queue name, vhost, queue type and membership status.

For example, it's now possible to get the number of messages ready by queue type:
```
sum(rabbitmq_queue_messages_ready *on (instance,job,vhost,queue) group_left(queue_type) rabbitmq_queue_info) by (queue_type)
```
or get a total number of messages ready excluding streams:
```
sum(rabbitmq_queue_messages_ready *on (instance,job,vhost,queue) group_left(queue_type) rabbitmq_queue_info{queue_type!="rabbit_stream_queue"})
```

NOTE: for consistency with other metrics (eg `rabbitmq_global_messages_*`), I use full module names as queue types (eg. `rabbit_quorum_queue`). Personally I'd prefer to unify this towards the short names but this would be a breaking change.