### PR TITLE
Remove redundant rabbit_queue_type APIs

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_management.erl
+++ b/deps/rabbit/src/rabbit_amqp_management.erl
@@ -437,7 +437,13 @@ encode_queue(Q, NumMsgs, NumConsumers) ->
                {{utf8, <<"durable">>}, {boolean, Durable}},
                {{utf8, <<"auto_delete">>}, {boolean, AutoDelete}},
                {{utf8, <<"exclusive">>}, {boolean, Exclusive}},
-               {{utf8, <<"type">>}, {utf8, rabbit_queue_type:to_binary(QType)}},
+               {{utf8, <<"type">>},
+                {utf8, case rabbit_queue_type:short_alias_of(QType) of
+                           undefined ->
+                               atom_to_binary(QType);
+                           ShortName ->
+                               ShortName
+                       end}},
                {{utf8, <<"arguments">>}, QArgs}
               ],
     KVList1 = if is_list(Replicas) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -20,7 +20,6 @@
          close/1,
          discover/1,
          short_alias_of/1,
-         feature_flag_name/1,
          to_binary/1,
          default/0,
          default_alias/0,
@@ -335,15 +334,6 @@ short_alias_of(<<"stream">>) ->
 short_alias_of(_Other) ->
     undefined.
 
-feature_flag_name(<<"quorum">>) ->
-    quorum_queue;
-feature_flag_name(<<"classic">>) ->
-    undefined;
-feature_flag_name(<<"stream">>) ->
-    stream_queue;
-feature_flag_name(_) ->
-    undefined.
-
 %% If the client does not specify the type, the virtual host does not have any
 %% metadata default, and rabbit.default_queue_type is not set in the application env,
 %% use this type as the last resort.
@@ -374,7 +364,7 @@ to_binary(Other) ->
 
 %% is a specific queue type implementation enabled
 -spec is_enabled(module()) -> boolean().
-is_enabled(Type) ->
+is_enabled(Type) when is_atom(Type) ->
     Type:is_enabled().
 
 -spec is_compatible(module(), boolean(), boolean(), boolean()) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -20,7 +20,6 @@
          close/1,
          discover/1,
          short_alias_of/1,
-         to_binary/1,
          default/0,
          default_alias/0,
          fallback/0,
@@ -299,7 +298,7 @@ discover(Other) when is_binary(Other) ->
     {ok, Mod} = rabbit_registry:lookup_module(queue, T),
     Mod.
 
--spec short_alias_of(queue_type()) -> binary().
+-spec short_alias_of(queue_type()) -> undefined | binary().
 %% The opposite of discover/1: returns a short alias given a module name
 short_alias_of(<<"rabbit_quorum_queue">>) ->
     <<"quorum">>;
@@ -351,16 +350,6 @@ default() ->
 -spec default_alias() -> binary().
 default_alias() ->
     short_alias_of(default()).
-
--spec to_binary(module()) -> binary().
-to_binary(rabbit_classic_queue) ->
-    <<"classic">>;
-to_binary(rabbit_quorum_queue) ->
-    <<"quorum">>;
-to_binary(rabbit_stream_queue) ->
-    <<"stream">>;
-to_binary(Other) ->
-    atom_to_binary(Other).
 
 %% is a specific queue type implementation enabled
 -spec is_enabled(module()) -> boolean().

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -166,19 +166,18 @@ do_add(Name, Metadata, ActingUser) ->
     case Metadata of
         #{default_queue_type := DQT} ->
             %% check that the queue type is known
-            rabbit_log:debug("Default queue type of virtual host '~ts' is ~tp", [Name, DQT]),
+            rabbit_log:debug("Default queue type of virtual host '~ts' is ~tp",
+                             [Name, DQT]),
             try rabbit_queue_type:discover(DQT) of
-                _ ->
-                    case rabbit_queue_type:feature_flag_name(DQT) of
-                        undefined -> ok;
-                        Flag when is_atom(Flag) ->
-                            case rabbit_feature_flags:is_enabled(Flag) of
-                                true  -> ok;
-                                false -> throw({error, queue_type_feature_flag_is_not_enabled})
-                            end
+                QueueType when is_atom(QueueType) ->
+                    case rabbit_queue_type:is_enabled(QueueType) of
+                        true ->
+                            ok;
+                        false ->
+                            throw({error, queue_type_feature_flag_is_not_enabled})
                     end
             catch _:_ ->
-                throw({error, invalid_queue_type, DQT})
+                      throw({error, invalid_queue_type, DQT})
             end;
         _ ->
             ok


### PR DESCRIPTION
As this functionality is covered by the rabbit_queue_type:is_enabled/1 API.

Remove rabbit_queue_type:to_binary/1
As it is covered by rabbit_queue_type:short_alias_of/1