### PR TITLE
Switch is_<queue_type> to using queue.type field in Management UI

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -251,7 +251,7 @@ format(Q, _Ctx) when ?is_amqqueue(Q) ->
                 S ->
                     S
             end,
-    [{type, classic},
+    [{type, rabbit_queue_type:short_alias_of(?MODULE)},
      {state, State},
      {node, node(amqqueue:get_pid(Q))}].
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1899,7 +1899,7 @@ format(Q, Ctx) when ?is_amqqueue(Q) ->
                             down
                     end
             end,
-    [{type, quorum},
+    [{type, rabbit_queue_type:short_alias_of(?MODULE)},
      {state, State},
      {node, LeaderNode},
      {members, Nodes},

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -277,14 +277,14 @@ format(Q, Ctx) ->
                                     down
                             end
                     end,
-            [{type, stream},
+            [{type, rabbit_queue_type:short_alias_of(?MODULE)},
              {state, State},
              {leader, LeaderNode},
              {online, Online},
              {members, Nodes},
              {node, node(Pid)}];
         _ ->
-            [{type, stream},
+            [{type, rabbit_queue_type:short_alias_of(?MODULE)},
              {state, down}]
     end.
 

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -3577,7 +3577,7 @@ format(Config) ->
                                        ?FUNCTION_NAME, [QRecord, #{}]),
 
     %% test all up case
-    ?assertEqual(quorum, proplists:get_value(type, Fmt)),
+    ?assertEqual(<<"quorum">>, proplists:get_value(type, Fmt)),
     ?assertEqual(running, proplists:get_value(state, Fmt)),
     ?assertEqual(Server, proplists:get_value(leader, Fmt)),
     ?assertEqual(Server, proplists:get_value(node, Fmt)),
@@ -3594,7 +3594,7 @@ format(Config) ->
                                                ?FUNCTION_NAME, [QRecord, #{}]),
             ok = rabbit_control_helper:command(start_app, Server2),
             ok = rabbit_control_helper:command(start_app, Server3),
-            ?assertEqual(quorum, proplists:get_value(type, Fmt2)),
+            ?assertEqual(<<"quorum">>, proplists:get_value(type, Fmt2)),
             ?assertEqual(minority, proplists:get_value(state, Fmt2)),
             ?assertEqual(Server, proplists:get_value(leader, Fmt2)),
             ?assertEqual(Server, proplists:get_value(node, Fmt2)),

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -1555,7 +1555,7 @@ format(Config) ->
                                        ?FUNCTION_NAME, [QRecord, #{}]),
 
     %% test all up case
-    ?assertEqual(stream, proplists:get_value(type, Fmt)),
+    ?assertEqual(<<"stream">>, proplists:get_value(type, Fmt)),
     ?assertEqual(running, proplists:get_value(state, Fmt)),
     ?assertEqual(Server, proplists:get_value(leader, Fmt)),
     ?assertEqual(Server, proplists:get_value(node, Fmt)),
@@ -1572,7 +1572,7 @@ format(Config) ->
                                                ?FUNCTION_NAME, [QRecord, #{}]),
             ok = rabbit_control_helper:command(start_app, Server3),
             ok = rabbit_control_helper:command(start_app, Server2),
-            ?assertEqual(stream, proplists:get_value(type, Fmt2)),
+            ?assertEqual(<<"stream">>, proplists:get_value(type, Fmt2)),
             ?assertEqual(minority, proplists:get_value(state, Fmt2)),
             ?assertEqual(Server, proplists:get_value(leader, Fmt2)),
             ?assertEqual(Server, proplists:get_value(node, Fmt2)),

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1768,40 +1768,20 @@ function select_queue_type(queuetype) {
     update();
 }
 
+function get_queue_type (queue) {    
+    return queue.type;
+}
+
 function is_quorum(queue) {
-    if (queue["arguments"]) {
-        if (queue["arguments"]["x-queue-type"]) {
-            return queue["arguments"]["x-queue-type"] === "quorum";
-        } else {
-            return false;
-        }
-    } else {
-        return false;
-    }
+    return get_queue_type(queue) === "quorum";
 }
 
 function is_stream(queue) {
-    if (queue["arguments"]) {
-        if (queue["arguments"]["x-queue-type"]) {
-            return queue["arguments"]["x-queue-type"] === "stream";
-        } else {
-            return false;
-        }
-    } else {
-        return false;
-    }
+    return get_queue_type(queue) === "stream";
 }
 
 function is_classic(queue) {
-    if (queue["arguments"]) {
-        if (queue["arguments"]["x-queue-type"]) {
-            return queue["arguments"]["x-queue-type"] === "classic";
-        } else {
-            return true;
-        }
-    } else {
-        return true;
-    }
+    return get_queue_type(queue) === "classic";
 }
 
 function ensure_queues_chart_range() {


### PR DESCRIPTION
x-queue-type is not mandatory. Using queue.type is more robust. 

See also https://github.com/rabbitmq/rabbitmq-server/pull/13603