### PR TITLE
Fix crash when consuming from unavailable quorum queue

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -1494,12 +1494,7 @@ handle_attach(#'v1_0.attach'{role = ?AMQP_ROLE_RECEIVER,
                                                          topic_permission_cache = TopicPermCache},
                                    rabbit_global_counters:consumer_created(?PROTOCOL),
                                    {ok, [A], State1};
-                               {error, Reason} ->
-                                   protocol_error(
-                                     ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
-                                     "Consuming from ~s failed: ~tp",
-                                     [rabbit_misc:rs(QName), Reason]);
-                               {protocol_error, _Type, Reason, Args} ->
+                               {error, _Type, Reason, Args} ->
                                    protocol_error(
                                      ?V_1_0_AMQP_ERROR_INTERNAL_ERROR,
                                      Reason, Args)

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -1816,8 +1816,7 @@ basic_get(Q, NoAck, LimiterPid, CTag, QStates) ->
                     rabbit_framing:amqp_table(), any(), rabbit_types:username(),
                     rabbit_queue_type:state()) ->
     {ok, rabbit_queue_type:state()} |
-    {error, term()} |
-    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
+    {error, Type :: atom(), Format :: string(), FormatArgs :: [term()]}.
 basic_consume(Q, NoAck, ChPid, LimiterPid,
               LimiterActive, ConsumerPrefetchCount, ConsumerTag,
               ExclusiveConsume, Args, OkMsg, ActingUser, QStates) ->

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1354,10 +1354,9 @@ handle_method(#'basic.consume'{queue        = QueueNameBin,
     CurrentConsumers = maps:size(ConsumerMapping),
     case maps:find(ConsumerTag, ConsumerMapping) of
         error when CurrentConsumers >= MaxConsumers ->  % false when MaxConsumers is 'infinity'
-            rabbit_misc:protocol_error(
-              not_allowed,
-              "reached maximum (~B) of consumers per channel",
-              [MaxConsumers]);
+            rabbit_misc:protocol_error(not_allowed,
+                                       "reached maximum (~B) of consumers per channel",
+                                       [MaxConsumers]);
         error ->
             QueueName = qbin_to_resource(QueueNameBin, VHostPath),
             check_read_permitted(QueueName, User, AuthzContext),
@@ -1368,13 +1367,13 @@ handle_method(#'basic.consume'{queue        = QueueNameBin,
                             _ ->
                                 ConsumerTag
                         end,
-            basic_consume(
-              QueueName, NoAck, ConsumerPrefetch, ActualTag,
-              ExclusiveConsume, Args, NoWait, State);
+            basic_consume(QueueName, NoAck, ConsumerPrefetch, ActualTag,
+                          ExclusiveConsume, Args, NoWait, State);
         {ok, _} ->
             %% Attempted reuse of consumer tag.
-            rabbit_misc:protocol_error(
-              not_allowed, "attempt to reuse consumer tag '~ts'", [ConsumerTag])
+            rabbit_misc:protocol_error(not_allowed,
+                                       "attempt to reuse consumer tag '~ts'",
+                                       [ConsumerTag])
     end;
 
 handle_method(#'basic.cancel'{consumer_tag = ConsumerTag, nowait = NoWait},

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -297,8 +297,12 @@ consume(Q, Spec, State0) when ?amqqueue_is_classic(Q) ->
             %% TODO: track pids as they change
             State = ensure_monitor(QPid, QRef, State0),
             {ok, State#?STATE{pid = QPid}};
-        Err ->
-            Err
+        {error, exclusive_consume_unavailable} ->
+            {error, access_refused, "~ts in exclusive use",
+             [rabbit_misc:rs(QRef)]};
+        {error, Reason} ->
+            {error, internal_error, "failed consuming from classic ~ts: ~tp",
+             [rabbit_misc:rs(QRef), Reason]}
     end.
 
 %% Delete this function when feature flag rabbitmq_4.0.0 becomes required.

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -522,7 +522,7 @@ consume(Q, Spec, State) ->
     case Mod:consume(Q, Spec, CtxState0) of
         {ok, CtxState} ->
             {ok, set_ctx(Q, Ctx#ctx{state = CtxState}, State)};
-        Err = {error, _Type, _Fmt, _FmtArgs} ->
+        {error, _Type, _Fmt, _FmtArgs} = Err->
             Err
     end.
 

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -211,8 +211,7 @@
                   consume_spec(),
                   queue_state()) ->
     {ok, queue_state(), actions()} |
-    {error, term()} |
-    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
+    {error, Type :: atom(), Format :: string(), FormatArgs :: [term()]}.
 
 -callback cancel(amqqueue:amqqueue(),
                  cancel_spec(),
@@ -516,15 +515,14 @@ new(Q, State) when ?is_amqqueue(Q) ->
 
 -spec consume(amqqueue:amqqueue(), consume_spec(), state()) ->
     {ok, state()} |
-    {error, term()} |
-    {protocol_error, Type :: atom(), Reason :: string(), Args :: term()}.
+    {error, Type :: atom(), Format :: string(), FormatArgs :: [term()]}.
 consume(Q, Spec, State) ->
     #ctx{state = CtxState0} = Ctx = get_ctx(Q, State),
     Mod = amqqueue:get_type(Q),
     case Mod:consume(Q, Spec, CtxState0) of
         {ok, CtxState} ->
             {ok, set_ctx(Q, Ctx#ctx{state = CtxState}, State)};
-        Err ->
+        Err = {error, _Type, _Fmt, _FmtArgs} ->
             Err
     end.
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1010,8 +1010,7 @@ consume(Q, Spec, QState0) when ?amqqueue_is_quorum(Q) ->
                      args => Args,
                      username => ActingUser,
                      priority => Priority},
-    case rabbit_fifo_client:checkout(
-           ConsumerTag, Mode, ConsumerMeta, QState0) of
+    case rabbit_fifo_client:checkout(ConsumerTag, Mode, ConsumerMeta, QState0) of
         {ok, _Infos, QState} ->
             case single_active_consumer_on(Q) of
                 true ->
@@ -1024,29 +1023,30 @@ consume(Q, Spec, QState0) when ?amqqueue_is_quorum(Q) ->
                                                  _ ->
                                                      waiting
                                              end,
-                            rabbit_core_metrics:consumer_created(
-                              ChPid, ConsumerTag, ExclusiveConsume,
-                              AckRequired, QName,
-                              Prefetch, ActivityStatus == single_active, %% Active
-                              ActivityStatus, Args),
-                            emit_consumer_created(
-                              ChPid, ConsumerTag, ExclusiveConsume,
-                              AckRequired, QName, Prefetch,
-                              Args, none, ActingUser),
+                            rabbit_core_metrics:consumer_created(ChPid, ConsumerTag,
+                                                                 ExclusiveConsume,
+                                                                 AckRequired, QName,
+                                                                 Prefetch,
+                                                                 ActivityStatus == single_active,
+                                                                 ActivityStatus, Args),
+                            emit_consumer_created(ChPid, ConsumerTag,
+                                                  ExclusiveConsume,
+                                                  AckRequired, QName,
+                                                  Prefetch, Args, none,
+                                                  ActingUser),
                             {ok, QState};
                         Err ->
                             consume_error(Err, QName)
                     end;
                 false ->
-                    rabbit_core_metrics:consumer_created(
-                      ChPid, ConsumerTag, ExclusiveConsume,
-                      AckRequired, QName,
-                      Prefetch, true, %% Active
-                      up, Args),
-                    emit_consumer_created(
-                      ChPid, ConsumerTag, ExclusiveConsume,
-                      AckRequired, QName, Prefetch,
-                      Args, none, ActingUser),
+                    rabbit_core_metrics:consumer_created(ChPid, ConsumerTag,
+                                                         ExclusiveConsume,
+                                                         AckRequired, QName,
+                                                         Prefetch, true,
+                                                         up, Args),
+                    emit_consumer_created(ChPid, ConsumerTag, ExclusiveConsume,
+                                          AckRequired, QName, Prefetch,
+                                          Args, none, ActingUser),
                     {ok, QState}
             end;
         Err ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1506,10 +1506,9 @@ consume(Q, QoS, #state{
                                       State1 = State0#state{queue_states = QStates},
                                       State = maybe_set_queue_qos1(QoS, State1),
                                       {ok, State};
-                                  {error, Reason} = Err ->
-                                      ?LOG_ERROR("Failed to consume from ~s: ~p",
-                                                 [rabbit_misc:rs(QName), Reason]),
-                                      Err
+                                  {error, Type, Fmt, Args} ->
+                                      ?LOG_ERROR(Fmt, Args),
+                                      {error, Type}
                               end
                       end)
             end;


### PR DESCRIPTION
Prior to this commit, when a client consumed from an unavailable quorum queue, the following crash occurred:
```
{badmatch,{error,noproc}}
[{rabbit_quorum_queue,consume,3,[{file,\"rabbit_quorum_queue.erl\"},{line,993}]}
```

This commit fixes this bug by returning any error when registering a quorum queue consumer to rabbit_queue_type.

This commit also refactors errors returned by
rabbit_queue_type:consume/3 to simplify and ensure seperation of concerns.

For example prior to this commit, the channel did error formatting specifically for consuming from streams. It's better if the channel is unaware of what queue type it consumes from and have each queue type implementation format their own errors.

Jira: RMQ-1582