### PR TITLE
RMQ-1263: An attempt to make shovel status tuple handling backwards compatible

### DIFF
--- a/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.RestartShovelCommand.erl
+++ b/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.RestartShovelCommand.erl
@@ -62,18 +62,22 @@ run([Name], #{node := Node, vhost := VHost}) ->
             case rabbit_shovel_status:find_matching_shovel(VHost, Name, Xs) of
                 undefined ->
                     {error, rabbit_data_coercion:to_binary(ErrMsg)};
-                Match ->
-                    {{_Name, _VHost}, _Type, {_State, Opts}, _Metrics, _Timestamp} = Match,
-                    {_, HostingNode} = lists:keyfind(node, 1, Opts),
-                    case rabbit_misc:rpc_call(
-                        HostingNode, rabbit_shovel_util, restart_shovel, [VHost, Name]) of
-                        {badrpc, _} = Error ->
-                            Error;
-                        {error, not_found} ->
-                            {error, rabbit_data_coercion:to_binary(ErrMsg)};
-                        ok -> ok
-                    end
+                {{_Name, _VHost}, _Type, {_State, Opts}, _Metrics, _Timestamp} ->
+                    restart_shovel(ErrMsg, Name, VHost, Opts);
+                {{_Name, _VHost}, _Type, {_State, Opts}, _Timestamp} ->
+                    restart_shovel(ErrMsg, Name, VHost, Opts)
             end
+    end.
+
+restart_shovel(ErrMsg, Name, VHost, Opts) ->
+    {_, HostingNode} = lists:keyfind(node, 1, Opts),
+    case rabbit_misc:rpc_call(
+        HostingNode, rabbit_shovel_util, restart_shovel, [VHost, Name]) of
+        {badrpc, _} = Error ->
+            Error;
+        {error, not_found} ->
+            {error, rabbit_data_coercion:to_binary(ErrMsg)};
+        ok -> ok
     end.
 
 output(Output, _Opts) ->

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
@@ -45,6 +45,10 @@ status(Node) ->
 format(Node, {Name, Type, Info, _Metrics, TS}) ->
     [{node, Node}, {timestamp, format_ts(TS)}] ++
         format_name(Type, Name) ++
+        format_info(Info);
+format(Node, {Name, Type, Info, TS}) ->
+    [{node, Node}, {timestamp, format_ts(TS)}] ++
+        format_name(Type, Name) ++
         format_info(Info).
 
 format_name(static,  Name)          -> [{name,  Name},


### PR DESCRIPTION
This is a followup for #13620. For cluster upgrades/mixed versions we want shovel commands and management status formatter to be backwards compatible. I hope I got it right :-)

PS. CrashCounter goes off for shovel_management even on main branch for me.