### PR TITLE
RMQ-1263: An attempt to make shovel status tuple handling forward compatible

### DIFF
--- a/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DeleteShovelCommand.erl
+++ b/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.DeleteShovelCommand.erl
@@ -76,25 +76,30 @@ run([Name], #{node := Node, vhost := VHost}) ->
                 undefined ->
                     try_force_removing(Node, VHost, Name, ActingUser),
                     {error, rabbit_data_coercion:to_binary(ErrMsg)};
-                Match ->
-                    {{_Name, _VHost}, _Type, {_State, Opts}, _Timestamp} = Match,
-                    {_, HostingNode} = lists:keyfind(node, 1, Opts),
-                    case rabbit_misc:rpc_call(
-                        HostingNode, rabbit_shovel_util, delete_shovel, [VHost, Name, ActingUser]) of
-                        {badrpc, _} = Error ->
-                            Error;
-                        {error, not_found} ->
-                            ErrMsg = rabbit_misc:format("Shovel with the given name was not found "
-                                                        "on the target node '~ts' and/or virtual host '~ts'. "
-                                                        "It may be failing to connect and report its state, will delete its runtime parameter...",
-                                                        [Node, VHost]),
-                            try_force_removing(HostingNode, VHost, Name, ActingUser),
-                            {error, rabbit_data_coercion:to_binary(ErrMsg)};
-                        ok ->
-                            _ = try_clearing_runtime_parameter(Node, VHost, Name, ActingUser),
-                            ok
-                    end
+                {{_Name, _VHost}, _Type, {_State, Opts}, _Timestamp} ->
+                    delete_shovel(ErrMsg, VHost, Opts, Name, Node, ActingUser);
+                %% Forward compatibility with >= 4.1
+                {{_Name, _VHost}, _Type, {_State, Opts}, _Metrics, _Timestamp} ->
+                    delete_shovel(ErrMsg, VHost, Opts, Name, Node, ActingUser)
             end
+    end.
+
+delete_shovel(ErrMsg, VHost, Opts, Name, Node, ActingUser) ->
+    {_, HostingNode} = lists:keyfind(node, 1, Opts),
+    case rabbit_misc:rpc_call(
+        HostingNode, rabbit_shovel_util, delete_shovel, [VHost, Name, ActingUser]) of
+        {badrpc, _} = Error ->
+            Error;
+        {error, not_found} ->
+            ErrMsg = rabbit_misc:format("Shovel with the given name was not found "
+                                        "on the target node '~ts' and/or virtual host '~ts'. "
+                                        "It may be failing to connect and report its state, will delete its runtime parameter...",
+                                        [Node, VHost]),
+            try_force_removing(HostingNode, VHost, Name, ActingUser),
+            {error, rabbit_data_coercion:to_binary(ErrMsg)};
+        ok ->
+            _ = try_clearing_runtime_parameter(Node, VHost, Name, ActingUser),
+            ok
     end.
 
 switches() ->

--- a/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ShovelStatusCommand.erl
+++ b/deps/rabbitmq_shovel/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ShovelStatusCommand.erl
@@ -75,11 +75,18 @@ aliases() ->
     [].
 
 output({stream, ShovelStatus}, _Opts) ->
-    Formatted = [fmt_name(Name,
-                          fmt_status(Status,
-                                     #{type => Type,
-                                       last_changed => fmt_ts(Timestamp)}))
-                 || {Name, Type, Status, Timestamp} <- ShovelStatus],
+    Formatted = lists:map(fun ({Name, Type, Status, Timestamp}) ->
+                              fmt_name(Name,
+                                       fmt_status(Status,
+                                                  #{type => Type,
+                                                    last_changed => fmt_ts(Timestamp)}));
+                              %% Forward compatibility with >= 4.1
+                              ({Name, Type, Status, _Metrics, Timestamp}) ->
+                                  fmt_name(Name,
+                                       fmt_status(Status,
+                                                  #{type => Type,
+                                                    last_changed => fmt_ts(Timestamp)}))
+                          end, ShovelStatus),
     {stream, Formatted};
 output(E, _Opts) ->
     'Elixir.RabbitMQ.CLI.DefaultOutput':output(E).

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_status.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_status.erl
@@ -191,7 +191,10 @@ inject_node_info(Node, Shovels) ->
 find_matching_shovel(VHost, Name, Shovels) ->
     case lists:filter(
         fun ({{V, S}, _Kind, _Status, _}) ->
-            VHost =:= V andalso Name =:= S
+                VHost =:= V andalso Name =:= S;
+            %% Forward compatibility with >= 4.1
+            ({{V, S}, _Kind, _Status, _Metrics, _}) ->
+                VHost =:= V andalso Name =:= S
         end, Shovels) of
             []  -> undefined;
         [S | _] -> S

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
@@ -45,6 +45,11 @@ status(Node) ->
 format(Node, {Name, Type, Info, TS}) ->
     [{node, Node}, {timestamp, format_ts(TS)}] ++
         format_name(Type, Name) ++
+        format_info(Info);
+%% Forward compatibility with >= 4.1
+format(Node, {Name, Type, Info, _Metrics, TS}) ->
+    [{node, Node}, {timestamp, format_ts(TS)}] ++
+        format_name(Type, Name) ++
         format_info(Info).
 
 format_name(static,  Name)          -> [{name,  Name},


### PR DESCRIPTION
I noticed two more places - Status command aggregates status across cluster and find_matching_shovel. 