### PR TITLE
Bump timeout in RabbitMQ AMQP 1.0 Erlang client

### DIFF
--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -3873,7 +3873,7 @@ leader_transfer_credit(QName, QType, Credit, Config) ->
          QName,
          #{arguments => #{<<"x-queue-type">> => {utf8, QType},
                           <<"x-queue-leader-locator">> => {utf8, <<"client-local">>}}}),
-       60000),
+       60_000, 5000),
     ok = close(Init),
 
     OpnConf = connection_config(0, Config),
@@ -5456,7 +5456,7 @@ dead_letter_into_stream(Config) ->
          #{arguments => #{<<"x-queue-type">> => {utf8, <<"stream">>},
                           <<"x-initial-cluster-size">> => {ulong, 1}
                          }}),
-       60000),
+       60_000, 5000),
     {ok, Receiver} = amqp10_client:attach_receiver_link(
                        Session1, <<"receiver">>, <<"/amq/queue/", QName1/binary>>,
                        settled, configuration,

--- a/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl
+++ b/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl
@@ -33,7 +33,7 @@
         set_token/2
        ].
 
--define(TIMEOUT, 20_000).
+-define(TIMEOUT, 30_000).
 -define(MANAGEMENT_NODE_ADDRESS, <<"/management">>).
 
 -type arguments() :: #{binary() => {atom(), term()}}.


### PR DESCRIPTION
Bump the timeout for management operations and link attachments from 20s to 30s. We've seen timeouts in CI.

We bump the poll interval of the `?awaitMatch` macro because CI sometimes flaked by crashing in
https://github.com/rabbitmq/rabbitmq-server/blob/0e803de6dd54bea8dd86290c76625c11302d2ea2/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_client.erl#L411 which indicates that the client lib received a response from a previous request.