### PR TITLE
Allow a previously reset node to rejoin its original cluster

### DIFF
--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -231,13 +231,15 @@ join(RemoteNode, NodeType)
                         ok = rabbit_mnesia:leave_discover_cluster(RemoteNode),
                         join(RemoteNode, NodeType)
                     catch
+                        %% Should we handle the catched error - my reasoning for
+                        %% ignoring it is that the error we want to show is the
+                        %% issue of joinging the cluster, not the potential error
+                        %% of leaving the cluster.
                         _ ->
                             rabbit_log:error(Msg),
                             Error
                     end
-            end;
-        {error, _} = Error ->
-            Error
+            end
     end.
 
 join_using_mnesia(ClusterNodes, NodeType) when is_list(ClusterNodes) ->

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -231,13 +231,13 @@ join(RemoteNode, NodeType)
                         ok = rabbit_mnesia:leave_discover_cluster(RemoteNode),
                         join(RemoteNode, NodeType)
                     catch
+                        Exception ->
                         %% Should we handle the catched error - my reasoning for
                         %% ignoring it is that the error we want to show is the
                         %% issue of joinging the cluster, not the potential error
                         %% of leaving the cluster.
-                        _ ->
                             rabbit_log:error(Msg),
-                            Error
+                            Exception
                     end
             end
     end.

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -227,7 +227,7 @@ join(RemoteNode, NodeType)
                                     "with node ~tp, but ~tp disagrees. ~tp will ask "
                                     "to leave the cluster and try again.",
                                     [RemoteNode, node(), node(), node()]),
-                    ok = rabbit_mnesia:leave_discover_cluster(RemoteNode),
+                    ok = rabbit_mnesia:leave_then_rediscover_cluster(RemoteNode),
                     join(RemoteNode, NodeType)
             end;
         {error, _} = Error ->

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -227,18 +227,8 @@ join(RemoteNode, NodeType)
                                     "with node ~tp, but ~tp disagrees. ~tp will ask "
                                     "to leave the cluster and try again.",
                                     [RemoteNode, node(), node(), node()]),
-                    try
-                        ok = rabbit_mnesia:leave_discover_cluster(RemoteNode),
-                        join(RemoteNode, NodeType)
-                    catch
-                        Exception ->
-                        %% Should we handle the catched error - my reasoning for
-                        %% ignoring it is that the error we want to show is the
-                        %% issue of joinging the cluster, not the potential error
-                        %% of leaving the cluster.
-                            rabbit_log:error(Msg),
-                            Exception
-                    end
+                    ok = rabbit_mnesia:leave_discover_cluster(RemoteNode),
+                    join(RemoteNode, NodeType)
             end
     end.
 

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -73,7 +73,7 @@
 -export([node_info/0, remove_node_if_mnesia_running/1]).
 
 %% Used internally in `rabbit_db_cluster'.
--export([members/0, leave_discover_cluster/1]).
+-export([members/0, leave_then_rediscover_cluster/1]).
 
 %% Used internally in `rabbit_khepri'.
 -export([mnesia_and_msg_store_files/0]).
@@ -922,7 +922,7 @@ remove_node_if_mnesia_running(Node) ->
             end
     end.
 
-leave_discover_cluster(DiscoveryNode) ->
+leave_then_rediscover_cluster(DiscoveryNode) ->
     {ClusterNodes, _, _} = discover_cluster([DiscoveryNode]),
     leave_cluster(rabbit_nodes:nodes_excl_me(ClusterNodes)).
 

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -155,7 +155,7 @@ init() ->
 %% we cluster to its cluster.
 
 -spec can_join_cluster(node())
-                        -> {ok, [node()]} | {ok, already_member} | {error, {inconsistent_cluster, string()}}.
+                      -> {ok, [node()]} | {ok, already_member} | {error, {inconsistent_cluster, string()} | {error, {erpc, noconnection}}}.
 
 can_join_cluster(DiscoveryNode) ->
     ensure_mnesia_dir(),

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -73,7 +73,7 @@
 -export([node_info/0, remove_node_if_mnesia_running/1]).
 
 %% Used internally in `rabbit_db_cluster'.
--export([members/0]).
+-export([members/0, leave_discover_cluster/1]).
 
 %% Used internally in `rabbit_khepri'.
 -export([mnesia_and_msg_store_files/0]).
@@ -179,7 +179,6 @@ can_join_cluster(DiscoveryNode) ->
                     {ok, already_member};
                 false ->
                     Msg = format_inconsistent_cluster_message(DiscoveryNode, node()),
-                    rabbit_log:error(Msg),
                     {error, {inconsistent_cluster, Msg}}
             end
     end.
@@ -923,15 +922,19 @@ remove_node_if_mnesia_running(Node) ->
             end
     end.
 
-leave_cluster() ->
-    case rabbit_nodes:nodes_excl_me(cluster_nodes(all)) of
-        []       -> ok;
-        AllNodes -> case lists:any(fun leave_cluster/1, AllNodes) of
-                        true  -> ok;
-                        false -> e(no_running_cluster_nodes)
-                    end
-    end.
+leave_discover_cluster(DiscoveryNode) ->
+    {ClusterNodes, _, _} = discover_cluster([DiscoveryNode]),
+    leave_cluster(rabbit_nodes:nodes_excl_me(ClusterNodes)).
 
+leave_cluster() ->
+    leave_cluster(rabbit_nodes:nodes_excl_me(cluster_nodes(all))).
+leave_cluster([]) ->
+    ok;
+leave_cluster(Nodes) when is_list(Nodes)  ->
+    case lists:any(fun leave_cluster/1, Nodes) of
+        true  -> ok;
+        false -> e(no_running_cluster_nodes)
+    end;
 leave_cluster(Node) ->
     case rpc:call(Node,
                   rabbit_mnesia, remove_node_if_mnesia_running, [node()]) of


### PR DESCRIPTION
If a cluster member for whatever reason gets its local state wiped, it has a hard time re-joining the cluster, as the old cluster members will think the node is already a member and reject the request (if mnesia is used).

## Proposed Changes

Mnesia: On failure due to 'already a member', ask to leave the cluster first and retry.
Khepri: no-op. Khepri is less strict already, and rabbit_khepri:can_join would accept a join request from a node that is already a member

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I would like early feedback here, as to if this naive approach is even OK, if there should be a limited set of retries, and if the logic should live in `rabbit_mnesia` or in `rabbit_db_cluster`?
It feels a bit wonky that a function called `can_join_cluster` would also try to leave a cluster and try again, so perhaps it would be better if `rabbit_db_cluster:join` instead initiates the leave and retry request?
