### PR TITLE
queue info metric: guard against whereis returning `undefined`

### DIFF
--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -433,9 +433,11 @@ membership(Pid, Members) when is_pid(Pid) ->
 membership({Name, Node}, Members) ->
     case Node =:= node() of
         true ->
-            case is_process_alive(whereis(Name)) of
-                true -> leader;
-                false -> undefined
+            case whereis(Name) of
+                Pid when is_pid(Pid) ->
+                    leader;
+                _ ->
+                    undefined
             end;
         false ->
             case lists:member(node(), Members) of


### PR DESCRIPTION
Follow up to https://github.com/rabbitmq/rabbitmq-server/pull/13583. It crashes with `called as is_process_alive(undefined)` under some conditions.