### PR TITLE
Re-evaluate stream SAC group after connection down event

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -598,26 +598,16 @@ augment_infos_with_user_provided_connection_name(Infos,
     end.
 
 close(Transport,
-      #stream_connection{socket = S, virtual_host = VirtualHost,
-                         outstanding_requests = Requests},
+      #stream_connection{socket = S},
       #stream_connection_state{consumers = Consumers}) ->
     [begin
-         %% we discard the result (updated requests) because they are no longer used
-         _ = maybe_unregister_consumer(VirtualHost, Consumer,
-                                       single_active_consumer(Properties),
-                                       Requests),
          case Log of
              undefined ->
                  ok; %% segment may not be defined on subscription (single active consumer)
              L ->
                  osiris_log:close(L)
          end
-     end
-     || #consumer{log = Log,
-                  configuration =
-                      #consumer_configuration{properties = Properties}} =
-            Consumer
-            <- maps:values(Consumers)],
+     end || #consumer{log = Log} <- maps:values(Consumers)],
     Transport:shutdown(S, write),
     Transport:close(S).
 


### PR DESCRIPTION
The same connection can contain several consumers belonging to a SAC group (group key = vhost + stream + consumer name). The whole new group must be re-evaluated to select a new active consumer after the consumers of the down connection are removed from it.

The previous behavior would not re-evaluate the new group and could select a consumer from the down connection, letting the group with only inactive consumers, as the selected active consumer would never receive the activation message from the stream SAC coordinator.

This commit fixes this problem by removing the consumers of the down down connection from the affected groups and then performing the appropriate operations for the groups to keep on consuming (e.g. notifying an active consumer that it needs to step down).

References #13372