### PR TITLE
Added 'unlimited' config setting for peer_discovery_retry_limit

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1401,10 +1401,19 @@ end}.
     ]}.
 
 {mapping, "cluster_formation.discovery_retry_limit", "rabbit.cluster_formation.discovery_retry_limit",
-    [
-     {datatype, integer},
-     {validators, ["non_zero_positive_integer"]}
-    ]}.
+    [{datatype, [{atom, unlimited}, integer]}]}.
+
+{translation, "rabbit.cluster_formation.discovery_retry_limit",
+ fun(Conf) ->
+   case cuttlefish:conf_get("cluster_formation.discovery_retry_limit", Conf, undefined) of
+      undefined -> cuttlefish:unset();
+      unlimited  -> unlimited;
+      Val when is_integer(Val) andalso Val > 0 -> Val;
+      _         -> cuttlefish:invalid("should be positive integer or 'unlimited'")
+  end
+ end
+}.
+
 {mapping, "cluster_formation.discovery_retry_interval", "rabbit.cluster_formation.discovery_retry_interval",
     [
      {datatype, integer},

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -274,7 +274,7 @@ cluster_formation.classic_config.nodes.peer2 = rabbit@hostname2",
             [{peer_discovery_backend,rabbit_peer_discovery_classic_config}]},
         {cluster_nodes,{[rabbit@hostname2,rabbit@hostname1],disc}}]}],
   []},
- 
+
   {cluster_formation_module_dns_alias,
   "cluster_formation.peer_discovery_backend = dns
 cluster_formation.dns.hostname = discovery.eng.example.local",
@@ -287,7 +287,7 @@ cluster_formation.dns.hostname = discovery.eng.example.local",
              ]}]}
         ]}],
   []},
- 
+
  {cluster_formation_disk,
   "cluster_formation.peer_discovery_backend = rabbit_peer_discovery_classic_config
    cluster_formation.classic_config.nodes.peer1 = rabbit@hostname1
@@ -758,17 +758,17 @@ tcp_listen_options.exit_on_close = false",
              {fail_if_no_peer_cert, false},
              {honor_ecc_order, true}]}]}],
   []},
-  
+
  {ssl_cert_login_from_cn,
   "ssl_cert_login_from = common_name",
   [{rabbit,[{ssl_cert_login_from, common_name}]}],
   []},
-  
+
  {ssl_cert_login_from_dn,
   "ssl_cert_login_from = distinguished_name",
   [{rabbit,[{ssl_cert_login_from, distinguished_name}]}],
   []},
- 
+
  {ssl_cert_login_from_san_dns,
   "ssl_cert_login_from      = subject_alternative_name
    ssl_cert_login_san_type  = dns
@@ -779,7 +779,7 @@ tcp_listen_options.exit_on_close = false",
       {ssl_cert_login_san_index, 0}
   ]}],
   []},
-  
+
 
   {ssl_options_bypass_pem_cache,
    "ssl_options.bypass_pem_cache = true",
@@ -837,6 +837,18 @@ tcp_listen_options.exit_on_close = false",
        [{cluster_formation,
             [{peer_discovery_backend,rabbit_peer_discovery_classic_config},
              {node_type,ram}]}]}],
+  []},
+ {cluster_formation_retry_limit_integer,
+  "cluster_formation.discovery_retry_limit = 500",
+  [{rabbit,
+       [{cluster_formation,
+            [{discovery_retry_limit, 500}]}]}],
+  []},
+ {cluster_formation_retry_limit_infinity,
+  "cluster_formation.discovery_retry_limit = unlimited",
+  [{rabbit,
+       [{cluster_formation,
+            [{discovery_retry_limit, unlimited}]}]}],
   []},
  {background_gc_enabled,
   "background_gc_enabled = true


### PR DESCRIPTION
## Proposed Changes
The peer discovery code can handle the Retry value to be either a non-negative integer, or the atom 'unlimited'.

```
-spec discovery_retries(Backend) -> {Retries, RetryDelay} when
      Backend :: backend(),
      Retries :: non_neg_integer() | unlimited,
      RetryDelay :: non_neg_integer().
```

But the cuttlefish config only allows non neg integers. I suggest we also allow the value 'unlimited' to be set through config.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
