### PR TITLE
Ignore stream connections in unexpected states

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -3221,7 +3221,9 @@ notify_connection_closed(#statem_data{
          {client_properties, ClientProperties}],
     rabbit_event:notify(connection_closed,
                         augment_infos_with_user_provided_connection_name(EventProperties,
-                                                                         Connection)).
+                                                                         Connection));
+notify_connection_closed(#statem_data{}) ->
+    ok.
 
 handle_frame_post_close(_Transport,
                         Connection,


### PR DESCRIPTION
A connection which terminated before it was fully established would lead to a function_clause, since metadata is not available to really call notify_connection_closed. We can just ignore such connections and not notify about them.

Resolves https://github.com/rabbitmq/rabbitmq-server/discussions/13670