### PR TITLE
Add new option require_auth_for_api_desc_page to mgmt

### DIFF
--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -15,7 +15,7 @@ define PROJECT_ENV
 	    {content_security_policy, "script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'"},
 	    {max_http_body_size, 10000000},
 	    {delegate_count, 5},
-	    {require_auth_for_api_desc_page, false}
+	    {require_auth_for_api_reference, false}
 	  ]
 endef
 

--- a/deps/rabbitmq_management/Makefile
+++ b/deps/rabbitmq_management/Makefile
@@ -14,7 +14,8 @@ define PROJECT_ENV
 	    {cors_max_age, 1800},
 	    {content_security_policy, "script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self'"},
 	    {max_http_body_size, 10000000},
-	    {delegate_count, 5}
+	    {delegate_count, 5},
+	    {require_auth_for_api_desc_page, false}
 	  ]
 endef
 

--- a/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
+++ b/deps/rabbitmq_management/priv/schema/rabbitmq_management.schema
@@ -654,3 +654,10 @@ end}.
     {datatype, {enum, [true, false]}},
     {include_default, false}
 ]}.
+
+%% Require authentication for the HTTP API reference page.
+
+{mapping, "management.require_auth_for_api_reference", "rabbitmq_management.require_auth_for_api_reference", [
+    {datatype, {enum, [true, false]}},
+    {include_default, false}
+]}.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_static.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_static.erl
@@ -11,9 +11,11 @@
 -module(rabbit_mgmt_wm_static).
 
 -include_lib("kernel/include/file.hrl").
+-include_lib("rabbitmq_web_dispatch/include/rabbitmq_web_dispatch_records.hrl").
 
 -export([init/2]).
 -export([malformed_request/2]).
+-export([is_authorized/2]).
 -export([forbidden/2]).
 -export([content_types_provided/2]).
 -export([resource_exists/2]).
@@ -45,6 +47,21 @@ do_init(Req, App, Path) ->
 
 malformed_request(Req, State) ->
     cowboy_static:malformed_request(Req, State).
+
+is_authorized(Req0=#{path := Path}, State)
+        when Path =:= <<"/api/index.html">>; Path =:= <<"/cli/index.html">> ->
+    case application:get_env(rabbitmq_management, require_auth_for_api_desc_page) of
+        {ok, true} ->
+            %% We temporarily use #context{} here to make authorization work,
+            %% and discard it immediately after since we only want to check
+            %% whether the user authenticates successfully.
+            {Res, Req, _} = rabbit_mgmt_util:is_authorized(Req0, #context{}),
+            {Res, Req, State};
+        _ ->
+            {true, Req0, State}
+    end;
+is_authorized(Req, State) ->
+    {true, Req, State}.
 
 forbidden(Req, State) ->
     cowboy_static:forbidden(Req, State).

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_static.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_static.erl
@@ -50,7 +50,7 @@ malformed_request(Req, State) ->
 
 is_authorized(Req0=#{path := Path}, State)
         when Path =:= <<"/api/index.html">>; Path =:= <<"/cli/index.html">> ->
-    case application:get_env(rabbitmq_management, require_auth_for_api_desc_page) of
+    case application:get_env(rabbitmq_management, require_auth_for_api_reference) of
         {ok, true} ->
             %% We temporarily use #context{} here to make authorization work,
             %% and discard it immediately after since we only want to check

--- a/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
+++ b/deps/rabbitmq_management/test/config_schema_SUITE_data/rabbitmq_management.snippets
@@ -497,6 +497,48 @@
   ], [rabbitmq_management]
  },
 
+ %%
+ %% Restrictions
+ %%
+
+  {restrictions_quorum_queue_replica_operations_disabled_case1,
+   "management.restrictions.quorum_queue_replica_operations.disabled = true",
+   [
+    {rabbitmq_management, [
+                           {restrictions, [
+                                {quorum_queue_replica_operations, [
+                                    {disabled, true}
+                                ]}
+                           ]}
+                          ]}
+   ], [rabbitmq_management]
+  },
+
+  {restrictions_operator_policy_changes_disabled_case1,
+   "management.restrictions.operator_policy_changes.disabled = true",
+   [
+    {rabbitmq_management, [
+                           {restrictions, [
+                                {operator_policy_changes, [
+                                    {disabled, true}
+                                ]}
+                           ]}
+                          ]}
+   ], [rabbitmq_management]
+  },
+
+ %%
+ %% Exotic options
+ %%
+
+  {auth_for_http_api_reference_case1,
+   "management.require_auth_for_api_reference = true",
+   [
+    {rabbitmq_management, [
+                           {require_auth_for_api_reference, true}
+                          ]}
+   ], [rabbitmq_management]
+  },
 
  %%
  %% Legacy listener configuration


### PR DESCRIPTION
This allows restricting access to the `/api/index.html` and the `/cli/index.html` page to authenticated users should the user really want to.

Tested manually. I don't really want to add tests for such a weird feature. :-) But I guess I can if someone insists.

This should be backported all the way to 3.13.