### PR TITLE
Avoid crash when reporting federation status

### DIFF
--- a/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
+++ b/deps/rabbitmq_federation_management/src/rabbit_federation_mgmt.erl
@@ -101,7 +101,12 @@ format(Node, Info, Chs) ->
                      [Ch || Ch <- Chs,
                             pget(name, pget(connection_details, Ch))
                                 =:= pget(local_connection, Info)]) of
-                  [Ch] -> [{local_channel, Ch}];
+                  [Ch|_] ->
+                      %% we iterate on responses from many nodes; if the link
+                      %% was restarted on another node, we might get duplicates;
+                      %% we don't really know which one is the most up-to-date
+                      %% so let's just take the first one
+                      [{local_channel, Ch}];
                   []   -> []
               end,
     [{node, Node} | format_info(Info)] ++ LocalCh.


### PR DESCRIPTION
This should address crashes like this in (found in user's logs):
```
exception error: no case clause matching
                  [[{connection_details,[]},
                    {name,<<"10.0.13.41:50497 -> 10.2.230.128:5671 (1)">>},
                    {node,rabbit@foobar},
                    {number,1},
                    {user,<<"...">>},
                    {user_who_performed_action,<<"...">>},
                    {vhost,<<"/">>}],
                   [{connection_details,[]},
                    {name,<<"10.0.13.41:50142 -> 10.2.230.128:5671 (1)">>},
                    {node,rabbit@foobar},
                    {number,1},
                    {user,<<"...">>},
                    {user_who_performed_action,<<"...">>},
                    {vhost,<<"/">>}]]
   in function  rabbit_federation_mgmt:format/3 (rabbit_federation_mgmt.erl, line 100)
   in call from rabbit_federation_mgmt:'-status/3-lc$^0/1-0-'/4 (rabbit_federation_mgmt.erl, line 89)
   in call from rabbit_federation_mgmt:'-status/4-lc$^0/1-0-'/3 (rabbit_federation_mgmt.erl, line 82)
   in call from rabbit_federation_mgmt:'-status/4-lc$^0/1-0-'/3 (rabbit_federation_mgmt.erl, line 82)
   in call from rabbit_federation_mgmt:status/4 (rabbit_federation_mgmt.erl, line 82)
   in call from rabbit_federation_mgmt:to_json/2 (rabbit_federation_mgmt.erl, line 57)
   in call from cowboy_rest:call/3 (src/cowboy_rest.erl, line 1590)
   in call from cowboy_rest:set_resp_body/2 (src/cowboy_rest.erl, line 1473)
```