### PR TITLE
Add a rabbitmq.conf setting for two more quorum queue-related keys

### DIFF
--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -384,6 +384,16 @@
 ## properties that may conflict or significantly change queue behavior and semantics, such as the 'exclusive' field.
 # quorum_queue.property_equivalence.relaxed_checks_on_redeclaration = true
 
+## Sets the initial quorum queue cluster size for newly declared quorum queues.
+## This value will be overridden if the 'x-quorum-initial-group-size' queue argument is provided.
+# quorum_queue.cluster_size = 3
+
+## Sets the maximum number of unconfirmed messages a channel can send
+## before publisher flow control is triggered.
+## The current default is configured to provide good performance and stability
+## when there are multiple publishers sending to the same quorum queue.
+# quorum_queue.commands_soft_limit = 32
+
 ## Changes classic queue storage implementation version.
 ## In 4.0.x, version 2 is the default and this is a forward compatibility setting,
 ## that is, it will be useful when a new version is developed.

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2610,6 +2610,15 @@ end}.
 {mapping, "quorum_queue.property_equivalence.relaxed_checks_on_redeclaration", "rabbit.quorum_relaxed_checks_on_redeclaration", [
     {datatype, {enum, [true, false]}}]}.
 
+{mapping, "quorum_queue.cluster_size", "rabbit.quorum_cluster_size", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
+{mapping, "quorum_queue.commands_soft_limit", "rabbit.quorum_commands_soft_limit", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
 
 %%
 %% Quorum Queue membership reconciliation

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1067,6 +1067,20 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
+  {quorum_cluster_size,
+   "quorum_queue.cluster_size = 3",
+   [{rabbit, [
+      {quorum_cluster_size, 3}
+     ]}],
+   []},
+
+  {quorum_commands_soft_limit,
+   "quorum_queue.commands_soft_limit = 32",
+   [{rabbit, [
+      {quorum_commands_soft_limit, 32}
+     ]}],
+   []},
+
   %%
   %% Runtime parameters
   %%


### PR DESCRIPTION
## Proposed Changes

Hi,

We would like to extend the quorum queue configuration under https://www.rabbitmq.com/docs/quorum-queues#configuration to support the INI-style format, allowing the following settings:

```
quorum_queue.cluster_size = 3
quorum_queue.commands_soft_limit = 32
```

This aims to provide a more consistent and simplified configuration experience for users.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [x] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
