### PR TITLE
Standardize on 'vhost' in logging

### DIFF
--- a/deps/rabbit/src/rabbit_vhost_process.erl
+++ b/deps/rabbit/src/rabbit_vhost_process.erl
@@ -13,7 +13,7 @@
 %% to vhost process registry. If vhost process PID is in the registry and the
 %% process is alive - the vhost is considered running.
 
-%% On termination, the ptocess will notify of vhost going down.
+%% On termination, the process will notify of vhost going down.
 
 %% The process will also check periodically if the vhost is still
 %% present in the database and stop the vhost supervision tree when it
@@ -35,7 +35,7 @@ start_link(VHost) ->
 
 init([VHost]) ->
     process_flag(trap_exit, true),
-    rabbit_log:debug("Recovering data for VHost ~ts", [VHost]),
+    rabbit_log:debug("Recovering data for vhost ~ts", [VHost]),
     try
         %% Recover the vhost data and save it to vhost registry.
         ok = rabbit_vhost:recover(VHost),


### PR DESCRIPTION
## Proposed Changes

Almost all logging of vhost is either `virtual host` or `vhost`. Grepping I only found one `VHost` logged. This PR switches that to `vhost` and fixes a typo.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
