### PR TITLE
Use RABBITMQ_ENABLED_PLUGINS over RABBITMQ_ENABLED_PLUGINS_FILE

### DIFF
--- a/selenium/bin/components/rabbitmq
+++ b/selenium/bin/components/rabbitmq
@@ -69,20 +69,22 @@ start_local_rabbitmq() {
   RABBITMQ_TEST_DIR="${RABBITMQ_CONFIG_DIR}" ${BIN_DIR}/gen-rabbitmq-conf ${RABBITMQ_CONFIG_DIR} $ENV_FILE /tmp$MOUNT_RABBITMQ_CONF
 
   print "> EFFECTIVE RABBITMQ_CONFIG_FILE: /tmp$MOUNT_RABBITMQ_CONF"
+  cp ${RABBITMQ_CONFIG_DIR}/enabled_plugins /tmp/etc/rabbitmq/
+  RABBITMQ_ENABLED_PLUGINS=`cat /tmp/etc/rabbitmq/enabled_plugins | awk -F'[][]' '{print $2}'`
+  print "> EFFECTIVE PLUGINS: $RABBITMQ_ENABLED_PLUGINS"
+
   ${BIN_DIR}/gen-advanced-config ${RABBITMQ_CONFIG_DIR} $ENV_FILE /tmp$MOUNT_ADVANCED_CONFIG
-  cp ${RABBITMQ_CONFIG_DIR}/enabled_plugins /tmp/etc/rabbitmq/
   RESULT=$?
-  cp ${RABBITMQ_CONFIG_DIR}/enabled_plugins /tmp/etc/rabbitmq/
   if [ $RESULT -eq 0 ]; then
-    print "> EFFECTIVE RABBITMQ_CONFIG_FILE: /tmp$MOUNT_ADVANCED_CONFIG"
-  	gmake --directory=${RABBITMQ_SERVER_ROOT} run-broker \
-  		RABBITMQ_ENABLED_PLUGINS_FILE=/tmp/etc/rabbitmq/enabled_plugins \
+    print "> EFFECTIVE RABBITMQ_CONFIG_FILE: /tmp$MOUNT_ADVANCED_CONFIG"    
+    gmake --directory=${RABBITMQ_SERVER_ROOT}  \
+        RABBITMQ_ENABLED_PLUGINS="$RABBITMQ_ENABLED_PLUGINS" \
   		RABBITMQ_CONFIG_FILE=/tmp$MOUNT_RABBITMQ_CONF \
-      RABBITMQ_ADVANCED_CONFIG_FILE=/tmp$MOUNT_ADVANCED_CONFIG
+        RABBITMQ_ADVANCED_CONFIG_FILE=/tmp$MOUNT_ADVANCED_CONFIG run-broker
   else
-    gmake --directory=${RABBITMQ_SERVER_ROOT} run-broker \
-  		RABBITMQ_ENABLED_PLUGINS_FILE=/tmp/etc/rabbitmq/enabled_plugins \
-  		RABBITMQ_CONFIG_FILE=/tmp$MOUNT_RABBITMQ_CONF
+    gmake --directory=${RABBITMQ_SERVER_ROOT} \
+        RABBITMQ_ENABLED_PLUGINS="$RABBITMQ_ENABLED_PLUGINS" \
+  		RABBITMQ_CONFIG_FILE=/tmp$MOUNT_RABBITMQ_CONF run-broker
   fi
   print "> RABBITMQ_TEST_DIR: ${RABBITMQ_CONFIG_DIR}"
 


### PR DESCRIPTION
gmake was ignoring RABBITMQ_ENABLED_PLUGINS_FILE. The majority of the suites were working because all plugins were enabled. But only when I wanted to specify just a few it did not work. It was always enabling all plugins.
With this change, the content of the file `enabled_plugins` in selenium is converted into the value of the env var RABBITMQ_ENABLED_PLUGINS.

This change is necessary for tanzu wsr testing.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

