### PR TITLE
GitHub Actions: Use RabbitMQ 4.0.9 for mixed-version testing

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -57,8 +57,7 @@ jobs:
       uses: dsaltares/fetch-gh-release-asset@master
       if: inputs.mixed_clusters
       with:
-        repo: 'rabbitmq/server-packages'
-        version: 'tags/alphas.1744021065493'
+        version: 'tags/v4.0.9'
         regex: true
         file: "rabbitmq-server-generic-unix-\\d.+\\.tar\\.xz"
         target: ./


### PR DESCRIPTION
## Why

We used a 4.0.x snapshot so far because we needed RabbitMQ 4.0.x to use khepri_mnesia_migration 0.7.2.

RabbitMQ 4.0.9 was released with this update of khepri_mnesia_migration, thus we don't need the snapshot anymore.