### PR TITLE
Khepri: Clean up the setup/clustering code of the integration code

### DIFF
--- a/deps/rabbit/src/rabbit_db.erl
+++ b/deps/rabbit/src/rabbit_db.erl
@@ -328,7 +328,7 @@ list_in_khepri(Path) ->
       Objects :: [term()].
 
 list_in_khepri(Path, Options) ->
-    case rabbit_khepri:match(Path, Options) of
+    case rabbit_khepri:get_many(Path, Options) of
         {ok, Map} -> maps:values(Map);
         _         -> []
     end.

--- a/deps/rabbit/src/rabbit_db_cluster.erl
+++ b/deps/rabbit/src/rabbit_db_cluster.erl
@@ -279,7 +279,7 @@ forget_member_using_khepri(_Node, true) ->
        #{domain => ?RMQLOG_DOMAIN_DB}),
     {error, not_supported};
 forget_member_using_khepri(Node, false = _RemoveWhenOffline) ->
-    rabbit_khepri:leave_cluster(Node).
+    rabbit_khepri:remove_member(Node).
 
 %% -------------------------------------------------------------------
 %% Cluster update.

--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -357,7 +357,7 @@ delete_vhost_in_mnesia_tx(VHostName) ->
 delete_vhost_in_khepri(VHostName) ->
     Pattern = khepri_vhost_rp_path(
                 VHostName, ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:adv_delete_many(Pattern) of
+    case rabbit_khepri:adv_delete(Pattern) of
         {ok, NodePropsMap} ->
             RTParams =
             maps:fold(

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -402,7 +402,7 @@ match_user_permissions_in_mnesia_tx(Username, VHostName) ->
 
 match_user_permissions_in_khepri('_' = _Username, '_' = _VHostName) ->
     Path = khepri_user_permission_path(?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:match(Path) of
+    case rabbit_khepri:get_many(Path) of
         {ok, Map} ->
             maps:values(Map);
         _ ->

--- a/deps/rabbit/test/metadata_store_phase1_SUITE.erl
+++ b/deps/rabbit/test/metadata_store_phase1_SUITE.erl
@@ -272,7 +272,7 @@ end_per_testcase(Testcase, Config) ->
       TableDefs),
 
     %% Clear all data in Khepri.
-    ok = rabbit_khepri:clear_store(),
+    ok = rabbit_khepri:delete("*"),
 
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
@@ -2719,4 +2719,4 @@ check_storage(khepri, none, Content) ->
     rabbit_khepri:info(),
     Path = [#if_all{conditions = [?KHEPRI_WILDCARD_STAR_STAR,
                                   #if_has_data{}]}],
-    ?assertEqual({ok, Content}, rabbit_khepri:match(Path)).
+    ?assertEqual({ok, Content}, rabbit_khepri:get_many(Path)).

--- a/deps/rabbitmq_shovel/test/rolling_upgrade_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/rolling_upgrade_SUITE.erl
@@ -265,6 +265,6 @@ child_id_format(Config) ->
             ?assertMatch(
                {ok, #{Path := _}},
                rabbit_ct_broker_helpers:rpc(
-                 Config, NewNode, rabbit_khepri, list,
-                 [Pattern]))
+                 Config, NewNode, rabbit_khepri, get_many,
+                 [Pattern ++ [?KHEPRI_WILDCARD_STAR]]))
     end.


### PR DESCRIPTION
## Why

The `rabbit_khepri` module grew during the work to add Khepri support to RabbitMQ and while Khepri was itself written. The current code is therefore unorganized.

## How

The pull request has two commits:
1. One to clean up and document the init and clustering code
2. One to clean up proxy functions and remove dead code