### PR TITLE
Management UI: add a TLS column to the listeners and ports table

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/overview.ejs
@@ -252,6 +252,7 @@
 <% } %>
     <th>Bound to</th>
     <th>Port</th>
+    <th>SSL</th>
   </tr>
   <%
       for (var i = 0; i < overview.listeners.length; i++) {
@@ -264,6 +265,7 @@
 <% } %>
     <td><%= listener.ip_address %></td>
     <td><%= listener.port %></td>
+    <td class="c"><%= fmt_boolean(listener.ssl || false) %></td>
   </tr>
   <% } %>
 </table>

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -279,12 +279,21 @@ listener(#listener{node = Node, protocol = Protocol,
      {protocol, Protocol},
      {ip_address, ip(IPAddress)},
      {port, Port},
-     {socket_opts, format_socket_opts(Opts)}].
+     {socket_opts, format_socket_opts(Opts)},
+     {ssl, is_ssl_socket(Opts)}
+    ].
 
 web_context(Props0) ->
     SslOpts = pget(ssl_opts, Props0, []),
     Props   = proplists:delete(ssl_opts, Props0),
     [{ssl_opts, format_socket_opts(SslOpts)} | Props].
+
+is_ssl_socket(Opts) ->
+    S = proplists:get_value(socket_opts, Opts, Opts),
+    (proplists:get_value(ssl_opts, S, undefined) =/= undefined) orelse
+    (proplists:get_value(cacertfile, S, undefined) =/= undefined) orelse
+    (proplists:get_value(certfile, S, undefined) =/= undefined) orelse
+    (proplists:get_value(keyfile, S, undefined) =/= undefined).
 
 format_socket_opts(Opts) ->
     format_socket_opts(Opts, []).


### PR DESCRIPTION
## Proposed Changes

While working on a custom plugin, I found this to be missing. The new cowboy sockets don't appear in Web context, so one does not know if it's TLS or not, except for deriving from the name of the protocol.

Would be nice to add also the Path, but not sure if it's worth the code changes for only the web mqtt/stomp.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI


Here it is how it looks:

<img width="563" alt="Screenshot 2025-04-26 at 19 18 28" src="https://github.com/user-attachments/assets/b1024877-7744-42be-8d99-39738c7c8fd8" />


