### PR TITLE
Remove unused Javascript functions

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -81,15 +81,6 @@ function dispatcher() {
     }
 }
 
-function getParameterByName(name) {
-    var match = RegExp('[#&]' + name + '=([^&]*)').exec(window.location.hash);
-    return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
-}
-
-function getAccessToken() {
-    return getParameterByName('access_token');
-}
-
 function start_app_login () {
   app = new Sammy.Application(function () {
     this.get('/', function () {})


### PR DESCRIPTION
A security scanner flagged the use of `RegExp` with unsanitized input. Turns out, these functions are no longer used and can be deleted.

```
lbakken@shostakovich ~/development/rabbitmq/rabbitmq-server (lukebakken/delete-unused-js $=)
$ git grep getAccessToken

lbakken@shostakovich ~/development/rabbitmq/rabbitmq-server (lukebakken/delete-unused-js $=)
$ git grep getParameterByName
```