### PR TITLE
STOMP: queue type tests - add queue.type assertions

### DIFF
--- a/deps/rabbitmq_stomp/Makefile
+++ b/deps/rabbitmq_stomp/Makefile
@@ -31,7 +31,7 @@ define PROJECT_APP_EXTRA_KEYS
 endef
 
 DEPS = ranch rabbit_common rabbit amqp_client
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_management
 
 PLT_APPS += rabbitmq_cli elixir
 

--- a/deps/rabbitmq_stomp/test/python_SUITE.erl
+++ b/deps/rabbitmq_stomp/test/python_SUITE.erl
@@ -31,13 +31,11 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    DataDir = ?config(data_dir, Config),
     {ok, _} = rabbit_ct_helpers:exec(["pip", "install", "-r", requirements_path(Config),
                                                         "--target", deps_path(Config)]),
     Config.
 
 end_per_suite(Config) ->
-    DataDir = ?config(data_dir, Config),
     ok = file:del_dir_r(deps_path(Config)),
     Config.
 
@@ -82,8 +80,10 @@ run(Config, Test) ->
     StompPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp),
     StompPortTls = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_stomp_tls),
     AmqpPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_amqp),
+    MgmtPort = rabbit_ct_broker_helpers:get_node_config(Config, 0, tcp_port_mgmt),
     NodeName = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     os:putenv("AMQP_PORT", integer_to_list(AmqpPort)),
+    os:putenv("MGMT_PORT", integer_to_list(MgmtPort)),
     os:putenv("STOMP_PORT", integer_to_list(StompPort)),
     os:putenv("STOMP_PORT_TLS", integer_to_list(StompPortTls)),
     os:putenv("RABBITMQ_NODENAME", atom_to_list(NodeName)),

--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/requirements.txt
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/requirements.txt
@@ -1,3 +1,3 @@
 stomp.py==8.1.0
 pika==1.1.0
-
+rabbitman===0.1.0

--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_quorum.py
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_quorum.py
@@ -10,7 +10,7 @@ import base
 import time
 import os
 import re
-
+import rabbitman
 
 class TestUserGeneratedQueueName(base.BaseTest):
 
@@ -33,6 +33,11 @@ class TestUserGeneratedQueueName(base.BaseTest):
 
         # let the quorum queue some time to start
         time.sleep(5)
+
+        client = rabbitman.Client(f'http://localhost:{(os.environ["MGMT_PORT"])}', 'guest', 'guest')
+        queue = client.get_queues_by_vhost_and_name("/", queueName)
+
+        self.assertEqual(queue['type'], 'quorum')
 
         connection = pika.BlockingConnection(
                 pika.ConnectionParameters(host='127.0.0.1', port=int(os.environ["AMQP_PORT"])))

--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_stream.py
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/x_queue_type_stream.py
@@ -10,7 +10,7 @@ import base
 import time
 import os
 import re
-import urllib.request, json
+import rabbitman
 
 class TestUserGeneratedQueueName(base.BaseTest):
 
@@ -34,11 +34,16 @@ class TestUserGeneratedQueueName(base.BaseTest):
                     'id': 1234,
                     'prefetch-count': 10
                 },
-               ack="client"
+                ack="client"
                 )
 
         # let the stream queue some time to start
         time.sleep(5)
+
+        client = rabbitman.Client(f'http://localhost:{(os.environ["MGMT_PORT"])}', 'guest', 'guest')
+        queue = client.get_queues_by_vhost_and_name("/", queueName)
+
+        self.assertEqual(queue['type'], 'stream')
 
         connection = pika.BlockingConnection(
                 pika.ConnectionParameters(host='127.0.0.1', port=int(os.environ["AMQP_PORT"])))


### PR DESCRIPTION
There are a couple of evergreen tests for queue types overrides. Fixing it here.