### PR TITLE
Allow multiple protocols in protocol listener health check

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1202,10 +1202,12 @@ or:
         <td></td>
         <td></td>
         <td></td>
-        <td class="path">/api/health/checks/protocol-listener/<i>protocol</i></td>
+        <td class="path">/api/health/checks/protocol-listener/<i>protocols</i></td>
         <td>
-          Responds a 200 OK if there is an active listener for the given protocol,
-          otherwise responds with a 503 Service Unavailable. Valid protocol names are: amqp091, amqp10, mqtt, stomp, web-mqtt, web-stomp.
+          Responds a 200 OK if all given protocols have active listeners,
+          otherwise responds with a 503 Service Unavailable. Multiple protocols
+          may be provided by separating the names with commas. Valid protocol
+          names are: amqp091, amqp10, mqtt, stomp, web-mqtt, web-stomp.
         </td>
       </tr>
       <tr>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -200,7 +200,7 @@ dispatcher() ->
      {"/health/checks/metadata-store/initialized/with-data",   rabbit_mgmt_wm_health_check_metadata_store_initialized_with_data, []},
      {"/health/checks/certificate-expiration/:within/:unit",   rabbit_mgmt_wm_health_check_certificate_expiration, []},
      {"/health/checks/port-listener/:port",                    rabbit_mgmt_wm_health_check_port_listener, []},
-     {"/health/checks/protocol-listener/:protocol",            rabbit_mgmt_wm_health_check_protocol_listener, []},
+     {"/health/checks/protocol-listener/:protocols",           rabbit_mgmt_wm_health_check_protocol_listener, []},
      {"/health/checks/virtual-hosts",                          rabbit_mgmt_wm_health_check_virtual_hosts, []},
      {"/health/checks/quorum-queues-without-elected-leaders/all-vhosts/",    rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts, []},
      {"/health/checks/quorum-queues-without-elected-leaders/vhost/:vhost/",  rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders, []},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
@@ -34,13 +34,12 @@ resource_exists(ReqData, Context) ->
 
 to_json(ReqData, Context) ->
     Protocol = normalize_protocol(protocol(ReqData)),
-    Listeners = rabbit_networking:active_listeners(),
-    Local = [L || #listener{node = N} = L <- Listeners, N == node()],
-    ProtoListeners = [L || #listener{protocol = P} = L <- Local, atom_to_list(P) == Protocol],
+    Listeners = rabbit_networking:node_listeners(node()),
+    ProtoListeners = [L || #listener{protocol = P} = L <- Listeners, atom_to_list(P) == Protocol],
     case ProtoListeners of
         [] ->
             Msg = <<"No active listener">>,
-            failure(Msg, Protocol, [P || #listener{protocol = P} <- Local], ReqData, Context);
+            failure(Msg, Protocol, [P || #listener{protocol = P} <- Listeners], ReqData, Context);
         _ ->
             Body = #{status   => ok,
                      protocol => list_to_binary(Protocol)},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
@@ -27,31 +27,37 @@ content_types_provided(ReqData, Context) ->
    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
-    {case protocol(ReqData) of
+    {case protocols(ReqData) of
          none -> false;
          _ -> true
      end, ReqData, Context}.
 
 to_json(ReqData, Context) ->
-    Protocol = normalize_protocol(protocol(ReqData)),
+    Protocols = string:split(protocols(ReqData), ",", all),
+    RequestedProtocols = sets:from_list(
+                           [normalize_protocol(P) || P <- Protocols],
+                           [{version, 2}]),
     Listeners = rabbit_networking:node_listeners(node()),
-    ProtoListeners = [L || #listener{protocol = P} = L <- Listeners, atom_to_list(P) == Protocol],
-    case ProtoListeners of
+    ActiveProtocols = sets:from_list(
+                        [atom_to_list(P) || #listener{protocol = P} <- Listeners],
+                        [{version, 2}]),
+    MissingProtocols = sets:to_list(sets:subtract(RequestedProtocols, ActiveProtocols)),
+    case MissingProtocols of
         [] ->
-            Msg = <<"No active listener">>,
-            failure(Msg, Protocol, [P || #listener{protocol = P} <- Listeners], ReqData, Context);
+            Body = #{status    => ok,
+                     protocols => [list_to_binary(P) || P <- sets:to_list(ActiveProtocols)]},
+            rabbit_mgmt_util:reply(Body, ReqData, Context);
         _ ->
-            Body = #{status   => ok,
-                     protocol => list_to_binary(Protocol)},
-            rabbit_mgmt_util:reply(Body, ReqData, Context)
+            Msg = <<"No active listener">>,
+            failure(Msg, MissingProtocols, sets:to_list(ActiveProtocols), ReqData, Context)
     end.
 
 failure(Message, Missing, Protocols, ReqData, Context) ->
     Body = #{
         status    => failed,
         reason    => Message,
-        missing   => list_to_binary(Missing),
-        protocols => Protocols
+        missing   => [list_to_binary(P) || P <- Missing],
+        protocols => [list_to_binary(P) || P <- Protocols]
     },
     {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body, ReqData, Context),
     {stop, cowboy_req:reply(503, #{}, Response, ReqData1), Context1}.
@@ -59,8 +65,8 @@ failure(Message, Missing, Protocols, ReqData, Context) ->
 is_authorized(ReqData, Context) ->
     rabbit_mgmt_util:is_authorized(ReqData, Context).
 
-protocol(ReqData) ->
-    rabbit_mgmt_util:id(protocol, ReqData).
+protocols(ReqData) ->
+    rabbit_mgmt_util:id(protocols, ReqData).
 
 normalize_protocol(Protocol) ->
     case string:lowercase(binary_to_list(Protocol)) of

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -384,7 +384,7 @@ protocol_listener_test(Config) ->
     Body0 = http_get_failed(Config, "/health/checks/protocol-listener/mqtt"),
     ?assertEqual(<<"failed">>, maps:get(<<"status">>, Body0)),
     ?assertEqual(true, maps:is_key(<<"reason">>, Body0)),
-    ?assertEqual(<<"mqtt">>, maps:get(<<"missing">>, Body0)),
+    ?assertEqual([<<"mqtt">>], maps:get(<<"missing">>, Body0)),
     ?assert(lists:member(<<"http">>, maps:get(<<"protocols">>, Body0))),
     ?assert(lists:member(<<"clustering">>, maps:get(<<"protocols">>, Body0))),
     ?assert(lists:member(<<"amqp">>, maps:get(<<"protocols">>, Body0))),
@@ -393,6 +393,14 @@ protocol_listener_test(Config) ->
     http_get_failed(Config, "/health/checks/protocol-listener/mqtts"),
     http_get_failed(Config, "/health/checks/protocol-listener/stomp"),
     http_get_failed(Config, "/health/checks/protocol-listener/stomp1.0"),
+
+    %% Multiple protocols may be supplied. The health check only returns OK if
+    %% all requested protocols are available.
+    Body1 = http_get_failed(Config, "/health/checks/protocol-listener/amqp,mqtt"),
+    ?assertEqual(<<"failed">>, maps:get(<<"status">>, Body1)),
+    ?assertEqual(true, maps:is_key(<<"reason">>, Body1)),
+    ?assert(lists:member(<<"mqtt">>, maps:get(<<"missing">>, Body1))),
+    ?assert(lists:member(<<"amqp">>, maps:get(<<"protocols">>, Body1))),
 
     passed.
 


### PR DESCRIPTION
## Proposed Changes

This covers the optional part of #13782: updating `GET /api/health/checks/protocol-listener/{protocol}` to accept multiple protocols, comma-separated. The check only returns `200 OK` when all of the request protocols have listeners available.

Connects #13782.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

**NOTE**: the field in the error response `missing` is updated to a list. I'm not sure if we should consider this as a breaking change or not.

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This PR also adds a commit which changes the helper used to look for active listeners from `rabbit_networking:active_listeners/0` to `rabbit_networking:node_listeners(node())` - this eliminates some unnecessary RPC calls. It's unrelated to the feature part of this change.