### PR TITLE
Add an 'is-in-service' health check wrapping `rabbit:is_serving/0`

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1242,6 +1242,19 @@ or:
         <td></td>
         <td></td>
         <td></td>
+        <td class="path">/api/health/checks/is-in-service</td>
+        <td>
+          Responds a 200 OK if the target node is booted, running, and ready to
+          serve clients, otherwise responds with a 503 Service Unavailable. If the
+          target node is being drained for maintenance then this check returns 503
+          Service Unavailable.
+        </td>
+      </tr>
+      <tr>
+        <td>X</td>
+        <td></td>
+        <td></td>
+        <td></td>
         <td class="path">/api/vhost-limits</td>
         <td>
             Lists per-vhost limits for all vhosts.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -207,6 +207,7 @@ dispatcher() ->
      {"/health/checks/quorum-queues-without-elected-leaders/all-vhosts/pattern/:pattern",    rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders_across_all_vhosts, []},
      {"/health/checks/quorum-queues-without-elected-leaders/vhost/:vhost/pattern/:pattern",  rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders, []},
      {"/health/checks/node-is-quorum-critical",                rabbit_mgmt_wm_health_check_node_is_quorum_critical, []},
+     {"/health/checks/is-in-service",                          rabbit_mgmt_wm_health_check_is_in_service, []},
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
      {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance_queues, [{queues, all}]},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_is_in_service.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_is_in_service.erl
@@ -1,0 +1,44 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_health_check_is_in_service).
+
+-export([init/2]).
+-export([to_json/2, content_types_provided/2]).
+-export([variances/2]).
+
+-include("rabbit_mgmt.hrl").
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+
+init(Req, _State) ->
+    Req1 = rabbit_mgmt_headers:set_no_cache_headers(
+             rabbit_mgmt_headers:set_common_permission_headers(
+               Req, ?MODULE), ?MODULE),
+    {cowboy_rest, Req1, #context{}}.
+
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
+content_types_provided(ReqData, Context) ->
+   {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    case rabbit:is_serving() of
+        true ->
+            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+        false ->
+            Msg = "this rabbit node is not currently available to serve",
+            failure(Msg, ReqData, Context)
+    end.
+
+failure(Message, ReqData, Context) ->
+    Body = #{
+        status => failed,
+        reason => rabbit_data_coercion:to_binary(Message)
+    },
+    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body, ReqData, Context),
+    {stop, cowboy_req:reply(?HEALTH_CHECK_FAILURE_STATUS, #{}, Response, ReqData1), Context1}.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -50,7 +50,8 @@ all_tests() -> [
                 metadata_store_initialized_with_data_test,
                 protocol_listener_test,
                 port_listener_test,
-                certificate_expiration_test
+                certificate_expiration_test,
+                is_in_service_test
                ].
 
 %% -------------------------------------------------------------------
@@ -446,6 +447,18 @@ certificate_expiration_test(Config) ->
     ?assertEqual(true, maps:is_key(<<"certfile">>, Expired)),
     ?assertEqual(true, maps:is_key(<<"certfile_expires_on">>, Expired)),
     ?assertEqual(true, maps:is_key(<<"interface">>, Expired)),
+
+    passed.
+
+is_in_service_test(Config) ->
+    Path = "/health/checks/is-in-service",
+    Check0 = http_get(Config, Path, ?OK),
+    ?assertEqual(<<"ok">>, maps:get(status, Check0)),
+
+    true = rabbit_ct_broker_helpers:mark_as_being_drained(Config, 0),
+    Body0 = http_get_failed(Config, Path),
+    ?assertEqual(<<"failed">>, maps:get(<<"status">>, Body0)),
+    true = rabbit_ct_broker_helpers:unmark_as_being_drained(Config, 0),
 
     passed.
 


### PR DESCRIPTION
## Proposed Changes

This is useful for a load balancer, for example, to be able to avoid sending new connections to a node which is running and has listeners bound to TCP ports but is being drained for maintenance.

This PR covers the first part of #13782: adding a new health-check `GET /api/health/checks/is-in-service`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it