### PR TITLE
QQ grow to a target quorum cluster size

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1528,25 +1528,14 @@ shrink_all(Node) ->
 grow(Node, VhostSpec, QueueSpec, Strategy) ->
     grow(Node, VhostSpec, QueueSpec, Strategy, promotable).
 
--spec grow(node(), binary(), binary(), all | even, membership()) ->
+-spec grow(node() | integer(), binary(), binary(), all | even, membership()) ->
     [{rabbit_amqqueue:name(),
       {ok, pos_integer()} | {error, pos_integer(), term()}}].
-grow(Node, VhostSpec, QueueSpec, Strategy, Membership) ->
+grow(Node, VhostSpec, QueueSpec, Strategy, Membership) when is_atom(Node) ->
     Running = rabbit_nodes:list_running(),
     [begin
          Size = length(get_nodes(Q)),
-         QName = amqqueue:get_name(Q),
-         rabbit_log:info("~ts: adding a new member (replica) on node ~w",
-                         [rabbit_misc:rs(QName), Node]),
-         case add_member(Q, Node, Membership) of
-             ok ->
-                 {QName, {ok, Size + 1}};
-             {error, Err} ->
-                 rabbit_log:warning(
-                   "~ts: failed to add member (replica) on node ~w, error: ~w",
-                   [rabbit_misc:rs(QName), Node, Err]),
-                 {QName, {error, Size, Err}}
-         end
+         maybe_grow(Q, Node, Membership, Size)
      end
      || Q <- rabbit_amqqueue:list(),
         amqqueue:get_type(Q) == ?MODULE,
@@ -1556,7 +1545,53 @@ grow(Node, VhostSpec, QueueSpec, Strategy, Membership) ->
         lists:member(Node, Running),
         matches_strategy(Strategy, get_nodes(Q)),
         is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
-        is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec) ].
+        is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec) ];
+
+grow(QuorumClusterSize, VhostSpec, QueueSpec, Strategy, Membership)
+  when is_integer(QuorumClusterSize) ->
+    Running = rabbit_nodes:list_running(),
+    TotalRunning = length(Running),
+
+    TargetQuorumClusterSize =
+        if QuorumClusterSize > TotalRunning ->
+            %% we cant grow beyond total running nodes
+            TotalRunning;
+        true ->
+            QuorumClusterSize
+        end,
+
+    lists:flatten(
+        [begin
+            QNodes = get_nodes(Q),
+            case length(QNodes) of
+                Size when Size < TargetQuorumClusterSize ->
+                    TargetAvailableNodes = Running -- QNodes,
+                    Node = hd(TargetAvailableNodes),
+                    maybe_grow(Q, Node, Membership, Size);
+                _ ->
+                    []
+            end
+        end
+        ||  _ <- lists:seq(1, TargetQuorumClusterSize),
+            Q <- rabbit_amqqueue:list(),
+            amqqueue:get_type(Q) == ?MODULE,
+            matches_strategy(Strategy, get_nodes(Q)),
+            is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
+            is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)]).
+
+maybe_grow(Q, Node, Membership, Size) ->
+    QName = amqqueue:get_name(Q),
+    rabbit_log:info("~ts: adding a new member (replica) on node ~w",
+                    [rabbit_misc:rs(QName), Node]),
+    case add_member(Q, Node, Membership) of
+        ok ->
+            {QName, {ok, Size + 1}};
+        {error, Err} ->
+            rabbit_log:warning(
+            "~ts: failed to add member (replica) on node ~w, error: ~w",
+            [rabbit_misc:rs(QName), Node, Err]),
+            {QName, {error, Size, Err}}
+    end.
 
 -spec transfer_leadership(amqqueue:amqqueue(), node()) -> {migrated, node()} | {not_migrated, atom()}.
 transfer_leadership(Q, Destination) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1548,7 +1548,7 @@ grow(Node, VhostSpec, QueueSpec, Strategy, Membership) when is_atom(Node) ->
         is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec) ];
 
 grow(QuorumClusterSize, VhostSpec, QueueSpec, Strategy, Membership)
-  when is_integer(QuorumClusterSize) ->
+  when is_integer(QuorumClusterSize), QuorumClusterSize > 0 ->
     Running = rabbit_nodes:list_running(),
     TotalRunning = length(Running),
 
@@ -1577,7 +1577,14 @@ grow(QuorumClusterSize, VhostSpec, QueueSpec, Strategy, Membership)
             amqqueue:get_type(Q) == ?MODULE,
             matches_strategy(Strategy, get_nodes(Q)),
             is_match(amqqueue:get_vhost(Q), VhostSpec) andalso
-            is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)]).
+            is_match(get_resource_name(amqqueue:get_name(Q)), QueueSpec)]);
+
+grow(QuorumClusterSize, _VhostSpec, _QueueSpec, _Strategy, _Membership)
+  when is_integer(QuorumClusterSize) ->
+    rabbit_log:warning(
+            "cannot grow queues to a quorum cluster size less than zero (~tp)",
+            [QuorumClusterSize]),
+    {error, bad_quorum_cluster_size}.
 
 maybe_grow(Q, Node, Membership, Size) ->
     QName = amqqueue:get_name(Q),

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -110,7 +110,8 @@ groups() ->
                                             node_removal_is_not_quorum_critical,
                                             select_nodes_with_least_replicas,
                                             select_nodes_with_least_replicas_node_down,
-                                            subscribe_from_each
+                                            subscribe_from_each,
+                                            grow_queue
 
 
                                            ]},
@@ -1535,6 +1536,77 @@ subscribe_from_each(Config) ->
      end || S <- Servers],
 
     ok.
+
+grow_queue(Config) ->
+    [Server0, Server1, _Server2, _Server3, _Server4] =
+        rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server0),
+    QQ = ?config(queue_name, Config),
+    AQ = ?config(alt_queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                  {<<"x-quorum-initial-group-size">>, long, 5}])),
+    ?assertEqual({'queue.declare_ok', AQ, 0, 0},
+                 declare(Ch, AQ, [{<<"x-queue-type">>, longstr, <<"quorum">>},
+                                  {<<"x-quorum-initial-group-size">>, long, 5}])),
+
+    QQs = [QQ, AQ],
+    MsgCount = 3,
+
+    [begin
+        RaName = ra_name(Q),
+        rabbit_ct_client_helpers:publish(Ch, Q, MsgCount),
+        wait_for_messages_ready([Server0], RaName, MsgCount),
+        {ok, Q0} = rpc:call(Server0, rabbit_amqqueue, lookup, [Q, <<"/">>]),
+        #{nodes := Nodes0} = amqqueue:get_type_state(Q0),
+        ?assertEqual(5, length(Nodes0))
+    end || Q <- QQs],
+
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_all_queues_shrink_member_to_current_member, []),
+
+    TargetClusterSize_1 = 1,
+    assert_grown_queues(QQs, Server0, TargetClusterSize_1, MsgCount),
+
+    %% grow queues to node 'Server1'
+    TargetClusterSize_2 = 2,
+    rpc:call(Server0, rabbit_quorum_queue, grow, [Server1, <<"/">>, <<".*">>, all]),
+    assert_grown_queues(QQs, Server0, TargetClusterSize_2, MsgCount),
+
+    %% grow queues to quorum cluster size '2' has no effect
+    rpc:call(Server0, rabbit_quorum_queue, grow, [TargetClusterSize_2, <<"/">>, <<".*">>, all]),
+    assert_grown_queues(QQs, Server0, TargetClusterSize_2, MsgCount),
+
+    %% grow queues to quorum cluster size '3'
+    TargetClusterSize_3 = 3,
+    rpc:call(Server0, rabbit_quorum_queue, grow, [TargetClusterSize_3, <<"/">>, <<".*">>, all]),
+    assert_grown_queues(QQs, Server0, TargetClusterSize_3, MsgCount),
+
+    %% grow queues to quorum cluster size '5'
+    TargetClusterSize_5 = 5,
+    rpc:call(Server0, rabbit_quorum_queue, grow, [TargetClusterSize_5, <<"/">>, <<".*">>, all]),
+    assert_grown_queues(QQs, Server0, TargetClusterSize_5, MsgCount),
+
+    %% shrink all queues again
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_all_queues_shrink_member_to_current_member, []),
+
+    assert_grown_queues(QQs, Server0, TargetClusterSize_1, MsgCount),
+
+    %% grow queues to quorum cluster size > '5' (limit = 5).
+    TargetClusterSize_10 = 10,
+    rpc:call(Server0, rabbit_quorum_queue, grow, [TargetClusterSize_10, <<"/">>, <<".*">>, all]),
+    assert_grown_queues(QQs, Server0, TargetClusterSize_5, MsgCount).
+
+assert_grown_queues(Qs, Node, TargetClusterSize, MsgCount) ->
+    [begin
+        RaName = ra_name(Q),
+        wait_for_messages_ready([Node], RaName, MsgCount),
+        {ok, Q0} = rpc:call(Node, rabbit_amqqueue, lookup, [Q, <<"/">>]),
+        #{nodes := Nodes0} = amqqueue:get_type_state(Q0),
+        ?assertEqual(TargetClusterSize, length(Nodes0))
+    end || Q <- Qs].
 
 gh_12635(Config) ->
     % https://github.com/rabbitmq/rabbitmq-server/issues/12635

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -1591,13 +1591,22 @@ grow_queue(Config) ->
     %% shrink all queues again
     rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
         force_all_queues_shrink_member_to_current_member, []),
-
     assert_grown_queues(QQs, Server0, TargetClusterSize_1, MsgCount),
 
     %% grow queues to quorum cluster size > '5' (limit = 5).
     TargetClusterSize_10 = 10,
     rpc:call(Server0, rabbit_quorum_queue, grow, [TargetClusterSize_10, <<"/">>, <<".*">>, all]),
-    assert_grown_queues(QQs, Server0, TargetClusterSize_5, MsgCount).
+    assert_grown_queues(QQs, Server0, TargetClusterSize_5, MsgCount),
+
+    %% shrink all queues again
+    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+        force_all_queues_shrink_member_to_current_member, []),
+    assert_grown_queues(QQs, Server0, TargetClusterSize_1, MsgCount),
+
+    %% attempt to grow queues to quorum cluster size < '0'.
+    BadTargetClusterSize = -5,
+    ?assertEqual({error, bad_quorum_cluster_size},
+        rpc:call(Server0, rabbit_quorum_queue, grow, [BadTargetClusterSize, <<"/">>, <<".*">>, all])).
 
 assert_grown_queues(Qs, Node, TargetClusterSize, MsgCount) ->
     [begin

--- a/deps/rabbitmq_cli/test/queues/grow_command_test.exs
+++ b/deps/rabbitmq_cli/test/queues/grow_command_test.exs
@@ -44,55 +44,55 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommandTest do
   end
 
   test "validate: when one argument is provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a"], %{}) == {:validation_failure, :not_enough_args}
+    assert @command.validate(["target@node"], %{}) == {:validation_failure, :not_enough_args}
   end
 
   test "validate: when a node and even are provided, returns a success" do
-    assert @command.validate(["quorum-queue-a", "even"], %{}) == :ok
+    assert @command.validate(["target@node", "even"], %{}) == :ok
   end
 
   test "validate: when a node and all are provided, returns a success" do
-    assert @command.validate(["quorum-queue-a", "all"], %{}) == :ok
+    assert @command.validate(["target@node", "all"], %{}) == :ok
   end
 
   test "validate: when a node and something else is provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a", "banana"], %{}) ==
+    assert @command.validate(["target@node", "banana"], %{}) ==
              {:validation_failure, "strategy 'banana' is not recognised."}
   end
 
   test "validate: when three arguments are provided, returns a failure" do
-    assert @command.validate(["quorum-queue-a", "extra-arg", "another-extra-arg"], %{}) ==
+    assert @command.validate(["target@node", "extra-arg", "another-extra-arg"], %{}) ==
              {:validation_failure, :too_many_args}
   end
 
   test "validate: when membership promotable is provided, returns a success" do
-    assert @command.validate(["quorum-queue-a", "all"], %{membership: "promotable"}) == :ok
+    assert @command.validate(["target@node", "all"], %{membership: "promotable", queue_pattern: "qq.*"}) == :ok
   end
 
   test "validate: when membership voter is provided, returns a success" do
-    assert @command.validate(["quorum-queue-a", "all"], %{membership: "voter"}) == :ok
+    assert @command.validate(["target@node", "all"], %{membership: "voter", queue_pattern: "qq.*"}) == :ok
   end
 
   test "validate: when membership non_voter is provided, returns a success" do
-    assert @command.validate(["quorum-queue-a", "all"], %{membership: "non_voter"}) == :ok
+    assert @command.validate(["target@node", "all"], %{membership: "non_voter", queue_pattern: "qq.*"}) == :ok
   end
 
   test "validate: when wrong membership is provided, returns failure" do
-    assert @command.validate(["quorum-queue-a", "all"], %{membership: "banana"}) ==
+    assert @command.validate(["target@node", "all"], %{membership: "banana", queue_pattern: "qq.*"}) ==
              {:validation_failure, "voter status 'banana' is not recognised."}
   end
 
   test "validate: when target quorum cluster size greater than zero, returns a success" do
-    assert @command.validate([7, "all"], %{membership: "voter"}) == :ok
+    assert @command.validate([7, "all"], %{membership: "voter", queue_pattern: "qq.*"}) == :ok
   end
 
   test "validate: when target quorum cluster size is zero, returns failure" do
-    assert @command.validate([0, "all"], %{membership: "voter"}) ==
+    assert @command.validate([0, "all"], %{membership: "voter", queue_pattern: "qq.*"}) ==
              {:validation_failure, "target quorum cluster size '0' must be greater than 0."}
   end
 
   test "validate: when target quorum cluster size is less than zero, returns failure" do
-    assert @command.validate([-1, "all"], %{membership: "voter"}) ==
+    assert @command.validate([-1, "all"], %{membership: "voter", queue_pattern: "qq.*"}) ==
              {:validation_failure, "target quorum cluster size '-1' must be greater than 0."}
   end
 
@@ -102,7 +102,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommandTest do
              {:badrpc, _},
              @command.run(
                ["target@node", "all"],
-               Map.merge(context[:opts], %{node: :jake@thedog})
+               Map.merge(context[:opts], %{node: :jake@thedog, queue_pattern: "qq.*"})
              )
            )
   end
@@ -113,7 +113,7 @@ defmodule RabbitMQ.CLI.Queues.Commands.GrowCommandTest do
              {:badrpc, _},
              @command.run(
                [5, "all"],
-               Map.merge(context[:opts], %{node: :jake@thedog})
+               Map.merge(context[:opts], %{node: :jake@thedog, queue_pattern: "qq.*"})
              )
            )
   end


### PR DESCRIPTION
## Proposed Changes

Hello team 👋 

The following changes are a proposed extension to the `rabbitmq-queues grow` command. Currently this command only allows growing queues to a single target node per execution, for a set of queues matching the `--queue-pattern`. This means the command needs to be executed a number of times to fully restore a quorum queue (replicas) back to N-number of nodes (which can also be expensive from the multiple RPCs from the temporary CLI execution node). As an extension to the `rabbitmq-queues grow` command, we'd like to allow growing queues to a specified number of nodes N / target quorum cluster size (allowing the broker to do all the grow processing to multiple nodes in one CLI execution). The command signature becomes:

```
rabbitmq-queues grow <node | quorum_cluster_size> .... 
``` 

When quorum queues get into a bad state, e.g. become leaderless (https://github.com/rabbitmq/rabbitmq-server/discussions/12701,  https://github.com/rabbitmq/rabbitmq-server/discussions/13101) and shrink operations (https://github.com/rabbitmq/rabbitmq-server/pull/12427) to a single node to attempt rescue are applied, fast recovery/growing back to N nodes / to a target quorum cluster size for the set of queues becomes a critical requirement. 

Please take a look. Thanks!

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it


