### PR TITLE
Add health checks for testing readiness to serve clients

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1269,6 +1269,29 @@ or:
         <td></td>
         <td></td>
         <td></td>
+        <td class="path">/api/health/checks/ready-to-serve-clients</td>
+        <td>
+          <p>
+            Responds a 200 OK if the target node is ready to serve clients, otherwise
+            responds with a 503 Service Unavailable. This check combines:
+          </p>
+          <ol>
+            <li>/api/health/checks/is-in-service</li>
+            <li>/api/health/checks/protocol-listener/amqp or /api/health/checks/protocol-listener/amqps</li>
+            <li>/api/health/checks/below-node-connection-limit</li>
+          </ol>
+          <p>
+            So this check will only return 200 OK if the target node is in service,
+            an AMQP or AMQPS listener is available and the target node has fewer active
+            AMQP and AMQPS connections that its configured limit.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td>X</td>
+        <td></td>
+        <td></td>
+        <td></td>
         <td class="path">/api/vhost-limits</td>
         <td>
             Lists per-vhost limits for all vhosts.

--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1257,6 +1257,18 @@ or:
         <td></td>
         <td></td>
         <td></td>
+        <td class="path">/api/health/checks/below-node-connection-limit</td>
+        <td>
+          Responds a 200 OK if the target node has fewer connections to the AMQP
+          and AMQPS ports than the configured maximum, otherwise responds with a
+          503 Service Unavailable.
+        </td>
+      </tr>
+      <tr>
+        <td>X</td>
+        <td></td>
+        <td></td>
+        <td></td>
         <td class="path">/api/vhost-limits</td>
         <td>
             Lists per-vhost limits for all vhosts.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -208,6 +208,7 @@ dispatcher() ->
      {"/health/checks/quorum-queues-without-elected-leaders/vhost/:vhost/pattern/:pattern",  rabbit_mgmt_wm_health_check_quorum_queues_without_elected_leaders, []},
      {"/health/checks/node-is-quorum-critical",                rabbit_mgmt_wm_health_check_node_is_quorum_critical, []},
      {"/health/checks/is-in-service",                          rabbit_mgmt_wm_health_check_is_in_service, []},
+     {"/health/checks/below-node-connection-limit",            rabbit_mgmt_wm_health_check_below_node_connection_limit, []},
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
      {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance_queues, [{queues, all}]},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -209,6 +209,7 @@ dispatcher() ->
      {"/health/checks/node-is-quorum-critical",                rabbit_mgmt_wm_health_check_node_is_quorum_critical, []},
      {"/health/checks/is-in-service",                          rabbit_mgmt_wm_health_check_is_in_service, []},
      {"/health/checks/below-node-connection-limit",            rabbit_mgmt_wm_health_check_below_node_connection_limit, []},
+     {"/health/checks/ready-to-serve-clients",                 rabbit_mgmt_wm_health_check_ready_to_serve_clients, []},
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
      {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance_queues, [{queues, all}]},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_below_node_connection_limit.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_below_node_connection_limit.erl
@@ -1,0 +1,63 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_health_check_below_node_connection_limit).
+
+-export([init/2]).
+-export([to_json/2, content_types_provided/2]).
+-export([variances/2]).
+
+-include("rabbit_mgmt.hrl").
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+
+init(Req, _State) ->
+    Req1 = rabbit_mgmt_headers:set_no_cache_headers(
+             rabbit_mgmt_headers:set_common_permission_headers(
+               Req, ?MODULE), ?MODULE),
+    {cowboy_rest, Req1, #context{}}.
+
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
+content_types_provided(ReqData, Context) ->
+   {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    ActiveConns = lists:foldl(
+                    fun(Protocol, Acc) ->
+                            Acc + protocol_connection_count(Protocol)
+                    end, 0, [amqp, 'amqp/ssl']),
+    Limit = rabbit_misc:get_env(rabbit, connection_max, infinity),
+    case ActiveConns < Limit of
+        true ->
+            rabbit_mgmt_util:reply(
+              #{status => ok,
+                limit => Limit,
+                connections => ActiveConns}, ReqData, Context);
+        false ->
+            Body = #{
+                status => failed,
+                reason => <<"node connection limit is reached">>,
+                limit => Limit,
+                connections => ActiveConns
+            },
+            {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(
+                                               Body, ReqData, Context),
+            {stop,
+             cowboy_req:reply(
+               ?HEALTH_CHECK_FAILURE_STATUS, #{}, Response, ReqData1),
+             Context1}
+    end.
+
+protocol_connection_count(Protocol) ->
+    case rabbit_networking:ranch_ref_of_protocol(Protocol) of
+        undefined ->
+            0;
+        RanchRef ->
+            #{active_connections := Count} = ranch:info(RanchRef),
+            Count
+    end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_ready_to_serve_clients.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_ready_to_serve_clients.erl
@@ -1,0 +1,81 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% A composite health check that combines:
+%% * GET /api/health/checks/is-in-service
+%% * GET /api/health/checks/protocol-listener/amqp
+%% * GET /api/health/checks/below-node-connection-limit
+
+-module(rabbit_mgmt_wm_health_check_ready_to_serve_clients).
+
+-export([init/2]).
+-export([to_json/2, content_types_provided/2]).
+-export([variances/2]).
+
+-include("rabbit_mgmt.hrl").
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+
+init(Req, _State) ->
+    Req1 = rabbit_mgmt_headers:set_no_cache_headers(
+             rabbit_mgmt_headers:set_common_permission_headers(
+               Req, ?MODULE), ?MODULE),
+    {cowboy_rest, Req1, #context{}}.
+
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
+content_types_provided(ReqData, Context) ->
+   {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    case check() of
+        {ok, Body} ->
+            rabbit_mgmt_util:reply(Body, ReqData, Context);
+        {error, Body} ->
+            {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(
+                                               Body, ReqData, Context),
+            {stop,
+             cowboy_req:reply(
+               ?HEALTH_CHECK_FAILURE_STATUS, #{}, Response, ReqData1),
+             Context1}
+    end.
+
+check() ->
+    case rabbit:is_serving() of
+        true ->
+            RanchRefs0 = [
+                rabbit_networking:ranch_ref_of_protocol(amqp),
+                rabbit_networking:ranch_ref_of_protocol('amqp/ssl')
+            ],
+            RanchRefs = [R || R <- RanchRefs0, R =/= undefined],
+            case RanchRefs of
+                [_ | _] ->
+                    ActiveConns = lists:foldl(
+                      fun(RanchRef, Acc) ->
+                              #{active_connections := Count} = ranch:info(RanchRef),
+                              Acc + Count
+                      end, 0, RanchRefs),
+                    Limit = rabbit_misc:get_env(rabbit, connection_max, infinity),
+                    case ActiveConns < Limit of
+                        true ->
+                            {ok, #{status => ok,
+                                   limit => Limit,
+                                   connections => ActiveConns}};
+                        false ->
+                            {error, #{status => failed,
+                                      reason => <<"node connection limit is reached">>,
+                                      limit => Limit,
+                                      connections => ActiveConns}}
+                    end;
+                [] ->
+                    {error, #{status => failed,
+                              reason => <<"no active listeners for AMQP/AMQPS">>}}
+            end;
+        false ->
+            {error, #{status => failed,
+                      reason => <<"the rabbit node is not currently available to serve">>}}
+    end.


### PR DESCRIPTION
## Proposed Changes

This covers the remaining two checks in https://github.com/rabbitmq/rabbitmq-server/issues/13782. One tests the connection limit for the node and the other is a kind of composite check that combines https://github.com/rabbitmq/rabbitmq-server/pull/13872 and checks whether listeners are available for AMQP/AMQPS.

Closes https://github.com/rabbitmq/rabbitmq-server/issues/13782

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website (https://github.com/rabbitmq/rabbitmq-website/pull/2264)
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

These checks only apply to AMQP + AMQPS because that's what the `connection_max` currently applies to. In the future these checks could be updated to also cover other protocols. If desired I could pick up https://github.com/rabbitmq/rabbitmq-server/pull/9876. We can use `ranch:info/1` as Loic suggested in https://github.com/rabbitmq/rabbitmq-server/issues/7593 to efficiently count connections per protocol.