### PR TITLE
Remove connection counts and limits from API health checks

### DIFF
--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -476,8 +476,6 @@ below_node_connection_limit_test(Config) ->
     Path = "/health/checks/below-node-connection-limit",
     Check0 = http_get(Config, Path, ?OK),
     ?assertEqual(<<"ok">>, maps:get(status, Check0)),
-    ?assertEqual(0, maps:get(connections, Check0)),
-    ?assertEqual(<<"infinity">>, maps:get(limit, Check0)),
 
     %% Set the connection limit low and open 'limit' connections.
     Limit = 10,
@@ -489,8 +487,6 @@ below_node_connection_limit_test(Config) ->
 
     Body0 = http_get_failed(Config, Path),
     ?assertEqual(<<"failed">>, maps:get(<<"status">>, Body0)),
-    ?assertEqual(10, maps:get(<<"limit">>, Body0)),
-    ?assertEqual(10, maps:get(<<"connections">>, Body0)),
 
     %% Clean up the connections and reset the limit.
     [catch rabbit_ct_client_helpers:close_connection(C) || C <- Connections],
@@ -519,8 +515,6 @@ ready_to_serve_clients_test(Config) ->
 
     Body1 = http_get_failed(Config, Path),
     ?assertEqual(<<"failed">>, maps:get(<<"status">>, Body1)),
-    ?assertEqual(10, maps:get(<<"limit">>, Body1)),
-    ?assertEqual(10, maps:get(<<"connections">>, Body1)),
 
     %% Clean up the connections and reset the limit.
     [catch rabbit_ct_client_helpers:close_connection(C) || C <- Connections],


### PR DESCRIPTION
## Proposed Changes

This is a minor change to remove the connection limit and current active count from health checks which returned them (introduced in https://github.com/rabbitmq/rabbitmq-server/pull/13879).

Returning the connection limit and active count are not really necessary for these checks. Instead of returning them in the response to the health check we log a warning when the connection limit is exceeded.

Connects #13782

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
