### PR TITLE
CI: tweak OCI workflow trigger

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -5,7 +5,7 @@
 #
 name: OCI (make)
 on:
-  push:
+  pull_request:
     paths:
       - deps/**
       - scripts/**
@@ -27,7 +27,7 @@ on:
         default: false
 env:
   REGISTRY_IMAGE: pivotalrabbitmq/rabbitmq
-  VERSION: 4.1.0+${{ github.sha }}
+  VERSION: 4.2.0+${{ github.sha }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -39,6 +39,8 @@ jobs:
         - ${{ github.event.inputs.otp_version || '27' }}
     runs-on: ubuntu-latest
     outputs:
+      # When dependabot, or a user from a fork, creates PRs, secrets are not injected, and the OCI workflow can't push the image
+      # This check acts as a gate keeper
       authorized: ${{ steps.authorized.outputs.authorized }}
     steps:
       - name: CHECK IF IMAGE WILL PUSH


### PR DESCRIPTION
## Proposed Changes

Building on push to any branch is wasteful and unnecessary, because most
of built images are never used. The workflow dispatch trigger covers the
use case to build an image from the latest commit in a branch.

The use case to validate/QA a PR is now covered by on pull request
trigger. This trigger has a caveat: PRs from forks won't produce a
docker image.

Why?
Because PRs from forks do not inject rabbitmq-server secrets. This is a
security mechanism from GitHub, to protect repository secrets.

With this trigger is possible to QA/validate PRs from other Core team
members. Technically, anyone with 'write' access to our repo to push
branches.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

