### PR TITLE
Improve memory use of `rabbit_mgmt_gc`

### DIFF
--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_gc.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_gc.erl
@@ -36,7 +36,7 @@ handle_info(start_gc, State) ->
     gc_queues(),
     gc_exchanges(),
     gc_nodes(),
-    {noreply, start_timer(State)}.
+    {noreply, start_timer(State), hibernate}.
 
 terminate(_Reason, #state{timer = TRef}) ->
     _ = erlang:cancel_timer(TRef),


### PR DESCRIPTION
The main change here is to hibernate the `rabbit_mgmt_gc` gen_server after it completes its GC run. It's an ideal process for hibernation since it wakes up periodically (every 2min by default) to do some work and is then completely idle.

Especially if the broker is mostly idle this server may not perform enough work to be GC'd naturally so its process memory use can grow steadily over time. It can get up to fairly high amounts (tens of MB) because of the work it does during each GC run: it creates a set out of metadata entities like vhosts, queues and exchanges. On an idle single-node broker with 50k exchanges for example, `rabbit_mgmt_gc` can creep up to around 50MB. With the hibernate change it stays at around 1KB between GC runs.

I've also updated the sets usage here from `gb_sets` to `sets` v2 as it's faster and more memory efficient.

<details><summary><code>tprof</code> comparison of sets...</summary>

```
> List = lists:seq(1, 50_000).
> tprof:profile(sets, from_list, [List, [{version, 2}]], #{type => call_memory}).

****** Process <0.94.0>  --  100.00% of total *** 
FUNCTION          CALLS   WORDS   PER CALL  [     %]
maps:from_keys/2      1  184335  184335.00  [100.00]
                         184335             [ 100.0]
ok
> tprof:profile(gb_sets, from_list, [List], #{type => call_memory}).

****** Process <0.97.0>  --  100.00% of total *** 
FUNCTION                  CALLS   WORDS   PER CALL  [    %]
lists:rumergel/3              1       2       2.00  [ 0.00]
gb_sets:from_ordset/1         1       3       3.00  [ 0.00]
lists:reverse/2               1  100000  100000.00  [16.76]
lists:usplit_1/5          49999  100002       2.00  [16.76]
gb_sets:balance_list_1/2  65535  396605       6.05  [66.48]
                                 596612             [100.0]
```

</details>

On `main` you can monitor `rabbit_mgmt_gc` with `observer_cli` or `recon` and create or import 50K exchanges. It will eventually creep up in MB of memory usage. Decrease the default time between wake-ups (`rabbit_mgmt_gc.erl:23`) to see it happen faster.