### PR TITLE
Allow non-deterministic builds

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-build.mk
+++ b/deps/rabbit_common/mk/rabbitmq-build.mk
@@ -15,7 +15,7 @@ ifneq ($(filter rabbitmq_cli,$(BUILD_DEPS) $(DEPS)),)
 RMQ_ERLC_OPTS += -pa $(DEPS_DIR)/rabbitmq_cli/ebin
 endif
 
-RMQ_ERLC_OPTS += +deterministic
+RMQ_ERLC_OPTS ?= +deterministic
 
 # Push our compilation options to both the normal and test ERLC_OPTS.
 ERLC_OPTS += $(RMQ_ERLC_OPTS)


### PR DESCRIPTION
Building from source using this command:

```
make RMQ_ERLC_OPTS= FULL=1
```

... then starting RabbitMQ via `make run-broker`, allows re-compilation from the erl shell:

```
1> c(rabbit).
Recompiling /home/lbakken/development/rabbitmq/rabbitmq-server/deps/rabbit/src/rabbit.erl
{ok,rabbit}
```

When `+deterministic` is passed to `erlc`, the `compile` data in each modules' information is missing the source path for the module.

Follow-up to #3442