### PR TITLE
OTP28: re:split change; street-address macro

### DIFF
--- a/deps/rabbit_common/src/rabbit_cert_info.erl
+++ b/deps/rabbit_common/src/rabbit_cert_info.erl
@@ -145,7 +145,7 @@ format_rdn(#'AttributeTypeAndValue'{type = T, value = V}) ->
             {?'id-at-pseudonym'              , "PSEUDONYM"},
             {?'id-domainComponent'           , "DC"},
             {?'id-emailAddress'              , "EMAILADDRESS"},
-            {?'street-address'               , "STREET"},
+            {17                              , "STREET"}, %% macro was removed in OTP28
             {{0,9,2342,19200300,100,1,1}     , "UID"}], %% Not in public_key.hrl
     case proplists:lookup(T, Fmts) of
         {_, Fmt} ->

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -7,7 +7,7 @@ export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = inets public_key
 BUILD_DEPS = rabbit_common rabbitmq_cli
-DEPS = rabbit rabbitmq_mqtt cowlib jose base64url oauth2_client
+DEPS = rabbit cowlib jose base64url oauth2_client
 TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client rabbitmq_mqtt rabbitmq_web_mqtt emqtt rabbitmq_amqp_client
 
 PLT_APPS += rabbitmq_cli

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -7,8 +7,8 @@ export BUILD_WITHOUT_QUIC
 
 LOCAL_DEPS = inets public_key
 BUILD_DEPS = rabbit_common rabbitmq_cli
-DEPS = rabbit cowlib jose base64url oauth2_client
-TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client rabbitmq_web_mqtt emqtt rabbitmq_amqp_client
+DEPS = rabbit rabbitmq_mqtt cowlib jose base64url oauth2_client
+TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client rabbitmq_mqtt rabbitmq_web_mqtt emqtt rabbitmq_amqp_client
 
 PLT_APPS += rabbitmq_cli
 

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1226,7 +1226,8 @@ vhost_in_username(UserBin) ->
             %% split at the last colon, disallowing colons in username
             case re:split(UserBin, ":(?!.*?:)") of
                 [_, _]      -> true;
-                [UserBin]   -> false
+                [UserBin]   -> false;
+                []          -> false
             end
     end.
 
@@ -1238,7 +1239,8 @@ get_vhost_username(UserBin) ->
             %% split at the last colon, disallowing colons in username
             case re:split(UserBin, ":(?!.*?:)") of
                 [Vhost, UserName] -> {Vhost,  UserName};
-                [UserBin]         -> Default
+                [UserBin]         -> Default;
+                []                -> Default
             end
     end.
 


### PR DESCRIPTION
https://github.com/erlang/otp/issues/9739

In OTP28+, splitting an empty string returns an empty list, not an empty string (the input).

Additionally `street-address` macro was removed in OTP28 - replace with the value it used to be.

Lastly, rabbitmq_auth_backend_oauth2 has an MQTT test, so add rabbitmq_mqtt to TEST_DEPS