### PR TITLE
Follow AMQP spec for durable field

### DIFF
--- a/deps/amqp10_client/src/amqp10_msg.erl
+++ b/deps/amqp10_client/src/amqp10_msg.erl
@@ -266,23 +266,24 @@ body_bin(#amqp10_msg{body = #'v1_0.amqp_value'{} = Body}) ->
 %% following stucture:
 %% {amqp10_disposition, {accepted | rejected, DeliveryTag}}
 -spec new(delivery_tag(), amqp10_body() | binary(), boolean()) -> amqp10_msg().
-new(DeliveryTag, Body, Settled) when is_binary(Body) ->
-    #amqp10_msg{transfer = #'v1_0.transfer'{delivery_tag = {binary, DeliveryTag},
-                                            settled = Settled,
-                                            message_format = {uint, ?MESSAGE_FORMAT}},
-                body = [#'v1_0.data'{content = Body}]};
+new(DeliveryTag, Bin, Settled) when is_binary(Bin) ->
+    Body = [#'v1_0.data'{content = Bin}],
+    new(DeliveryTag, Body, Settled);
 new(DeliveryTag, Body, Settled) -> % TODO: constrain to amqp types
-    #amqp10_msg{transfer = #'v1_0.transfer'{delivery_tag = {binary, DeliveryTag},
-                                            settled = Settled,
-                                            message_format = {uint, ?MESSAGE_FORMAT}},
-                body = Body}.
+    #amqp10_msg{
+       transfer = #'v1_0.transfer'{
+                     delivery_tag = {binary, DeliveryTag},
+                     settled = Settled,
+                     message_format = {uint, ?MESSAGE_FORMAT}},
+       %% This lib is safe by default.
+       header = #'v1_0.header'{durable = true},
+       body = Body}.
 
 %% @doc Create a new settled amqp10 message using the specified delivery tag
 %% and body.
 -spec new(delivery_tag(), amqp10_body() | binary()) -> amqp10_msg().
 new(DeliveryTag, Body) ->
     new(DeliveryTag, Body, false).
-
 
 % First 3 octets are the format
 % the last 1 octet is the version

--- a/release-notes/4.2.0.md
+++ b/release-notes/4.2.0.md
@@ -3,6 +3,21 @@
 RabbitMQ 4.2.0 is a new feature release.
 
 
+## Breaking Changes and Compatibility Notes
+
+### Default value for AMQP 1.0 `durable` field.
+
+Starting with RabbitMQ 4.2, if a sending client omits the header section, RabbitMQ [assumes](https://github.com/rabbitmq/rabbitmq-server/pull/13918) the `durable` field to be `false` complying with the AMQP 1.0 spec:
+```
+<field name="durable" type="boolean" default="false"/>
+```
+
+AMQP 1.0 apps or client libraries must set the `durable` field of the header section to `true` to mark the message as durable.
+
+Team RabbitMQ recommends client libraries to send messages as durable by default.
+All AMQP 1.0 client libraries [maintained by Team RabbitMQ](https://www.rabbitmq.com/client-libraries/amqp-client-libraries) send messages as durable by default.
+
+
 ## Features
 
 ### Incoming and Outgoing Message Interceptors for native protocols


### PR DESCRIPTION
The AMQP spec defines:
```
<field name="durable" type="boolean" default="false"/>
```

RabbitMQ 4.0 and 4.1 interpret the durable field as true if not set.
The idea was to favour safety over performance.
This complies with the AMQP spec because the spec allows other target or
node specific defaults for the durable field:
> If the header section is omitted the receiver MUST assume the appropriate
> default values (or the meaning implied by no value being set) for the fields
> within the header unless other target or node specific defaults have otherwise
> been set.

However, some client libraries completely omit the header section if the
app expliclity sets durable=false. This complies with the spec, but it
means that RabbitMQ cannot diffentiate between "client app forgot to set
the durable field" vs "client lib opted in for an optimisation omitting
the header section".

This is problematic with JMS message selectors where JMS apps can filter
on JMSDeliveryMode. To be able to correctly filter on JMSDeliveryMode,
RabbitMQ needs to know whether the JMS app sent the message as
PERSISTENT or NON_PERSISTENT.

Rather than relying on client libs to always send the header section
including the durable field, this commit makes RabbitMQ comply with the
default value for durable in the AMQP spec.
Some client lib maintainers accepted to send the header section, while
other maintainers refused to do so:
https://github.com/Azure/go-amqp/issues/330
https://issues.apache.org/jira/browse/QPIDJMS-608

Likely the AMQP spec was designed to omit the header section when
performance is important, as is the case with durable=false. Omitting
the header section means saving a few bytes per message on the wire and
some marshalling and unmarshalling overhead on both client and server.

Therefore, it's better to push the "safe by default" behaviour from the broker
back to the client libs. Client libs should send messages as durable by
default unless the client app expliclity opts in to send messages as
non-durable. This is also what JMS does: By default JMS apps send
messages as PERSISTENT:
> The message producer's default delivery mode is PERSISTENT.

Therefore, this commit also makes the AMQP Erlang client send messages as
durable, by default.

This commit will apply to RabbitMQ 4.2.
It's arguably not a breaking change because in RabbitMQ, message durability
is actually more determined by the queue type the message is sent to rather than the
durable field of the message:
* Quroum queues and streams store messages durably (fsync or replicate)
  no matter what the durable field is
* MQTT QoS 0 queues hold messages in memory no matter what the
  durable field is
* Classic queues do not fsync even if the durable field is set to true

In addition, the RabbitMQ AMQP Java library introduced in RabbitMQ 4.0 sends messages with
durable=true:
https://github.com/rabbitmq/rabbitmq-amqp-java-client/blob/53e3dd6abbcbce8ca4f2257da56b314786b037cc/src/main/java/com/rabbitmq/client/amqp/impl/AmqpPublisher.java#L91

Nevertheless I added a breaking change section to the 4.2 release notes to be extra clear and transparent.

The tests for selecting messages by JMSDeliveryMode relying on the
behaviour in this commit can be found on the `jms` branch. They got green after rebasing onto this branch without setting the `priority` field.