### PR TITLE
Delete single-active-consumer policy

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -544,7 +544,7 @@ filter_quorum_critical(Queues, ReplicaStates, Self) ->
 capabilities() ->
     #{unsupported_policies => [%% Classic policies
                                <<"max-priority">>, <<"queue-mode">>,
-                               <<"single-active-consumer">>, <<"ha-mode">>, <<"ha-params">>,
+                               <<"ha-mode">>, <<"ha-params">>,
                                <<"ha-sync-mode">>, <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
                                <<"queue-master-locator">>,
                                %% Stream policies

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1335,7 +1335,7 @@ capabilities() ->
                                <<"dead-letter-routing-key">>, <<"max-length">>,
                                <<"max-in-memory-length">>, <<"max-in-memory-bytes">>,
                                <<"max-priority">>, <<"overflow">>, <<"queue-mode">>,
-                               <<"single-active-consumer">>, <<"delivery-limit">>,
+                               <<"delivery-limit">>,
                                <<"ha-mode">>, <<"ha-params">>, <<"ha-sync-mode">>,
                                <<"ha-promote-on-shutdown">>, <<"ha-promote-on-failure">>,
                                <<"queue-master-locator">>,


### PR DESCRIPTION
`single-active-consumer` shouldn't be listed under `unsupported_policies` for quorum queues and streams because it isn't a valid policy in the first place, see https://www.rabbitmq.com/docs/consumers#sac-cannot-be-enabled-with-a-policy