### PR TITLE
Add CQ and QQ Observer CLI plugins from boot steps

### DIFF
--- a/deps/rabbit/src/rabbit_observer_cli.erl
+++ b/deps/rabbit/src/rabbit_observer_cli.erl
@@ -10,10 +10,8 @@
 -export([init/0, add_plugin/1]).
 
 init() ->
-    application:set_env(observer_cli, plugins, [
-        rabbit_observer_cli_classic_queues:plugin_info(),
-        rabbit_observer_cli_quorum_queues:plugin_info()
-    ]).
+    %% prepare observer_cli.plugins for add_plugin/1
+    application:set_env(observer_cli, plugins, application:get_env(observer_cli, plugins, [])).
 
 %% must be executed after observer_cli boot_step
 add_plugin(PluginInfo) ->

--- a/deps/rabbit/src/rabbit_observer_cli_classic_queues.erl
+++ b/deps/rabbit/src/rabbit_observer_cli_classic_queues.erl
@@ -7,10 +7,19 @@
 
 -module(rabbit_observer_cli_classic_queues).
 
--export([plugin_info/0]).
+-export([add_plugin/0, plugin_info/0]).
 -export([attributes/1, sheet_header/0, sheet_body/1]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
+
+-rabbit_boot_step({?MODULE,
+                   [{description, "Classic queues observer_cli plugin"},
+                    {mfa,         {?MODULE, add_plugin, []}},
+                    {requires,    [rabbit_observer_cli]},
+                    {enables,     routing_ready}]}).
+
+add_plugin() ->
+    rabbit_observer_cli:add_plugin(plugin_info()).
 
 plugin_info() ->
     #{

--- a/deps/rabbit/src/rabbit_observer_cli_quorum_queues.erl
+++ b/deps/rabbit/src/rabbit_observer_cli_quorum_queues.erl
@@ -7,10 +7,19 @@
 
 -module(rabbit_observer_cli_quorum_queues).
 
--export([plugin_info/0]).
+-export([add_plugin/0, plugin_info/0]).
 -export([attributes/1, sheet_header/0, sheet_body/1]).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
+
+-rabbit_boot_step({?MODULE,
+                   [{description, "Quorum queues observer_cli plugin"},
+                    {mfa,         {?MODULE, add_plugin, []}},
+                    {requires,    [rabbit_observer_cli]},
+                    {enables,     routing_ready}]}).
+
+add_plugin() ->
+    rabbit_observer_cli:add_plugin(plugin_info()).
 
 plugin_info() ->
     #{


### PR DESCRIPTION
Do not hard code them, also preserve user-provided plugins list
