### PR TITLE
Fix selenium issue closing popup warning dialog since recent upgrade 

### DIFF
--- a/selenium/test/pageobjects/BasePage.js
+++ b/selenium/test/pageobjects/BasePage.js
@@ -14,7 +14,7 @@ const ADMIN_TAB = By.css('div#menu ul#tabs li#admin')
 const STREAM_CONNECTIONS_TAB = By.css('div#menu ul#tabs li#stream-connections')
 
 const FORM_POPUP_WARNING = By.css('div.form-popup-warn')
-const FORM_POPUP_WARNING_CLOSE_BUTTON = By.css('div.form-popup-warn span#close')
+const FORM_POPUP_WARNING_CLOSE_BUTTON = By.css('div.form-popup-warn span')
 
 const FORM_POPUP_OPTIONS = By.css('div.form-popup-options')
 const ADD_MINUS_BUTTON = By.css('div#main table.list thead tr th.plus-minus')

--- a/selenium/test/utils.js
+++ b/selenium/test/utils.js
@@ -64,6 +64,25 @@ module.exports = {
     let chromeCapabilities = Capabilities.chrome();
     const options = new chrome.Options()
     chromeCapabilities.setAcceptInsecureCerts(true);  
+    let seleniumArgs = [
+      "--window-size=1920,1080",
+      "--enable-automation",
+      "guest",
+      "disable-infobars",
+      "--disable-notifications",
+      "--lang=en",
+      "--disable-search-engine-choice-screen",
+      "disable-popup-blocking",
+      "--credentials_enable_service=false",
+      "profile.password_manager_enabled=false",
+      "profile.reduce-security-for-testing",
+      "profile.managed_default_content_settings.popups=1",
+      "profile.managed_default_content_settings.notifications.popups=1",
+      "profile.password_manager_leak_detection=false"
+    ]
+    if (!runLocal) {
+      seleniumArgs.push("--headless=new")
+    }
     chromeCapabilities.set('goog:chromeOptions', {
       excludeSwitches: [ // disable info bar
         'enable-automation',
@@ -71,21 +90,7 @@ module.exports = {
       prefs: {
         'profile.password_manager_enabled' : false      
       },
-      args: [
-          "--enable-automation",
-          "guest",
-          "disable-infobars",
-          "--disable-notifications",
-          "--lang=en",
-          "--disable-search-engine-choice-screen",
-          "disable-popup-blocking",
-          "--credentials_enable_service=false",
-          "profile.password_manager_enabled=false",
-          "profile.reduce-security-for-testing",
-          "profile.managed_default_content_settings.popups=1",
-          "profile.managed_default_content_settings.notifications.popups=1",
-          "profile.password_manager_leak_detection=false"
-      ]
+      args: seleniumArgs
     });
     let driver = builder
       .forBrowser('chrome')


### PR DESCRIPTION
When running in interact mode, selenium is able to find the button in the popup warning dialogs. However, when running in headless mode, it cannot find it. 
