### PR TITLE
Oauth2: Support variable expansion when checking resource access

### DIFF
--- a/.github/workflows/test-authnz.yaml
+++ b/.github/workflows/test-authnz.yaml
@@ -72,7 +72,7 @@ jobs:
         docker build -t mocha-test --target test .
 
     - name: Run Suites
-      id: run-suites
+      id: tests
       run: |        
         IMAGE_TAG=$(find PACKAGES/rabbitmq-server-generic-unix-*.tar.xz | awk -F 'PACKAGES/rabbitmq-server-generic-unix-|.tar.xz' '{print $2}')
         CONF_DIR_PREFIX="$(mktemp -d)" RABBITMQ_DOCKER_IMAGE=pivotalrabbitmq/rabbitmq:$IMAGE_TAG \
@@ -83,7 +83,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4.3.2
       env: 
-          SELENIUM_ARTIFACTS: ${{ steps.run-suites.outputs.SELENIUM_ARTIFACTS }}
+          SELENIUM_ARTIFACTS: ${{ steps.tests.outputs.SELENIUM_ARTIFACTS }}
       with:
         name: test-artifacts-${{ matrix.browser }}-${{ matrix.erlang_version }}        
         path: |

--- a/.github/workflows/test-management-ui-for-pr.yaml
+++ b/.github/workflows/test-management-ui-for-pr.yaml
@@ -57,6 +57,7 @@ jobs:
         docker build -t mocha-test --target test .
 
     - name: Run short UI suites on a standalone rabbitmq server
+      id: tests
       run: |
         IMAGE_TAG=$(find PACKAGES/rabbitmq-server-generic-unix-*.tar.xz | awk -F 'PACKAGES/rabbitmq-server-generic-unix-|.tar.xz' '{print $2}')
         CONF_DIR_PREFIX="$(mktemp -d)" RABBITMQ_DOCKER_IMAGE=pivotalrabbitmq/rabbitmq:$IMAGE_TAG \
@@ -67,7 +68,7 @@ jobs:
       if: ${{ failure() && steps.tests.outcome == 'failed' }}
       uses: actions/upload-artifact@v4
       env: 
-          SELENIUM_ARTIFACTS: ${{ steps.run-suites.outputs.SELENIUM_ARTIFACTS }}
+          SELENIUM_ARTIFACTS: ${{ steps.tests.outputs.SELENIUM_ARTIFACTS }}
       with:
         name: test-artifacts-${{ matrix.browser }}-${{ matrix.erlang_version }}
         path: |

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -87,11 +87,8 @@ user_login_authorization(Username, AuthProps) ->
 check_vhost_access(#auth_user{impl = DecodedTokenFun},
                    VHost, _AuthzData) ->
     with_decoded_token(DecodedTokenFun(),
-        fun(_Token) ->
-            DecodedToken = DecodedTokenFun(),
-            Scopes = get_scope(DecodedToken),
-            ScopeString = rabbit_oauth2_scope:concat_scopes(Scopes, ","),
-            rabbit_log:debug("Matching virtual host '~ts' against the following scopes: ~ts", [VHost, ScopeString]),
+        fun(Token) ->
+            Scopes = get_expanded_scopes(Token, #resource{virtual_host = VHost}),
             rabbit_oauth2_scope:vhost_access(VHost, Scopes)
         end).
 
@@ -99,7 +96,7 @@ check_resource_access(#auth_user{impl = DecodedTokenFun},
                       Resource, Permission, _AuthzContext) ->
     with_decoded_token(DecodedTokenFun(),
         fun(Token) ->
-            Scopes = get_scope(Token),
+            Scopes = get_expanded_scopes(Token, Resource),
             rabbit_oauth2_scope:resource_access(Resource, Permission, Scopes)
         end).
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -97,7 +97,6 @@ check_resource_access(#auth_user{impl = DecodedTokenFun},
     with_decoded_token(DecodedTokenFun(),
         fun(Token) ->
             Scopes = get_expanded_scopes(Token, Resource),
-            rabbit_log:debug("Checking against scopes: ~p", [Scopes]),
             rabbit_oauth2_scope:resource_access(Resource, Permission, Scopes)
         end).
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -97,6 +97,7 @@ check_resource_access(#auth_user{impl = DecodedTokenFun},
     with_decoded_token(DecodedTokenFun(),
         fun(Token) ->
             Scopes = get_expanded_scopes(Token, Resource),
+            rabbit_log:debug("Checking against scopes: ~p", [Scopes]),
             rabbit_oauth2_scope:resource_access(Resource, Permission, Scopes)
         end).
 

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_scope.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_scope.erl
@@ -41,6 +41,7 @@ resource_access(#resource{virtual_host = VHost, name = Name},
         end,
         get_scope_permissions(Scopes)).
 
+-spec topic_access(rabbit_types:r(atom()), permission(), map(), [binary()]) -> boolean().
 topic_access(#resource{virtual_host = VHost, name = ExchangeName},
              Permission,
              #{routing_key := RoutingKey},

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_auth_backend_oauth2_test_util.erl
@@ -117,6 +117,8 @@ fixture_token() ->
 
 token_with_sub(TokenFixture, Sub) ->
     maps:put(<<"sub">>, Sub, TokenFixture).
+token_with_claim(TokenFixture, Name, Value) ->
+    maps:put(Name, Value, TokenFixture).
 token_with_scopes(TokenFixture, Scopes) ->
     maps:put(<<"scope">>, Scopes, TokenFixture).
 


### PR DESCRIPTION
## Proposed Changes

This PR adds variable expansion when checking resource access or vhost access on oauth2 authentication backend. RabbitMQ only supported variable expansion when checking topic access.

It addresses feature request https://github.com/rabbitmq/rabbitmq-server/issues/13894

Doc's PR https://github.com/rabbitmq/rabbitmq-website/pull/2278

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
