### PR TITLE
Clear management auth storage when redirecting to login

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -1316,7 +1316,8 @@ function update_status(status) {
 
 function with_req(method, path, body, fun) {
     if(!has_auth_credentials()) {
-        // navigate to the login form
+        // Clear any lingering auth settings in local storage and navigate to the login form.
+        clear_auth();
         location.reload();
         return;
     }


### PR DESCRIPTION
This branch redirects the client to the login page when the cookie expires. To complete the logout process we should also clear any auth data stored in local storage: local storage has no built-in expiration mechanism.

To test this locally you can use `make run-broker`, set the session timeout to one minute for quick testing:

```erl
application:set_env(rabbitmq_management, login_session_timeout, 1)
```

go to the management page (`http://localhost:15672/#/`), login with default credentials and wait a minute. After this change the local storage only contains info like `rabbitmq.vhost` and `rabbitmq.version`.