### PR TITLE
[skip ci] Fix plugin version warning formatting

### DIFF
--- a/deps/rabbit/src/rabbit_plugins.erl
+++ b/deps/rabbit/src/rabbit_plugins.erl
@@ -361,7 +361,7 @@ check_plugins_versions(PluginName, AllPlugins, RequiredVersions) ->
                                     rabbit_log:warning(
                                         "~tp plugin version is not defined."
                                         " Requirement ~tp for plugin ~tp is ignored",
-                                        [Versions, PluginName]);
+                                        [Name, Versions, PluginName]);
                                 _  -> ok
                             end,
                             Acc;


### PR DESCRIPTION
This doesn't fail the test, but shows up
as a end_per_testcase failure.

https://github.com/rabbitmq/rabbitmq-server/actions/runs/15322789846/job/43110071803?pr=13959