### PR TITLE
Log ranch timeout and tls errors

### DIFF
--- a/deps/rabbit/src/rabbit_networking.erl
+++ b/deps/rabbit/src/rabbit_networking.erl
@@ -33,7 +33,7 @@
          close_all_user_connections/2,
          force_connection_event_refresh/1, force_non_amqp_connection_event_refresh/1,
          handshake/2, handshake/3, tcp_host/1,
-         ranch_ref/1, ranch_ref/2, ranch_ref_of_protocol/1,
+         ranch_ref/1, ranch_ref/2, ranch_ref_of_protocol/1, ranch_ref_to_protocol/1,
          listener_of_protocol/1, stop_ranch_listener_of_protocol/1,
          list_local_connections_of_protocol/1]).
 
@@ -232,6 +232,21 @@ ranch_ref(IPAddress, Port) ->
 -spec ranch_ref_of_protocol(atom()) -> ranch:ref() | undefined.
 ranch_ref_of_protocol(Protocol) ->
     ranch_ref(listener_of_protocol(Protocol)).
+
+-spec ranch_ref_to_protocol(ranch:ref()) -> atom() | undefined.
+ranch_ref_to_protocol({acceptor, IPAddress, Port}) ->
+    MatchSpec = #listener{
+                   node = node(),
+                   ip_address = IPAddress,
+                   port = Port,
+                   _ = '_'
+                  },
+    case ets:match_object(?ETS_TABLE, MatchSpec) of
+        []    -> undefined;
+        [Row] -> Row#listener.protocol
+    end;
+ranch_ref_to_protocol(_) ->
+    undefined.
 
 -spec listener_of_protocol(atom()) -> #listener{}.
 listener_of_protocol(Protocol) ->
@@ -547,7 +562,7 @@ failed_to_recv_proxy_header(Ref, Error) ->
     end,
     rabbit_log:debug(Msg, [Error]),
     % The following call will clean up resources then exit
-    _ = ranch:handshake(Ref),
+    _ = catch ranch:handshake(Ref),
     exit({shutdown, failed_to_recv_proxy_header}).
 
 handshake(Ref, ProxyProtocolEnabled) ->
@@ -562,14 +577,34 @@ handshake(Ref, ProxyProtocolEnabled, BufferStrategy) ->
                 {error, protocol_error, Error} ->
                     failed_to_recv_proxy_header(Ref, Error);
                 {ok, ProxyInfo} ->
-                    {ok, Sock} = ranch:handshake(Ref),
+                    Sock = try_ranch_handshake(Ref),
                     ok = tune_buffer_size(Sock, BufferStrategy),
                     {ok, {rabbit_proxy_socket, Sock, ProxyInfo}}
             end;
         false ->
-            {ok, Sock} = ranch:handshake(Ref),
+            Sock = try_ranch_handshake(Ref),
             ok = tune_buffer_size(Sock, BufferStrategy),
             {ok, Sock}
+    end.
+
+try_ranch_handshake(Ref) ->
+    try ranch:handshake(Ref) of
+        {ok, Sock} ->
+            Sock
+    catch
+        %% Don't log on Reason = closed to prevent flooding the log
+        %% specially since a TCP health check, such as the default
+        %% (with cluster-operator) readinessProbe periodically opens
+        %% and closes a connection, as mentioned in
+        %% https://github.com/rabbitmq/rabbitmq-server/pull/12304
+        exit:{shutdown, {closed, _} = Reason} ->
+            exit({shutdown, Reason});
+        exit:{shutdown, {Reason, {PeerIp, PeerPort} = PeerInfo}} ->
+            PeerAddress = io_lib:format("~ts:~tp", [rabbit_misc:ntoab(PeerIp), PeerPort]),
+            Protocol = ranch_ref_to_protocol(Ref),
+            rabbit_log:error("~p error during handshake for protocol ~p and peer ~ts",
+                             [Reason, Protocol, PeerAddress]),
+            exit({shutdown, {Reason, PeerInfo}})
     end.
 
 tune_buffer_size(Sock, dynamic_buffer) ->


### PR DESCRIPTION
## Proposed Changes

This PR addresses https://github.com/rabbitmq/rabbitmq-server/issues/11171 

The proposed changes catch the exit signal emitted by `ranch:handshake` in `rabbit_networking:handshake` and log an error message in case the reason for shutting down the connection is other than `closed`. 

The reason for not logging `closed` shutdown exit exceptions has been added as a context comment in the source.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

