### PR TITLE
Federation: move ETS initialisation to supervisor

### DIFF
--- a/deps/rabbitmq_federation_common/src/rabbit_federation_common_app.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_common_app.erl
@@ -16,7 +16,6 @@
 -export([init/1]).
 
 start(_Type, _StartArgs) ->
-    ?FEDERATION_ETS = ets:new(?FEDERATION_ETS, [set, public, named_table]),
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 stop(_State) ->

--- a/deps/rabbitmq_federation_common/src/rabbit_federation_sup.erl
+++ b/deps/rabbitmq_federation_common/src/rabbit_federation_sup.erl
@@ -45,6 +45,7 @@ stop() ->
 %%----------------------------------------------------------------------------
 
 init([]) ->
+    ?FEDERATION_ETS = ets:new(?FEDERATION_ETS, [set, public, named_table]),
     Status = #{
         id       => status,
         start    => {rabbit_federation_status, start_link, []},


### PR DESCRIPTION
Events can be received after the boot step but before the application is started. Creating the ETS in the supervisor solves this, as it is started just before the event handler is installed.

To test this, just start a node with federation enabled and check the logs.

Reported by @ikavgo 

```
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0> ** gen_event handler rabbit_federation_event crashed.
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0> ** Was installed in rabbit_event
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0> ** Last event was: {event,parameter_set,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                           [{component,global},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                            {name,cluster_name},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                            {value,<<"localhost">>},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                            {user_who_performed_action,<<"rmq-internal">>}],
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                           none,1748856377295}
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0> ** When handler state == []
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0> ** Reason == {badarg,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                  [{ets,match_object,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [rabbit_federation_common,'_'],
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{error_info,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                            #{cause => id,module => erl_stdlib_errors}}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {ets,tab2list,1,[{file,"ets.erl"},{line,2263}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {rabbit_federation_parameters,adjust,1,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{file,"rabbit_federation_parameters.erl"},{line,72}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {rabbit_federation_event,handle_event,2,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{file,"rabbit_federation_event.erl"},{line,39}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {gen_event,server_update,4,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{file,"gen_event.erl"},{line,1921}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {gen_event,server_notify,4,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{file,"gen_event.erl"},{line,1903}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {gen_event,server_notify,4,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{file,"gen_event.erl"},{line,1905}]},
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                   {gen_event,handle_msg,6,
2025-06-02 11:26:17.296615+02:00 [error] <0.414.0>                       [{file,"gen_event.erl"},{line,1640}]}]}
```