### PR TITLE
PoC: Include queue's consumers to the list of basic queue data 

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
@@ -366,7 +366,7 @@ list_queue_stats(Ranges, Objs, Interval) ->
     [proplists:proplist()].
 list_core_queue_data(Ranges, Objs) ->
     Ids = [id_lookup(queue_stats, Obj) || Obj <- Objs],
-    DataLookup = get_data_from_nodes({rabbit_mgmt_data, all_list_basic_queue_data, [Ids, Ranges]}),
+    DataLookup = get_data_from_nodes({rabbit_mgmt_data, all_detail_queue_data, [Ids, Ranges]}),
     adjust_hibernated_memory_use(
       [begin
        Id = id_lookup(queue_stats, Obj),
@@ -374,9 +374,10 @@ list_core_queue_data(Ranges, Objs) ->
        QueueData = maps:get(Id, DataLookup),
        Props = maps:get(queue_stats, QueueData),
        ConsumerStats = rabbit_mgmt_data_compat:fill_consumer_active_fields(
-          maps:get(consumer_stats, QueueData)),
+                         maps:get(consumer_stats, QueueData)),
+       Consumers = [{consumer_details, ConsumerStats}],
 
-       {Pid, combine(Props, Obj) ++ ConsumerStats}
+       {Pid, combine(Props, Obj) ++ Consumers}
        end || Obj <- Objs]).
 
 -spec list_basic_queue_stats(ranges(), [proplists:proplist()], integer()) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_db.erl
@@ -147,7 +147,7 @@ augment_exchanges(Xs, Ranges, _)    ->
 -spec augment_queues([proplists:proplist()], ranges(), core | basic | detailed | full) -> any().
 augment_queues(Qs, ?NO_RANGES = Ranges, core) ->
    submit_cached(queues,
-                 fun(Interval, Queues) ->
+                 fun(_Interval, Queues) ->
                          list_core_queue_data(Ranges, Queues)
                  end, Qs, max(60000, length(Qs) * 2));
 augment_queues(Qs, ?NO_RANGES = Ranges, basic) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue.erl
@@ -48,10 +48,10 @@ to_json(ReqData, Context) ->
                             rabbit_mgmt_format:strip_pids(Q)),
                 rabbit_mgmt_util:reply(ensure_defaults(Payload), ReqData, Context);
             true ->
-                Q = case rabbit_mgmt_util:enable_queue_totals(ReqData) of
-                    false -> rabbit_mgmt_db:list_core_queue_data([queue(ReqData)],
-                        [queue(ReqData)], core);
-                    true  -> queue_with_totals(ReqData)
+                [Q] = case rabbit_mgmt_util:enable_queue_totals(ReqData) of
+                    false -> rabbit_mgmt_db:augment_queues([queue(ReqData)],
+                        rabbit_mgmt_util:range_ceil(ReqData), core);
+                    true  -> [queue_with_totals(ReqData)]
                 end,
                 rabbit_mgmt_util:reply(
                     rabbit_mgmt_format:strip_pids(Q),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue.erl
@@ -49,7 +49,8 @@ to_json(ReqData, Context) ->
                 rabbit_mgmt_util:reply(ensure_defaults(Payload), ReqData, Context);
             true ->
                 Q = case rabbit_mgmt_util:enable_queue_totals(ReqData) of
-                    false -> queue(ReqData);
+                    false -> rabbit_mgmt_db:list_core_queue_data([queue(ReqData)],
+                        [queue(ReqData)], core);
                     true  -> queue_with_totals(ReqData)
                 end,
                 rabbit_mgmt_util:reply(

--- a/selenium/suites/mgt/mgt-only-queuesAndStreams.sh
+++ b/selenium/suites/mgt/mgt-only-queuesAndStreams.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEST_CASES_PATH=/queuesAndStreams
+TEST_CONFIG_PATH=/basic-auth
+PROFILES="disable-metrics"
+
+source $SCRIPT/../../bin/suite_template $@
+run

--- a/selenium/test/basic-auth/rabbitmq.disable-metrics.conf
+++ b/selenium/test/basic-auth/rabbitmq.disable-metrics.conf
@@ -1,0 +1,3 @@
+
+management.disable_stats = true
+management_agent.disable_metrics_collector = true


### PR DESCRIPTION
## Proposed Changes

This is just a. PoC that explores if it is possible to include queue consumers to the list of basic data .. not basic stats but basic data. 
This way users can still monitor and troubleshoot issues related to consumers without having to enable stats.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

