### PR TITLE
Mqtt tests: start just required dependencies

### DIFF
--- a/deps/rabbitmq_mqtt/test/cluster_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/cluster_SUITE.erl
@@ -67,7 +67,8 @@ end_per_suite(Config) ->
 init_per_group(Group, Config) ->
     rabbit_ct_helpers:set_config(
       Config, [{rmq_nodes_count, 5},
-               {mqtt_version, Group}]).
+               {mqtt_version, Group},
+               {start_rmq_with_plugins_disabled, true}]).
 
 end_per_group(_, Config) ->
     Config.
@@ -79,11 +80,13 @@ init_per_testcase(Testcase, Config) ->
         {rmq_nodename_suffix, Testcase},
         {rmq_nodes_clustered, true}
       ]),
-    rabbit_ct_helpers:run_setup_steps(
+    Config2 = rabbit_ct_helpers:run_setup_steps(
       Config1,
       [fun merge_app_env/1] ++
       setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    Config2.
 
 end_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:run_steps(Config,

--- a/deps/rabbitmq_mqtt/test/command_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/command_SUITE.erl
@@ -42,11 +42,14 @@ init_per_suite(Config) ->
         {rmq_extra_tcp_ports, [tcp_port_mqtt_extra,
                                tcp_port_mqtt_tls_extra]},
         {rmq_nodes_clustered, true},
-        {rmq_nodes_count, 3}
+        {rmq_nodes_count, 3},
+        {start_rmq_with_plugins_disabled, true}
       ]),
-    rabbit_ct_helpers:run_setup_steps(Config1,
+    Config2 = rabbit_ct_helpers:run_setup_steps(Config1,
       rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+      rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    Config2.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,

--- a/deps/rabbitmq_mqtt/test/config_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/config_SUITE.erl
@@ -34,8 +34,11 @@ suite() ->
 %% Testsuite setup/teardown.
 %% -------------------------------------------------------------------
 
-init_per_suite(Config) ->
+init_per_suite(Config0) ->
     rabbit_ct_helpers:log_environment(),
+    Config = rabbit_ct_helpers:set_config(
+               Config0,
+               [{start_rmq_with_plugins_disabled, true}]),
     rabbit_ct_helpers:run_setup_steps(Config).
 
 end_per_suite(Config) ->

--- a/deps/rabbitmq_mqtt/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/config_schema_SUITE.erl
@@ -30,11 +30,15 @@ end_per_suite(Config) ->
 init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase),
     Config1 = rabbit_ct_helpers:set_config(Config, [
-        {rmq_nodename_suffix, Testcase}
+        {rmq_nodename_suffix, Testcase},
+        {start_rmq_with_plugins_disabled, true}
       ]),
-    rabbit_ct_helpers:run_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    Config2 = rabbit_ct_helpers:run_steps(
+                Config1,
+                rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    Config2.
 
 end_per_testcase(Testcase, Config) ->
     Config1 = rabbit_ct_helpers:run_steps(Config,

--- a/deps/rabbitmq_mqtt/test/feature_flag_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/feature_flag_SUITE.erl
@@ -27,14 +27,18 @@ init_per_suite(Config) ->
     Config1 = rabbit_ct_helpers:set_config(
                 Config,
                 [{mqtt_version, v5},
-                 {rmq_nodename_suffix, ?MODULE}]),
+                 {rmq_nodename_suffix, ?MODULE},
+                 {start_rmq_with_plugins_disabled, true}
+                ]),
     Config2 = rabbit_ct_helpers:merge_app_env(
                 Config1,
                 {rabbit, [{forced_feature_flags_on_init, []}]}),
-    rabbit_ct_helpers:run_setup_steps(
-      Config2,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    Config3 = rabbit_ct_helpers:run_setup_steps(
+                Config2,
+                rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config3, rabbitmq_mqtt),
+    Config3.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(

--- a/deps/rabbitmq_mqtt/test/federation_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/federation_SUITE.erl
@@ -22,11 +22,16 @@ init_per_suite(Config) ->
                 Config,
                 [{rmq_nodename_suffix, ?MODULE},
                  {rmq_nodes_count, 2},
-                 {rmq_nodes_clustered, false}]),
-    rabbit_ct_helpers:run_setup_steps(
-      Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+                 {rmq_nodes_clustered, false},
+                 {start_rmq_with_plugins_disabled, true}
+                ]),
+    Config2 = rabbit_ct_helpers:run_setup_steps(
+                Config1,
+                rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    util:enable_plugin(Config2, rabbitmq_federation),
+    Config2.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(

--- a/deps/rabbitmq_mqtt/test/java_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/java_SUITE.erl
@@ -59,12 +59,16 @@ init_per_group(Group, Config0) ->
                          {rmq_certspwd, "bunnychow"},
                          {rmq_nodes_clustered, true},
                          {rmq_nodes_count, 3},
-                         {mqtt_version, Group}]),
-    rabbit_ct_helpers:run_setup_steps(
-      Config,
-      [fun merge_app_env/1] ++
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+                         {mqtt_version, Group},
+                         {start_rmq_with_plugins_disabled, true}
+                        ]),
+    Config1 = rabbit_ct_helpers:run_setup_steps(
+                Config,
+                [fun merge_app_env/1] ++
+                    rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config1, rabbitmq_mqtt),
+    Config1.
 
 end_per_group(_, Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,

--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -164,7 +164,8 @@ init_per_suite(Config) ->
                 Config, {rabbit, [
                                   {quorum_tick_interval, 1000},
                                   {stream_tick_interval, 1000},
-                                  {forced_feature_flags_on_init, []}
+                                  {forced_feature_flags_on_init, []},
+                                  {start_rmq_with_plugins_disabled, true}
                                  ]}),
     rabbit_ct_helpers:run_setup_steps(Config1).
 
@@ -189,10 +190,12 @@ init_per_group(Group, Config0) ->
                Config0,
                [{rmq_nodes_count, Nodes},
                 {rmq_nodename_suffix, Suffix}]),
-    rabbit_ct_helpers:run_steps(
-      Config,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    Config1 = rabbit_ct_helpers:run_steps(
+                Config,
+                rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config1, rabbitmq_mqtt),
+    Config1.
 
 end_per_group(G, Config)
   when G =:= cluster_size_1;

--- a/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/protocol_interop_SUITE.erl
@@ -69,15 +69,16 @@ init_per_group(Group, Config0) ->
     Config1 = rabbit_ct_helpers:set_config(
                 Config0,
                 [{rmq_nodes_count, Nodes},
-                 {mqtt_version, v5}]),
+                 {mqtt_version, v5},
+                 {start_rmq_with_plugins_disabled, true}
+                ]),
     Config = rabbit_ct_helpers:run_steps(
                Config1,
                rabbit_ct_broker_helpers:setup_steps() ++
                rabbit_ct_client_helpers:setup_steps()),
-
-    Plugins = [rabbitmq_stomp,
-               rabbitmq_stream],
-    [ok = rabbit_ct_broker_helpers:enable_plugin(Config, 0, Plugin) || Plugin <- Plugins],
+    util:enable_plugin(Config, rabbitmq_mqtt),
+    util:enable_plugin(Config, rabbitmq_stomp),
+    util:enable_plugin(Config, rabbitmq_stream),
     Config.
 
 end_per_group(_Group, Config) ->

--- a/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/proxy_protocol_SUITE.erl
@@ -37,13 +37,17 @@ init_per_suite(Config) ->
     Config1 = rabbit_ct_helpers:set_config(Config, [
         {rmq_nodename_suffix, Suffix},
         {rmq_certspwd, "bunnychow"},
-        {rabbitmq_ct_tls_verify, verify_none}
+        {rabbitmq_ct_tls_verify, verify_none},
+        {start_rmq_with_plugins_disabled, true}
     ]),
     MqttConfig = mqtt_config(),
-    rabbit_ct_helpers:run_setup_steps(Config1,
-        [ fun(Conf) -> merge_app_env(MqttConfig, Conf) end ] ++
-            rabbit_ct_broker_helpers:setup_steps() ++
-            rabbit_ct_client_helpers:setup_steps()).
+    Config2 = rabbit_ct_helpers:run_setup_steps(
+                Config1,
+                [ fun(Conf) -> merge_app_env(MqttConfig, Conf) end ] ++
+                    rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    Config2.
 
 mqtt_config() ->
     {rabbitmq_mqtt, [

--- a/deps/rabbitmq_mqtt/test/reader_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/reader_SUITE.erl
@@ -62,12 +62,18 @@ merge_app_env(Config) ->
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
-    Config1 = rabbit_ct_helpers:set_config(Config, {rmq_nodename_suffix, ?MODULE}),
-    rabbit_ct_helpers:run_setup_steps(
-      Config1,
-      [fun merge_app_env/1] ++
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    Config1 = rabbit_ct_helpers:set_config(
+                Config,
+                [{rmq_nodename_suffix, ?MODULE},
+                 {start_rmq_with_plugins_disabled, true}
+                ]),
+    Config2 = rabbit_ct_helpers:run_setup_steps(
+                Config1,
+                [fun merge_app_env/1] ++
+                    rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    Config2.
 
 end_per_suite(Config) ->
     rabbit_ct_helpers:run_teardown_steps(Config,

--- a/deps/rabbitmq_mqtt/test/util.erl
+++ b/deps/rabbitmq_mqtt/test/util.erl
@@ -24,7 +24,8 @@
          assert_message_expiry_interval/2,
          await_exit/1,
          await_exit/2,
-         non_clean_sess_opts/0
+         non_clean_sess_opts/0,
+         enable_plugin/2
         ]).
 
 all_connection_pids(Config) ->
@@ -171,3 +172,8 @@ start_client(ClientId, Config, Node, AdditionalOpts) ->
               ] ++ WsOpts ++ AdditionalOpts,
     {ok, C} = emqtt:start_link(Options),
     {C, Connect}.
+
+enable_plugin(Config, Plugin) ->
+    Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    [rabbit_ct_broker_helpers:enable_plugin(Config, Node, Plugin)
+     || Node <- Nodes].

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -160,14 +160,18 @@ init_per_group(Group, Config0) ->
                 Config0,
                 [{mqtt_version, v5},
                  {rmq_nodes_count, Nodes},
-                 {rmq_nodename_suffix, Suffix}]),
+                 {rmq_nodename_suffix, Suffix},
+                 {start_rmq_with_plugins_disabled, true}
+                ]),
     Config = rabbit_ct_helpers:merge_app_env(
                Config1,
                {rabbit, [{quorum_tick_interval, 200}]}),
-    rabbit_ct_helpers:run_steps(
-      Config,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps()).
+    Config2 = rabbit_ct_helpers:run_steps(
+                Config,
+                rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps()),
+    util:enable_plugin(Config2, rabbitmq_mqtt),
+    Config2.
 
 end_per_group(G, Config)
   when G =:= cluster_size_1;
@@ -890,6 +894,7 @@ subscription_options_persisted(Config) ->
                                        {<<"t2">>, [{nl, false}, {rap, true}, {qos, 1}]}]),
     unlink(C1),
     ok = rabbit_ct_broker_helpers:restart_node(Config, 0),
+    util:enable_plugin(Config, rabbitmq_mqtt),
     C2 = connect(ClientId, Config, [{clean_start, false}]),
     ok = emqtt:publish(C2, <<"t1">>, <<"m1">>),
     ok = emqtt:publish(C2, <<"t2">>, <<"m2">>, [{retain, true}]),
@@ -1714,6 +1719,7 @@ will_delay_node_restart(Config) ->
     timer:sleep(SleepMs),
     assert_nothing_received(),
     ok = rabbit_ct_broker_helpers:start_node(Config, 0),
+    util:enable_plugin(Config, rabbitmq_mqtt),
     %% After node 0 restarts, we should receive the Will Message promptly on both nodes 0 and 1.
     receive {publish, #{client_pid := Sub1,
                         payload := Payload}} -> ok


### PR DESCRIPTION
MQTT tests depend on a few plugins, which are just used in 1 or 2 suites each. These have caused issues in CI, triggering a bug in rabbitmq_federation where the mirrored supervisor submits a transaction while the cluster is being shut down. The transaction hangs and the whole rabbitmq_mqtt job times out.

This bug has been addressed, however it is best to start just the required plugins on each SUITE.

