### PR TITLE
Run Quorum Queue property test on different OTP versions

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -87,6 +87,18 @@ jobs:
         sudo systemctl is-active --quiet apparmor.service && sudo systemctl stop apparmor.service
         sudo systemctl disable apparmor.service
 
+    - name: RUN LOW VERSION ERLANG NODE IN DOCKER
+      if: inputs.make_target == 'ct-rabbit_fifo_prop'
+      run: |
+        # This version must be at least 1 major version lower than inputs.erlang_version
+        LOW_ERLANG_VERSION="26.2"
+
+        # Create ~/.erlang.cookie by starting a distributed node
+        erl -sname temp_node -eval 'halt().' -noshell
+
+        docker run -d --network host --name erlang_low_version erlang:${LOW_ERLANG_VERSION} \
+          erl -sname rabbit_fifo_prop@localhost -setcookie $(cat ~/.erlang.cookie) -noinput
+
     - name: RUN TESTS
       if: inputs.plugin != 'rabbitmq_cli'
       run: |

--- a/.github/workflows/test-make-tests.yaml
+++ b/.github/workflows/test-make-tests.yaml
@@ -32,6 +32,7 @@ jobs:
           - ct-metadata_store_clustering
           - ct-quorum_queue
           - ct-rabbit_stream_queue
+          - ct-rabbit_fifo_prop
     uses: ./.github/workflows/test-make-target.yaml
     with:
       erlang_version: ${{ inputs.erlang_version }}

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -267,7 +267,7 @@ PARALLEL_CT_SET_2_B = clustering_recovery crashing_queues deprecated_features di
 PARALLEL_CT_SET_2_C = disk_monitor dynamic_qq unit_disk_monitor unit_file_handle_cache unit_log_management unit_operator_policy
 PARALLEL_CT_SET_2_D = queue_length_limits queue_parallel quorum_queue_member_reconciliation rabbit_fifo rabbit_fifo_dlx rabbit_stream_coordinator
 
-PARALLEL_CT_SET_3_A = definition_import per_user_connection_channel_limit_partitions per_vhost_connection_limit_partitions policy priority_queue_recovery rabbit_fifo_prop rabbit_fifo_v0 rabbit_stream_sac_coordinator unit_credit_flow unit_queue_consumers unit_queue_location unit_quorum_queue
+PARALLEL_CT_SET_3_A = definition_import per_user_connection_channel_limit_partitions per_vhost_connection_limit_partitions policy priority_queue_recovery rabbit_fifo_v0 rabbit_stream_sac_coordinator unit_credit_flow unit_queue_consumers unit_queue_location unit_quorum_queue
 PARALLEL_CT_SET_3_B = cluster_upgrade list_consumers_sanity_check list_queues_online_and_offline logging lqueue maintenance_mode rabbit_fifo_q
 PARALLEL_CT_SET_3_C = cli_forget_cluster_node feature_flags_v2 mc_unit message_containers_deaths_v2 message_size_limit metadata_store_migration
 PARALLEL_CT_SET_3_D = metadata_store_phase1 metrics mirrored_supervisor peer_discovery_classic_config proxy_protocol runtime_parameters unit_stats_and_metrics unit_supervisor2 unit_vm_memory_monitor
@@ -282,7 +282,7 @@ PARALLEL_CT_SET_2 = $(sort $(PARALLEL_CT_SET_2_A) $(PARALLEL_CT_SET_2_B) $(PARAL
 PARALLEL_CT_SET_3 = $(sort $(PARALLEL_CT_SET_3_A) $(PARALLEL_CT_SET_3_B) $(PARALLEL_CT_SET_3_C) $(PARALLEL_CT_SET_3_D))
 PARALLEL_CT_SET_4 = $(sort $(PARALLEL_CT_SET_4_A) $(PARALLEL_CT_SET_4_B) $(PARALLEL_CT_SET_4_C) $(PARALLEL_CT_SET_4_D))
 
-SEQUENTIAL_CT_SUITES = amqp_client clustering_management dead_lettering feature_flags metadata_store_clustering quorum_queue rabbit_stream_queue
+SEQUENTIAL_CT_SUITES = amqp_client clustering_management dead_lettering feature_flags metadata_store_clustering quorum_queue rabbit_stream_queue rabbit_fifo_prop
 PARALLEL_CT_SUITES = $(PARALLEL_CT_SET_1) $(PARALLEL_CT_SET_2) $(PARALLEL_CT_SET_3) $(PARALLEL_CT_SET_4)
 
 ifeq ($(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES)),)

--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -56,7 +56,9 @@
     await_condition_with_retries/2,
 
     eventually/1, eventually/3,
-    consistently/1, consistently/3
+    consistently/1, consistently/3,
+    
+    is_ci/0
   ]).
 
 -define(SSL_CERT_PASSWORD, "test").
@@ -1174,6 +1176,12 @@ consistently({Line, Assertion} = TestObj, PollInterval, PollCount)
     Assertion(),
     timer:sleep(PollInterval),
     consistently(TestObj, PollInterval, PollCount - 1).
+
+is_ci() ->
+    case os:getenv("CI") of
+        "true" -> true;
+        _ -> false
+    end.
 
 %% -------------------------------------------------------------------
 %% Cover-related functions.


### PR DESCRIPTION
 ## What?

PR #13971 added a property test that applies the same quorum queue Raft
commands on different quorum queue members on different Erlang nodes
ensuring that the state machine ends up in exaclty the same state.
The different Erlang nodes run the **same** Erlang/OTP version however.

This commit adds another property test where the different Erlang nodes
run **different** Erlang/OTP versions.

 ## Why?

This test allows spotting any non-determinism that could occur when
running quorum queue members in a mixed version cluster, where mixed
version means in our context different Erlang/OTP versions.

 ## How?

CI runs currently tests with Erlang 27.

This commit starts an Erlang 26 node in docker, specifically for the
`rabbit_fifo_prop_SUITE`.

Test case `two_nodes_different_otp_version` running Erlang 27 then transfers
a few Erlang modules (e.g. module `rabbit_fifo`) to the Erlang 26 node.
The test case then runs the Ra commands on its own node in Erlang 27 and
on the Erlang 26 node in Docker.

By default, this test case is skipped locally to avoid any local dependency on
Docker and to avoid assuming specific OTP versions being installed on the local host.
However, to run this test case locally, simply start a lower versioned Erlang node as
follows:
```
erl -sname rabbit_fifo_prop@localhost
```
