### PR TITLE
Avoid unnecessary list allocation

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -999,7 +999,7 @@ message_properties(Message, Confirm, #q{ttl = TTL}) ->
 
 calculate_msg_expiry(Msg, TTL) ->
     MsgTTL = mc:ttl(Msg),
-    case lists:min([TTL, MsgTTL]) of
+    case min(TTL, MsgTTL) of
         undefined -> undefined;
         T ->
             os:system_time(microsecond) + T * 1000


### PR DESCRIPTION
Avoid unnecessary list allocation for every message being sent to a classic queue.