### PR TITLE
Avoid using the size/1 BIF

### DIFF
--- a/deps/amqp10_client/src/amqp10_client_frame_reader.erl
+++ b/deps/amqp10_client/src/amqp10_client_frame_reader.erl
@@ -253,7 +253,7 @@ handle_input(expecting_frame_body, Data,
             handle_input(expecting_frame_header, Rest, State);
         {<<Body:BodyLength/binary, Rest/binary>>, _} ->
             State1 = State#state{frame_state = undefined},
-            BytesBody = size(Body),
+            BytesBody = byte_size(Body),
             {DescribedPerformative, BytesParsed} = amqp10_binary_parser:parse(Body),
             Performative = amqp10_framing:decode(DescribedPerformative),
             Payload = if BytesParsed < BytesBody ->

--- a/deps/amqp10_client/src/amqp10_client_session.erl
+++ b/deps/amqp10_client/src/amqp10_client_session.erl
@@ -1180,7 +1180,7 @@ decode_as_msg(Transfer, Payload, undefined) ->
     Sections = amqp10_framing:decode_bin(Payload),
     {ok, amqp10_msg:from_amqp_records([Transfer | Sections])};
 decode_as_msg(Transfer, Payload, FooterOpt) ->
-    PosSections = decode_sections([], Payload, size(Payload), 0),
+    PosSections = decode_sections([], Payload, byte_size(Payload), 0),
     Sections = lists:map(fun({_Pos, S}) -> S end, PosSections),
     Msg = amqp10_msg:from_amqp_records([Transfer | Sections]),
     OkMsg = {ok, Msg},

--- a/deps/amqp10_common/src/amqp10_binary_generator.erl
+++ b/deps/amqp10_common/src/amqp10_binary_generator.erl
@@ -120,10 +120,12 @@ generate1({char,V}) when V>=0 andalso V=<16#10ffff -> <<16#73,V:32>>;
 generate1({timestamp,V})                           -> <<16#83,V:64/signed>>;
 generate1({uuid,     V})                           -> <<16#98,V:16/binary>>;
 
-generate1({utf8, V}) when size(V) =< ?VAR_1_LIMIT   -> [16#a1, size(V), V];
-generate1({utf8, V})                                -> [<<16#b1, (size(V)):32>>, V];
-generate1({symbol, V}) when size(V) =< ?VAR_1_LIMIT -> [16#a3, size(V), V];
-generate1({symbol, V})                              -> [<<16#b3, (size(V)):32>>, V];
+generate1({utf8, V})
+  when byte_size(V) =< ?VAR_1_LIMIT                -> [16#a1, byte_size(V), V];
+generate1({utf8, V})                               -> [<<16#b1, (byte_size(V)):32>>, V];
+generate1({symbol, V})
+  when byte_size(V) =< ?VAR_1_LIMIT                -> [16#a3, byte_size(V), V];
+generate1({symbol, V})                             -> [<<16#b3, (byte_size(V)):32>>, V];
 generate1({binary, V}) ->
     Size = iolist_size(V),
     case Size =< ?VAR_1_LIMIT  of

--- a/deps/rabbit/src/rabbit_amqp_filtex.erl
+++ b/deps/rabbit/src/rabbit_amqp_filtex.erl
@@ -88,7 +88,7 @@ match_simple_type({suffix, SuffixSize, Suffix}, Val) ->
     case is_binary(Val) of
         true ->
             case Val of
-                <<_:(size(Val) - SuffixSize)/binary, Suffix:SuffixSize/binary>> ->
+                <<_:(byte_size(Val) - SuffixSize)/binary, Suffix:SuffixSize/binary>> ->
                     true;
                 _ ->
                     false
@@ -187,9 +187,9 @@ validate_app_props(_, _) ->
 
 %% [filtex-v1.0-wd09 4.1.1]
 parse_string_modifier_prefix(<<"&s:", Suffix/binary>>) ->
-    {suffix, size(Suffix), Suffix};
+    {suffix, byte_size(Suffix), Suffix};
 parse_string_modifier_prefix(<<"&p:", Prefix/binary>>) ->
-    {prefix, size(Prefix), Prefix};
+    {prefix, byte_size(Prefix), Prefix};
 parse_string_modifier_prefix(<<"&&", _/binary>> = String) ->
     %% "Escape prefix for case-sensitive matching of a string starting with ‘&’"
     string:slice(String, 1);

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -113,7 +113,7 @@ mainloop(Deb, State = #v1{sock = Sock, buf = Buf, buf_len = BufLen}) ->
         {data, Data} ->
             State1 = maybe_resize_buffer(State, Data),
             recvloop(Deb, State1#v1{buf = [Data | Buf],
-                                    buf_len = BufLen + size(Data),
+                                    buf_len = BufLen + byte_size(Data),
                                     pending_recv = false});
         closed when State#v1.connection_state =:= closed ->
             ok;
@@ -403,7 +403,7 @@ handle_frame0(Mode, Channel, Body, State) ->
 
 %% "The frame body is defined as a performative followed by an opaque payload." [2.3.2]
 parse_frame_body(Body, _Channel) ->
-    BytesBody = size(Body),
+    BytesBody = byte_size(Body),
     {DescribedPerformative, BytesParsed} = amqp10_binary_parser:parse(Body),
     Performative = amqp10_framing:decode(DescribedPerformative),
     if BytesParsed < BytesBody ->

--- a/deps/rabbit/src/rabbit_queue_index.erl
+++ b/deps/rabbit/src/rabbit_queue_index.erl
@@ -418,7 +418,7 @@ publish(MsgOrId, SeqId, _Location, MsgProps, IsPersistent, JournalSizeHint, Stat
                                false -> ?PUB_TRANS_JPREFIX
                            end):?JPREFIX_BITS,
                           SeqId:?SEQ_BITS, Bin/binary,
-                          (size(MsgBin)):?EMBEDDED_SIZE_BITS>>, MsgBin]),
+                          (byte_size(MsgBin)):?EMBEDDED_SIZE_BITS>>, MsgBin]),
     maybe_flush_journal(
       JournalSizeHint,
       add_to_journal(SeqId, {IsPersistent, Bin, MsgBin}, State1)).
@@ -434,7 +434,7 @@ maybe_needs_confirming(MsgProps, MsgOrId,
                 Msg ->
                     mc:get_annotation(id, Msg)
             end,
-    ?MSG_ID_BYTES = size(MsgId),
+    ?MSG_ID_BYTES = byte_size(MsgId),
     case {MsgProps#message_properties.needs_confirming, MsgOrId} of
       {true,  MsgId} -> UC1  = sets:add_element(MsgId, UC),
                         State#qistate{unconfirmed     = UC1};


### PR DESCRIPTION
Avoid using the size/1 BIF for performance critical code because according to
https://whatsapp.github.io/erlang-language-platform/docs/erlang-error-index/w/W0050/ 
> The BIF is not optimized by the JIT