### PR TITLE
Fix `export` module attribute

### DIFF
--- a/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_address.erl
+++ b/deps/rabbitmq_amqp_client/src/rabbitmq_amqp_address.erl
@@ -6,9 +6,9 @@
 
 -module(rabbitmq_amqp_address).
 
--export[exchange/1,
-        exchange/2,
-        queue/1].
+-export([exchange/1,
+         exchange/2,
+         queue/1]).
 
 -spec exchange(unicode:unicode_binary()) ->
     unicode:unicode_binary().


### PR DESCRIPTION
The correct format is:
```erl
-export(Functions).
```

ELP detected this malformed syntax.

Interestingly, prior to this commit, the functions were still exported:
```
rabbitmq_amqp_address:module_info(exports).
[{exchange,1},
 {exchange,2},
 {queue,1},
 {module_info,0},
 {module_info,1}]
```