### PR TITLE
ci: update project version in nightly OCI

### DIFF
--- a/.github/workflows/oci-make-nightly.yaml
+++ b/.github/workflows/oci-make-nightly.yaml
@@ -22,6 +22,9 @@ jobs:
           - main
           - v4.1.x
           - v4.0.x
+        include:
+          - branch: main
+            project_version: 4.2.0
 
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +32,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
+          fetch-tags: true
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Determine closes tag
+        id: tag
+        if: matrix.branch != 'main'
+        shell: bash
+        run: |
+          t=$(git describe --tags --abbrev=0 ${{ matrix.branch }})
+          printf "project_version=%s\n" "${t:1}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Configure Erlang
         uses: erlef/setup-beam@v1
@@ -39,7 +53,7 @@ jobs:
       - name: make package-generic-unix
         id: make
         run: |
-          make package-generic-unix PROJECT_VERSION=${{ matrix.branch }}+${{ github.sha }}
+          make package-generic-unix PROJECT_VERSION=${{ matrix.project_version || steps.tag.outputs.project_version }}+${{ github.sha }}
 
       - name: Upload package-generic-unix
         uses: actions/upload-artifact@v4
@@ -87,7 +101,7 @@ jobs:
             suffix=-otp${{ matrix.otp_version }}
           tags: |
             type=sha,format=long
-            type=schedule,pattern=nightly.{{date 'YYYYMMDD'}},prefix=${{ matrix.branch }}+
+            type=schedule,pattern=nightly.{{date 'YYYYMMDD'}},prefix=${{ matrix.branch }}-
             type=raw,value=${{ matrix.branch }}
 
       - name: Set up QEMU


### PR DESCRIPTION

## Proposed Changes

The leading `v` in `PROJECT_VERSION` is breaking some tests that
parse the version returned by the broker.

Prior to #13890, the "nightly" OCI was built on every commit, and other workflows/tests
relied on those images. The OCI (Make) workflow sets the `PROJECT_VERSION` to a hardcoded
value + a commit SHA. This PR mimics that behaviour for RabbitMQ project version.

There is one improvement: the semver part of the project version now follows the closest
(i.e. latest) tag on their respective branch. For example, OCIs from branch v4.0.x will follow
the tags for 4.0 releases e.g. 4.0.9, and use the tag as the semver component in the project version,
resulting in RabbitMQ reporting its version as `{tag}+{git-commit-sha}`. `main` is hard-coded to
4.2.0, instead of following a tag.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

