### PR TITLE
WIP: Add per-queue-type disk limits

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1242,6 +1242,26 @@ fun(Conf) ->
 end}.
 
 %%
+%% Per-queue-type disk limits
+%% =====================
+%%
+
+%% TODO: do relative limits make sense - what would they be relative to? The
+%% full disk size?
+%% {mapping, "quorum_queue_disk_limit.relative", "rabbit.quorum_queue_disk_limit", [
+%%     {datatype, float}]}.
+
+{mapping, "quorum_queue_disk_limit.absolute", "rabbit.quorum_queue_disk_limit", [
+    {datatype, [integer, string]},
+    {validators, ["is_supported_information_unit"]}
+]}.
+
+{mapping, "stream_queue_disk_limit.absolute", "rabbit.stream_queue_disk_limit", [
+    {datatype, [integer, string]},
+    {validators, ["is_supported_information_unit"]}
+]}.
+
+%%
 %% Clustering
 %% =====================
 %%

--- a/deps/rabbit/src/rabbit_disk_usage.erl
+++ b/deps/rabbit/src/rabbit_disk_usage.erl
@@ -1,0 +1,76 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_disk_usage).
+
+%% Functions for calculating disk usage of a given directory.
+
+-include_lib("kernel/include/file.hrl").
+
+-export([scan/1]).
+
+%% @doc Calculates the disk usage in bytes of the given directory.
+%%
+%% On especially large directories this can be an expensive operation since
+%% each sub-directory is scanned recursively and each file's metadata must be
+%% read.
+-spec scan(Dir) -> {ok, Size} | {error, Error} when
+    Dir :: filename:filename_all(),
+    Size :: non_neg_integer(),
+    Error :: not_directory | file:posix() | badarg.
+scan(Dir) ->
+    case file:read_file_info(Dir) of
+        {ok, #file_info{type = directory, size = S}} ->
+            {ok, Gatherer} = gatherer:start_link(),
+            scan_directory(Dir, Gatherer),
+            Size = sum(Gatherer, S),
+            gatherer:stop(Gatherer),
+            {ok, Size};
+        {ok, #file_info{}} ->
+            {error, not_directory};
+        {error, _} = Err ->
+            Err
+    end.
+
+scan_directory(Dir, Gatherer) ->
+    gatherer:fork(Gatherer),
+    worker_pool:submit_async(fun() -> scan_directory0(Dir, Gatherer) end).
+
+scan_directory0(Dir, Gatherer) ->
+    link(Gatherer),
+    Size = case file:list_dir_all(Dir) of
+               {ok, Entries} ->
+                   lists:foldl(
+                     fun(Entry, Acc) ->
+                             Path = filename:join(Dir, Entry),
+                             case file:read_file_info(Path) of
+                                 {ok, #file_info{type = directory,
+                                                 size = S}} ->
+                                     scan_directory(Path, Gatherer),
+                                     Acc + S;
+                                 {ok, #file_info{size = S}} ->
+                                     Acc + S;
+                                 _ ->
+                                     Acc
+                             end
+                     end, 0, Entries);
+               _ ->
+                   0
+           end,
+    gatherer:in(Gatherer, Size),
+    gatherer:finish(Gatherer),
+    unlink(Gatherer),
+    ok.
+
+-spec sum(pid(), non_neg_integer()) -> non_neg_integer().
+sum(Gatherer, Size) ->
+    case gatherer:out(Gatherer) of
+        empty ->
+            Size;
+        {value, S} ->
+            sum(Gatherer, Size + S)
+    end.

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -304,6 +304,16 @@
 
 -callback queue_vm_ets() -> {StatsKeys :: [atom()], ETSNames:: [[atom()]]}.
 
+%% The disk usage limit for the queue type, if any.
+-callback disk_limit() -> rabbit_queue_type_disk_monitor:disk_usage_limit_spec() | undefined.
+%% Calculate the disk space in bytes of the queue type.
+%% This callback is optional but must be implemented if `disk_limit/0' is
+%% defined.
+-callback disk_footprint() -> {ok, Bytes :: non_neg_integer()} | {error, file:posix()}.
+
+-optional_callbacks([disk_footprint/0,
+                     disk_limit/0]).
+
 -spec discover(binary() | atom()) -> queue_type().
 discover(<<"undefined">>) ->
     fallback();

--- a/deps/rabbit/src/rabbit_queue_type_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_queue_type_disk_monitor.erl
@@ -1,0 +1,159 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_queue_type_disk_monitor).
+
+%% A server for alarming on high disk usage per queue type.
+%%
+%% The server scans periodically and checks each queue type against its limit
+%% using the `disk_footprint/0' and `disk_limit/0' callbacks in
+%% `rabbit_queue_type'. Typically this callback uses `rabbit_disk_usage:scan/1'.
+%%
+%% Also see `rabbit_disk_monitoring' which periodically checks the total space
+%% taken on the mounted disk containing `rabbit:data_dir/0'.
+
+-include_lib("kernel/include/logger.hrl").
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(limit, {queue_type :: queue_type(),
+                type_module :: module(),
+                limit :: Bytes :: non_neg_integer()}).
+
+-record(state, {limits :: [#limit{}],
+                alarmed = alarmed() :: alarmed(),
+                timer :: timer:tref() | undefined}).
+
+-type queue_type() :: atom().
+-type alarmed() :: sets:set(queue_type()).
+
+-type disk_usage_limit_spec() :: %% A total number of bytes
+                                 {absolute, non_neg_integer()} |
+                                 %% %% A fraction of the disk's capacity.
+                                 %% {relative, float()} |
+                                 %% A string which will be parsed and
+                                 %% interpreted as an absolute limit.
+                                 string().
+
+%%----------------------------------------------------------------------------
+
+start_link() ->
+	gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    Limits = lists:foldl(
+               fun({Type, TypeModule}, Acc) ->
+                       case get_limit(Type, TypeModule) of
+                           {ok, Limit} ->
+                               [#limit{queue_type = Type,
+                                       type_module = TypeModule,
+                                       limit = Limit} | Acc];
+                           error ->
+                               Acc
+                       end
+               end, [], rabbit_registry:lookup_all(queue)),
+    Timer = erlang:send_after(5_000, self(), scan),
+    {ok, #state{limits = Limits, timer = Timer}}.
+
+handle_call(_Request, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(scan, #state{alarmed = Alarmed0} = State) ->
+    Alarmed = lists:foldl(fun scan/2, alarmed(), State#state.limits),
+    ok = handle_alarmed(Alarmed0, Alarmed),
+    Timer = erlang:send_after(5_000, self(), scan),
+    {noreply, State#state{alarmed = Alarmed, timer = Timer}};
+handle_info(Info, State) ->
+    ?LOG_DEBUG("~tp unhandled msg: ~tp", [?MODULE, Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%----------------------------------------------------------------------------
+
+alarmed() -> sets:new([{version, 2}]).
+
+-spec get_limit(atom(), module()) -> {ok, disk_usage_limit_spec()} | error.
+get_limit(QType, QTypeModule) ->
+    try QTypeModule:disk_limit() of
+        undefined ->
+            error;
+        {absolute, Abs} when is_integer(Abs) andalso Abs >= 0 ->
+            {ok, Abs};
+        %% {relative, Rel} when is_float(Rel) andalso Rel >= 0.0 ->
+        %%     TODO: to convert to abs we need to cache the disk capacity for
+        %%     the first `relative' spec we see.
+        %%     Do we even need relative? Should it be proportional to the disk
+        %%     capacity or to the other components?
+        %%     {ok, {relative, Rel}};
+        String when is_list(String) ->
+            case rabbit_resource_monitor_misc:parse_information_unit(String) of
+                {ok, Bytes} ->
+                    {ok, Bytes};
+                {error, parse_error} ->
+                    ?LOG_WARNING("Unable to parse disk limit ~tp for queue "
+                                 "type '~ts'", [String, QType]),
+                    error
+            end
+    catch
+        error:undef ->
+            error
+    end.
+
+-spec scan(Limit :: #limit{}, alarmed()) -> alarmed().
+scan(#limit{queue_type = QType,
+            type_module = QTypeModule,
+            limit = Limit}, Alarmed) ->
+    %% NOTE: `disk_footprint/0' is an optional callback but it should always
+    %% be implemented if the queue type implements `disk_limit/0'.
+    case QTypeModule:disk_footprint() of
+        {ok, Bytes} ->
+            %% TODO: remove this printf debugging...
+            ?LOG_INFO("Measured queue type '~ts' at ~p bytes (limit ~p)", [QType, Bytes, Limit]),
+            case Bytes >= Limit of
+                true -> sets:add_element(QTypeModule, Alarmed);
+                false -> Alarmed
+            end;
+        {error, enoent} ->
+            Alarmed;
+        {error, Error} ->
+            ?LOG_WARNING("Failed to calculate disk usage of queue type '~ts': "
+                         "~tp", [QType, Error]),
+            Alarmed
+    end.
+
+-spec handle_alarmed(Before :: alarmed(), After :: alarmed()) -> ok.
+handle_alarmed(NoChange, NoChange) ->
+    ok;
+handle_alarmed(Before, After) ->
+    Added = sets:subtract(After, Before),
+    ?LOG_WARNING("Newly alarmed: ~p", [Added]),
+    ok = sets:fold(
+           fun(QType, ok) ->
+                   rabbit_alarm:set_alarm({alarm(QType), []})
+           end, ok, Added),
+    Removed = sets:subtract(Before, After),
+    ?LOG_WARNING("Stopped alarming: ~p", [Removed]),
+    ok = sets:fold(
+           fun(QType, ok) ->
+                   rabbit_alarm:clear_alarm(alarm(QType))
+           end, ok, Removed),
+    ok.
+
+alarm(QType) ->
+    {resource_limit, {queue_type_disk, QType}, node()}.

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -67,6 +67,8 @@
 -export([notify_decorators/1,
          notify_decorators/3,
          spawn_notify_decorators/3]).
+-export([disk_footprint/0,
+         disk_limit/0]).
 
 -export([is_enabled/0,
          is_compatible/3,
@@ -2065,6 +2067,19 @@ notify_decorators(QName, F, A) ->
     end.
 
 is_stateful() -> true.
+
+-spec disk_footprint() -> {ok, Bytes :: non_neg_integer()} | {error, file:posix()}.
+disk_footprint() ->
+    case ra_system:fetch(?RA_SYSTEM) of
+        #{data_dir := Dir} ->
+            rabbit_disk_usage:scan(Dir);
+        _ ->
+            {ok, 0}
+    end.
+
+-spec disk_limit() -> rabbit_queue_type_disk_monitor:disk_usage_limit_spec() | undefined.
+disk_limit() ->
+    application:get_env(rabbit, quorum_queue_disk_limit, undefined).
 
 force_shrink_member_to_current_member(VHost, Name) ->
     Node = node(),

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -40,7 +40,9 @@
          format/2,
          capabilities/0,
          notify_decorators/1,
-         is_stateful/0]).
+         is_stateful/0,
+         disk_footprint/0,
+         disk_limit/0]).
 
 -export([list_with_minimum_quorum/0]).
 
@@ -1356,6 +1358,19 @@ capabilities() ->
 notify_decorators(Q) when ?is_amqqueue(Q) ->
     %% Not supported
     ok.
+
+-spec disk_footprint() -> {ok, Bytes :: non_neg_integer()} | {error, file:posix()}.
+disk_footprint() ->
+    case application:get_env(osiris, data_dir) of
+        {ok, Dir} ->
+            rabbit_disk_usage:scan(Dir);
+        _ ->
+            {ok, 0}
+    end.
+
+-spec disk_limit() -> rabbit_queue_type_disk_monitor:disk_usage_limit_spec() | undefined.
+disk_limit() ->
+    application:get_env(rabbit, stream_queue_disk_limit, undefined).
 
 resend_all(#stream_client{leader = LeaderPid,
                           writer_id = WriterId,

--- a/example.conf
+++ b/example.conf
@@ -1,0 +1,2 @@
+quorum_queue_disk_limit.absolute = 2GiB
+stream_queue_disk_limit.absolute = 10GiB


### PR DESCRIPTION
This is an extension of the idea of the free disk space alarm. That option enables blocking publishers when the free disk space on the data dir's disk falls below some threshold. This feature blocks publishers of individual queue types when the disk space taken by the queue type exceeds the configured threshold.

This change is incomplete: it only affects QQs and streams and AMQP 0-9-1 so far. I thought I'd open this as a draft early though to hear if anyone has thoughts on this as a feature.

<details><summary>How to demo the changes...</summary>

1. `make run-broker RABBITMQ_CONFIG_FILE=example.conf`
2. In that shell start the monitor `rabbit_queue_type_disk_monitor:start_link()` (should become part of a sup tree eventually)
3. Start a QQ producer/consumer `perf-test -qq -u qq -x 1 -y 1 --rate 5 --confirm 5`
4. Start a stream producer/consumer `perf-test -sq -u sq -x 1 -y 1 --rate 5 --confirm 5`
5. Go to the QQ data dir: `cd /tmp/rabbitmq-test-instances/<node>/mnesia/<node>/quorum/<node>/`
6. Create a big file larger than the QQ disk limit: `dd if=/dev/zero of=ballast.bin bs=1G count=3`
7. Wait a few seconds and notice that the QQ perf-test command has stopped but not the stream one.
8. `rm ballast.bin` and the QQ perf-test command should continue

---

</details>