### PR TITLE
Avoid list allocation

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -2806,7 +2806,7 @@ smallest_raft_index(#?STATE{messages = Messages,
     SmallestDlxRaIdx = rabbit_fifo_dlx:smallest_raft_index(DlxState),
     SmallestMsgsRaIdx = rabbit_fifo_q:get_lowest_index(Messages),
     SmallestRaIdx = rabbit_fifo_index:smallest(Indexes),
-    lists:min([SmallestDlxRaIdx, SmallestMsgsRaIdx, SmallestRaIdx]).
+    min(min(SmallestDlxRaIdx, SmallestMsgsRaIdx), SmallestRaIdx).
 
 make_requeue(ConsumerKey, Notify, [{MsgId, Idx, Header, Msg}], Acc) ->
     lists:reverse([{append,


### PR DESCRIPTION
This is similar to https://github.com/rabbitmq/rabbitmq-server/pull/14056. The performance benefit is probably negligbile though since this is called only after each batch of Ra commands.
Nevertheless, it's unnecessary to allocate a list with 3 elements and therefore 6 words on the heap, so let's optimise it.