### PR TITLE
Federation: update makefile to avoid dialyzer compilation errors

### DIFF
--- a/deps/rabbitmq_federation/Makefile
+++ b/deps/rabbitmq_federation/Makefile
@@ -4,6 +4,7 @@ PROJECT_DESCRIPTION = Deprecated no-op RabbitMQ Federation
 DEPS = rabbitmq_queue_federation rabbitmq_exchange_federation
 LOCAL_DEPS = rabbit
 
+DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk
 
 .DEFAULT_GOAL = all


### PR DESCRIPTION
They just happen with a combination of OTP 27.3 and Elixir 1.17

