### PR TITLE
Miscellaneous minor improvements in stream SAC coordinator

### DIFF
--- a/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_sac_coordinator_SUITE.erl
@@ -562,10 +562,15 @@ import_state_v4_test(_) ->
     OldState5 = apply_ensure_monitors(OldMod, Cmd4, OldState4),
     Cmd5 = register_consumer_command(P, 1, App1, Pid2, 2),
     OldState6 = apply_ensure_monitors(OldMod, Cmd5, OldState5),
-    Cmd6 = activate_consumer_command(P, App1),
+    %% a duplicate consumer sneaks in
+    %% this should not happen in real life, but it tests the dedup
+    %% logic in the import function
+    Cmd6 = register_consumer_command(P, 1, App1, Pid0, 0),
     OldState7 = apply_ensure_monitors(OldMod, Cmd6, OldState6),
+    Cmd7 = activate_consumer_command(P, App1),
+    OldState8 = apply_ensure_monitors(OldMod, Cmd7, OldState7),
 
-    Export = OldMod:state_to_map(OldState7),
+    Export = OldMod:state_to_map(OldState8),
     #?STATE{groups = Groups, pids_groups = PidsGroups} = ?MOD:import_state(4, Export),
     assertHasGroup({<<"/">>, S, App0},
                    grp(-1, [csr(Pid0, 0, active),


### PR DESCRIPTION
This commit handles edge cases in the stream SAC coordinator to make sure it does not crash during execution. Most of these edge cases consist in an inconsistent state, so there are very unlikely to happen.

This commit also makes sure there is no duplicate in the consumer list of a group. Consumers are also now identified only by their connection PID and their subscription ID, as now the timestamp they contain in their state does not allow a field-by-field comparison.