### PR TITLE
Bump ActiveMQ to v6.1.7

### DIFF
--- a/deps/amqp10_client/Makefile
+++ b/deps/amqp10_client/Makefile
@@ -51,7 +51,7 @@ HEX_TARBALL_FILES += ../../rabbitmq-components.mk \
 # ActiveMQ for the testsuite.
 # --------------------------------------------------------------------
 
-ACTIVEMQ_VERSION := 5.18.3
+ACTIVEMQ_VERSION := 6.1.7
 ACTIVEMQ_URL := 'https://archive.apache.org/dist/activemq/$(ACTIVEMQ_VERSION)/apache-activemq-$(ACTIVEMQ_VERSION)-bin.tar.gz'
 
 ACTIVEMQ := $(abspath test/system_SUITE_data/apache-activemq-$(ACTIVEMQ_VERSION)/bin/activemq)


### PR DESCRIPTION
We've experienced lots of failures in CI:
```
GEN    test/system_SUITE_data/apache-activemq-5.18.3-bin.tar.gz
make: *** [Makefile:65: test/system_SUITE_data/apache-activemq-5.18.3-bin.tar.gz] Error 28
make: Leaving directory '/home/runner/work/rabbitmq-server/rabbitmq-server/deps/amqp10_client'
Error: Process completed with exit code 2.
```

Bumping to the latest ActiveMQ Classic version may or may not help with these failures.

Either way, we want to test against the latest ActiveMQ version. Version 5.18.3 reached end-of-life and is no longer maintained.
