### PR TITLE
When the client disconnects, the 'channel' process may generate a large number of exception logs.

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -639,7 +639,12 @@ handle_cast(ready_for_close,
     {stop, normal, State};
 
 handle_cast(terminate, State = #ch{cfg = #conf{writer_pid = WriterPid}}) ->
-    ok = rabbit_writer:flush(WriterPid),
+    try
+       ok = rabbit_writer:flush(WriterPid)
+    catch
+        Class:Reason ->
+            rabbit_log:info("Failed to flushing writer ~tp, Error:~tp", [WriterPid, {Class,Reason}])
+    end,
     {stop, normal, State};
 
 handle_cast({command, #'basic.consume_ok'{consumer_tag = CTag} = Msg},


### PR DESCRIPTION
When the client disconnects, flushing writer in the termination may result in a large number of exceptions due to the writer being closed.
The exceptions are as follows:

2025-06-24 17:56:06.661 [error] <0.1381.0> ** Generic server <0.1381.0> terminating, ** Last message in was {'$gen_cast',terminate}, ** When Server state == {ch, {conf,running,rabbit_framing_amqp_0_9_1,1, <0.1371.0>,<0.1379.0>,<0.1371.0>, <<"10.225.80.5:50760 -> 10.225.80.6:5673">>, {user,<<"rabbit_inside_user">>,[], [{rabbit_auth_backend_internal, #Fun<rabbit_auth_backend_internal.3.16580688>}]}, <<"/">>, <<"lzz.localdomain_rc.py_reply_89a60f0ef2114da2b3f150ca359ecf46">>, <0.1373.0>, [{<<"authentication_failure_close">>,bool,true}, {<<"connection.blocked">>,bool,true}, {<<"consumer_cancel_notify">>,bool,true}, {<<"need_notify_server_info_with_heartbeat">>,bool, true}], none,5,1800000,#{},infinity,1000000000}, {lstate,<0.1380.0>,false}, none,3, {1, [{pending_ack,2,<<"1">>,-576460618632, {resource,<<"/">>,queue, <<"lzz.localdomain_rc.py_reply_89a60f0ef2114da2b3f150ca359ecf46">>}, 1}], []}, undefined, #{<<"1">> =>, {{amqqueue, {resource,<<"/">>,queue, <<"lzz.localdomain_rc.py_reply_89a60f0ef2114da2b3f150ca359ecf46">>}, false,false,none, [{<<"x-expires">>,signedint,1800000}, {<<"x-queue-type">>,longstr,<<"classic">>}], <0.1385.0>,[],[],[],undefined,undefined,[],[], live,0,[],<<"/">>, #{user => <<"rabbit_inside_user">>, system_creation => 1750758840399767062, recover_on_declare => false, creator =>, {1750758936,"10.225.80.5",50760,"rc.py"}}, rabbit_classic_queue,#{}}, {false,5,false, [{zclient,tuple, {1750758936,"10.225.80.5",50760,"rc.py"}}]}}}, #{{resource,<<"/">>,queue, <<"lzz.localdomain_rc.py_reply_89a60f0ef2114da2b3f150ca359ecf46">>} =>, {1,{<<"1">>,nil,nil}}}, {state,none,30000,undefined}, false,1, {rabbit_confirms,undefined,#{}}, [],[],none,flow,[], {rabbit_queue_type, #{{resource,<<"/">>,queue, <<"lzz.localdomain_rc.py_reply_89a60f0ef2114da2b3f150ca359ecf46">>} =>, {ctx,rabbit_classic_queue, {rabbit_classic_queue,<0.1385.0>,#{}, #{<0.1385.0> => ok}, false}}}}, #Ref<0.2472179985.4173070337.136448>,false, {erlang,#Ref<0.2472179985.4173070337.136063>}, "rc.py",true,0,false,undefined,undefined,undefined, false}, ** Reason for termination == , ** {{shutdown,{writer,send_failed,closed}}, {gen_server,call,[<0.1379.0>,flush,infinity]}},
2025-06-24 17:56:06.665 [error] <0.1381.0>   crasher:, initial call: rabbit_channel:init/1, pid: <0.1381.0>, registered_name: [], exception exit: {{shutdown,{writer,send_failed,closed}}, {gen_server,call,[<0.1379.0>,flush,infinity]}}, in function  gen_server2:terminate/3 (gen_server2.erl, line 1172), ancestors: [<0.1378.0>,<0.1376.0>,<0.1369.0>,<0.1368.0>,<0.1169.0>, <0.1168.0>,<0.1167.0>,<0.1165.0>,<0.1164.0>,rabbit_sup, <0.249.0>], message_queue_len: 1, messages: [{'EXIT',<0.1378.0>,shutdown}], links: [<0.1378.0>], dictionary: [{msg_io_dt_cfg,{1750758936,2}}, {zext_options_dt_cfg,{1750758966,[]}}, {zlog_consumer_dt_cfg,{1750758936,false}}, {channel_operation_timeout,15000}, {rbt_trace_enable,true}, {process_name, {rabbit_channel, {<<"10.225.80.5:50760 -> 10.225.80.6:5673">>,1}}}, {counter_publish_size_dt_cfg,{1750758936,undefined}}, {peer_info, {"10.225.80.5",50760, "10.225.80.5:50760 -> 10.225.80.6:5673 - rc.py:3382128:dfe6ba8d-a42f-4ece-93df-11bff0410814", "rc.py",0}}, {peer_host_port_compname,{"10.225.80.5",50760,"rc.py"}}, {permission_cache_can_expire,false}, {debug_openv_dt_cfg,{1750758936,[]}}, {z_qref_type_dic, [{{resource,<<"/">>,queue, <<"lzz.localdomain_rc.py_reply_89a60f0ef2114da2b3f150ca359ecf46">>}, rabbit_classic_queue}]}, {zconsumer_num,1}, {virtual_host,<<"/">>}, {msg_size_for_gc,458}, {rand_seed, {#{max => 288230376151711743,type => exsplus, next => #Fun<rand.5.65977474>, jump => #Fun<rand.3.65977474>}, [20053568771696737|52030598835932017]}}, {top_queue_msg_dt_cfg, {1750758936, {0,0,0,undefined,false,false,undefined,undefined}}}], trap_exit: true, status: running, heap_size: 4185, stack_size: 28, reductions: 50613, neighbours:,

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
