### PR TITLE
By @tomyouyou: Avoid a scary log exception when a closing connection runs into an exception during a command writer flush operation

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -643,7 +643,7 @@ handle_cast(terminate, State = #ch{cfg = #conf{writer_pid = WriterPid}}) ->
        ok = rabbit_writer:flush(WriterPid)
     catch
         Class:Reason ->
-            rabbit_log:info("Failed to flushing writer ~tp, Error:~tp", [WriterPid, {Class,Reason}])
+            rabbit_log:debug("Failed to flush pending writes on a terminating connection, reason: ~tp", [Reason])
     end,
     {stop, normal, State};
 

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -639,7 +639,12 @@ handle_cast(ready_for_close,
     {stop, normal, State};
 
 handle_cast(terminate, State = #ch{cfg = #conf{writer_pid = WriterPid}}) ->
-    ok = rabbit_writer:flush(WriterPid),
+    try
+       ok = rabbit_writer:flush(WriterPid)
+    catch
+        Class:Reason ->
+            rabbit_log:info("Failed to flushing writer ~tp, Error:~tp", [WriterPid, {Class,Reason}])
+    end,
     {stop, normal, State};
 
 handle_cast({command, #'basic.consume_ok'{consumer_tag = CTag} = Msg},


### PR DESCRIPTION
This is #14121 by @tomyouyou with log message tweaks from me.

The goal of this change is to avoid a scary looking exception on a connection that's closing and cannot do much about a writer flush failure.