### PR TITLE
Use registry:lookup_type_module inside exchange:type_to_module

### DIFF
--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -539,7 +539,7 @@ invalid_module(T) ->
 type_to_module(T) ->
     case get({xtype_to_module, T}) of
         undefined ->
-            case rabbit_registry:lookup_module(exchange, T) of
+            case rabbit_registry:lookup_type_module(exchange, T) of
                 {ok, Module}       -> put({xtype_to_module, T}, Module),
                                       Module;
                 {error, not_found} -> invalid_module(T)


### PR DESCRIPTION
Without this change delete/3 callback for custom exchange type wasn't called and warning about invalid exchange type appeared in the logs. What is interesting - that exchange module was logged as an invalid type for previously declared exchange of that module ¯\_(ツ)_/¯.
