### PR TITLE
cluster_minority_SUITE: Fix race in `remove_node_when_seed_node_is_leader`

### DIFF
--- a/deps/rabbit/test/cluster_minority_SUITE.erl
+++ b/deps/rabbit/test/cluster_minority_SUITE.erl
@@ -396,6 +396,10 @@ remove_node_when_seed_node_is_leader(Config) ->
     case Pong of
         {pong, leader} ->
             ?awaitMatch(
+               {ok, #{cluster_change_permitted := true}, _},
+               rabbit_ct_broker_helpers:rpc(Config, A, ra, member_overview, [AMember]),
+               60000),
+            ?awaitMatch(
                ok,
                rabbit_control_helper:command(
                  forget_cluster_node, A, [atom_to_list(B)], []),


### PR DESCRIPTION
## Why

When node A becomes the leader, it still takes a few exchanges with followers to allow cluster changes again.

Concurrently, the testcase blocks traffic between A and other nodes to simulate a network partition. If this happens after A becomes the leader but before cluster changes are permitted again, the testcase will never succeed and will eventually abort with:

    Case: cluster_minority_SUITE:remove_node_when_seed_node_is_leader
    Reason: {error,
                {{awaitMatch,
                     [{module,cluster_minority_SUITE},
                      {expression, "..."},
                      {pattern,"ok"},
                      {value,
                          {error,69,<<"Error:\ncluster_change_not_permitted">>}}]},

## How

Before blocking traffic, we wait for cluster changes to be permitted again on node A.