### PR TITLE
Handle type state being undefined for very old queues

### DIFF
--- a/deps/rabbit/src/amqqueue.erl
+++ b/deps/rabbit/src/amqqueue.erl
@@ -464,7 +464,7 @@ set_policy_version(#amqqueue{} = Queue, PV) ->
 % type_state (new in v2)
 
 -spec get_type_state(amqqueue()) -> map().
-get_type_state(#amqqueue{type_state = TState}) ->
+get_type_state(#amqqueue{type_state = TState}) when is_map(TState) ->
     TState;
 get_type_state(_) ->
     #{}.


### PR DESCRIPTION
## Proposed Changes

Field `#amqqueue.type_state` can be undefined for queues declared on old RabbitMQ versions before 3.8.0. Ensure `amqqueue:get_type_state/1` always returns a map according to its type spec to make life of calling code easier.

Before this change the newly introduced `emit_queue_info` crashed on such very old queues when calling `/metrics/per-object` prometheus endpoint

```
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>   crasher:
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>     initial call: cowboy_stream_h:request_process/3
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>     pid: <0.3422.0>
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>     registered_name: []
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>     exception error: bad map: undefined
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in function  prometheus_rabbitmq_core_metrics_collector:'-emit_queue_info/3-fun-0-'/3
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from lists:foldl/3 (lists.erl, line 2146)
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from prometheus_rabbitmq_core_metrics_collector:emit_queue_info/3 (prometheus_rabbitmq_core_metrics_collector.erl, line 453)
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from prometheus_rabbitmq_core_metrics_collector:collect_mf/2 (prometheus_rabbitmq_core_metrics_collector.erl, line 322)
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from prometheus_collector:collect_mf/3 (src/prometheus_collector.erl, line 173)
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from prometheus_registry:'-collect/2-lc$^0/1-0-'/3 (src/prometheus_registry.erl, line 86)
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from prometheus_registry:collect/2 (src/prometheus_registry.erl, line 87)
2025-07-11 09:42:43.972536+02:00 [error] <0.3422.0>       in call from prometheus_text_format:format/1 (src/formats/prometheus_text_format.erl, line 73)
```
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

