### PR TITLE
Show current state of deprecated features

### DIFF
--- a/deps/rabbit/src/rabbit_depr_ff_extra.erl
+++ b/deps/rabbit/src/rabbit_depr_ff_extra.erl
@@ -58,11 +58,13 @@ cli_info0(DeprecatedFeature) ->
 
               App = maps:get(provided_by, FeatureProps),
               DeprecationPhase = maps:get(deprecation_phase, FeatureProps, ""),
+              State = maps:get(state, FeatureProps, ""),
               Desc = maps:get(desc, FeatureProps, ""),
               DocUrl = maps:get(doc_url, FeatureProps, ""),
               Info = #{name => FeatureName,
                        desc => unicode:characters_to_binary(Desc),
                        deprecation_phase => DeprecationPhase,
+                       state => State,
                        doc_url => unicode:characters_to_binary(DocUrl),
                        provided_by => App},
               [Info | Acc]

--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -361,9 +361,16 @@ get_warning(FeatureProps, Permitted) when is_map(FeatureProps) ->
 %% @returns A map of selected deprecated features.
 
 list(all) ->
-    maps:filter(
-      fun(_, FeatureProps) -> ?IS_DEPRECATION(FeatureProps) end,
-      rabbit_ff_registry_wrapper:list(all));
+    maps:map(fun(FeatureName, FeatureProps) ->
+                     FeatureProps#{state => case is_permitted_nolog(FeatureName)
+                                            of
+                                                true  -> permitted;
+                                                false -> denied
+                                            end}
+             end,
+             maps:filter(
+               fun(_, FeatureProps) -> ?IS_DEPRECATION(FeatureProps) end,
+               rabbit_ff_registry_wrapper:list(all)));
 list(used) ->
     maps:filter(
       fun(FeatureName, FeatureProps) ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_deprecated_features_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/list_deprecated_features_command.ex
@@ -12,9 +12,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListDeprecatedFeaturesCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def formatter(), do: RabbitMQ.CLI.Formatters.Table
+  def formatter(), do: RabbitMQ.CLI.Formatters.PrettyTable
 
-  @info_keys ~w(name deprecation_phase provided_by desc doc_url)a
+  @info_keys ~w(name deprecation_phase state provided_by desc doc_url)a
 
   def info_keys(), do: @info_keys
 
@@ -23,7 +23,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListDeprecatedFeaturesCommand do
   def switches(), do: [used: :boolean]
 
   def merge_defaults([], opts) do
-    {["name", "deprecation_phase"], Map.merge(%{used: false}, opts)}
+    {["name", "deprecation_phase", "state"], Map.merge(%{used: false}, opts)}
   end
 
   def merge_defaults(args, opts) do

--- a/deps/rabbitmq_cli/test/ctl/list_deprecated_features_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/list_deprecated_features_command_test.exs
@@ -24,12 +24,12 @@ defmodule ListDeprecatedFeaturesCommandTest do
       @df1 => %{
         desc: ~c"My deprecated feature #1",
         provided_by: :ListDeprecatedFeaturesCommandTest,
-        deprecation_phase: :permitted_by_default
+        deprecation_phase: :permitted_by_default,
       },
       @df2 => %{
         desc: ~c"My deprecated feature #2",
         provided_by: :ListDeprecatedFeaturesCommandTest,
-        deprecation_phase: :removed
+        deprecation_phase: :removed,
       }
     }
 
@@ -47,8 +47,8 @@ defmodule ListDeprecatedFeaturesCommandTest do
     ]
 
     full_result = [
-      [{:name, @df1}, {:deprecation_phase, :permitted_by_default}],
-      [{:name, @df2}, {:deprecation_phase, :removed}]
+      [{:name, @df1}, {:deprecation_phase, :permitted_by_default}, {:state, :permitted}],
+      [{:name, @df2}, {:deprecation_phase, :removed}, {:state, :denied}]
     ]
 
     {
@@ -65,7 +65,7 @@ defmodule ListDeprecatedFeaturesCommandTest do
   end
 
   test "merge_defaults with no command, print just use the names" do
-    assert match?({["name", "deprecation_phase"], %{}}, @command.merge_defaults([], %{}))
+    assert match?({["name", "deprecation_phase", "state"], %{}}, @command.merge_defaults([], %{}))
   end
 
   test "validate: return bad_info_key on a single bad arg", context do
@@ -125,7 +125,7 @@ defmodule ListDeprecatedFeaturesCommandTest do
 
   @tag test_timeout: 30000
   test "run: sufficiently long timeouts don't interfere with results", context do
-    matches_found = @command.run(["name", "deprecation_phase"], context[:opts])
+    matches_found = @command.run(["name", "deprecation_phase", "state"], context[:opts])
 
     assert Enum.all?(context[:full_result], fn feature_name ->
              Enum.find(matches_found, fn found -> found == feature_name end)

--- a/deps/rabbitmq_management/priv/www/js/tmpl/deprecated-features.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/deprecated-features.ejs
@@ -24,6 +24,7 @@
     <tr>
       <th><%= fmt_sort('Name', 'name') %></th>
       <th><%= fmt_sort('Deprecation phase', 'deprecation_phase') %></th>
+      <th><%= fmt_sort('Current Configuration', 'state') %></th>
       <th>Description</th>
     </tr>
   </thead>
@@ -43,6 +44,7 @@
          <abbr class="status-<%= fmt_string(state_color) %>">In use</abbr>
          <% } %>
          <%= fmt_deprecation_phase(deprecated_feature.deprecation_phase, DEPRECATION_PHASES) %></td>
+         <td><%= fmt_string(deprecated_feature.state) %></td>
          <td>
          <p><%= fmt_string(deprecated_feature.desc) %></p>
          <% if (deprecated_feature.doc_url) { %>


### PR DESCRIPTION
When listing deprecated features, apart from the deprecation phase, show the current state (whether the configuration permits usage).

New column in the CLI outout:
```
> rabbitmqctl list_deprecated_features
┌───────────────────────────────┬──────────────────────┬───────────┐
│ name                          │ deprecation_phase    │ state     │
├───────────────────────────────┼──────────────────────┼───────────┤
│ amqp_address_v1               │ permitted_by_default │ permitted │
├───────────────────────────────┼──────────────────────┼───────────┤
│ amqp_filter_set_bug           │ permitted_by_default │ permitted │
├───────────────────────────────┼──────────────────────┼───────────┤
│ classic_queue_mirroring       │ removed              │ denied    │
├───────────────────────────────┼──────────────────────┼───────────┤
│ df1_from_list_df_testsuite    │ permitted_by_default │ permitted │
├───────────────────────────────┼──────────────────────┼───────────┤
│ df2_from_list_df_testsuite    │ removed              │ denied    │
├───────────────────────────────┼──────────────────────┼───────────┤
│ global_qos                    │ permitted_by_default │ permitted │
├───────────────────────────────┼──────────────────────┼───────────┤
│ management_metrics_collection │ permitted_by_default │ permitted │
├───────────────────────────────┼──────────────────────┼───────────┤
│ queue_master_locator          │ permitted_by_default │ denied    │
├───────────────────────────────┼──────────────────────┼───────────┤
│ ram_node_type                 │ permitted_by_default │ denied    │
├───────────────────────────────┼──────────────────────┼───────────┤
│ transient_nonexcl_queues      │ permitted_by_default │ permitted │
└───────────────────────────────┴──────────────────────┴───────────┘
```

New column in the Management UI:
<img width="628" height="305" alt="Screenshot 2025-07-14 at 15 54 36" src="https://github.com/user-attachments/assets/eea13ac9-e4de-4545-bf1d-ae31fc8e1cc9" />
