### PR TITLE
Make AMQP 1.0 faster

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_generator.erl
+++ b/deps/amqp10_common/src/amqp10_binary_generator.erl
@@ -204,9 +204,9 @@ constructor(array) -> 16#f0; % use large array type for all nested arrays
 constructor({described, Descriptor, Primitive}) ->
     [16#00, generate1(Descriptor), constructor(Primitive)].
 
-generate2(symbol, {symbol, V}) -> [<<(size(V)):32>>, V];
-generate2(utf8, {utf8, V}) -> [<<(size(V)):32>>, V];
-generate2(binary, {binary, V}) -> [<<(size(V)):32>>, V];
+generate2(symbol, {symbol, V}) -> [<<(byte_size(V)):32>>, V];
+generate2(utf8, {utf8, V}) -> [<<(byte_size(V)):32>>, V];
+generate2(binary, {binary, V}) -> [<<(byte_size(V)):32>>, V];
 generate2(boolean, true) -> 16#01;
 generate2(boolean, false) -> 16#00;
 generate2(boolean, {boolean, true}) -> 16#01;

--- a/deps/amqp10_common/src/amqp10_composite.erl
+++ b/deps/amqp10_common/src/amqp10_composite.erl
@@ -1,0 +1,336 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(amqp10_composite).
+
+-include("amqp10_framing.hrl").
+
+-export([flow/2,
+         transfer/2,
+         disposition/2,
+         header/2,
+         properties/2]).
+
+-spec flow(#'v1_0.flow'{}, nonempty_list()) ->
+    #'v1_0.flow'{}.
+flow(F, [F1, F2, F3, F4]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4)};
+flow(F, [F1, F2, F3, F4, F5]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5)};
+flow(F, [F1, F2, F3, F4, F5, F6]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5),
+                  delivery_count = ntu(F6)};
+flow(F, [F1, F2, F3, F4, F5, F6, F7]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5),
+                  delivery_count = ntu(F6),
+                  link_credit = ntu(F7)};
+flow(F, [F1, F2, F3, F4, F5, F6, F7, F8]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5),
+                  delivery_count = ntu(F6),
+                  link_credit = ntu(F7),
+                  available = ntu(F8)};
+flow(F, [F1, F2, F3, F4, F5, F6, F7, F8, F9]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5),
+                  delivery_count = ntu(F6),
+                  link_credit = ntu(F7),
+                  available = ntu(F8),
+                  drain = ntu(F9)};
+flow(F, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5),
+                  delivery_count = ntu(F6),
+                  link_credit = ntu(F7),
+                  available = ntu(F8),
+                  drain = ntu(F9),
+                  echo = ntu(F10)};
+flow(F, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]) ->
+    F#'v1_0.flow'{next_incoming_id = ntu(F1),
+                  incoming_window = ntu(F2),
+                  next_outgoing_id = ntu(F3),
+                  outgoing_window = ntu(F4),
+                  handle = ntu(F5),
+                  delivery_count = ntu(F6),
+                  link_credit = ntu(F7),
+                  available = ntu(F8),
+                  drain = ntu(F9),
+                  echo = ntu(F10),
+                  properties = amqp10_framing:decode(F11)}.
+
+-spec transfer(#'v1_0.transfer'{}, nonempty_list()) ->
+    #'v1_0.transfer'{}.
+transfer(T, [F1]) ->
+    T#'v1_0.transfer'{handle = ntu(F1)};
+transfer(T, [F1, F2]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2)};
+transfer(T, [F1, F2, F3]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3)};
+transfer(T, [F1, F2, F3, F4]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4)};
+transfer(T, [F1, F2, F3, F4, F5]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5)};
+transfer(T, [F1, F2, F3, F4, F5, F6]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5),
+                      more = ntu(F6)};
+transfer(T, [F1, F2, F3, F4, F5, F6, F7]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5),
+                      more = ntu(F6),
+                      rcv_settle_mode = ntu(F7)};
+transfer(T, [F1, F2, F3, F4, F5, F6, F7, F8]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5),
+                      more = ntu(F6),
+                      rcv_settle_mode = ntu(F7),
+                      state = amqp10_framing:decode(F8)};
+transfer(T, [F1, F2, F3, F4, F5, F6, F7, F8, F9]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5),
+                      more = ntu(F6),
+                      rcv_settle_mode = ntu(F7),
+                      state = amqp10_framing:decode(F8),
+                      resume = ntu(F9)};
+transfer(T, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5),
+                      more = ntu(F6),
+                      rcv_settle_mode = ntu(F7),
+                      state = amqp10_framing:decode(F8),
+                      resume = ntu(F9),
+                      aborted = ntu(F10)};
+transfer(T, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]) ->
+    T#'v1_0.transfer'{handle = ntu(F1),
+                      delivery_id = ntu(F2),
+                      delivery_tag = ntu(F3),
+                      message_format = ntu(F4),
+                      settled = ntu(F5),
+                      more = ntu(F6),
+                      rcv_settle_mode = ntu(F7),
+                      state = amqp10_framing:decode(F8),
+                      resume = ntu(F9),
+                      aborted = ntu(F10),
+                      batchable = ntu(F11)}.
+
+-spec disposition(#'v1_0.disposition'{}, nonempty_list()) ->
+    #'v1_0.disposition'{}.
+disposition(D, [F1, F2]) ->
+    D#'v1_0.disposition'{role = ntu(F1),
+                         first = ntu(F2)};
+disposition(D, [F1, F2, F3]) ->
+    D#'v1_0.disposition'{role = ntu(F1),
+                         first = ntu(F2),
+                         last = ntu(F3)};
+disposition(D, [F1, F2, F3, F4]) ->
+    D#'v1_0.disposition'{role = ntu(F1),
+                         first = ntu(F2),
+                         last = ntu(F3),
+                         settled = ntu(F4)};
+disposition(D, [F1, F2, F3, F4, F5]) ->
+    D#'v1_0.disposition'{role = ntu(F1),
+                         first = ntu(F2),
+                         last = ntu(F3),
+                         settled = ntu(F4),
+                         state = amqp10_framing:decode(F5)};
+disposition(D, [F1, F2, F3, F4, F5, F6]) ->
+    D#'v1_0.disposition'{role = ntu(F1),
+                         first = ntu(F2),
+                         last = ntu(F3),
+                         settled = ntu(F4),
+                         state = amqp10_framing:decode(F5),
+                         batchable = ntu(F6)}.
+
+-spec header(#'v1_0.header'{}, list()) ->
+    #'v1_0.header'{}.
+header(H, []) ->
+    H;
+header(H, [F1]) ->
+    H#'v1_0.header'{durable = ntu(F1)};
+header(H, [F1, F2]) ->
+    H#'v1_0.header'{durable = ntu(F1),
+                    priority = ntu(F2)};
+header(H, [F1, F2, F3]) ->
+    H#'v1_0.header'{durable = ntu(F1),
+                    priority = ntu(F2),
+                    ttl = ntu(F3)};
+header(H, [F1, F2, F3, F4]) ->
+    H#'v1_0.header'{durable = ntu(F1),
+                    priority = ntu(F2),
+                    ttl = ntu(F3),
+                    first_acquirer = ntu(F4)};
+header(H, [F1, F2, F3, F4, F5]) ->
+    H#'v1_0.header'{durable = ntu(F1),
+                    priority = ntu(F2),
+                    ttl = ntu(F3),
+                    first_acquirer = ntu(F4),
+                    delivery_count = ntu(F5)}.
+
+-spec properties(#'v1_0.properties'{}, list()) ->
+    #'v1_0.properties'{}.
+properties(P, []) ->
+    P;
+properties(P, [F1]) ->
+    P#'v1_0.properties'{message_id = ntu(F1)};
+properties(P, [F1, F2]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2)};
+properties(P, [F1, F2, F3]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3)};
+properties(P, [F1, F2, F3, F4]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4)};
+properties(P, [F1, F2, F3, F4, F5]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5)};
+properties(P, [F1, F2, F3, F4, F5, F6]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7, F8]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7),
+                        content_encoding = ntu(F8)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7, F8, F9]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7),
+                        content_encoding = ntu(F8),
+                        absolute_expiry_time = ntu(F9)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7),
+                        content_encoding = ntu(F8),
+                        absolute_expiry_time = ntu(F9),
+                        creation_time = ntu(F10)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7),
+                        content_encoding = ntu(F8),
+                        absolute_expiry_time = ntu(F9),
+                        creation_time = ntu(F10),
+                        group_id = ntu(F11)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7),
+                        content_encoding = ntu(F8),
+                        absolute_expiry_time = ntu(F9),
+                        creation_time = ntu(F10),
+                        group_id = ntu(F11),
+                        group_sequence = ntu(F12)};
+properties(P, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13]) ->
+    P#'v1_0.properties'{message_id = ntu(F1),
+                        user_id = ntu(F2),
+                        to = ntu(F3),
+                        subject = ntu(F4),
+                        reply_to = ntu(F5),
+                        correlation_id = ntu(F6),
+                        content_type = ntu(F7),
+                        content_encoding = ntu(F8),
+                        absolute_expiry_time = ntu(F9),
+                        creation_time = ntu(F10),
+                        group_id = ntu(F11),
+                        group_sequence = ntu(F12),
+                        reply_to_group_id = ntu(F13)}.
+
+%% null to undefined
+-compile({inline, [ntu/1]}).
+ntu(null) ->
+    undefined;
+ntu(Other) ->
+    Other.

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -500,37 +500,29 @@ maps_upsert(Key, TaggedVal, KVList) ->
 
 encode(Sections) when is_list(Sections) ->
     [amqp10_framing:encode_bin(Section) || Section <- Sections,
-                                           not is_empty(Section)].
+                                           not omit(Section)].
 
-is_empty(#'v1_0.header'{durable = undefined,
-                        priority = undefined,
-                        ttl = undefined,
-                        first_acquirer = undefined,
-                        delivery_count = undefined}) ->
+omit(#'v1_0.message_annotations'{content = []}) ->
     true;
-is_empty(#'v1_0.delivery_annotations'{content = []}) ->
+omit(#'v1_0.properties'{message_id = undefined,
+                        user_id = undefined,
+                        to = undefined,
+                        subject = undefined,
+                        reply_to = undefined,
+                        correlation_id = undefined,
+                        content_type = undefined,
+                        content_encoding = undefined,
+                        absolute_expiry_time = undefined,
+                        creation_time = undefined,
+                        group_id = undefined,
+                        group_sequence = undefined,
+                        reply_to_group_id = undefined}) ->
     true;
-is_empty(#'v1_0.message_annotations'{content = []}) ->
+omit(#'v1_0.application_properties'{content = []}) ->
     true;
-is_empty(#'v1_0.properties'{message_id = undefined,
-                            user_id = undefined,
-                            to = undefined,
-                            subject = undefined,
-                            reply_to = undefined,
-                            correlation_id = undefined,
-                            content_type = undefined,
-                            content_encoding = undefined,
-                            absolute_expiry_time = undefined,
-                            creation_time = undefined,
-                            group_id = undefined,
-                            group_sequence = undefined,
-                            reply_to_group_id = undefined}) ->
+omit(#'v1_0.footer'{content = []}) ->
     true;
-is_empty(#'v1_0.application_properties'{content = []}) ->
-    true;
-is_empty(#'v1_0.footer'{content = []}) ->
-    true;
-is_empty(_) ->
+omit(_) ->
     false.
 
 message_annotation(Key, State, Default)


### PR DESCRIPTION
This PR results in noteworthy performance improvements for AMQP 1.0 (depending on the workload).

Stream filtering via AMQP SQL Filters or AMQP Property Filters where the
broker reads messages from the stream into memory and the filter returns
false, i.e. messages are not sent to the client:
* Before this PR: ~400,000 msgs/s
* After this PR:  ~500,000 msgs/s

There is also a ~10% increase in end-to-end throughput for normal
AMQP workloads, e.g. when sending to and receiving from a classic queue.

Prior to this PR, a lot of garbage was created leading to many minor
garbage collections.

This PR reduces the garbage being generated.
The new module amqp10_composite performs very well:
* Single tuple update setting multiple fields at once, sometimes done even in-place
  without copying the tuple.
* The list of fields is passed into X registers, no need for any new
  allocations.

On the serialisation side, this PR also generates less garbage by:
1. Avoiding tuple_to_list/1
2. Omitting trailing elements of the list that are null

This will also lead to fewer bytes per message sent on the wire and less
resource usage for the clients as they need to parse fewer fields.
