### PR TITLE
Deny `amqp_filter_set_bug` by default

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -34,7 +34,7 @@
 
 -rabbit_deprecated_feature(
    {amqp_filter_set_bug,
-    #{deprecation_phase => permitted_by_default,
+    #{deprecation_phase => denied_by_default,
       doc_url => "https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set"
      }}).
 


### PR DESCRIPTION
The deprecated feature flag `amqp_filter_set_bug` was introduced in RabbitMQ 4.1 with phase `permitted_by_default`.
See https://github.com/rabbitmq/rabbitmq-server/pull/12415

This commit which will land in RabbitMQ 4.2 changes the phase to `denied_by_default`.