### PR TITLE
Handle exceptions in rabbit_ct_helpers:await_condition_with_retries/2 to continue waiting

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -1130,12 +1130,16 @@ await_condition(ConditionFun, Timeout) ->
 await_condition_with_retries(_ConditionFun, 0) ->
     ct:fail("Condition did not materialize in the expected period of time");
 await_condition_with_retries(ConditionFun, RetriesLeft) ->
-    case ConditionFun() of
+    try ConditionFun() of
         false ->
             timer:sleep(50),
             await_condition_with_retries(ConditionFun, RetriesLeft - 1);
         true ->
             ok
+    catch
+        _:_ ->
+            timer:sleep(50),
+            await_condition_with_retries(ConditionFun, RetriesLeft - 1)
     end.
 
 %% Pass in any EUnit test object. Example:


### PR DESCRIPTION
## Proposed Changes

Hi folks, we want this helper to continue waiting despite some test condition throwing exceptions. Needed for some plugins.
Also, this removes a lot of unnecessary custom wait functions in unit tests.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
