### PR TITLE
Remove awkward IO.inspect/1 in rabbitmqctl status command

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -142,8 +142,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
           xs -> alarm_lines(xs, node_name)
         end
 
-    IO.inspect(m[:tags])
-
     tags_section =
       [
         "\n#{bright("Tags")}\n"


### PR DESCRIPTION
## Proposed Changes

The `rabbitmqctl status` command has for a while now been showing an awkward empty list below the banner. Looks like an `IO.inspect/1` which was left for debugging purposes, which should've been removed after.

```
ayandad@host1 sbin % ./rabbitmqctl status
Status of node rabbit@host1 ...
[]
Runtime

OS PID: 44225
OS: macOS
Uptime (seconds): 5
Is under maintenance?: false
RabbitMQ version: 4.1.2
RabbitMQ release series support status: see https://www.rabbitmq.com/release-information
Node name: rabbit@host1
Erlang configuration: Erlang/OTP 28 [erts-16.0.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit] [dtrace]
Crypto library: OpenSSL 3.5.0 8 Apr 2025
Erlang processes: 314 used, 1048576 limit
Scheduler run queue: 1
Cluster heartbeat timeout (net_ticktime): 60

Plugins

```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
