### PR TITLE
#14151 by @tomyouyou

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -205,6 +205,11 @@ init_it(Recover, From, State = #q{q = Q0}) ->
                    State#q{backing_queue = BQ, backing_queue_state = BQS}}}
     end.
 
+stop_for_init(none, {Operation, Reason, _Reply, State}) ->
+    {Operation, Reason, State};
+stop_for_init(_From, Result) ->
+    Result.
+
 init_it2(Recover, From, State = #q{q                   = Q,
                                    backing_queue       = undefined,
                                    backing_queue_state = undefined}) ->
@@ -229,16 +234,16 @@ init_it2(Recover, From, State = #q{q                   = Q,
                                             fun() -> emit_stats(State1) end),
                     noreply(State1);
                 false ->
-                    {stop, normal, {existing, Q1}, State}
+                    stop_for_init(From, {stop, normal, {existing, Q1}, State})
             end;
         {error, timeout} ->
             Reason = {protocol_error, internal_error,
                       "Could not declare ~ts on node '~ts' because the "
                       "metadata store operation timed out",
                       [rabbit_misc:rs(amqqueue:get_name(Q)), node()]},
-            {stop, normal, Reason, State};
+            stop_for_init(From, {stop, normal, Reason, State});
         Err ->
-            {stop, normal, Err, State}
+            stop_for_init(From, {stop, normal, Err, State})
     end.
 
 recovery_status(new)              -> {no_barrier, new};


### PR DESCRIPTION
This is #14151 by @tomyouyou re-submitted by me to provide some context and make more suites run.

The value returned by the function in question is eventually returned by `handle_call/3`, which
supports two types of responses: explicit via `gen_server:reply/2` and "automatic" via a return value, where the `From` value is implicitly used by the gen .

This PR addresses a case where a `handle_call/3` returns a `{stop, Reason, Reply, NewState}`, in which case the reply is sent by a OTP loop process before `gen_server` terminates. The reply will implicitly (for a `handle_call/3` implementation reader) use the caller/`From` value, which in some cases can be `none`.