### PR TITLE
Fix error popup text display

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -710,6 +710,8 @@ format({shutdown, _} = Error) ->
     ?LOG_DEBUG("Metadata store is unavailable: ~p", [Error]),
     rabbit_data_coercion:to_binary(
       rabbit_misc:format("Metadata store is unavailable. Please try again.", []));
+format(E) when is_binary(E) ->
+    E;
 format(E) ->
     rabbit_data_coercion:to_binary(rabbit_misc:format("~tp", [E])).
 
@@ -733,8 +735,8 @@ add_parameter(VHost, Param, Username) ->
     case Result of
         ok                -> ok;
         {error_string, E} ->
-            S = rabbit_misc:format(" (~ts/~ts/~ts)", [VHost, Comp, Key]),
-            exit(rabbit_data_coercion:to_binary(rabbit_misc:escape_html_tags(E ++ S)))
+            S = rabbit_misc:format(" (vhost: \"~ts\" / component: \"~ts\" / key: \"~ts\")", [VHost, Comp, Key]),
+            exit(rabbit_data_coercion:to_utf8_binary(E ++ S))
     end.
 
 add_global_parameter(Param, Username) ->
@@ -770,8 +772,8 @@ add_policy(VHost, Param, Username) ->
            maps:get('apply-to', Param, <<"all">>),
            Username) of
         ok                -> ok;
-        {error_string, E} -> S = rabbit_misc:format(" (~ts/~ts)", [VHost, Key]),
-                             exit(rabbit_data_coercion:to_binary(rabbit_misc:escape_html_tags(E ++ S)))
+        {error_string, E} -> S = rabbit_misc:format(" (vhost: \"~ts\" key: \"~ts\")", [VHost, Key]),
+                             exit(rabbit_data_coercion:to_utf8_binary(E ++ S))
     end.
 
 -spec add_vhost(map(), rabbit_types:username()) -> ok | no_return().

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -69,7 +69,7 @@
 -export([get_parent/0]).
 -export([store_proc_name/1, store_proc_name/2, get_proc_name/0]).
 -export([moving_average/4]).
--export([escape_html_tags/1, b64decode_or_throw/1]).
+-export([b64decode_or_throw/1]).
 -export([get_env/3]).
 -export([get_channel_operation_timeout/0]).
 -export([random/1]).
@@ -1181,25 +1181,6 @@ moving_average(Time,  HalfLife,  Next, Current) ->
 
 random(N) ->
     rand:uniform(N).
-
--spec escape_html_tags(string()) -> binary().
-
-escape_html_tags(S) ->
-    escape_html_tags(rabbit_data_coercion:to_list(S), []).
-
-
--spec escape_html_tags(string(), string()) -> binary().
-
-escape_html_tags([], Acc) ->
-    rabbit_data_coercion:to_binary(lists:reverse(Acc));
-escape_html_tags("<" ++ Rest, Acc) ->
-    escape_html_tags(Rest, lists:reverse("&lt;", Acc));
-escape_html_tags(">" ++ Rest, Acc) ->
-    escape_html_tags(Rest, lists:reverse("&gt;", Acc));
-escape_html_tags("&" ++ Rest, Acc) ->
-    escape_html_tags(Rest, lists:reverse("&amp;", Acc));
-escape_html_tags([C | Rest], Acc) ->
-    escape_html_tags(Rest, [C | Acc]).
 
 %% If the server we are talking to has non-standard net_ticktime, and
 %% our connection lasts a while, we could get disconnected because of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -877,8 +877,7 @@ with_vhost_and_props(Fun, ReqData, Context) ->
                             bad_request(Error, ReqData1, Context)
                     end;
                 {error, Reason} ->
-                    bad_request(rabbit_mgmt_format:escape_html_tags(Reason),
-                                ReqData1, Context)
+                    bad_request(Reason, ReqData1, Context)
             end
     end.
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_healthchecks.erl
@@ -48,8 +48,7 @@ to_json(ReqData, Context) ->
         {badrpc, Err} ->
             failure(rabbit_mgmt_format:print("~tp", Err), ReqData, Context);
         {error_string, Err} ->
-            S = rabbit_mgmt_format:escape_html_tags(
-                  rabbit_data_coercion:to_list(rabbit_mgmt_format:print(Err))),
+            S = rabbit_mgmt_format:print(Err),
             failure(S, ReqData, Context)
     end.
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_parameter.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_parameter.erl
@@ -61,10 +61,7 @@ accept_content(ReqData0, Context = #context{user = User}) ->
                           ok ->
                               {true, ReqData, Context};
                           {error_string, Reason} ->
-                              S = rabbit_mgmt_format:escape_html_tags(
-                                    rabbit_data_coercion:to_list(Reason)),
-                              rabbit_mgmt_util:bad_request(
-                                rabbit_data_coercion:to_binary(S), ReqData, Context)
+                              rabbit_mgmt_util:bad_request(Reason, ReqData, Context)
                       end
               end)
     end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_policy.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_policy.erl
@@ -60,8 +60,7 @@ accept_content(ReqData0, Context = #context{user = #user{username = Username}}) 
                           ok ->
                               {true, ReqData, Context};
                           {error_string, Reason} ->
-                              rabbit_mgmt_util:bad_request(
-                                rabbit_mgmt_format:escape_html_tags(Reason), ReqData, Context)
+                              rabbit_mgmt_util:bad_request(Reason, ReqData, Context)
                       end
               end)
     end.

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_format.erl
@@ -15,7 +15,7 @@
 -export([to_amqp_table/1, listener/1, web_context/1, properties/1, basic_properties/1]).
 -export([record/2, to_basic_properties/1]).
 -export([addr/1, port/1]).
--export([format_nulls/1, escape_html_tags/1]).
+-export([format_nulls/1]).
 -export([print/2, print/1]).
 
 -export([format_queue_stats/1, format_queue_basic_stats/1,
@@ -550,27 +550,6 @@ format_null_item([{_K, _V} | _T] = L) ->
     format_nulls(L);
 format_null_item(Value) ->
     Value.
-
-
--spec escape_html_tags(string()) -> binary().
-
-escape_html_tags(S) ->
-    escape_html_tags(rabbit_data_coercion:to_list(S), []).
-
-
--spec escape_html_tags(string(), string()) -> binary().
-
-escape_html_tags([], Acc) ->
-    rabbit_data_coercion:to_binary(lists:reverse(Acc));
-escape_html_tags("<" ++ Rest, Acc) ->
-    escape_html_tags(Rest, lists:reverse("&lt;", Acc));
-escape_html_tags(">" ++ Rest, Acc) ->
-    escape_html_tags(Rest, lists:reverse("&gt;", Acc));
-escape_html_tags("&" ++ Rest, Acc) ->
-    escape_html_tags(Rest, lists:reverse("&amp;", Acc));
-escape_html_tags([C | Rest], Acc) ->
-    escape_html_tags(Rest, [C | Acc]).
-
 
 -spec clean_consumer_details(proplists:proplist()) -> proplists:proplist().
 clean_consumer_details(Obj) ->

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
@@ -275,8 +275,8 @@ not_authorised(Reason, ReqData, Context) ->
 
 halt_response(Code, Type, Reason, ReqData, Context) ->
     ReasonFormatted = format_reason(Reason),
-    Json = #{<<"error">>  => Type,
-             <<"reason">> => ReasonFormatted},
+    Json = #{error  => Type,
+             reason => ReasonFormatted},
     ReqData1 = cowboy_req:reply(Code,
         #{<<"content-type">> => <<"application/json">>},
         rabbit_json:encode(Json), ReqData),
@@ -288,7 +288,7 @@ not_authenticated(Reason, ReqData, Context, _AuthConfig) ->
 format_reason(Tuple) when is_tuple(Tuple) ->
     tuple(Tuple);
 format_reason(Binary) when is_binary(Binary) ->
-    Binary;
+    unicode:characters_to_binary(Binary);
 format_reason(Other) ->
     case is_string(Other) of
         true ->  print("~ts", [Other]);


### PR DESCRIPTION
When validation fails for a policy parameter, the resulting popup can't be read due to one extra binary encoding as well as code that escapes HTML entites. Since the [EJS template uses `<%= ... %>` for the popup](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_management/priv/www/js/tmpl/popup.ejs#L2), it will display the text as-is, and not render any HTML.

The following definitions import, when imported into a 4.x broker via the management UI, will reproduce the issue: 
[defs-pp.json](https://github.com/user-attachments/files/21400854/defs-pp.json)

Popup display when current `main` code is used:
<img width="654" height="125" alt="image" src="https://github.com/user-attachments/assets/b0e27d32-24bf-49d5-aff6-9b08fd3afb3c" />

Popup display when this PR is applied:
<img width="687" height="174" alt="image" src="https://github.com/user-attachments/assets/ad5887ea-e2d0-4ed3-bd5b-86018dd6eec4" />

You can also observe this behavior in a 4.x broker by going to Admin -> Policies and creating a policy with `ha-mode: all`