### PR TITLE
Add a configurable limit for number of exchanges

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1012,6 +1012,20 @@ end}.
 {mapping, "max_message_size", "rabbit.max_message_size",
     [{datatype, integer}, {validators, ["max_message_size"]}]}.
 
+{mapping, "cluster_exchange_limit", "rabbit.cluster_exchange_limit",
+  [{datatype, [{atom, infinity}, integer]}, {validators, ["non_negative_integer"]}]}.
+
+{translation, "rabbit.cluster_exchange_limit",
+ fun(Conf) ->
+  case cuttlefish:conf_get("cluster_exchange_limit", Conf, undefined) of
+      undefined -> cuttlefish:unset();
+      infinity  -> infinity;
+      Val when is_integer(Val) -> Val;
+      _         -> cuttlefish:invalid("should be a non-negative integer")
+  end
+ end
+}.
+
 %% Customising Socket Options.
 %%
 %% See (https://www.erlang.org/doc/man/inet.html#setopts-2) for

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -266,10 +266,11 @@ count_in_mnesia() ->
     mnesia:table_info(?MNESIA_TABLE, size).
 
 count_in_khepri() ->
-    Path = khepri_exchange_path(?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:count(Path) of
-        {ok, Count} -> Count;
-        _           -> 0
+    try
+        ets:info(?KHEPRI_PROJECTION, size)
+    catch
+        error:badarg ->
+            0
     end.
 
 %% -------------------------------------------------------------------
@@ -869,7 +870,12 @@ exists_in_mnesia(Name) ->
     ets:member(?MNESIA_TABLE, Name).
 
 exists_in_khepri(Name) ->
-    rabbit_khepri:exists(khepri_exchange_path(Name)).
+    try
+        ets:member(?KHEPRI_PROJECTION, Name)
+    catch
+        error:badarg ->
+            false
+    end.
 
 %% -------------------------------------------------------------------
 %% clear().

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -102,9 +102,13 @@ serial(X) ->
       Internal :: boolean(),
       Args :: rabbit_framing:amqp_table(),
       Username :: rabbit_types:username(),
-      Ret :: {ok, rabbit_types:exchange()} | {error, timeout}.
+      Ret :: {ok, rabbit_types:exchange()} |
+             {error, timeout} |
+             %% May exit with `#amqp_error{}` if validations fail:
+             rabbit_types:channel_exit().
 
 declare(XName, Type, Durable, AutoDelete, Internal, Args, Username) ->
+    ok = check_exchange_limits(XName),
     X = rabbit_exchange_decorator:set(
           rabbit_policy:set(#exchange{name        = XName,
                                       type        = Type,
@@ -139,6 +143,25 @@ declare(XName, Type, Durable, AutoDelete, Internal, Args, Username) ->
             ?LOG_WARNING("ignoring exchange.declare for exchange ~tp,
                                 exchange.delete in progress~n.", [XName]),
             {ok, X}
+    end.
+
+check_exchange_limits(XName) ->
+    Limit = rabbit_misc:get_env(rabbit, cluster_exchange_limit, infinity),
+    case rabbit_db_exchange:count() >= Limit of
+        false ->
+            ok;
+        true ->
+            case rabbit_db_exchange:exists(XName) of
+                true ->
+                    %% Allow re-declares of existing exchanges when at the
+                    %% exchange limit.
+                    ok;
+                false ->
+                    rabbit_misc:protocol_error(
+                      precondition_failed,
+                      "cannot declare ~ts: exchange limit of ~tp is reached",
+                      [rabbit_misc:rs(XName), Limit])
+            end
     end.
 
 %% Used with binaries sent over the wire; the type may not exist.


### PR DESCRIPTION
This is like @SimonUnge's past work for [vhosts](https://github.com/rabbitmq/rabbitmq-server/pull/7798) and [queues](https://github.com/rabbitmq/rabbitmq-server/pull/11196) but for limiting the total number of exchanges.

Vhosts and queues are more expensive since they run processes while exchanges are just metadata. A limit would be good for exchanges too though, because if you create a really large number of them you can increase the memory footprint by quite a bit - through taking more space in the metadata store and making more work for monitoring. By default the limit is unset and it can be enabled with `cluster_exchange_limit = 100` or explicitly disabled with `cluster_exchange_limit = infinity`, like the vhost limit.

I've also added some small changes to the Khepri impls for `rabbit_db_exchange`'s `count/0` and `exists/1` so that we use the projection ETS table rather than a query, to make this as cheap as possible.