### PR TITLE
Introduce a few new rabbit_plugins and rabbit_nodes functions

### DIFF
--- a/deps/rabbit/test/unit_plugin_directories_SUITE.erl
+++ b/deps/rabbit/test/unit_plugin_directories_SUITE.erl
@@ -61,6 +61,10 @@ listing_plugins_from_multiple_directories(Config) ->
               end,
     Path = FirstDir ++ PathSep ++ SecondDir,
     Got = lists:sort([{Name, Vsn} || #plugin{name = Name, version = Vsn} <- rabbit_plugins:list(Path)]),
+    PluginsMap = maps:from_list(Got),
+    ?assert(maps:is_key(plugin_first_dir, PluginsMap)),
+    ?assert(maps:is_key(plugin_second_dir, PluginsMap)),
+    ?assert(maps:is_key(plugin_both, PluginsMap)),
     %% `rabbit` was loaded automatically by `rabbit_plugins:list/1`.
     %% We want to unload it now so it does not interfere with other
     %% testcases.


### PR DESCRIPTION
Sometimes a plugin needs to list online peers
that are running, reachable, not under maintenance and have a specific plugin enabled.

This commit introduces a few helper functions
to make such cluster member queries trivial.
