### PR TITLE
Use RMQ_ERLC_OPTS for ERL_COMPILER_OPTIONS

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -363,7 +363,7 @@ RMQ_ERLC_OPTS += -DTRACE_SUPERVISOR2=true
 endif
 
 # https://www.erlang.org/doc/apps/parsetools/leex.html#file/2
-export ERL_COMPILER_OPTIONS := deterministic
+export ERL_COMPILER_OPTIONS := $(RMQ_ERLC_OPTS)
 
 # --------------------------------------------------------------------
 # Documentation.


### PR DESCRIPTION
This should make the `deterministic` flag optional again for local re-compile using `c()` in the `erl` shell.

I'm also looking into why the two `*_sql_*` files are modified on every build...

```
lrbakken@SEA-3LG5HVJUWJK ~/development/rabbitmq/rabbitmq-server (lukebakken/make-deterministic-optional-again *)
$ git st
On branch lukebakken/make-deterministic-optional-again
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   deps/rabbit/Makefile
        modified:   deps/rabbit/src/rabbit_amqp_sql_lexer.erl
        modified:   deps/rabbit/src/rabbit_amqp_sql_parser.erl
```