### PR TITLE
Add config option for enabling local_random_exchange

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2592,7 +2592,13 @@ fun(Conf) ->
     end
 end}.
 
+%% Enable or disable local random exchange
+%%
+%% {enable_local_random_exchange, false},
 
+{mapping, "enable_local_random_exchange", "rabbit.enable_local_random_exchange", [
+    {datatype, {enum, [true, false]}}
+]}.
 
 %%
 %% Backing queue version

--- a/deps/rabbit/src/rabbit_exchange_type_local_random.erl
+++ b/deps/rabbit/src/rabbit_exchange_type_local_random.erl
@@ -58,11 +58,12 @@ info(_X) -> [].
 info(_X, _) -> [].
 serialise_events() -> false.
 validate(_X) ->
-    case rabbit_feature_flags:is_enabled(?MODULE) of
+    case rabbit_feature_flags:is_enabled(?MODULE) andalso
+         rabbit_misc:get_env(rabbit, enable_local_random_exchange, true) of
         true ->
             ok;
         false ->
-            rabbit_misc:amqp_error(
+            rabbit_misc:protocol_error(
               precondition_failed,
               "x-local-random exchange feature not available", [],
               'exchange.declare')

--- a/deps/rabbit/test/rabbit_local_random_exchange_SUITE.erl
+++ b/deps/rabbit/test/rabbit_local_random_exchange_SUITE.erl
@@ -21,7 +21,8 @@ groups() ->
     [
      {non_parallel_tests, [], [
                                routed_to_one_local_queue_test,
-                               no_route
+                               no_route,
+                               enable_local_random_exchange_config_test
                               ]}
     ].
 
@@ -195,6 +196,30 @@ make_exchange_name(Config, Suffix) ->
 make_queue_name(Config, Node) ->
     B = rabbit_ct_helpers:get_config(Config, test_resource_name),
     erlang:list_to_binary("q-" ++ B ++ "-" ++ integer_to_list(Node)).
+
+enable_local_random_exchange_config_test(Config) ->
+    E = make_exchange_name(Config, "config-test"),
+    
+    %% Disable the config flag
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                 [rabbit, enable_local_random_exchange, false]),
+    
+    %% Try to create exchange - should fail
+    ?assertExit({{shutdown, {server_initiated_close, 406, _}}, _},
+                declare_exchange(Config, E)),
+    
+    %% Re-enable the config flag
+    rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
+                                 [rabbit, enable_local_random_exchange, true]),
+    
+    %% Now exchange creation should succeed
+    declare_exchange(Config, E),
+    
+    %% Clean up
+    run_on_node(Config, 0,
+                fun(Chan) ->
+                        amqp_channel:call(Chan, #'exchange.delete'{exchange = E})
+                end).
 
 flush(T) ->
     receive X ->


### PR DESCRIPTION
## Proposed Changes

This adds config option which can be used to prevent creation of local random exchanges. If RabbitMQ is behind a load balancer then local random exchanges can't be used effectively, so it would be useful for operators to set enable_local_random_exchange = false to prevent them from being created.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
