### PR TITLE
[skip ci] Add module name to the FF debug log

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1000,12 +1000,12 @@ query_supported_feature_flags() ->
       AllFeatureFlags :: feature_flags().
 %% @private
 
-prepare_queried_feature_flags([{App, _Module, Attributes} | Rest],
+prepare_queried_feature_flags([{App, Module, Attributes} | Rest],
                               AllFeatureFlags) ->
     ?LOG_DEBUG(
       "Feature flags: application `~ts` has ~b feature flags (including "
-      "deprecated features)",
-      [App, length(Attributes)],
+      "deprecated features) in module `~ts`",
+      [App, length(Attributes), Module],
       #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
     AllFeatureFlags1 = lists:foldl(
                          fun({FeatureName, FeatureProps}, AllFF) ->


### PR DESCRIPTION
Without this change, the logs looked confusing:
```
[debug] <0.217.0> Feature flags: application `rabbit` has 1 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 23 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 1 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 1 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 1 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 1 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 1 feature flags (including deprecated features)
[debug] <0.217.0> Feature flags: application `rabbit` has 2 feature flags (including deprecated features)
```

it wasn't clear why the same app was queried multiple times with different results.