### PR TITLE
Permit amqp_filter_set_bug by default

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -34,7 +34,7 @@
 
 -rabbit_deprecated_feature(
    {amqp_filter_set_bug,
-    #{deprecation_phase => denied_by_default,
+    #{deprecation_phase => permitted_by_default,
       doc_url => "https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-filter-set"
      }}).
 


### PR DESCRIPTION
This partially reverts https://github.com/rabbitmq/rabbitmq-server/pull/14245.
This makes 4.2 <-> 3.13 mixed version tests succeed.
We can set this flag to `denied_by_default` in 4.3.
