### PR TITLE
Remove flake in prometheus_http_SUITE

### DIFF
--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -15,6 +15,9 @@
 
 -compile([export_all, nowarn_export_all]).
 
+-import(rabbit_ct_helpers, [eventually/1]).
+-import(rabbit_ct_broker_helpers, [rpc/4]).
+
 all() ->
     [
         {group, default_config},
@@ -831,6 +834,7 @@ stream_pub_sub_metrics(Config) ->
                  lists:sort(maps:to_list(MaxOffsetLag))),
     dispose_stream_connection(S1, C1, list_to_binary(Stream1)),
     dispose_stream_connection(S2, C2, list_to_binary(Stream2)),
+    eventually(?_assertEqual([], rpc(Config, rabbit_amqqueue, list_by_type, [stream]))),
     ok.
 
 core_metrics_special_chars(Config) ->


### PR DESCRIPTION
Sometimes the metrics for streams created by `stream_pub_sub_metrics` would be returned when the next test starts, breaking the assertions.