### PR TITLE
Validate 3.13->4.2 upgrade before releasing 4.2 alpha

### DIFF
--- a/.github/workflows/release-4.2.x-alphas.yaml
+++ b/.github/workflows/release-4.2.x-alphas.yaml
@@ -13,8 +13,15 @@ on:
 env:
   DEV_WORKFLOW_REPOSITORY: "rabbitmq/server-packages"
 jobs:
+  test_mixed_versions:
+    name: Test mixed clusters before release
+    uses: ./.github/workflows/test-mixed.yaml
+    with:
+      previous_version: 'tags/v3.13.7'
+
   trigger_alpha_build:
     runs-on: ubuntu-latest
+    needs: test_mixed_versions
     steps:
       - name: Compute prerelease identifier from commit SHA
         run: echo "PRERELEASE_IDENTIFIER=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV


### PR DESCRIPTION
3.13<->4.2 tests run weekly so it's easy to miss that they failed. This led to the first 4.2 alpha being released with a broken upgrade path from 3.13 (due to https://github.com/rabbitmq/rabbitmq-server/pull/14245). This PR adds mixed-version tests with 3.13 as a mandatory step before a 4.2 alpha is released.