### PR TITLE
Do not log every transient dependency when listing plugins

### DIFF
--- a/deps/rabbit/src/rabbit_plugins.erl
+++ b/deps/rabbit/src/rabbit_plugins.erl
@@ -695,20 +695,6 @@ remove_plugins(Plugins) ->
               IsAPlugin =
               lists:member(Plugin, ActualPlugins) orelse
               lists:member(Name, PluginDeps),
-              if
-                  IsOTPApp ->
-                      ?LOG_DEBUG(
-                        "Plugins discovery: "
-                        "ignoring ~ts, Erlang/OTP application",
-                        [Name]);
-                  not IsAPlugin ->
-                      ?LOG_DEBUG(
-                        "Plugins discovery: "
-                        "ignoring ~ts, not a RabbitMQ plugin",
-                        [Name]);
-                  true ->
-                      ok
-              end,
               not (IsOTPApp orelse not IsAPlugin)
       end, Plugins).
 


### PR DESCRIPTION
The code path in question is executed every time
rabbit_plugins:list/2 (e.g. rabbit_plugins:is_enabled/1) is used, which with some distributed plugins can
happen once or several times a minute.

Given the maturity of the plugins subsystem, we
arguably can drop tho