### PR TITLE
Do not "pre convert" `running_nodes` to strings

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -275,7 +275,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
       cluster_tags: result |> Keyword.get(:cluster_tags, []),
       disk_nodes: result |> Keyword.get(:nodes, []) |> Keyword.get(:disc, []),
       ram_nodes: result |> Keyword.get(:nodes, []) |> Keyword.get(:ram, []),
-      running_nodes: result |> Keyword.get(:running_nodes, []) |> Enum.map(&to_string/1),
+      running_nodes: result |> Keyword.get(:running_nodes, []),
       alarms: Keyword.get(result, :alarms) |> Keyword.values() |> Enum.concat() |> Enum.uniq(),
       maintenance_status: Keyword.get(result, :maintenance_status, []) |> Enum.into(%{}),
       partitions: Keyword.get(result, :partitions, []) |> Enum.into(%{}),


### PR DESCRIPTION
Follow-up to #14118

Without this PR:

```
$ ./sbin/rabbitmqctl -n rabbit-1 cluster_status --formatter=json | jq '.running_nodes'
"rabbit-3@SEA-3LG5HVJUWJKrabbit-2@SEA-3LG5HVJUWJKrabbit-1@SEA-3LG5HVJUWJK"
```

With this PR:

```
$ ./sbin/rabbitmqctl -n rabbit-1 cluster_status --formatter=json | jq '.running_nodes'
[
  "rabbit-3@SEA-3LG5HVJUWJK",
  "rabbit-2@SEA-3LG5HVJUWJK",
  "rabbit-1@SEA-3LG5HVJUWJK"
]
```