### PR TITLE
Detach link for link-level errors

### DIFF
--- a/deps/rabbit/test/amqp_dotnet_SUITE.erl
+++ b/deps/rabbit/test/amqp_dotnet_SUITE.erl
@@ -35,7 +35,10 @@ groups() ->
        redelivery,
        released,
        routing,
-       invalid_routes,
+       attach_sender_to_missing_exchange,
+       attach_sender_to_invalid_address,
+       attach_receiver_from_missing_queue,
+       attach_receiver_from_invalid_address,
        auth_failure,
        access_failure_not_allowed,
        access_failure_send,
@@ -176,7 +179,16 @@ routing(Config) ->
                                        }),
     run(?FUNCTION_NAME, Config).
 
-invalid_routes(Config) ->
+attach_sender_to_missing_exchange(Config) ->
+    run(?FUNCTION_NAME, Config).
+
+attach_sender_to_invalid_address(Config) ->
+    run(?FUNCTION_NAME, Config).
+
+attach_receiver_from_missing_queue(Config) ->
+    run(?FUNCTION_NAME, Config).
+
+attach_receiver_from_invalid_address(Config) ->
     run(?FUNCTION_NAME, Config).
 
 auth_failure(Config) ->


### PR DESCRIPTION
 ## What?
Refuse or detach the link instead of ending the session for many
link-level errors, including the following:
* Source queue or target exchange doesn't exist during attach
* Trying to consume from an exclusive queue on a different connection
* Delivery of message to a target queue fails
* Wrong delivery-id
* Wrong settled flag
* Queue declaration fails for dynamic queues
* Publishing to internal exchange

 ## Why?
Because many errors are scoped to a single terminus, detaching just that link
preserves the rest of the session’s links - avoiding needless disruption of
other traffic. AMQP 1.0’s error model is hierarchical; RabbitMQ should escalate to
ending the session only for session-level faults or if the client keeps
using a destroyed link.

 ## How?
Refuse link as per figure 2.33
