### PR TITLE
Make rabbit_ct_broker_helpers:configure_metadata_store/1 handle relative feature flag op lists

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -1133,6 +1133,13 @@ configure_metadata_store(Config) ->
                       {rabbit,
                        [{forced_feature_flags_on_init,
                          {rel, [khepri_db], []}}]});
+                {rel, ListToEnable, ListToSkip} ->
+                    Rel1 = {rel, [khepri_db | ListToEnable], ListToSkip},
+                    rabbit_ct_helpers:merge_app_env(
+                      Config1, {rabbit, [
+                        {forced_feature_flags_on_init, Rel1}
+                      ]}
+                    );
                 _ ->
                     rabbit_ct_helpers:merge_app_env(
                       Config1,
@@ -1149,6 +1156,13 @@ configure_metadata_store(Config) ->
                       {rabbit,
                        [{forced_feature_flags_on_init,
                          {rel, [], [khepri_db]}}]});
+                {rel, ListToEnable, ListToSkip} ->
+                    Rel1 = {rel, ListToEnable, [khepri_db | ListToSkip]},
+                    rabbit_ct_helpers:merge_app_env(
+                      Config1, {rabbit, [
+                             {forced_feature_flags_on_init, Rel1}
+                      ]}
+                    );
                 _ ->
                     rabbit_ct_helpers:merge_app_env(
                       Config1,


### PR DESCRIPTION
The function relies on such a relative list itself but does not assume that a test suite could use it.
