### PR TITLE
rabbit_definitions: Import topic permissions after exchanges

### DIFF
--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -409,8 +409,12 @@ create_or_get_in_mnesia(#exchange{name = XName} = X) ->
       end).
 
 create_or_get_in_khepri(#exchange{name = XName} = X) ->
-    Path = khepri_exchange_path(XName),
-    case rabbit_khepri:create(Path, X) of
+    Path0 = khepri_exchange_path(XName),
+    Path1 = khepri_path:combine_with_conditions(
+              Path0, [#if_any{conditions =
+                              [#if_node_exists{exists = false},
+                               #if_has_payload{has_payload = false}]}]),
+    case rabbit_khepri:put(Path1, X) of
         ok ->
             {new, X};
         {error, {khepri, mismatching_node, #{node_props := #{data := ExistingX}}}} ->

--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -508,9 +508,9 @@ apply_defs(Map, ActingUser, SuccessFun) when is_function(SuccessFun) ->
         concurrent_for_all(vhosts,             ActingUser, Map, fun add_vhost/2),
         validate_limits(Map),
         concurrent_for_all(permissions,        ActingUser, Map, fun add_permission/2),
-        concurrent_for_all(topic_permissions,  ActingUser, Map, fun add_topic_permission/2),
 
         concurrent_for_all(exchanges,          ActingUser, Map, fun add_exchange/2),
+        concurrent_for_all(topic_permissions,  ActingUser, Map, fun add_topic_permission/2),
 
         sequential_for_all(global_parameters,  ActingUser, Map, fun add_global_parameter/2),
         %% importing policies concurrently can be unsafe as queues will be getting


### PR DESCRIPTION
## Why

Topic permissions depend on an exchange, in addition to a user and a vhost like other permissions.

This fixes a bug where an exchange imported after a topic permission that depends on it caused the following crash when Khepri is used:

```erlang
{case_clause,{error,{khepri,mismatching_node,
                            #{node_name => <<"exchange_name">>,
                              node_props => #{payload_version => 1},
                              node_path =>
                                  [rabbitmq,vhosts,<<"/">>,exchanges,
                                   <<"exchange_name">>],
                              condition => {if_node_exists,false},
                              node_is_target => true}}}}
```

The crash comes from the fact that the exchange code expect to either create the tree node in Khepri for that exchange, or there is an existing tree node holding an exchange tree node. Here, there was a tree node created implicitly when the topic permission was stored, but that tree node didn't have an exchange record (because the exchange was not imported yet).

## How

We simply swap the import of topic permissions and exchanges.

In addition to that, we also relax the conditions used to write a new exchange record in Khepri. This is not strictly required, but this makes the code more robust (see the second commit in the branch).