### PR TITLE
Add RABBITMQ_MAX_OPEN_FILES variable to the startup script

### DIFF
--- a/deps/rabbit/scripts/rabbitmq-server
+++ b/deps/rabbit/scripts/rabbitmq-server
@@ -39,6 +39,13 @@ start_rabbitmq_server() {
 
     _rmq_env_set_erl_libs
 
+    if [ -n "$RABBITMQ_MAX_OPEN_FILES" ]; then
+        if ! ulimit -n ${RABBITMQ_MAX_OPEN_FILES}; then
+            echo "Error: Failed to set maximum number of open files to ${RABBITMQ_MAX_OPEN_FILES}" >&2
+            exit 1
+        fi
+    fi
+
     RABBITMQ_START_RABBIT=
     [ "x" = "x$RABBITMQ_ALLOW_INPUT" ] && RABBITMQ_START_RABBIT=" -noinput"
     if test -z "$RABBITMQ_NODE_ONLY"; then


### PR DESCRIPTION
In some environments it may be tricky to run a command before RabbitMQ is started. Kubernetes For example, upgrading to Containerd 2.0 accidentally lowered the value of available descriptors in GKE
(https://cloud.google.com/kubernetes-engine/docs/troubleshooting/known-issues#containerd-ulimit-reduced). While this particular issue is resolved in newer GKE versions, it was a good example of why a variable like this would be helpful. Kubernetes-level solutions (on the node or with a daemonset) would require a different level of access for users.