### PR TITLE
Shovel amqp1.0: fix delete after validation

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -183,7 +183,7 @@ amqp10_src_validation(_Def, User) ->
      {<<"src-uri">>, validate_uri_fun(User), mandatory},
      {<<"src-address">>, fun rabbit_parameter_validation:binary/2, mandatory},
      {<<"src-prefetch-count">>, fun rabbit_parameter_validation:number/2, optional},
-     {<<"src-delete-after">>, fun validate_delete_after/2, optional}
+     {<<"src-delete-after">>, fun validate_amqp10_delete_after/2, optional}
     ].
 
 amqp091_src_validation(_Def, User) ->
@@ -300,6 +300,12 @@ validate_delete_after(_Name, <<"queue-length">>)   -> ok;
 validate_delete_after(_Name, N) when is_integer(N), N >= 0 -> ok;
 validate_delete_after(Name,  Term) ->
     {error, "~ts should be a number greater than or equal to 0, \"never\" or \"queue-length\", actually was "
+     "~tp", [Name, Term]}.
+
+validate_amqp10_delete_after(_Name, <<"never">>)          -> ok;
+validate_amqp10_delete_after(_Name, N) when is_integer(N), N >= 0 -> ok;
+validate_amqp10_delete_after(Name,  Term) ->
+    {error, "~ts should be a number greater than or equal to 0 or \"never\", actually was "
      "~tp", [Name, Term]}.
 
 validate_internal_owner(Name, Term0) ->

--- a/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
@@ -29,7 +29,8 @@ groups() ->
           simple_amqp10_dest,
           simple_amqp10_src,
           amqp091_to_amqp10_with_dead_lettering,
-          amqp10_to_amqp091_application_properties
+          amqp10_to_amqp091_application_properties,
+          test_amqp10_delete_after_queue_length
         ]},
       {with_map_config, [], [
           simple,
@@ -340,6 +341,25 @@ autodelete_amqp091_dest(Config, {AckMode, After, ExpSrc, ExpDest}) ->
             expect_count(Session, Dest, ExpDest),
             expect_count(Session, Src, ExpSrc)
     end.
+
+test_amqp10_delete_after_queue_length(Config) ->
+    Src = ?config(srcq, Config),
+    Dest = ?config(destq, Config),
+    Uri = shovel_test_utils:make_uri(Config, 0),
+    Error = rabbit_ct_broker_helpers:rpc(
+              Config, 0,
+              rabbit_runtime_parameters, set,
+              [<<"/">>, <<"shovel">>, <<"test">>, [{<<"src-uri">>,  Uri},
+                                                   {<<"dest-uri">>, [Uri]},
+                                                   {<<"src-protocol">>, <<"amqp10">>},
+                                                   {<<"src-address">>, Src},
+                                                   {<<"src-delete-after">>, <<"queue-length">>},
+                                                   {<<"dest-protocol">>, <<"amqp10">>},
+                                                   {<<"dest-address">>, Dest}],
+               none]),
+    ?assertMatch({error_string, _}, Error),
+    {_, Msg} = Error,
+    ?assertMatch(match, re:run(Msg, "Validation failed.*", [{capture, none}])).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
Queue-length is not supported, so it should fail already during validation and not shovel startup

Existing bug, unrelated to local shovels. It can be backported.