### PR TITLE
Shovel: introduce operating modes

### DIFF
--- a/deps/rabbitmq_shovel/include/rabbit_shovel.hrl
+++ b/deps/rabbitmq_shovel/include/rabbit_shovel.hrl
@@ -5,6 +5,8 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
+-define(SHOVEL_APP, rabbitmq_shovel).
+
 -record(endpoint,
         {uris,
          resource_declaration

--- a/deps/rabbitmq_shovel/priv/schema/rabbitmq_shovel.schema
+++ b/deps/rabbitmq_shovel/priv/schema/rabbitmq_shovel.schema
@@ -2,6 +2,10 @@
 %% RabbitMQ Shovel plugin
 %% ----------------------------------------------------------------------------
 
+{mapping, "shovel.operating_mode", "rabbitmq_shovel.operating_mode", [
+     [{datatype, {enum, [standard, alternative, library]}}]
+]}.
+
 {mapping, "shovel.topology.predeclared", "rabbitmq_shovel.topology.predeclared", [
      [{datatype, {enum, [true, false]}}]
 ]}.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -26,13 +26,13 @@ start_link() ->
             {ok, Pid0}                       -> Pid0;
             {error, {already_started, Pid0}} -> Pid0
           end,
-    IsStandard = rabbit_shovel_operating_mode:is_standard(),
-    Shovels = case IsStandard of
-        false ->
+    OpMode = rabbit_shovel_operating_mode:operating_mode(),
+    Shovels = case OpMode of
+        standard ->
+            rabbit_runtime_parameters:list_component(<<"shovel">>);
+        _Other ->
             %% when operating in a non-standard mode, do not start any shovels
-            [];
-        true ->
-            rabbit_runtime_parameters:list_component(<<"shovel">>)
+            []
     end,
     [start_child({pget(vhost, Shovel), pget(name, Shovel)},
                  pget(value, Shovel)) || Shovel <- Shovels],

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -26,7 +26,14 @@ start_link() ->
             {ok, Pid0}                       -> Pid0;
             {error, {already_started, Pid0}} -> Pid0
           end,
-    Shovels = rabbit_runtime_parameters:list_component(<<"shovel">>),
+    IsStandard = rabbit_shovel_operating_mode:is_standard(),
+    Shovels = case IsStandard of
+        false ->
+            %% when operating in a non-standard mode, do not start any shovels
+            [];
+        true ->
+            rabbit_runtime_parameters:list_component(<<"shovel">>)
+    end,
     [start_child({pget(vhost, Shovel), pget(name, Shovel)},
                  pget(value, Shovel)) || Shovel <- Shovels],
     {ok, Pid}.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_operating_mode.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_operating_mode.erl
@@ -1,0 +1,34 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_shovel_operating_mode).
+
+-include("rabbit_shovel.hrl").
+
+-export([
+  operating_mode/0,
+  is_standard/0,
+  is_alternative/0
+]).
+
+-type operating_mode() :: 'standard' | atom().
+
+%%
+%% API
+%%
+
+-spec operating_mode() -> operating_mode().
+operating_mode() ->
+    application:get_env(?SHOVEL_APP, operating_mode, standard).
+
+-spec is_standard() -> boolean().
+is_standard() ->
+    operating_mode() =:= standard.
+
+-spec is_alternative() -> boolean().
+is_alternative() ->
+    operating_mode() =/= standard.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_operating_mode.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_operating_mode.erl
@@ -10,9 +10,7 @@
 -include("rabbit_shovel.hrl").
 
 -export([
-  operating_mode/0,
-  is_standard/0,
-  is_alternative/0
+  operating_mode/0
 ]).
 
 -type operating_mode() :: 'standard' | atom().
@@ -24,11 +22,3 @@
 -spec operating_mode() -> operating_mode().
 operating_mode() ->
     application:get_env(?SHOVEL_APP, operating_mode, standard).
-
--spec is_standard() -> boolean().
-is_standard() ->
-    operating_mode() =:= standard.
-
--spec is_alternative() -> boolean().
-is_alternative() ->
-    operating_mode() =/= standard.

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -39,19 +39,21 @@
                     {enables, recovery}]}).
 
 register() ->
-    case rabbit_shovel_operating_mode:is_standard() of
-        true ->
+    OpMode = rabbit_shovel_operating_mode:operating_mode(),
+    case OpMode of
+        standard ->
             rabbit_registry:register(runtime_parameter, <<"shovel">>, ?MODULE);
-        false ->
-            ?LOG_DEBUG("Shovel: skipping runtime parameter registration, operating mode: ~ts", [rabbit_shovel_operating_mode:operating_mode()])
+        _Other ->
+            ?LOG_DEBUG("Shovel: skipping runtime parameter registration, operating mode: ~ts", [OpMode])
     end.
 
 unregister() ->
-    case rabbit_shovel_operating_mode:is_standard() of
-        true ->
+    OpMode = rabbit_shovel_operating_mode:operating_mode(),
+    case OpMode of
+        standard ->
             rabbit_registry:unregister(runtime_parameter, <<"shovel">>);
-        false ->
-            ?LOG_DEBUG("Shovel: skipping runtime parameter deregistration, operating mode: ~ts", [rabbit_shovel_operating_mode:operating_mode()])
+        _Other ->
+            ?LOG_DEBUG("Shovel: skipping runtime parameter deregistration, operating mode: ~ts", [OpMode])
     end.
 
 validate(_VHost, <<"shovel">>, Name, Def0, User) ->
@@ -75,19 +77,21 @@ pget2(K1, K2, Defs) -> case {pget(K1, Defs), pget(K2, Defs)} of
                        end.
 
 notify(VHost, <<"shovel">>, Name, Definition, _Username) ->
-    case rabbit_shovel_operating_mode:is_standard() of
-        true ->
+    OpMode = rabbit_shovel_operating_mode:operating_mode(),
+    case OpMode of
+        standard ->
             rabbit_shovel_dyn_worker_sup_sup:adjust({VHost, Name}, Definition);
-        false ->
-            ?LOG_DEBUG("Shovel: ignoring a runtime parameter update, operating mode: ~ts", [rabbit_shovel_operating_mode:operating_mode()])
+        _Other ->
+            ?LOG_DEBUG("Shovel: ignoring a runtime parameter update, operating mode: ~ts", [OpMode])
     end.
 
 notify_clear(VHost, <<"shovel">>, Name, _Username) ->
-    case rabbit_shovel_operating_mode:is_standard() of
-        true ->
+    OpMode = rabbit_shovel_operating_mode:operating_mode(),
+    case OpMode of
+        standard ->
             rabbit_shovel_dyn_worker_sup_sup:stop_child({VHost, Name});
-        false ->
-            ?LOG_DEBUG("Shovel: ignoring a cleared runtime parameter, operating mode: ~ts", [rabbit_shovel_operating_mode:operating_mode()])
+        _Other ->
+            ?LOG_DEBUG("Shovel: ignoring a cleared runtime parameter, operating mode: ~ts", [OpMode])
     end.
 
 %%----------------------------------------------------------------------------

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_sup.erl
@@ -8,6 +8,9 @@
 -module(rabbit_shovel_sup).
 -behaviour(supervisor).
 
+-include_lib("kernel/include/logger.hrl").
+-include_lib("logging.hrl").
+
 -export([start_link/0, init/1]).
 
 -import(rabbit_shovel_config, []).
@@ -22,6 +25,7 @@ start_link() ->
 
 init([Configurations]) ->
     OpMode = rabbit_shovel_operating_mode:operating_mode(),
+    ?LOG_DEBUG("Shovel: operating mode set to ~ts", [OpMode]),
     StaticShovelSpecs = make_child_specs(OpMode, Configurations),
     Len = dict:size(Configurations),
     ChildSpecs = [


### PR DESCRIPTION
Sometimes you want a plugin to act as a library
and not an application. That is, for its modules
to be available at compile time and on a running
node but, say, the actual runtime parameter
handling and supervision of shovels to be
handled by another plugin.

Since we do not currently have a concept of
"library plugins" or "library dependencies",
this approach demonstrates one example of how
some plugins can be used effectively as libraries.

Per discussion with @mkuratczyk @Zerpet.