### PR TITLE
Backport #14401

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -601,6 +601,10 @@ function fmt_object_state(obj) {
         explanation = 'The queue does not have sufficient online members to ' +
             'make progress'
     }
+    else if (obj.state == 'timeout') {
+        colour = 'yellow';
+        explanation = 'The queue leader did not respond to its status request ';
+    }
 
     return fmt_state(colour, text, explanation);
 }


### PR DESCRIPTION
This is a backport of https://github.com/rabbitmq/rabbitmq-server/pull/14401 to `v4.1.x`.