### PR TITLE
Only start `os_mon` application on `win32`

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -125,7 +125,7 @@ define PROJECT_ENV
 	  ]
 endef
 
-LOCAL_DEPS = sasl os_mon inets compiler public_key crypto ssl syntax_tools xmerl
+LOCAL_DEPS = sasl inets compiler public_key crypto ssl syntax_tools xmerl
 
 BUILD_DEPS = rabbitmq_cli
 DEPS = ranch cowlib rabbit_common amqp10_common rabbitmq_prelaunch ra sysmon_handler stdout_formatter recon redbug observer_cli osiris syslog systemd seshat horus khepri khepri_mnesia_migration cuttlefish gen_batch_server

--- a/deps/rabbit/src/rabbit_disk_monitor.erl
+++ b/deps/rabbit/src/rabbit_disk_monitor.erl
@@ -139,6 +139,10 @@ init([Limit]) ->
                {unix, _} ->
                    start_portprogram();
                {win32, _OSname} ->
+                   %% Note: os_mon is not automatically started as it is only
+                   %% used on win32 for the time being. Rather than start it
+                   %% on all systems, we start it here.
+                   ok = rabbit_misc:ensure_os_mon(),
                    not_used
            end,
     State3 = State2#state{port=Port, os=OS},

--- a/deps/rabbit/src/vm_memory_monitor.erl
+++ b/deps/rabbit/src/vm_memory_monitor.erl
@@ -275,6 +275,12 @@ init_state_by_os(State0 = #state{os_type = {unix, linux}, os_pid = OsPid}) ->
     PageSize = get_linux_pagesize(),
     ProcFile = io_lib:format("/proc/~ts/statm", [OsPid]),
     State0#state{page_size = PageSize, proc_file = ProcFile};
+init_state_by_os(State = #state{os_type = {win32, _}}) ->
+    %% Note: os_mon is not automatically started as it is only
+    %% used on win32 for the time being. Rather than start it
+    %% on all systems, we start it here.
+    ok = rabbit_misc:ensure_os_mon(),
+    State;
 init_state_by_os(State) ->
     State.
 

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -90,6 +90,8 @@
 -export([remote_sup_child/2]).
 -export([for_each_while_ok/2, fold_while_ok/3]).
 
+-export([ensure_os_mon/0]).
+
 %% Horrible macro to use in guards
 -define(IS_BENIGN_EXIT(R),
         R =:= noproc; R =:= noconnection; R =:= nodedown; R =:= normal;
@@ -1615,3 +1617,11 @@ fold_while_ok(Fun, Acc0, [Elem | Rest]) ->
     end;
 fold_while_ok(_Fun, Acc, []) ->
     {ok, Acc}.
+
+ensure_os_mon() ->
+    ensure_os_mon(os:type()).
+
+ensure_os_mon({win32, _}) ->
+    ok = application:ensure_started(os_mon);
+ensure_os_mon(_) ->
+    ok.


### PR DESCRIPTION
`os_mon` is only used on `win32` systems, so there is no need to start it on `unix` systems. In addition, `os_mon` can pollute the log files with memory high watermark messages that can be confused with those emitted by RabbitMQ's memory monitor.

At some point, RabbitMQ _should_ use `os_mon` for disk and memory monitoring, but that day is a ways away.