### PR TITLE
Ensure that `tar` sets file modified time correctly

### DIFF
--- a/packaging/generic-unix/Makefile
+++ b/packaging/generic-unix/Makefile
@@ -38,7 +38,7 @@ dist:
 	@elixir --version
 	@echo '--------------------------------------------------'
 	@echo
-	xzcat $(SOURCE_DIST_FILE) | tar -xf -
+	tar --touch --xz --extract --file $(SOURCE_DIST_FILE)
 
 # web-manpages are not used by generic-unix but by `make release` in the
 # Umbrella. Those manpages are copied to www.rabbitmq.com


### PR DESCRIPTION
For some reason, when the source dist archive is built, the file modified times can be in the future. By adding the `--touch` argument, all files have their modified time set to the extraction time. This prevents the "infinite loop make" behavior described in rabbitmq/rabbitmq-server#14440

These changes also update the arguments passed to `tar` to use full arguments that are easier to understand, as well as removes the need for the `xzcat` command, as all build enviroments should have `xz` support built into GNU `tar`.

Related to: https://github.com/rabbitmq/rabbitmq-packaging/pull/58
Part of the fix for: https://github.com/rabbitmq/rabbitmq-server/issues/14440
