### PR TITLE
Fix in OCI trigger for PRs

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -79,7 +79,7 @@ jobs:
         - ${{ github.event.inputs.otp_version || '28' }}
     needs: build-package-generic-unix
     runs-on: ubuntu-latest
-    if: ${{ needs.build-package-generic-unix.outputs.authorized }} == 'true'
+    if: ${{ needs.build-package-generic-unix.outputs.authorized }} == true
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
The output is of type bool, and the comparison was checking for string
'true'. In JS 'true' is not equal true (bool) :shrug:

I can't quite prove the fix because I have permissions to push. We will see if this
fix is effective when a new external PR is submitted.
