### PR TITLE
Re-arrange shovel test suites

### DIFF
--- a/deps/rabbitmq_shovel/test/amqp091_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_dynamic_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(dynamic_SUITE).
+-module(amqp091_dynamic_SUITE).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").

--- a/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(configuration_SUITE).
+-module(amqp091_static_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").

--- a/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_dynamic_SUITE.erl
@@ -11,6 +11,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
+-import(shovel_test_utils, [await_credit/1]).
+
 all() ->
     [
       {group, non_parallel_tests},
@@ -397,6 +399,7 @@ publish_expect(Session, Source, Dest, Tag, Payload) ->
     {ok, Sender} = amqp10_client:attach_sender_link(Session, LinkName, Source,
                                                     unsettled, unsettled_state),
     ok = await_amqp10_event(link, Sender, attached),
+    await_credit(Sender),
     publish(Sender, Tag, Payload),
     amqp10_client:detach_link(Sender),
     expect_one(Session, Dest).

--- a/deps/rabbitmq_shovel/test/amqp10_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_static_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(amqp10_SUITE).
+-module(amqp10_static_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/deps/rabbitmq_shovel/test/local_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_static_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(local_SUITE).
+-module(local_static_SUITE).
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("common_test/include/ct.hrl").

--- a/deps/rabbitmq_shovel/test/unit_parsing_and_validation_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/unit_parsing_and_validation_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(config_SUITE).
+-module(unit_parsing_and_validation_SUITE).
 
 -compile(export_all).
 

--- a/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(parameters_SUITE).
+-module(unit_runtime_parameter_SUITE).
 
 -compile(export_all).
 


### PR DESCRIPTION
More specifically:

 * Use more descriptive names
 * Make it instantly obvious which suite is for dynamic and which is for static shovels, and what protocol is used
 * Prefix unit test suites accordingly
 * Reuse an extracted version of `await_credit/1`
 * `await_credit/1` before publishing in a flaky AMQP 1.0 shovel test
