### PR TITLE
Re-arrange shovel test suites

### DIFF
--- a/deps/rabbitmq_shovel/test/amqp091_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_dynamic_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(dynamic_SUITE).
+-module(amqp091_dynamic_SUITE).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").

--- a/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(configuration_SUITE).
+-module(amqp091_static_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").

--- a/deps/rabbitmq_shovel/test/unit_parsing_and_validation_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/unit_parsing_and_validation_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(config_SUITE).
+-module(unit_parsing_and_validation_SUITE).
 
 -compile(export_all).
 

--- a/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/unit_runtime_parameter_SUITE.erl
@@ -5,7 +5,7 @@
 %% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
--module(parameters_SUITE).
+-module(unit_runtime_parameter_SUITE).
 
 -compile(export_all).
 


### PR DESCRIPTION
 * Use more descriptive names
 * Prefix unit test suites accordingly

This is a `v4.1.x` version of https://github.com/rabbitmq/rabbitmq-server/pull/14465.

**This is a non-functional change** and can go into `v4.1.x` during the backport freeze period.