### PR TITLE
Local shovels: skip tests in mixed-version

### DIFF
--- a/deps/rabbitmq_shovel/test/local_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_static_SUITE.erl
@@ -61,10 +61,19 @@ init_per_suite(Config) ->
             "dest_queue_down"
           ]}
       ]),
-    rabbit_ct_helpers:run_setup_steps(Config1,
-      rabbit_ct_broker_helpers:setup_steps() ++
-      rabbit_ct_client_helpers:setup_steps() ++
-      [fun stop_shovel_plugin/1]).
+    Config2 = rabbit_ct_helpers:run_setup_steps(
+                Config1,
+                rabbit_ct_broker_helpers:setup_steps() ++
+                    rabbit_ct_client_helpers:setup_steps() ++
+                    [fun stop_shovel_plugin/1]),
+    [Node] = rabbit_ct_broker_helpers:get_node_configs(Config2, nodename),
+    case rabbit_ct_broker_helpers:enable_feature_flag(
+           Config2, [Node], 'rabbitmq_4.0.0') of
+        ok ->
+            Config2;
+        _ ->
+            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
+    end.
 
 end_per_suite(Config) ->
     application:stop(amqp10_client),


### PR DESCRIPTION
Local shovels require rabbitmq_4_0_0 feature flag, so it can't run in mixed-version clusters with 3.13.x

