### PR TITLE
Local shovels: exclude tests in mixed-versions with 3.13.x

### DIFF
--- a/deps/rabbitmq_shovel/test/local_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_dynamic_SUITE.erl
@@ -97,17 +97,10 @@ init_per_suite(Config0) ->
           "dest_queue_down"
         ]}
       ]),
-    Config2 = rabbit_ct_helpers:run_setup_steps(Config1,
-                                                rabbit_ct_broker_helpers:setup_steps() ++
-                                                    rabbit_ct_client_helpers:setup_steps()),
-    [Node] = rabbit_ct_broker_helpers:get_node_configs(Config2, nodename),
-    case rabbit_ct_broker_helpers:enable_feature_flag(
-           Config2, [Node], 'rabbitmq_4.0.0') of
-        ok ->
-            Config2;
-        _ ->
-            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
-    end.
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+          rabbit_ct_client_helpers:setup_steps()).
 
 end_per_suite(Config) ->
     application:stop(amqp10_client),
@@ -116,7 +109,14 @@ end_per_suite(Config) ->
       rabbit_ct_broker_helpers:teardown_steps()).
 
 init_per_group(_, Config) ->
-    Config.
+    [Node] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    case rabbit_ct_broker_helpers:enable_feature_flag(
+           Config, [Node], 'rabbitmq_4.0.0') of
+        ok ->
+            Config;
+        _ ->
+            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
+    end.
 
 end_per_group(_, Config) ->
     Config.

--- a/deps/rabbitmq_shovel/test/local_dynamic_cluster_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_dynamic_cluster_SUITE.erl
@@ -50,15 +50,9 @@ init_per_suite(Config0) ->
           "dest_queue_down"
         ]}
       ]),
-    Config2 = rabbit_ct_helpers:run_setup_steps(Config1,
-                                                rabbit_ct_broker_helpers:setup_steps() ++
-                                                    rabbit_ct_client_helpers:setup_steps()),
-    case rabbit_ct_broker_helpers:enable_feature_flag(Config2, 'rabbitmq_4.0.0') of
-        ok ->
-            Config2;
-        _ ->
-            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
-    end.
+    rabbit_ct_helpers:run_setup_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+          rabbit_ct_client_helpers:setup_steps()).
 
 end_per_suite(Config) ->
     application:stop(amqp10_client),
@@ -67,7 +61,12 @@ end_per_suite(Config) ->
       rabbit_ct_broker_helpers:teardown_steps()).
 
 init_per_group(_, Config) ->
-    Config.
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, 'rabbitmq_4.0.0') of
+        ok ->
+            Config;
+        _ ->
+            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
+    end.
 
 end_per_group(_, Config) ->
     Config.

--- a/deps/rabbitmq_shovel/test/local_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_static_SUITE.erl
@@ -61,19 +61,10 @@ init_per_suite(Config) ->
             "dest_queue_down"
           ]}
       ]),
-    Config2 = rabbit_ct_helpers:run_setup_steps(
-                Config1,
-                rabbit_ct_broker_helpers:setup_steps() ++
-                    rabbit_ct_client_helpers:setup_steps() ++
-                    [fun stop_shovel_plugin/1]),
-    [Node] = rabbit_ct_broker_helpers:get_node_configs(Config2, nodename),
-    case rabbit_ct_broker_helpers:enable_feature_flag(
-           Config2, [Node], 'rabbitmq_4.0.0') of
-        ok ->
-            Config2;
-        _ ->
-            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
-    end.
+    rabbit_ct_helpers:run_setup_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+          rabbit_ct_client_helpers:setup_steps() ++
+          [fun stop_shovel_plugin/1]).
 
 end_per_suite(Config) ->
     application:stop(amqp10_client),
@@ -82,7 +73,14 @@ end_per_suite(Config) ->
       rabbit_ct_broker_helpers:teardown_steps()).
 
 init_per_group(_, Config) ->
-    Config.
+    [Node] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+    case rabbit_ct_broker_helpers:enable_feature_flag(
+           Config, [Node], 'rabbitmq_4.0.0') of
+        ok ->
+            Config;
+        _ ->
+            {skip, "This suite requires rabbitmq_4.0.0 feature flag"}
+    end.
 
 end_per_group(_, Config) ->
     Config.


### PR DESCRIPTION
The test suites need to be excluded at group level, so the end_per_suite is always executed and the cluster stopped. Otherwise, clusters remain running in CI and the following suites find the TCP ports busy.

