### PR TITLE
rabbit_fifo: Expose each smallest raft index in `overview/1`

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -912,7 +912,8 @@ overview(#?STATE{consumers = Cons,
                  in_memory_message_bytes => 0, %% backwards compat
                  num_in_memory_ready_messages => 0, %% backwards compat
                  release_cursor_enqueue_counter => EnqCount,
-                 smallest_raft_index => smallest_raft_index(State)
+                 smallest_raft_index => smallest_raft_index(State),
+                 smallest_raft_index_overview => smallest_raft_index_overview(State)
                  },
     DlxOverview = rabbit_fifo_dlx:overview(DlxState),
     maps:merge(maps:merge(Overview, DlxOverview), SacOverview).
@@ -2825,6 +2826,13 @@ smallest_raft_index(#?STATE{messages = Messages,
     SmallestMsgsRaIdx = rabbit_fifo_q:get_lowest_index(Messages),
     SmallestRaIdx = rabbit_fifo_index:smallest(Indexes),
     min(min(SmallestDlxRaIdx, SmallestMsgsRaIdx), SmallestRaIdx).
+
+smallest_raft_index_overview(#?STATE{messages = Messages,
+                                     ra_indexes = Indexes,
+                                     dlx = DlxState}) ->
+    #{message => rabbit_fifo_q:get_lowest_index(Messages),
+      checked_out => rabbit_fifo_index:smallest(Indexes),
+      dlx => rabbit_fifo_dlx:smallest_raft_index(DlxState)}.
 
 make_requeue(ConsumerKey, Notify, [{MsgId, Idx, Header, Msg}], Acc) ->
     lists:reverse([{append,


### PR DESCRIPTION
This is meant to be used as a debugging tool via an eval command. It can be hard to tell from the outside why a QQ is not snapshotting. Looking at the `overview/1` is a nice debugging tool. The `smallest_raft_index` key (and other info like the `release_cursors`) point out why a snapshot isn't being taken. The `smallest_raft_index` is the minimum of three criteria though:

* oldest ready message
* oldest checked out message
* oldest message in the dlx state

This change adds all of those indexes so that it is clear which criteria is keeping the `smallest_raft_index` down.