### PR TITLE
Use Khepri by default in CT tests

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -1104,8 +1104,8 @@ configured_metadata_store(Config) ->
             mnesia;
         _ ->
             case os:getenv("RABBITMQ_METADATA_STORE") of
-                "khepri" -> khepri;
-                _        -> mnesia
+                "mnesia" -> mnesia;
+                _ -> khepri
             end
     end.
 


### PR DESCRIPTION
When starting a new cluster, Khepri is the default metadata store in 4.2. Let's also make Khepri the default metadata store in CT tests.