### PR TITLE
Additional JSON CLI formatter fix

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/formatters/json.ex
@@ -93,6 +93,11 @@ defmodule RabbitMQ.CLI.Formatters.Json do
 
   defp convert_erlang_strings([]),  do: []
 
+  defp convert_erlang_strings([b | _rest]=data) when is_binary(b) do
+    # Assume this is a list of strings already converted
+    data
+  end
+
   defp convert_erlang_strings(data) when is_list(data) do
     try do
       case :unicode.characters_to_binary(data, :utf8) do


### PR DESCRIPTION
Fixes #14509 

A list of binaries was incorrectly converted by `unicode:characters_to_binary` into one big binary. Add a function head to match this case.

Also, add tests for the values that were not correctly formatted prior to #14101 and #14381