### PR TITLE
Shrink queue process state in case of abnormal queue [member] process termination to reduce peak memory footprint

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1674,6 +1674,24 @@ end}.
 % Logging section
 % ==========================
 
+{mapping, "log.summarize_process_state", "rabbit.summarize_process_state_when_logged", [
+    {datatype, {enum, [true, false]}}
+]}.
+
+{mapping, "log.error_logger_format_depth", "kernel.error_logger_format_depth", [
+    {datatype, [{atom, unlimited}, integer]}
+]}.
+{translation, "kernel.error_logger_format_depth",
+ fun(Conf) ->
+   case cuttlefish:conf_get("log.error_logger_format_depth", Conf, undefined) of
+     undefined -> cuttlefish:unset();
+     unlimited -> unlimited;
+     Val when is_integer(Val) andalso Val > 0 -> Val;
+     _ -> cuttlefish:invalid("should be positive integer or 'unlimited'")
+   end
+ end
+}.
+
 {mapping, "log.dir", "rabbit.log_root", [
     {datatype, string},
     {validators, ["dir_writable"]}]}.

--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -34,7 +34,8 @@
          handle_pre_hibernate/1, resume/1, msg_rates/1,
          info/2, invoke/3, is_duplicate/2, set_queue_mode/2,
          set_queue_version/2,
-         zip_msgs_and_acks/4]).
+         zip_msgs_and_acks/4,
+         format_state/1]).
 
 -record(state, {bq, bqss, max_priority}).
 -record(passthrough, {bq, bqs}).
@@ -663,3 +664,12 @@ zip_msgs_and_acks(Pubs, AckTags) ->
               Id = mc:get_annotation(id, Msg),
               {Id, AckTag}
       end, Pubs, AckTags).
+
+format_state(S = #passthrough{bq = BQ, bqs = BQS0}) ->
+    case erlang:function_exported(BQ, format_state, 1) of
+        true ->
+            BQS1 = BQ:format_state(BQS0),
+            S#passthrough{bqs = BQS1};
+        _ ->
+            S#passthrough{bqs = passthrough_bqs_truncated}
+    end.


### PR DESCRIPTION
* Call `Mod:format_state/1` if exported to possibly truncate huge states
* Add more information about truncated ram_pending_ack and disk_pending_ack
* Add `log.error_logger_format_depth` cuttlefish schema value

You can use this branch to test these changes - it calls `exit()` the first time a delivery is attempted to a consumer:

https://github.com/lukebakken/rmq-rabbitmq-server/tree/lukebakken/fix-format-status-test-exit

I've used it with PerfTest to crash the queue process:

```
cd rabbitmq-perf-test
make ARGS='--producers 1 --consumers 1 --pmessages 1010 --flag persistent' run
```

Finally, see this discussion!

https://github.com/rabbitmq/rabbitmq-server/discussions/14349