### PR TITLE
Disallow multiple consumers on one volatile queue

### DIFF
--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -341,7 +341,7 @@ consume(Q, Spec, #stream_client{} = QState0)
               ok_msg := OkMsg,
               acting_user := ActingUser} = Spec,
             ?LOG_DEBUG("~s:~s Local pid resolved ~0p",
-                             [?MODULE, ?FUNCTION_NAME, LocalPid]),
+                       [?MODULE, ?FUNCTION_NAME, LocalPid]),
             case parse_offset_arg(
                    rabbit_misc:table_lookup(Args, <<"x-stream-offset">>)) of
                 {ok, OffsetSpec} ->


### PR DESCRIPTION
There can be at most one consumer per volatile queue instance. This consumer must also have attached on the same channel/session as the creator of the queue.

Prior to this commit, it was possible for clients on other connections or sessions to attach a receiving link to an existing volatile queue name, even though no messages would be delivered.

It's better for RabbitMQ to directly refuse the link at attach time.