### PR TITLE
Fix regression with Khepri binding args

### DIFF
--- a/deps/rabbit/test/bindings_SUITE.erl
+++ b/deps/rabbit/test/bindings_SUITE.erl
@@ -37,6 +37,7 @@ groups() ->
 all_tests() ->
     [
      %% Queue bindings
+     binding_args,
      bind_and_unbind,
      bind_and_delete,
      bind_and_delete_source_exchange,
@@ -116,6 +117,56 @@ end_per_testcase(Testcase, Config) ->
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
+
+binding_args(Config) ->
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    Q = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', Q, 0, 0}, declare(Ch, Q, [])),
+
+    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+    amqp_channel:register_confirm_handler(Ch, self()),
+
+    %% Create two bindings that differ only in their binding arguments.
+    Exchange = <<"amq.direct">>,
+    RoutingKey = <<"some-key">>,
+    BindingArgs1 = [{<<"app">>, longstr, <<"app-1">>}],
+    BindingArgs2 = [{<<"app">>, longstr, <<"app-2">>}],
+    #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{exchange = Exchange,
+                                                             routing_key = RoutingKey,
+                                                             queue = Q,
+                                                             arguments = BindingArgs1}),
+    #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{exchange = Exchange,
+                                                             routing_key = RoutingKey,
+                                                             queue = Q,
+                                                             arguments = BindingArgs2}),
+    ok = amqp_channel:cast(Ch,
+                           #'basic.publish'{exchange = Exchange,
+                                            routing_key = RoutingKey},
+                           #amqp_msg{payload = <<"m1">>}),
+    receive #'basic.ack'{} -> ok
+    after 9000 -> ct:fail(confirm_timeout)
+    end,
+
+    ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = <<"m1">>}},
+                 amqp_channel:call(Ch, #'basic.get'{queue = Q, no_ack = true})),
+
+    %% If we delete the 1st binding, we expect RabbitMQ to still route via the 2nd binding.
+    #'queue.unbind_ok'{} = amqp_channel:call(Ch, #'queue.unbind'{exchange = Exchange,
+                                                                 routing_key = RoutingKey,
+                                                                 queue = Q,
+                                                                 arguments = BindingArgs1}),
+    ok = amqp_channel:cast(Ch,
+                           #'basic.publish'{exchange = Exchange,
+                                            routing_key = RoutingKey},
+                           #amqp_msg{payload = <<"m2">>}),
+    receive #'basic.ack'{} -> ok
+    after 9000 -> ct:fail(confirm_timeout)
+    end,
+
+    ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = <<"m2">>}},
+                 amqp_channel:call(Ch, #'basic.get'{queue = Q, no_ack = true})).
+
 bind_and_unbind(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
 

--- a/deps/rabbit/test/bindings_SUITE.erl
+++ b/deps/rabbit/test/bindings_SUITE.erl
@@ -13,7 +13,6 @@
 -include_lib("rabbitmq_ct_helpers/include/rabbit_assert.hrl").
 
 -compile([nowarn_export_all, export_all]).
--compile(export_all).
 
 suite() ->
     [{timetrap, 5 * 60000}].
@@ -37,7 +36,6 @@ groups() ->
 all_tests() ->
     [
      %% Queue bindings
-     binding_args,
      bind_and_unbind,
      bind_and_delete,
      bind_and_delete_source_exchange,
@@ -50,6 +48,7 @@ all_tests() ->
      list_with_multiple_vhosts,
      list_with_multiple_arguments,
      bind_to_unknown_queue,
+     binding_args,
      %% Exchange bindings
      bind_and_unbind_exchange,
      bind_and_delete_exchange_source,
@@ -117,55 +116,6 @@ end_per_testcase(Testcase, Config) ->
 %% -------------------------------------------------------------------
 %% Testcases.
 %% -------------------------------------------------------------------
-
-binding_args(Config) ->
-    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
-    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
-    Q = ?config(queue_name, Config),
-    ?assertEqual({'queue.declare_ok', Q, 0, 0}, declare(Ch, Q, [])),
-
-    #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
-    amqp_channel:register_confirm_handler(Ch, self()),
-
-    %% Create two bindings that differ only in their binding arguments.
-    Exchange = <<"amq.direct">>,
-    RoutingKey = <<"some-key">>,
-    BindingArgs1 = [{<<"app">>, longstr, <<"app-1">>}],
-    BindingArgs2 = [{<<"app">>, longstr, <<"app-2">>}],
-    #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{exchange = Exchange,
-                                                             routing_key = RoutingKey,
-                                                             queue = Q,
-                                                             arguments = BindingArgs1}),
-    #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{exchange = Exchange,
-                                                             routing_key = RoutingKey,
-                                                             queue = Q,
-                                                             arguments = BindingArgs2}),
-    ok = amqp_channel:cast(Ch,
-                           #'basic.publish'{exchange = Exchange,
-                                            routing_key = RoutingKey},
-                           #amqp_msg{payload = <<"m1">>}),
-    receive #'basic.ack'{} -> ok
-    after 9000 -> ct:fail(confirm_timeout)
-    end,
-
-    ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = <<"m1">>}},
-                 amqp_channel:call(Ch, #'basic.get'{queue = Q, no_ack = true})),
-
-    %% If we delete the 1st binding, we expect RabbitMQ to still route via the 2nd binding.
-    #'queue.unbind_ok'{} = amqp_channel:call(Ch, #'queue.unbind'{exchange = Exchange,
-                                                                 routing_key = RoutingKey,
-                                                                 queue = Q,
-                                                                 arguments = BindingArgs1}),
-    ok = amqp_channel:cast(Ch,
-                           #'basic.publish'{exchange = Exchange,
-                                            routing_key = RoutingKey},
-                           #amqp_msg{payload = <<"m2">>}),
-    receive #'basic.ack'{} -> ok
-    after 9000 -> ct:fail(confirm_timeout)
-    end,
-
-    ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = <<"m2">>}},
-                 amqp_channel:call(Ch, #'basic.get'{queue = Q, no_ack = true})).
 
 bind_and_unbind(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
@@ -747,6 +697,60 @@ bind_to_unknown_queue(Config) ->
     ?assertEqual([],
                  rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_binding, list, [<<"/">>])),
     ok.
+
+binding_args(Config) ->
+    case rabbit_ct_broker_helpers:enable_feature_flag(Config, 'rabbitmq_4.2.0') of
+        {skip, _} = Skip ->
+            Skip;
+        ok ->
+            Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+            Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+            Q = ?config(queue_name, Config),
+            ?assertEqual({'queue.declare_ok', Q, 0, 0}, declare(Ch, Q, [])),
+
+            #'confirm.select_ok'{} = amqp_channel:call(Ch, #'confirm.select'{}),
+            amqp_channel:register_confirm_handler(Ch, self()),
+
+            %% Create two bindings that differ only in their binding arguments.
+            Exchange = <<"amq.direct">>,
+            RoutingKey = <<"some-key">>,
+            BindingArgs1 = [{<<"app">>, longstr, <<"app-1">>}],
+            BindingArgs2 = [{<<"app">>, longstr, <<"app-2">>}],
+            #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{exchange = Exchange,
+                                                                     routing_key = RoutingKey,
+                                                                     queue = Q,
+                                                                     arguments = BindingArgs1}),
+            #'queue.bind_ok'{} = amqp_channel:call(Ch, #'queue.bind'{exchange = Exchange,
+                                                                     routing_key = RoutingKey,
+                                                                     queue = Q,
+                                                                     arguments = BindingArgs2}),
+            ok = amqp_channel:cast(Ch,
+                                   #'basic.publish'{exchange = Exchange,
+                                                    routing_key = RoutingKey},
+                                   #amqp_msg{payload = <<"m1">>}),
+            receive #'basic.ack'{} -> ok
+            after 9000 -> ct:fail(confirm_timeout)
+            end,
+
+            ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = <<"m1">>}},
+                         amqp_channel:call(Ch, #'basic.get'{queue = Q, no_ack = true})),
+
+            %% If we delete the 1st binding, we expect RabbitMQ to still route via the 2nd binding.
+            #'queue.unbind_ok'{} = amqp_channel:call(Ch, #'queue.unbind'{exchange = Exchange,
+                                                                         routing_key = RoutingKey,
+                                                                         queue = Q,
+                                                                         arguments = BindingArgs1}),
+            ok = amqp_channel:cast(Ch,
+                                   #'basic.publish'{exchange = Exchange,
+                                                    routing_key = RoutingKey},
+                                   #amqp_msg{payload = <<"m2">>}),
+            receive #'basic.ack'{} -> ok
+            after 9000 -> ct:fail(confirm_timeout)
+            end,
+
+            ?assertMatch({#'basic.get_ok'{}, #amqp_msg{payload = <<"m2">>}},
+                         amqp_channel:call(Ch, #'basic.get'{queue = Q, no_ack = true}))
+    end.
 
 bind_and_unbind_exchange(Config) ->
     Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),


### PR DESCRIPTION
Fixes #14533

This PR fixes the bug for clusters created in >=4.2.
For clusters being upgraded from <4.2 to >= 4.2, the bug still exists, which may be acceptable given the edge case for the bug to be triggered. To fix the bug for upgrades <4.2, RabbitMQ needs a way to migrate projections. One option is to unregister and register the projection in the `rabbitmq_4.2.0` feature flag migration callback. This would require to block routing while this migration function runs.