### PR TITLE
Check for protected tag during user update and deletion via management API

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -53,6 +53,8 @@
 
 -export([set_resp_not_found/2]).
 
+-export([is_protected_user/1]).
+
 -import(rabbit_misc, [pget/2]).
 
 -include("rabbit_mgmt.hrl").
@@ -207,6 +209,14 @@ is_authorized_user(ReqData, Context, Username, Password, ReplyWhenFailed) ->
                                                 Password,
                                                 ReplyWhenFailed,
                                                 auth_config()).
+
+is_protected_user(Username) ->
+    case rabbit_auth_backend_internal:lookup_user(Username) of
+        {ok, User} ->
+            Tags = internal_user:get_tags(User),
+            rabbit_web_dispatch_access_control:is_protected_user(Tags);
+        {error, _} -> false
+    end.
 
 vhost_from_headers(ReqData) ->
     rabbit_web_dispatch_access_control:vhost_from_headers(ReqData).

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
@@ -24,7 +24,7 @@
 -export([id/2]).
 -export([not_authorised/3, halt_response/5]).
 
--export([is_admin/1, is_policymaker/1, is_monitor/1, is_mgmt_user/1]).
+-export([is_admin/1, is_policymaker/1, is_monitor/1, is_mgmt_user/1, is_protected_user/1]).
 
 -import(rabbit_misc, [pget/2]).
 
@@ -243,6 +243,7 @@ is_policymaker(T) -> intersects(T, [administrator, policymaker]).
 is_monitor(T)     -> intersects(T, [administrator, monitoring]).
 is_mgmt_user(T)   -> intersects(T, [administrator, monitoring, policymaker,
                                     management]).
+is_protected_user(T) -> intersects(T, [protected]).
 
 intersects(A, B) -> lists:any(fun(I) -> lists:member(I, B) end, A).
 

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_access_control.erl
@@ -245,7 +245,10 @@ is_mgmt_user(T)   -> intersects(T, [administrator, monitoring, policymaker,
                                     management]).
 is_protected_user(T) -> intersects(T, [protected]).
 
-intersects(A, B) -> lists:any(fun(I) -> lists:member(I, B) end, A).
+intersects(A, [B]) ->
+    lists:member(B, A);
+intersects(A, B) ->
+    lists:any(fun(I) -> lists:member(I, B) end, A).
 
 user_matches_vhost(ReqData, User) ->
     case vhost(ReqData) of


### PR DESCRIPTION
## Proposed Changes

Implements `protected` users proposed in [rabbitmq#14282](https://github.com/rabbitmq/rabbitmq-server/discussions/14282)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

I will update relevant [documentation](https://github.com/rabbitmq/rabbitmq-website/blob/d4b76ff21082a7cbb8ca556e0f5f99eb40baecd2/docs/management/index.md?plain=1#L191) once this change is reviewed.
