### PR TITLE
Correctly implement `format_state/1` in `rabbit_priority_queue`

### DIFF
--- a/deps/rabbit/src/rabbit_priority_queue.erl
+++ b/deps/rabbit/src/rabbit_priority_queue.erl
@@ -665,11 +665,15 @@ zip_msgs_and_acks(Pubs, AckTags) ->
               {Id, AckTag}
       end, Pubs, AckTags).
 
-format_state(S = #passthrough{bq = BQ, bqs = BQS0}) ->
+format_state(State = #state{bq = BQ, bqss = BQSs0}) when is_list(BQSs0) ->
     case erlang:function_exported(BQ, format_state, 1) of
         true ->
-            BQS1 = BQ:format_state(BQS0),
-            S#passthrough{bqs = BQS1};
+            BQSs1 = foreach1(fun (_Priority, BQSN) ->
+                                     BQ:format_state(BQSN)
+                             end, State),
+            State#state{bqss = BQSs1};
         _ ->
-            S#passthrough{bqs = passthrough_bqs_truncated}
-    end.
+            State#state{bqss = bqss_truncated}
+    end;
+format_state(State = #passthrough{bq = BQ, bqs = BQS}) ->
+    ?passthrough1(format_state(BQS)).


### PR DESCRIPTION
Follow-up to #14523 

The previous implementation did not take the unique `passthrough` record into account when formatting state.

To test the priority and non-priority scenarios, add `exit(kaboom)` in `rabbit_amqqueue_process` `handle_call({basic_consume...` then run PerfTest with these arguments:

```
--producers 1 --consumers 1 --pmessages 100 --queue-args x-max-priority=10

--producers 1 --consumers 1 --pmessages 100
```