### PR TITLE
Amqp10 shovel: retry with insufficient_credit error

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -359,7 +359,7 @@ send_msg(Link, Msg) ->
             ok;
         {error, insufficient_credit} ->
             receive {amqp10_event, {link, Link, credited}} ->
-                        ok = amqp10_client:send_msg(Link, Msg)
+                    send_msg(Link, Msg)
             after ?LINK_CREDIT_TIMEOUT ->
                       {stop, credited_timeout}
             end


### PR DESCRIPTION
Fixes an existing amqp1.0 shovel failure