### PR TITLE
Reduce ETS copy overhead when delivering to target queues

### DIFF
--- a/deps/rabbit/src/amqqueue.erl
+++ b/deps/rabbit/src/amqqueue.erl
@@ -14,6 +14,7 @@
          new/9,
          new_with_version/9,
          new_with_version/10,
+         new_target/4,
          fields/0,
          fields/1,
          field_vhost/0,
@@ -39,6 +40,7 @@
          % options
          get_options/1,
          set_options/2,
+         get_extra_bcc/1,
          % pid
          get_pid/1,
          set_pid/2,
@@ -77,7 +79,8 @@
          qnode/1,
          to_printable/1,
          to_printable/2,
-         macros/0]).
+         macros/0
+        ]).
 
 -define(record_version, amqqueue_v2).
 -define(is_backwards_compat_classic(T),
@@ -119,6 +122,17 @@
           type = ?amqqueue_v1_type :: module() | ets:match_pattern(),
           type_state = #{} :: map() | ets:match_pattern()
          }).
+
+%% A subset of the amqqueue record containing just the necessary fields
+%% to deliver a message to a target queue.
+-record(queue_target,
+        {name :: rabbit_amqqueue:name(),
+         type :: rabbit_queue_type:queue_type(),
+         pid :: pid() | ra_server_id() | none,
+         extra_bcc :: rabbit_misc:resource_name() | none
+        }).
+
+-opaque target() :: #queue_target{}.
 
 -type amqqueue() :: amqqueue_v2().
 -type amqqueue_v2() :: #amqqueue{
@@ -175,6 +189,7 @@
               amqqueue_v2/0,
               amqqueue_pattern/0,
               amqqueue_v2_pattern/0,
+              target/0,
               ra_server_id/0]).
 
 -spec new(rabbit_amqqueue:name(),
@@ -328,6 +343,17 @@ new_with_version(?record_version,
               options         = Options,
               type            = ensure_type_compat(Type)}.
 
+-spec new_target(rabbit_amqqueue:name(),
+                 rabbit_queue_type:queue_type(),
+                 pid() | ra_server_id() | none,
+                 rabbit_misc:resource_name() | none) ->
+    target().
+new_target(Name, Type, Pid, ExtraBcc) ->
+    #queue_target{name = Name,
+                  type = Type,
+                  pid = Pid,
+                  extra_bcc = ExtraBcc}.
+
 -spec is_amqqueue(any()) -> boolean().
 
 is_amqqueue(#amqqueue{}) -> true.
@@ -361,15 +387,21 @@ set_arguments(#amqqueue{} = Queue, Args) ->
 % options
 
 -spec get_options(amqqueue()) -> amqqueue_options().
-
 get_options(#amqqueue{options = Options}) ->
     Options.
 
 -spec set_options(amqqueue(), amqqueue_options()) -> amqqueue().
-
 set_options(#amqqueue{} = Queue, Options) ->
     Queue#amqqueue{options = Options}.
 
+-spec get_extra_bcc(amqqueue() | target()) ->
+    rabbit_misc:resource_name() | none.
+get_extra_bcc(#amqqueue{options = #{extra_bcc := Name}}) ->
+    Name;
+get_extra_bcc(#amqqueue{})  ->
+    none;
+get_extra_bcc(#queue_target{extra_bcc = Name}) ->
+    Name.
 
 % decorators
 
@@ -418,9 +450,10 @@ set_operator_policy(#amqqueue{} = Queue, Policy) ->
 
 % name
 
--spec get_name(amqqueue()) -> rabbit_amqqueue:name().
+-spec get_name(amqqueue() | target()) -> rabbit_amqqueue:name().
 
-get_name(#amqqueue{name = Name}) -> Name.
+get_name(#amqqueue{name = Name}) -> Name;
+get_name(#queue_target{name = Name}) -> Name.
 
 -spec set_name(amqqueue(), rabbit_amqqueue:name()) -> amqqueue().
 
@@ -429,9 +462,10 @@ set_name(#amqqueue{} = Queue, Name) ->
 
 % pid
 
--spec get_pid(amqqueue_v2()) -> pid() | ra_server_id() | none.
+-spec get_pid(amqqueue_v2() | target()) -> pid() | ra_server_id() | none.
 
-get_pid(#amqqueue{pid = Pid}) -> Pid.
+get_pid(#amqqueue{pid = Pid}) -> Pid;
+get_pid(#queue_target{pid = Pid}) -> Pid.
 
 -spec set_pid(amqqueue_v2(), pid() | ra_server_id() | none) -> amqqueue_v2().
 
@@ -488,9 +522,10 @@ set_state(#amqqueue{} = Queue, State) ->
 
 %% New in v2.
 
--spec get_type(amqqueue()) -> atom().
+-spec get_type(amqqueue() | target()) -> atom().
 
-get_type(#amqqueue{type = Type}) -> Type.
+get_type(#amqqueue{type = Type}) -> Type;
+get_type(#queue_target{type = Type}) -> Type.
 
 -spec get_vhost(amqqueue()) -> rabbit_types:vhost() | undefined.
 
@@ -628,8 +663,6 @@ to_printable(QName = #resource{name = Name, virtual_host = VHost}, Type) ->
        <<"name">> => Name,
        <<"virtual_host">> => VHost,
        <<"type">> => Type}.
-
-% private
 
 macros() ->
     io:format(

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -2528,7 +2528,7 @@ incoming_link_transfer(
             QNames = rabbit_exchange:route(X, Mc2, #{return_binding_keys => true}),
             rabbit_trace:tap_in(Mc2, QNames, ConnName, ChannelNum, Username, Trace),
             Opts = #{correlation => {HandleInt, DeliveryId}},
-            Qs0 = rabbit_amqqueue:lookup_many(QNames),
+            Qs0 = rabbit_db_queue:get_targets(QNames),
             Qs = rabbit_amqqueue:prepend_extra_bcc(Qs0),
             Mc = ensure_mc_cluster_compat(Mc2),
             case rabbit_queue_type:deliver(Qs, Mc, Opts, QStates0) of
@@ -2674,8 +2674,8 @@ process_routing_confirm([], _SenderSettles = false, DeliveryId, U) ->
     Disposition = released(DeliveryId),
     {U, [Disposition]};
 process_routing_confirm([_|_] = Qs, SenderSettles, DeliveryId, U0) ->
-    QNames = rabbit_amqqueue:queue_names(Qs),
     false = maps:is_key(DeliveryId, U0),
+    QNames = rabbit_amqqueue:queue_names(Qs),
     Map = maps:from_keys(QNames, ok),
     U = U0#{DeliveryId => {Map, SenderSettles, false}},
     rabbit_global_counters:messages_routed(?PROTOCOL, map_size(Map)),

--- a/deps/rabbit/src/rabbit_amqqueue.erl
+++ b/deps/rabbit/src/rabbit_amqqueue.erl
@@ -11,7 +11,7 @@
          delete_immediately/1, delete_exclusive/2, delete/4, purge/1,
          forget_all_durable/1]).
 -export([pseudo_queue/2, pseudo_queue/3]).
--export([exists/1, lookup/1, lookup/2, lookup_many/1, lookup_durable_queue/1,
+-export([exists/1, lookup/1, lookup/2, lookup_durable_queue/1,
          not_found_or_absent_dirty/1,
          with/2, with/3, with_or_die/2,
          assert_equivalence/5,
@@ -366,14 +366,6 @@ lookup(Name) when is_record(Name, resource) ->
 
 lookup_durable_queue(QName) ->
     rabbit_db_queue:get_durable(QName).
-
--spec lookup_many(rabbit_exchange:route_return()) ->
-    [amqqueue:amqqueue() | {amqqueue:amqqueue(), route_infos()}].
-lookup_many([]) ->
-    %% optimisation
-    [];
-lookup_many(Names) when is_list(Names) ->
-    rabbit_db_queue:get_many(Names).
 
 -spec lookup(binary(), binary()) ->
     rabbit_types:ok(amqqueue:amqqueue()) |

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -1222,7 +1222,7 @@ handle_method(#'basic.publish'{exchange    = ExchangeNameBin,
             check_user_id_header(Message0, User),
             Message = rabbit_msg_interceptor:intercept_incoming(Message0, MsgIcptCtx),
             QNames = rabbit_exchange:route(Exchange, Message, #{return_binding_keys => true}),
-            Queues = rabbit_amqqueue:lookup_many(QNames),
+            Queues = rabbit_db_queue:get_targets(QNames),
             rabbit_trace:tap_in(Message, QNames, ConnName, ChannelNum,
                                 Username, TraceState),
             %% TODO: call delivery_to_queues with plain args
@@ -2126,7 +2126,12 @@ deliver_to_queues(XName,
             rabbit_misc:protocol_error(
               resource_error,
               "Stream coordinator unavailable for ~ts",
-              [rabbit_misc:rs(Resource)])
+              [rabbit_misc:rs(Resource)]);
+        {error, Reason} ->
+            rabbit_misc:protocol_error(
+              resource_error,
+              "failed to deliver message: ~tp",
+              [Reason])
     end.
 
 process_routing_mandatory(_Mandatory = true,

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -287,16 +287,17 @@ format(Q, _Ctx) when ?is_amqqueue(Q) ->
      {state, State},
      {node, node(amqqueue:get_pid(Q))}].
 
--spec init(amqqueue:amqqueue()) -> {ok, state()}.
-init(Q) when ?amqqueue_is_classic(Q) ->
+-spec init(amqqueue:amqqueue() | amqqueue:target()) ->
+    {ok, state()}.
+init(Q) ->
     {ok, #?STATE{pid = amqqueue:get_pid(Q)}}.
 
 -spec close(state()) -> ok.
 close(_State) ->
     ok.
 
--spec update(amqqueue:amqqueue(), state()) -> state().
-update(Q, #?STATE{pid = Pid} = State) when ?amqqueue_is_classic(Q) ->
+-spec update(amqqueue:amqqueue() | amqqueue:target(), state()) -> state().
+update(Q, #?STATE{pid = Pid} = State) ->
     case amqqueue:get_pid(Q) of
         Pid ->
             State;
@@ -473,7 +474,7 @@ settlement_action(Type, QRef, MsgSeqs, Acc) ->
 
 supports_stateful_delivery() -> true.
 
--spec deliver([{amqqueue:amqqueue(), state()}],
+-spec deliver([{amqqueue:amqqueue() | amqqueue:target(), state()}],
               Delivery :: mc:state(),
               rabbit_queue_type:delivery_options()) ->
     {[{amqqueue:amqqueue(), state()}], rabbit_queue_type:actions()}.

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -287,9 +287,8 @@ format(Q, _Ctx) when ?is_amqqueue(Q) ->
      {state, State},
      {node, node(amqqueue:get_pid(Q))}].
 
--spec init(amqqueue:amqqueue()) ->
-    {ok, state()}.
-init(Q) ->
+-spec init(amqqueue:amqqueue()) -> {ok, state()}.
+init(Q) when ?amqqueue_is_classic(Q) ->
     {ok, #?STATE{pid = amqqueue:get_pid(Q)}}.
 
 -spec close(state()) -> ok.

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -287,7 +287,7 @@ format(Q, _Ctx) when ?is_amqqueue(Q) ->
      {state, State},
      {node, node(amqqueue:get_pid(Q))}].
 
--spec init(amqqueue:amqqueue() | amqqueue:target()) ->
+-spec init(amqqueue:amqqueue()) ->
     {ok, state()}.
 init(Q) ->
     {ok, #?STATE{pid = amqqueue:get_pid(Q)}}.
@@ -474,10 +474,10 @@ settlement_action(Type, QRef, MsgSeqs, Acc) ->
 
 supports_stateful_delivery() -> true.
 
--spec deliver([{amqqueue:amqqueue() | amqqueue:target(), state()}],
+-spec deliver([{amqqueue:target(), state()}],
               Delivery :: mc:state(),
               rabbit_queue_type:delivery_options()) ->
-    {[{amqqueue:amqqueue(), state()}], rabbit_queue_type:actions()}.
+    {[{amqqueue:target(), state()}], rabbit_queue_type:actions()}.
 deliver(Qs0, Msg0, Options) ->
     %% add guid to content here instead of in rabbit_basic:message/3,
     %% as classic queues are the only ones that need it

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -511,10 +511,10 @@ lookup_target(#resource{name = NameBin} = Name) ->
         false ->
             try
                 ets:lookup_element(?KHEPRI_TARGET_PROJECTION, Name, 2, not_found) of
-                {Type, Pid, ExtraBcc} ->
-                    amqqueue:new_target(Name, Type, Pid, ExtraBcc);
                 not_found ->
-                    not_found
+                    not_found;
+                Target ->
+                    amqqueue:new_target(Name, Target)
             catch
                 error:badarg ->
                     not_found

--- a/deps/rabbit/src/rabbit_dead_letter.erl
+++ b/deps/rabbit/src/rabbit_dead_letter.erl
@@ -44,7 +44,7 @@ publish(Msg0, Reason, #exchange{name = XName} = DLX, RK,
     Routed0 = rabbit_exchange:route(DLX, DLMsg, #{return_binding_keys => true}),
     {Cycles, Routed} = detect_cycles(Reason, DLMsg, Routed0),
     lists:foreach(fun log_cycle_once/1, Cycles),
-    Qs0 = rabbit_amqqueue:lookup_many(Routed),
+    Qs0 = rabbit_db_queue:get_targets(Routed),
     Qs = rabbit_amqqueue:prepend_extra_bcc(Qs0),
     _ = rabbit_queue_type:deliver(Qs, DLMsg, #{}, stateless),
     ok.

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -1361,7 +1361,6 @@ register_rabbit_queue_target_projection() ->
                     _VHost = ?KHEPRI_WILDCARD_STAR,
                     _Name = ?KHEPRI_WILDCARD_STAR),
     Fun = fun(_Path, Q) ->
-                  ?assert(amqqueue:is_amqqueue(Q)),
                   Name = amqqueue:get_name(Q),
                   Type = amqqueue:get_type(Q),
                   Pid = amqqueue:get_pid(Q),

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -204,12 +204,13 @@
 -callback policy_changed(amqqueue:amqqueue()) -> ok.
 
 %% intitialise and return a queue type specific session context
--callback init(amqqueue:amqqueue()) ->
+-callback init(amqqueue:amqqueue() | amqqueue:target()) ->
     {ok, queue_state()} | {error, Reason :: term()}.
 
 -callback close(queue_state()) -> ok.
-%% update the queue type state from amqqrecord
--callback update(amqqueue:amqqueue(), queue_state()) -> queue_state().
+
+-callback update(amqqueue:amqqueue() | amqqueue:target(), queue_state()) ->
+    queue_state().
 
 -callback consume(amqqueue:amqqueue(),
                   consume_spec(),
@@ -232,10 +233,10 @@
 
 -callback supports_stateful_delivery() -> boolean().
 
--callback deliver([{amqqueue:amqqueue(), queue_state()}],
+-callback deliver([{amqqueue:amqqueue() | amqqueue:target(), queue_state()}],
                   Message :: mc:state(),
                   Options :: delivery_options()) ->
-    {[{amqqueue:amqqueue(), queue_state()}], actions()}.
+    {[{amqqueue:amqqueue() | amqqueue:target(), queue_state()}], actions()}.
 
 -callback settle(queue_name(), settle_op(), rabbit_types:ctag(),
                  [non_neg_integer()], queue_state()) ->
@@ -619,14 +620,15 @@ publish_at_most_once(#resource{} = XName, Msg) ->
             Err
     end;
 publish_at_most_once(X, Msg)
-    when element(1, X) == exchange -> % hacky but good enough
+  when element(1, X) == exchange -> % hacky but good enough
     QNames = rabbit_exchange:route(X, Msg, #{return_binding_keys => true}),
-    Qs = rabbit_amqqueue:lookup_many(QNames),
+    Qs = rabbit_db_queue:get_targets(QNames),
     _ = deliver(Qs, Msg, #{}, stateless),
     ok.
 
--spec deliver([amqqueue:amqqueue() |
-               {amqqueue:amqqueue(), rabbit_exchange:route_infos()}],
+-spec deliver([amqqueue:amqqueue() | amqqueue:target() |
+               {amqqueue:amqqueue() | amqqueue:target(),
+                rabbit_exchange:route_infos()}],
               Message :: mc:state(),
               delivery_options(),
               stateless | state()) ->
@@ -688,14 +690,13 @@ deliver0(Qs, Message0, Options, #?STATE{} = State0) ->
               end, State0, Xs),
     {ok, State, Actions}.
 
-queue_binding_keys(Q)
-  when ?is_amqqueue(Q) ->
-    {Q, #{}};
 queue_binding_keys({Q, #{binding_keys := BindingKeys}})
-  when ?is_amqqueue(Q) andalso is_map(BindingKeys) ->
+  when is_map(BindingKeys) ->
     {Q, BindingKeys};
-queue_binding_keys({Q, _RouteInfos})
-  when ?is_amqqueue(Q) ->
+queue_binding_keys({Q, RouteInfos})
+  when is_map(RouteInfos) ->
+    {Q, #{}};
+queue_binding_keys(Q) ->
     {Q, #{}}.
 
 add_binding_keys(Message, BindingKeys)
@@ -775,9 +776,15 @@ removed_from_rabbit_registry(_Type) -> ok.
 get_ctx(QOrQref, State) ->
     get_ctx_with(QOrQref, State, undefined).
 
-get_ctx_with(Q, #?STATE{ctxs = Contexts}, InitState)
-  when ?is_amqqueue(Q) ->
-    Ref = qref(Q),
+get_ctx_with(#resource{kind = queue} = QRef, Contexts, undefined) ->
+    case get_ctx(QRef, Contexts, undefined) of
+        undefined ->
+            exit({queue_context_not_found, QRef});
+        Ctx ->
+            Ctx
+    end;
+get_ctx_with(Q, #?STATE{ctxs = Contexts}, InitState) ->
+    Ref = amqqueue:get_name(Q),
     case Contexts of
         #{Ref := #ctx{module = Mod,
                       state = State} = Ctx} ->
@@ -797,13 +804,6 @@ get_ctx_with(Q, #?STATE{ctxs = Contexts}, InitState)
             Mod = amqqueue:get_type(Q),
             #ctx{module = Mod,
                  state = InitState}
-    end;
-get_ctx_with(#resource{kind = queue} = QRef, Contexts, undefined) ->
-    case get_ctx(QRef, Contexts, undefined) of
-        undefined ->
-            exit({queue_context_not_found, QRef});
-        Ctx ->
-            Ctx
     end.
 
 get_ctx(QRef, #?STATE{ctxs = Contexts}, Default) ->
@@ -817,7 +817,7 @@ set_ctx(QRef, Ctx, #?STATE{ctxs = Contexts} = State) ->
 
 qref(#resource{kind = queue} = QName) ->
     QName;
-qref(Q) when ?is_amqqueue(Q) ->
+qref(Q) ->
     amqqueue:get_name(Q).
 
 -spec known_queue_type_modules() -> [module()].

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -212,8 +212,7 @@ is_compatible(_Durable = true,
 is_compatible(_, _, _) ->
     false.
 
--spec init(amqqueue:amqqueue()) ->
-    {ok, rabbit_fifo_client:state()} | {error, not_found}.
+-spec init(amqqueue:amqqueue()) -> {ok, rabbit_fifo_client:state()}.
 init(Q) when ?is_amqqueue(Q) ->
     {ok, SoftLimit} = application:get_env(rabbit, quorum_commands_soft_limit),
     {Name, _} = MaybeLeader = amqqueue:get_pid(Q),

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -212,7 +212,7 @@ is_compatible(_Durable = true,
 is_compatible(_, _, _) ->
     false.
 
--spec init(amqqueue:amqqueue() | amqqueue:target()) ->
+-spec init(amqqueue:amqqueue()) ->
     {ok, rabbit_fifo_client:state()} | {error, not_found}.
 init(Q) when ?is_amqqueue(Q) ->
     {ok, SoftLimit} = application:get_env(rabbit, quorum_commands_soft_limit),
@@ -229,15 +229,7 @@ init(Q) when ?is_amqqueue(Q) ->
     %% server tried is the one we want
     Servers0 = [{Name, N} || N <- Nodes],
     Servers = [Leader | lists:delete(Leader, Servers0)],
-    {ok, rabbit_fifo_client:init(Servers, SoftLimit)};
-init(QueueTarget) ->
-    QName = amqqueue:get_name(QueueTarget),
-    case rabbit_amqqueue:lookup(QName) of
-        {ok, Q} ->
-            init(Q);
-        Error ->
-            Error
-    end.
+    {ok, rabbit_fifo_client:init(Servers, SoftLimit)}.
 
 -spec close(rabbit_fifo_client:state()) -> ok.
 close(State) ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1013,8 +1013,16 @@ init(Q) when ?is_amqqueue(Q) ->
             {error, stream_not_found};
         {error, coordinator_unavailable} = E ->
             ?LOG_WARNING("Failed to start stream client ~tp: coordinator unavailable",
-                               [rabbit_misc:rs(QName)]),
+                         [rabbit_misc:rs(QName)]),
             E
+    end;
+init(QueueTarget) ->
+    QName = amqqueue:get_name(QueueTarget),
+    case rabbit_amqqueue:lookup(QName) of
+        {ok, Q} ->
+            init(Q);
+        Error ->
+            Error
     end.
 
 close(#stream_client{readers = Readers,
@@ -1024,8 +1032,7 @@ close(#stream_client{readers = Readers,
                          rabbit_core_metrics:consumer_deleted(self(), CTag, QName)
                  end, Readers).
 
-update(Q, State)
-  when ?is_amqqueue(Q) ->
+update(_Q, State) ->
     State.
 
 update_leader_pid(Pid, #stream_client{leader = Pid} =  State) ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1015,14 +1015,6 @@ init(Q) when ?is_amqqueue(Q) ->
             ?LOG_WARNING("Failed to start stream client ~tp: coordinator unavailable",
                          [rabbit_misc:rs(QName)]),
             E
-    end;
-init(QueueTarget) ->
-    QName = amqqueue:get_name(QueueTarget),
-    case rabbit_amqqueue:lookup(QName) of
-        {ok, Q} ->
-            init(Q);
-        Error ->
-            Error
     end.
 
 close(#stream_client{readers = Readers,

--- a/deps/rabbit/src/rabbit_volatile_queue.erl
+++ b/deps/rabbit/src/rabbit_volatile_queue.erl
@@ -16,6 +16,7 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 
 -export([new/1,
+         new_target/1,
          new_name/0,
          is/1,
          key_from_name/1,
@@ -93,6 +94,16 @@ new(#resource{virtual_host = Vhost,
 
 new0(Name, Pid, Vhost) ->
     amqqueue:new(Name, Pid, false, true, none, [], Vhost, #{}, ?MODULE).
+
+-spec new_target(rabbit_amqqueue:name()) ->
+    amqqueue:target() | error.
+new_target(#resource{name = NameBin} = Name) ->
+    case pid_from_name(NameBin) of
+        {ok, Pid} when is_pid(Pid) ->
+            amqqueue:new_target(Name, {?MODULE, Pid, none});
+        _ ->
+            error
+    end.
 
 -spec is(rabbit_misc:resource_name()) ->
     boolean().

--- a/deps/rabbit/test/rabbit_db_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_queue_SUITE.erl
@@ -31,7 +31,7 @@ all_tests() ->
     [
      create_or_get,
      get,
-     get_many,
+     get_targets,
      get_all,
      get_all_by_vhost,
      get_all_by_type,
@@ -131,20 +131,24 @@ get1(_Config) ->
                  rabbit_db_queue:get(rabbit_misc:r(?VHOST, queue, <<"test-queue2">>))),
     passed.
 
-get_many(Config) ->
-    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, get_many1, [Config]).
+get_targets(Config) ->
+    passed = rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, get_targets1, [Config]).
 
-get_many1(_Config) ->
+get_targets1(_Config) ->
     QName = rabbit_misc:r(?VHOST, queue, <<"test-queue">>),
     QName2 = rabbit_misc:r(?VHOST, queue, <<"test-queue2">>),
     Q = new_queue(QName, rabbit_classic_queue),
     Q2 = new_queue(QName2, rabbit_classic_queue),
     ok = rabbit_db_queue:set(Q),
-    ?assertEqual([Q], rabbit_db_queue:get_many([QName])),
-    ?assertEqual([Q], rabbit_db_queue:get_many([QName, QName2])),
-    ?assertEqual([], rabbit_db_queue:get_many([QName2])),
+    Target = {rabbit_classic_queue, none, none},
+    QTarget = amqqueue:new_target(QName, Target),
+    QTarget2 = amqqueue:new_target(QName2, Target),
+    ?assertEqual([QTarget], rabbit_db_queue:get_targets([QName])),
+    ?assertEqual([QTarget], rabbit_db_queue:get_targets([QName, QName2])),
+    ?assertEqual([], rabbit_db_queue:get_targets([QName2])),
     ok = rabbit_db_queue:set(Q2),
-    ?assertEqual(lists:sort([Q, Q2]), lists:sort(rabbit_db_queue:get_many([QName, QName2]))),
+    ?assertEqual(lists:sort([QTarget, QTarget2]),
+                 lists:sort(rabbit_db_queue:get_targets([QName, QName2]))),
     passed.
 
 get_all(Config) ->

--- a/deps/rabbitmq_management/test/clustering_SUITE.erl
+++ b/deps/rabbitmq_management/test/clustering_SUITE.erl
@@ -214,7 +214,7 @@ queue_on_other_node(Config) ->
     Conn = rabbit_ct_client_helpers:open_unmanaged_connection(Config, 1),
     {ok, Chan} = amqp_connection:open_channel(Conn),
     _ = queue_declare(Chan, <<"some-queue">>),
-    _ = wait_for_queue(Config, "/queues/%2F/some-queue"),
+    eventually(?_assertEqual(1, length(http_get(Config, "/queues/%2F"))), 2000, 5),
 
     {ok, Chan2} = amqp_connection:open_channel(?config(conn, Config)),
     consume(Chan2, <<"some-queue">>),
@@ -899,7 +899,6 @@ wait_for_queue(Config, Path, Keys) ->
 
 wait_for_queue(_Config, Path, Keys, 0) ->
     exit({timeout, {Path, Keys}});
-
 wait_for_queue(Config, Path, Keys, Count) ->
     Res = http_get(Config, Path),
     case present(Keys, Res) of

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -1697,7 +1697,7 @@ deliver_to_queues(Message,
                   RoutedToQNames,
                   State0 = #state{queue_states = QStates0,
                                   cfg = #cfg{proto_ver = ProtoVer}}) ->
-    Qs0 = rabbit_amqqueue:lookup_many(RoutedToQNames),
+    Qs0 = rabbit_db_queue:get_targets(RoutedToQNames),
     Qs = rabbit_amqqueue:prepend_extra_bcc(Qs0),
     case rabbit_queue_type:deliver(Qs, Message, Options, QStates0) of
         {ok, QStates, Actions} ->

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -133,7 +133,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
 supports_stateful_delivery() ->
     false.
 
--spec deliver([{amqqueue:amqqueue(), stateless}],
+-spec deliver([{amqqueue:amqqueue() | amqqueue:target(), stateless}],
               Msg :: mc:state(),
               rabbit_queue_type:delivery_options()) ->
     {[], rabbit_queue_type:actions()}.

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_qos0_queue.erl
@@ -133,7 +133,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) ->
 supports_stateful_delivery() ->
     false.
 
--spec deliver([{amqqueue:amqqueue() | amqqueue:target(), stateless}],
+-spec deliver([{amqqueue:target(), stateless}],
               Msg :: mc:state(),
               rabbit_queue_type:delivery_options()) ->
     {[], rabbit_queue_type:actions()}.

--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_exchange_type_recent_history.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_exchange_type_recent_history.erl
@@ -91,12 +91,12 @@ add_binding(_Tx, #exchange{ name = XName },
         {ok, X} ->
             Msgs = get_msgs_from_cache(XName),
             [begin
-                 Qs = rabbit_exchange:route(X, Msg),
-                 case rabbit_amqqueue:lookup_many(Qs) of
+                 QNames = rabbit_exchange:route(X, Msg),
+                 case rabbit_db_queue:get_targets(QNames) of
                      [] ->
-                         destination_not_found_error(Qs);
-                     QPids ->
-                         deliver_messages(QPids, [Msg])
+                         destination_not_found_error(QNames);
+                     Qs ->
+                         deliver_messages(Qs, [Msg])
                  end
              end || Msg <- Msgs]
     end,

--- a/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
@@ -382,7 +382,7 @@ forward(Tag, Msg0, #{dest := #{current := #{queue_states := QState} = Current} =
         end,
     Msg = set_annotations(Msg0, Dest),
     RoutedQNames = route(Msg, Dest),
-    Queues = rabbit_amqqueue:lookup_many(RoutedQNames),
+    Queues = rabbit_db_queue:get_targets(RoutedQNames),
     messages_received(AckMode),
     case rabbit_queue_type:deliver(Queues, Msg, Options, QState) of
         {ok, QState1, Actions} ->


### PR DESCRIPTION
 ## What?
This commit avoids copying the full amqqueue record from ETS per incoming message
and target queue.
The amqqueue record contains 21 elements and for some queue types,
especially streams, some elements are themselves nested terms.

 ## How?

In Khepri, use a new `rabbit_khepri_queue_target` projection which
contains a subset of the full amqqueue record.

This way all relevant information to deliver to a target queue can be
looked up in a single ets:lookup_element call.

Alternative approaches are described in https://github.com/erlang/otp/issues/10211

 ## Benchmark

Fanout to 3 streams

Start broker:
```
make run-broker TEST_TMPDIR="$HOME/scratch/rabbit/test" \
    FULL=1 \
    RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="+S 5" \
    RABBITMQ_CONFIG_FILE="$HOME/scratch/rabbit/high-credit.config" \
    PLUGINS="rabbitmq_management"
```

`high-credit.config` contains:
```
[
 {rabbit, [
  %% Maximum incoming-window of AMQP 1.0 session.
  %% Default: 400
  {max_incoming_window, 5000},

  %% Maximum link-credit RabbitMQ grants to AMQP 1.0 sender.
  %% Default: 128
  {max_link_credit, 2000},

  %% Maximum link-credit RabbitMQ AMQP 1.0 session grants to sending queue.
  %% Default: 256
  {max_queue_credit, 5000},

  {loopback_users, []}
 ]},

 {rabbitmq_management_agent, [
  {disable_metrics_collector, true}
 ]}
].
```

Create the 3 streams and bindings to the fanout exchange:
```
deps/rabbitmq_management/bin/rabbitmqadmin declare queue queue_type=stream durable=true name=ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss1 && \
    deps/rabbitmq_management/bin/rabbitmqadmin declare queue queue_type=stream durable=true name=ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss2 && \
    deps/rabbitmq_management/bin/rabbitmqadmin declare queue queue_type=stream durable=true name=ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss3 && \
    deps/rabbitmq_management/bin/rabbitmqadmin declare binding source=amq.fanout destination=ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss1 && \
    deps/rabbitmq_management/bin/rabbitmqadmin declare binding source=amq.fanout destination=ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss2 && \
    deps/rabbitmq_management/bin/rabbitmqadmin declare binding source=amq.fanout destination=ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss3

```

Start the client:
```
quiver-arrow send //host.docker.internal//exchanges/amq.fanout --summary --count 1m --body-size 4
```

`main` branch:
```
Count ............................................. 1,000,000 messages
Duration ............................................... 16.3 seconds
Message rate ......................................... 61,237 messages/s
```

with this PR:
```
Count ............................................. 1,000,000 messages
Duration ............................................... 14.2 seconds
Message rate ......................................... 70,309 messages/s
```

Hence, this PR increases the throughput when sending to 3 streams via AMQP by ~14%.