### PR TITLE
Add support to fetch cacertfiles from Amazon S3

### DIFF
--- a/deps/rabbitmq_aws/priv/schema/rabbitmq_aws.schema
+++ b/deps/rabbitmq_aws/priv/schema/rabbitmq_aws.schema
@@ -17,3 +17,33 @@
 
 {mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
     [{datatype, {enum, [true, false]}}]}.
+
+%% @doc Directory path where downloaded CA certificate files from S3 will be stored
+{mapping, "aws.cacertfiles.download_path", "rabbitmq_aws.cacertfiles_download_path",
+    [{datatype, string}, {default, "/tmp/rabbitmq-aws-cacertfiles"}]}.
+
+%% @doc Fetch cacertfile from Amazon S3, store locally and pass to auth_oauth2.https.cacertfile
+{mapping, "aws.arns.auth_oauth2.https.cacertfile", "rabbit.aws_arns",
+    [{datatype, string}]}.
+
+%% @doc Fetch cacertfile from Amazon S3, store locally and pass to ssl_options.cacertfile
+{mapping, "aws.arns.ssl_options.cacertfile", "rabbit.aws_arns",
+    [{datatype, string}]}.
+
+%% @doc Fetch cacertfile from Amazon S3, store locally and pass to auth_ldap.ssl_options.cacertfile
+{mapping, "aws.arns.auth_ldap.ssl_options.cacertfile", "rabbit.aws_arns",
+    [{datatype, string}]}.
+
+{translation, "rabbit.aws_arns",
+fun(Conf) ->
+    lists:foldl(fun({Key, Handler}, Acc) ->
+        case cuttlefish:conf_get(Key, Conf, undefined) of
+            undefined -> Acc;
+            Arn -> [{Key, Arn, Handler} | Acc]
+        end
+    end, [], [
+        {"aws.arns.auth_oauth2.https.cacertfile", oauth2_https_cacertfile},
+        {"aws.arns.ssl_options.cacertfile", ssl_options_cacertfile},
+        {"aws.arns.auth_ldap.ssl_options.cacertfile", ldap_ssl_options_cacertfile}
+    ])
+end}.

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_app.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_app.erl
@@ -16,7 +16,13 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
-    rabbitmq_aws_sup:start_link().
+    case rabbitmq_aws_sup:start_link() of
+        {ok, Pid} ->
+            rabbitmq_aws_resource_fetcher:process_arns(),
+            {ok, Pid};
+        Error ->
+            Error
+    end.
 
 stop(_State) ->
     ok.

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_resource_fetcher.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_resource_fetcher.erl
@@ -1,0 +1,117 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbitmq_aws_resource_fetcher).
+
+%% API
+-export([
+    process_arns/0
+]).
+
+%% Export all for unit tests
+-ifdef(TEST).
+-compile(export_all).
+-endif.
+
+-include("rabbitmq_aws.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-spec process_arns() -> ok.
+%% @doc Fetch certificate files from Amazon S3 and update application
+%%      configuration when users don't have access to the local file system
+%% @end
+process_arns() ->
+    case application:get_env(rabbit, aws_arns) of
+        {ok, ArnList} ->
+            lists:foreach(fun({_Key, Arn, Handler}) ->
+                case resolve_arn(Arn) of
+                    {ok, Content} ->
+                        FilePath = write_to_file(Arn, Content),
+                        case Handler of
+                            oauth2_https_cacertfile ->
+                                update_env(rabbitmq_auth_backend_oauth2, key_config, cacertfile, FilePath);
+                            ssl_options_cacertfile ->
+                                update_env(rabbit, ssl_options, cacertfile, FilePath);
+                            ldap_ssl_options_cacertfile ->
+                                update_env(rabbitmq_auth_backend_ldap, ssl_options, cacertfile, FilePath)
+                        end,
+                        ?LOG_INFO("Fetched ARN ~p and stored to ~p", [Arn, FilePath]);
+                    {error, Reason} ->
+                        ?LOG_ERROR("Failed to resolve ARN ~p: ~p", [Arn, Reason])
+                end
+            end, ArnList);
+        _ ->
+            ok
+    end.
+
+-spec update_env(atom(), atom(), atom(), string()) -> ok.
+update_env(App, ConfigKey, Key, Value) ->
+    Config = case application:get_env(App, ConfigKey) of
+        {ok, ExistingConfig} -> ExistingConfig;
+        undefined -> []
+    end,
+    NewConfig = lists:keystore(Key, 1, Config, {Key, Value}),
+    application:set_env(App, ConfigKey, NewConfig).
+
+-spec resolve_arn(string()) -> {ok, binary()} | {error, term()}.
+resolve_arn(Arn) ->
+    ?LOG_INFO("Attempting to resolve ARN: ~p", [Arn]),
+    case parse_arn(Arn) of
+        {ok, #{service := "s3"}} ->
+            fetch_s3_object(Arn);
+        {ok, #{service := Service}} ->
+            ?LOG_ERROR("Unsupported service: ~p", [Service]),
+            {error, {unsupported_service, Service}};
+        {error, _} = Error ->
+            ?LOG_ERROR("Failed to parse ARN ~p: ~p", [Arn, Error]),
+            Error
+    end.
+
+-spec parse_arn(string()) -> {ok, map()} | {error, term()}.
+parse_arn(Arn) ->
+    ArnBin = list_to_binary(Arn),
+    case binary:split(ArnBin, <<":">>, [global]) of
+        [<<"arn">>, Partition, Service, Region, Account, Resource] ->
+            {ok, #{
+                partition => binary_to_list(Partition),
+                service => binary_to_list(Service),
+                region => binary_to_list(Region),
+                account => binary_to_list(Account),
+                resource => binary_to_list(Resource)
+            }};
+        _ ->
+            {error, invalid_arn_format}
+    end.
+
+-spec fetch_s3_object(string()) -> {ok, binary()} | {error, term()}.
+fetch_s3_object(Arn) ->
+    {ok, #{resource := Resource}} = parse_arn(Arn),
+    [Bucket | KeyParts] = string:tokens(Resource, "/"),
+    Key = string:join(KeyParts, "/"),
+    % Set region from environment variable
+    {ok, Region} = rabbitmq_aws_config:region(),
+    rabbitmq_aws:set_region(Region),
+    % Refresh credentials to pick up environment variables
+    rabbitmq_aws:refresh_credentials(),
+    Path = "/" ++ Bucket ++ "/" ++ Key,
+    case rabbitmq_aws:get("s3", Path) of
+        {ok, {_Headers, Body}} ->
+            {ok, Body};
+        {error, Reason} ->
+            {error, Reason};
+        Other ->
+            {error, {unexpected_response, Other}}
+    end.
+
+-spec write_to_file(string(), binary()) -> string().
+write_to_file(Arn, Content) ->
+    {ok, TempDir} = application:get_env(rabbitmq_aws, cacertfiles_download_path),
+    Filename = re:replace(Arn, "[^a-zA-Z0-9]", "_", [global, {return, list}]),
+    ok = filelib:ensure_dir(TempDir ++ "/"),
+    FilePath = TempDir ++ "/" ++ Filename,
+    ok = rabbit_file:write_file(FilePath, Content),
+    FilePath.

--- a/deps/rabbitmq_aws/test/rabbitmq_aws_resource_fetcher_tests.erl
+++ b/deps/rabbitmq_aws/test/rabbitmq_aws_resource_fetcher_tests.erl
@@ -1,0 +1,65 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbitmq_aws_resource_fetcher_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_arn_s3_test() ->
+    Arn = "arn:aws:s3:::private-ca-42/cacertfile.pem",
+    {ok, Parsed} = rabbitmq_aws_resource_fetcher:parse_arn(Arn),
+    ?assertEqual("aws", maps:get(partition, Parsed)),
+    ?assertEqual("s3", maps:get(service, Parsed)),
+    ?assertEqual("", maps:get(region, Parsed)),
+    ?assertEqual("", maps:get(account, Parsed)),
+    ?assertEqual("private-ca-42/cacertfile.pem", maps:get(resource, Parsed)).
+
+parse_arn_s3_nested_path_test() ->
+    Arn = "arn:aws:s3:::my-bucket/path/to/cert.pem",
+    {ok, Parsed} = rabbitmq_aws_resource_fetcher:parse_arn(Arn),
+    ?assertEqual("my-bucket/path/to/cert.pem", maps:get(resource, Parsed)).
+
+parse_arn_invalid_test() ->
+    ?assertEqual({error, invalid_arn_format}, rabbitmq_aws_resource_fetcher:parse_arn("invalid")).
+
+parse_arn_empty_test() ->
+    ?assertEqual({error, invalid_arn_format}, rabbitmq_aws_resource_fetcher:parse_arn("")).
+
+parse_arn_incomplete_test() ->
+    ?assertEqual({error, invalid_arn_format}, rabbitmq_aws_resource_fetcher:parse_arn("arn:aws:s3")).
+
+update_env_test() ->
+    application:set_env(rabbitmq_auth_backend_oauth2, key_config, [{cacertfile, "old_cert"}]),
+
+    rabbitmq_aws_resource_fetcher:update_env(rabbitmq_auth_backend_oauth2, key_config, cacertfile, "/tmp/new_cert"),
+
+    {ok, KeyConfig} = application:get_env(rabbitmq_auth_backend_oauth2, key_config),
+    ?assertEqual("/tmp/new_cert", proplists:get_value(cacertfile, KeyConfig)).
+
+update_env_new_key_test() ->
+    application:set_env(rabbitmq_auth_backend_oauth2, key_config, [{other_key, "value"}]),
+
+    rabbitmq_aws_resource_fetcher:update_env(rabbitmq_auth_backend_oauth2, key_config, cacertfile, "/tmp/cert"),
+
+    {ok, KeyConfig} = application:get_env(rabbitmq_auth_backend_oauth2, key_config),
+    ?assertEqual("/tmp/cert", proplists:get_value(cacertfile, KeyConfig)),
+    ?assertEqual("value", proplists:get_value(other_key, KeyConfig)).
+
+write_to_file_test() ->
+    application:set_env(rabbitmq_aws, cacertfiles_download_path, "/tmp/test-certs"),
+
+    Content = "test certificate content",
+    Arn = "arn:aws:s3:::bucket/cert.pem",
+
+    FilePath = rabbitmq_aws_resource_fetcher:write_to_file(Arn, Content),
+
+    ?assert(filelib:is_file(FilePath)),
+
+    {ok, ReadContent} = file:read_file(FilePath),
+    ?assertEqual(Content, binary_to_list(ReadContent)),
+
+    file:delete(FilePath).


### PR DESCRIPTION
In collaboration with [Sunfinite](https://github.com/sunfinite) - thanks for kicking off first commit

## Proposed Changes

Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

When rabbitmq user configures or operates rabbitmq, user may want to configure rabbitmq to access information such as private CA certs/credentials etc,  in AWS service rather than passing those information as local file or plain-text configuration to improve security and usability. For example, if user intends to configure LDAP for authentication and authorization, user as of today needs to define a local certs file and inform rabbitmq with config or environment variable .

With this AWS Resource Fetcher feature, user can pass in Amazon Resource Name(ARN) of the certs through new configuration schema eg: ```aws.arns.auth_ldap.ssl_options.cacertfile```. The fetcher will fetch the relevant cert files from AWS S3 from user's account and assign it to the appropriate LDAP plugin application environment. 

For corner case handling: 

0. Change is backward compatible if user doesn't configure any new ARN based attributes.
1. If the user configurates both arn attribute and normal attribute for the same content, the value fetched according to arn attribute will prevail. 
2. If the fetcher failed to fetch from user resource, an unique  error message will be thrown and rabbitmq start-up will fail.

This PR is working in progress to solicit early feedbacks. We are working on to add more functionalities such as allowing customer to configure Secret Manager arn for rabbitmq to retrieve credentials. 


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ x ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ x ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
