### PR TITLE
Add `NON_DETERMINISTIC` make variable

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -367,7 +367,9 @@ RMQ_ERLC_OPTS += -DTRACE_SUPERVISOR2=true
 endif
 
 # https://www.erlang.org/doc/apps/parsetools/leex.html#file/2
-YRL_ERLC_OPTS ?= +deterministic
+ifndef NON_DETERMINISTIC
+YRL_ERLC_OPTS += +deterministic
+endif
 
 # --------------------------------------------------------------------
 # Documentation.

--- a/deps/rabbit_common/mk/rabbitmq-build.mk
+++ b/deps/rabbit_common/mk/rabbitmq-build.mk
@@ -15,7 +15,9 @@ ifneq ($(filter rabbitmq_cli,$(BUILD_DEPS) $(DEPS)),)
 RMQ_ERLC_OPTS += -pa $(DEPS_DIR)/rabbitmq_cli/ebin
 endif
 
-RMQ_ERLC_OPTS ?= +deterministic
+ifndef NON_DETERMINISTIC
+RMQ_ERLC_OPTS += +deterministic
+endif
 
 # Push our compilation options to both the normal and test ERLC_OPTS.
 ERLC_OPTS += $(RMQ_ERLC_OPTS)


### PR DESCRIPTION
Follow-up to:
* #3442
* 93db480bc4022e4daea8961cf6668c9cad282e6a
* #13899
* #14326

Simply changing `+=` to `?=` doesn't work as there are other important statements added to `RMQ_ERLC_OPTS` that can't be left out when `make RMQ_ERLC_OPTS=''` is run. This only became apparent when a completely cleaned-out checkout of `rabbitmq/rabbitmq-server` was attempted to be built with that command.

This adds `NON_DETERMINISTIC` which will be used like this:

```
make NON_DETERMINISTIC=true
```

...and `+deterministic` won't be passed to `erlc` or other commands.