### PR TITLE
Follow up #14449: fix OCI trigger

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -79,7 +79,7 @@ jobs:
         - ${{ github.event.inputs.otp_version || '28' }}
     needs: build-package-generic-unix
     runs-on: ubuntu-latest
-    if: ${{ needs.build-package-generic-unix.outputs.authorized }} == 'true'
+    if: ${{ needs.build-package-generic-unix.outputs.authorized == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Proposed Changes

Follow up to #14449. The trigger is still wrong. I tested locally with `act` and now it's behaving as expected:
external users without access to secrets do not trigger OCI builds.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

