### PR TITLE
Shovels: Optimise amqp10 client messages for shovel usage

### DIFF
--- a/deps/amqp10_client/src/amqp10_raw_msg.erl
+++ b/deps/amqp10_client/src/amqp10_raw_msg.erl
@@ -1,0 +1,76 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+-module(amqp10_raw_msg).
+
+-include_lib("amqp10_common/include/amqp10_framing.hrl").
+-include_lib("amqp10_common/include/amqp10_types.hrl").
+
+%% Just for AMQP10 shovel usage. It avoids the binary <-> amqp10 <-> mc
+%% conversion, with all the unnecessary encoding/decoding steps.
+%% It allows for just binary <-> mc conversion, as the payload is stored as is
+
+-export([new/3,
+         settled/1,
+         delivery_tag/1,
+         payload/1,
+         handle/1,
+         set_handle/2,
+         transfer/1,
+         is/1]).
+
+-record(amqp10_raw_msg,
+        {settled :: boolean(),
+         delivery_tag :: non_neg_integer(),
+         payload :: binary(),
+         handle :: non_neg_integer() | undefined
+        }).
+
+-opaque amqp10_raw_msg() :: #amqp10_raw_msg{}.
+
+-export_type([amqp10_raw_msg/0]).
+
+-spec new(boolean(), non_neg_integer(), binary()) ->
+          amqp10_raw_msg().
+new(Settled, DeliveryTag, Payload) ->
+    #amqp10_raw_msg{settled = Settled,
+                    delivery_tag = DeliveryTag,
+                    payload = Payload}.
+
+-spec settled(amqp10_raw_msg()) -> boolean().
+settled(#amqp10_raw_msg{settled = Settled}) ->
+    Settled.
+
+-spec delivery_tag(amqp10_raw_msg()) -> non_neg_integer().
+delivery_tag(#amqp10_raw_msg{delivery_tag = DeliveryTag}) ->
+    DeliveryTag.
+
+-spec payload(amqp10_raw_msg()) -> binary().
+payload(#amqp10_raw_msg{payload = Payload}) ->
+    Payload.
+
+-spec handle(amqp10_raw_msg()) -> non_neg_integer().
+handle(#amqp10_raw_msg{handle = Handle}) ->
+    Handle.
+
+-spec set_handle(non_neg_integer(), amqp10_raw_msg()) ->
+    amqp10_raw_msg().
+set_handle(Handle, #amqp10_raw_msg{} = Msg) ->
+    Msg#amqp10_raw_msg{handle = Handle}.
+
+-spec transfer(amqp10_raw_msg()) -> #'v1_0.transfer'{}.
+transfer(#amqp10_raw_msg{settled = Settled,
+                         delivery_tag = DeliveryTag,
+                         handle = Handle}) ->
+    #'v1_0.transfer'{
+       delivery_tag = {binary, rabbit_data_coercion:to_binary(DeliveryTag)},
+       settled = Settled,
+       handle = {uint, Handle},
+       message_format = {uint, ?MESSAGE_FORMAT}}.
+
+-spec is(term()) -> boolean().
+is(Record) ->
+    is_record(Record, amqp10_raw_msg).

--- a/deps/rabbitmq_shovel/test/amqp10_shovel_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp10_shovel_SUITE.erl
@@ -74,7 +74,9 @@ amqp_encoded_data_list(_Config) ->
             #'v1_0.data'{content = <<"one">>},
             #'v1_0.data'{content = <<"two">>}
            ],
-    Msg = amqp10_msg:new(55, Body),
+    [_Transfer | Sections] = amqp10_msg:to_amqp_records(amqp10_msg:new(<<"55">>, Body)),
+    Bin = iolist_to_binary([amqp10_framing:encode_bin(S) || S <- Sections]),
+    Msg = amqp10_raw_msg:new(true, 55, Bin),
     rabbit_amqp10_shovel:handle_source({amqp10_msg, linkref, Msg}, State),
 
     ?assert(meck:validate(rabbit_shovel_behaviour)),
@@ -91,8 +93,11 @@ amqp_encoded_amqp_value(_Config) ->
     State = #{source => #{},
               dest => #{module => rabbit_amqp10_shovel},
               ack_mode => no_ack},
+
     Body = #'v1_0.amqp_value'{content = {utf8, <<"hi">>}},
-    Msg = amqp10_msg:new(55, Body),
+    [_Transfer | Sections] = amqp10_msg:to_amqp_records(amqp10_msg:new(<<"55">>, Body)),
+    Bin = iolist_to_binary([amqp10_framing:encode_bin(S) || S <- Sections]),
+    Msg = amqp10_raw_msg:new(true, 55, Bin),
     rabbit_amqp10_shovel:handle_source({amqp10_msg, linkref, Msg}, State),
 
     ?assert(meck:validate(rabbit_shovel_behaviour)),


### PR DESCRIPTION
AMQP10 shovels don't need the amqp10 message format, the binary can be translated directly into a message container and also the other way around. The new amqp10_raw_msg just stores the payload and information required to create the transfer frame, skipping a few unnecessary encoding/decoding operations of the AMQP10 sections.

These changes provide a 16% throughput improvement when shovelling 1.0 <-> 1.0