### PR TITLE
AWS plugin: enable Cuttlefish schema tests

### DIFF
--- a/deps/rabbitmq_aws/Makefile
+++ b/deps/rabbitmq_aws/Makefile
@@ -1,6 +1,7 @@
 PROJECT = rabbitmq_aws
-PROJECT_DESCRIPTION = A minimalistic AWS API interface used by rabbitmq-autocluster (3.6.x) and other RabbitMQ plugins
-PROJECT_REGISTERED = rabbitmq_aws
+PROJECT_DESCRIPTION = AWS API library used by rabbitmq_peer_discovery_aws
+PROJECT_MOD = rabbitmq_aws
+PROJECT_REGISTERED = rabbitmq_aws_sup
 
 define PROJECT_ENV
 []
@@ -8,9 +9,10 @@ endef
 
 LOCAL_DEPS = crypto inets ssl xmerl public_key
 BUILD_DEPS = rabbit_common
-# We do not depend on rabbit therefore can't run the broker.
-DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk
-TEST_DEPS = meck
+TEST_DEPS = meck rabbit rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+
+DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
+DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_aws/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_aws/test/config_schema_SUITE.erl
@@ -1,0 +1,53 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(config_schema_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+        run_snippets
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:run_setup_steps(Config),
+    rabbit_ct_config_schema:init_schemas(rabbitmq_aws, Config1).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+run_snippets(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, run_snippets1, [Config]).
+
+run_snippets1(Config) ->
+    rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_aws/test/config_schema_SUITE_data/rabbitmq_aws.snippets
+++ b/deps/rabbitmq_aws/test/config_schema_SUITE_data/rabbitmq_aws.snippets
@@ -1,0 +1,15 @@
+[
+    {rabbitmq_aws_prefer_imdsv2_false,
+        "aws.prefer_imdsv2 = false",
+        [{rabbit, [
+            {aws_prefer_imdsv2, false}
+        ]}],
+        [rabbitmq_aws]},
+
+    {rabbitmq_aws_prefer_imdsv2_true,
+        "aws.prefer_imdsv2 = true",
+        [{rabbit, [
+            {aws_prefer_imdsv2, true}
+        ]}],
+        [rabbitmq_aws]}
+].


### PR DESCRIPTION
These changes add the minimum required changes and artifacts to enable cuttlefish schema tests, which can be run with this command:

```
make -C deps/rabbitmq_aws ct-config_schema
```

cc @sunfinite @BeichenZhang-BCZ

Prerequisite for #14572