### PR TITLE
Allow configuring whether queue types are enabled

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2629,6 +2629,18 @@ end}.
     {datatype, {enum, [true, false]}}
 ]}.
 
+%% Enable queue types
+
+{mapping, "queue_types.classic.enabled", "rabbit.classic_queues_enabled", [
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "queue_types.stream.enabled", "rabbit.stream_queues_enabled", [
+    {datatype, {enum, [true, false]}}
+]}.
+{mapping, "queue_types.quorum.enabled", "rabbit.quorum_queues_enabled", [
+    {datatype, {enum, [true, false]}}
+]}.
+
 %%
 %% Backing queue version
 %%

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -126,7 +126,7 @@ validate_policy(Args) ->
     end.
 
 -spec is_enabled() -> boolean().
-is_enabled() -> true.
+is_enabled() -> application:get_env(rabbit, classic_queues_enabled, true).
 
 -spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
 is_compatible(_, _, _) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -201,7 +201,7 @@ merge_policy_value(<<"target-group-size">>, Val, OpVal) ->
 %%----------- rabbit_queue_type ---------------------------------------------
 
 -spec is_enabled() -> boolean().
-is_enabled() -> true.
+is_enabled() -> application:get_env(rabbit, quorum_queues_enabled, true).
 
 -spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
 is_compatible(_Durable = true,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -133,7 +133,7 @@
 -type client() :: #stream_client{}.
 
 -spec is_enabled() -> boolean().
-is_enabled() -> true.
+is_enabled() -> application:get_env(rabbit, stream_queues_enabled, true).
 
 -spec is_compatible(boolean(), boolean(), boolean()) -> boolean().
 is_compatible(_Durable = true,


### PR DESCRIPTION
This change adds config options for controlling the `is_enabled/0` queue type callback for classic queues, quorum queues and stream queues. This is useful for operators to be able to control whether users can declare these queues - i.e. to prevent users from declaring queue types which cannot be supported operationally.

Setting

    queue_types.stream.enabled = false

In a config file for example prevents stream queues from being declared.