### PR TITLE
amqp_ssl: simplify

### DIFF
--- a/deps/amqp_client/src/amqp_client.erl
+++ b/deps/amqp_client/src/amqp_client.erl
@@ -18,10 +18,6 @@
 %%---------------------------------------------------------------------------
 
 start() ->
-    %% rabbit_common needs compiler and syntax_tools, see
-    %%
-    %%  * https://github.com/rabbitmq/rabbitmq-erlang-client/issues/72
-    %%  * https://github.com/rabbitmq/rabbitmq-common/pull/149
     {ok, _} = application:ensure_all_started(rabbit_common),
     {ok, _} = application:ensure_all_started(amqp_client),
     ok.


### PR DESCRIPTION
Now that Erlang 26 is the minimum required version.
