### PR TITLE
Update Cowboy to 2.14.1

### DIFF
--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -40,7 +40,7 @@ endif
 # all projects use the same versions. It avoids conflicts.
 
 dep_accept = hex 0.3.5
-dep_cowboy = hex 2.14.0
+dep_cowboy = hex 2.14.1
 dep_cowlib = hex 2.16.0
 dep_credentials_obfuscation = hex 3.5.0
 dep_cuttlefish = hex 3.5.0


### PR DESCRIPTION
The patch release contains a fix for an HTTP/2 Websocket issue.

Doesn't need to be backported further than 4.2.