### PR TITLE
clustering_recovery_SUITE: Skip tests that require RabbitMQ 4.2.0 in mixed-version testing

### DIFF
--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -152,8 +152,12 @@ init_per_testcase(Testcase, Config) ->
                 rabbit_ct_client_helpers:setup_steps()),
     case Config3 of
         _ when is_list(Config3) andalso
-               (Testcase =:= autodelete_transient_queue_after_partition_recovery_2 orelse
+               (Testcase =:= autodelete_transient_queue_after_partition_recovery_1 orelse
+                Testcase =:= autodelete_durable_queue_after_partition_recovery_1 orelse
+                Testcase =:= autodelete_transient_queue_after_partition_recovery_2 orelse
                 Testcase =:= autodelete_durable_queue_after_partition_recovery_2 orelse
+                Testcase =:= exclusive_transient_queue_after_partition_recovery_1 orelse
+                Testcase =:= exclusive_durable_queue_after_partition_recovery_1 orelse
                 Testcase =:= exclusive_transient_queue_after_partition_recovery_2 orelse
                 Testcase =:= exclusive_durable_queue_after_partition_recovery_2) ->
             NewEnough = ok =:= rabbit_ct_broker_helpers:enable_feature_flag(
@@ -169,7 +173,7 @@ init_per_testcase(Testcase, Config) ->
                     rabbit_ct_helpers:testcase_finished(Config3, Testcase),
                     {skip,
                      "The old node does not have improvements to "
-                     "rabbit_node_monitor"}
+                     "rabbit_amqqueue_process and rabbit_node_monitor"}
             end;
         _ ->
             %% Other testcases or failure to setup broker and client.


### PR DESCRIPTION
## Why

The `*_queue_after_partition_recovery_1` testcases rely on the fact that the queue process retries to delete its queue record in its terminate function.

RabbitMQ 4.1.x and before don't have that. Thus, depending on the timing of the election of the Khepri leader after a network partition, the test might fail.

This is a follow-up commit to #14573.