### PR TITLE
clustering_recovery_SUITE: Run on its own in CI

### DIFF
--- a/.github/workflows/test-make-tests.yaml
+++ b/.github/workflows/test-make-tests.yaml
@@ -31,6 +31,7 @@ jobs:
           - parallel-ct-set-5
           - ct-amqp_client
           - ct-clustering_management
+          - ct-clustering_recovery
           - eunit ct-dead_lettering
           - ct-feature_flags
           - ct-metadata_store_clustering

--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -182,6 +182,7 @@ SLOW_CT_SUITES := amqp_client \
 		  cluster \
 		  cluster_rename \
 		  clustering_management \
+		  clustering_recovery \
 		  config_schema \
 		  confirms_rejects \
 		  consumer_timeout \
@@ -267,7 +268,7 @@ PARALLEL_CT_SET_1_C = amqp_proxy_protocol amqpl_consumer_ack backing_queue bindi
 PARALLEL_CT_SET_1_D = amqqueue_backward_compatibility channel_interceptor channel_operation_timeout classic_queue classic_queue_prop config_schema peer_discovery_dns peer_discovery_tmp_hidden_node per_node_limit per_user_connection_channel_limit
 
 PARALLEL_CT_SET_2_A = cluster confirms_rejects consumer_timeout rabbit_access_control rabbit_confirms rabbit_core_metrics_gc rabbit_cuttlefish rabbit_db_binding rabbit_db_exchange
-PARALLEL_CT_SET_2_B = clustering_recovery crashing_queues deprecated_features direct_exchange_routing_v2 disconnect_detected_during_alarm exchanges unit_gen_server2
+PARALLEL_CT_SET_2_B = crashing_queues deprecated_features direct_exchange_routing_v2 disconnect_detected_during_alarm exchanges unit_gen_server2
 PARALLEL_CT_SET_2_C = disk_monitor dynamic_qq unit_disk_monitor unit_file_handle_cache unit_log_management unit_operator_policy prevent_startup_if_node_was_reset
 PARALLEL_CT_SET_2_D = queue_length_limits queue_parallel quorum_queue_member_reconciliation rabbit_fifo rabbit_fifo_dlx rabbit_stream_coordinator
 
@@ -289,7 +290,7 @@ PARALLEL_CT_SET_3 = $(sort $(PARALLEL_CT_SET_3_A) $(PARALLEL_CT_SET_3_B) $(PARAL
 PARALLEL_CT_SET_4 = $(sort $(PARALLEL_CT_SET_4_A) $(PARALLEL_CT_SET_4_B) $(PARALLEL_CT_SET_4_C) $(PARALLEL_CT_SET_4_D))
 PARALLEL_CT_SET_5 = $(PARALLEL_CT_SET_5_A)
 
-SEQUENTIAL_CT_SUITES = amqp_client clustering_management dead_lettering feature_flags metadata_store_clustering quorum_queue rabbit_stream_queue rabbit_fifo_prop
+SEQUENTIAL_CT_SUITES = amqp_client clustering_management clustering_recovery dead_lettering feature_flags metadata_store_clustering quorum_queue rabbit_stream_queue rabbit_fifo_prop
 PARALLEL_CT_SUITES = $(PARALLEL_CT_SET_1) $(PARALLEL_CT_SET_2) $(PARALLEL_CT_SET_3) $(PARALLEL_CT_SET_4) $(PARALLEL_CT_SET_5)
 
 ifeq ($(filter-out $(SEQUENTIAL_CT_SUITES) $(PARALLEL_CT_SUITES),$(CT_SUITES)),)


### PR DESCRIPTION
… instead of as part of a parallel CT group.

## Why

This testsuite takes quite a lot of time. It affects the time to run the parallel CT set 2 significantly, especially if it has to be restarted.