### PR TITLE
Make 3.13->4.2 tests actually use v4.2.x, not main

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -25,6 +25,14 @@ on:
       plugin:
         required: true
         type: string
+      # in almost all cases this should not be set and the ref that triggered
+      # the workflow will be used. however, mixed version tests for skip-version
+      # upgrades (eg. 3.13->4.2) need this because they run on scheduled
+      # and scheduled workflows get `main` as ref
+      ref:
+        required: false
+        type: string
+        description: 'Git ref (branch, tag, or SHA) to checkout'
 jobs:
   test:
     name: ${{ inputs.plugin }} (${{ inputs.make_target }})
@@ -33,6 +41,8 @@ jobs:
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.ref }}
 
     - name: FETCH TAGS
       run: git fetch --tags

--- a/.github/workflows/test-make-tests.yaml
+++ b/.github/workflows/test-make-tests.yaml
@@ -17,6 +17,14 @@ on:
       previous_version:
         required: false
         type: string
+      # in almost all cases this should not be set and the ref that triggered
+      # the workflow will be used. however, mixed version tests for skip-version
+      # upgrades (eg. 3.13->4.2) need this because they run on scheduled
+      # and scheduled workflows get `main` as ref
+      ref:
+        required: false
+        type: string
+        description: 'Git ref (branch, tag, or SHA) to checkout'
 jobs:
   test-rabbit:
     name: Test rabbit
@@ -47,6 +55,7 @@ jobs:
       previous_version: ${{ inputs.previous_version }}
       make_target: ${{ matrix.make_target }}
       plugin: rabbit
+      ref: ${{ inputs.ref }}
 
   test-rabbitmq-mqtt:
     name: Test rabbitmq_mqtt
@@ -59,6 +68,7 @@ jobs:
       previous_version: ${{ inputs.previous_version }}
       make_target: parallel-ct-set-1
       plugin: rabbitmq_mqtt
+      ref: ${{ inputs.ref }}
 
   # The integration_SUITE requires secrets and
   # is therefore run from a separate workflow.
@@ -73,6 +83,7 @@ jobs:
       previous_version: ${{ inputs.previous_version }}
       make_target: ct-config_schema ct-unit
       plugin: rabbitmq_peer_discovery_aws
+      ref: ${{ inputs.ref }}
 
   test-plugin:
     name: Test plugins
@@ -132,3 +143,4 @@ jobs:
       previous_version: ${{ inputs.previous_version }}
       make_target: tests
       plugin: ${{ matrix.plugin }}
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/test-mixed.yaml
+++ b/.github/workflows/test-mixed.yaml
@@ -28,3 +28,4 @@ jobs:
       previous_version: 'tags/v3.13.7'
       metadata_store: ${{ matrix.metadata_store }}
       mixed_clusters: true
+      ref: 'v4.2.x'


### PR DESCRIPTION
Scheduled workflows get `main` as ref. This was fine when this workflow was added since that was before v4.2.x branch existed. Now we need a bit of gymnastics to test 3.13.7->v4.2.x, even though by default we get main, not v4.2.x
