### PR TITLE
rabbitmq_streams: Check rabbit_queue_types is_enabled/0 during declare

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -47,9 +47,12 @@ create(VirtualHost, Reference, Arguments, Username) ->
     StreamQueueArguments = stream_queue_arguments(Arguments),
     maybe
         ok ?= validate_stream_queue_arguments(StreamQueueArguments),
+        true ?= rabbit_stream_queue:is_enabled(),
         do_create_stream(VirtualHost, Reference, StreamQueueArguments, Username)
     else
         error ->
+            {error, validation_failed};
+        false ->
             {error, validation_failed};
         {error, _} = Err ->
             Err


### PR DESCRIPTION
`rabbit_amqqueue:declare/7` consults the `is_enabled/0` callback of `rabbit_queue_type` before attempting to create a queue. `rabbit_stream_manager` emulates `rabbit_amqqueue:declare/7` rather than calling it directly. To align with the `is_enabled/0` check in `rabbit_amqqueue:declare/7`, `rabbit_stream_manager` needs to check the callback during stream creation.

This is a follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/14624