### PR TITLE
rabbit_vhost: Allow vhosts with not-enabled default queue types

### DIFF
--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -215,7 +215,12 @@ do_add(Name, Metadata0, ActingUser) ->
                         true ->
                             ok;
                         false ->
-                            throw({error, queue_type_feature_flag_is_not_enabled})
+                            ?LOG_WARNING("Default queue type '~ts' of virtual "
+                                         "host '~ts' is not enabled. All "
+                                         "declarations relying on the default "
+                                         "queue type will fail.",
+                                         [QueueType, Name]),
+                            ok
                     end
             catch _:_ ->
                       throw({error, invalid_queue_type, DQT})


### PR DESCRIPTION
The prior validation for vhosts' default queue types ensures that the default queue type can be declared. This seems slightly heavy-handed since users might never rely on default-queue-type behavior. Instead the creation of the vhost should succeed but warn the user that declarations relying on the default queue type will fail - the `is_enabled/0` callback of `rabbit_queue_type` should be limited to block queue declarations, and not block the creation of a vhost.

This is a follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/14624