### PR TITLE
Fix crash for operator policy HTTP API

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_operator_policy.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_operator_policy.erl
@@ -82,7 +82,11 @@ is_authorized(ReqData, Context) ->
 %%--------------------------------------------------------------------
 
 policy(ReqData) ->
-    rabbit_policy:lookup_op(
-      rabbit_mgmt_util:vhost(ReqData), name(ReqData)).
+    case rabbit_mgmt_util:vhost(ReqData) of
+        not_found ->
+            not_found;
+        Vhost ->
+            rabbit_policy:lookup_op(Vhost, name(ReqData))
+    end.
 
 name(ReqData) -> rabbit_mgmt_util:id(name, ReqData).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -3459,8 +3459,15 @@ operator_policy_test(Config) ->
              "/operator-policies/%2F/policy_even",
              PolicyEven,
              {group, '2xx'}),
+    http_put(Config,
+             "/operator-policies/absent_vhost/policy_even",
+             PolicyEven,
+             404),
+
     assert_item(PolicyPos,  http_get(Config, "/operator-policies/%2F/policy_pos",  ?OK)),
     assert_item(PolicyEven, http_get(Config, "/operator-policies/%2F/policy_even", ?OK)),
+    http_get(Config, "/operator-policies/absent_vhost/policy_even", 404),
+
     List = [PolicyPos, PolicyEven],
     assert_list(List, http_get(Config, "/operator-policies",     ?OK)),
     assert_list(List, http_get(Config, "/operator-policies/%2F", ?OK)),


### PR DESCRIPTION
This commit fixes the following crash for a GET or a PUT on HTTP API path `/api/operator-policies/vhost/name` if the supplied `vhost` doesn't exists:
```
crasher:
  initial call: cowboy_stream_h:request_process/3
  pid: <0.688.0>
  registered_name: []
  exception error: no function clause matching
                   rabbit_db_rtparams:get({not_found,<<"operator_policy">>,
                                           <<"my_policy">>}) (rabbit_db_rtparams.erl:145)
    in function  rabbit_runtime_parameters:lookup0/2 (rabbit_runtime_parameters.erl:363)
    in call from rabbit_runtime_parameters:lookup/3 (rabbit_runtime_parameters.erl:336)
    in call from rabbit_policy:lookup_op/2 (rabbit_policy.erl:326)
    in call from rabbit_mgmt_wm_operator_policy:resource_exists/2 (rabbit_mgmt_wm_operator_policy.erl:38)
    in call from cowboy_rest:call/3 (src/cowboy_rest.erl:1577)
    in call from cowboy_rest:expect/6 (src/cowboy_rest.erl:1560)
    in call from cowboy_rest:upgrade/4 (src/cowboy_rest.erl:281)
```

Also, instead of returning a 500 response code, RabbitMQ will now return a 404 response code.
