### PR TITLE
Require feature flag `quorum_queue_non_voters`

### DIFF
--- a/deps/rabbit/src/rabbit_core_ff.erl
+++ b/deps/rabbit/src/rabbit_core_ff.erl
@@ -177,9 +177,8 @@
 
 -rabbit_feature_flag(
    {quorum_queue_non_voters,
-    #{desc =>
-          "Allows new quorum queue members to be added as non voters initially.",
-      stability => stable,
+    #{desc => "Allows new quorum queue members to be added as non voters initially.",
+      stability => required,
       depends_on => [quorum_queue]
      }}).
 

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1389,13 +1389,7 @@ do_add_member(Q, Node, Membership, Timeout)
     Conf = make_ra_conf(Q, ServerId, Membership, MachineVersion),
     case ra:start_server(?RA_SYSTEM, Conf) of
         ok ->
-            ServerIdSpec  =
-            case rabbit_feature_flags:is_enabled(quorum_queue_non_voters) of
-                true ->
-                    maps:with([id, uid, membership], Conf);
-                false ->
-                    maps:get(id, Conf)
-            end,
+            ServerIdSpec = maps:with([id, uid, membership], Conf),
             case ra:add_member(Members, ServerIdSpec, Timeout) of
                 {ok, {RaIndex, RaTerm}, Leader} ->
                     Fun = fun(Q1) ->

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -2810,10 +2810,8 @@ add_member(Config) ->
 
 add_member_2(Config) ->
     %% this tests a scenario where an older node version is running a QQ
-    %% and a member is added on a newer node version (for mixe testing)
+    %% and a member is added on a newer node version (for mixed testing)
 
-    %% we dont validate the ff was enabled as this test should pass either way
-    _ = rabbit_ct_broker_helpers:enable_feature_flag(Config, quorum_queue_non_voters),
     [Server0, Server1 | _] = _Servers0 =
         rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Ch = rabbit_ct_client_helpers:open_channel(Config, Server1),


### PR DESCRIPTION
Require feature flag `quorum_queue_non_voters` for RabbitMQ 4.3 and delete the compatibility code.