### PR TITLE
add shorthand for internal_loopback backend

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -453,14 +453,15 @@ end}.
 fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("auth_backends", Conf),
     BackendModule = fun
-        (internal) -> rabbit_auth_backend_internal;
-        (ldap)     -> rabbit_auth_backend_ldap;
-        (http)     -> rabbit_auth_backend_http;
-        (oauth)    -> rabbit_auth_backend_oauth2;
-        (oauth2)   -> rabbit_auth_backend_oauth2;
-        (cache)    -> rabbit_auth_backend_cache;
-        (amqp)     -> rabbit_auth_backend_amqp;
-        (dummy)    -> rabbit_auth_backend_dummy;
+        (internal)          -> rabbit_auth_backend_internal;
+        (internal_loopback) -> rabbit_auth_backend_internal_loopback;
+        (ldap)              -> rabbit_auth_backend_ldap;
+        (http)              -> rabbit_auth_backend_http;
+        (oauth)             -> rabbit_auth_backend_oauth2;
+        (oauth2)            -> rabbit_auth_backend_oauth2;
+        (cache)             -> rabbit_auth_backend_cache;
+        (amqp)              -> rabbit_auth_backend_amqp;
+        (dummy)             -> rabbit_auth_backend_dummy;
         (Other) when is_atom(Other) -> Other;
         (_) -> cuttlefish:invalid("Unknown/unsupported auth backend")
     end,

--- a/deps/rabbitmq_web_dispatch/priv/schema/rabbitmq_web_dispatch.schema
+++ b/deps/rabbitmq_web_dispatch/priv/schema/rabbitmq_web_dispatch.schema
@@ -16,14 +16,15 @@
 fun(Conf) ->
     Settings = cuttlefish_variable:filter_by_prefix("http_dispatch.auth_backends", Conf),
     BackendModule = fun
-        (internal) -> rabbit_auth_backend_internal;
-        (ldap)     -> rabbit_auth_backend_ldap;
-        (http)     -> rabbit_auth_backend_http;
-        (oauth)    -> rabbit_auth_backend_oauth2;
-        (oauth2)   -> rabbit_auth_backend_oauth2;
-        (cache)    -> rabbit_auth_backend_cache;
-        (amqp)     -> rabbit_auth_backend_amqp;
-        (dummy)    -> rabbit_auth_backend_dummy;
+        (internal)          -> rabbit_auth_backend_internal;
+        (internal_loopback) -> rabbit_auth_backend_internal_loopback;
+        (ldap)              -> rabbit_auth_backend_ldap;
+        (http)              -> rabbit_auth_backend_http;
+        (oauth)             -> rabbit_auth_backend_oauth2;
+        (oauth2)            -> rabbit_auth_backend_oauth2;
+        (cache)             -> rabbit_auth_backend_cache;
+        (amqp)              -> rabbit_auth_backend_amqp;
+        (dummy)             -> rabbit_auth_backend_dummy;
         (Other) when is_atom(Other) -> Other;
         (_) -> cuttlefish:invalid("Unknown/unsupported auth backend")
     end,


### PR DESCRIPTION
## Proposed Changes

As discussed in #14746, the short-hand for the `internal_loopback` auth backend added by #13767 is missing from the schema. This PR adds a mapping from `internal_loopback` to `rabbit_auth_backend_internal_loopback`

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
