### PR TITLE
Definitions: fix queue type

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -1049,10 +1049,11 @@ list_queues() ->
 queue_definition(Q) ->
     #resource{virtual_host = VHost, name = Name} = amqqueue:get_name(Q),
     TypeModule =  amqqueue:get_type(Q),
+    {ok, Type} = rabbit_registry:lookup_type_name(queue, TypeModule),
     #{
         <<"vhost">> => VHost,
         <<"name">> => Name,
-        <<"type">> => rabbit_registry:lookup_type_name(queue, TypeModule),
+        <<"type">> => Type,
         <<"durable">> => amqqueue:is_durable(Q),
         <<"auto_delete">> => amqqueue:is_auto_delete(Q),
         <<"arguments">> => rabbit_misc:amqp_table(amqqueue:get_arguments(Q))


### PR DESCRIPTION
`lookup_type_name` returns a tagged tuple `{ok, Type}`, which was stored directly on the `type` field.
This PR just stores the type.

