### PR TITLE
Do not wait before trying to dispatch a chunk of messages

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -3706,7 +3706,6 @@ send_chunks(DeliverVersion,
             setopts(Transport, Socket, [{nopush, false}]),
             case Retry of
                 true ->
-                    timer:sleep(1),
                     send_chunks(DeliverVersion,
                                 Transport,
                                 Consumer,


### PR DESCRIPTION
A stream connection waited artificially before retrying to send a chunk after Osiris returned an end_of_stream result. It was initially to let some messages arrive in the stream.

This wait time does not seem necessary and can be even counter productive. A connection with many consumers on the same stream that gets published to can get many notifications from Osiris and ended up waiting for each consumers. This can make the connection blocks for several seconds and unable to perform other operations like simple RPC.

This commit removes the wait time.

References rabbitmq/rabbitmq-stream-java-client#863