### PR TITLE
unit_access_control_authn_authz_context_propagation_SUITE: Declare test auth backend module

### DIFF
--- a/deps/rabbit/test/unit_access_control_authn_authz_context_propagation_SUITE.erl
+++ b/deps/rabbit/test/unit_access_control_authn_authz_context_propagation_SUITE.erl
@@ -43,7 +43,8 @@ end_per_group(_, Config) ->
 
 init_per_testcase(Testcase, Config) ->
     AuthConfig = {rabbit, [
-      {auth_backends, [rabbit_auth_backend_context_propagation_mock]}
+      {auth_backends, [rabbit_auth_backend_context_propagation_mock]},
+      {test_auth_backends, [rabbit_auth_backend_context_propagation_mock]}
     ]
     },
     rabbit_ct_helpers:testcase_started(Config, Testcase),


### PR DESCRIPTION
## Why

rabbit_access_control now ensures all configured auth backend modules are provided by `rabbit` or an enabled plugin. This is not the case for this testsuite's own auth backend.

## How

Declare `rabbit_auth_backend_context_propagation_mock` as a test auth backend module.