### PR TITLE
Make selenium test images configurable

### DIFF
--- a/selenium/bin/components/devkeycloak
+++ b/selenium/bin/components/devkeycloak
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KEYCLOAK_DOCKER_IMAGE=quay.io/keycloak/keycloak:20.0
+KEYCLOAK_DOCKER_IMAGE=${KEYCLOAK_DOCKER_IMAGE:-quay.io/keycloak/keycloak:20.0}
 
 init_devkeycloak() {
   DEVKEYCLOAK_CONFIG_PATH=${DEVKEYCLOAK_CONFIG_PATH:-multi-oauth/devkeycloak}

--- a/selenium/bin/components/devkeycloak-proxy
+++ b/selenium/bin/components/devkeycloak-proxy
@@ -1,5 +1,4 @@
-
-HTTPD_DOCKER_IMAGE=httpd:latest
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
 
 ensure_devkeycloak-proxy() {
   if docker ps | grep devkeycloak-proxy &> /dev/null; then

--- a/selenium/bin/components/forward-proxy
+++ b/selenium/bin/components/forward-proxy
@@ -1,5 +1,4 @@
-
-HTTPD_DOCKER_IMAGE=httpd:latest
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
 
 ensure_forward-proxy() {
   if docker ps | grep forward-proxy &> /dev/null; then

--- a/selenium/bin/components/keycloak
+++ b/selenium/bin/components/keycloak
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KEYCLOAK_DOCKER_IMAGE=quay.io/keycloak/keycloak:20.0
+KEYCLOAK_DOCKER_IMAGE=${KEYCLOAK_DOCKER_IMAGE:-quay.io/keycloak/keycloak:20.0}
 
 ensure_keycloak() {
   if docker ps | grep keycloak &> /dev/null; then

--- a/selenium/bin/components/mock-auth-backend-http
+++ b/selenium/bin/components/mock-auth-backend-http
@@ -10,9 +10,11 @@ ensure_mock-auth-backend-http() {
 init_mock-auth-backend-http() {
   AUTH_BACKEND_HTTP_BASEURL=${AUTH_BACKEND_HTTP_BASEURL:-http://localhost:8888}
   AUTH_BACKEND_HTTP_DIR=${TEST_CASES_DIR}/mock-auth-backend-http
+  MOCKSERVER_DOCKER_IMAGE=${MOCKSERVER_DOCKER_IMAGE:-mockserver/mockserver}
 
   print "> AUTH_BACKEND_HTTP_BASEURL: ${AUTH_BACKEND_HTTP_BASEURL}"
   print "> AUTH_BACKEND_HTTP_DIR: ${AUTH_BACKEND_HTTP_DIR}"
+  print "> MOCKSERVER_DOCKER_IMAGE: ${MOCKSERVER_DOCKER_IMAGE}"
 
 }
 start_mock-auth-backend-http() {
@@ -28,7 +30,7 @@ start_mock-auth-backend-http() {
     --publish 8888:1080 \
     --env MOCKSERVER_INITIALIZATION_JSON_PATH="/config/defaultExpectations.json" \
     -v ${AUTH_BACKEND_HTTP_DIR}:/config \
-    mockserver/mockserver
+    ${MOCKSERVER_DOCKER_IMAGE}
 
   wait_for_url $AUTH_BACKEND_HTTP_BASEURL/ready
   end "mock-auth-backend-http is ready"

--- a/selenium/bin/components/mock-auth-backend-ldap
+++ b/selenium/bin/components/mock-auth-backend-ldap
@@ -9,8 +9,10 @@ ensure_mock-auth-backend-ldap() {
 }
 init_mock-auth-backend-ldap() {
   AUTH_BACKEND_LDAP_DIR=${TEST_CONFIG_DIR}/mock-auth-backend-ldap
+  OPENLDAP_DOCKER_IMAGE=${OPENLDAP_DOCKER_IMAGE:-osixia/openldap:1.5.0}
 
   print "> AUTH_BACKEND_LDAP_DIR: ${AUTH_BACKEND_LDAP_DIR}"
+  print "> OPENLDAP_DOCKER_IMAGE: ${OPENLDAP_DOCKER_IMAGE}"
 }
 start_mock-auth-backend-ldap() {
   begin "Starting mock-auth-backend-ldap ..."
@@ -28,7 +30,7 @@ start_mock-auth-backend-ldap() {
     --publish 389:389 \
     --publish 636:636 \
     -v ${AUTH_BACKEND_LDAP_DIR}:/config \
-    osixia/openldap:1.5.0
+    ${OPENLDAP_DOCKER_IMAGE}
 
   wait_for_message mock-auth-backend-ldap "starting"
   docker exec mock-auth-backend-ldap ldapadd \

--- a/selenium/bin/components/prodkeycloak
+++ b/selenium/bin/components/prodkeycloak
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-KEYCLOAK_DOCKER_IMAGE=quay.io/keycloak/keycloak:20.0
+KEYCLOAK_DOCKER_IMAGE=${KEYCLOAK_DOCKER_IMAGE:-quay.io/keycloak/keycloak:20.0}
 
 ensure_prodkeycloak() {
   if docker ps | grep prodkeycloak &> /dev/null; then

--- a/selenium/bin/components/prodkeycloak-proxy
+++ b/selenium/bin/components/prodkeycloak-proxy
@@ -1,5 +1,4 @@
-
-HTTPD_DOCKER_IMAGE=httpd:latest
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
 
 ensure_prodkeycloak-proxy() {
   if docker ps | grep prodkeycloak-proxy &> /dev/null; then
@@ -17,7 +16,7 @@ init_prodkeycloak-proxy() {
   print "> PROXY_HOSTNAME: ${PROXY_HOSTNAME}"
   print "> PROXY_PORT: ${PROXY_PORT}"
   
-}
+  print "> HTTPD_DOCKER_IMAGE: ${HTTPD_DOCKER_IMAGE}"
 
 start_prodkeycloak-proxy() {
   begin "Starting prodkeycloak-proxy ..."

--- a/selenium/bin/components/proxy
+++ b/selenium/bin/components/proxy
@@ -1,5 +1,4 @@
-
-HTTPD_DOCKER_IMAGE=httpd:latest
+HTTPD_DOCKER_IMAGE=${HTTPD_DOCKER_IMAGE:-httpd:latest}
 
 ensure_proxy() {
   if docker ps | grep proxy &> /dev/null; then

--- a/selenium/bin/components/uaa
+++ b/selenium/bin/components/uaa
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-UAA_DOCKER_IMAGE=cloudfoundry/uaa:75.21.0
+UAA_DOCKER_IMAGE=${UAA_DOCKER_IMAGE:-cloudfoundry/uaa:75.21.0}
 
 ensure_uaa() {
   if docker ps | grep uaa &> /dev/null; then


### PR DESCRIPTION
## Proposed Changes

Make all images used by Selenium tests configurable.

Because it makes it easier to customise the image. For example, to run
with an older or newer version, or to customise the registry and use a
proxy.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

