### PR TITLE
Yet another JSON CLI formatter fix

### DIFF
--- a/deps/rabbitmq_cli/test/json_formatting_test.exs
+++ b/deps/rabbitmq_cli/test/json_formatting_test.exs
@@ -100,5 +100,9 @@ defmodule JSONFormattingTest do
     assert Map.has_key?(rabbit, "data_dir")
     data_dir = rabbit["data_dir"]
     assert is_binary(data_dir)
+
+    assert Map.has_key?(rabbit, "tcp_listeners")
+    tcp_listeners = rabbit["tcp_listeners"]
+    assert is_list(tcp_listeners)
   end
 end


### PR DESCRIPTION
The bug addressed by this PR was found while running the following command:

```
rabbitmqctl environment --formatter=json
```

...after configuring the `rabbit` application to use `cacerts` with a list of binaries as the value, rather than `cacertfile`.

This PR also fixes the formatting of the `tcp_listeners` and `ssl_listeners` output, because `[5672]` is a valid list of unicode codepoints that `unicode:characters_to_binary` will happily convert it, resulting in `"tcp_listeners": "ᘨ"` in the output.

I also ensured that the fixes in #14511 and #14398 still work as intended.