### PR TITLE
Handle multiple alarms consistently in protocol readers

### DIFF
--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -335,7 +335,7 @@ start_connection(Parent, HelperSups, RanchRef, Deb, Sock) ->
                 throttle            = #throttle{
                                          last_blocked_at = never,
                                          should_block = false,
-                                         blocked_by = sets:new(),
+                                         blocked_by = sets:new([{version, 2}]),
                                          connection_blocked_message_sent = false
                                          },
                 proxy_socket = rabbit_net:maybe_get_proxy_socket(Sock)},
@@ -1310,7 +1310,7 @@ handle_method0(#'connection.open'{virtual_host = VHost},
     ok = send_on_channel0(Sock, #'connection.open_ok'{}, Protocol),
 
     Alarms = rabbit_alarm:register(self(), {?MODULE, conserve_resources, []}),
-    BlockedBy = sets:from_list([{resource, Alarm} || Alarm <- Alarms]),
+    BlockedBy = sets:from_list([{resource, Alarm} || Alarm <- Alarms], [{version, 2}]),
     Throttle1 = Throttle#throttle{blocked_by = BlockedBy},
 
     {ok, ChannelSupSupPid} =

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -38,7 +38,7 @@
           proc_state = connect_packet_unprocessed :: connect_packet_unprocessed |
                                                      rabbit_mqtt_processor:state(),
           connection_state = running :: running | blocked,
-          conserve = false :: boolean(),
+          blocked_by = sets:new([{version, 2}]) :: sets:set(rabbit_alarm:resource_alarm_source()),
           stats_timer :: option(rabbit_event:state()),
           keepalive = rabbit_mqtt_keepalive:init() :: rabbit_mqtt_keepalive:state(),
           conn_name :: option(binary())
@@ -141,8 +141,9 @@ websocket_init(State0 = #state{socket = Sock}) ->
         {ok, ConnStr} ->
             ConnName = rabbit_data_coercion:to_binary(ConnStr),
             ?LOG_INFO("Accepting Web MQTT connection ~s", [ConnName]),
-            _ = rabbit_alarm:register(self(), {?MODULE, conserve_resources, []}),
-            State = State0#state{conn_name = ConnName},
+            Alarms = rabbit_alarm:register(self(), {?MODULE, conserve_resources, []}),
+            State = State0#state{conn_name = ConnName,
+                                 blocked_by = sets:from_list(Alarms, [{version, 2}])},
             process_flag(trap_exit, true),
             {[], State, hibernate};
         {error, Reason} ->
@@ -152,8 +153,8 @@ websocket_init(State0 = #state{socket = Sock}) ->
 -spec conserve_resources(pid(),
                          rabbit_alarm:resource_alarm_source(),
                          rabbit_alarm:resource_alert()) -> ok.
-conserve_resources(Pid, _, {_, Conserve, _}) ->
-    Pid ! {conserve_resources, Conserve},
+conserve_resources(Pid, Source, {_, Conserve, _}) ->
+    Pid ! {conserve_resources, Source, Conserve},
     ok.
 
 -spec websocket_handle(ping | pong | {text | binary | ping | pong, binary()}, State) ->
@@ -176,8 +177,15 @@ websocket_handle(Frame, State) ->
 -spec websocket_info(any(), State) ->
     {cowboy_websocket:commands(), State} |
     {cowboy_websocket:commands(), State, hibernate}.
-websocket_info({conserve_resources, Conserve}, State) ->
-    handle_credits(State#state{conserve = Conserve});
+websocket_info({conserve_resources, Source, Conserve},
+               #state{blocked_by = BlockedBy0} = State) ->
+    BlockedBy = case Conserve of
+                    true ->
+                        sets:add_element(Source, BlockedBy0);
+                    false ->
+                        sets:del_element(Source, BlockedBy0)
+                end,
+    handle_credits(State#state{blocked_by = BlockedBy});
 websocket_info({bump_credit, Msg}, State) ->
     credit_flow:handle_bump_msg(Msg),
     handle_credits(State);
@@ -402,10 +410,11 @@ handle_credits(State0) ->
     {[{active, Active}], State, hibernate}.
 
 control_throttle(State = #state{connection_state = ConnState,
-                                conserve = Conserve,
+                                blocked_by = BlockedBy,
                                 proc_state = PState,
                                 keepalive = KState
                                }) ->
+    Conserve = not sets:is_empty(BlockedBy),
     Throttle = case PState of
                    connect_packet_unprocessed -> Conserve;
                    _ -> rabbit_mqtt_processor:throttle(Conserve, PState)


### PR DESCRIPTION
The MQTT, WebMQTT and STOMP reader modules tracked whether they were blocked by any alarm, but they should instead keep a set of active alarms. Only tracking the `Conserve` part of the alarm notification from `rabbit_alarm` doesn't work correctly if a cluster enters and exits multiple alarms. For example if a cluster had both memory and disk alarms active and then cleared memory, these readers would unblock while they should remain blocked until both alarms are cleared.

Keeping a set of `rabbit_alarm:resource_alarm_source()`s matches the AMQP 0-9-1 and 1.0 readers. This change also updates the 0-9-1 reader to use map-based `sets` for the sake of consistency.