### PR TITLE
Update RabbitMQ series versions in discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -16,8 +16,8 @@ body:
     attributes:
       label: RabbitMQ series
       options:
-        - 4.0.x
         - 4.1.x
+        - 4.2.x
     validations:
       required: true
   - type: input

--- a/.github/DISCUSSION_TEMPLATE/other.yml
+++ b/.github/DISCUSSION_TEMPLATE/other.yml
@@ -23,6 +23,7 @@ body:
     attributes:
       label: RabbitMQ version used
       options:
+        - 4.2.x
         - 4.1.x
         - 4.0.x
         - 3.13.x or older


### PR DESCRIPTION
Since v4.2.0 is now released we can add 4.2.x to the discussion templates