### PR TITLE
Prometheus: stream HTTP responses (a double digit % reduction of both CPU and memory footprint)

### DIFF
--- a/deps/rabbitmq_prometheus/Makefile
+++ b/deps/rabbitmq_prometheus/Makefile
@@ -9,7 +9,7 @@ endef
 PROJECT := rabbitmq_prometheus
 PROJECT_DESCRIPTION = Prometheus metrics for RabbitMQ
 PROJECT_MOD := rabbit_prometheus_app
-DEPS = accept cowboy rabbit rabbitmq_management_agent prometheus rabbitmq_web_dispatch
+DEPS = cowboy rabbit rabbitmq_management_agent prometheus rabbitmq_web_dispatch
 BUILD_DEPS = amqp_client rabbit_common rabbitmq_management
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers rabbitmq_stream
 

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -373,7 +373,7 @@ content_type_test(Config) ->
 
 encoding_test(Config) ->
     {Headers, Body} = http_get(Config, [{"accept-encoding", "deflate"}], 200),
-    ?assertMatch("identity", proplists:get_value("content-encoding", Headers)),
+    ?assertMatch(undefined, proplists:get_value("content-encoding", Headers)),
     ?assertEqual(match, re:run(Body, "^# TYPE", [{capture, none}, multiline])).
 
 gzip_encoding_test(Config) ->

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -39,7 +39,6 @@ endif
 # We do that in this file, which is included by all projects, to ensure
 # all projects use the same versions. It avoids conflicts.
 
-dep_accept = hex 0.3.5
 dep_cowboy = hex 2.14.1
 dep_cowlib = hex 2.16.0
 dep_credentials_obfuscation = hex 3.5.0


### PR DESCRIPTION
`prometheus_text_format:format/1` produces a binary of the format for the entire registry. For clusters with many resources, this can lead to large replies from `/metrics/[:registry]` especially for large registries like `per-object`. Instead of formatting the response and then sending it, we can stream the response by taking advantage of the new `format_into/3` callback (which needs to be added upstream to the `prometheus` dep). This uses `cowboy_req:stream_body/3` to stream the iodata as `prometheus` works through the registry.

This should hopefully be a nice memory improvement. The other benefit is that results are sent eagerly. For a stress-testing example,

1. `make run-broker`
2. `rabbitmqctl import_definitions path/to/100k-classic-queues.json`
3. `curl -s localhost:15692/metrics/per-object`

Before this change `curl` would wait for around 8 seconds and then the entire response would arrive. With this change the results start streaming in immediately.

Discussed in #14865