### PR TITLE
Build system: fix rabbit_common, amqp_client, amqp10_client publishing to hex.pm

### DIFF
--- a/deps/amqp10_client/Makefile
+++ b/deps/amqp10_client/Makefile
@@ -44,8 +44,6 @@ dep_elvis_mk = git https://github.com/inaka/elvis.mk.git master
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 
-HEX_TARBALL_FILES += git-revisions.txt
-
 # --------------------------------------------------------------------
 # ActiveMQ for the testsuite.
 # --------------------------------------------------------------------

--- a/deps/amqp10_common/Makefile
+++ b/deps/amqp10_common/Makefile
@@ -48,6 +48,4 @@ PLT_APPS = eunit
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 
-HEX_TARBALL_FILES += git-revisions.txt
-
 -include development.post.mk

--- a/deps/amqp_client/Makefile
+++ b/deps/amqp_client/Makefile
@@ -53,5 +53,3 @@ PLT_APPS = ssl public_key
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
-
-HEX_TARBALL_FILES += git-revisions.txt

--- a/deps/rabbit_common/Makefile
+++ b/deps/rabbit_common/Makefile
@@ -48,10 +48,4 @@ PLT_APPS += mnesia crypto ssl
 include ../../rabbitmq-components.mk
 include ../../erlang.mk
 
-HEX_TARBALL_FILES += git-revisions.txt \
-		     mk/rabbitmq-build.mk \
-		     mk/rabbitmq-dist.mk \
-		     mk/rabbitmq-early-plugin.mk \
-		     mk/rabbitmq-hexpm.mk
-
 -include development.post.mk


### PR DESCRIPTION
`HEX_TARBALL_FILES` included ../../rabbitmq-components.mk which modern `rebar3 compile` considers to be unsafe and fails on (quite reasonably).

FTR, the error looks like this:

```
===> Fetching rebar_alias v0.2.0
===> Analyzing applications...
===> Compiling rebar_alias
===> Verifying dependencies...
===> Fetching amqp_client v4.1.5
escript: exception error: no function clause matching
                 rebar_fetch:format_error({error,
                                           {hex_tarball,
                                            {inner_tarball,
                                             {"../../rabbitmq-components.mk",
                                              unsafe_path}}}}) (/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar_fetch.erl, line 99)
  in function  rebar3:handle_error/2 (/home/runner/work/rebar3/rebar3/apps/rebar/src/rebar3.erl, line 383)
  in call from escript:run/2 (escript.erl, line 904)
  in call from escript:start/1 (escript.erl, line 418)
  in call from init:start_it/1
  in call from init:start_em/1
  in call from init:do_boot/3
```

Excluding this relative path addresses the issue.

rabbit_common/Makefile arguably does not need to
add any .mk files to the tarball but let's
deal with that in a separate change.
