### PR TITLE
Always set and fix up TLS options in LDAP plugin

### DIFF
--- a/deps/rabbit_common/src/rabbit_ssl_options.erl
+++ b/deps/rabbit_common/src/rabbit_ssl_options.erl
@@ -39,7 +39,6 @@ wrap_password_opt(Opts0) ->
     end.
 
 -spec fix(rabbit_types:infos()) -> rabbit_types:infos().
-
 fix(Config) ->
     fix_verify_fun(
       fix_ssl_protocol_versions(


### PR DESCRIPTION
There's an edge case in LDAP SSL configuration. If you set...

```
auth_ldap.use_ssl = true
```

...but nothing else, you'll eventually hit this error:

```
{error, {options, incompatible,
    [{verify, verify_peer}, {cacerts, undefined}]}}
```

This is due to the fact that without any SSL options, the `rabbit_ssl_options:fix_client/1` function won't be hit, and thus system certs won't be added via `public_key:cacerts_get/0` and `cacerts` option.

This PR adds `verify, verify_peer` as the default SSL option and ensures that `rabbit_ssl_options:fix_client/1` is always called. Since `verify_peer` is the default since OTP 26, we can just add it here.