### PR TITLE
rabbit_feature_flags: Reset registry after copying feature states

### DIFF
--- a/deps/rabbit/src/rabbit_feature_flags.erl
+++ b/deps/rabbit/src/rabbit_feature_flags.erl
@@ -1331,6 +1331,7 @@ copy_feature_states_after_reset(RemoteNode) ->
        #{domain => ?RMQLOG_DOMAIN_FEAT_FLAGS}),
     case do_write_enabled_feature_flags_list(EnabledFeatureNames) of
         ok ->
+            ok = reset_registry(),
             ok;
         {error, Reason} ->
             File = enabled_feature_flags_list_file(),


### PR DESCRIPTION
## Why

The copy is likely to install a different list of enabled feature flags compared to the possibly loaded registry. Therefore it needs to be reset.

## How

This is already the case, but the reset is done from the clustering code and not right after the copy, leaving a time frame where the feature states are inconsistent between the loaded registry and the on-disk record.

This should be the responsibility of the Feature flags subsystem anyway.