### PR TITLE
Update nightly OCI: build only supported versions

### DIFF
--- a/.github/workflows/oci-make-nightly.yaml
+++ b/.github/workflows/oci-make-nightly.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   build-package-generic-unix:
     strategy:
+      fail-fast: false
       matrix:
         otp_version:
           - '27'
@@ -24,7 +25,6 @@ jobs:
           - main
           - v4.2.x
           - v4.1.x
-          - v4.0.x
         include:
           - branch: main
             project_version: 4.3.0


### PR DESCRIPTION

## Proposed Changes

Build only supported versions in Nightly OCI workflow.

Because older versions are failing to build in Elixir 1.19. We don't
provide support for earlier versions anyway.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

Changes to support Elixir 1.19 are already in `main` and supported v4 branches, included in #14912
