### PR TITLE
support amqp10 message without body

### DIFF
--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -635,10 +635,7 @@ msg_body_decoded([#'v1_0.footer'{content = FC} | Rem], Msg) ->
     msg_body_decoded(Rem, Msg#msg_body_decoded{footer = FC}).
 
 msg_body_encoded([], _Payload, Msg) ->
-    %% handle empty body
-    Msg;
-msg_body_encoded(undefined, _Payload, Msg) ->
-    %% treat undefined body the same as [].
+    %% handle empty or undefined body
     Msg;
 msg_body_encoded([#'v1_0.header'{} = H | Rem], Payload, Msg) ->
     msg_body_encoded(Rem, Payload, Msg#msg_body_encoded{header = H});


### PR DESCRIPTION
## Proposed Changes

Currently RabbitMQ-server does not support an AMQP 1.0 message with empty/undefined body.
My understanding of the AMQP 1.0 protocol is that this is perfectly valid case.
Many systems sends a message with properties only. They _could_ set an empty array as Body, but that need changes in sometimes hundreds of client-applications.

This change will accept if Body is 'undefined'.

I used AmqpNetLite library and published a message where BodySection is not set

        var message = new Message
        {
            // BodySection = <notset>
            Properties = new Properties()
        };
and the error occured. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
