### PR TITLE
Make `rabbitmq_aws` use the IPv6 discovery endpoints if the node is configured to use IPv6

### DIFF
--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -15,7 +15,10 @@
 -define(DEFAULT_PROFILE, "default").
 
 -define(INSTANCE_AZ, "placement/availability-zone").
+
+% https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
 -define(INSTANCE_HOST, "169.254.169.254").
+-define(INSTANCE_HOST_6, "fd00:ec2::254").
 
 % rabbitmq/rabbitmq-peer-discovery-aws#25
 

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -420,13 +420,22 @@ instance_availability_zone_url() ->
 instance_credentials_url(Role) ->
     instance_metadata_url(string:join([?INSTANCE_METADATA_BASE, ?INSTANCE_CREDENTIALS, Role], "/")).
 
+-spec instance_metadata_host() -> string().
+%% @doc Return the appropriate instance metadata host based on IP family configuration
+%% @end
+instance_metadata_host() ->
+    case proplists:get_value(inet6, inet:get_rc(), false) of
+        true -> ?INSTANCE_HOST_6;
+        false -> ?INSTANCE_HOST
+    end.
+
 -spec instance_metadata_url(string()) -> string().
 %% @doc Build the Instance Metadata service URL for the specified path
 %% @end
 instance_metadata_url(Path) ->
     rabbitmq_aws_urilib:build(#uri{
         scheme = http,
-        authority = {undefined, ?INSTANCE_HOST, undefined},
+        authority = {undefined, instance_metadata_host(), undefined},
         path = Path,
         query = []
     }).


### PR DESCRIPTION
This PR follows the same pattern as
`rabbit_peer_discovery_httpc:maybe_configure_inet6/0`, where `inet:get_rc/0` is used to determine if we're running in an IPv6-only environment. If so, the correct IPv6 address will be used for EC2 IMDS HTTP API requests.

Fixes #14974