### PR TITLE
Set settlement modes when handling link errors

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -1136,7 +1136,9 @@ handle_frame(#'v1_0.attach'{name = {utf8, NameBin} = Name,
                             handle = Handle,
                             role = Role,
                             source = Source,
-                            target = Target} = Attach,
+                            target = Target,
+                            snd_settle_mode = SndSettleMode,
+                            rcv_settle_mode = RcvSettleMode} = Attach,
              State) ->
     try
         ok = validate_attach(Attach),
@@ -1152,7 +1154,9 @@ handle_frame(#'v1_0.attach'{name = {utf8, NameBin} = Name,
                                      handle = Handle,
                                      role = ?AMQP_ROLE_RECEIVER,
                                      source = Source,
-                                     target = null};
+                                     target = null,
+                                     snd_settle_mode = SndSettleMode,
+                                     rcv_settle_mode = RcvSettleMode};
                               ?AMQP_ROLE_RECEIVER ->
                                   #'v1_0.attach'{
                                      name = Name,
@@ -1160,7 +1164,9 @@ handle_frame(#'v1_0.attach'{name = {utf8, NameBin} = Name,
                                      role = ?AMQP_ROLE_SENDER,
                                      source = null,
                                      target = Target,
-                                     initial_delivery_count = ?UINT(?INITIAL_DELIVERY_COUNT)}
+                                     initial_delivery_count = ?UINT(?INITIAL_DELIVERY_COUNT),
+                                     snd_settle_mode = SndSettleMode,
+                                     rcv_settle_mode = RcvSettleMode}
                           end,
             Detach = #'v1_0.detach'{handle = Handle,
                                     closed = true,


### PR DESCRIPTION
Follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/14389

Without these changes, the attach frame doesn't set any settlement mode. This leads to settlement negotiation errors hiding the actual error.

For example,
omq amqp -y 0 -t /queues/no-such-queue
omq amqp -x 0 -T /queues/no-such-queue

Returned `amqp: sender settlement mode "unsettled" requested, received "mixed" from server"`, when the actual error in the next (detach) frame was `amqp:not-found`. However, the attach frame triggers a client-side error before the detach frame is processed.