### PR TITLE
Support `mqttv3.1` WebSocket subprotocol in addition to `mqtt`

### DIFF
--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -106,11 +106,11 @@ init(Req, Opts) ->
         undefined ->
             no_supported_sub_protocol(undefined, Req);
         Protocol ->
-            case lists:member(<<"mqtt">>, Protocol) of
+            case lists:search(fun(P) -> P =:= <<"mqtt">> orelse P =:= <<"mqttv3.1">> end, Protocol) of
                 false ->
                     no_supported_sub_protocol(Protocol, Req);
-                true ->
-                    Req1 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, <<"mqtt">>, Req),
+                {value, MatchedProtocol} ->
+                    Req1 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, MatchedProtocol, Req),
                     State = #state{socket = maps:get(proxy_header, Req, undefined),
                                    stats_timer = rabbit_event:init_stats_timer()},
                     WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),


### PR DESCRIPTION
Addresses #15001

The Web MQTT handler only accepts the `mqtt` WebSocket subprotocol, rejecting clients that request `mqttv3.1`. This prevents some MQTT clients from establishing WebSocket connections.

This change updates the protocol negotiation to accept either `mqtt` or `mqttv3.1` subprotocols. The handler uses `lists:search/2` to find the first matching protocol and echoes that exact value back in the `sec-websocket-protocol` response header, ensuring proper protocol negotiation with the client.