### PR TITLE
Expose Osiris replica IP address family to rabbitmq.conf

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2756,6 +2756,23 @@ end}.
  end
 }.
 
+{mapping, "stream.replication.address_family", "osiris.replica_ip_address_family", [
+    {datatype, [{enum, [inet6, inet, ipv6, ipv4]}]}
+]}.
+
+{translation, "osiris.replica_ip_address_family",
+    fun(Conf) ->
+        case cuttlefish:conf_get("stream.replication.address_family", Conf, undefined) of
+            undefined -> cuttlefish:unset();
+            inet      -> inet;
+            inet6     -> inet6;
+            ipv4      -> inet;
+            ipv6      -> inet6;
+            Other     -> cuttlefish:invalid(io_lib:format("~p is not a supported address family", [Other]))
+        end
+    end
+}.
+
 {mapping, "stream.replication.port_range.min", "osiris.port_range", [
     {datatype, [integer]},
     {validators, ["non_zero_positive_integer"]}

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1198,10 +1198,38 @@ credential_validator.regexp = ^abc\\d+",
    []},
 
   %%
-  %% Stream replication port range
+  %% Stream replication
   %%
 
-  {stream_replication_port_range,
+  {stream_replication_address_family_ipv4_case1,
+   "stream.replication.address_family = inet",
+   [{osiris, [
+      {replica_ip_address_family, inet}
+     ]}],
+   []},
+
+  {stream_replication_address_family_ipv4_case2,
+   "stream.replication.address_family = ipv4",
+   [{osiris, [
+      {replica_ip_address_family, inet}
+     ]}],
+   []},
+
+  {stream_replication_address_family_ipv6_case1,
+   "stream.replication.address_family = inet6",
+   [{osiris, [
+      {replica_ip_address_family, inet6}
+     ]}],
+   []},
+
+  {stream_replication_address_family_ipv6_case2,
+   "stream.replication.address_family = ipv6",
+   [{osiris, [
+      {replica_ip_address_family, inet6}
+     ]}],
+   []},
+
+  {stream_replication_port_range_min_max,
    "
     stream.replication.port_range.min = 4000
     stream.replication.port_range.max = 4600
@@ -1211,7 +1239,7 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
-  {stream_replication_port_range,
+  {stream_replication_port_range_min_only,
    "
     stream.replication.port_range.min = 4000
    ",
@@ -1220,7 +1248,7 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
-  {stream_replication_port_range,
+  {stream_replication_port_range_max,
    "
     stream.replication.port_range.max = 4600
    ",


### PR DESCRIPTION
This exposes Osiris (stream) replica IP address family setting introduced in https://github.com/rabbitmq/osiris/pull/177 to `rabbitmq.conf`.

References #15005.
