### PR TITLE
Reorder queue creation form to make vhost dropdown reset less likely

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -227,20 +227,6 @@
   <div class="hider">
     <form action="#/queues" method="put">
       <table class="form">
-<% if (display.vhosts) { %>
-        <tr>
-          <th><label>Virtual host:</label></th>
-          <td>
-            <select name="vhost">
-              <% for (var i = 0; i < vhosts.length; i++) { %>
-              <option value="<%= fmt_string(vhosts[i].name) %>" <%= (vhosts[i].name === current_vhost) ? 'selected="selected"' : '' %>><%= fmt_string(vhosts[i].name) %></option>
-              <% } %>
-            </select>
-          </td>
-        </tr>
-<% } else { %>
-        <tr><td><input type="hidden" name="vhost" value="<%= fmt_string(vhosts[0].name) %>"/></td></tr>
-<% } %>
         <tr>
           <th><label>Type:</label></th>
           <td>
@@ -258,6 +244,20 @@
             </select>
           </td>
         </tr>
+<% if (display.vhosts) { %>
+        <tr>
+          <th><label>Virtual host:</label></th>
+          <td>
+            <select name="vhost">
+              <% for (var i = 0; i < vhosts.length; i++) { %>
+              <option value="<%= fmt_string(vhosts[i].name) %>" <%= (vhosts[i].name === current_vhost) ? 'selected="selected"' : '' %>><%= fmt_string(vhosts[i].name) %></option>
+              <% } %>
+            </select>
+          </td>
+        </tr>
+<% } else { %>
+        <tr><td><input type="hidden" name="vhost" value="<%= fmt_string(vhosts[0].name) %>"/></td></tr>
+<% } %>
         <tr>
           <th><label>Name:</label></th>
           <td><input type="text" name="name"/><span class="mand">*</span></td>


### PR DESCRIPTION
Fixes #15015

When creating a queue in the management UI, selecting a non-`/` virtual host, then a queue type different than the default for that virtual host causes the vhost selection to reset to `/`. This happens because changing the queue type calls `update()`, which re-renders the entire form to display specific data for that virtual host, losing the user's virtual host selection.

This change reorders the "Add a new queue" form fields so that "Type" appears before "Virtual host". Users now select the queue type first, triggering the form re-render before they make their vhost selection. This prevents the vhost reset without requiring JS wizardry/hacks to preserve form state across re-renders.