### PR TITLE
Fix Prometheus and dependencies loading

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1038,9 +1038,10 @@ do_run_postlaunch_phase(Plugins) ->
         %% * Collectors: the `rabbitmq_prometheus' plugin explicitly registers
         %%   all collectors.
         %% * Instrumenters: no instrumenters are used.
-        _ = application:load(prometheus),
-        ok = application:set_env(prometheus, collectors, [default]),
-        ok = application:set_env(prometheus, instrumenters, []),
+        ok = application:set_env(prometheus, collectors, [default],
+                                 [{persistent, true}]),
+        ok = application:set_env(prometheus, instrumenters, [],
+                                 [{persistent, true}]),
 
         %% However, we want to run their boot steps and actually start
         %% them one by one, to ensure a dependency is fully started


### PR DESCRIPTION
A new dependency of the Prometheus library (ddskerl) is not loaded properly, breaking stop_app in some occasions.

Per discussion with @lhoguin and @dumbbell.

References #14885