### PR TITLE
[skip ci] Optional delay in `make restart-cluster`

### DIFF
--- a/deps/rabbit_common/mk/rabbitmq-run.mk
+++ b/deps/rabbit_common/mk/rabbitmq-run.mk
@@ -33,6 +33,8 @@ RABBITMQCTL ?= $(RABBITMQ_SCRIPTS_DIR)/rabbitmqctl
 RABBITMQ_UPGRADE ?= $(RABBITMQ_SCRIPTS_DIR)/rabbitmq-upgrade
 endif
 
+RESTART_DELAY ?= 0
+
 export RABBITMQ_SCRIPTS_DIR RABBITMQCTL RABBITMQ_PLUGINS RABBITMQ_SERVER RABBITMQ_UPGRADE
 
 # We export MAKE to be sure scripts and tests use the proper command.
@@ -415,6 +417,8 @@ restart-cluster:
 			$(RABBITMQ_UPGRADE) -n "$$nodename" drain; \
 		$(MAKE) stop-node \
 		  RABBITMQ_NODENAME="$$nodename"; \
+		echo "Sleeping for $(RESTART_DELAY) seconds..."; \
+		sleep $(RESTART_DELAY); \
 		$(MAKE) start-background-broker \
 		  NOBUILD=1 \
 		  RABBITMQ_NODENAME="$$nodename" \


### PR DESCRIPTION
`make restart-cluster` allows simple rolling restart/upgrade testing. `make restart-cluster RESTART_DELAY=N` adds an option to force a delay from when a node goes down, till it start up again. This is useful in some tests scenarios, such as:

1. forcing the cluster to work longer in a mixed-version configuration

2. forcing the stopped member to fall behind in terms of replication to trigger a more demanding catch-up