### PR TITLE
Fix empty state field in /api/deprecated-features/used endpoint

### DIFF
--- a/deps/rabbit/src/rabbit_depr_ff_extra.erl
+++ b/deps/rabbit/src/rabbit_depr_ff_extra.erl
@@ -58,14 +58,17 @@ cli_info0(DeprecatedFeature) ->
 
               App = maps:get(provided_by, FeatureProps),
               DeprecationPhase = maps:get(deprecation_phase, FeatureProps, ""),
-              State = maps:get(state, FeatureProps, ""),
               Desc = maps:get(desc, FeatureProps, ""),
               DocUrl = maps:get(doc_url, FeatureProps, ""),
-              Info = #{name => FeatureName,
-                       desc => unicode:characters_to_binary(Desc),
-                       deprecation_phase => DeprecationPhase,
-                       state => State,
-                       doc_url => unicode:characters_to_binary(DocUrl),
-                       provided_by => App},
+              BaseInfo = #{name => FeatureName,
+                          desc => unicode:characters_to_binary(Desc),
+                          deprecation_phase => DeprecationPhase,
+                          doc_url => unicode:characters_to_binary(DocUrl),
+                          provided_by => App},
+              Info = maps:merge(BaseInfo,
+                               case maps:find(state, FeatureProps) of
+                                   {ok, State} -> #{state => State};
+                                   error        -> #{}
+                               end),
               [Info | Acc]
       end, [], lists:sort(maps:keys(DeprecatedFeature))).

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -4218,7 +4218,9 @@ list_deprecated_features_test(Config) ->
     ?assertEqual(<<"permitted_by_default">>, maps:get(deprecation_phase, Feature)),
     ?assertEqual(atom_to_binary(?MODULE), maps:get(provided_by, Feature)),
     ?assertEqual(list_to_binary(Desc), maps:get(desc, Feature)),
-    ?assertEqual(list_to_binary(DocUrl), maps:get(doc_url, Feature)).
+    ?assertEqual(list_to_binary(DocUrl), maps:get(doc_url, Feature)),
+    ?assert(maps:is_key(state, Feature)),
+    ?assert(lists:member(maps:get(state, Feature), [<<"permitted">>, <<"denied">>])).
 
 list_used_deprecated_features_test(Config) ->
     Desc = "This is a deprecated feature in use",
@@ -4239,7 +4241,8 @@ list_used_deprecated_features_test(Config) ->
     ?assertEqual(<<"removed">>, maps:get(deprecation_phase, Feature)),
     ?assertEqual(atom_to_binary(?MODULE), maps:get(provided_by, Feature)),
     ?assertEqual(list_to_binary(Desc), maps:get(desc, Feature)),
-    ?assertEqual(list_to_binary(DocUrl), maps:get(doc_url, Feature)).
+    ?assertEqual(list_to_binary(DocUrl), maps:get(doc_url, Feature)),
+    ?assertNot(maps:is_key(state, Feature)).
 
 cluster_and_node_tags_test(Config) ->
     Overview = http_get(Config, "/overview"),


### PR DESCRIPTION
The /api/deprecated-features/used endpoint was returning an empty state field in the JSON response. This was a regression introduced in #14229, which added the state field to show whether deprecated features are permitted or denied.

The issue was that rabbit_depr_ff_extra:cli_info0/1 always tried to extract the state field with a default empty string, even when rabbit_deprecated_features:list(used) doesn't include a state field (unlike list(all) which does).

This commit fixes the issue by only including the state field when it exists in the feature properties, using maps:find/2 and maps:merge/2 to conditionally add it.

The fix ensures that:
- /api/deprecated-features returns state field with valid values
- /api/deprecated-features/used omits the state field entirely

Tests are updated to verify this behavior.

GitHub issue: #14340

## Proposed Changes

This PR fixes a regression introduced in #14229 where the `/api/deprecated-features/used` endpoint was returning an empty `state` field in the JSON response.

**The Problem:**

- PR #14229 added a `state` field to show whether deprecated features are `permitted` or `denied`
- The `rabbit_deprecated_features:list(all)` function includes the `state` field, but `list(used)` does not
- However, `rabbit_depr_ff_extra:cli_info0/1` always tried to extract the `state` field with a default empty string, resulting in `"state": ""` in the response for the `/used` endpoint

**The Solution:**

- Modified `rabbit_depr_ff_extra:cli_info0/1` to conditionally include the `state` field only when it exists in the feature properties
- Used `maps:find/2` and `maps:merge/2` for a more idiomatic Erlang approach
- Updated tests to verify that:
  - `/api/deprecated-features` includes the `state` field with valid values (`permitted` or `denied`)
  - `/api/deprecated-features/used` omits the `state` field entirely

This ensures the API response matches the expected behavior: the `state` field is either set correctly or omitted, never empty.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
