### PR TITLE
Output descriptive error if AMQP message has no body

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -191,7 +191,8 @@ mapify([Key, Value | Rest]) ->
 %% We re-use the match context avoiding creation of sub binaries.
 -spec parse_many(binary(), opts()) ->
     [amqp10_binary_generator:amqp10_type() |
-     {{pos, non_neg_integer()}, amqp10_binary_generator:amqp10_type() | body}].
+     {{pos, non_neg_integer()},
+      amqp10_binary_generator:amqp10_type() | {body, pos_integer()}}].
 parse_many(Binary, Opts) ->
     OptionServerMode = lists:member(server_mode, Opts),
     pm(Binary, OptionServerMode, 0).

--- a/deps/rabbit/src/mc_amqp.erl
+++ b/deps/rabbit/src/mc_amqp.erl
@@ -636,7 +636,7 @@ msg_body_encoded([{{pos, Pos}, #'v1_0.application_properties'{content = APC}} | 
                                      application_properties = APC,
                                      bare_and_footer_application_properties_pos = Pos - BarePos
                                     });
-%% Base case: we assert the last part contains the mandatory body:
+%% Base case: The last part must contain the mandatory body:
 msg_body_encoded([{{pos, Pos}, {body, Code}}], Payload, Msg)
   when is_binary(Payload) ->
     %% AMQP sender omitted properties and application-properties sections.
@@ -648,7 +648,9 @@ msg_body_encoded([{{pos, Pos}, {body, Code}}], Payload, Msg)
 msg_body_encoded([{{pos, Pos}, {body, Code}}], BarePos, Msg)
   when is_integer(BarePos) ->
     Msg#msg_body_encoded{bare_and_footer_body_pos = Pos - BarePos,
-                         body_code = Code}.
+                         body_code = Code};
+msg_body_encoded([], _, #msg_body_encoded{body_code = uninit}) ->
+    throw(missing_amqp_message_body).
 
 %% We extract the binary part of the payload exactly once when the bare message starts.
 binary_part_bare_and_footer(Payload, Start) ->

--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -2406,7 +2406,11 @@ incoming_link_transfer(
     validate_message_size(PayloadSize, MaxMessageSize),
     rabbit_msg_size_metrics:observe(?PROTOCOL, PayloadSize),
     messages_received(Settled),
-    Mc0 = mc:init(mc_amqp, PayloadBin, #{}),
+    Mc0 = try mc:init(mc_amqp, PayloadBin, #{})
+          catch missing_amqp_message_body ->
+                    link_error(?V_1_0_AMQP_ERROR_DECODE_ERROR,
+                               "message has no body", [])
+          end,
     case lookup_target(LinkExchange, LinkRKey, Mc0, Vhost, User, PermCache0) of
         {ok, X, RoutingKeys, Mc1, PermCache} ->
             check_user_id(Mc1, User),

--- a/deps/rabbit/test/amqp_dotnet_SUITE.erl
+++ b/deps/rabbit/test/amqp_dotnet_SUITE.erl
@@ -42,7 +42,8 @@ groups() ->
        auth_failure,
        access_failure_not_allowed,
        access_failure_send,
-       streams
+       streams,
+       message_without_body
       ]
      }].
 
@@ -211,6 +212,9 @@ access_failure_send(Config) ->
 
 streams(Config) ->
     declare_queue(Config, ?FUNCTION_NAME, "stream"),
+    run(?FUNCTION_NAME, Config).
+
+message_without_body(Config) ->
     run(?FUNCTION_NAME, Config).
 
 %% -------------------------------------------------------------------

--- a/release-notes/4.0.1.md
+++ b/release-notes/4.0.1.md
@@ -136,6 +136,8 @@ Starting with RabbitMQ 4.0, RabbitMQ strictly validates that
 [non-reserved annotation keys](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-annotations).
 As a result, clients can only send symbolic keys that begin with `x-`.
 
+Starting with RabbitMQ 4.0, RabbitMQ also strictly validates that an AMQP message contains the mandatory body.
+
 ### MQTT
 
 RabbitMQ 3.13 [rabbitmq.conf](https://www.rabbitmq.com/docs/configure#config-file) settings `mqtt.default_user`, `mqtt.default_password`,


### PR DESCRIPTION
According to the AMQP spec, a message must have a body.

amqpnetlite and Azure Service Bus support non-compliant AMQP where a message might have no body. RabbitMQ implements the AMQP spec correctly requiring a message body. This commit provides a nice error description if a client wrongly sends a message without a body.

Prior to this commit, the session got terminated with the following non-descriptive error:
```
[{mc_amqp,msg_body_encoded,
     [[],0,
      {msg_body_encoded,undefined,[],
          {'v1_0.properties',undefined,undefined,undefined,undefined,
              undefined,undefined,undefined,undefined,undefined,undefined,
              undefined,undefined,undefined},
          [],
          <<0,83,115,69>>,
          [],uninit,uninit}],
     [{file,"mc_amqp.erl"},{line,612}]},
 {mc_amqp,init,1,[{file,"mc_amqp.erl"},{line,145}]},
 {mc,init,4,[{file,"mc.erl"},{line,157}]},
 {rabbit_amqp_session,incoming_link_transfer,4,
     [{file,"rabbit_amqp_session.erl"},{line,2409}]},
 {rabbit_amqp_session,handle_frame,2,
     [{file,"rabbit_amqp_session.erl"},{line,983}]},
 {rabbit_amqp_session,handle_cast,2,
     [{file,"rabbit_amqp_session.erl"},{line,558}]},
 {gen_server,try_handle_cast,3,[{file,"gen_server.erl"},{line,2460}]},
 {gen_server,handle_msg,3,[{file,"gen_server.erl"},{line,2418}]}]
```

(Note that transfer frames without payload are allowed though.)