### PR TITLE
Provide queue name and reason to publisher for rejected messages

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2787,7 +2787,7 @@ handle_queue_actions(Actions, State) ->
     lists:foldl(
       fun({settled, QRef, MsgSeqNos}, S0) ->
               confirm(MsgSeqNos, QRef, S0);
-         ({rejected, _QRef, MsgSeqNos}, S0) ->
+         ({rejected, _QRef, _Reason, MsgSeqNos}, S0) ->
               {U, Rej} =
               lists:foldr(
                 fun(SeqNo, {U1, Acc}) ->

--- a/deps/rabbit/src/rabbit_queue_type.erl
+++ b/deps/rabbit/src/rabbit_queue_type.erl
@@ -81,6 +81,7 @@
 
 -type queue_name() :: rabbit_amqqueue:name().
 -type queue_state() :: term().
+-type reject_reason() :: maxlen | down.
 %% sequence number typically
 -type correlation() :: term().
 -type arguments() :: queue_arguments | consumer_arguments.
@@ -101,6 +102,7 @@
     %% indicate to the queue type module that a message has been delivered
     %% fully to the queue
     {settled, queue_name(), [correlation()]} |
+    {rejected, queue_name(), reject_reason(), [correlation()]} |
     {deliver, rabbit_types:ctag(), boolean(), [rabbit_amqqueue:qmsg()]} |
     {block | unblock, QueueName :: term()} |
     credit_reply_action().
@@ -158,6 +160,7 @@
               credit_reply_action/0,
               action/0,
               actions/0,
+              reject_reason/0,
               settle_op/0,
               queue_type/0,
               credit/0,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1125,7 +1125,7 @@ deliver(QSs, Msg0, Options) ->
               case deliver0(QName, Correlation, Msg, S0) of
                   {reject_publish, S} ->
                       {[{Q, S} | Qs],
-                       [{rejected, QName, [Correlation]} | Actions]};
+                       [{rejected, QName, maxlen, [Correlation]} | Actions]};
                   {ok, S, As} ->
                       {[{Q, S} | Qs], As ++ Actions}
               end

--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -384,11 +384,13 @@ quorum_queue_rejects(Config) ->
     %% The queue will reject m3.
     V = ?config(mqtt_version, Config),
     if V =:= v3 orelse V =:= v4 ->
-           %% v3 and v4 do not support NACKs. Therefore, the server should drop the message.
+           %% v3 and v4 do not support NACKs.
+           %% Therefore, the server should drop the message.
            ?assertEqual(puback_timeout, util:publish_qos1_timeout(C, Name, <<"m3">>, 700));
        V =:= v5 ->
-           %% v5 supports NACKs. Therefore, the server should send us a NACK.
-           ?assertMatch({ok, #{reason_code_name := implementation_specific_error}},
+           %% v5 supports NACKs.
+           %% Therefore, the server should send us a NACK with the correct reason.
+           ?assertMatch({ok, #{reason_code_name := quota_exceeded}},
                         emqtt:publish(C, Name, <<"m3">>, qos1))
     end,
 

--- a/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
@@ -656,7 +656,8 @@ handle_dest_queue_actions(Actions, State) ->
     lists:foldl(
       fun({settled, QName, MsgSeqNos}, S0) ->
               confirm(MsgSeqNos, QName, S0);
-         ({rejected, _QName, MsgSeqNos}, #{dest := Dst = #{unconfirmed := U0}} = S0) ->
+         ({rejected, _QName, _Reason, MsgSeqNos},
+          #{dest := Dst = #{unconfirmed := U0}} = S0) ->
               {U, Rej} =
               lists:foldr(
                 fun(SeqNo, {U1, Acc}) ->

--- a/release-notes/4.3.0.md
+++ b/release-notes/4.3.0.md
@@ -72,6 +72,20 @@ compared to other versions.
 
 ### Core Server
 
+#### Enhancements
+
+ * When a message is rejected by a queue, RabbitMQ now provides the queue name and rejection reason to AMQP 1.0 publishers
+   in the `Rejected` outcome. This is particularly useful when multiple queues are bound to an exchange, as it allows
+   publishers to identify which specific queue out of several target queues rejected the message and why
+   (e.g., maximum queue length reached or queue unavailable). Previously, publishers had no way to determine which queue
+   rejected their message or the reason for rejection.
+
+   The queue name and reason are included in the `info` field of the `Rejected` outcome's `error` field:
+   * `queue: <queue name>`
+   * `reason: maxlen | unavailable`
+
+   GitHub issue: [#15075](https://github.com/rabbitmq/rabbitmq-server/pull/15075)
+
 #### Bug Fixes
 
  * Quorum queue at-most-once dead lettering for the overflow behaviour `drop-head` now happens in the correct order.
@@ -112,6 +126,17 @@ compared to other versions.
    and log less (at `debug` level) as a result.
 
    GitHub issue: [#14923](https://github.com/rabbitmq/rabbitmq-server/discussions/14923)
+
+
+### MQTT Plugin
+
+#### Enhancements
+
+ * For MQTT 5.0 publishers, when a message is rejected because the target queue's maximum length is exceeded,
+   RabbitMQ now returns a `Quota exceeded` reason code in the PUBACK packet. This provides publishers with
+   actionable information about why their message was rejected.
+
+   GitHub issue: [#15075](https://github.com/rabbitmq/rabbitmq-server/pull/15075)
 
 
 ### Shovel Plugin


### PR DESCRIPTION
 ## What?
1. This commit adds the name of the queue that rejected a message as well as the reason why the message was rejected in the Rejected outcome for AMQP 1.0.
2. For MQTT 5.0 publishers, the reason is provided in the PUBACK packet.

 ## Why?
It may be helpful for publishers to know which queue out of multilple target queues rejected the message. One such use case is described in https://github.com/rabbitmq/rabbitmq-server/issues/1443 It may also be helpful to know for publishers whether the given target queue rejected the message because its maximum queue length was reached or because the target queue happens to be unavailable.

 ## How?
RabbitMQ will include the UTF-8 encoded queue name (rather than an AMQP address) as well as the reason in the `info` field of the Rejected outcome's `error` field:
* `queue: <queue name>`
* `reason: maxlen | unavailable`

For MQTT 5.0, if the queue length limit is exceeded, RabbitMQ will return the reason code for `Quota exceeded` to the publisher.

Docs PR: https://github.com/rabbitmq/rabbitmq-website/pull/2413