### PR TITLE
Fix `dialyze` target in plugins when `asdf` is used

### DIFF
--- a/deps/oauth2_client/Makefile
+++ b/deps/oauth2_client/Makefile
@@ -11,8 +11,5 @@ PLT_APPS = rabbit
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-# Required to properly autopatch jose.
-ELIXIR = system
-
 include rabbitmq-components.mk
 include erlang.mk

--- a/deps/rabbit_common/mk/rabbitmq-early-plugin.mk
+++ b/deps/rabbit_common/mk/rabbitmq-early-plugin.mk
@@ -4,9 +4,6 @@
 
 DIALYZER_OPTS ?= -Werror_handling -Wunmatched_returns -Wunknown
 
-dialyze: ELIXIR_LIBS = $(dir $(shell readlink -f `which elixir`))/../lib
-dialyze: ERL_LIBS = $(APPS_DIR):$(DEPS_DIR):$(ELIXIR_LIBS)
-
 # --------------------------------------------------------------------
 # Common Test flags.
 # --------------------------------------------------------------------

--- a/deps/rabbitmq_auth_backend_oauth2/Makefile
+++ b/deps/rabbitmq_auth_backend_oauth2/Makefile
@@ -19,8 +19,5 @@ dep_base64url = hex 1.0.1
 
 dep_emqtt = git https://github.com/emqx/emqtt.git 1.14.6
 
-# Required to properly autopatch jose.
-ELIXIR = system
-
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -30,10 +30,6 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk
 VERBOSE_TEST ?= true
 MAX_CASES ?= 1
 
-# Force enable Elixir in this project since
-# this is an Elixir application.
-ELIXIR = system
-
 # We are still using Mix for testing.
 MIX_TEST_OPTS ?= ""
 MIX_TEST = ERL_COMPILER_OPTIONS=deterministic MIX_ENV=test mix do compile --warnings-as-errors, test --max-cases=$(MAX_CASES) --warnings-as-errors

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -1,3 +1,7 @@
+# Force enable Elixir in all projects since
+# running dialyzer on any of them requires it
+ELIXIR = system
+
 ifeq ($(.DEFAULT_GOAL),)
 # Define default goal to `all` because this file defines some targets
 # before the inclusion of erlang.mk leading to the wrong target becoming


### PR DESCRIPTION
[This](https://github.com/ninenines/erlang.mk/commit/e13b4c7) `erlang.mk` commit fixed the detection of Elixir libraries for `asdf` users, but the "old way" remained in `rabbitmq-early-plugin.mk`. Removing the `dialyze` target env definitions and setting `ELIXIR = system` in `rabbitmq-components.mk` fixes this issue, and, the value of `ERL_LIBS` that is set is the same. Win-win.