### PR TITLE
Remove duplicated key 'name' from @info_keys

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/schema_info_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/diagnostics/commands/schema_info_command.ex
@@ -16,7 +16,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.SchemaInfoCommand do
   @info_keys ~w(name snmp load_order active_replicas all_nodes attributes checkpoints disc_copies
     disc_only_copies external_copies frag_properties master_nodes ram_copies
     storage_properties subscribers user_properties cstruct local_content
-    where_to_commit where_to_read name access_mode cookie load_by_force
+    where_to_commit where_to_read access_mode cookie load_by_force
     load_node record_name size storage_type type where_to_write index arity
     majority memory commit_work where_to_wlock load_reason record_validation
    version wild_pattern index_info)a


### PR DESCRIPTION
## Proposed Changes

There are two `name` in `@info_keys` so there are the same column names in the help documentation.

```
% rabbitmqctl help schema_info                                                                                                                                           

Usage

rabbitmqctl [--node <node>] [--longnames] [--quiet] schema_info [--no-table-headers] [<column> ...] [--timeout <timeout>]

Lists schema database tables and their properties.

Arguments and Options

<column>
        must be one of access_mode, active_replicas, all_nodes, arity, attributes, checkpoints, commit_work, cookie
        cstruct, disc_copies, disc_only_copies, external_copies, frag_properties, index, index_info, load_by_force, load_node,
        load_order, load_reason, local_content, majority, master_nodes, memory, name, name, ram_copies, record_name,
        record_validation, size, snmp, storage_properties, storage_type, subscribers, type, user_properties, version,
        where_to_commit, where_to_read, where_to_wlock, where_to_write, wild_pattern
```

Please see the line ` load_order, load_reason, local_content, majority, master_nodes, memory, name, name, ram_copies, record_name`.
 `name` is displayed twice.

## Types of Changes

- [x] Documentation improvements (corrections, new content, etc)

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [ ] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments
