### PR TITLE
Coerce the configured OAuth2 resource_server_id to binary to support different data types

### DIFF
--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_resource_server.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_oauth2_resource_server.erl
@@ -58,7 +58,7 @@ resolve_resource_server_from_audience(Audience) ->
 
 -spec get_root_resource_server_id() -> resource_server_id().
 get_root_resource_server_id() ->
-    get_env(resource_server_id, <<>>).
+    rabbit_data_coercion:to_binary(get_env(resource_server_id, <<>>)).
 
 -spec get_root_resource_server() -> resource_server().
 get_root_resource_server() ->

--- a/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_resource_server_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/rabbit_oauth2_resource_server_SUITE.erl
@@ -13,6 +13,7 @@
 -include("oauth2.hrl").
 
 -define(RABBITMQ,<<"rabbitmq">>).
+-define(RABBITMQ_ATOM,rabbitmq).
 -define(RABBITMQ_RESOURCE_ONE,<<"rabbitmq1">>).
 -define(RABBITMQ_RESOURCE_TWO,<<"rabbitmq2">>).
 -define(OAUTH_PROVIDER_A,<<"A">>).
@@ -30,7 +31,8 @@ all() -> [
 ].
 groups() -> [
     {with_rabbitmq_as_resource_server_id, [], [
-        resolve_resource_server_for_rabbitmq_audience,
+        resolve_resource_server_for_rabbitmq_audience_with_binary_config_id,
+        resolve_resource_server_for_rabbitmq_audience_with_atom_config_id,
         resolve_resource_server_for_rabbitmq_plus_unknown_audience,
         resolve_resource_server_for_none_audience_returns_no_aud_found,
         resolve_resource_server_for_unknown_audience_returns_no_matching_aud_found,
@@ -62,7 +64,8 @@ groups() -> [
         {verify_configuration_inheritance_with_rabbitmq2, [],
             verify_configuration_inheritance_with_rabbitmq2()},
         {with_rabbitmq_as_resource_server_id, [], [
-            resolve_resource_server_for_rabbitmq_audience,
+            resolve_resource_server_for_rabbitmq_audience_with_binary_config_id,
+            resolve_resource_server_for_rabbitmq_audience_with_atom_config_id,
             resolve_resource_server_id_for_rabbitmq1,
             resolve_resource_server_id_for_rabbitmq2
         ]}
@@ -259,10 +262,30 @@ end_per_group(with_scope_aliases, Config) ->
 end_per_group(_any, Config) ->
     Config.
 
+init_per_testcase(resolve_resource_server_for_rabbitmq_audience_with_atom_config_id, Config) ->
+    set_env(resource_server_id, ?RABBITMQ_ATOM),
+    Config;
+
+init_per_testcase(_any, Config) ->
+    Config.
+
+end_per_testcase(resolve_resource_server_for_rabbitmq_audience_with_atom_config_id, Config) ->
+    set_env(resource_server_id, ?RABBITMQ),
+    Config;
+
+end_per_testcase(_any, Config) ->
+    Config.
 
 %% --- Test cases
 
-resolve_resource_server_for_rabbitmq_audience(_) ->
+resolve_resource_server_for_rabbitmq_audience_with_binary_config_id(_) ->
+    {ok, RSI} = get_env(resource_server_id),
+    ?assert(erlang:is_binary(RSI)),
+    assert_resource_server_id(?RABBITMQ, ?RABBITMQ).
+
+resolve_resource_server_for_rabbitmq_audience_with_atom_config_id(_) ->
+    {ok, RSI} = get_env(resource_server_id),
+    ?assert(erlang:is_atom(RSI)),
     assert_resource_server_id(?RABBITMQ, ?RABBITMQ).
 
 resolve_resource_server_for_rabbitmq_plus_unknown_audience(_) ->


### PR DESCRIPTION
## Proposed Changes

When configuring the `rabbitmq_auth_backend_oauth2` plugin using **classic** or **advanced** config, `resource_server_id` may be specified as a different type from binary or iolist, e.g. atom, as below:

```
{rabbitmq_auth_backend_oauth2,
   [
       {resource_server_id, rabbitmqid},
       ...
   ]
},
```

This works fine for older versions of rabbit (=< rabbitmq-3.13.x). However as from RabbitMQ 4.x, oauth2 authentication checks fail as illustrated below (i.e. upgrading to RabbitMQ-4.x using same classic/advanced oauth2 config files fails, unless configs are manually updated. which shouldn't be the case, the plugin should mediate the configured `resource_server_id` types as before):

```

[debug] <0.479069.0> User '' authentication failed with error:badarg:
[debug] <0.479069.0> [{erlang,iolist_to_binary,
[debug] <0.479069.0>          [[rabbitmqid,<<".">>]],
[debug] <0.479069.0>          [{error_info,#{module => erl_erts_errors}}]},
[debug] <0.479069.0>  {rabbit_oauth2_resource_server,get_root_resource_server,0,
[debug] <0.479069.0>                                 [{file,"rabbit_oauth2_resource_server.erl"},
[debug] <0.479069.0>                                  {line,84}]},
[debug] <0.479069.0>  {rabbit_oauth2_resource_server,get_resource_server,1,
[debug] <0.479069.0>                                 [{file,"rabbit_oauth2_resource_server.erl"},
[debug] <0.479069.0>                                  {line,107}]},
[debug] <0.479069.0>  {rabbit_oauth2_resource_server,resolve_resource_server_from_audience,1,
[debug] <0.479069.0>                                 [{file,"rabbit_oauth2_resource_server.erl"},
[debug] <0.479069.0>                                  {line,56}]},
[debug] <0.479069.0>  {uaa_jwt,resolve_resource_server_given_audience,1,
[debug] <0.479069.0>           [{file,"uaa_jwt.erl"},{line,104}]},
[debug] <0.479069.0>  {rabbit_auth_backend_oauth2,authenticate,2,
[debug] <0.479069.0>                              [{file,"rabbit_auth_backend_oauth2.erl"},
[debug] <0.479069.0>                               {line,156}]},
[debug] <0.479069.0>  {rabbit_auth_backend_oauth2,user_login_authentication,2,
[debug] <0.479069.0>                              [{file,"rabbit_auth_backend_oauth2.erl"},
[debug] <0.479069.0>                               {line,65}]},
[debug] <0.479069.0>  {rabbit_access_control,try_authenticate,3,
[debug] <0.479069.0>                         [{file,"rabbit_access_control.erl"},{line,236}]}]

```

This change coerces the configured oauth2 `resource_server_id` to binary, to support different configured types, in particular, atom types.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it


