### PR TITLE
amqp_client, rabbitmq_auth_mechanism_ssl: fix Dialyzer on Erlang/OTP 28.3

### DIFF
--- a/deps/amqp_client/Makefile
+++ b/deps/amqp_client/Makefile
@@ -49,7 +49,7 @@ DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk \
 	      rabbit_common/mk/rabbitmq-hexpm.mk
 
-PLT_APPS = ssl public_key
+PLT_APPS = crypto ssl public_key
 
 include ../../rabbitmq-components.mk
 include ../../erlang.mk

--- a/deps/rabbitmq_auth_mechanism_ssl/Makefile
+++ b/deps/rabbitmq_auth_mechanism_ssl/Makefile
@@ -19,5 +19,7 @@ TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp10_client
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
+PLT_APPS = crypto public_key
+
 include ../../rabbitmq-components.mk
 include ../../erlang.mk


### PR DESCRIPTION
Erlang/OTP 28.3 has introduced references to new
types in the `crypto` module from `public_key`.

Our PLT_APPS list must include both `public_key` and `crypto`,
otherwise Dialyzer on Erlang/OTP 28.3 will fail.
