### PR TITLE
rabbit_quorum_queue: Remove old compatibility code in `status/2`

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1290,60 +1290,28 @@ status(Vhost, QueueName) ->
                           {<<"Term">>, <<>>},
                           {<<"Machine Version">>, MacVer}
                          ];
-                     {error, _} ->
-                         %% try the old method
-                         case get_sys_status(ServerId) of
-                             {ok, Sys} ->
-                                 {_, M} = lists:keyfind(ra_server_state, 1, Sys),
-                                 {_, RaftState} = lists:keyfind(raft_state, 1, Sys),
-                                 #{commit_index := Commit,
-                                   machine_version := MacVer,
-                                   current_term := Term,
-                                   last_applied := LastApplied,
-                                   log := #{last_index := Last,
-                                            last_written_index_term := {LastWritten, _},
-                                            snapshot_index := SnapIdx}} = M,
-                                 [{<<"Node Name">>, N},
-                                  {<<"Raft State">>, RaftState},
-                                  {<<"Membership">>, voter},
-                                  {<<"Last Log Index">>, Last},
-                                  {<<"Last Written">>, LastWritten},
-                                  {<<"Last Applied">>, LastApplied},
-                                  {<<"Commit Index">>, Commit},
-                                  {<<"Snapshot Index">>, SnapIdx},
-                                  {<<"Term">>, Term},
-                                  {<<"Machine Version">>, MacVer}
-                                 ];
-                             {error, Err} ->
-                                 [{<<"Node Name">>, N},
-                                  {<<"Raft State">>, Err},
-                                  {<<"Membership">>, <<>>},
-                                  {<<"Last Log Index">>, <<>>},
-                                  {<<"Last Written">>, <<>>},
-                                  {<<"Last Applied">>, <<>>},
-                                  {<<"Commit Index">>, <<>>},
-                                  {<<"Snapshot Index">>, <<>>},
-                                  {<<"Term">>, <<>>},
-                                  {<<"Machine Version">>, <<>>}
-                                 ]
-                         end
+                     {error, Reason} ->
+                         State = case is_atom(Reason) of
+                                     true -> Reason;
+                                     false -> unknown
+                                 end,
+                         [{<<"Node Name">>, N},
+                          {<<"Raft State">>, State},
+                          {<<"Membership">>, <<>>},
+                          {<<"Last Log Index">>, <<>>},
+                          {<<"Last Written">>, <<>>},
+                          {<<"Last Applied">>, <<>>},
+                          {<<"Commit Index">>, <<>>},
+                          {<<"Snapshot Index">>, <<>>},
+                          {<<"Term">>, <<>>},
+                          {<<"Machine Version">>, <<>>}
+                         ]
                  end
              end || N <- Nodes];
         {ok, _Q} ->
             {error, not_quorum_queue};
         {error, not_found} = E ->
             E
-    end.
-
-get_sys_status(Proc) ->
-    try lists:nth(5, element(4, sys:get_status(Proc))) of
-        Sys -> {ok, Sys}
-    catch
-        _:Err when is_tuple(Err) ->
-            {error, element(1, Err)};
-        _:_ ->
-            {error, other}
-
     end.
 
 add_member(VHost, Name, Node, Membership, Timeout)


### PR DESCRIPTION
The `sys:get_status/1` fallback doesn't work as expected since the changes in Ra for OTP 27: <https://github.com/rabbitmq/ra/commit/ab280c7a88f7395c2c7765e8d6f3eaf3c9413196>. This code is meant for mixed-versions compatibility with nodes that don't have the `rabbit_quorum_queue:key_metrics_rpc/1` function which was added in v3.13.0.

Quorum queues with a member down could see a failure of the
quorum_status CLI command like so:

    % rabbitmq rabbitmq-queues quorum_status --vhost / "qq-1"
    Status of quorum queue qq-1 on node rabbit@ip-10-0-6-91.ap-southeast-2.compute.internal ...
    Error:
    {{:badmatch, false}, [{:rabbit_quorum_queue, :"-status/2-lc$^0/1-0-", 2, [file: ~c"rabbit_quorum_queue.erl", line: 1287]}, {:rabbit_quorum_queue, :status, 2, []}]}

The badmatch comes from this line in `rabbit_quorum_queue:status/2`:

```erlang
{_, M} = lists:keyfind(ra_server_state, 1, Sys)
```

The `Sys` return was `[{data, Sys}]` since the linked change in Ra, so
the `keyfind/3` would always return `false`.

This PR just removes this old code since current RabbitMQ versions are not mixed-version compatible with 3.12 or below. (And 4.3 will not be compatible with 3.13.)