### PR TITLE
Prelaunch: look for .ez files when discovering rabbitmq.conf schemas in 3rd party plugins

### DIFF
--- a/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
+++ b/deps/rabbitmq_prelaunch/src/rabbit_prelaunch_conf.erl
@@ -350,7 +350,7 @@ list_apps1([Dir | Rest], Apps) ->
         {ok, Filenames} ->
             NewApps = [list_to_atom(
                          hd(
-                           string:split(filename:basename(F, ".ex"), "-")))
+                           string:split(filename:basename(F, ".ez"), "-")))
                        || F <- Filenames],
             Apps1 = lists:umerge(Apps, lists:sort(NewApps)),
             list_apps1(Rest, Apps1);


### PR DESCRIPTION
Spotted by @gomoripeti.

Due to this bug, `rabbitmq.conf` (Cuttlefish) schemas would not be loaded from 3rd party plugins distributed as `.ez` files.