### PR TITLE
Use defaults for `durable` and `auto_delete` when importing definitions

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -882,8 +882,8 @@ add_exchange_int(Exchange, Name, ActingUser) ->
                        end,
             case rabbit_exchange:declare(Name,
                                          rabbit_exchange:check_type(maps:get(type, Exchange, undefined)),
-                                         maps:get(durable,                         Exchange, undefined),
-                                         maps:get(auto_delete,                     Exchange, undefined),
+                                         maps:get(durable,                         Exchange, true),
+                                         maps:get(auto_delete,                     Exchange, false),
                                          Internal,
                                          args(maps:get(arguments, Exchange, undefined)),
                                          ActingUser) of


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/15128

If a definitions file does not specify `durable` or `auto_delete`, `undefined` is used which wreaks havoc when that exchange is later used in an unbind operation.