### PR TITLE
CQ: Use open_eventually in recovery

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_index_v2.erl
@@ -262,7 +262,8 @@ recover_segments(State, _, StoreState, _, []) ->
 recover_segments(State0, ContainsCheckFun, StoreState0, CountersRef, [Segment|Tail]) ->
     SegmentEntryCount = segment_entry_count(),
     SegmentFile = segment_file(Segment, State0),
-    {ok, Fd} = file:open(SegmentFile, [read, read_ahead, write, raw, binary]),
+    {ok, Fd} = rabbit_file:open_eventually(SegmentFile,
+        [read, read_ahead, write, raw, binary]),
     case file:read(Fd, ?HEADER_SIZE) of
         {ok, <<?MAGIC:32,?VERSION:8,
                _FromSeqId:64/unsigned,_ToSeqId:64/unsigned,

--- a/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
+++ b/deps/rabbit/src/rabbit_classic_queue_store_v2.erl
@@ -435,7 +435,7 @@ get_read_fd(Segment, State = #qs{ read_segment = Segment,
     {ok, Fd, State};
 get_read_fd(Segment, State = #qs{ read_fd = OldFd }) ->
     maybe_close_fd(OldFd),
-    case file:open(segment_file(Segment, State), [read, raw, binary]) of
+    case rabbit_file:open_eventually(segment_file(Segment, State), [read, raw, binary]) of
         {ok, Fd} ->
             case file:read(Fd, ?HEADER_SIZE) of
                 {ok, <<?MAGIC:32,?VERSION:8,

--- a/deps/rabbit/src/rabbit_file.erl
+++ b/deps/rabbit/src/rabbit_file.erl
@@ -368,5 +368,8 @@ open_eventually(File, Modes, N) ->
         %% try again up to 3 times.
         {error, eacces} ->
             timer:sleep(10),
-            open_eventually(File, Modes, N - 1)
+            open_eventually(File, Modes, N - 1);
+        %% Other errors we return immediately.
+        Error ->
+            Error
     end.


### PR DESCRIPTION
It's possible for Windows to be so stubborn that the file can't be opened after open_eventually has given up, which causes a crash and force the queue to be restarted, then trying to open that same file during recovery still errors out.

Using open_eventually there may or may not help.

Also use open_eventually in queue store's get_read_fd as a crash log has shown it can happen there as well.

#15134 

Note that this isn't a "real fix" but just more workarounds for some annoying Windows behavior.