### PR TITLE
Return friendly error when AMQP 1.0 receiver has no source

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -2719,6 +2719,8 @@ ensure_source(#'v1_0.source'{
         _ ->
             exit_not_implemented("Dynamic source not supported: ~tp", [Source0])
     end;
+ensure_source(undefined, _, _, _, _, _, _, _, _) ->
+    {error, source_required};
 ensure_source(Source = #'v1_0.source'{dynamic = true}, _, _, _, _, _, _, _, _) ->
     exit_not_implemented("Dynamic source not supported: ~tp", [Source]);
 ensure_source(Source0 = #'v1_0.source'{address = Address,


### PR DESCRIPTION
When a client attaches an AMQP 1.0 receiver link without specifying a source address, RabbitMQ crashes with a `function_clause` error and returns an Erlang stack trace to the client. This makes it difficult for developers to understand what went wrong.

Previously, the client received:
```
SessionError: function_clause
[{rabbit_amqp_session,ensure_source,
     [undefined,false,<<...>>,<<...>>,
      {user,<<...>>,[administrator],[...]},
      <<...>>,<0.585.0>,[],[]],
     [{file,"rabbit_amqp_session.erl"},{line,2665}]},
 {rabbit_amqp_session,handle_attach,2,...},
 ...]
```

This change adds a new clause to `ensure_source/9` that catches the case where the source is `undefined`. Instead of crashing, the function now returns `{error, source_address_required}`, which `handle_attach/2` maps to an `amqp:invalid-field` error with a clear message.

Now, the client receives:
```
LinkError: Attach refused: source_address_required
  condition: 'amqp:invalid-field',
  description: 'Attach refused: source_address_required'
```

The error condition `amqp:invalid-field` is appropriate here because the client failed to provide a required field in the attach frame, not because a resource was not found.

Fixes https://github.com/rabbitmq/rabbitmq-server/discussions/14300