### PR TITLE
 Always explicitly use rabbit_framing_amqp_0_9_1

### DIFF
--- a/deps/amqp_client/src/amqp_channel.erl
+++ b/deps/amqp_client/src/amqp_channel.erl
@@ -927,7 +927,7 @@ is_connection_method(Method) ->
     ?PROTOCOL:lookup_class_name(ClassId) == connection.
 
 server_misbehaved(#amqp_error{} = AmqpError, State = #state{number = Number}) ->
-    case rabbit_binary_generator:map_exception(Number, AmqpError, ?PROTOCOL) of
+    case rabbit_binary_generator:map_exception(Number, AmqpError) of
         {0, _} ->
             handle_shutdown({server_misbehaved, AmqpError}, State);
         {_, Close} ->

--- a/deps/amqp_client/src/amqp_connection_type_sup.erl
+++ b/deps/amqp_client/src/amqp_connection_type_sup.erl
@@ -51,11 +51,11 @@ start_channels_manager(Sup, Conn, ConnName, Type) ->
 start_infrastructure_fun(Sup, Conn, network) ->
     fun (Sock, ConnName) ->
             {ok, ChMgr} = start_channels_manager(Sup, Conn, ConnName, network),
-            {ok, AState} = rabbit_command_assembler:init(?PROTOCOL),
+            {ok, AState} = rabbit_command_assembler:init(),
             {ok, GCThreshold} = application:get_env(amqp_client, writer_gc_threshold),
 
             WriterStartMFA = {rabbit_writer, start_link,
-                              [Sock, 0, ?FRAME_MIN_SIZE, ?PROTOCOL, Conn,
+                              [Sock, 0, ?FRAME_MIN_SIZE, Conn,
                                ConnName, false, GCThreshold]},
             WriterChildSpec = #{id => writer,
                                 start => WriterStartMFA,

--- a/deps/amqp_client/src/amqp_direct_connection.erl
+++ b/deps/amqp_client/src/amqp_direct_connection.erl
@@ -144,6 +144,10 @@ connect(Params = #amqp_params_direct{username     = Username,
                          connected_at =
                            os:system_time(milli_seconds)},
     DecryptedPassword = credentials_obfuscation:decrypt(Password),
+    %% @todo We must use rabbit_direct:connect/5 for compatibility.
+    %%       But the protocol argument is ignored on new nodes.
+    %%       At some point it can be removed as all nodes 4.3+ have
+    %%       rabbit_direct:connect/4 as well.
     case rpc:call(Node, rabbit_direct, connect,
                   [{Username, DecryptedPassword}, VHost, ?PROTOCOL, self(),
                    connection_info(State1)], ?DIRECT_OPERATION_TIMEOUT) of

--- a/deps/amqp_client/src/amqp_gen_connection.erl
+++ b/deps/amqp_client/src/amqp_gen_connection.erl
@@ -353,7 +353,7 @@ server_initiated_close(Close, State) ->
 server_misbehaved_close(AmqpError, State) ->
     ?LOG_WARNING("Connection (~tp) closing: server misbehaved: ~tp",
                  [self(), AmqpError]),
-    {0, Close} = rabbit_binary_generator:map_exception(0, AmqpError, ?PROTOCOL),
+    {0, Close} = rabbit_binary_generator:map_exception(0, AmqpError),
     set_closing_state(abrupt, #closing{reason = server_misbehaved,
                                        close = Close}, State).
 

--- a/deps/amqp_client/src/amqp_main_reader.erl
+++ b/deps/amqp_client/src/amqp_main_reader.erl
@@ -147,7 +147,7 @@ process_frame(Type, ChNumber, Payload,
               State = #state{connection       = Connection,
                              channels_manager = ChMgr,
                              astate           = AState}) ->
-    case rabbit_command_assembler:analyze_frame(Type, Payload, ?PROTOCOL) of
+    case rabbit_command_assembler:analyze_frame(Type, Payload) of
         heartbeat when ChNumber /= 0 ->
             amqp_gen_connection:server_misbehaved(
                 Connection,

--- a/deps/rabbit/src/mc_amqpl.erl
+++ b/deps/rabbit/src/mc_amqpl.erl
@@ -41,7 +41,6 @@
 -define(AMQP10_APP_PROPERTIES_HEADER, <<"x-amqp-1.0-app-properties">>).
 -define(AMQP10_MESSAGE_ANNOTATIONS_HEADER, <<"x-amqp-1.0-message-annotations">>).
 -define(AMQP10_FOOTER, <<"x-amqp-1.0-footer">>).
--define(PROTOMOD, rabbit_framing_amqp_0_9_1).
 -define(CLASS_ID, 60).
 
 -opaque state() :: #content{}.
@@ -310,7 +309,7 @@ prepare(read, Content) ->
     rabbit_binary_parser:ensure_content_decoded(Content);
 prepare(store, Content) ->
     rabbit_binary_parser:clear_decoded_content(
-      rabbit_binary_generator:ensure_content_encoded(Content, ?PROTOMOD)).
+      rabbit_binary_generator:ensure_content_encoded(Content)).
 
 convert_to(?MODULE, Content, _Env) ->
     Content;

--- a/deps/rabbit/src/rabbit_channel_sup.erl
+++ b/deps/rabbit/src/rabbit_channel_sup.erl
@@ -31,11 +31,11 @@
 
 -type start_link_args() ::
         {'tcp', rabbit_net:socket(), rabbit_channel:channel_number(),
-         non_neg_integer(), pid(), string(), rabbit_types:protocol(),
+         non_neg_integer(), pid(), string(),
          rabbit_types:user(), rabbit_types:vhost(), rabbit_framing:amqp_table(),
          pid()} |
         {'direct', rabbit_channel:channel_number(), pid(), string(),
-         rabbit_types:protocol(), rabbit_types:user(), rabbit_types:vhost(),
+         rabbit_types:user(), rabbit_types:vhost(),
          rabbit_framing:amqp_table(), pid()}.
 
 -define(FAIR_WAIT, 70000).
@@ -44,16 +44,16 @@
 
 -spec start_link(start_link_args()) -> {'ok', pid(), {pid(), any()}}.
 
-start_link({tcp, Sock, Channel, FrameMax, ReaderPid, ConnName, Protocol, User,
+start_link({tcp, Sock, Channel, FrameMax, ReaderPid, ConnName, User,
             VHost, Capabilities, Collector}) ->
     {ok, SupPid} = supervisor:start_link(
                      ?MODULE, {tcp, Sock, Channel, FrameMax,
-                               ReaderPid, Protocol, {ConnName, Channel}}),
+                               ReaderPid, {ConnName, Channel}}),
     [LimiterPid] = rabbit_misc:find_child(SupPid, limiter),
     [WriterPid] = rabbit_misc:find_child(SupPid, writer),
     StartMFA = {rabbit_channel, start_link,
                 [Channel, ReaderPid, WriterPid, ReaderPid, ConnName,
-                 Protocol, User, VHost, Capabilities, Collector,
+                 User, VHost, Capabilities, Collector,
                  LimiterPid]},
     ChildSpec = #{id => channel,
                   start => StartMFA,
@@ -63,16 +63,16 @@ start_link({tcp, Sock, Channel, FrameMax, ReaderPid, ConnName, Protocol, User,
                   type => worker,
                   modules => [rabbit_channel]},
     {ok, ChannelPid} = supervisor:start_child(SupPid, ChildSpec),
-    {ok, AState} = rabbit_command_assembler:init(Protocol),
+    {ok, AState} = rabbit_command_assembler:init(),
     {ok, SupPid, {ChannelPid, AState}};
-start_link({direct, Channel, ClientChannelPid, ConnPid, ConnName, Protocol,
+start_link({direct, Channel, ClientChannelPid, ConnPid, ConnName,
             User, VHost, Capabilities, Collector, AmqpParams}) ->
     {ok, SupPid} = supervisor:start_link(
                      ?MODULE, {direct, {ConnName, Channel}}),
     [LimiterPid] = rabbit_misc:find_child(SupPid, limiter),
     StartMFA = {rabbit_channel, start_link,
                 [Channel, ClientChannelPid, ClientChannelPid, ConnPid,
-                 ConnName, Protocol, User, VHost, Capabilities, Collector,
+                 ConnName, User, VHost, Capabilities, Collector,
                  LimiterPid, AmqpParams]},
     ChildSpec = #{id => channel,
                   start => StartMFA,
@@ -94,9 +94,9 @@ init(Type) ->
                  auto_shutdown => any_significant},
     {ok, {SupFlags, child_specs(Type)}}.
 
-child_specs({tcp, Sock, Channel, FrameMax, ReaderPid, Protocol, Identity}) ->
+child_specs({tcp, Sock, Channel, FrameMax, ReaderPid, Identity}) ->
     StartMFA = {rabbit_writer, start_link,
-                [Sock, Channel, FrameMax, Protocol, ReaderPid, Identity, true]},
+                [Sock, Channel, FrameMax, ReaderPid, Identity, true]},
     [
         #{
             id => writer,

--- a/deps/rabbit/src/rabbit_connection_tracking.erl
+++ b/deps/rabbit/src/rabbit_connection_tracking.erl
@@ -34,7 +34,6 @@
          delete_tracked_connection_vhost_entry/1,
          list/0, list/1, list_on_node/1, list_on_node/2, list_of_user/1,
          tracked_connection_from_connection_created/1,
-         tracked_connection_from_connection_state/1,
          lookup/1, lookup/2, count/0]).
 
 -export([count_local_tracked_items_in_vhost/1,
@@ -381,26 +380,6 @@ tracked_connection_from_connection_created(EventDetails) ->
                         type         = pget(type, EventDetails),
                         peer_host    = pget(peer_host, EventDetails),
                         peer_port    = pget(peer_port, EventDetails)}.
-
-tracked_connection_from_connection_state(#connection{
-                                            vhost = VHost,
-                                            connected_at = Ts,
-                                            peer_host = PeerHost,
-                                            peer_port = PeerPort,
-                                            user = Username,
-                                            name = Name
-                                           }) ->
-    tracked_connection_from_connection_created(
-      [{name, Name},
-       {node, node()},
-       {vhost, VHost},
-       {user, Username},
-       {user_who_performed_action, Username},
-       {connected_at, Ts},
-       {pid, self()},
-       {type, network},
-       {peer_port, PeerPort},
-       {peer_host, PeerHost}]).
 
 close_connections(Tracked, Message) ->
     close_connections(Tracked, Message, 0).

--- a/deps/rabbit/test/mc_unit_SUITE.erl
+++ b/deps/rabbit/test/mc_unit_SUITE.erl
@@ -200,6 +200,7 @@ amqpl_table_x_header_array_of_tbls(_Config) ->
 amqpl_death_records(_Config) ->
     Content = #content{class_id = 60,
                        properties = #'P_basic'{headers = []},
+                       properties_bin = none,
                        payload_fragments_rev = [<<"data">>]},
     Msg0 = mc:prepare(store, mc:init(mc_amqpl, Content, annotations())),
 
@@ -235,6 +236,7 @@ amqpl_death_records(_Config) ->
 is_death_cycle(_Config) ->
     Content = #content{class_id = 60,
                        properties = #'P_basic'{headers = []},
+                       properties_bin = none,
                        payload_fragments_rev = [<<"data">>]},
     Msg0 = mc:prepare(store, mc:init(mc_amqpl, Content, annotations())),
 
@@ -639,8 +641,7 @@ amqp_amqpl(_Config) ->
 
     %% validate content is serialisable
     _ = rabbit_binary_generator:build_simple_content_frames(1, Content,
-                                                            1000000,
-                                                            rabbit_framing_amqp_0_9_1),
+                                                            1000000),
 
     ok.
 

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -403,7 +403,6 @@ enq_expire_enq_deq_test(Config) ->
     {S1, ok, _} = apply(meta(Config, Idx1, 100, {notify, 1, self()}), Enq1, S0),
     Msg2 = #basic_message{content = #content{properties = #'P_basic'{},
                                              % class_id = 60,
-                                             % protocol = ?PROTOMOD,
                                              payload_fragments_rev = [<<"msg2">>]}},
     Enq2 = rabbit_fifo:make_enqueue(self(), 2, Msg2),
     Idx2 = ?LINE,

--- a/deps/rabbit/test/rabbit_fifo_prop_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_prop_SUITE.erl
@@ -1952,11 +1952,13 @@ msg_gen() ->
                                    routing_keys = [<<>>],
                                    content =
                                    #content{payload_fragments_rev = [Bin],
-                                            properties = #'P_basic'{}}}))).
+                                            properties = #'P_basic'{},
+                                            properties_bin = none}}))).
 
 msg(Bin) when is_binary(Bin) ->
     #basic_message{content = #content{payload_fragments_rev = [Bin],
-                                      properties = #'P_basic'{}}}.
+                                      properties = #'P_basic'{},
+                                      properties_bin = none}}.
 
 checkout_cancel_gen(Pid) ->
     {checkout, Pid, cancel}.

--- a/deps/rabbit/test/unit_amqp091_content_framing_SUITE.erl
+++ b/deps/rabbit/test/unit_amqp091_content_framing_SUITE.erl
@@ -117,10 +117,8 @@ test_content_framing(FrameMax, BodyBin) ->
         rabbit_binary_generator:build_simple_content_frames(
           1,
           rabbit_binary_generator:ensure_content_encoded(
-            rabbit_basic:build_content(#'P_basic'{}, BodyBin),
-            rabbit_framing_amqp_0_9_1),
-          FrameMax,
-          rabbit_framing_amqp_0_9_1),
+            rabbit_basic:build_content(#'P_basic'{}, BodyBin)),
+          FrameMax),
     %% header is formatted correctly and the size is the total of the
     %% fragments
     <<_FrameHeader:7/binary, _ClassAndWeight:4/binary,
@@ -148,13 +146,11 @@ content_transcoding(_Config) ->
                 C1
         end,
     EnsureEncoded =
-        fun (Protocol) ->
-                fun (C0) ->
-                        C1 = rabbit_binary_generator:ensure_content_encoded(
-                               C0, Protocol),
-                        true = C1#content.properties_bin =/= none,
-                        C1
-                end
+        fun (C0) ->
+                C1 = rabbit_binary_generator:ensure_content_encoded(
+                       C0),
+                true = C1#content.properties_bin =/= none,
+                C1
         end,
     %% Beyond the assertions in Ensure*, the only testable guarantee
     %% is that the operations should never fail.
@@ -171,14 +167,13 @@ content_transcoding(_Config) ->
          sequence_with_content([ClearEncoded, Op]),
          sequence_with_content([ClearDecoded, Op])
      end || Op <- [ClearDecoded, ClearEncoded, EnsureDecoded,
-                   EnsureEncoded(rabbit_framing_amqp_0_9_1)]],
+                   EnsureEncoded]],
     passed.
 
 sequence_with_content(Sequence) ->
     lists:foldl(fun (F, V) -> F(F(V)) end,
                 rabbit_binary_generator:ensure_content_encoded(
-                  rabbit_basic:build_content(#'P_basic'{}, <<>>),
-                  rabbit_framing_amqp_0_9_1),
+                  rabbit_basic:build_content(#'P_basic'{}, <<>>)),
                 Sequence).
 
 table_codec(_Config) ->

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -39,9 +39,6 @@
           port,
           %% client port
           peer_port,
-          %% protocol implementation module,
-          %% e.g. rabbit_framing_amqp_0_9_1
-          protocol,
           user,
           %% heartbeat timeout value used, 0 means
           %% heartbeats are disabled
@@ -74,6 +71,10 @@
          properties_bin, %% either 'none', or an encoded properties binary
          %% Note: at most one of properties and properties_bin can be
          %% 'none' at once.
+         %% @todo The protocol field can be safely removed entirely in the
+         %%       RabbitMQ version that follows the LTS that is after
+         %%       RabbitMQ 4.3 (so if LTS is 4.5, remove in 4.6).
+         %%       Only compat code for reading from disk will be necessary.
          protocol, %% The protocol under which properties_bin was encoded
          payload_fragments_rev %% list of binaries, in reverse order (!)
          }).

--- a/deps/rabbit_common/src/rabbit_binary_parser.erl
+++ b/deps/rabbit_common/src/rabbit_binary_parser.erl
@@ -140,10 +140,9 @@ parse_array(<<$V, Rest/binary>>) ->
 ensure_content_decoded(Content = #content{properties = Props})
   when Props =/= none ->
     Content;
-ensure_content_decoded(Content = #content{properties_bin = PropBin,
-                                          protocol = Protocol})
+ensure_content_decoded(Content = #content{properties_bin = PropBin})
   when PropBin =/= none ->
-    Content#content{properties = Protocol:decode_properties(
+    Content#content{properties = rabbit_framing_amqp_0_9_1:decode_properties(
                                    Content#content.class_id, PropBin)}.
 
 clear_decoded_content(Content = #content{properties = none}) ->

--- a/deps/rabbit_common/src/rabbit_command_assembler.erl
+++ b/deps/rabbit_common/src/rabbit_command_assembler.erl
@@ -9,7 +9,7 @@
 -include("rabbit_framing.hrl").
 -include("rabbit.hrl").
 
--export([analyze_frame/3, init/1, process/2]).
+-export([analyze_frame/2, init/0, process/2]).
 
 %%----------------------------------------------------------------------------
 
@@ -19,7 +19,6 @@
 
 -type frame_type() :: ?FRAME_METHOD | ?FRAME_HEADER | ?FRAME_BODY |
                       ?FRAME_HEARTBEAT.
--type protocol()   :: rabbit_framing:protocol().
 -type method()     :: rabbit_framing:amqp_method_record().
 -type class_id()   :: rabbit_framing:amqp_class_id().
 -type weight()     :: non_neg_integer().
@@ -32,14 +31,14 @@
         {'content_body',   binary()}.
 
 -type state() ::
-        {'method',         protocol()} |
-        {'content_header', method(), class_id(), protocol()} |
-        {'content_body',   method(), body_size(), class_id(), protocol()}.
+        'method' |
+        {'content_header', method(), class_id()} |
+        {'content_body',   method(), body_size(), class_id()}.
 
--spec analyze_frame(frame_type(), binary(), protocol()) ->
+-spec analyze_frame(frame_type(), binary()) ->
           frame() | 'heartbeat' | 'error'.
 
--spec init(protocol()) -> {ok, state()}.
+-spec init() -> {ok, state()}.
 -spec process(frame(), state()) ->
           {ok, state()} |
           {ok, method(), state()} |
@@ -49,72 +48,70 @@
 %%--------------------------------------------------------------------
 
 analyze_frame(?FRAME_METHOD,
-              <<ClassId:16, MethodId:16, MethodFields/binary>>,
-              Protocol) ->
-    MethodName = Protocol:lookup_method_name({ClassId, MethodId}),
+              <<ClassId:16, MethodId:16, MethodFields/binary>>) ->
+    MethodName = rabbit_framing_amqp_0_9_1:lookup_method_name({ClassId, MethodId}),
     {method, MethodName, MethodFields};
 analyze_frame(?FRAME_HEADER,
-              <<ClassId:16, Weight:16, BodySize:64, Properties/binary>>,
-              _Protocol) ->
+              <<ClassId:16, Weight:16, BodySize:64, Properties/binary>>) ->
     {content_header, ClassId, Weight, BodySize, Properties};
-analyze_frame(?FRAME_BODY, Body, _Protocol) ->
+analyze_frame(?FRAME_BODY, Body) ->
     {content_body, Body};
-analyze_frame(?FRAME_HEARTBEAT, <<>>, _Protocol) ->
+analyze_frame(?FRAME_HEARTBEAT, <<>>) ->
     heartbeat;
-analyze_frame(_Type, _Body, _Protocol) ->
+analyze_frame(_Type, _Body) ->
     error.
 
-init(Protocol) -> {ok, {method, Protocol}}.
+init() -> {ok, method}.
 
-process({method, MethodName, FieldsBin}, {method, Protocol}) ->
+process({method, MethodName, FieldsBin}, method) ->
     try
-        Method = Protocol:decode_method_fields(MethodName, FieldsBin),
-        case Protocol:method_has_content(MethodName) of
-            true  -> {ClassId, _MethodId} = Protocol:method_id(MethodName),
-                     {ok, {content_header, Method, ClassId, Protocol}};
-            false -> {ok, Method, {method, Protocol}}
+        Method = rabbit_framing_amqp_0_9_1:decode_method_fields(MethodName, FieldsBin),
+        case rabbit_framing_amqp_0_9_1:method_has_content(MethodName) of
+            true  -> {ClassId, _MethodId} = rabbit_framing_amqp_0_9_1:method_id(MethodName),
+                     {ok, {content_header, Method, ClassId}};
+            false -> {ok, Method, method}
         end
     catch exit:#amqp_error{} = Reason -> {error, Reason}
     end;
-process(_Frame, {method, _Protocol}) ->
+process(_Frame, method) ->
     unexpected_frame("expected method frame, "
                      "got non method frame instead", [], none);
 process({content_header, ClassId, 0, 0, PropertiesBin},
-        {content_header, Method, ClassId, Protocol}) ->
-    Content = empty_content(ClassId, PropertiesBin, Protocol),
-    {ok, Method, Content, {method, Protocol}};
+        {content_header, Method, ClassId}) ->
+    Content = empty_content(ClassId, PropertiesBin),
+    {ok, Method, Content, method};
 process({content_header, ClassId, 0, BodySize, PropertiesBin},
-        {content_header, Method, ClassId, Protocol}) ->
-    Content = empty_content(ClassId, PropertiesBin, Protocol),
-    {ok, {content_body, Method, BodySize, Content, Protocol}};
+        {content_header, Method, ClassId}) ->
+    Content = empty_content(ClassId, PropertiesBin),
+    {ok, {content_body, Method, BodySize, Content}};
 process({content_header, HeaderClassId, 0, _BodySize, _PropertiesBin},
-        {content_header, Method, ClassId, _Protocol}) ->
+        {content_header, Method, ClassId}) ->
     unexpected_frame("expected content header for class ~w, "
                      "got one for class ~w instead",
                      [ClassId, HeaderClassId], Method);
-process(_Frame, {content_header, Method, ClassId, _Protocol}) ->
+process(_Frame, {content_header, Method, ClassId}) ->
     unexpected_frame("expected content header for class ~w, "
                      "got non content header frame instead", [ClassId], Method);
 process({content_body, FragmentBin},
         {content_body, Method, RemainingSize,
-         Content = #content{payload_fragments_rev = Fragments}, Protocol}) ->
+         Content = #content{payload_fragments_rev = Fragments}}) ->
     NewContent = Content#content{
                    payload_fragments_rev = [FragmentBin | Fragments]},
     case RemainingSize - size(FragmentBin) of
-        0  -> {ok, Method, NewContent, {method, Protocol}};
-        Sz -> {ok, {content_body, Method, Sz, NewContent, Protocol}}
+        0  -> {ok, Method, NewContent, method};
+        Sz -> {ok, {content_body, Method, Sz, NewContent}}
     end;
-process(_Frame, {content_body, Method, _RemainingSize, _Content, _Protocol}) ->
+process(_Frame, {content_body, Method, _RemainingSize, _Content}) ->
     unexpected_frame("expected content body, "
                      "got non content body frame instead", [], Method).
 
 %%--------------------------------------------------------------------
 
-empty_content(ClassId, PropertiesBin, Protocol) ->
+empty_content(ClassId, PropertiesBin) ->
     #content{class_id              = ClassId,
              properties            = none,
              properties_bin        = PropertiesBin,
-             protocol              = Protocol,
+             protocol              = rabbit_framing_amqp_0_9_1,
              payload_fragments_rev = []}.
 
 unexpected_frame(Format, Params, Method) when is_atom(Method) ->

--- a/deps/rabbit_common/src/rabbit_types.erl
+++ b/deps/rabbit_common/src/rabbit_types.erl
@@ -172,7 +172,10 @@
                           username    :: username(),
                           connection  :: connection()}).
 
-%% old AMQP 0-9-1-centric type, avoid when possible
+%% Old AMQP 0-9-1-centric type, DO NOT USE.
+%% @todo This can be removed in a future release when
+%%       we no longer need to worry about amqp_client
+%%       direct connection compatibility.
 -type(protocol() :: rabbit_framing:protocol()).
 
 -type(protocol_name() :: 'amqp0_9_1' | 'amqp1_0' | 'mqtt' | 'stomp' | any()).

--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -482,10 +482,10 @@ encrypt_decrypt_term(_Config) ->
 frame_encoding_does_not_fail_with_empty_binary_payload(_Config) ->
     [begin
          Content = #content{
-             class_id = 60, properties = none, properties_bin = <<0,0>>, protocol = rabbit_framing_amqp_0_9_1,
+             class_id = 60, properties = none, properties_bin = <<0,0>>,
              payload_fragments_rev = P
          },
-         ExpectedFrames = rabbit_binary_generator:build_simple_content_frames(1, Content, 0, rabbit_framing_amqp_0_9_1)
+         ExpectedFrames = rabbit_binary_generator:build_simple_content_frames(1, Content, 0)
      end || {P, ExpectedFrames} <- [
                     {[], [[<<2,0,1,0,0,0,14>>,[<<0,60,0,0,0,0,0,0,0,0,0,0>>,<<0,0>>],206]]},
                     {[<<>>], [[<<2,0,1,0,0,0,14>>,[<<0,60,0,0,0,0,0,0,0,0,0,0>>,<<0,0>>],206]]},
@@ -497,15 +497,13 @@ frame_encoding_does_not_fail_with_empty_binary_payload(_Config) ->
 map_exception_does_not_fail_with_unicode_explaination_case1(_Config) ->
     NonAsciiExplaination = "no queue 'non_ascii_name_😍_你好' in vhost '/'",
     rabbit_binary_generator:map_exception(0,
-        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'},
-        rabbit_framing_amqp_0_9_1),
+        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'}),
     ok.
 
 map_exception_does_not_fail_with_unicode_explaination_case2(_Config) ->
     NonAsciiExplaination = "no queue 'кролик 🐰' in vhost '/'",
     rabbit_binary_generator:map_exception(0,
-        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'},
-        rabbit_framing_amqp_0_9_1),
+        #amqp_error{name = not_found, explanation = NonAsciiExplaination, method = 'queue.declare'}),
     ok.
 
 amqp_table_conversion(_Config) ->


### PR DESCRIPTION
This commit removes the 'protocol' field from rabbit_channel's
'#conf' record; rabbit_reader's '#connection' record (defined
in rabbit.hrl); and rabbit_writer's '#wstate' record.

The 'protocol' field in the '#content' record is still present
but no longer used. It can be removed in the RabbitMQ version
that follows the next LTS, as then all we will need is some
compatibility code when reading older messages from disk (and
not when sending messages across clusters), making its removal
less dangerous than now.

As amqp_client does a few RPC calls we are leaving functions
with a 'Protocol' argument that is ignored. They can be removed
in a few releases when we no longer have to worry about older
amqp_client versions connecting, similarly to '#content'.