### PR TITLE
Remove the use of `infinity` in `rabbit_web_dispatch_registry`

### DIFF
--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -277,3 +277,5 @@
 %% Max value for stream max segment size
 -define(MAX_STREAM_MAX_SEGMENT_SIZE, 3_000_000_000).
 
+%% Preferred value instead of `infinity`
+-define(GEN_SERVER_CALL_TIMEOUT, 60000).

--- a/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_registry.erl
+++ b/deps/rabbitmq_web_dispatch/src/rabbit_web_dispatch_registry.erl
@@ -8,7 +8,7 @@
 -module(rabbit_web_dispatch_registry).
 
 -include_lib("kernel/include/logger.hrl").
-
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -behaviour(gen_server).
 
@@ -30,10 +30,10 @@ start_link() ->
 
 add(Name, Listener, Selector, Handler, Link) ->
     gen_server:call(?MODULE, {add, Name, Listener, Selector, Handler, Link},
-                    infinity).
+                    ?GEN_SERVER_CALL_TIMEOUT).
 
 remove(Name) ->
-    gen_server:call(?MODULE, {remove, Name}, infinity).
+    gen_server:call(?MODULE, {remove, Name}, ?GEN_SERVER_CALL_TIMEOUT).
 
 %% @todo This needs to be dispatch instead of a fun too.
 %% But I'm not sure what code is using this.
@@ -56,7 +56,7 @@ lookup(Listener, Req) ->
 %% This is called in a somewhat obfuscated manner in
 %% rabbit_mgmt_external_stats:rabbit_web_dispatch_registry_list_all()
 list_all() ->
-    gen_server:call(?MODULE, list_all, infinity).
+    gen_server:call(?MODULE, list_all, ?GEN_SERVER_CALL_TIMEOUT).
 
 %% Callback Methods
 


### PR DESCRIPTION
This PR changes three `gen_server:call` invocations to use a 60 second timeout, rather than infinity. It's part of a larger undertaking to evaluate and, possibly, remove other usages of `infinity` in the RabbitMQ codebase.

The motivation for this particular change is evidence of `rabbit_web_dispatch_registry:remove/1` never returning during a broker shutdown, after that broker had been put into maintenance mode. This is most likely a one-off event, but the `infinity` timeout didn't help.