### PR TITLE
Add missing CRL cache support to `rabbitmq.conf` configuration

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -335,6 +335,50 @@ end}.
 {mapping, "ssl_options.crl_check", "rabbit.ssl_options.crl_check",
     [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
 
+{mapping, "ssl_options.crl_sources.$index", "rabbit.ssl_options.crl_cache",
+    [{datatype, {enum, [http, dir]}}]}.
+
+{mapping, "ssl_options.crl_sources.$index.timeout", "rabbit.ssl_options.crl_cache",
+    [{datatype, integer}]}.
+
+{mapping, "ssl_options.crl_sources.$index.path", "rabbit.ssl_options.crl_cache",
+    [{datatype, string}]}.
+
+{translation, "rabbit.ssl_options.crl_cache",
+fun(Conf) ->
+    Entries = cuttlefish_variable:filter_by_prefix("ssl_options.crl_sources", Conf),
+    case Entries of
+        [] -> cuttlefish:unset();
+        _ ->
+            Sources = lists:foldl(
+                fun({[_, _, Index, Opt], Val}, Acc) ->
+                    K = list_to_atom(Index),
+                    [{K, {list_to_existing_atom(Opt), Val}} | Acc];
+                   ({[_, _, Index], Val}, Acc) ->
+                    K = list_to_atom(Index),
+                    [{K, {type, Val}} | Acc]
+                end, [], Entries),
+            Grouped = maps:to_list(maps:groups_from_list(fun({K, _}) -> K end, fun({_, V}) -> V end, Sources)),
+            CrlOpts = lists:map(
+                fun({_, Props}) ->
+                    Type = proplists:get_value(type, Props),
+                    case Type of
+                        http ->
+                            case proplists:get_keys(Props) -- [type, timeout] of
+                                [] -> {http, proplists:get_value(timeout, Props, 5000)};
+                                _ -> cuttlefish:invalid("http source only supports 'timeout' option")
+                            end;
+                        dir ->
+                            case proplists:get_keys(Props) -- [type, path] of
+                                [] -> {dir, proplists:get_value(path, Props)};
+                                _ -> cuttlefish:invalid("dir source only supports 'path' option")
+                            end
+                    end
+                end, Grouped),
+            {ssl_crl_cache, {internal, CrlOpts}}
+    end
+end}.
+
 {mapping, "ssl_options.depth", "rabbit.ssl_options.depth",
     [{datatype, integer}, {validators, ["byte"]}]}.
 

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -83,6 +83,35 @@ ssl_options.fail_if_no_peer_cert = true",
              {verify,verify_peer},
              {fail_if_no_peer_cert,true}]}]}],
   []},
+ {ssl_options_crl_cache_http,
+  "ssl_options.crl_check = true
+ssl_options.crl_sources.0 = http
+ssl_options.crl_sources.0.timeout = 5000",
+  [{rabbit,
+       [{ssl_options,
+            [{crl_check,true},
+             {crl_cache,{ssl_crl_cache,{internal,[{http,5000}]}}}]}]}],
+  []},
+ {ssl_options_crl_cache_dir,
+  "ssl_options.crl_check = true
+ssl_options.crl_sources.0 = dir
+ssl_options.crl_sources.0.path = /var/lib/rabbitmq/crls",
+  [{rabbit,
+       [{ssl_options,
+            [{crl_check,true},
+             {crl_cache,{ssl_crl_cache,{internal,[{dir,"/var/lib/rabbitmq/crls"}]}}}]}]}],
+  []},
+ {ssl_options_crl_cache_both,
+  "ssl_options.crl_check = true
+ssl_options.crl_sources.0 = http
+ssl_options.crl_sources.0.timeout = 5000
+ssl_options.crl_sources.1 = dir
+ssl_options.crl_sources.1.path = /var/lib/rabbitmq/crls",
+  [{rabbit,
+       [{ssl_options,
+            [{crl_check,true},
+             {crl_cache,{ssl_crl_cache,{internal,[{http,5000},{dir,"/var/lib/rabbitmq/crls"}]}}}]}]}],
+  []},
  {tcp_listener,
   "listeners.tcp.default = 5673",
     [{rabbit,[{tcp_listeners,[5673]}]}],[]},


### PR DESCRIPTION
Add crl_cache support to rabbitmq.conf configuration RabbitMQ's modern `rabbitmq.conf` format does not support the `crl_cache` SSL option, forcing users to fall back to the legacy Erlang-style `advanced.config` file for this single setting. This creates an inconsistent configuration experience when using Certificate Revocation List (CRL) validation.

This adds schema mappings for `ssl_options.crl_sources` using indexed syntax. The implementation translates these settings into the required Erlang term format `{crl_cache, {ssl_crl_cache, {internal,
[Options]}}}`. Two CRL source types are supported: `http` with an optional `timeout` parameter (defaults to 5000ms), and `dir` with a required `path` parameter. Validation ensures that only appropriate options are used with each source type.

Users can now configure multiple CRL sources using indexed syntax:

```
ssl_options.crl_sources.0 = http
ssl_options.crl_sources.0.timeout = 5000
ssl_options.crl_sources.1 = dir
ssl_options.crl_sources.1.path = /var/lib/rabbitmq/crls
```

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/2338