### PR TITLE
Return policy fields and `delivery_limit` when stats are disabled

### DIFF
--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -273,7 +273,10 @@ format(Q, _Ctx) when ?is_amqqueue(Q) ->
             end,
     [{type, rabbit_queue_type:short_alias_of(?MODULE)},
      {state, State},
-     {node, node(amqqueue:get_pid(Q))}].
+     {node, node(amqqueue:get_pid(Q))},
+     {policy, i(policy, Q)},
+     {operator_policy, i(operator_policy, Q)},
+     {effective_policy_definition, i(effective_policy_definition, Q)}].
 
 -spec init(amqqueue:amqqueue()) -> {ok, state()}.
 init(Q) when ?amqqueue_is_classic(Q) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -355,21 +355,7 @@ gather_policy_config(Q, IsQueueDeclaration) ->
     OverflowBin = args_policy_lookup(<<"overflow">>, fun policy_has_precedence/2, Q),
     Overflow = overflow(OverflowBin, drop_head, QName),
     MaxBytes = args_policy_lookup(<<"max-length-bytes">>, fun min/2, Q),
-    DeliveryLimit = case args_policy_lookup(<<"delivery-limit">>,
-                                            fun resolve_delivery_limit/2, Q) of
-                        undefined ->
-                            case IsQueueDeclaration of
-                                true ->
-                                    ?LOG_INFO(
-                                              "~ts: delivery_limit not set, defaulting to ~b",
-                                              [rabbit_misc:rs(QName), ?DEFAULT_DELIVERY_LIMIT]);
-                                false ->
-                                    ok
-                            end,
-                            ?DEFAULT_DELIVERY_LIMIT;
-                        DL ->
-                            DL
-                    end,
+    DeliveryLimit = get_delivery_limit(Q, IsQueueDeclaration),
     Expires = args_policy_lookup(<<"expires">>, fun min/2, Q),
     MsgTTL = args_policy_lookup(<<"message-ttl">>, fun min/2, Q),
     DeadLetterHandler = dead_letter_handler(Q, Overflow),
@@ -393,12 +379,6 @@ ra_machine_config(Q) when ?is_amqqueue(Q) ->
       single_active_consumer_on => single_active_consumer_on(Q),
       created => erlang:system_time(millisecond)
      }.
-
-resolve_delivery_limit(PolVal, ArgVal)
-  when PolVal < 0 orelse ArgVal < 0 ->
-    max(PolVal, ArgVal);
-resolve_delivery_limit(PolVal, ArgVal) ->
-    min(PolVal, ArgVal).
 
 policy_has_precedence(Policy, _QueueArg) ->
     Policy.
@@ -1908,6 +1888,29 @@ i_totals(Q) when ?is_amqqueue(Q) ->
              {messages, 0}]
     end.
 
+resolve_delivery_limit(PolVal, ArgVal)
+  when PolVal < 0 orelse ArgVal < 0 ->
+    max(PolVal, ArgVal);
+resolve_delivery_limit(PolVal, ArgVal) ->
+    min(PolVal, ArgVal).
+
+get_delivery_limit(Q) ->
+    get_delivery_limit(Q, false).
+
+get_delivery_limit(Q, ShouldLog) ->
+    PolicyValue = args_policy_lookup(<<"delivery-limit">>, fun resolve_delivery_limit/2, Q),
+    get_delivery_limit({handle_policy_value, PolicyValue}, Q, ShouldLog).
+
+get_delivery_limit({handle_policy_value, undefined}, Q, true) ->
+    QName = amqqueue:get_name(Q),
+    ?LOG_INFO("~ts: delivery_limit not set, defaulting to ~b",
+                [rabbit_misc:rs(QName), ?DEFAULT_DELIVERY_LIMIT]),
+    ?DEFAULT_DELIVERY_LIMIT;
+get_delivery_limit({handle_policy_value, undefined}, _Q, false) ->
+    ?DEFAULT_DELIVERY_LIMIT;
+get_delivery_limit({handle_policy_value, Limit}, _Q, _ShouldLog) when is_integer(Limit) ->
+    Limit.
+
 i(name,        Q) when ?is_amqqueue(Q) -> amqqueue:get_name(Q);
 i(durable,     Q) when ?is_amqqueue(Q) -> amqqueue:is_durable(Q);
 i(auto_delete, Q) when ?is_amqqueue(Q) -> amqqueue:is_auto_delete(Q);
@@ -2042,6 +2045,8 @@ i(message_bytes_dlx, Q) when ?is_amqqueue(Q) ->
         {timeout, _} ->
             0
     end;
+i(delivery_limit, Q) when ?is_amqqueue(Q) ->
+    get_delivery_limit(Q);
 i(_K, _Q) -> ''.
 
 open_files(Name) ->
@@ -2147,7 +2152,11 @@ format(Q, Ctx) when ?is_amqqueue(Q) ->
      {node, LeaderNode},
      {members, Nodes},
      {leader, LeaderNode},
-     {online, Online}].
+     {online, Online},
+     {policy, i(policy, Q)},
+     {operator_policy, i(operator_policy, Q)},
+     {effective_policy_definition, i(effective_policy_definition, Q)},
+     {delivery_limit, i(delivery_limit, Q)}].
 
 -spec quorum_messages(rabbit_amqqueue:name()) -> non_neg_integer().
 


### PR DESCRIPTION
When `management_agent.disable_metrics_collector` and `management.disable_stats` are both set to `true`, the HTTP API returns minimal queue information that excludes policy-related fields and `delivery_limit`. This causes `policy`, `operator_policy`, `effective_policy_definition`, and `delivery_limit` to be `null` in API responses, even though these are configuration metadata rather than statistics.

This change adds these four fields to the `format/2` function in both `rabbit_classic_queue` and `rabbit_quorum_queue` modules. The fields now appear in the type-specific formatting that runs regardless of metrics collection status. The three policy fields use existing `i/2` function implementations that call `rabbit_policy` module functions. For `delivery_limit`, this change adds an `i(delivery_limit, Q)` function to `rabbit_quorum_queue` that extracts the delivery limit from the queue's `x-delivery-limit` argument, returning `unlimited` when not set.

Fixes #15182