### PR TITLE
Correctly add `customize_hostname_check` to `ssl` options

### DIFF
--- a/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
+++ b/deps/rabbitmq_auth_backend_http/src/rabbit_auth_backend_http.erl
@@ -249,16 +249,17 @@ do_http_req(Path0, Query) ->
 
 ssl_options() ->
     case application:get_env(?APP, ssl_options) of
-        {ok, Opts0} when is_list(Opts0) ->
-            Opts1 = [{ssl, rabbit_ssl_options:fix_client(Opts0)}],
+        {ok, SslOpts0} when is_list(SslOpts0) ->
+            SslOpts1 = rabbit_ssl_options:fix_client(SslOpts0),
             case application:get_env(?APP, ssl_hostname_verification) of
                 {ok, wildcard} ->
                     ?LOG_DEBUG("Enabling wildcard-aware hostname verification for HTTP client connections"),
                     %% Needed for HTTPS connections that connect to servers that use wildcard certificates.
                     %% See https://erlang.org/doc/man/public_key.html#pkix_verify_hostname_match_fun-1.
-                    [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | Opts1];
+                    SslOpts2 = [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | SslOpts1],
+                    [{ssl, SslOpts2}];
                 _ ->
-                    Opts1
+                    [{ssl, SslOpts1}]
             end;
         _ -> []
     end.


### PR DESCRIPTION
Follow-up to #11344

Prior to this fix, the `customize_hostname_check` option was incorrectly added to the general options passed to `httpc:request`, which results in the following error when the request is made:

```
[debug] <0.1.0> Enabling wildcard-aware hostname verification for HTTP client connections
[notice] <0.1.0> Invalid option {customize_hostname_check,
[notice] <0.1.0>                    [{match_fun,#Fun<public_key.6.112534691>}]} ignored
[notice] <0.1.0>
```

With this fix, you can see that `customize_hostname_check` is added to the `ssl` section of the options:

```
1> redbug:start("rabbit_auth_backend_http:ssl_options->return").
...
...
...
% rabbit_auth_backend_http:ssl_options/0 -> [{ssl,
                                              [{customize_hostname_check,
                                                [{match_fun,
                                                  #Fun<public_key.6.112534691>}]},
                                               {versions,
                                                ['tlsv1.3','tlsv1.2',
                                                 'tlsv1.1',tlsv1]},
                                               {hibernate_after,6000},
                                               {keyfile,
                                                "key.pem"},
                                               {depth,10},
                                               {crl_check,false},
                                               {certfile,
                                                "certificate.pem"},
                                               {cacertfile,
                                                "ca_certificate.pem"},
                                               {fail_if_no_peer_cert,false},
                                               {verify,verify_peer}]}]
```