### PR TITLE
Fix double-wrapping of encrypted password in etcd client

### DIFF
--- a/deps/rabbitmq_peer_discovery_etcd/src/rabbitmq_peer_discovery_etcd_v3_client.erl
+++ b/deps/rabbitmq_peer_discovery_etcd/src/rabbitmq_peer_discovery_etcd_v3_client.erl
@@ -361,7 +361,7 @@ obfuscate(Password) ->
 
 deobfuscate(undefined) -> undefined;
 deobfuscate(Password) ->
-    credentials_obfuscation:decrypt({encrypted, to_binary(Password)}).
+    credentials_obfuscation:decrypt(Password).
 
 disconnect(ConnName, #statem_data{connection_monitor = Ref}) ->
     maybe_demonitor(Ref),

--- a/deps/rabbitmq_peer_discovery_etcd/test/system_SUITE.erl
+++ b/deps/rabbitmq_peer_discovery_etcd/test/system_SUITE.erl
@@ -480,10 +480,6 @@ assert_full_cluster(Config) ->
 %%
 %% Helpers
 %%
-
-start_client(Endpoints) ->
-    start_client(Endpoints, undefined, undefined).
-
 start_client(Endpoints, Username, Password) ->
     Settings = case Username of
                    undefined ->


### PR DESCRIPTION
## Problem

The etcd peer discovery plugin crashes during startup when username and password authentication is configured. The crash occurs with a `function_clause` error in `rabbit_data_coercion:to_list/1` when it receives a double-wrapped encrypted password structure.

The bug is in `deobfuscate/1` which wraps an already-encrypted password with another `{encrypted, ...}` tuple, creating `{encrypted, {encrypted, Binary}}`. This double-wrapped structure causes `to_list/1` to fail because it has no clause matching this pattern.

## Solution

This PR removes the extra wrapping in `deobfuscate/1`. The password parameter is already in the correct format `{encrypted, Binary}` or `{plaintext, Binary}` from the `obfuscate/1` call, so it passes directly to `credentials_obfuscation:decrypt/1` without modification.

This matches the pattern used in other modules like `rabbit_federation_util` and `amqp_direct_connection` which call `credentials_obfuscation:decrypt/1` directly on encrypted values.

## Testing

Added authentication to the etcd test suite to reproduce and verify the fix. The test suite now starts etcd with authentication enabled, creates a `rabbitmq` user with password, and passes credentials to the etcd client. All tests pass with the fix applied.

Fixes #15191