### PR TITLE
Remove looking glass from rabbit_fifo_int_SUITE

### DIFF
--- a/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_int_SUITE.erl
@@ -56,12 +56,11 @@ init_per_group(_, Config) ->
     PrivDir = ?config(priv_dir, Config),
     _ = application:load(ra),
     ok = application:set_env(ra, data_dir, PrivDir),
-    application:ensure_all_started(logger),
-    application:ensure_all_started(ra),
-    application:ensure_all_started(lg),
+    {ok, _} = application:ensure_all_started(logger),
+    {ok, _} = application:ensure_all_started(ra),
     SysCfg = ra_system:default_config(),
     ra_env:configure_logger(logger),
-    ra_system:start(SysCfg#{name => ?RA_SYSTEM}),
+    {ok, _} = ra_system:start(SysCfg#{name => ?RA_SYSTEM}),
     Config.
 
 end_per_group(_, Config) ->


### PR DESCRIPTION
Looking glass got removed from RabbitMQ in a previous version.

This commit fixes the following error:
```
{lg,{"no such file or directory","lg.app"}}
```