### PR TITLE
Quorum queues: fix error logging during node drain

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2395,7 +2395,8 @@ transfer_leadership(_CandidateNodes) ->
                   ok ->
                       ?LOG_DEBUG("Successfully stopped Ra server ~tp", [RaLeader]);
                   {error, nodedown} ->
-                      ?LOG_ERROR("Failed to stop Ra server ~tp: target node was reported as down")
+                      ?LOG_ERROR("Failed to stop Ra server ~tp: target node was reported as down",
+                                 [RaLeader])
               end,
               ok
           end || Q <- Queues],
@@ -2442,7 +2443,8 @@ stop_local_quorum_queue_followers() ->
             ok     ->
                 ?LOG_DEBUG("Successfully stopped Ra server ~tp", [RaNode]);
             {error, nodedown} ->
-                ?LOG_ERROR("Failed to stop Ra server ~tp: target node was reported as down")
+                ?LOG_ERROR("Failed to stop Ra server ~tp: target node was reported as down",
+                           [RaNode])
         end
      end || Q <- Queues],
     ?LOG_INFO("Stopped all local replicas of quorum queues hosted on this node").


### PR DESCRIPTION
## Proposed Changes

This PR fixes two error log calls in `rabbit_quorum_queue` that used a `~tp` format placeholder but did not provide any formatting arguments.


## Types of Changes

- [x] Bug fix (non-breaking change)

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

This is a small, localized fix: keep the existing log message, only add the missing argument lists ([RaLeader] / [RaNode]) to match the `~tp` placeholder.
