### PR TITLE
rabbit_khepri: Optimize cleanup in topic binding projection

### DIFF
--- a/deps/rabbit/src/rabbit_db_topic_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_topic_exchange.erl
@@ -26,7 +26,7 @@
 -define(MNESIA_NODE_TABLE, rabbit_topic_trie_node).
 -define(MNESIA_EDGE_TABLE, rabbit_topic_trie_edge).
 -define(MNESIA_BINDING_TABLE, rabbit_topic_trie_binding).
--define(KHEPRI_PROJECTION, rabbit_khepri_topic_trie_v2).
+-define(KHEPRI_PROJECTION, rabbit_khepri_topic_trie_v3).
 
 -type match_result() :: [rabbit_types:binding_destination() |
                          {rabbit_amqqueue:name(), rabbit_types:binding_key()}].
@@ -533,8 +533,8 @@ trie_child_in_khepri(X, Node, Word) ->
            #trie_edge{exchange_name = X,
                       node_id       = Node,
                       word          = Word}) of
-        [#topic_trie_edge{node_id = NextNode}] -> {ok, NextNode};
-        []                                     -> error
+        [#topic_trie_edge_v2{node_id = NextNode}] -> {ok, NextNode};
+        []                                        -> error
     end.
 
 trie_bindings_in_khepri(X, Node, BKeys) ->
@@ -543,7 +543,7 @@ trie_bindings_in_khepri(X, Node, BKeys) ->
            #trie_edge{exchange_name = X,
                       node_id       = Node,
                       word          = bindings}) of
-        [#topic_trie_edge{node_id = {bindings, Bindings}}] ->
+        [#topic_trie_edge_v2{node_id = {bindings, Bindings}}] ->
             [case BKeys of
                  true ->
                      {Dest, Args};

--- a/deps/rabbit_common/include/rabbit.hrl
+++ b/deps/rabbit_common/include/rabbit.hrl
@@ -102,6 +102,7 @@
 
 -record(topic_trie_node, {trie_node, edge_count, binding_count}).
 -record(topic_trie_edge, {trie_edge, node_id}).
+-record(topic_trie_edge_v2, {trie_edge, node_id, child_count}).
 -record(topic_trie_binding, {trie_binding, value = const}).
 
 -record(trie_node, {exchange_name, node_id}).


### PR DESCRIPTION
## Why

Before this patch, the projection function that managed the topic bindings graph only kept track of "topic word -> topic word" = "this node ID". Reading and updating this graph was efficient.

However, deleting a node in this graph was expensive because it used `ets:match/3` to determine if an edge was pointing to nothing and could be reclaimed. `ets:match()` does a full scan of the table. On my laptop, this scan took 20 ms with 100k topic bindings, thus >30 minutes to delete all of them.

## How

The new projection function tracks the number of children a target node has as well. This way, it knows that if this counter reaches 0, the edge can be reclaimed.

The same test with 100k topic bindings takes 3.5 seconds to delete them.