### PR TITLE
Fix test case `quorum_unaffected_after_vhost_failure`

### DIFF
--- a/deps/rabbit/test/dynamic_qq_SUITE.erl
+++ b/deps/rabbit/test/dynamic_qq_SUITE.erl
@@ -206,9 +206,9 @@ quorum_unaffected_after_vhost_failure(Config) ->
 
     %% Crash vhost on both nodes
     {ok, SupA} = rabbit_ct_broker_helpers:rpc(Config, A, rabbit_vhost_sup_sup, get_vhost_sup, [<<"/">>]),
-    exit(SupA, foo),
     {ok, SupB} = rabbit_ct_broker_helpers:rpc(Config, B, rabbit_vhost_sup_sup, get_vhost_sup, [<<"/">>]),
-    exit(SupB, foo),
+    exit(SupA, kill),
+    exit(SupB, kill),
 
     ?awaitMatch(
        Servers,


### PR DESCRIPTION
Make the vhost actually fail in test case
`quorum_unaffected_after_vhost_failure`.

Previously, the logs didn't indicate any vhost failure. Atom `kill` showed various errors in the logs providing evidence that the vhost actually fails.
