### PR TITLE
Handle empty list case in `mirrored_supervisor:child/2`

### DIFF
--- a/deps/rabbit/src/mirrored_supervisor.erl
+++ b/deps/rabbit/src/mirrored_supervisor.erl
@@ -225,9 +225,11 @@ fold(FunAtom, Sup, AggFun) ->
                     D <- [delegate(M)]]).
 
 child(Sup, Id) ->
-    [Pid] = [Pid || {Id1, Pid, _, _} <- ?SUPERVISOR:which_children(Sup),
-                    Id1 =:= Id],
-    Pid.
+    case [Pid || {Id1, Pid, _, _} <- ?SUPERVISOR:which_children(Sup),
+                 Id1 =:= Id] of
+        [Pid] -> Pid;
+        [] -> undefined
+    end.
 
 delegate(Sup) -> child(Sup, delegate).
 mirroring(Sup) -> child(Sup, mirroring).


### PR DESCRIPTION
During production testing of `amazon-mq/rabbitmq-queue-migration`, a badmatch exception was observed during shovel cleanup:

```
exit:{{{badmatch,[]},[{mirrored_supervisor,child,2,...}]},
     {gen_server2,call,[<0.1346.0>,{delete_child,...},infinity]}}
```

The exception occurs in `mirrored_supervisor:child/2` when the list comprehension returns an empty list instead of a single-element list. The function uses pattern matching `[Pid] = [...]` which fails when no matching child is found in the supervisor's children list.

This change updates `child/2` to use a case statement that returns `undefined` when the list is empty, matching the behavior expected by `check_stop/3` which already handles `undefined` as "child not found". The empty list case is safe to treat as `undefined` because it indicates the child has already been removed from the supervisor, which is the desired end state for deletion operations.

While we could not reliably reproduce the race condition in testing, the fix is defensive and aligns with how `terminate_child` can return `{error, not_found}` when a child doesn't exist. This change makes `delete_child` operations more robust.
