### PR TITLE
rabbit/Makefile: Drop Horus temporary pinning

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -126,14 +126,8 @@ endef
 LOCAL_DEPS = sasl os_mon inets compiler public_key crypto ssl syntax_tools
 
 BUILD_DEPS = rabbitmq_cli
-DEPS = ranch cowlib rabbit_common amqp10_common rabbitmq_prelaunch ra sysmon_handler stdout_formatter recon redbug observer_cli osiris syslog systemd seshat horus khepri khepri_mnesia_migration cuttlefish gen_batch_server
+DEPS = ranch cowlib rabbit_common amqp10_common rabbitmq_prelaunch ra sysmon_handler stdout_formatter recon redbug observer_cli osiris syslog systemd seshat khepri khepri_mnesia_migration cuttlefish gen_batch_server
 TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers meck proper amqp_client rabbitmq_amqp_client rabbitmq_amqp1_0
-
-# We pin a version of Horus even if we don't use it directly (it is a
-# dependency of Khepri). But currently, we can't update Khepri while still
-# needing the fix in Horus 0.3.1. This line and the mention of `horus` above
-# should be removed with the next update of Khepri.
-dep_horus = hex 0.3.1
 
 PLT_APPS += mnesia runtime_tools
 


### PR DESCRIPTION
## Why

We added this pinning at a time KHepri depended on an older version of Horus and we couldn't update Khepri.

Now we use the latest version of Khepri which uses the latest version of Horus. We can and must drop this temporary pinning to get that latest version.