### PR TITLE
Management UI: Fix typo and add help text for x-quorum-target-group-size

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -249,6 +249,9 @@ var HELP = {
     'queue-initial-cluster-size':
        'Set the queue initial cluster size.',
 
+    'quorum-queue-target-group-size':
+       'The target number of replicas for the quorum queue. When set and the periodic membership reconciliation is enabled, RabbitMQ will automatically adjust the number of queue replicas to match this target size.<br/>(Sets the "<a target="_blank" href="https://www.rabbitmq.com/docs/quorum-queues#member-reconciliation">x-quorum-target-group-size</a>" argument.)',
+
     'queue-type':
        'Set the queue type, determining the type of queue to use: raft-based high availability or classic queue. Valid values are <code>quorum</code> or <code>classic</code>. It defaults to <code>classic</code>. <br/>',
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-arguments.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/quorum-queue-arguments.ejs
@@ -8,6 +8,6 @@
 <span class="argument-link" field="arguments" key="x-max-length-bytes" type="number">Max length bytes</span> <span class="help" id="queue-max-length-bytes"></span>
 | <span class="argument-link" field="arguments" key="x-delivery-limit" type="number">Delivery limit</span><span class="help" id="delivery-limit"></span>
 | <span class="argument-link" field="arguments" key="x-quorum-initial-group-size" type="number">Initial cluster size</span><span class="help" id="queue-initial-cluster-size"></span><br/>
-  <span class="argument-link" field="arguments" key="x-quorum-target-group-size" type="number">Target cluster size</span><span class="help" id="qourum-queue-target-group-size"></span>
+| <span class="argument-link" field="arguments" key="x-quorum-target-group-size" type="number">Target cluster size</span> <span class="help" id="quorum-queue-target-group-size"></span>
   | <span class="argument-link" field="arguments" key="x-dead-letter-strategy" type="string">Dead letter strategy</span><span class="help" id="queue-dead-letter-strategy"></span>
 | <span class="argument-link" field="arguments" key="x-queue-leader-locator" type="string">Leader locator</span><span class="help" id="queue-leader-locator"></span>


### PR DESCRIPTION
## Proposed Changes

- Fix the quorum queue argument help tooltip: correct the help span ID and add accurate help text for `x-quorum-target-group-size`, including the link to the member reconciliation section.


## Types of Changes

- [x] Bug fix (non-breaking change)

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

- Help text now points to the member reconciliation section that documents `x-quorum-target-group-size`.
