### PR TITLE
Very minor clarification in rabbitmq-plugins man page

### DIFF
--- a/deps/rabbit/docs/rabbitmq-plugins.8
+++ b/deps/rabbit/docs/rabbitmq-plugins.8
@@ -183,7 +183,7 @@ Modify node's enabled plugin state directly without contacting the node.
 .It Fl -online
 Treat a failure to connect to the running broker as fatal.
 .It Ar plugin
-One or more plugins to enable.
+One or more plugins to enable separated by space.
 .El
 .Pp
 Enables the specified plugins and all their dependencies.
@@ -203,7 +203,7 @@ Modify node's enabled plugin state directly without contacting the node.
 .It Fl -online
 Treat a failure to connect to the running broker as fatal.
 .It Ar plugin
-One or more plugins to disable.
+One or more plugins to disable separated by space.
 .El
 .Pp
 Disables the specified plugins and all their dependencies.
@@ -221,7 +221,7 @@ Modify node's enabled plugin state directly without contacting the node.
 .It Fl -online
 Treat a failure to connect to the running broker as fatal.
 .It Ar plugin
-Zero or more plugins to disable.
+Zero or more plugins to enable separated by space.
 .El
 .Pp
 Enables the specified plugins and all their dependencies.


### PR DESCRIPTION

## Proposed Changes

Clarify that plugin names are separated by spaces as already done by `rabbitmq-plugins set --help`.

This is already what most people would assume but I was hesitant if plugin names are comma or space separated. So wanted to leave no doubt about it for people like me :)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
