### PR TITLE
rabbit_db_{exchange,vhost}: be more defensive

### DIFF
--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -348,6 +348,9 @@ update_in_khepri(XName, Fun) ->
                 {error, _} = Error ->
                     Error
             end;
+        {ok, #{Path := #{}}} ->
+            %% The node exists but has no data, e.g. due to a concurrent deletion.
+            ok;
         {error, {khepri, node_not_found, _}} ->
             ok;
         {error, _} = Error ->

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -182,6 +182,9 @@ merge_metadata_in_khepri(VHostName, Metadata) ->
                 {error, _} = Error ->
                     Error
             end;
+        {ok, #{Path := #{}}} ->
+            %% The node exists but has no data, e.g. due to a concurrent deletion.
+            {error, {no_such_vhost, VHostName}};
         {error, {khepri, node_not_found, _}} ->
             {error, {no_such_vhost, VHostName}};
         {error, _} = Error ->
@@ -456,6 +459,9 @@ update_in_khepri(VHostName, UpdateFun) ->
                 Error ->
                     throw(Error)
             end;
+        {ok, #{Path := #{}}} ->
+            %% The node exists but has no data, e.g. due to a concurrent deletion.
+            throw({error, {no_such_vhost, VHostName}});
         {error, {khepri, node_not_found, _}} ->
             throw({error, {no_such_vhost, VHostName}});
         Error ->


### PR DESCRIPTION
when a path query returns an empty result.

During concurrent deletes in rabbitmq_exchange_federation's exchange_SUITE, the lack of handling for these cases produces test flakes.

Note that rabbit_db_queue has a catch-all (_) clause which makes that module immune to this problem.
