### PR TITLE
Prevent federation links from restarting during node shutdown (the pre-4.2.0 vintage edition)

### DIFF
--- a/deps/rabbitmq_federation/src/rabbit_federation_app.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_app.erl
@@ -10,7 +10,7 @@
 -include_lib("rabbitmq_federation/include/logging.hrl").
 
 -behaviour(application).
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 %% Dummy supervisor - see Ulf Wiger's comment at
 %% http://erlang.org/pipermail/erlang-questions/2010-April/050508.html
@@ -30,6 +30,10 @@
 
 start(_Type, _StartArgs) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+prep_stop(State) ->
+    rabbit_federation_app_state:mark_as_shutting_down(),
+    State.
 
 stop(_State) ->
     rabbit_federation_pg:stop_scope(),

--- a/deps/rabbitmq_federation/src/rabbit_federation_app_state.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_app_state.erl
@@ -1,0 +1,30 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% Tracks transient application state using persistent_term storage.
+%% This is used to prevent link restarts during node shutdown.
+-module(rabbit_federation_app_state).
+
+-export([is_shutting_down/0,
+         mark_as_shutting_down/0,
+         reset_shutting_down_marker/0]).
+
+-define(SHUTDOWN_KEY, {?MODULE, shutting_down}).
+
+-spec is_shutting_down() -> boolean().
+is_shutting_down() ->
+    persistent_term:get(?SHUTDOWN_KEY, false).
+
+-spec mark_as_shutting_down() -> ok.
+mark_as_shutting_down() ->
+    persistent_term:put(?SHUTDOWN_KEY, true),
+    ok.
+
+-spec reset_shutting_down_marker() -> ok.
+reset_shutting_down_marker() ->
+    _ = persistent_term:erase(?SHUTDOWN_KEY),
+    ok.

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
@@ -64,7 +64,16 @@ list_routing_keys(XN) -> call(XN, list_routing_keys).
 start_link(Args) ->
     gen_server2:start_link(?MODULE, Args, [{timeout, infinity}]).
 
-init({Upstream, XName}) ->
+init(Args) ->
+    case rabbit_federation_app_state:is_shutting_down() of
+        true  ->
+            ?LOG_DEBUG("Exchange federation link: voluntarily stopping, the node (or plugin) is stopping"),
+            ignore;
+        false ->
+            init_link(Args)
+    end.
+
+init_link({Upstream, XName}) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_FEDERATION,
                                   exchange => XName}),
     %% If we are starting up due to a policy change then it's possible
@@ -298,14 +307,20 @@ record_binding(B = #binding{destination = Dest},
                   end,
     {DoIt, State#state{bindings = maps:put(key(B), Set, Bs)}}.
 
+-spec forget_binding(#binding{}, #state{}) -> {boolean(), #state{}}.
 forget_binding(B = #binding{destination = Dest},
                State = #state{bindings = Bs}) ->
-    Dests = sets:del_element(Dest, maps:get(key(B), Bs)),
-    {DoIt, Bs1} = case sets:size(Dests) of
-                      0 -> {true,  maps:remove(key(B), Bs)};
-                      _ -> {false, maps:put(key(B), Dests, Bs)}
-                  end,
-    {DoIt, State#state{bindings = Bs1}}.
+    case maps:find(key(B), Bs) of
+        {ok, Dests0} ->
+            Dests = sets:del_element(Dest, Dests0),
+            {DoIt, Bs1} = case sets:size(Dests) of
+                              0 -> {true,  maps:remove(key(B), Bs)};
+                              _ -> {false, maps:put(key(B), Dests, Bs)}
+                          end,
+            {DoIt, State#state{bindings = Bs1}};
+        error ->
+            {false, State}
+    end.
 
 binding_op(UpdateFun, Cmd, B = #binding{args = Args},
            State = #state{cmd_channel = Ch}) ->

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link_sup_sup.erl
@@ -29,6 +29,7 @@ start_link() ->
     %% and other places, so we have to start it very early outside of the supervision tree.
     %% The scope is stopped in stop/1.
     _ = rabbit_federation_pg:start_scope(),
+    rabbit_federation_app_state:reset_shutting_down_marker(),
     mirrored_supervisor:start_link({local, ?SUPERVISOR}, ?SUPERVISOR,
                                    ?MODULE, []).
 

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -52,7 +52,16 @@ q(QName) ->
 
 %%----------------------------------------------------------------------------
 
-init({Upstream, Queue}) when ?is_amqqueue(Queue) ->
+init(Args) ->
+    case rabbit_federation_app_state:is_shutting_down() of
+        true  ->
+            ?LOG_DEBUG("Queue federation link: voluntarily stopping, the node (or plugin) is stopping"),
+            ignore;
+        false ->
+            init_link(Args)
+    end.
+
+init_link({Upstream, Queue}) when ?is_amqqueue(Queue) ->
     QName = amqqueue:get_name(Queue),
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_FEDERATION,
                                   queue => QName}),

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link_sup_sup.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link_sup_sup.erl
@@ -29,6 +29,7 @@ start_link() ->
     %% and other places, so we have to start it very early outside of the supervision tree.
     %% The scope is stopped in stop/1.
     _ = rabbit_federation_pg:start_scope(),
+    rabbit_federation_app_state:reset_shutting_down_marker(),
     mirrored_supervisor:start_link({local, ?SUPERVISOR}, ?SUPERVISOR,
                                    ?MODULE, []).
 

--- a/deps/rabbitmq_federation/test/unit_SUITE.erl
+++ b/deps/rabbitmq_federation/test/unit_SUITE.erl
@@ -17,7 +17,10 @@ all() -> [
     obfuscate_upstream,
     obfuscate_upstream_params_network,
     obfuscate_upstream_params_network_with_char_list_password_value,
-    obfuscate_upstream_params_direct
+    obfuscate_upstream_params_direct,
+    shutdown_flag_defaults_to_false,
+    shutdown_flag_can_be_set,
+    shutdown_flag_can_be_cleared
 ].
 
 init_per_suite(Config) ->
@@ -62,4 +65,24 @@ obfuscate_upstream_params_network_with_char_list_password_value(_Config) ->
     },
     ObfuscatedUpstreamParams = rabbit_federation_util:obfuscate_upstream_params(UpstreamParams),
     ?assertEqual(UpstreamParams, rabbit_federation_util:deobfuscate_upstream_params(ObfuscatedUpstreamParams)),
+    ok.
+
+shutdown_flag_defaults_to_false(_Config) ->
+    rabbit_federation_app_state:reset_shutting_down_marker(),
+    ?assertEqual(false, rabbit_federation_app_state:is_shutting_down()),
+    ok.
+
+shutdown_flag_can_be_set(_Config) ->
+    rabbit_federation_app_state:reset_shutting_down_marker(),
+    ?assertEqual(false, rabbit_federation_app_state:is_shutting_down()),
+    rabbit_federation_app_state:mark_as_shutting_down(),
+    ?assertEqual(true, rabbit_federation_app_state:is_shutting_down()),
+    ok.
+
+shutdown_flag_can_be_cleared(_Config) ->
+    rabbit_federation_app_state:reset_shutting_down_marker(),
+    rabbit_federation_app_state:mark_as_shutting_down(),
+    ?assertEqual(true, rabbit_federation_app_state:is_shutting_down()),
+    rabbit_federation_app_state:reset_shutting_down_marker(),
+    ?assertEqual(false, rabbit_federation_app_state:is_shutting_down()),
     ok.


### PR DESCRIPTION
This is a port of https://github.com/rabbitmq/rabbitmq-server/pull/15258 to `v4.1.x`, before the federation plugin split into two (well, three) during the `4.2.0` development cycle.