### PR TITLE
Federation: make connection.close timeout configurable

### DIFF
--- a/deps/rabbitmq_exchange_federation/.gitignore
+++ b/deps/rabbitmq_exchange_federation/.gitignore
@@ -1,0 +1,1 @@
+test/config_schema_SUITE_data/schema/

--- a/deps/rabbitmq_exchange_federation/Makefile
+++ b/deps/rabbitmq_exchange_federation/Makefile
@@ -5,7 +5,8 @@ PROJECT_MOD = rabbit_exchange_federation_app
 define PROJECT_ENV
 [
 	    {pgroup_name_cluster_id, false},
-	    {internal_exchange_check_interval, 90000}
+	    {internal_exchange_check_interval, 90000},
+	    {connection_close_timeout, 5000}
 	  ]
 endef
 

--- a/deps/rabbitmq_exchange_federation/priv/schema/rabbitmq_exchange_federation.schema
+++ b/deps/rabbitmq_exchange_federation/priv/schema/rabbitmq_exchange_federation.schema
@@ -1,0 +1,16 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+{mapping, "federation.exchanges.connection_close_timeout", "rabbitmq_exchange_federation.connection_close_timeout", [
+    {datatype, integer},
+    {validators, ["non_negative_integer", "connection_close_timeout"]}
+]}.
+
+{validator, "connection_close_timeout", "timeout must not exceed 5000ms",
+fun(Timeout) when is_integer(Timeout) ->
+    Timeout =< 5000
+end}.

--- a/deps/rabbitmq_exchange_federation/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_exchange_federation/test/config_schema_SUITE.erl
@@ -1,0 +1,54 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(config_schema_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+        run_snippets
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:run_setup_steps(Config),
+    rabbit_ct_config_schema:init_schemas(rabbitmq_exchange_federation, Config1).
+
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test Cases
+%% -------------------------------------------------------------------
+
+run_snippets(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, run_snippets1, [Config]).
+
+run_snippets1(Config) ->
+    rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_exchange_federation/test/config_schema_SUITE_data/rabbitmq_exchange_federation.snippets
+++ b/deps/rabbitmq_exchange_federation/test/config_schema_SUITE_data/rabbitmq_exchange_federation.snippets
@@ -1,0 +1,17 @@
+[
+{connection_close_timeout_default,
+    "federation.exchanges.connection_close_timeout = 5000",
+    [{rabbitmq_exchange_federation, [
+        {connection_close_timeout, 5000}
+    ]}],
+    [rabbitmq_exchange_federation]
+},
+
+{connection_close_timeout_custom,
+    "federation.exchanges.connection_close_timeout = 3000",
+    [{rabbitmq_exchange_federation, [
+        {connection_close_timeout, 3000}
+    ]}],
+    [rabbitmq_exchange_federation]
+}
+].

--- a/deps/rabbitmq_queue_federation/.gitignore
+++ b/deps/rabbitmq_queue_federation/.gitignore
@@ -1,0 +1,1 @@
+test/config_schema_SUITE_data/schema/

--- a/deps/rabbitmq_queue_federation/Makefile
+++ b/deps/rabbitmq_queue_federation/Makefile
@@ -4,7 +4,8 @@ PROJECT_MOD = rabbit_queue_federation_app
 
 define PROJECT_ENV
 [
-	    {pgroup_name_cluster_id, false}
+	    {pgroup_name_cluster_id, false},
+	    {connection_close_timeout, 5000}
 	  ]
 endef
 

--- a/deps/rabbitmq_queue_federation/priv/schema/rabbitmq_queue_federation.schema
+++ b/deps/rabbitmq_queue_federation/priv/schema/rabbitmq_queue_federation.schema
@@ -1,0 +1,16 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+{mapping, "federation.queues.connection_close_timeout", "rabbitmq_queue_federation.connection_close_timeout", [
+    {datatype, integer},
+    {validators, ["non_negative_integer", "connection_close_timeout"]}
+]}.
+
+{validator, "connection_close_timeout", "timeout must not exceed 5000ms",
+fun(Timeout) when is_integer(Timeout) ->
+    Timeout =< 5000
+end}.

--- a/deps/rabbitmq_queue_federation/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_queue_federation/test/config_schema_SUITE.erl
@@ -1,0 +1,54 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(config_schema_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+        run_snippets
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:run_setup_steps(Config),
+    rabbit_ct_config_schema:init_schemas(rabbitmq_queue_federation, Config1).
+
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test Cases
+%% -------------------------------------------------------------------
+
+run_snippets(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, run_snippets1, [Config]).
+
+run_snippets1(Config) ->
+    rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_queue_federation/test/config_schema_SUITE_data/rabbitmq_queue_federation.snippets
+++ b/deps/rabbitmq_queue_federation/test/config_schema_SUITE_data/rabbitmq_queue_federation.snippets
@@ -1,0 +1,17 @@
+[
+{connection_close_timeout_default,
+    "federation.queues.connection_close_timeout = 5000",
+    [{rabbitmq_queue_federation, [
+        {connection_close_timeout, 5000}
+    ]}],
+    [rabbitmq_queue_federation]
+},
+
+{connection_close_timeout_custom,
+    "federation.queues.connection_close_timeout = 3000",
+    [{rabbitmq_queue_federation, [
+        {connection_close_timeout, 3000}
+    ]}],
+    [rabbitmq_queue_federation]
+}
+].


### PR DESCRIPTION
Currently the worst case scenario is 10s per connection.

Since any lower default will be wrong for someone, let's just make the whole thing configurable in each plugin.

Updating to `v4.1.x` will require a separate PR because before `4.2.0`, there is just one federation plugin for both queue and exchange federation.
