### PR TITLE
Federation: make connection.close timeout configurable (pre-4.2.0 vintage edition)

### DIFF
--- a/deps/rabbitmq_federation/.gitignore
+++ b/deps/rabbitmq_federation/.gitignore
@@ -1,0 +1,1 @@
+test/config_schema_SUITE_data/schema/

--- a/deps/rabbitmq_federation/Makefile
+++ b/deps/rabbitmq_federation/Makefile
@@ -5,7 +5,9 @@ PROJECT_MOD = rabbit_federation_app
 define PROJECT_ENV
 [
 	    {pgroup_name_cluster_id, false},
-	    {internal_exchange_check_interval, 90000}
+	    {internal_exchange_check_interval, 90000},
+	    {exchange_connection_close_timeout, 5000},
+	    {queue_connection_close_timeout, 5000}
 	  ]
 endef
 

--- a/deps/rabbitmq_federation/priv/schema/rabbitmq_federation.schema
+++ b/deps/rabbitmq_federation/priv/schema/rabbitmq_federation.schema
@@ -1,0 +1,21 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+{mapping, "federation.exchanges.connection_close_timeout", "rabbitmq_federation.exchange_connection_close_timeout", [
+    {datatype, integer},
+    {validators, ["non_negative_integer", "connection_close_timeout"]}
+]}.
+
+{mapping, "federation.queues.connection_close_timeout", "rabbitmq_federation.queue_connection_close_timeout", [
+    {datatype, integer},
+    {validators, ["non_negative_integer", "connection_close_timeout"]}
+]}.
+
+{validator, "connection_close_timeout", "timeout must not exceed 5000ms",
+fun(Timeout) when is_integer(Timeout) ->
+    Timeout =< 5000
+end}.

--- a/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_exchange_link.erl
@@ -209,8 +209,9 @@ terminate(Reason, #state{downstream_connection = DConn,
                          queue                 = Queue}) when Reason =:= shutdown;
                                                               Reason =:= {shutdown, restart};
                                                               Reason =:= gone ->
+    Timeout = connection_close_timeout(),
     _ = timer:cancel(TRef),
-    rabbit_federation_link_util:ensure_connection_closed(DConn),
+    rabbit_federation_link_util:ensure_connection_closed(DConn, Timeout),
 
     ?LOG_DEBUG("Exchange federation: link is shutting down, resource cleanup mode: ~tp", [Upstream#upstream.resource_cleanup_mode]),
     case Upstream#upstream.resource_cleanup_mode of
@@ -223,7 +224,7 @@ terminate(Reason, #state{downstream_connection = DConn,
             delete_upstream_exchange(Conn, IntExchange)
     end,
 
-    rabbit_federation_link_util:ensure_connection_closed(Conn),
+    rabbit_federation_link_util:ensure_connection_closed(Conn, Timeout),
     rabbit_federation_link_util:log_terminate(Reason, Upstream, UParams, XName),
     ok;
 %% unexpected shutdown
@@ -233,14 +234,15 @@ terminate(Reason, #state{downstream_connection = DConn,
                          upstream_params       = UParams,
                          downstream_exchange   = XName,
                          internal_exchange_timer = TRef}) ->
+    Timeout = connection_close_timeout(),
     _ = timer:cancel(TRef),
 
-    rabbit_federation_link_util:ensure_connection_closed(DConn),
+    rabbit_federation_link_util:ensure_connection_closed(DConn, Timeout),
 
     %% unlike in the clean shutdown case above, we keep the queue
     %% and exchange around
 
-    rabbit_federation_link_util:ensure_connection_closed(Conn),
+    rabbit_federation_link_util:ensure_connection_closed(Conn, Timeout),
     rabbit_federation_link_util:log_terminate(Reason, Upstream, UParams, XName),
     ok.
 
@@ -507,7 +509,7 @@ open_command_channel(Conn, Upstream = #upstream{name = UName}, UParams, DownXNam
             erlang:monitor(process, CCh),
             {ok, CCh};
         E ->
-            rabbit_federation_link_util:ensure_connection_closed(Conn),
+            rabbit_federation_link_util:ensure_connection_closed(Conn, connection_close_timeout()),
             _ = rabbit_federation_link_util:connection_error(command_channel, E,
                                                              Upstream, UParams, DownXName, S0),
             E
@@ -708,3 +710,10 @@ handle_down(DCh, Reason, _Ch, _CmdCh, DCh, Args, State) ->
 handle_down(ChPid, Reason, Ch, CmdCh, _DCh, Args, State)
   when ChPid =:= Ch; ChPid =:= CmdCh ->
     rabbit_federation_link_util:handle_upstream_down(Reason, Args, State).
+
+connection_close_timeout() ->
+    Default = rabbit_federation_link_util:connection_close_timeout(),
+    Configured = application:get_env(rabbitmq_federation,
+                                     exchange_connection_close_timeout,
+                                     Default),
+    erlang:min(Configured, Default).

--- a/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
+++ b/deps/rabbitmq_federation/src/rabbit_federation_queue_link.erl
@@ -190,9 +190,10 @@ terminate(Reason, #state{dconn           = DConn,
                          upstream        = Upstream,
                          upstream_params = UParams,
                          queue           = Q}) when ?is_amqqueue(Q) ->
+    Timeout = connection_close_timeout(),
     QName = amqqueue:get_name(Q),
-    rabbit_federation_link_util:ensure_connection_closed(DConn),
-    rabbit_federation_link_util:ensure_connection_closed(Conn),
+    rabbit_federation_link_util:ensure_connection_closed(DConn, Timeout),
+    rabbit_federation_link_util:ensure_connection_closed(Conn, Timeout),
     rabbit_federation_link_util:log_terminate(Reason, Upstream, UParams, QName),
     _ = pg:leave(?FEDERATION_PG_SCOPE, pgname({rabbit_federation_queue, QName}), self()),
     ok.
@@ -337,3 +338,10 @@ handle_down(DCh, Reason, _Ch, DCh, Args, State) ->
     rabbit_federation_link_util:handle_downstream_down(Reason, Args, State);
 handle_down(Ch, Reason, Ch, _DCh, Args, State) ->
     rabbit_federation_link_util:handle_upstream_down(Reason, Args, State).
+
+connection_close_timeout() ->
+    Default = rabbit_federation_link_util:connection_close_timeout(),
+    Configured = application:get_env(rabbitmq_federation,
+                                     queue_connection_close_timeout,
+                                     Default),
+    erlang:min(Configured, Default).

--- a/deps/rabbitmq_federation/test/config_schema_SUITE.erl
+++ b/deps/rabbitmq_federation/test/config_schema_SUITE.erl
@@ -1,0 +1,54 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(config_schema_SUITE).
+
+-compile(export_all).
+
+all() ->
+    [
+        run_snippets
+    ].
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:run_setup_steps(Config),
+    rabbit_ct_config_schema:init_schemas(rabbitmq_federation, Config1).
+
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase),
+    Config1 = rabbit_ct_helpers:set_config(Config, [
+        {rmq_nodename_suffix, Testcase}
+      ]),
+    rabbit_ct_helpers:run_steps(Config1,
+      rabbit_ct_broker_helpers:setup_steps() ++
+      rabbit_ct_client_helpers:setup_steps()).
+
+end_per_testcase(Testcase, Config) ->
+    Config1 = rabbit_ct_helpers:run_steps(Config,
+      rabbit_ct_client_helpers:teardown_steps() ++
+      rabbit_ct_broker_helpers:teardown_steps()),
+    rabbit_ct_helpers:testcase_finished(Config1, Testcase).
+
+%% -------------------------------------------------------------------
+%% Test Cases
+%% -------------------------------------------------------------------
+
+run_snippets(Config) ->
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+      ?MODULE, run_snippets1, [Config]).
+
+run_snippets1(Config) ->
+    rabbit_ct_config_schema:run_snippets(Config).

--- a/deps/rabbitmq_federation/test/config_schema_SUITE_data/rabbitmq_federation.snippets
+++ b/deps/rabbitmq_federation/test/config_schema_SUITE_data/rabbitmq_federation.snippets
@@ -1,0 +1,33 @@
+[
+{exchange_connection_close_timeout_default,
+    "federation.exchanges.connection_close_timeout = 5000",
+    [{rabbitmq_federation, [
+        {exchange_connection_close_timeout, 5000}
+    ]}],
+    [rabbitmq_federation]
+},
+
+{exchange_connection_close_timeout_custom,
+    "federation.exchanges.connection_close_timeout = 3000",
+    [{rabbitmq_federation, [
+        {exchange_connection_close_timeout, 3000}
+    ]}],
+    [rabbitmq_federation]
+},
+
+{queue_connection_close_timeout_default,
+    "federation.queues.connection_close_timeout = 5000",
+    [{rabbitmq_federation, [
+        {queue_connection_close_timeout, 5000}
+    ]}],
+    [rabbitmq_federation]
+},
+
+{queue_connection_close_timeout_custom,
+    "federation.queues.connection_close_timeout = 3000",
+    [{rabbitmq_federation, [
+        {queue_connection_close_timeout, 3000}
+    ]}],
+    [rabbitmq_federation]
+}
+].


### PR DESCRIPTION
Backport #15269 to v4.1.x, where federation is a single plugin.
