### PR TITLE
Speed up tests

### DIFF
--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -3467,8 +3467,8 @@ last_queue_confirms(Config) ->
     end,
 
     %% Make quorum queue unavailable.
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 2),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 1),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, 2),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, 1),
 
     DTag2 = <<"t2">>,
     DTag3 = <<"t3">>,
@@ -3483,8 +3483,8 @@ last_queue_confirms(Config) ->
     after 200 -> ok
     end,
 
-    ok = rabbit_ct_broker_helpers:start_node(Config, 1),
-    ok = rabbit_ct_broker_helpers:start_node(Config, 2),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, 1),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, 2),
     %% Since the quorum queue has become available, we should now get a confirmation for m2.
     receive {amqp10_disposition, {accepted, DTag2}} -> ok
     after 30_000 -> ct:fail({missing_accepted, DTag2})
@@ -3543,7 +3543,7 @@ target_queue_deleted(Config) ->
     ?assertEqual(2, length(Members)),
     [{RaName, ReplicaNode}] = Members -- [ServerId0],
     ct:pal("Stopping node ~s to make quorum queue unavailable...", [ReplicaNode]),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, ReplicaNode),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, ReplicaNode),
     flush("quorum queue is down"),
 
     DTag2 = <<"t2">>,
@@ -3559,7 +3559,7 @@ target_queue_deleted(Config) ->
     after 100 -> ok
     end,
 
-    ok = rabbit_ct_broker_helpers:start_node(Config, ReplicaNode),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, ReplicaNode),
     %% Since the quorum queue has become available, we should now get a confirmation for m2.
     receive {amqp10_disposition, {accepted, DTag2}} -> ok
     after 30_000 -> ct:fail({missing_accepted, DTag2})
@@ -3680,7 +3680,7 @@ target_classic_queue_rejects(Config) ->
 
     %% Make 2nd classic queue down.
     flush("stopping node"),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 1),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, 1),
 
     %% We expect that the server closes links that receive from classic queues that are down.
     ExpectedErr2 = #'v1_0.error'{condition = ?V_1_0_AMQP_ERROR_ILLEGAL_STATE},
@@ -3703,7 +3703,7 @@ target_classic_queue_rejects(Config) ->
     {ok, R1Msg3} = amqp10_client:get_msg(Receiver1),
     ?assertEqual([<<"m3">>], amqp10_msg:body(R1Msg3)),
 
-    ok = rabbit_ct_broker_helpers:start_node(Config, 1),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, 1),
     %% Now that the 2nd classic queue is up again, we should be able to attach a new receiver
     %% and be able to send to and receive again.
     {ok, Receiver2b} = amqp10_client:attach_receiver_link(Session, <<"receiver 2b">>, Address2, settled),
@@ -3849,8 +3849,8 @@ link_flow_control(Config) ->
     ?assertEqual([<<1>>], amqp10_msg:body(Msg1)),
 
     %% Make quorum queue unavailable.
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 2),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 1),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, 2),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, 1),
 
     NumMsgs = 1000,
     %% Since the quorum queue is unavailable, we expect our quorum queue sender to run
@@ -3875,8 +3875,8 @@ link_flow_control(Config) ->
     end,
 
     %% Make quorum queue available again.
-    ok = rabbit_ct_broker_helpers:start_node(Config, 1),
-    ok = rabbit_ct_broker_helpers:start_node(Config, 2),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, 1),
+    ok = rabbit_ct_broker_helpers:start_broker(Config, 2),
 
     %% Now, we exepct that the messages sent earlier make it actually into the quorum queue.
     %% Therefore, RabbitMQ should grant our quorum queue sender more credits.

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_health_checks_SUITE.erl
@@ -212,8 +212,8 @@ is_quorum_critical_test(Config) ->
     RaName = binary_to_atom(<<"%2F_", QName/binary>>, utf8),
     {ok, [_, {_, Server2}, {_, Server3}], _} = ra:members({RaName, Server}),
 
-    ok = rabbit_ct_broker_helpers:stop_node(Config, Server2),
-    ok = rabbit_ct_broker_helpers:stop_node(Config, Server3),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, Server2),
+    ok = rabbit_ct_broker_helpers:stop_broker(Config, Server3),
 
     Body = http_get_failed(Config, EndpointPath),
     ?assertEqual(<<"failed">>, maps:get(<<"status">>, Body)),

--- a/deps/rabbitmq_shovel/test/local_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/local_dynamic_SUITE.erl
@@ -218,8 +218,7 @@ local_to_local_counters(Config) ->
     Src = ?config(srcq, Config),
     Dest = ?config(destq, Config),
     %% Let's restart the node so the counters are reset
-    ok = rabbit_ct_broker_helpers:stop_node(Config, 0),
-    ok = rabbit_ct_broker_helpers:start_node(Config, 0),
+    ok = rabbit_ct_broker_helpers:restart_node(Config, 0),
     with_amqp10_session(
       Config,
       fun (Sess) ->


### PR DESCRIPTION
```
rabbit_ct_broker_helpers:stop_broker/2
rabbit_ct_broker_helpers:start_broker/2
```

is about 6 seconds faster compared to

```
rabbit_ct_broker_helpers:stop_node/2
rabbit_ct_broker_helpers:start_node/2
```

This commit uses the faster versions in many tests where for example we only want to trigger a leader change or a queue becoming unavailable.

In some test cases, we actually want the entire Erlang node to be down. Those tests continue to use `rabbit_ct_broker_helpers:stop_node/2`.