### PR TITLE
Queue federation: add a Blue-Green deployment simulation suite

### DIFF
--- a/deps/rabbitmq_queue_federation/test/blue_green_migration_with_queue_federation_SUITE.erl
+++ b/deps/rabbitmq_queue_federation/test/blue_green_migration_with_queue_federation_SUITE.erl
@@ -37,7 +37,7 @@ all() ->
 groups() ->
     [
      {blue_green_migration, [], [
-                                 blue_green_migration_simulation
+                                 case1
                                 ]}
     ].
 
@@ -118,7 +118,7 @@ cleanup_vhosts(Config) ->
 %% Test case
 %% -------------------------------------------------------------------
 
-blue_green_migration_simulation(Config) ->
+case1(Config) ->
     VHostPairs = lists:zip(?BLUE_VHOSTS, ?GREEN_VHOSTS),
 
     %% Green vhosts federate from their corresponding blue vhosts.


### PR DESCRIPTION
See test comments in commit b069d3c60b8f63cd91855a252bf45209108cf212 for the steps involved.

This is a reasonable approximation of the Blue/Green Deployment doc guide and [this blog post](https://www.rabbitmq.com/blog/2025/07/29/latest-benefits-of-rmq-and-migrating-to-qq-along-the-way) by yours truly and @Zerpet.