### PR TITLE
Disable dependabot for selenium in 4.1.x

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -154,18 +154,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  - package-ecosystem: "npm"
-    directory: "/selenium"
-    schedule:
-      interval: "daily"
-    target-branch: "v4.1.x"
-    cooldown:
-      semver-minor-days: 3
-      semver-major-days: 3
-    groups:
-      minor-patch-updates:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
+
 


### PR DESCRIPTION
## Proposed Changes

Disable dependabot for selenium in 4.1.x because this branch will stop being updated after 4.1.8 ships (and will be updated in the backports repo instead)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Build system and/or CI

