### PR TITLE
Management: fix incorrect template for stream queue user policy arguments

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -990,7 +990,7 @@ QUEUE_TYPE["stream"] = {
     },
     tmpl: {
         "arguments"    : "stream-queue-arguments",
-        "user_policy_arguments": "quorum-queue-user-policy-arguments",
+        "user_policy_arguments": "stream-queue-user-policy-arguments",
         "operator_policy_arguments": "stream-queue-operator-policy-arguments",
         "list"   : "stream-queue-list",
         "stats"  : "stream-queue-stats",


### PR DESCRIPTION
The `stream` queue type configuration in `global.js` incorrectly pointed to `quorum-queue-user-policy-arguments` for its `user_policy_arguments` template.

This caused the "Queues [Quorum]" section to appear twice in the Policies management UI (once for actual Quorum queues, and once incorrectly for Stream queues).

This commit updates the configuration to use the correct `stream-queue-user-policy-arguments` template.

Before:
<img width="924" height="706" alt="Screenshot 2026-01-22 at 18 52 41" src="https://github.com/user-attachments/assets/1605ca75-62d2-4670-b0b8-597859957bd8" />

After:
<img width="918" height="635" alt="Screenshot 2026-01-22 at 18 53 07" src="https://github.com/user-attachments/assets/0ee6ee66-97bf-4510-9627-bde0f1ed4cf4" />
