### PR TITLE
Ignore unhandled queue actions

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -2139,12 +2139,11 @@ handle_queue_actions(Actions, State) ->
               S#state{outgoing_pending = queue:in(Action, Pending)};
           ({queue_down, QName}, #state{stashed_down = L} = S) ->
               S#state{stashed_down = [QName | L]};
-          ({Action, _QName}, S)
-            when Action =:= block orelse
-                 Action =:= unblock ->
-              %% Ignore since we rely on our own mechanism to detect if a client sends to fast
-              %% into a link: If the number of outstanding queue confirmations grows,
-              %% we won't grant new credits to publishers.
+          (_Action, S) ->
+              %% Ignore 'block' and 'unblock' queue actions since we rely on our
+              %% own mechanism to detect if a client sends to fast into a link:
+              %% If the number of outstanding queue confirmations grows, we won't
+              %% grant new credits to publishers.
               S
       end, State, Actions).
 

--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2803,6 +2803,8 @@ handle_queue_actions(Actions, State) ->
               S0;
          ({unblock, QName}, S0) ->
               credit_flow:unblock(QName),
+              S0;
+         (_Action, S0) ->
               S0
       end, State, Actions).
 

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -435,8 +435,7 @@ handle_event(QName, {down, Pid, Info}, #?STATE{monitored = Monitored,
             {ok, State#?STATE{unconfirmed = U},
              [{rejected, QName, down, MsgIds} | Actions0]}
     end;
-handle_event(_QName, Action, State)
-  when element(1, Action) =:= credit_reply ->
+handle_event(_QName, Action, State) ->
     {ok, State, [Action]}.
 
 supports_stateful_delivery() -> true.

--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -668,9 +668,6 @@ handle_ra_event(QName, Leader, {applied, Seqs},
 handle_ra_event(QName, From, {machine, Del}, State0)
       when element(1, Del) == delivery ->
     handle_delivery(QName, From, Del, State0);
-handle_ra_event(_QName, _From, {machine, Action}, State)
-  when element(1, Action) =:= credit_reply ->
-    {ok, State, [Action]};
 handle_ra_event(_QName, _, {machine, {queue_status, Status}},
                 #state{} = State) ->
     %% just set the queue status
@@ -727,7 +724,9 @@ handle_ra_event(QName, Leader, close_cached_segments,
              end
      end, []};
 handle_ra_event(_QName, _Leader, {machine, eol}, State) ->
-    {eol, [{unblock, cluster_name(State)}]}.
+    {eol, [{unblock, cluster_name(State)}]};
+handle_ra_event(_QName, _Leader, {machine, Action}, State) ->
+    {ok, State, [Action]}.
 
 -spec close(state()) -> ok.
 close(#state{cached_segments = undefined}) ->

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -259,9 +259,7 @@ handle_queue_actions(Actions, State0) ->
           ({queue_down, _QRef}, S0) ->
               %% target classic queue is down, but not deleted
               S0;
-          ({block, _QName}, S0) ->
-              S0;
-          ({unblock, _QName}, S0) ->
+          (_Action, S0) ->
               S0
       end, State0, Actions).
 

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -673,7 +673,9 @@ handle_event(_QName, {stream_local_member_change, Pid},
 handle_event(_QName, eol, #stream_client{name = Name}) ->
     {eol, [{unblock, Name}]};
 handle_event(QName, deleted_replica, State) ->
-    {ok, State, [{queue_down, QName}]}.
+    {ok, State, [{queue_down, QName}]};
+handle_event(_QName, Action, State) ->
+    {ok, State, [Action]}.
 
 is_recoverable(Q) ->
     Node = node(),

--- a/deps/rabbit/src/rabbit_volatile_queue.erl
+++ b/deps/rabbit/src/rabbit_volatile_queue.erl
@@ -252,7 +252,9 @@ handle_event(QName, {deliver, Msg}, #?STATE{name = QName,
 handle_event(QName, {deliver, _Msg}, #?STATE{name = QName,
                                              dropped = Dropped} = State) ->
     rabbit_global_counters:messages_dead_lettered(maxlen, ?MODULE, disabled, 1),
-    {ok, State#?STATE{dropped = Dropped + 1}, []}.
+    {ok, State#?STATE{dropped = Dropped + 1}, []};
+handle_event(_QName, Action, State) ->
+    {ok, State, [Action]}.
 
 deliver_actions(QName, Ctag, Mc) ->
     Msgs = [{QName, self(), undefined, _Redelivered = false, Mc}],

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -2081,7 +2081,9 @@ handle_queue_actions(Actions, #state{} = State0) ->
           ({unblock, QName}, S = #state{queues_soft_limit_exceeded = QSLE}) ->
               S#state{queues_soft_limit_exceeded = sets:del_element(QName, QSLE)};
           ({queue_down, QName}, S) ->
-              handle_queue_down(QName, S)
+              handle_queue_down(QName, S);
+          (_Action, S) ->
+              S
       end, State0, Actions).
 
 handle_queue_down(QName, State0 = #state{cfg = #cfg{client_id = ClientId}}) ->


### PR DESCRIPTION
 ## What?
Ignore any unhandled queue actions.

 ## Why?
This makes it easier to introduce new queue actions in the future in a backwards compatible way. For example, in the future, we might want to add queue actions that are only handled by some specific queue client (e.g. AMQP 1.0 session process).