### PR TITLE
Fix quorum queues rejecting messages during deletion

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -15,7 +15,8 @@
          list_for_source_and_destination/2, list_for_source_and_destination/3,
          list_explicit/0]).
 -export([new_deletions/0, combine_deletions/2, add_deletion/5,
-         process_deletions/1, notify_deletions/2, group_bindings_fold/3]).
+         process_deletions/1, notify_deletions/2, group_bindings_fold/3,
+         delete_for_destination/2]).
 -export([info_keys/0, info/1, info/2, info_all/1, info_all/2, info_all/4]).
 
 -export([reverse_binding/1]).
@@ -532,3 +533,11 @@ fetch_deletion(XName, Deletions) ->
         error ->
             error
     end.
+
+%% @doc This function is used to delete bindings before a quorum queue is deleted.
+%% It is to avoid bindings pointing to queues under deletion.
+-spec delete_for_destination(rabbit_types:binding_destination(), rabbit_types:username()) -> ok.
+delete_for_destination(QName, User) ->
+    Deletions = rabbit_db_binding:delete_for_destination(QName),
+    process_deletions(Deletions),
+    notify_deletions(Deletions, User).

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -873,6 +873,7 @@ delete(Q, _IfUnused, _IfEmpty, ActingUser) when ?amqqueue_is_quorum(Q) ->
     QNodes = get_nodes(Q),
     %% TODO Quorum queue needs to support consumer tracking for IfUnused
     Timeout = ?DELETE_TIMEOUT,
+    rabbit_binding:delete_for_destination(QName, ActingUser),
     {ok, ReadyMsgs, _} = stat(Q),
     Servers = [{Name, Node} || Node <- QNodes],
     case ra:delete_cluster(Servers, Timeout) of

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -78,6 +78,7 @@ groups() ->
                                             leadership_takeover,
                                             delete_declare,
                                             delete_member_during_node_down,
+                                            delete_while_publishing,
                                             metrics_cleanup_on_leadership_takeover,
                                             metrics_cleanup_on_leader_crash,
                                             consume_in_minority,
@@ -2734,6 +2735,39 @@ delete_declare0(Config) ->
     %% Ensure that is a new queue and it's empty
     wait_for_messages_ready(Servers, RaName, 0),
     wait_for_messages_pending_ack(Servers, RaName, 0).
+
+delete_while_publishing(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config,
+                                                                   nodename),
+
+    PublisherChan = rabbit_ct_client_helpers:open_channel(Config, Server),
+    DeleterChan = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(PublisherChan, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+
+    #'queue.bind_ok'{} = amqp_channel:call(
+                           PublisherChan, #'queue.bind'{queue = QQ,
+                                             exchange = <<"amq.fanout">>}),
+
+    #'confirm.select_ok'{} = amqp_channel:call(PublisherChan, #'confirm.select'{}),
+
+    spawn(fun() ->
+        timer:sleep(100),
+        delete_queues(DeleterChan, [QQ])
+    end),
+
+    [begin
+        ok = amqp_channel:cast(PublisherChan,
+                               #'basic.publish'{
+                                    exchange = <<"amq.fanout">>,
+                                    routing_key = QQ},
+                                #amqp_msg{payload = erlang:integer_to_binary(N)})
+    end || N <- lists:seq(1, 30000)],
+
+    % we should not receive a nack, all messages should be confirmed
+    ?assert(amqp_channel:wait_for_confirms_or_die(PublisherChan)).
 
 sync_queue(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
Hi,

Here is a proposal for the fix of #15334 as discussed. 

Let me know what you think.

## Proposed Changes

- implement a method to clear bindings before a queue is deleted
- leave the "after delete" procedure to make sure to clean up after deletion in case new bindings were created
- clear the bindings before the ra:delete_cluster call
- usage of default exchange may result in rejections

Fixes: #15334


Please describe the big picture of your changes here to communicate to the RabbitMQ team why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

A pull request that doesn't explain **why** the change was made has a much lower chance of being accepted.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #15334)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it
