### PR TITLE
rabbit_shovel_behavior: correct callback type specs

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_behaviour.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_behaviour.erl
@@ -69,8 +69,8 @@
 -callback parse_source(definition()) -> {source_config(), Headers :: proplists:proplist()}.
 -callback parse_dest({VHost :: binary(), Name :: binary()}, ClusterName :: atom(), definition(), Headers :: proplists:proplist()) -> dest_config().
 
--callback validate_src(definition()) -> [ok | {error, Reason :: string()}].
--callback validate_dest(definition()) -> [ok | {error, Reason :: string()}].
+-callback validate_src(definition()) -> [ok | {error, Format :: string(), Args :: list()}].
+-callback validate_dest(definition()) -> [ok | {error, Format :: string(), Args :: list()}].
 
 -callback validate_src_funs(definition(), User :: binary()) ->
     [{Tag :: binary(), fun((Name :: atom(), Value :: term()) -> ok | {error, string()}), mandatory()}].


### PR DESCRIPTION
They had an incorrect return value in the signature, as proven by

 * `rabbit_runtime_parameters:set/5`
 * `rabbit_shovel_parameters:validate/5`

plus the values actually returned in the behavior implementations:

 * [`rabbit_amqp091_shovel`](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_shovel/src/rabbit_amqp091_shovel.erl#L205-L210)
 * [`rabbit_amqp10_shovel`](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl#L136)
 * [`rabbit_local_shovel`](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl#L199-L204)

that return 3-tuples that include a format string and an argument list.