### PR TITLE
Management UI: use direct path for HTTP API documentation link

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/layout.ejs
@@ -43,7 +43,7 @@
 <div id="main"></div>
 <div id="footer">
   <ul>
-    <li><a rel="noopener noreferrer" href="api/" target="_blank">HTTP API</a></li>
+    <li><a rel="noopener noreferrer" href="api/index.html" target="_blank">HTTP API</a></li>
     <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/docs" target="_blank">Documentation</a></li>
     <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/tutorials" target="_blank">Tutorials</a></li>
     <li><a rel="noopener noreferrer" href="https://www.rabbitmq.com/release-information" target="_blank">New releases</a></li>


### PR DESCRIPTION
## Proposed Changes

This change updates the HTTP API documentation link in the management UI footer from `api/` to `api/index.html`.

Previously, clicking the "HTTP API" link would trigger a server-side redirect from `/api` to `/api/index.html`. By using the direct path, we avoid this unnecessary redirect and slightly improve the user experience.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it



