### PR TITLE
rabbit_osiris_metrics: Use committed_offset counter

### DIFF
--- a/deps/rabbit/src/rabbit_osiris_metrics.erl
+++ b/deps/rabbit/src/rabbit_osiris_metrics.erl
@@ -57,10 +57,10 @@ handle_cast(_Request, State) ->
 handle_info(tick, #state{timeout = Timeout} = State) ->
     Data = osiris_counters:overview(),
     _ = maps:map(
-      fun ({osiris_writer, QName}, #{offset := Offs,
+      fun ({osiris_writer, QName}, #{committed_offset := COffs,
                                      first_offset := FstOffs}) ->
-              COffs = Offs + 1 - FstOffs,
-              rabbit_core_metrics:queue_stats(QName, COffs, 0, COffs, 0),
+              Offsets = COffs + 1 - FstOffs,
+              rabbit_core_metrics:queue_stats(QName, Offsets, 0, Offsets, 0),
               Infos = try
                           %% TODO complete stats!
                           case rabbit_amqqueue:lookup(QName) of


### PR DESCRIPTION
This change uses the committed offset as the last offset in the calculation of available offsets rather than the last-written offset. Stream readers can't access tail data until it becomes committed so this is a more accurate count for "ready" messages.

This is meant to extend https://github.com/rabbitmq/rabbitmq-server/pull/15225 so it's for v4.3.x only.