### PR TITLE
rabbitmq_cli: change tmpdir to rabbitmq_cli/logs for background node

### DIFF
--- a/deps/rabbitmq_cli/Makefile
+++ b/deps/rabbitmq_cli/Makefile
@@ -119,6 +119,7 @@ tests:: escript test-deps
 	$(verbose) $(MAKE) -C ../../ install-cli
 	$(verbose) $(MAKE) -C ../../ start-background-broker \
 		ENABLED_PLUGINS="rabbitmq_federation rabbitmq_stomp rabbitmq_stream_management amqp_client" \
+                TMPDIR=$(PWD)/deps/rabbitmq_cli/logs \
 		$(if $(filter khepri,$(RABBITMQ_METADATA_STORE)),,RABBITMQ_FEATURE_FLAGS="-khepri_db"); \
 		rm -f logs; \
 		log_dir=$$(../../sbin/rabbitmqctl eval 'io:format("~s~n", [maps:get(log_base_dir,rabbit_prelaunch:get_context())]).'); \


### PR DESCRIPTION
This allows CI to collect logs as for any other plugin
Also all test changes are contained inside the plugin directory

