### PR TITLE
Management UI: Add autocomplete, autofocus and label linking to input at login page.

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/login.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/login.ejs
@@ -5,12 +5,12 @@
     <div id="login-status"></div>
     <table class="form">
       <tr>
-        <th><label>Username:</label></th>
-        <td><input type="text" name="username"/><span class="mand">*</span></td>
+        <th><label for="username">Username:</label></th>
+        <td><input id="username" type="text" name="username" autofocus autocomplete="username"/><span class="mand">*</span></td>
       </tr>
       <tr>
-        <th><label>Password:</label></th>
-        <td><input type="password" name="password"/><span class="mand">*</span></td>
+        <th><label for="password">Password:</label></th>
+        <td><input id="password" type="password" name="password" autocomplete="current-password"/><span class="mand">*</span></td>
       </tr>
       <tr>
         <th>&nbsp;</th>


### PR DESCRIPTION
## Proposed Changes

The only purpose of the login page is to put login as password thus first action is to get username focus. This PR adds auto focus to this input. Also as a side effect updates the autocomplete attributes and adds ids to inputs to link labels properly to input, which makes label clickable to focus the input also (just minor tweak).

UI should be visually 100% the same.