### PR TITLE
rabbit_quorum_queue:stat/2 use find_leader/1

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -1168,17 +1168,16 @@ stat(Q) when ?is_amqqueue(Q) ->
 -spec stat(amqqueue:amqqueue(), non_neg_integer()) -> {'ok', non_neg_integer(), non_neg_integer()}.
 
 stat(Q, Timeout) when ?is_amqqueue(Q) ->
-    Leader = amqqueue:get_pid(Q),
     try
-        case rabbit_fifo_client:stat(Leader, Timeout) of
-          {ok, _, _} = Success -> Success;
-          {error, _}           -> {ok, 0, 0};
-          {timeout, _}         -> {ok, 0, 0}
+        maybe
+            Leader ?= find_leader(Q),
+            {ok, _, _} = Result ?= rabbit_fifo_client:stat(Leader, Timeout),
+            Result
+        else
+            _ -> {ok, 0, 0}
         end
     catch
-        _:_ ->
-            %% Leader is not available, cluster might be in minority
-            {ok, 0, 0}
+        _:_ -> {ok, 0, 0}
     end.
 
 -spec purge(amqqueue:amqqueue()) ->

--- a/deps/rabbit/test/dynamic_qq_SUITE.erl
+++ b/deps/rabbit/test/dynamic_qq_SUITE.erl
@@ -176,12 +176,18 @@ takeover_on(Config, Fun) ->
                                 arguments = Args,
                                 durable = true}),
     ok = rabbit_ct_broker_helpers:start_node(Config, A),
-    ACh2 = rabbit_ct_client_helpers:open_channel(Config, A),
-    #'queue.declare_ok'{message_count = 10} =
-        amqp_channel:call(
-          ACh2, #'queue.declare'{queue   = QName,
-                                 arguments = Args,
-                                 durable = true}),
+
+    ?awaitMatch(
+       #'queue.declare_ok'{message_count = 10},
+       begin
+           ACh2 = rabbit_ct_client_helpers:open_channel(Config, A),
+           amqp_channel:call(
+             ACh2, #'queue.declare'{queue   = QName,
+                                    arguments = Args,
+                                    durable = true,
+                                    passive = true})
+       end,
+       60000),
     ok.
 
 quorum_unaffected_after_vhost_failure(Config) ->


### PR DESCRIPTION
This should deflake:
make -C deps/rabbit ct-dynamic_qq t=cluster_size_3:takeover_on_failure
