### PR TITLE
Introduce `rabbitmq-upgrade has_reached_target_cluster_size`

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/has_reached_target_cluster_size_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/upgrade/commands/has_reached_target_cluster_size_command.ex
@@ -1,0 +1,117 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Upgrade.Commands.HasReachedTargetClusterSizeCommand do
+  @moduledoc """
+  Exits with a non-zero code if the node has not yet reached
+  its target cluster size.
+
+  The default target cluster size is 1. Users of this health check
+  are expected to override it to the desired value using
+  `cluster_formation.target_cluster_size_hint` in `rabbitmq.conf`.
+
+  This command is meant to be used by automation tooling during
+  rolling upgrades but can also double as a health check.
+  """
+
+  alias RabbitMQ.CLI.Core.DocGuide
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:ctl, :diagnostics, :upgrade]
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :reached_target_cluster_size, [], timeout) do
+      true ->
+        true
+
+      false ->
+        online = :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :running_count, [], timeout)
+        target = :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :target_cluster_size_hint, [], timeout)
+
+        case {online, target} do
+          {o, t} when is_integer(o) and is_integer(t) ->
+            {false, o, t}
+
+          _ ->
+            false
+        end
+
+      {:badrpc, _} = err ->
+        err
+    end
+  end
+
+  def output(true, %{silent: true}) do
+    {:ok, :check_passed}
+  end
+
+  def output(true, %{formatter: "json"}) do
+    {:ok, %{"result" => "ok"}}
+  end
+
+  def output(true, %{node: node_name}) do
+    {:ok, "Target cluster size has been reached on node #{node_name}"}
+  end
+
+  def output({false, online, target}, %{silent: true})
+      when is_integer(online) and is_integer(target) do
+    {:error, :check_failed}
+  end
+
+  def output({false, online, target}, %{node: node_name, formatter: "json"})
+      when is_integer(online) and is_integer(target) do
+    {:error, :check_failed,
+     %{
+       "result" => "error",
+       "message" =>
+         "Target cluster size on node #{node_name} has not been reached: #{online} of #{target} nodes are online",
+       "online" => online,
+       "target" => target
+     }}
+  end
+
+  def output({false, online, target}, %{node: node_name})
+      when is_integer(online) and is_integer(target) do
+    {:error,
+     "Target cluster size on node #{node_name} has not been reached: #{online} of #{target} nodes are online"}
+  end
+
+  def output(false, %{silent: true}) do
+    {:error, :check_failed}
+  end
+
+  def output(false, %{node: node_name}) do
+    {:error,
+     "Target cluster size on node #{node_name} has not been reached"}
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "has_reached_target_cluster_size"
+
+  def usage_doc_guides() do
+    [
+      DocGuide.upgrade(),
+      DocGuide.cluster_formation()
+    ]
+  end
+
+  def help_section(), do: :upgrade
+
+  def description(),
+    do:
+      "Health check that exits with a non-zero code if the cluster has not yet reached its target size"
+
+  def banner([], %{node: node_name}) do
+    "Checking if target cluster size has been reached on node #{node_name} ..."
+  end
+end

--- a/deps/rabbitmq_cli/test/diagnostics/has_reached_target_cluster_size_command_test.exs
+++ b/deps/rabbitmq_cli/test/diagnostics/has_reached_target_cluster_size_command_test.exs
@@ -1,0 +1,50 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule DiagnosticsHasReachedTargetClusterSizeCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Upgrade.Commands.HasReachedTargetClusterSizeCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "scopes include diagnostics" do
+    assert Enum.member?(@command.scopes(), :diagnostics)
+  end
+
+  test "scopes include upgrade" do
+    assert Enum.member?(@command.scopes(), :upgrade)
+  end
+
+  test "scopes include ctl" do
+    assert Enum.member?(@command.scopes(), :ctl)
+  end
+
+  test "run: returns true on a running single node", context do
+    await_rabbitmq_startup()
+
+    assert @command.run([], context[:opts]) == true
+  end
+end

--- a/deps/rabbitmq_cli/test/upgrade/has_reached_target_cluster_size_command_test.exs
+++ b/deps/rabbitmq_cli/test/upgrade/has_reached_target_cluster_size_command_test.exs
@@ -1,0 +1,70 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+##
+## Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.  All rights reserved.
+
+defmodule HasReachedTargetClusterSizeCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Upgrade.Commands.HasReachedTargetClusterSizeCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok,
+     opts: %{
+       node: get_rabbit_hostname(),
+       timeout: context[:test_timeout] || 30000
+     }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?(
+             {:badrpc, _},
+             @command.run([], Map.merge(context[:opts], %{node: :jake@thedog}))
+           )
+  end
+
+  test "run: returns true on a running single node (default target size is 1)", context do
+    await_rabbitmq_startup()
+
+    assert @command.run([], context[:opts]) == true
+  end
+
+  test "output: when the result is true, returns successfully", context do
+    assert match?({:ok, _}, @command.output(true, context[:opts]))
+  end
+
+  test "output: when the result is false with counts, returns an error", context do
+    assert match?({:error, _}, @command.output({false, 2, 5}, context[:opts]))
+  end
+
+  test "output: when the result is false without counts, returns an error", context do
+    assert match?({:error, _}, @command.output(false, context[:opts]))
+  end
+end

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -211,6 +211,7 @@ dispatcher() ->
      {"/health/checks/is-in-service",                          rabbit_mgmt_wm_health_check_is_in_service, []},
      {"/health/checks/below-node-connection-limit",            rabbit_mgmt_wm_health_check_below_node_connection_limit, []},
      {"/health/checks/ready-to-serve-clients",                 rabbit_mgmt_wm_health_check_ready_to_serve_clients, []},
+     {"/health/checks/reached-target-cluster-size",            rabbit_mgmt_wm_health_check_reached_target_cluster_size, []},
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
      {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance_queues, [{queues, all}]},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_reached_target_cluster_size.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_reached_target_cluster_size.erl
@@ -1,0 +1,49 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_mgmt_wm_health_check_reached_target_cluster_size).
+
+-export([init/2]).
+-export([to_json/2, content_types_provided/2]).
+-export([variances/2]).
+
+-include("rabbit_mgmt.hrl").
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+
+init(Req, _State) ->
+    Req1 = rabbit_mgmt_headers:set_no_cache_headers(
+             rabbit_mgmt_headers:set_common_permission_headers(
+               Req, ?MODULE), ?MODULE),
+    {cowboy_rest, Req1, #context{}}.
+
+variances(Req, Context) ->
+    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
+
+content_types_provided(ReqData, Context) ->
+   {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
+
+to_json(ReqData, Context) ->
+    case rabbit_nodes:reached_target_cluster_size() of
+        true ->
+            rabbit_mgmt_util:reply(#{status => ok}, ReqData, Context);
+        false ->
+            Online = rabbit_nodes:running_count(),
+            Target = rabbit_nodes:target_cluster_size_hint(),
+            Msg = io_lib:format("target cluster size not reached: ~b of ~b nodes are online",
+                                [Online, Target]),
+            failure(Msg, Online, Target, ReqData, Context)
+    end.
+
+failure(Message, Online, Target, ReqData, Context) ->
+    Body = #{
+        status => failed,
+        reason => rabbit_data_coercion:to_binary(Message),
+        online => Online,
+        target => Target
+    },
+    {Response, ReqData1, Context1} = rabbit_mgmt_util:reply(Body, ReqData, Context),
+    {stop, cowboy_req:reply(?HEALTH_CHECK_FAILURE_STATUS, #{}, Response, ReqData1), Context1}.


### PR DESCRIPTION
aliased as `rabbitmq-diagnostics has_reached_target_cluster_size`.

References rabbitmq/cluster-operator#2016.
