### PR TITLE
Report TLS in Erlang distribution in the CLI

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/listeners.ex
@@ -270,6 +270,7 @@ defmodule RabbitMQ.CLI.Core.Listeners do
   def protocol_label(:"http/prometheus"), do: "Prometheus exporter API over HTTP"
   def protocol_label(:"https/prometheus"), do: "Prometheus exporter API over TLS (HTTPS)"
   def protocol_label(:clustering), do: "inter-node and CLI tool communication"
+  def protocol_label(:"clustering/ssl"), do: "inter-node and CLI tool communication over TLS"
   def protocol_label(other), do: to_string(other)
 
   def normalize_protocol(proto) do
@@ -315,6 +316,10 @@ defmodule RabbitMQ.CLI.Core.Listeners do
       "ui" -> "http"
       "cli" -> "clustering"
       "distribution" -> "clustering"
+      "cli/ssl" -> "clustering/ssl"
+      "cli/tls" -> "clustering/ssl"
+      "distribution/ssl" -> "clustering/ssl"
+      "distribution/tls" -> "clustering/ssl"
       "webmqtt" -> "http/web-mqtt"
       "web-mqtt" -> "http/web-mqtt"
       "web_mqtt" -> "http/web-mqtt"

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_health_check_protocol_listener.erl
@@ -109,6 +109,10 @@ normalize_protocol(Protocol) ->
         "ui" -> "http";
         "cli" -> "clustering";
         "distribution" -> "clustering";
+        "cli/ssl" -> "clustering/ssl";
+        "cli/tls" -> "clustering/ssl";
+        "distribution/ssl" -> "clustering/ssl";
+        "distribution/tls" -> "clustering/ssl";
         "webmqtt" -> "http/web-mqtt";
         "web-mqtt" -> "http/web-mqtt";
         "web_mqtt" -> "http/web-mqtt";


### PR DESCRIPTION
follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/15399

the initial PR solved the problem for the Management UI and API, but we also report listeners in the CLI. This change addresses this part.