### PR TITLE
shovel: Ignore not_found when deleting a child

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -99,7 +99,10 @@ stop_child({VHost, ShovelName} = Name) ->
 stop_and_delete_child(Id) ->
     case mirrored_supervisor:terminate_child(?SUPERVISOR, Id) of
         ok ->
-            ok = mirrored_supervisor:delete_child(?SUPERVISOR, Id);
+            case mirrored_supervisor:delete_child(?SUPERVISOR, Id) of
+                ok -> ok;
+                {error, not_found} -> ok
+            end;
         {error, not_found} = Error ->
             Error
     end.


### PR DESCRIPTION
Should resolve CI failures with this error
```
=== === Reason: {exception,
                     {badmatch,{error,not_found}},
                     [{rabbit_shovel_dyn_worker_sup_sup,
                          stop_and_delete_child,1,
                          [{file,"src/rabbit_shovel_dyn_worker_sup_sup.erl"},
                           {line,102}]},
                      {rabbit_shovel_dyn_worker_sup_sup,stop_child,1,
                          [{file,"src/rabbit_shovel_dyn_worker_sup_sup.erl"},
                           {line,87}]},
                      {rabbit_shovel_parameters,notify_clear,4,
                          [{file,"src/rabbit_shovel_parameters.erl"},
                           {line,74}]},
                      {rabbit_runtime_parameters,clear,4,[]}]}
```