### PR TITLE
Show oldest stream message timestamp in management UI

### DIFF
--- a/deps/rabbit/src/rabbit_osiris_metrics.erl
+++ b/deps/rabbit/src/rabbit_osiris_metrics.erl
@@ -28,7 +28,8 @@
          memory,
          readers,
          consumers,
-         segments
+         segments,
+         first_timestamp
         ]).
 
 -record(state, {timeout :: non_neg_integer()}).

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -75,7 +75,7 @@
 -define(INFO_KEYS, [name, durable, auto_delete, arguments, leader, members, online, state,
                     messages, messages_ready, messages_unacknowledged, committed_offset,
                     policy, operator_policy, effective_policy_definition, type, memory,
-                    consumers, segments, committed_chunk_id]).
+                    consumers, segments, committed_chunk_id, first_timestamp]).
 
 -define(UNMATCHED_THRESHOLD, 200).
 
@@ -818,6 +818,14 @@ i(committed_chunk_id = F, Q) ->
             ''
     end;
 i(segments = F, Q) ->
+    Key = {osiris_writer, amqqueue:get_name(Q)},
+    case osiris_counters:counters(Key, [F]) of
+        #{F := V} ->
+            V;
+        _ ->
+            ''
+    end;
+i(first_timestamp = F, Q) ->
     Key = {osiris_writer, amqqueue:get_name(Q)},
     case osiris_counters:counters(Key, [F]) of
         #{F := V} ->

--- a/deps/rabbitmq_management/priv/www/js/formatters.js
+++ b/deps/rabbitmq_management/priv/www/js/formatters.js
@@ -92,10 +92,16 @@ function fmt_date0(d) {
 }
 
 function fmt_timestamp(ts) {
+    if (ts == undefined) {
+        return UNKNOWN_REPR;
+    }
     return fmt_date(new Date(ts));
 }
 
 function fmt_timestamp_mini(ts) {
+    if (ts == undefined) {
+        return UNKNOWN_REPR;
+    }
     return fmt_date_mini(new Date(ts));
 }
 

--- a/deps/rabbitmq_management/priv/www/js/tmpl/stream-queue-stats.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/stream-queue-stats.ejs
@@ -28,6 +28,10 @@
         <th>Segments</th>
         <td><%= fmt_string(queue.segments) %></td>
       </tr>
+      <tr>
+        <th>Oldest message</th>
+        <td><%= fmt_timestamp_mini(queue.first_timestamp) %></td>
+      </tr>
     </table>
 
     <table class="facts">


### PR DESCRIPTION
This change shows the `first_timestamp` counter's value as a detail in the management UI as a formatted timestamp. This is somewhat useful for attaching offset listeners by timestamp - you know the oldest timestamp in the stream you can start from.

<details><summary>Example...</summary>

<img width="1322" height="718" alt="oldest-message" src="https://github.com/user-attachments/assets/f7a2682f-b224-41c8-88c8-9a2f89dd37ac" />

</details>