### PR TITLE
Fix observer_cli plugin error for classic queues

### DIFF
--- a/deps/rabbit/src/rabbit_observer_cli_classic_queues.erl
+++ b/deps/rabbit/src/rabbit_observer_cli_classic_queues.erl
@@ -80,8 +80,8 @@ sheet_body(State) ->
                         [
                             Pid, Vhost, Name,
                             format_int(MsgQ + GS2Q), format_int(MsgQ), format_int(GS2Q),
-                            proplists:get_value(q3, BQInfo),
-                            element(3, proplists:get_value(delta, BQInfo)),
+                            proplists:get_value(q_head, BQInfo),
+                            element(3, proplists:get_value(q_tail, BQInfo)),
                             proplists:get_value(num_pending_acks, BQInfo),
                             proplists:get_value(num_unconfirmed, BQInfo),
                             proplists:get_value(qi_buffer_size, BQInfo, 0),


### PR DESCRIPTION
The CQv1 removal in #14769 renamed the backing_queue_status keys from q3/delta to q_head/q_tail, but the observer_cli plugin was not updated. Looking up the old keys returned undefined, causing a badarg error making the CQ observer CLI plugin unusable:

```
Error in process <0.536.0> on node rabbit with exit value:
{badarg,
    [{erlang,element,
         [3,undefined],
         [{error_info,#{module => erl_erts_errors}}]},
     {rabbit_observer_cli_classic_queues,'-sheet_body/1-lc$^0/1-0-',1,
         [{file,"rabbit_observer_cli_classic_queues.erl"},{line,86}]},
     {rabbit_observer_cli_classic_queues,sheet_body,1,
         [{file,"rabbit_observer_cli_classic_queues.erl"},{line,95}]},
     {observer_cli_plugin,render_sheet_body,8,
         [{file,"src/observer_cli_plugin.erl"},{line,348}]},
     {observer_cli_plugin,render_sheet,4,
         [{file,"src/observer_cli_plugin.erl"},{line,307}]},
     {observer_cli_plugin,render_worker,6,
         [{file,"src/observer_cli_plugin.erl"},{line,197}]}]}
```