### PR TITLE
amqp10 mock_server: reuseaddr

### DIFF
--- a/deps/amqp10_client/test/mock_server.erl
+++ b/deps/amqp10_client/test/mock_server.erl
@@ -19,7 +19,10 @@
 -include("src/amqp10_client_internal.hrl").
 
 start(Port) ->
-    {ok, LSock} = gen_tcp:listen(Port, [binary, {packet, 0}, {active, false}]),
+    {ok, LSock} = gen_tcp:listen(Port, [binary,
+                                        {packet, 0},
+                                        {active, false},
+                                        {reuseaddr, true}]),
     Pid = spawn(?MODULE, run, [LSock]),
     {LSock, Pid}.
 


### PR DESCRIPTION
To avoid tests failing if the port was not released by the OS between the tests.

Example failure:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/21824670111/job/62966399172

Looks like the failures started after we switched to `peer` to run broker in tests - since `peer` starts/stops nodes faster, it's more likely we'll start the mock server before the port is released after the previous test. Therefore, I don't think we need to backport this.