### PR TITLE
Force tracing plugin to use UTF-8 encoding instead of default Latin1.

### DIFF
--- a/deps/rabbitmq_tracing/src/rabbit_tracing_consumer.erl
+++ b/deps/rabbitmq_tracing/src/rabbit_tracing_consumer.erl
@@ -194,7 +194,7 @@ log(text, Record, State) ->
             RQs  -> [RQs]
         end ++
         [Record#log_record.properties, Record#log_record.payload],
-    print_log(io_lib:format(Fmt, Args), State);
+    print_log(unicode:characters_to_binary(io_lib:format(Fmt, Args)), State);
 
 log(json, Record, State) ->
     _ = print_log([rabbit_json:encode(


### PR DESCRIPTION
Entire trace record will be rejected if payload contains any non-Latin1 character, which leads to missed trace records despite of successful processing of the messages themselves.

## Proposed Changes
Tracing is used to monitor message exchange, and it is really unclear why the system works but specific messages are not presented in the trace files.

The entire project works fine with UTF-8 encoded payload, including official Docker images preconfigured to use UTF-8 as a system wide locale, so it is obvious to use UTF-8 encoding by default in the tracing plugin,

Additional options (like drop down list with encodings to use by tracing plugin) were not implemented  as it is not tracing plugin feature, but a missing of support in the tracing plugin of the specified encoding, despite it is used by server itself.

No related issues were found.

No unit tests were implemented for this change.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix ~(non-breaking change which fixes issue #NNNN)~
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

It is a retry for PR #15133
CLA **is** signed.