### PR TITLE
Clarify ENABLED_PLUGINS behavior for run-broker and start-cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,19 @@ will run the older version.
 ``` shell
 # Run from repository root.
 # Starts a node with management and two stream plugins enabled
-gmake run-broker ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management"
+gmake ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" run-broker
 ```
+
+**Note:** The `ENABLED_PLUGINS` variable only takes effect when starting a fresh node. On subsequent restarts, RabbitMQ preserves the enabled_plugins file, ignoring the `ENABLED_PLUGINS` value. To change the plugin list on restart, do one of the following:
+* Add the `virgin-test-tmpdir` target (this will delete all data!):
+    ```
+    gmake ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" virgin-test-tmpdir run-broker
+    ```
+* Delete the `enabled_plugins` file:
+    ```
+    rm /tmp/rabbitmq-test-instances/rabbit@*/enabled_plugins`
+    ```
+* Use the `./sbin/rabbitmq-plugins enable/disable` commands.
 
 The nodes will be started in the background. They will use `rabbit@{hostname}` for its name, so CLI will be able to contact
 it without an explicit `-n` (`--node`) argument:
@@ -126,7 +137,7 @@ it without an explicit `-n` (`--node`) argument:
 ``` shell
 # Run from repository root.
 # Starts a three node cluster with management and two stream plugins enabled
-gmake start-cluster NODES=3 ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management"
+gmake NODES=3 ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" start-cluster
 ```
 
 The node will use `rabbit-{n}@{hostname}` for names, so CLI must
@@ -168,7 +179,7 @@ When working on management UI code, besides starting the node with
 
 ``` shell
 # starts a node with management and two stream plugins enabled
-gmake run-broker ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management"
+gmake ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" run-broker
 ```
 
 (or any other set of plugins), it is highly recommended to use [BrowserSync](https://browsersync.io/#install)

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,15 @@ endif
 
 # Plugins to enable for `gmake run-broker`, `gmake start-cluster`, etc.
 # To override:
-#     gmake run-broker ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream"
-#     gmake start-cluster NODES=3 ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management"
+#     gmake ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream" run-broker
+#     gmake NODES=3 ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream rabbitmq_stream_management" start-cluster
+#
+# Note: ENABLED_PLUGINS only takes effect on first start. On subsequent starts,
+# the enabled_plugins file is preserved. To change plugins on restart, either:
+#   - Add the `virgin-test-tmpdir` target to gmake:
+#         gmake ENABLED_PLUGINS="rabbitmq_management rabbitmq_stream" virgin-test-tmpdir run-broker
+#   - Delete the enabled_plugins file: rm /tmp/rabbitmq-test-instances/rabbit@*/enabled_plugins
+#   - Use rabbitmq-plugins: ./sbin/rabbitmq-plugins enable <plugin>
 ENABLED_PLUGINS ?= rabbitmq_management
 RABBITMQ_ENABLED_PLUGINS ?= $(call comma_list,$(ENABLED_PLUGINS))
 # This is necessary for the recursively called targets


### PR DESCRIPTION
Following changes in PR #15072 and PR #15357, the ENABLED_PLUGINS variable now only takes effect when starting a fresh node. On subsequent restarts, RabbitMQ preserves the enabled_plugins file, ignoring the ENABLED_PLUGINS value passed to make.

This behavior change ensures that plugins enabled via rabbitmq-plugins CLI persist across restarts, which is the expected RabbitMQ behavior. However, it can be confusing for contributors (like me!) who expect ENABLED_PLUGINS to always override the plugin list.

This change adds documentation to both the Makefile and CONTRIBUTING.md explaining the new behavior and providing two methods to change plugins on restart: deleting the enabled_plugins file or using the rabbitmq-plugins CLI commands.

The enabled_plugins file location is $TEST_TMPDIR/rabbit@*/enabled_plugins, which defaults to /tmp/rabbitmq-test-instances/rabbit@*/enabled_plugins.