### PR TITLE
4.3: Mark queue_master_locator as denied_by_default

### DIFF
--- a/deps/rabbit/src/rabbit_queue_location.erl
+++ b/deps/rabbit/src/rabbit_queue_location.erl
@@ -24,7 +24,7 @@
 
 -rabbit_deprecated_feature(
    {queue_master_locator,
-    #{deprecation_phase => permitted_by_default,
+    #{deprecation_phase => denied_by_default,
       messages =>
       #{when_permitted =>
         "queue-master-locator is deprecated. "

--- a/deps/rabbit/test/classic_queue_SUITE.erl
+++ b/deps/rabbit/test/classic_queue_SUITE.erl
@@ -41,8 +41,13 @@ groups() ->
 %% Testsuite setup/teardown.
 %% -------------------------------------------------------------------
 
-init_per_suite(Config) ->
+init_per_suite(Config0) ->
     rabbit_ct_helpers:log_environment(),
+    %% Remove when queue_master_locator is removed entirely.
+    Config = rabbit_ct_helpers:merge_app_env(
+                Config0,
+                {rabbit,
+                 [{permit_deprecated_features, #{queue_master_locator => true}}]}),
     rabbit_ct_helpers:run_setup_steps(Config, []).
 
 end_per_suite(Config) ->

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -95,7 +95,11 @@ groups() ->
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
     inets:start(),
-    Config.
+    %% Remove when queue_master_locator is removed entirely.
+    rabbit_ct_helpers:merge_app_env(
+                Config,
+                {rabbit,
+                 [{permit_deprecated_features, #{queue_master_locator => true}}]}).
 end_per_suite(Config) ->
     Config.
 

--- a/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
+++ b/deps/rabbit/test/rabbitmq_4_0_deprecations_SUITE.erl
@@ -31,8 +31,8 @@
          when_transient_nonexcl_is_permitted_by_default/1,
          when_transient_nonexcl_is_not_permitted_from_conf/1,
 
-         when_queue_master_locator_is_permitted_by_default/1,
-         when_queue_master_locator_is_not_permitted_from_conf/1
+         when_queue_master_locator_is_permitted_from_conf/1,
+         when_queue_master_locator_is_not_permitted_by_default/1
         ]).
 
 suite() ->
@@ -58,8 +58,8 @@ groups() ->
       [when_transient_nonexcl_is_permitted_by_default,
        when_transient_nonexcl_is_not_permitted_from_conf]},
      {queue_master_locator, [],
-      [when_queue_master_locator_is_permitted_by_default,
-       when_queue_master_locator_is_not_permitted_from_conf]}
+      [when_queue_master_locator_is_permitted_from_conf,
+       when_queue_master_locator_is_not_permitted_by_default]}
     ].
 
 %% -------------------------------------------------------------------
@@ -110,12 +110,12 @@ init_per_testcase(
                    #{transient_nonexcl_queues => false}}]}),
     init_per_testcase1(Testcase, Config1);
 init_per_testcase(
-    when_queue_master_locator_is_not_permitted_from_conf = Testcase, Config) ->
+    when_queue_master_locator_is_permitted_from_conf = Testcase, Config) ->
     Config1 = rabbit_ct_helpers:merge_app_env(
                 Config,
                 {rabbit,
                  [{permit_deprecated_features,
-                   #{queue_master_locator => false}}]}),
+                   #{queue_master_locator => true}}]}),
     init_per_testcase1(Testcase, Config1);
 init_per_testcase(Testcase, Config) ->
     init_per_testcase1(Testcase, Config).
@@ -278,7 +278,7 @@ when_transient_nonexcl_is_not_permitted_from_conf(Config) ->
 %% (x-)queue-master-locator
 %% -------------------------------------------------------------------
 
-when_queue_master_locator_is_permitted_by_default(Config) ->
+when_queue_master_locator_is_permitted_from_conf(Config) ->
     [NodeA] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, NodeA),
@@ -301,7 +301,7 @@ when_queue_master_locator_is_permitted_by_default(Config) ->
          Config, NodeA,
          ["Deprecated features: `queue_master_locator`: queue-master-locator is deprecated"])).
 
-when_queue_master_locator_is_not_permitted_from_conf(Config) ->
+when_queue_master_locator_is_not_permitted_by_default(Config) ->
     [NodeA] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
 
     Ch = rabbit_ct_client_helpers:open_channel(Config, NodeA),
@@ -329,7 +329,7 @@ when_queue_master_locator_is_not_permitted_from_conf(Config) ->
        log_file_contains_message(
          Config, NodeA,
          ["Deprecated features: `queue_master_locator`: Feature `queue_master_locator` is deprecated",
-          "Its use is not permitted per the configuration"])).
+          "By default, this feature is not permitted anymore"])).
 
 %% -------------------------------------------------------------------
 %% Helpers.

--- a/deps/rabbitmq_cli/test/ctl/set_policy_command_test.exs
+++ b/deps/rabbitmq_cli/test/ctl/set_policy_command_test.exs
@@ -163,9 +163,9 @@ defmodule SetPolicyCommandTest do
   test "queue master locator policy validation", context do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
     context = Map.put(context, :opts, vhost_opts)
-    pass_validation(context, "{\"queue-master-locator\":\"min-masters\"}")
-    pass_validation(context, "{\"queue-master-locator\":\"client-local\"}")
-    pass_validation(context, "{\"queue-master-locator\":\"random\"}")
+    fail_validation(context, "{\"queue-master-locator\":\"min-masters\"}")
+    fail_validation(context, "{\"queue-master-locator\":\"client-local\"}")
+    fail_validation(context, "{\"queue-master-locator\":\"random\"}")
     fail_validation(context, "{\"queue-master-locator\":\"made_up\"}")
   end
 

--- a/deps/rabbitmq_sharding/test/rabbit_sharding_SUITE.erl
+++ b/deps/rabbitmq_sharding/test/rabbit_sharding_SUITE.erl
@@ -44,9 +44,14 @@ groups() ->
 %% Test suite setup/teardown.
 %% -------------------------------------------------------------------
 
-init_per_suite(Config) ->
+init_per_suite(Config0) ->
     inets:start(),
     rabbit_ct_helpers:log_environment(),
+    %% Remove when queue_master_locator is removed entirely.
+    Config = rabbit_ct_helpers:merge_app_env(
+                Config0,
+                {rabbit,
+                 [{permit_deprecated_features, #{queue_master_locator => true}}]}),
     Config1 = rabbit_ct_helpers:set_config(Config, [
         {rmq_nodename_suffix, ?MODULE},
         {rmq_nodes_count,     2}


### PR DESCRIPTION
Use [`queue_leader_locator`](https://www.rabbitmq.com/docs/quorum-queues#leader-placement), the modern name that's been available for a few years now.