### PR TITLE
HTTP API: report crypto lib version

### DIFF
--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -60,7 +60,7 @@
 -export([os_cmd/1, pwsh_cmd/1, win32_cmd/2]).
 -export([is_os_process_alive/1]).
 -export([version/0, otp_release/0, platform_and_version/0, otp_system_version/0,
-         rabbitmq_and_erlang_versions/0, which_applications/0]).
+         crypto_lib_version/0, rabbitmq_and_erlang_versions/0, which_applications/0]).
 -export([sequence_error/1]).
 -export([check_expiry/1]).
 -export([base64url/1]).
@@ -222,6 +222,7 @@
 -spec version() -> string().
 -spec otp_release() -> string().
 -spec otp_system_version() -> string().
+-spec crypto_lib_version() -> binary().
 -spec platform_and_version() -> string().
 -spec rabbitmq_and_erlang_versions() -> {string(), string()}.
 -spec which_applications() -> [{atom(), string(), string()}].
@@ -1061,6 +1062,9 @@ platform_and_version() ->
 
 otp_system_version() ->
     string:strip(erlang:system_info(system_version), both, $\n).
+
+crypto_lib_version() ->
+    rabbit_runtime:crypto_lib_version().
 
 rabbitmq_and_erlang_versions() ->
   {version(), otp_release()}.

--- a/deps/rabbit_common/src/rabbit_runtime.erl
+++ b/deps/rabbit_common/src/rabbit_runtime.erl
@@ -18,6 +18,7 @@
 -export([get_gc_info/1, gc_all_processes/0]).
 -export([get_erl_path/0]).
 -export([ulimit/0]).
+-export([crypto_lib_version/0]).
 
 -spec guess_number_of_cpu_cores() -> pos_integer().
 guess_number_of_cpu_cores() ->
@@ -64,6 +65,11 @@ get_erl_path() ->
         _ ->
             filename:join(BinDir, "erl")
     end.
+
+-spec crypto_lib_version() -> binary().
+crypto_lib_version() ->
+    [{_, _, Version}] = crypto:info_lib(),
+    rabbit_data_coercion:to_binary(Version).
 
 %% To increase the number of file descriptors: on Windows set ERL_MAX_PORTS
 %% environment variable, on Linux set `ulimit -n`.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_overview.erl
@@ -51,6 +51,7 @@ to_json(ReqData, Context = #context{user = User = #user{tags = Tags}}) ->
                  {node_tags,                 node_tags()},
                  {erlang_version,            erlang_version()},
                  {erlang_full_version,       erlang_full_version()},
+                 {crypto_lib_version,        rabbit_runtime:crypto_lib_version()},
                  {disable_stats,                 rabbit_mgmt_util:disable_stats(ReqData)},
                  {default_queue_type,            rabbit_queue_type:default_alias()},
                  {is_op_policy_updating_enabled, not rabbit_mgmt_features:is_op_policy_updating_disabled()},

--- a/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
+++ b/deps/rabbitmq_management_agent/src/rabbit_mgmt_external_stats.erl
@@ -29,7 +29,8 @@
                      auth_mechanisms, applications, contexts, log_files,
                      db_dir, config_files, net_ticktime, enabled_plugins,
                      mem_calculation_strategy, ra_open_file_metrics,
-                     rabbitmq_version, erlang_version, erlang_full_version]).
+                     rabbitmq_version, erlang_version, erlang_full_version,
+                     crypto_lib_version]).
 
 -define(TEN_MINUTES_AS_SECONDS, 600).
 
@@ -275,7 +276,9 @@ i(rabbitmq_version, State) ->
 i(erlang_version, State) ->
     {State, list_to_binary(rabbit_misc:otp_release())};
 i(erlang_full_version, State) ->
-    {State, list_to_binary(rabbit_misc:otp_system_version())}.
+    {State, list_to_binary(rabbit_misc:otp_system_version())};
+i(crypto_lib_version, State) ->
+    {State, rabbit_misc:crypto_lib_version()}.
 
 resource_alarm_set(Source) ->
     lists:member({{resource_limit, Source, node()},[]},


### PR DESCRIPTION
in `GET /api/overview` and `GET /api/nodes`, `GET /api/nodes/{node}`.

We have been exposing RabbitMQ and Erlang versions for over a decade, and crypto lib version in
`rabbitmq-diagnostics status` for years, too.
