### PR TITLE
tests: reserve enough ports for all node boot attempts

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_broker_helpers.erl
@@ -518,7 +518,8 @@ tcp_port_base_for_broker0(Config, I, PortsCount) ->
     tcp_port_base_for_broker1(Base, I, PortsCount).
 
 tcp_port_base_for_broker1(Base, I, PortsCount) ->
-    Base + I * PortsCount * ?NODE_START_ATTEMPTS.
+    %% the initial attempt + NODE_START_ATTEMPTS retries
+    Base + I * PortsCount * (?NODE_START_ATTEMPTS + 1).
 
 %% @todo Refactor to simplify this...
 update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_amqp = Key | Rest]) ->


### PR DESCRIPTION
We start counting attempts at 0 so we actually have 4 attempts. However, without this fix, the 4th attempt port range would collide with the port range of the initial boot attempt of the next node.

Example failure:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/21994536153/job/63550723108