### PR TITLE
rabbit_db: Fix handling of async m2k puts

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_binding_m2k_converter.erl
@@ -55,10 +55,6 @@ copy_to_khepri(rabbit_route = Table,
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:transaction(
                 fun() ->
                         %% Add the binding to the set at the binding's
@@ -95,10 +91,6 @@ delete_from_khepri(rabbit_route = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_exchange_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_exchange_m2k_converter.erl
@@ -55,10 +55,6 @@ copy_to_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(rabbit_exchange_serial = Table,
@@ -74,10 +70,6 @@ copy_to_khepri(rabbit_exchange_serial = Table,
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Serial, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -103,10 +95,6 @@ delete_from_khepri(rabbit_exchange = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State);
 delete_from_khepri(rabbit_exchange_serial = Table, Key, State) ->
@@ -118,10 +106,6 @@ delete_from_khepri(rabbit_exchange_serial = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_maintenance_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_maintenance_m2k_converter.erl
@@ -56,10 +56,6 @@ copy_to_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -85,10 +81,6 @@ delete_from_khepri(rabbit_node_maintenance_states = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_msup_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_msup_m2k_converter.erl
@@ -56,10 +56,6 @@ copy_to_khepri(mirrored_sup_childspec = Table,
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -86,10 +82,6 @@ delete_from_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_queue_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_queue_m2k_converter.erl
@@ -55,10 +55,6 @@ copy_to_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -84,10 +80,6 @@ delete_from_khepri(rabbit_queue = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_rtparams_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams_m2k_converter.erl
@@ -55,10 +55,6 @@ copy_to_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -84,10 +80,6 @@ delete_from_khepri(rabbit_runtime_parameters = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_user_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_user_m2k_converter.erl
@@ -56,10 +56,6 @@ copy_to_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(
@@ -81,10 +77,6 @@ copy_to_khepri(
                             #{rabbit_db_user:khepri_user_path(Username) =>
                                   #if_node_exists{exists = true}},
                         async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(
@@ -110,10 +102,6 @@ copy_to_khepri(
                             #{rabbit_db_user:khepri_user_path(Username) =>
                                   #if_node_exists{exists = true}},
                         async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -139,10 +127,6 @@ delete_from_khepri(rabbit_user = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State);
 delete_from_khepri(rabbit_user_permission = Table, Key, State) ->
@@ -157,10 +141,6 @@ delete_from_khepri(rabbit_user_permission = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State);
 delete_from_khepri(rabbit_topic_permission = Table, Key, State) ->
@@ -177,10 +157,6 @@ delete_from_khepri(rabbit_topic_permission = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 

--- a/deps/rabbit/src/rabbit_db_vhost_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_vhost_m2k_converter.erl
@@ -56,10 +56,6 @@ copy_to_khepri(
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data copy: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:put(Path, Record, Extra)
       end, State);
 copy_to_khepri(Table, Record, State) ->
@@ -85,10 +81,6 @@ delete_from_khepri(rabbit_vhost = Table, Key, State) ->
     rabbit_db_m2k_converter:with_correlation_id(
       fun(CorrId) ->
               Extra = #{async => CorrId},
-              ?LOG_DEBUG(
-                 "Mnesia->Khepri data delete: [~0p] path: ~0p corr: ~0p",
-                 [Table, Path, CorrId],
-                 #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
               rabbit_khepri:delete(Path, Extra)
       end, State).
 


### PR DESCRIPTION
## Why

Several `rabbit_db_*_m2k_converter` modules use async puts to Khepri to parallelize writes and make them faster. This is handled by the `rabbit_db_m2k_converter:with_correlation_id/2` function.

Ra will send back a Ra event message for each async write to reply with the result of the write. The problem is that the code behind `with_correlation_id/2` has a logic issue: it only consumes 1 Ra event every 64 async writes. It will consume all of them at the end of the overall, but meeawhile, messages will accumulate. If there are a lot of Mnesia records to copy, this can fill the process mailbox and slow it down significantly.

## How

The logic is changed to regularily consume all messages in the mailbox with a timeout of 0. Only at the end, remaining messages are consumed with an infinity timeout because we know how many messages we are expecting (the actual timeout is handled by the write itself).