### PR TITLE
GH actions: fetch tags using actions/checkout

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -42,9 +42,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref }}
-
-    - name: FETCH TAGS
-      run: git fetch --tags
+        fetch-tags: true
 
     - name: EXTRACT ACTIVEMQ VERSION
       if: inputs.plugin == 'amqp10_client'

--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -32,9 +32,8 @@ jobs:
     steps:
     - name: CHECKOUT REPOSITORY
       uses: actions/checkout@v6
-
-    - name: FETCH TAGS
-      run: git fetch --tags
+      with:
+        fetch-tags: true
 
     - name: SETUP OTP & ELIXIR
       uses: erlef/setup-beam@v1.19


### PR DESCRIPTION
This functionality was broken in the past, but should be fixed now. https://github.com/actions/checkout/pull/2356

Manually fetching tags would sometimes fail with
fatal: could not read Username for 'https://github.com': No such device or address

See https://github.com/rabbitmq/rabbitmq-server/commit/beaa476a for context.