### PR TITLE
tests: don't check rabbitmq-plugins and rabbitmq-diagnostics

### DIFF
--- a/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
+++ b/deps/rabbitmq_ct_helpers/src/rabbit_ct_helpers.erl
@@ -402,17 +402,10 @@ ensure_rabbitmqctl_cmd(Config) ->
         false ->
             Error;
         _ ->
-            Cmd = [Rabbitmqctl],
-            Env = [
-                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqctl)}
-                  ],
-            case exec(Cmd, [drop_stdout, {env, Env}]) of
-                {error, 64, _} ->
+            case filelib:is_file(Rabbitmqctl) of
+                true ->
                     set_config(Config, {rabbitmqctl_cmd, Rabbitmqctl});
-                {error, Code, Reason} ->
-                    ct:pal("Exec failed with exit code ~tp: ~tp", [Code, Reason]),
-                    Error;
-                _ ->
+                false ->
                     Error
             end
     end.
@@ -475,14 +468,10 @@ ensure_rabbitmq_plugins_cmd(Config) ->
         false ->
             Error;
         _ ->
-            Cmd = [Rabbitmqplugins],
-            Env = [
-                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqplugins)}
-                  ],
-            case exec(Cmd, [drop_stdout, {env, Env}]) of
-                {error, 64, _} ->
+            case filelib:is_file(Rabbitmqplugins) of
+                true ->
                     set_config(Config, {rabbitmq_plugins_cmd, Rabbitmqplugins});
-                _ ->
+                false ->
                     Error
             end
     end.
@@ -505,19 +494,12 @@ ensure_rabbitmq_queues_cmd(Config) ->
         false ->
             Error;
         _ ->
-            Cmd = [RabbitmqQueues],
-            Env = [
-                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(RabbitmqQueues)}
-                  ],
-            case exec(Cmd, [drop_stdout, {env, Env}]) of
-                {error, 64, _} ->
+            case filelib:is_file(RabbitmqQueues) of
+                true ->
                     set_config(Config,
                                {rabbitmq_queues_cmd,
                                 RabbitmqQueues});
-                {error, Code, Reason} ->
-                    ct:pal("Exec failed with exit code ~tp: ~tp", [Code, Reason]),
-                    Error;
-                _ ->
+                false ->
                     Error
             end
     end.
@@ -540,19 +522,12 @@ ensure_rabbitmq_streams_cmd(Config) ->
         false ->
             Error;
         _ ->
-            Cmd = [RabbitmqStreams],
-            Env = [
-                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(RabbitmqStreams)}
-                  ],
-            case exec(Cmd, [drop_stdout, {env, Env}]) of
-                {error, 64, _} ->
+            case filelib:is_file(RabbitmqStreams) of
+                true ->
                     set_config(Config,
                                {rabbitmq_streams_cmd,
                                 RabbitmqStreams});
-                {error, Code, Reason} ->
-                    ct:pal("Exec failed with exit code ~tp: ~tp", [Code, Reason]),
-                    Error;
-                _ ->
+                false ->
                     Error
             end
     end.
@@ -575,19 +550,12 @@ ensure_rabbitmq_diagnostics_cmd(Config) ->
         false ->
             Error;
         _ ->
-            Cmd = [RabbitmqDiagnostics],
-            Env = [
-                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(RabbitmqDiagnostics)}
-                  ],
-            case exec(Cmd, [drop_stdout, {env, Env}]) of
-                {error, 64, _} ->
+            case filelib:is_file(RabbitmqDiagnostics) of
+                true ->
                     set_config(Config,
                                {rabbitmq_diagnostics_cmd,
                                 RabbitmqDiagnostics});
-                {error, Code, Reason} ->
-                    ct:pal("Exec failed with exit code ~tp: ~tp", [Code, Reason]),
-                    Error;
-                _ ->
+                false ->
                     Error
             end
     end.


### PR DESCRIPTION
Thanks to our slow CLI startup and slow CI workers, it takes ~5 seconds to run these two commands, just to check if they are available. We do it many times across many tests/groups/suites.

Let's not waste CPUs on that.