### PR TITLE
Added configuration options to disable Prometheus metrics and endpoints

### DIFF
--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -181,3 +181,23 @@ end}.
 %% Authentication options ========================================================
 {mapping, "prometheus.authentication.enabled", "rabbitmq_prometheus.authentication.enabled",
     [{datatype, boolean}]}.
+
+%% Endpoint disable options ========================================================
+{mapping, "prometheus.disable_memory_breakdown_endpoint", "rabbitmq_prometheus.disable_memory_breakdown_endpoint",
+    [{datatype, {enum, [true, false]}}, {default, false}]}.
+
+{mapping, "prometheus.disable_per_object_endpoint", "rabbitmq_prometheus.disable_per_object_endpoint",
+    [{datatype, {enum, [true, false]}}, {default, true}]}.
+
+{mapping, "prometheus.disable_detailed_endpoint", "rabbitmq_prometheus.disable_detailed_endpoint",
+    [{datatype, {enum, [true, false]}}, {default, false}]}.
+
+%% Metric blocklist options ========================================================
+{mapping, "prometheus.disabled_metrics.$metric", "rabbitmq_prometheus.disabled_metrics",
+    [{datatype, atom}]}.
+
+{translation, "rabbitmq_prometheus.disabled_metrics",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("prometheus.disabled_metrics", Conf),
+    [V || {_, V} <- Settings]
+end}.

--- a/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
+++ b/deps/rabbitmq_prometheus/priv/schema/rabbitmq_prometheus.schema
@@ -184,13 +184,13 @@ end}.
 
 %% Endpoint disable options ========================================================
 {mapping, "prometheus.disable_memory_breakdown_endpoint", "rabbitmq_prometheus.disable_memory_breakdown_endpoint",
-    [{datatype, {enum, [true, false]}}, {default, false}]}.
+    [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "prometheus.disable_per_object_endpoint", "rabbitmq_prometheus.disable_per_object_endpoint",
-    [{datatype, {enum, [true, false]}}, {default, true}]}.
+    [{datatype, {enum, [true, false]}}]}.
 
 {mapping, "prometheus.disable_detailed_endpoint", "rabbitmq_prometheus.disable_detailed_endpoint",
-    [{datatype, {enum, [true, false]}}, {default, false}]}.
+    [{datatype, {enum, [true, false]}}]}.
 
 %% Metric blocklist options ========================================================
 {mapping, "prometheus.disabled_metrics.$metric", "rabbitmq_prometheus.disabled_metrics",

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -477,7 +477,7 @@ add_metric_family({Name, Type, Help, Metrics}, Callback) ->
     Callback(create_mf(MN, Help, Type, Metrics)).
 
 mf(Callback, Prefix, Contents, Data) ->
-    DisabledMetrics = normalize_disabled_metrics(application:get_env(rabbitmq_prometheus, disabled_metrics, [])),
+    DisabledMetrics = rabbit_prometheus_util:normalize_disabled_metrics(application:get_env(rabbitmq_prometheus, disabled_metrics, [])),
     _ = [begin
          Fun = case Conversion of
                    undefined ->
@@ -512,17 +512,6 @@ mf(Callback, Prefix, Contents, Data) ->
             )
         )
     end || {Index, Conversion, Name, Type, Help, Key} <- Contents, not lists:member(Name, DisabledMetrics)].
-
-normalize_disabled_metrics(Metrics) ->
-    [normalize_metric_name(M) || M <- Metrics].
-
-normalize_metric_name(Metric) when is_atom(Metric) ->
-    case atom_to_list(Metric) of
-        "rabbitmq_detailed_" ++ Rest -> list_to_atom(Rest);
-        "rabbitmq_cluster_" ++ Rest -> list_to_atom(Rest);
-        "rabbitmq_" ++ Rest -> list_to_atom(Rest);
-        _ -> Metric
-    end.
 
 mf_totals(Callback, Name, Type, Help, Size) ->
     Callback(

--- a/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
+++ b/deps/rabbitmq_prometheus/src/collectors/prometheus_rabbitmq_core_metrics_collector.erl
@@ -477,6 +477,7 @@ add_metric_family({Name, Type, Help, Metrics}, Callback) ->
     Callback(create_mf(MN, Help, Type, Metrics)).
 
 mf(Callback, Prefix, Contents, Data) ->
+    DisabledMetrics = normalize_disabled_metrics(application:get_env(rabbitmq_prometheus, disabled_metrics, [])),
     _ = [begin
          Fun = case Conversion of
                    undefined ->
@@ -493,7 +494,7 @@ mf(Callback, Prefix, Contents, Data) ->
                 {Type, Fun, Data}
             )
         )
-    end || {Index, Conversion, Name, Type, Help} <- Contents],
+    end || {Index, Conversion, Name, Type, Help} <- Contents, not lists:member(Name, DisabledMetrics)],
     [begin
         Fun = case Conversion of
                   undefined ->
@@ -510,7 +511,18 @@ mf(Callback, Prefix, Contents, Data) ->
                 {Type, Fun, Data}
             )
         )
-    end || {Index, Conversion, Name, Type, Help, Key} <- Contents].
+    end || {Index, Conversion, Name, Type, Help, Key} <- Contents, not lists:member(Name, DisabledMetrics)].
+
+normalize_disabled_metrics(Metrics) ->
+    [normalize_metric_name(M) || M <- Metrics].
+
+normalize_metric_name(Metric) when is_atom(Metric) ->
+    case atom_to_list(Metric) of
+        "rabbitmq_detailed_" ++ Rest -> list_to_atom(Rest);
+        "rabbitmq_cluster_" ++ Rest -> list_to_atom(Rest);
+        "rabbitmq_" ++ Rest -> list_to_atom(Rest);
+        _ -> Metric
+    end.
 
 mf_totals(Callback, Name, Type, Help, Size) ->
     Callback(

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_dispatcher.erl
@@ -35,7 +35,7 @@ build_dispatcher() ->
             true  -> PerObjectCollectors
         end
     ),
-    case application:get_env(rabbitmq_prometheus, disable_per_object_endpoint, false) of
+    case application:get_env(rabbitmq_prometheus, disable_per_object_endpoint, true) of
         true -> ok;
         false ->
             prometheus_registry:register_collectors('per-object',

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
@@ -44,9 +44,18 @@ is_authorized(ReqData, Context) ->
 
 setup() ->
     setup_metrics(telemetry_registry()),
-    setup_metrics('per-object'),
-    setup_metrics('memory-breakdown'),
-    setup_metrics('detailed').
+    case application:get_env(rabbitmq_prometheus, disable_per_object_endpoint, false) of
+        true -> ok;
+        false -> setup_metrics('per-object')
+    end,
+    case application:get_env(rabbitmq_prometheus, disable_memory_breakdown_endpoint, false) of
+        true -> ok;
+        false -> setup_metrics('memory-breakdown')
+    end,
+    case application:get_env(rabbitmq_prometheus, disable_detailed_endpoint, false) of
+        true -> ok;
+        false -> setup_metrics('detailed')
+    end.
 
 setup_metrics(Registry) ->
     ScrapeDuration = [{name, ?SCRAPE_DURATION},

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_handler.erl
@@ -44,7 +44,7 @@ is_authorized(ReqData, Context) ->
 
 setup() ->
     setup_metrics(telemetry_registry()),
-    case application:get_env(rabbitmq_prometheus, disable_per_object_endpoint, false) of
+    case application:get_env(rabbitmq_prometheus, disable_per_object_endpoint, true) of
         true -> ok;
         false -> setup_metrics('per-object')
     end,

--- a/deps/rabbitmq_prometheus/src/rabbit_prometheus_util.erl
+++ b/deps/rabbitmq_prometheus/src/rabbit_prometheus_util.erl
@@ -1,0 +1,24 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_prometheus_util).
+
+-export([normalize_disabled_metrics/1,
+         normalize_metric_name/1]).
+
+-spec normalize_disabled_metrics([atom()]) -> [atom()].
+normalize_disabled_metrics(Metrics) ->
+    [normalize_metric_name(M) || M <- Metrics].
+
+-spec normalize_metric_name(atom()) -> atom().
+normalize_metric_name(Metric) when is_atom(Metric) ->
+    case atom_to_list(Metric) of
+        "rabbitmq_detailed_" ++ Rest -> list_to_atom(Rest);
+        "rabbitmq_cluster_" ++ Rest  -> list_to_atom(Rest);
+        "rabbitmq_" ++ Rest          -> list_to_atom(Rest);
+        _                            -> Metric
+    end.

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
 [
@@ -13,6 +13,9 @@
   {endpoint_path,
    "prometheus.path = /metriczzz",
    [{rabbitmq_prometheus,[
+                          {disable_detailed_endpoint, false},
+                          {disable_memory_breakdown_endpoint, false},
+                          {disable_per_object_endpoint, true},
                           {path, "/metriczzz"}
                          ]}],
    [rabbitmq_prometheus]},
@@ -24,6 +27,9 @@
    {tcp_listener_port_only,
     "prometheus.tcp.port = 15692",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {tcp_config,[
                                         {port,15692}
                                        ]}
@@ -34,6 +40,9 @@
     "prometheus.tcp.ip   = 192.168.1.2
      prometheus.tcp.port = 15692",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {tcp_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15692}
@@ -45,6 +54,9 @@
     "prometheus.tcp.compress = true",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{compress, true}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -55,6 +67,9 @@
      prometheus.tcp.idle_timeout = 123",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{compress,     true},
                                                        {idle_timeout, 123}]}]}
                            ]}
@@ -68,6 +83,9 @@
      prometheus.tcp.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{compress,           true},
                                                        {idle_timeout,       123},
                                                        {inactivity_timeout, 456},
@@ -82,6 +100,9 @@
      prometheus.tcp.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{idle_timeout,       123},
                                                        {inactivity_timeout, 456},
                                                        {request_timeout,    789}]}]}
@@ -93,6 +114,9 @@
     "prometheus.tcp.shutdown_timeout = 7000",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{shutdown_timeout, 7000}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -102,6 +126,9 @@
     "prometheus.tcp.max_keepalive = 120",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -111,6 +138,9 @@
     "prometheus.tcp.max_connections = 4096",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{max_connections, 4096}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -120,6 +150,9 @@
     "prometheus.tcp.max_connections = infinity",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {tcp_config, [{max_connections, infinity}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -128,6 +161,9 @@
    {tcp_listener,
     "prometheus.tcp.listener = 192.1.1.2:15676",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {tcp_config,[
                                         {ip, "192.1.1.2"},
                                         {port,15676}
@@ -138,6 +174,9 @@
    {tcp_listener_none,
     "prometheus.tcp.listener = none",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {tcp_config,[]}
                           ]}],
     [rabbitmq_prometheus]},
@@ -149,6 +188,9 @@
    {tls_listener_port_only,
     "prometheus.ssl.port = 15691",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {port,15691}
                                        ]}
@@ -159,6 +201,9 @@
     "prometheus.ssl.ip   = 192.168.1.2
      prometheus.ssl.port = 15691",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691}
@@ -175,6 +220,9 @@
      prometheus.ssl.verify   = verify_none
      prometheus.ssl.fail_if_no_peer_cert = false",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691},
@@ -217,6 +265,9 @@
      prometheus.ssl.ciphers.8 = ECDH-RSA-AES256-SHA384
      prometheus.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
     [{rabbitmq_prometheus,[
+                           {disable_detailed_endpoint, false},
+                           {disable_memory_breakdown_endpoint, false},
+                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691},
@@ -254,6 +305,9 @@
     "prometheus.ssl.compress = true",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{compress, true}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -264,6 +318,9 @@
      prometheus.ssl.idle_timeout = 123",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{compress,     true},
                                                          {idle_timeout, 123}]}]}
                            ]}
@@ -277,6 +334,9 @@
      prometheus.ssl.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{compress,           true},
                                                          {idle_timeout,       123},
                                                          {inactivity_timeout, 456},
@@ -291,6 +351,9 @@
      prometheus.ssl.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{idle_timeout,       123},
                                                          {inactivity_timeout, 456},
                                                          {request_timeout,    789}]}]}
@@ -302,6 +365,9 @@
     "prometheus.ssl.shutdown_timeout = 7000",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{shutdown_timeout, 7000}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -311,6 +377,9 @@
     "prometheus.ssl.max_keepalive = 120",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -320,6 +389,9 @@
     "prometheus.ssl.max_connections = 4096",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{max_connections, 4096}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -329,6 +401,9 @@
     "prometheus.ssl.max_connections = infinity",
     [
      {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
                             {ssl_config, [{max_connections, infinity}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -338,7 +413,64 @@
     "prometheus.authentication.enabled = true",
     [
      {rabbitmq_prometheus, [
-                            {authentication, [{enabled, true}]}
+                            {authentication, [{enabled, true}]},
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   %%
+   %% Endpoint disable options
+   %%
+
+   {disable_memory_breakdown_endpoint,
+    "prometheus.disable_memory_breakdown_endpoint = true",
+    [
+     {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, true},
+                            {disable_per_object_endpoint, true}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   {disable_per_object_endpoint,
+    "prometheus.disable_per_object_endpoint = true",
+    [
+     {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   {disable_detailed_endpoint,
+    "prometheus.disable_detailed_endpoint = true",
+    [
+     {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, true},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true}
+                           ]}
+    ], [rabbitmq_prometheus]
+   },
+
+   %%
+   %% Metric blocklist options
+   %%
+
+   {disabled_metrics,
+    "prometheus.disabled_metrics.1 = queue_messages
+     prometheus.disabled_metrics.2 = connection_incoming_bytes_total",
+    [
+     {rabbitmq_prometheus, [
+                            {disable_detailed_endpoint, false},
+                            {disable_memory_breakdown_endpoint, false},
+                            {disable_per_object_endpoint, true},
+                            {disabled_metrics, [queue_messages, connection_incoming_bytes_total]}
                            ]}
     ], [rabbitmq_prometheus]
    },

--- a/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
+++ b/deps/rabbitmq_prometheus/test/config_schema_SUITE_data/rabbitmq_prometheus.snippets
@@ -13,9 +13,6 @@
   {endpoint_path,
    "prometheus.path = /metriczzz",
    [{rabbitmq_prometheus,[
-                          {disable_detailed_endpoint, false},
-                          {disable_memory_breakdown_endpoint, false},
-                          {disable_per_object_endpoint, true},
                           {path, "/metriczzz"}
                          ]}],
    [rabbitmq_prometheus]},
@@ -27,9 +24,6 @@
    {tcp_listener_port_only,
     "prometheus.tcp.port = 15692",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {tcp_config,[
                                         {port,15692}
                                        ]}
@@ -40,9 +34,6 @@
     "prometheus.tcp.ip   = 192.168.1.2
      prometheus.tcp.port = 15692",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {tcp_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15692}
@@ -54,9 +45,6 @@
     "prometheus.tcp.compress = true",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{compress, true}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -67,9 +55,6 @@
      prometheus.tcp.idle_timeout = 123",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{compress,     true},
                                                        {idle_timeout, 123}]}]}
                            ]}
@@ -83,9 +68,6 @@
      prometheus.tcp.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{compress,           true},
                                                        {idle_timeout,       123},
                                                        {inactivity_timeout, 456},
@@ -100,9 +82,6 @@
      prometheus.tcp.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{idle_timeout,       123},
                                                        {inactivity_timeout, 456},
                                                        {request_timeout,    789}]}]}
@@ -114,9 +93,6 @@
     "prometheus.tcp.shutdown_timeout = 7000",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{shutdown_timeout, 7000}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -126,9 +102,6 @@
     "prometheus.tcp.max_keepalive = 120",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -138,9 +111,6 @@
     "prometheus.tcp.max_connections = 4096",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{max_connections, 4096}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -150,9 +120,6 @@
     "prometheus.tcp.max_connections = infinity",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {tcp_config, [{max_connections, infinity}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -161,9 +128,6 @@
    {tcp_listener,
     "prometheus.tcp.listener = 192.1.1.2:15676",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {tcp_config,[
                                         {ip, "192.1.1.2"},
                                         {port,15676}
@@ -174,9 +138,6 @@
    {tcp_listener_none,
     "prometheus.tcp.listener = none",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {tcp_config,[]}
                           ]}],
     [rabbitmq_prometheus]},
@@ -188,9 +149,6 @@
    {tls_listener_port_only,
     "prometheus.ssl.port = 15691",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {port,15691}
                                        ]}
@@ -201,9 +159,6 @@
     "prometheus.ssl.ip   = 192.168.1.2
      prometheus.ssl.port = 15691",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691}
@@ -220,9 +175,6 @@
      prometheus.ssl.verify   = verify_none
      prometheus.ssl.fail_if_no_peer_cert = false",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691},
@@ -265,9 +217,6 @@
      prometheus.ssl.ciphers.8 = ECDH-RSA-AES256-SHA384
      prometheus.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
     [{rabbitmq_prometheus,[
-                           {disable_detailed_endpoint, false},
-                           {disable_memory_breakdown_endpoint, false},
-                           {disable_per_object_endpoint, true},
                            {ssl_config,[
                                         {ip, "192.168.1.2"},
                                         {port,15691},
@@ -305,9 +254,6 @@
     "prometheus.ssl.compress = true",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{compress, true}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -318,9 +264,6 @@
      prometheus.ssl.idle_timeout = 123",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{compress,     true},
                                                          {idle_timeout, 123}]}]}
                            ]}
@@ -334,9 +277,6 @@
      prometheus.ssl.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{compress,           true},
                                                          {idle_timeout,       123},
                                                          {inactivity_timeout, 456},
@@ -351,9 +291,6 @@
      prometheus.ssl.request_timeout = 789",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{idle_timeout,       123},
                                                          {inactivity_timeout, 456},
                                                          {request_timeout,    789}]}]}
@@ -365,9 +302,6 @@
     "prometheus.ssl.shutdown_timeout = 7000",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{shutdown_timeout, 7000}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -377,9 +311,6 @@
     "prometheus.ssl.max_keepalive = 120",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{cowboy_opts, [{max_keepalive, 120}]}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -389,9 +320,6 @@
     "prometheus.ssl.max_connections = 4096",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{max_connections, 4096}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -401,9 +329,6 @@
     "prometheus.ssl.max_connections = infinity",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {ssl_config, [{max_connections, infinity}]}
                            ]}
     ], [rabbitmq_prometheus]
@@ -413,10 +338,7 @@
     "prometheus.authentication.enabled = true",
     [
      {rabbitmq_prometheus, [
-                            {authentication, [{enabled, true}]},
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true}
+                            {authentication, [{enabled, true}]}
                            ]}
     ], [rabbitmq_prometheus]
    },
@@ -429,9 +351,7 @@
     "prometheus.disable_memory_breakdown_endpoint = true",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, true},
-                            {disable_per_object_endpoint, true}
+                            {disable_memory_breakdown_endpoint, true}
                            ]}
     ], [rabbitmq_prometheus]
    },
@@ -440,8 +360,6 @@
     "prometheus.disable_per_object_endpoint = true",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
                             {disable_per_object_endpoint, true}
                            ]}
     ], [rabbitmq_prometheus]
@@ -451,9 +369,7 @@
     "prometheus.disable_detailed_endpoint = true",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, true},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true}
+                            {disable_detailed_endpoint, true}
                            ]}
     ], [rabbitmq_prometheus]
    },
@@ -467,9 +383,6 @@
      prometheus.disabled_metrics.2 = connection_incoming_bytes_total",
     [
      {rabbitmq_prometheus, [
-                            {disable_detailed_endpoint, false},
-                            {disable_memory_breakdown_endpoint, false},
-                            {disable_per_object_endpoint, true},
                             {disabled_metrics, [queue_messages, connection_incoming_bytes_total]}
                            ]}
     ], [rabbitmq_prometheus]

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_disabled_metrics_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_disabled_metrics_SUITE.erl
@@ -110,18 +110,10 @@ disable_multiple_metrics_test(Config) ->
     ?assertEqual(nomatch, re:run(Body, "^rabbitmq_connection_incoming_bytes_total ", [{capture, none}, multiline])).
 
 normalize_metric_name_test(_Config) ->
-    ?assertEqual(queue_messages, normalize_metric_name(rabbitmq_queue_messages)),
-    ?assertEqual(queue_messages, normalize_metric_name(rabbitmq_detailed_queue_messages)),
-    ?assertEqual(vhost_status, normalize_metric_name(rabbitmq_cluster_vhost_status)),
-    ?assertEqual(other_metric, normalize_metric_name(other_metric)).
-
-normalize_metric_name(Metric) when is_atom(Metric) ->
-    case atom_to_list(Metric) of
-        "rabbitmq_detailed_" ++ Rest -> list_to_atom(Rest);
-        "rabbitmq_cluster_" ++ Rest -> list_to_atom(Rest);
-        "rabbitmq_" ++ Rest -> list_to_atom(Rest);
-        _ -> Metric
-    end.
+    ?assertEqual(queue_messages, rabbit_prometheus_util:normalize_metric_name(rabbitmq_queue_messages)),
+    ?assertEqual(queue_messages, rabbit_prometheus_util:normalize_metric_name(rabbitmq_detailed_queue_messages)),
+    ?assertEqual(vhost_status, rabbit_prometheus_util:normalize_metric_name(rabbitmq_cluster_vhost_status)),
+    ?assertEqual(other_metric, rabbit_prometheus_util:normalize_metric_name(other_metric)).
 
 %% Helpers
 

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_disabled_metrics_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_disabled_metrics_SUITE.erl
@@ -1,0 +1,134 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(rabbit_prometheus_disabled_metrics_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbitmq_ct_helpers/include/rabbit_mgmt_test.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+        {group, default_settings},
+        {group, disabled_endpoints},
+        {group, disabled_metrics}
+    ].
+
+groups() ->
+    [
+        {default_settings, [], [
+            per_object_endpoint_disabled_by_default_test
+        ]},
+        {disabled_endpoints, [], [
+            disable_per_object_endpoint_test,
+            disable_detailed_endpoint_test,
+            disable_memory_breakdown_endpoint_test
+        ]},
+        {disabled_metrics, [], [
+            disable_single_metric_test,
+            disable_multiple_metrics_test,
+            normalize_metric_name_test
+        ]}
+    ].
+
+init_per_group(default_settings, Config) ->
+    init_group(Config);
+init_per_group(disabled_endpoints, Config) ->
+    EndpointConfig = {rabbitmq_prometheus, [
+        {disable_per_object_endpoint, true},
+        {disable_detailed_endpoint, true},
+        {disable_memory_breakdown_endpoint, true}
+    ]},
+    Config1 = rabbit_ct_helpers:merge_app_env(Config, EndpointConfig),
+    init_group(Config1);
+init_per_group(disabled_metrics, Config) ->
+    MetricsConfig = {rabbitmq_prometheus, [
+        {disabled_metrics, [queue_messages, connection_incoming_bytes_total]}
+    ]},
+    Config1 = rabbit_ct_helpers:merge_app_env(Config, MetricsConfig),
+    init_group(Config1).
+
+init_group(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    inets:start(),
+    rabbit_ct_helpers:run_setup_steps(Config,
+        rabbit_ct_broker_helpers:setup_steps() ++
+        rabbit_ct_client_helpers:setup_steps()).
+
+end_per_group(_, Config) ->
+    inets:stop(),
+    rabbit_ct_helpers:run_teardown_steps(Config,
+        rabbit_ct_client_helpers:teardown_steps() ++
+        rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_started(Config, Testcase).
+
+end_per_testcase(Testcase, Config) ->
+    rabbit_ct_helpers:testcase_finished(Config, Testcase).
+
+%% Tests
+
+disable_per_object_endpoint_test(Config) ->
+    Port = rabbit_mgmt_test_util:config_port(Config, tcp_port_prometheus),
+    URI = lists:flatten(io_lib:format("http://localhost:~tp/metrics/per-object", [Port])),
+    {ok, {{_, Code, _}, _, _}} = httpc:request(get, {URI, []}, ?HTTPC_OPTS, []),
+    ?assertEqual(404, Code).
+
+disable_detailed_endpoint_test(Config) ->
+    Port = rabbit_mgmt_test_util:config_port(Config, tcp_port_prometheus),
+    URI = lists:flatten(io_lib:format("http://localhost:~tp/metrics/detailed", [Port])),
+    {ok, {{_, Code, _}, _, _}} = httpc:request(get, {URI, []}, ?HTTPC_OPTS, []),
+    ?assertEqual(404, Code).
+
+disable_memory_breakdown_endpoint_test(Config) ->
+    Port = rabbit_mgmt_test_util:config_port(Config, tcp_port_prometheus),
+    URI = lists:flatten(io_lib:format("http://localhost:~tp/metrics/memory-breakdown", [Port])),
+    {ok, {{_, Code, _}, _, _}} = httpc:request(get, {URI, []}, ?HTTPC_OPTS, []),
+    ?assertEqual(404, Code).
+
+per_object_endpoint_disabled_by_default_test(Config) ->
+    Port = rabbit_mgmt_test_util:config_port(Config, tcp_port_prometheus),
+    URI = lists:flatten(io_lib:format("http://localhost:~tp/metrics/per-object", [Port])),
+    {ok, {{_, Code, _}, _, _}} = httpc:request(get, {URI, []}, ?HTTPC_OPTS, []),
+    ?assertEqual(404, Code).
+
+disable_single_metric_test(Config) ->
+    {_, Body} = http_get(Config, [], 200),
+    ?assertEqual(nomatch, re:run(Body, "^rabbitmq_queue_messages ", [{capture, none}, multiline])),
+    ?assertEqual(match, re:run(Body, "^rabbitmq_connections ", [{capture, none}, multiline])).
+
+disable_multiple_metrics_test(Config) ->
+    {_, Body} = http_get(Config, [], 200),
+    ?assertEqual(nomatch, re:run(Body, "^rabbitmq_queue_messages ", [{capture, none}, multiline])),
+    ?assertEqual(nomatch, re:run(Body, "^rabbitmq_connection_incoming_bytes_total ", [{capture, none}, multiline])).
+
+normalize_metric_name_test(_Config) ->
+    ?assertEqual(queue_messages, normalize_metric_name(rabbitmq_queue_messages)),
+    ?assertEqual(queue_messages, normalize_metric_name(rabbitmq_detailed_queue_messages)),
+    ?assertEqual(vhost_status, normalize_metric_name(rabbitmq_cluster_vhost_status)),
+    ?assertEqual(other_metric, normalize_metric_name(other_metric)).
+
+normalize_metric_name(Metric) when is_atom(Metric) ->
+    case atom_to_list(Metric) of
+        "rabbitmq_detailed_" ++ Rest -> list_to_atom(Rest);
+        "rabbitmq_cluster_" ++ Rest -> list_to_atom(Rest);
+        "rabbitmq_" ++ Rest -> list_to_atom(Rest);
+        _ -> Metric
+    end.
+
+%% Helpers
+
+http_get(Config, ReqHeaders, CodeExp) ->
+    Port = rabbit_mgmt_test_util:config_port(Config, tcp_port_prometheus),
+    URI = lists:flatten(io_lib:format("http://localhost:~tp/metrics", [Port])),
+    {ok, {{_, CodeAct, _}, Headers, Body}} =
+        httpc:request(get, {URI, ReqHeaders}, ?HTTPC_OPTS, []),
+    ?assertMatch(CodeExp, CodeAct),
+    {Headers, Body}.

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -122,7 +122,8 @@ init_per_group(per_object_metrics, Config0) ->
     init_aggregated_metrics(per_object_metrics, Config1);
 init_per_group(per_object_endpoint_metrics, Config0) ->
     PathConfig = {rabbitmq_prometheus, [
-        {return_per_object_metrics, false}
+        {return_per_object_metrics, false},
+        {disable_per_object_endpoint, false}
     ]},
     Config1 = rabbit_ct_helpers:merge_app_env(Config0, PathConfig),
     init_aggregated_metrics(per_object_endpoint_metrics, Config1);

--- a/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
+++ b/deps/rabbitmq_prometheus/test/rabbit_prometheus_http_SUITE.erl
@@ -260,7 +260,11 @@ init_per_group(memory_breakdown_endpoint_metrics, Config) ->
 init_aggregated_metrics(Group, Config0) ->
     Config1 = rabbit_ct_helpers:merge_app_env(
         Config0,
-        [{rabbit, [{collect_statistics, coarse}, {collect_statistics_interval, 100}]}]
+        [{rabbit, [{collect_statistics, coarse}, {collect_statistics_interval, 100}]},
+         %% Enable the per-object endpoint so the readiness probe below can
+         %% confirm queue stats have been collected. Per-object is opt-in by
+         %% default, but tests in these groups depend on it.
+         {rabbitmq_prometheus, [{disable_per_object_endpoint, false}]}]
     ),
     Config2 = init_per_group(Group, Config1, []),
 


### PR DESCRIPTION
## Proposed Changes

This PR adds configuration options to the rabbitmq_prometheus plugin that allow operators to:

Disable specific Prometheus endpoints - New configuration flags to disable the /metrics/per-object, /metrics/detailed, and /metrics/memory-breakdown endpoints individually:

```
disable_per_object_endpoint (default: true)
disable_detailed_endpoint (default: false)
disable_memory_breakdown_endpoint (default: false)
```

Disable individual metrics - A new disabled_metrics configuration option that accepts a list of metric names to exclude from scrape responses. The implementation normalizes metric names by stripping rabbitmq_, rabbitmq_detailed_, and rabbitmq_cluster_ prefixes, allowing users to specify metrics in any format.

Why this is useful:
- Reduces scrape payload size when certain metrics are not needed
- Improves scrape performance by skipping unnecessary metric collection
- Allows operators to disable expensive endpoints (like per-object) in large deployments
- Provides fine-grained control over which metrics are exposed

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc.
