### PR TITLE
Make the list of ignored node DB directories extensible

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -117,6 +117,9 @@ define PROJECT_ENV
       	{dead_letter_worker_publisher_confirm_timeout, 180000},
 		{vhost_process_reconciliation_run_interval, 30},
 		{stream_read_ahead, true},
+		%% names of additional directories to ignore when determining whether
+		%% a node is starting as a blank one (with an unintialized data directory)
+		{additional_ignored_data_filenames, []},
 		%% for testing
 		{vhost_process_reconciliation_enabled, true},
 		{license_line, "Licensed under the MPL 2.0. Website: https://rabbitmq.com"}

--- a/deps/rabbit/src/rabbit_mnesia.erl
+++ b/deps/rabbit/src/rabbit_mnesia.erl
@@ -1057,23 +1057,37 @@ mnesia_and_msg_store_files() ->
         {ok, []} ->
             [];
         {ok, List0} ->
-            IgnoredFiles0 =
-            [rabbit_node_monitor:cluster_status_filename(),
-             rabbit_node_monitor:running_nodes_filename(),
-             rabbit_node_monitor:coordination_filename(),
-             rabbit_node_monitor:stream_filename(),
-             rabbit_node_monitor:default_quorum_filename(),
-             rabbit_node_monitor:classic_filename(),
-             rabbit_node_monitor:quorum_filename(),
-             rabbit_feature_flags:enabled_feature_flags_list_file(),
-             rabbit_khepri:dir(),
-             rabbit_plugins:user_provided_plugins_data_dir()],
+            IgnoredFiles0 = core_ignored_filenames() ++ additional_ignored_filenames(),
             IgnoredFiles = [filename:basename(File) || File <- IgnoredFiles0],
             ?LOG_DEBUG("Files and directories found in node's data directory: ~ts, of them to be ignored: ~ts",
                             [string:join(lists:usort(List0), ", "), string:join(lists:usort(IgnoredFiles), ", ")]),
             List = List0 -- IgnoredFiles,
             ?LOG_DEBUG("Files and directories found in node's data directory sans ignored ones: ~ts", [string:join(lists:usort(List), ", ")]),
             List
+    end.
+
+-spec core_ignored_filenames() -> rabbit_types:option([file:filename_all()]).
+core_ignored_filenames() ->
+    [
+        rabbit_node_monitor:cluster_status_filename(),
+        rabbit_node_monitor:running_nodes_filename(),
+        rabbit_node_monitor:coordination_filename(),
+        rabbit_node_monitor:stream_filename(),
+        rabbit_node_monitor:default_quorum_filename(),
+        rabbit_node_monitor:classic_filename(),
+        rabbit_node_monitor:quorum_filename(),
+        rabbit_feature_flags:enabled_feature_flags_list_file(),
+        rabbit_khepri:dir(),
+        rabbit_plugins:user_provided_plugins_data_dir()
+    ].
+
+-spec additional_ignored_filenames() -> rabbit_types:option([file:filename_all()]).
+additional_ignored_filenames() ->
+    case application:get_env(rabbit, additional_ignored_data_filenames) of
+        undefined ->
+            [];
+        {ok, Value} when is_list(Value) ->
+            Value
     end.
 
 is_only_clustered_disc_node() ->


### PR DESCRIPTION
## Proposed Changes

This is the most minimalistic way of making the list of (sub)directories that
are ignored when determining whether a node should start as a blank one (a node with an unintialized data directory).

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes

## Further Comments

Per discussion with @deadtrickster.