### PR TITLE
Add missing QUEUE_TYPE for rabbit_mqtt_qos0_queue

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/global.js
+++ b/deps/rabbitmq_management/priv/www/js/global.js
@@ -998,6 +998,21 @@ QUEUE_TYPE["stream"] = {
     }
 };
 
+QUEUE_TYPE["rabbit_mqtt_qos0_queue"] = {
+    label: "MQTT QoS0",
+    params: {},
+    actions: {
+        get_message: false,
+        purge: false
+    },
+    tmpl: {
+        "list"   : "classic-queue-list",
+        "stats"  : "classic-queue-stats",
+        "node_details" : "classic-queue-node-details"
+    }
+};
+
+
 // here I'll shortcut for now and let it be like that
 // other queue types can inject themlves where they want.
 // since the 'sections' object will likely keep key insertion

--- a/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/policies.ejs
@@ -84,7 +84,7 @@
               <option value="exchanges">Exchanges</option>
               <option value="queues">Queues</option>
               <% for (const [typename, type_config] of Object.entries(QUEUE_TYPE)) { %>
-                  <% if (typename != "default") { %>
+                  <% if (typename != "default" && type_config.policy_apply_to ) { %>
               <option value="<%= type_config.policy_apply_to %>"><%= type_config.label %> Queues</option>
                   <% } %>
               <% } %>
@@ -114,7 +114,7 @@
                   <span class="argument-link" field="definition" key="queue-leader-locator" type="string">Leader locator</span><span class="help" id="queue-leader-locator"></span></br>
                 </td>
                 <% for (const [typename, type_config] of Object.entries(QUEUE_TYPE)) { %>
-                    <% if (typename != "default") { %>
+                    <% if (typename != "default" && type_config.tmpl.user_policy_arguments) { %>
                         <%= format(type_config.tmpl.user_policy_arguments, {}) %>
                   <% } %>
                 <% } %>
@@ -245,7 +245,7 @@
             <select name="apply-to">
               <option value="queues">Queues</option>
               <% for (const [typename, type_config] of Object.entries(QUEUE_TYPE)) { %>
-                  <% if (typename != "default") { %>
+                  <% if (typename != "default"  && type_config.policy_apply_to  ) { %>
                       <option value="<%= type_config.policy_apply_to %>"><%= type_config.label %> Queues</option>
                   <% } %>
               <% } %>
@@ -262,7 +262,7 @@
             <div class="multifield" id="definitionop"></div>
             <table class="argument-links">
                 <% for (const [typename, type_config] of Object.entries(QUEUE_TYPE)) { %>
-                    <% if (typename != "default") { %>
+                    <% if (typename != "default" && type_config.tmpl.operator_policy_arguments) { %>
                         <%= format(type_config.tmpl.operator_policy_arguments, {}) %>
                     <% } %>
                 <% } %>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queue.ejs
@@ -101,7 +101,7 @@
 <%= format('publish', {'mode': 'queue', 'queue': queue}) %>
 
 <% if (QUEUE_TYPE(queue).actions.get_message) { %>
-  <%= format(QUEUE_TYPE(queue).tmpl.get_message, {queue: queue}) %>
+  <%= format((QUEUE_TYPE(queue).tmpl && QUEUE_TYPE(queue).tmpl.get_message) || "classic-queue-get-message", {queue: queue}) %>
 <% } %>
 
 <% if (is_user_policymaker) { %>

--- a/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/queues.ejs
@@ -233,7 +233,7 @@
             <select name="queuetype" onchange="select_queue_type(queuetype)">
                 <option value="default">Default for virtual host</option>
                 <% for (const [typename, type_config] of Object.entries(QUEUE_TYPE)) { %>
-                  <% if (typename != "default") { %>
+                  <% if (typename != "default" && type_config.tmpl.arguments) { %>
                   <% if (queue_type == typename) { %>
                       <option value="<%= typename%>" selected><%= type_config["label"]%></option>
                   <% } else { %>


### PR DESCRIPTION
Add `rabbit_mqtt_qos0_queue` queue type.

Use `classic-queue-get-message` template when `get_message` action is enabled and not template was configured.
This code keeps backward compatibility with how the get-message UI used to work. Originally, the queue page (queue.ejs) contained the get-message HTML inline. It has since been moved into a separate template that is selected via the queue type’s QueueType.tmpl.get_message attribute.
Some plugins outside rabbitmq-server were written for the old behaviour: they enable the get-message action but never set a get-message template, because the UI was always present. The RabbitMQ Delayed Message plugin is one example: it enables the get-message action but does not declare get_message on its queue type. With this fallback, such queue types still get a template (the classic-queue get-message template) and the UI continues to work without requiring those plugins to be updated.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI