### PR TITLE
Fix #13748: Definition import should ignore the UTF-8 BOM of the uploade

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -439,6 +439,9 @@ decode(Keys, Body) ->
 
 decode(<<"">>) ->
     {ok, #{}};
+%% Strip the UTF-8 BOM if present.
+decode(<<16#EF, 16#BB, 16#BF, Rest/binary>>) ->
+    decode(Rest);
 decode(Body) ->
     try
       Decoded = rabbit_json:decode(Body),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -176,6 +176,9 @@ is_authorized(ReqData, Context) ->
 
 decode(<<"">>) ->
     {ok, #{}};
+%% Strip the UTF-8 BOM if present.
+decode(<<16#EF, 16#BB, 16#BF, Rest/binary>>) ->
+    decode(Rest);
 decode(Body) ->
     try
       Decoded = rabbit_json:decode(Body),


### PR DESCRIPTION
Fixes #13748

## Summary
This PR fixes: Definition import should ignore the UTF-8 BOM of the uploaded file

## Changes
```
deps/rabbit/src/rabbit_definitions.erl                      | 3 +++
 deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl | 3 +++
 2 files changed, 6 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*