### PR TITLE
AWS peer discovery triggers OCI build

### DIFF
--- a/.github/workflows/oci-make.yaml
+++ b/.github/workflows/oci-make.yaml
@@ -14,6 +14,10 @@ on:
       - rabbitmq-components.mk
       - packaging/**
       - .github/workflows/oci-make.yaml
+  workflow_run:
+    workflows: [Peer Discovery AWS Integration Test]
+    types:
+      - requested
   workflow_dispatch:
     inputs:
       otp_version:


### PR DESCRIPTION
The AWS peer discovery workflow relies on the OCI
image existing. We used to build the OCI image for every commit, so the image always existed. Now we build the OCI conditionally, so we should trigger the OCI build
when the AWS job starts. Otherwise it will time out waiting for the image.

This should prevent AWS peer discovery workflow failures/cancellations like this one:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/22321141332/job/64579431308
