### PR TITLE
CT: Allow skipping slapd tests on self-hosted runners

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
@@ -127,6 +127,10 @@ suite() ->
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
+    case os:getenv("RUNNER_ENVIRONMENT") of
+        "self-hosted" -> os:putenv("RABBITMQ_CT_SKIP_AS_ERROR", "0");
+        _ -> ok
+    end,
     rabbit_ct_helpers:run_setup_steps(Config, [fun init_slapd/1]).
 
 end_per_suite(Config) ->


### PR DESCRIPTION
This is a followup of `peer` PR which made self-hosted runner fail for this test suite instead of skipping it as before. Now it will only be skipped on self-hosted runners.

This should be backported everywhere `peer` is backported to.