### PR TITLE
QQ DLX: use a pipeline command for checkout

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_dlx_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_client.erl
@@ -15,6 +15,7 @@
 -record(state,{
           queue_resource :: rabbit_types:r(queue),
           leader :: ra:server_id(),
+          checkout_corr :: undefined | reference(),
           last_msg_id :: non_neg_integer() | -1
          }).
 -type state() :: #state{}.
@@ -35,39 +36,32 @@ settle(MsgIds, #state{leader = Leader} = State)
     {ok, State}.
 
 -spec checkout(rabbit_amqqueue:name(), ra:server_id(), non_neg_integer()) ->
-    {ok, state()} | {error, non_local_leader | ra_command_failed}.
+    state().
 checkout(QResource, Leader, NumUnsettled) ->
     Cmd = rabbit_fifo_dlx:make_checkout(self(), NumUnsettled),
-    State = #state{queue_resource = QResource,
-                   leader = Leader,
-                   last_msg_id = -1},
-    process_command(Cmd, State, 5).
+    Corr = make_ref(),
+    ra:pipeline_command(Leader, Cmd, Corr, normal),
+    #state{queue_resource = QResource,
+           leader = Leader,
+           checkout_corr = Corr,
+           last_msg_id = -1}.
 
-process_command(_Cmd, _State, 0) ->
-    {error, ra_command_failed};
-process_command(Cmd, #state{leader = Leader} = State, Tries) ->
-    case ra:process_command(Leader, Cmd, 60_000) of
-        {ok, ok, Leader} ->
-            {ok, State#state{leader = Leader}};
-        {ok, ok, NonLocalLeader} ->
-            ?LOG_WARNING("Failed to process command ~tp on quorum queue leader ~tp because actual leader is ~tp.",
-                               [Cmd, Leader, NonLocalLeader]),
-            {error, non_local_leader};
-        Err ->
-            ?LOG_WARNING("Failed to process command ~tp on quorum queue leader ~tp: ~tp~n"
-                               "Trying ~b more time(s)...",
-                               [Cmd, Leader, Err, Tries]),
-            process_command(Cmd, State, Tries - 1)
-    end.
-
--spec handle_ra_event(pid(), term(), state()) ->
-    {ok, state(), actions()}.
+-spec handle_ra_event(term(), term(), state()) ->
+    {ok, state(), actions()} | {reject, state()} | ignore.
 handle_ra_event(Leader, {dlx_delivery, _} = Del,
                 #state{leader = _Leader} = State) when node(Leader) == node() ->
     handle_delivery(Del, State);
-handle_ra_event(From, Evt, State) ->
+handle_ra_event(_From, {applied, [{Corr, ok}]},
+                #state{checkout_corr = Corr} = State)
+  when is_reference(Corr) ->
+    {ok, State#state{checkout_corr = undefined}, []};
+handle_ra_event(_From, {rejected, {not_leader, _Leader, Corr}},
+                #state{checkout_corr = Corr} = State)
+  when is_reference(Corr) ->
+    {reject, State};
+handle_ra_event(From, Evt, _State) ->
     ?LOG_DEBUG("Ignoring ra event ~tp from ~tp", [Evt, From]),
-    {ok, State, []}.
+    ignore.
 
 handle_delivery({dlx_delivery, [{FstId, _} | _] = IdMsgs},
                 #state{queue_resource = QRes,

--- a/deps/rabbit/src/rabbit_fifo_dlx_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_client.erl
@@ -8,14 +8,12 @@
 
 -include_lib("kernel/include/logger.hrl").
 
-
--export([checkout/3, settle/2, handle_ra_event/3,
+-export([checkout/3, settle/2, handle_registration/1, handle_ra_event/3,
          overview/1]).
 
 -record(state,{
           queue_resource :: rabbit_types:r(queue),
           leader :: ra:server_id(),
-          checkout_corr :: undefined | reference(),
           last_msg_id :: non_neg_integer() | -1
          }).
 -type state() :: #state{}.
@@ -36,32 +34,34 @@ settle(MsgIds, #state{leader = Leader} = State)
     {ok, State}.
 
 -spec checkout(rabbit_amqqueue:name(), ra:server_id(), non_neg_integer()) ->
-    state().
+    {reference(), state()}.
 checkout(QResource, Leader, NumUnsettled) ->
     Cmd = rabbit_fifo_dlx:make_checkout(self(), NumUnsettled),
     Corr = make_ref(),
     ra:pipeline_command(Leader, Cmd, Corr, normal),
-    #state{queue_resource = QResource,
-           leader = Leader,
-           checkout_corr = Corr,
-           last_msg_id = -1}.
+    {Corr, #state{queue_resource = QResource,
+                  leader = Leader,
+                  last_msg_id = -1}}.
 
--spec handle_ra_event(term(), term(), state()) ->
-    {ok, state(), actions()} | {reject, state()} | ignore.
+-spec handle_registration(term()) ->
+    {registered, reference()} | {not_leader, reference()} | ignore.
+handle_registration({{_, _}, {applied, [{Corr, ok}]}})
+  when is_reference(Corr) ->
+    {registered, Corr};
+handle_registration({{_, _}, {rejected, {not_leader, _Leader, Corr}}})
+  when is_reference(Corr) ->
+    {not_leader, Corr};
+handle_registration(_Evt) ->
+    ignore.
+
+-spec handle_ra_event(pid(), term(), state()) ->
+    {ok, state(), actions()}.
 handle_ra_event(Leader, {dlx_delivery, _} = Del,
                 #state{leader = _Leader} = State) when node(Leader) == node() ->
     handle_delivery(Del, State);
-handle_ra_event(_From, {applied, [{Corr, ok}]},
-                #state{checkout_corr = Corr} = State)
-  when is_reference(Corr) ->
-    {ok, State#state{checkout_corr = undefined}, []};
-handle_ra_event(_From, {rejected, {not_leader, _Leader, Corr}},
-                #state{checkout_corr = Corr} = State)
-  when is_reference(Corr) ->
-    {reject, State};
-handle_ra_event(From, Evt, _State) ->
+handle_ra_event(From, Evt, State) ->
     ?LOG_DEBUG("Ignoring ra event ~tp from ~tp", [Evt, From]),
-    ignore.
+    {ok, State, []}.
 
 handle_delivery({dlx_delivery, [{FstId, _} | _] = IdMsgs},
                 #state{queue_resource = QRes,

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -116,20 +116,20 @@ handle_continue(QRef, undefined) ->
                                          dead_letter_worker_consumer_prefetch),
     {ok, SettleTimeout} = application:get_env(rabbit,
                                               dead_letter_worker_publisher_confirm_timeout),
-    {ok, Q} = rabbit_amqqueue:lookup(QRef),
-    {ClusterName, _MaybeOldLeaderNode} = amqqueue:get_pid(Q),
-    case rabbit_fifo_dlx_client:checkout(QRef, {ClusterName, node()}, Prefetch) of
-        {ok, ConsumerState} ->
-            {noreply, lookup_topology(#state{queue_ref = QRef,
-                                             queue_type_state = rabbit_queue_type:init(),
-                                             settle_timeout = SettleTimeout,
-                                             dlx_client_state = ConsumerState,
-                                             monitor_ref = erlang:monitor(process, ClusterName)
-                                            })};
-        {error, non_local_leader = Reason} ->
-            {stop, {shutdown, Reason}, undefined};
-        Error ->
-            {stop, Error, undefined}
+    case rabbit_amqqueue:lookup(QRef) of
+        {ok, Q} ->
+            {ClusterName, _MaybeOldLeaderNode} = amqqueue:get_pid(Q),
+            ConsumerState = rabbit_fifo_dlx_client:checkout(
+                              QRef, {ClusterName, node()}, Prefetch),
+            {noreply, lookup_topology(
+                        #state{queue_ref = QRef,
+                               queue_type_state = rabbit_queue_type:init(),
+                               settle_timeout = SettleTimeout,
+                               dlx_client_state = ConsumerState,
+                               monitor_ref = erlang:monitor(process, ClusterName)
+                              })};
+        {error, not_found} ->
+            {stop, {shutdown, queue_not_found}, undefined}
     end.
 
 terminate(_Reason, State) ->
@@ -146,25 +146,36 @@ handle_cast({dlx_event, _LeaderPid, lookup_topology},
 handle_cast({dlx_event, LeaderPid, Evt},
             #state{queue_ref = _QRef,
                    dlx_client_state = DlxState0} = State0) ->
-    %% received dead-letter message from source queue
-    {ok, DlxState, Actions} = rabbit_fifo_dlx_client:handle_ra_event(LeaderPid, Evt, DlxState0),
-    State1 = State0#state{dlx_client_state = DlxState},
-    State = handle_queue_actions(Actions, State1),
-    {noreply, State};
-handle_cast({queue_event, QRef, Evt},
-            #state{queue_type_state = QTypeState0} = State0) ->
-
-    case rabbit_queue_type:handle_event(QRef, Evt, QTypeState0) of
-        {ok, QTypeState1, Actions} ->
-            %% received e.g. confirm from target queue
-            State1 = State0#state{queue_type_state = QTypeState1},
+    case rabbit_fifo_dlx_client:handle_ra_event(LeaderPid, Evt, DlxState0) of
+        {ok, DlxState, Actions} ->
+            State1 = State0#state{dlx_client_state = DlxState},
             State = handle_queue_actions(Actions, State1),
             {noreply, State};
-        {eol, Actions} ->
-            State = handle_queue_actions(Actions, State0),
-            remove_queue(QRef, State);
-        {protocol_error, _Type, _Reason, _Args} ->
+        ignore ->
             {noreply, State0}
+    end;
+handle_cast({queue_event, QRef, Evt},
+            #state{dlx_client_state = DlxState0,
+                   queue_type_state = QTypeState0} = State0) ->
+    case maybe_handle_dlx_event(Evt, DlxState0) of
+        {ok, DlxState, Actions} ->
+            State1 = State0#state{dlx_client_state = DlxState},
+            State = handle_queue_actions(Actions, State1),
+            {noreply, State};
+        {reject, _DlxState} ->
+            {stop, {shutdown, not_leader}, State0};
+        ignore ->
+            case rabbit_queue_type:handle_event(QRef, Evt, QTypeState0) of
+                {ok, QTypeState1, Actions} ->
+                    State1 = State0#state{queue_type_state = QTypeState1},
+                    State = handle_queue_actions(Actions, State1),
+                    {noreply, State};
+                {eol, Actions} ->
+                    State = handle_queue_actions(Actions, State0),
+                    remove_queue(QRef, State);
+                {protocol_error, _Type, _Reason, _Args} ->
+                    {noreply, State0}
+            end
     end;
 handle_cast(settle_timeout, State0) ->
     State = State0#state{timer = undefined},
@@ -568,6 +579,11 @@ cancel_timer(#state{timer = TRef} = State)
     State#state{timer = undefined};
 cancel_timer(State) ->
     State.
+
+maybe_handle_dlx_event({{_, _} = ServerId, Evt}, DlxState) ->
+    rabbit_fifo_dlx_client:handle_ra_event(ServerId, Evt, DlxState);
+maybe_handle_dlx_event(_Evt, _DlxState) ->
+    ignore.
 
 queue_names(Qs) ->
     lists:map(fun amqqueue:get_name/1, Qs).

--- a/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
+++ b/deps/rabbit/src/rabbit_fifo_dlx_worker.erl
@@ -73,6 +73,9 @@
           queue_ref :: rabbit_amqqueue:name(),
           %% monitors source queue
           monitor_ref :: reference(),
+          %% Set to a reference while waiting for the checkout command to be
+          %% applied by the leader. Cleared to 'undefined' once registered.
+          checkout_corr :: undefined | reference(),
           %% configured (x-)dead-letter-exchange of source queue
           exchange_ref :: rabbit_exchange:name() | undefined,
           %% configured (x-)dead-letter-routing-key of source queue
@@ -119,15 +122,14 @@ handle_continue(QRef, undefined) ->
     case rabbit_amqqueue:lookup(QRef) of
         {ok, Q} ->
             {ClusterName, _MaybeOldLeaderNode} = amqqueue:get_pid(Q),
-            ConsumerState = rabbit_fifo_dlx_client:checkout(
-                              QRef, {ClusterName, node()}, Prefetch),
-            {noreply, lookup_topology(
-                        #state{queue_ref = QRef,
-                               queue_type_state = rabbit_queue_type:init(),
-                               settle_timeout = SettleTimeout,
-                               dlx_client_state = ConsumerState,
-                               monitor_ref = erlang:monitor(process, ClusterName)
-                              })};
+            {Corr, ConsumerState} = rabbit_fifo_dlx_client:checkout(
+                                      QRef, {ClusterName, node()}, Prefetch),
+            {noreply, #state{queue_ref = QRef,
+                             monitor_ref = erlang:monitor(process, ClusterName),
+                             checkout_corr = Corr,
+                             dlx_client_state = ConsumerState,
+                             queue_type_state = rabbit_queue_type:init(),
+                             settle_timeout = SettleTimeout}};
         {error, not_found} ->
             {stop, {shutdown, queue_not_found}, undefined}
     end.
@@ -139,43 +141,45 @@ handle_call(Request, From, State) ->
     ?LOG_INFO("~ts received unhandled call from ~tp: ~tp", [?MODULE, From, Request]),
     {noreply, State}.
 
-handle_cast({dlx_event, _LeaderPid, lookup_topology},
-            #state{queue_ref = _} = State0) ->
+%% While registering, only handle the checkout confirmation delivered
+%% via the ra_event_formatter as a queue_event.
+handle_cast({queue_event, _QRef, Evt},
+            #state{checkout_corr = Corr} = State0)
+  when is_reference(Corr) ->
+    case rabbit_fifo_dlx_client:handle_registration(Evt) of
+        {registered, Corr} ->
+            {noreply, lookup_topology(State0#state{checkout_corr = undefined})};
+        {not_leader, Corr} ->
+            {stop, {shutdown, not_leader}, State0};
+        ignore ->
+            {noreply, State0}
+    end;
+handle_cast(_Msg, #state{checkout_corr = Corr} = State)
+  when is_reference(Corr) ->
+    {noreply, State};
+handle_cast({dlx_event, _LeaderPid, lookup_topology}, State0) ->
     State = lookup_topology(State0),
     redeliver_and_ack(State);
 handle_cast({dlx_event, LeaderPid, Evt},
-            #state{queue_ref = _QRef,
-                   dlx_client_state = DlxState0} = State0) ->
+            #state{dlx_client_state = DlxState0} = State0) ->
     case rabbit_fifo_dlx_client:handle_ra_event(LeaderPid, Evt, DlxState0) of
         {ok, DlxState, Actions} ->
             State1 = State0#state{dlx_client_state = DlxState},
             State = handle_queue_actions(Actions, State1),
-            {noreply, State};
-        ignore ->
-            {noreply, State0}
+            {noreply, State}
     end;
 handle_cast({queue_event, QRef, Evt},
-            #state{dlx_client_state = DlxState0,
-                   queue_type_state = QTypeState0} = State0) ->
-    case maybe_handle_dlx_event(Evt, DlxState0) of
-        {ok, DlxState, Actions} ->
-            State1 = State0#state{dlx_client_state = DlxState},
+            #state{queue_type_state = QTypeState0} = State0) ->
+    case rabbit_queue_type:handle_event(QRef, Evt, QTypeState0) of
+        {ok, QTypeState1, Actions} ->
+            State1 = State0#state{queue_type_state = QTypeState1},
             State = handle_queue_actions(Actions, State1),
             {noreply, State};
-        {reject, _DlxState} ->
-            {stop, {shutdown, not_leader}, State0};
-        ignore ->
-            case rabbit_queue_type:handle_event(QRef, Evt, QTypeState0) of
-                {ok, QTypeState1, Actions} ->
-                    State1 = State0#state{queue_type_state = QTypeState1},
-                    State = handle_queue_actions(Actions, State1),
-                    {noreply, State};
-                {eol, Actions} ->
-                    State = handle_queue_actions(Actions, State0),
-                    remove_queue(QRef, State);
-                {protocol_error, _Type, _Reason, _Args} ->
-                    {noreply, State0}
-            end
+        {eol, Actions} ->
+            State = handle_queue_actions(Actions, State0),
+            remove_queue(QRef, State);
+        {protocol_error, _Type, _Reason, _Args} ->
+            {noreply, State0}
     end;
 handle_cast(settle_timeout, State0) ->
     State = State0#state{timer = undefined},
@@ -193,8 +197,6 @@ redeliver_and_ack(State0) ->
 handle_info({'DOWN', Ref, process, _, _},
             #state{monitor_ref = Ref,
                    queue_ref = QRef}) ->
-    %% Source quorum queue is down. Therefore, terminate ourself.
-    %% The new leader will re-create another dlx_worker.
     ?LOG_DEBUG("~ts terminating itself because leader of ~ts is down...",
                      [?MODULE, rabbit_misc:rs(QRef)]),
     supervisor:terminate_child(rabbit_fifo_dlx_sup, self());
@@ -579,11 +581,6 @@ cancel_timer(#state{timer = TRef} = State)
     State#state{timer = undefined};
 cancel_timer(State) ->
     State.
-
-maybe_handle_dlx_event({{_, _} = ServerId, Evt}, DlxState) ->
-    rabbit_fifo_dlx_client:handle_ra_event(ServerId, Evt, DlxState);
-maybe_handle_dlx_event(_Evt, _DlxState) ->
-    ignore.
 
 queue_names(Qs) ->
     lists:map(fun amqqueue:get_name/1, Qs).


### PR DESCRIPTION
Before this change, with two leader elections in short succession, we could end up in a situation where no DLX worker is running.

single_dlx_worker test appeared to be flaky, but it actually triggered a real race condition:

A node that briefly was a leader, started a DLX worker which registered itself as a consumer via ra:process_command.

When that node loses leadership a moment later, process_command on the now-follower Ra server redirects the checkout command to the actual leader, where it gets committed to the Raft log. This overwrites the new/real leader's worker registration, terminating the leader's worker.

The result is that the leader has no DLX worker: the old leader's worker is stopped to allow the new leader to take over, but the new leader's worker exits due to a stale checkout.

This PR should address this failure:
https://github.com/rabbitmq/rabbitmq-server/actions/runs/22343794026/job/64653112641?pr=15502