### PR TITLE
Definition import: strip UTF BOM

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -439,10 +439,8 @@ decode(Keys, Body) ->
 
 decode(<<"">>) ->
     {ok, #{}};
-%% Strip the UTF-8 BOM if present.
-decode(<<16#EF, 16#BB, 16#BF, Rest/binary>>) ->
-    decode(Rest);
-decode(Body) ->
+decode(Body0) ->
+    Body = rabbit_misc:strip_bom(Body0),
     try
       Decoded = rabbit_json:decode(Body),
       Normalised = atomise_map_keys(Decoded),

--- a/deps/rabbit/test/definition_import_SUITE.erl
+++ b/deps/rabbit/test/definition_import_SUITE.erl
@@ -54,7 +54,8 @@ groups() ->
                                import_case19,
                                import_case20,
                                import_case21,
-                               import_case22
+                               import_case22,
+                               import_case23
                               ]},
 
         {boot_time_import_using_classic_source, [], [
@@ -340,6 +341,20 @@ import_case22(Config) ->
     ?assertEqual(false, vhost:is_protected_from_deletion(VHost2)),
 
     ok.
+
+%% Tests that definition files with any Unicode BOM prefix are imported successfully.
+import_case23(Config) ->
+    {ok, Body} = file:read_file(filename:join(?config(data_dir, Config), "case2.json")),
+    %% UTF-8
+    import_raw(Config, <<239, 187, 191, Body/binary>>),
+    %% UTF-16 BE
+    import_raw(Config, <<254, 255, Body/binary>>),
+    %% UTF-32 LE
+    import_raw(Config, <<255, 254, 0, 0, Body/binary>>),
+    %% UTF-16 LE
+    import_raw(Config, <<255, 254, Body/binary>>),
+    %% UTF-32 BE
+    import_raw(Config, <<0, 0, 254, 255, Body/binary>>).
 
 export_import_round_trip_case1(Config) ->
     case rabbit_ct_helpers:is_mixed_versions() of

--- a/deps/rabbit_common/src/rabbit_misc.erl
+++ b/deps/rabbit_common/src/rabbit_misc.erl
@@ -77,6 +77,7 @@
 -export([get_gc_info/1]).
 -export([group_proplists_by/2]).
 -export([raw_read_file/1]).
+-export([strip_bom/1]).
 -export([find_child/2]).
 -export([is_regular_file/1]).
 -export([safe_ets_update_counter/3, safe_ets_update_counter/4, safe_ets_update_counter/5,
@@ -1237,6 +1238,19 @@ raw_read_file(File) ->
     catch
         error:{badmatch, Error} -> Error
     end.
+
+-spec strip_bom(binary()) -> binary().
+%% UTF-8
+strip_bom(<<239, 187, 191, Rest/binary>>) -> Rest;
+%% UTF-16 BE
+strip_bom(<<254, 255, Rest/binary>>) -> Rest;
+%% UTF-32 LE (must precede UTF-16 LE to avoid partial match)
+strip_bom(<<255, 254, 0, 0, Rest/binary>>) -> Rest;
+%% UTF-16 LE
+strip_bom(<<255, 254, Rest/binary>>) -> Rest;
+%% UTF-32 BE
+strip_bom(<<0, 0, 254, 255, Rest/binary>>) -> Rest;
+strip_bom(Bin) -> Bin.
 
 -spec is_regular_file(Name) -> boolean() when
       Name :: file:filename_all().

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -176,10 +176,8 @@ is_authorized(ReqData, Context) ->
 
 decode(<<"">>) ->
     {ok, #{}};
-%% Strip the UTF-8 BOM if present.
-decode(<<16#EF, 16#BB, 16#BF, Rest/binary>>) ->
-    decode(Rest);
-decode(Body) ->
+decode(Body0) ->
+    Body = rabbit_misc:strip_bom(Body0),
     try
       Decoded = rabbit_json:decode(Body),
       Normalised = maps:fold(fun(K, V, Acc) ->


### PR DESCRIPTION
Definition import: strip leading UTF BOM

Originally proposed in #15527 by @danielalanbates.

Borrows a function from our rabbitmq.conf parser,
see Kyorai/cuttlefish#64.

Fixes #13748.