### PR TITLE
Add debugging for MQTT flake

### DIFF
--- a/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/mqtt_shared_SUITE.erl
@@ -1484,13 +1484,13 @@ duplicate_client_id(Config) ->
     eventually(?_assertEqual(0, length(all_connection_pids(Config)))).
 
 session_reconnect(Config) ->
-    session_switch(Config, true).
+    session_switch(Config, true, ?FUNCTION_NAME).
 
 session_takeover(Config) ->
-    session_switch(Config, false).
+    session_switch(Config, false, ?FUNCTION_NAME).
 
-session_switch(Config, Disconnect) ->
-    Topic = ClientId = atom_to_binary(?FUNCTION_NAME),
+session_switch(Config, Disconnect, Name) ->
+    Topic = ClientId = atom_to_binary(Name),
     %% Connect to old node in mixed version cluster.
     C1 = connect(ClientId, Config, 1, non_clean_sess_opts()),
     {ok, _, [1]} = emqtt:subscribe(C1, Topic, qos1),
@@ -1515,7 +1515,9 @@ session_switch(Config, Disconnect) ->
     %% New connection should be able to unsubscribe.
     ?assertMatch({ok, _, _}, emqtt:unsubscribe(C2, Topic)),
     {ok, _} = emqtt:publish(C2, Topic, <<"m2">>, qos1),
-    receive Unexpected -> ct:fail({unexpected, Unexpected})
+    receive Unexpected ->
+                ct:pal("C1=~p C2=~p", [C1, C2]),
+                ct:fail({unexpected, Unexpected})
     after 300 -> ok
     end,
 


### PR DESCRIPTION
```
=== Ended at 2026-02-24 16:00:20
=== Location: [{mqtt_shared_SUITE,session_switch,1518},
              {test_server,ts_tc,1796},
              {test_server,run_test_case_eval1,1305},
              {test_server,run_test_case_eval,1237}]
=== === Reason: {failed,
                     {test_case_failed,
                         {unexpected,
                             {publish,
                                 #{client_pid => <0.1399.0>,dup => false,
                                   packet_id => 1,payload => <<"m1">>,
                                   properties => undefined,qos => 1,
                                   retain => false,
                                   topic => <<"session_switch">>,
                                   via => #Port<0.353>}}}}}
```
