### PR TITLE
Expose the rest of aten settings to rabbitmq.conf

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2637,6 +2637,46 @@ end}.
   end
 }.
 
+{mapping, "raft.adaptive_failure_detector.scaling_factor", "aten.scaling_factor", [
+  {datatype, float}
+]}.
+
+{translation, "aten.scaling_factor",
+  fun(Conf) ->
+      case cuttlefish:conf_get("raft.adaptive_failure_detector.scaling_factor", Conf, undefined) of
+          undefined -> cuttlefish:unset();
+          Val       -> Val
+      end
+  end
+}.
+
+{mapping, "raft.adaptive_failure_detector.heartbeat_interval", "aten.heartbeat_interval", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
+{translation, "aten.heartbeat_interval",
+  fun(Conf) ->
+      case cuttlefish:conf_get("raft.adaptive_failure_detector.heartbeat_interval", Conf, undefined) of
+          undefined -> cuttlefish:unset();
+          Val       -> Val
+      end
+  end
+}.
+
+{mapping, "raft.adaptive_failure_detector.detection_threshold", "aten.detection_threshold", [
+  {datatype, float}
+]}.
+
+{translation, "aten.detection_threshold",
+  fun(Conf) ->
+      case cuttlefish:conf_get("raft.adaptive_failure_detector.detection_threshold", Conf, undefined) of
+          undefined -> cuttlefish:unset();
+          Val       -> Val
+      end
+  end
+}.
+
 {mapping, "default_queue_type", "rabbit.default_queue_type", [
     {datatype, atom}
 ]}.

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1111,6 +1111,27 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
+   {raft_adaptive_failure_detector_scaling_factor,
+   "raft.adaptive_failure_detector.scaling_factor = 1.5",
+   [{aten, [
+      {scaling_factor, 1.5}
+     ]}],
+   []},
+
+   {raft_adaptive_failure_detector_heartbeat_interval,
+   "raft.adaptive_failure_detector.heartbeat_interval = 100",
+   [{aten, [
+      {heartbeat_interval, 100}
+     ]}],
+   []},
+
+   {raft_adaptive_failure_detector_detection_threshold,
+   "raft.adaptive_failure_detector.detection_threshold = 0.99",
+   [{aten, [
+      {detection_threshold, 0.99}
+     ]}],
+   []},
+
   %%
   %% Backing queue version
   %%


### PR DESCRIPTION
Previously only the poll interval was exposed for no particular reason.