### PR TITLE
python_SUITE: Wait for bindings to be active before publishing messages

### DIFF
--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/parsing.py
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/parsing.py
@@ -12,6 +12,7 @@ import functools
 import time
 import sys
 import os
+import test_util
 
 def connect(cnames):
     ''' Decorator that creates stomp connections and issues CONNECT '''
@@ -212,7 +213,11 @@ class TestParsing(unittest.TestCase):
         for cd in [self.cd1, self.cd2]:
             cd.sendall(subscribe.encode('utf-8'))
 
-        time.sleep(0.1)
+        bindings_count = 0
+        while bindings_count != 2:
+            time.sleep(0.1)
+            output = test_util.rabbitmqctl_output(['list_bindings'])
+            bindings_count = output.split().count('da9d4779')
 
         cmd = ('SEND\n'
                'content-type:text/plain\n'

--- a/deps/rabbitmq_stomp/test/python_SUITE_data/src/test_util.py
+++ b/deps/rabbitmq_stomp/test/python_SUITE_data/src/test_util.py
@@ -50,3 +50,11 @@ def rabbitmqctl(args):
     cmdline = [ctl, '-n', os.getenv('RABBITMQ_NODENAME')]
     cmdline.extend(args)
     subprocess.check_call(cmdline)
+
+def rabbitmqctl_output(args):
+    ctl = os.getenv('RABBITMQCTL')
+    cmdline = [ctl, '-n', os.getenv('RABBITMQ_NODENAME')]
+    cmdline.extend(args)
+    output = subprocess.check_output(cmdline).decode('utf-8')
+    print(output)
+    return output


### PR DESCRIPTION
## Why

Sometimes, the message was published too soon. This led to a consumer waiting forever and to the testsuite timing out.

## How

We use `rabbitmqctl list_bindings` in a loop to determine when the bindings are active.