### PR TITLE
rabbit_peer_discovery: Handle error/timeout when querying cluster members

### DIFF
--- a/deps/rabbit/src/rabbit_peer_discovery.erl
+++ b/deps/rabbit/src/rabbit_peer_discovery.erl
@@ -603,11 +603,22 @@ do_query_node_props(Nodes, FromNode) when Nodes =/= [] ->
     %% node to the upstream node, regardless of their level.
     _ = logger:set_primary_config(level, debug),
 
-    %% TODO: Replace with `rabbit_nodes:list_members/0' when the oldest
-    %% supported version has it.
     MembersPerNode = [try
-                          {ok,
-                           erpc_call(Node, rabbit_nodes, all, [], FromNode)}
+                          Members0 = erpc_call(
+                                       Node,
+                                       rabbit_nodes, list_members, [],
+                                       FromNode),
+                          %% If `rabbit_nodes:list_members/0' returns an empty
+                          %% list, it means Khepri couldn't return it at this
+                          %% point. Let's assume the node is alone.
+                          Members1 = case Members0 of
+                                         [] ->
+                                             ThisNode = node(),
+                                             [ThisNode];
+                                         _ ->
+                                             Members0
+                                     end,
+                          {ok, Members1}
                       catch
                           Class:Reason ->
                               {Class, Reason}


### PR DESCRIPTION
## Why

If `rabbit_mnesia:members/0` hit an error, it always returned the node itself.

`rabbit_khepri:members/0` returns an empty list to distinguish an error and let the caller handle it.

When peer discovery queries the cluster members ant it fails, it didn't handle the empty list so far. This led to errors while sorting nodes to determine which one to use as the cluster seed.

## How

If `rabbit_nodes:list_members/0` returns an empty list, the code assumes that the node is alone/unclustered (i.e. like what would be implicitly done if Mnesia was used).