### PR TITLE
rabbitmq_cli: Remove compatibility code

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/helpers.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/helpers.ex
@@ -63,12 +63,6 @@ defmodule RabbitMQ.CLI.Core.Helpers do
 
   def with_nodes_in_cluster(node, fun, timeout \\ :infinity) do
     case :rpc.call(node, :rabbit_nodes, :list_running, [], timeout) do
-      {:badrpc, {:EXIT, {:undef, [{:rabbit_nodes, :list_running, [], []} | _]}}} ->
-        case :rpc.call(node, :rabbit_mnesia, :cluster_nodes, [:running], timeout) do
-          {:badrpc, _} = err -> err
-          value -> fun.(value)
-        end
-
       {:badrpc, _} = err ->
         err
 

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -34,16 +34,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
 
   def run([], %{node: node_name, timeout: timeout} = opts) do
     status0 =
-      case :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :cli_cluster_status, []) do
-        {:badrpc, {:EXIT, {:undef, _}}} ->
-          :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :status, [])
-
-        {:badrpc, _} = err ->
-          err
-
-        status ->
-          status
-      end
+      :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :cli_cluster_status, [])
 
     case status0 do
       {:badrpc, _} = err ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -25,13 +25,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
 
   def run([], %{node: node_name} = opts) do
     ret =
-      case :rabbit_misc.rpc_call(node_name, :rabbit_db, :force_load_on_next_boot, []) do
-        {:badrpc, {:EXIT, {:undef, _}}} ->
-          :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :force_load_next_boot, [])
-
-        ret0 ->
-          ret0
-      end
+      :rabbit_misc.rpc_call(node_name, :rabbit_db, :force_load_on_next_boot, [])
 
     case ret do
       {:badrpc, :nodedown} ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -14,13 +14,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
   def run([], %{node: node_name}) do
-    case :rabbit_misc.rpc_call(node_name, :rabbit_db, :force_reset, []) do
-      {:badrpc, {:EXIT, {:undef, _}}} ->
-        :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :force_reset, [])
-
-      ret ->
-        ret
-    end
+    :rabbit_misc.rpc_call(node_name, :rabbit_db, :force_reset, [])
   end
 
   def output({:error, :mnesia_unexpectedly_running}, %{node: node_name}) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -40,12 +40,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
       RabbitMQ.CLI.Core.Helpers.defer(fn ->
         _ = :rabbit_event.start_link()
 
-        try do
-          :rabbit_db_cluster.forget_member(to_atom(node_to_remove), true)
-        catch
-          :error, :undef ->
-            :rabbit_mnesia.forget_cluster_node(to_atom(node_to_remove), true)
-        end
+        :rabbit_db_cluster.forget_member(to_atom(node_to_remove), true)
       end)
     ])
   end
@@ -55,13 +50,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
     args = [atom_name, false]
 
     ret =
-      case :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :forget_member, args) do
-        {:badrpc, {:EXIT, {:undef, _}}} ->
-          :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :forget_cluster_node, args)
-
-        ret0 ->
-          ret0
-      end
+      :rabbit_misc.rpc_call(node_name, :rabbit_db_cluster, :forget_member, args)
 
     case ret do
       {:error, {:failed_to_remove_node, ^atom_name, :rabbit_still_running}} ->

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -29,26 +29,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
     long_or_short_names = Config.get_option(:longnames, opts)
     target_node_normalised = Helpers.normalise_node(target_node, long_or_short_names)
 
-    ret =
-      :rabbit_misc.rpc_call(
-        node_name,
-        :rabbit_db_cluster,
-        :join,
-        [target_node_normalised, node_type]
-      )
-
-    case ret do
-      {:badrpc, {:EXIT, {:undef, _}}} ->
-        :rabbit_misc.rpc_call(
-          node_name,
-          :rabbit_mnesia,
-          :join_cluster,
-          [target_node_normalised, node_type]
-        )
-
-      _ ->
-        ret
-    end
+    :rabbit_misc.rpc_call(
+      node_name,
+      :rabbit_db_cluster,
+      :join,
+      [target_node_normalised, node_type]
+    )
   end
 
   def output({:ok, :already_member}, _) do

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -14,13 +14,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
   def run([], %{node: node_name}) do
-    case :rabbit_misc.rpc_call(node_name, :rabbit_db, :reset, []) do
-      {:badrpc, {:EXIT, {:undef, _}}} ->
-        :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :reset, [])
-
-      ret ->
-        ret
-    end
+    :rabbit_misc.rpc_call(node_name, :rabbit_db, :reset, [])
   end
 
   def output({:error, :mnesia_unexpectedly_running}, %{node: node_name}) do


### PR DESCRIPTION
[Why]
This code was introduced to support the old and new `rabbit_nodes` and `rabbit_db_*` APIs.

With the removal of Mnesia, `rabbit_mnesia won't have the called functions anymore.

The CLI will then only be able to talk to a recent version of RabbitMQ. That's why we don't neet the `rabbit_nodes` anymore either.