### PR TITLE
rabbit_tracking: Replace a call to `mnesia` by one to `ets`

### DIFF
--- a/deps/rabbit/src/rabbit_tracking.erl
+++ b/deps/rabbit/src/rabbit_tracking.erl
@@ -106,7 +106,7 @@ delete_tracked_entry_internal(Node, Tab, TableNameFun, Key) ->
             ok;
         _ ->
             %% Node could be down, but also in a mixed version cluster this function is not
-            %% implemented on pre 3.11.x releases. Ensure that we clean up any mnesia table
-            mnesia:dirty_delete(TableNameFun(Node), Key)
+            %% implemented on pre 3.11.x releases. Ensure that we clean up any ETS table
+            _ = ets:delete(TableNameFun(Node), Key)
     end,
     ok.


### PR DESCRIPTION
## Why

Connection and channel tracking uses ETS. This `mnesia:dirty_delete/2` call must be a left-over.

## How

Let's replace it by a call to `ets:detele/2`.