### PR TITLE
GitHub Actions: Add 15-minutes timeout to `test-upgrades` scenario run

### DIFF
--- a/.github/workflows/test-upgrades.yaml
+++ b/.github/workflows/test-upgrades.yaml
@@ -138,16 +138,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run scenario
+        timeout-minutes: 15
         run: |
           sh NEW/.github/workflows/test-upgrades.sh \
             '${{ matrix.scenario }}' \
             '${{ matrix.node_count }}'
 
-      - name: Upload data dirs for next job
+      - name: Upload data dirs
         if: always()
-        uses: pyTooling/upload-artifact@v6
+        uses: actions/upload-artifact@v6
         with:
           name: instances-data-dirs-${{ matrix.scenario }}-${{ matrix.node_count }}-nodes
-          path: test-instances
+          path: test-instances/*/log/*
           include-hidden-files: true
           if-no-files-found: error


### PR DESCRIPTION
## Why

Some scenarios seem to get stuck indefinitely in CI. We need to add a timeout to 1) avoid that a job runs for hours and 2) hopefully collect some logs after the specific step is killed.