### PR TITLE
rabbit_plugins: Use `rabbit:data_dir/0` not `rabbit_mnesia:dir/0`

### DIFF
--- a/deps/rabbit/src/rabbit_plugins.erl
+++ b/deps/rabbit/src/rabbit_plugins.erl
@@ -99,7 +99,7 @@ user_provided_plugins_data_dir() ->
         {ok, PluginsDataDir} ->
             PluginsDataDir;
         _ ->
-            DataDir = rabbit_mnesia:dir(),
+            DataDir = rabbit:data_dir(),
             filename:join([DataDir, "user_provided_plugins_data_dir"])
     end.
 


### PR DESCRIPTION
## Why

`rabbit_mnesia:dir/0` is no longer the API to get the data directory for some time. It will go away in the short term.