### PR TITLE
rabbit_binding: Handle errors from `rabbit_db_binding:delete_for_destination/1`

### DIFF
--- a/deps/rabbit/src/rabbit_binding.erl
+++ b/deps/rabbit/src/rabbit_binding.erl
@@ -538,6 +538,10 @@ fetch_deletion(XName, Deletions) ->
 %% It is to avoid bindings pointing to queues under deletion.
 -spec delete_for_destination(rabbit_types:binding_destination(), rabbit_types:username()) -> ok.
 delete_for_destination(QName, User) ->
-    Deletions = rabbit_db_binding:delete_for_destination(QName),
-    process_deletions(Deletions),
-    notify_deletions(Deletions, User).
+    case rabbit_db_binding:delete_for_destination(QName) of
+        Deletions when is_map(Deletions) ->
+            process_deletions(Deletions),
+            notify_deletions(Deletions, User);
+        {error, _} ->
+            ok
+    end.

--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -859,6 +859,11 @@ delete_for_source_in_khepri(#resource{virtual_host = VHost, name = SrcName}) ->
               end
       end, [], Bindings).
 
+-spec delete_for_destination(Dst) -> Ret when
+      Dst :: rabbit_types:binding_destination(),
+      Ret :: Deletions | Error,
+      Deletions :: rabbit_binding:deletions(),
+      Error :: {error, any()}.
 
 delete_for_destination(Dst) ->
     rabbit_khepri:handle_fallback(


### PR DESCRIPTION
## Why

Unlike Mnesia, Khepri can return errors. We need to handle that instead of assuming it will always be a map.

While here, add a spec to `rabbit_db_binding:delete_for_destination/1`.