### PR TITLE
rabbitmq_shovel: detach link when closing amqp10 connections

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_amqp10_shovel.erl
@@ -421,7 +421,7 @@ close_source(#{source := #{current := #{conn := Conn,
 close_source(_Config) -> ok.
 
 connection_close(Conn, Sess, LinkRef) ->
-    _ = amqp10_client:detach_link(LinkRef),
+    catch amqp10_client:detach_link(LinkRef),
     _ = amqp10_client:end_session(Sess),
     _ = amqp10_client:close_connection(Conn).
 


### PR DESCRIPTION
When using an autodelete shovel, acks to source might still be in-flight when the connections start to close. Let's give them a short buffer to finish sending acks and then close.

`shovel_dynamic_SUITE:autodelete_classic_on_publish_with_rejections/1` often flakes in CI because of this