### PR TITLE
Grafana: replace TCP sockets panel with file descriptors panel

### DIFF
--- a/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json
+++ b/deps/rabbitmq_prometheus/docker/grafana/dashboards/RabbitMQ-Overview.json
@@ -1812,12 +1812,268 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "File descriptors available to the node OS process. Computed as the OS-level limit minus the number of file descriptors currently in use by the node.\n\nWhen this value reaches zero, the node will not be able to accept new connections or open new files.\n\n* [Networking and RabbitMQ](https://www.rabbitmq.com/docs/networking)\n* [File and Socket Descriptor Limits](https://www.rabbitmq.com/docs/networking#open-file-handle-limit)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "orange",
+                "value": 0
+              },
+              {
+                "color": "transparent",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?0(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#56A64B",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?1(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2CC0C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?2(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3274D9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?3(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A352CC",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?4(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF780A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?5(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#96D98D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?6(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFEE52",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?7(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#8AB8FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?8(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#CA95E5",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^rabbit@[a-zA-Z\\.\\-]*?9(\\b|\\.)/"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFB357",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max", "min"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(rabbitmq_process_max_fds - rabbitmq_process_open_fds) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\", namespace=\"$namespace\", rabbitmq_endpoint=\"$endpoint\"}",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{rabbitmq_node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "File descriptors available",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 28
       },
       "id": 27,
       "panels": [],
@@ -2043,7 +2299,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "id": 9,
       "options": {
@@ -2297,7 +2553,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 29
       },
       "id": 19,
       "options": {
@@ -2338,7 +2594,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 34
       },
       "id": 11,
       "panels": [],
@@ -2564,7 +2820,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 13,
       "options": {
@@ -2634,7 +2890,7 @@
         "h": 5,
         "w": 2,
         "x": 12,
-        "y": 27
+        "y": 35
       },
       "id": 73,
       "interval": "30s",
@@ -2845,7 +3101,7 @@
         "h": 5,
         "w": 10,
         "x": 14,
-        "y": 27
+        "y": 35
       },
       "id": 74,
       "options": {
@@ -3230,7 +3486,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "id": 61,
       "options": {
@@ -3484,7 +3740,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 40
       },
       "id": 18,
       "options": {
@@ -3602,7 +3858,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 45
       },
       "id": 34,
       "options": {
@@ -3869,7 +4125,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 45
       },
       "id": 12,
       "options": {
@@ -3910,7 +4166,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 50
       },
       "id": 29,
       "panels": [],
@@ -4136,7 +4392,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 51
       },
       "id": 14,
       "options": {
@@ -4393,7 +4649,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 51
       },
       "id": 15,
       "options": {
@@ -4647,7 +4903,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 56
       },
       "id": 20,
       "options": {
@@ -4901,7 +5157,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 56
       },
       "id": 21,
       "options": {
@@ -5155,7 +5411,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 61
       },
       "id": 22,
       "options": {
@@ -5273,7 +5529,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 53
+        "y": 61
       },
       "id": 24,
       "options": {
@@ -5391,7 +5647,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 66
       },
       "id": 25,
       "options": {
@@ -5509,7 +5765,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 66
       },
       "id": 23,
       "options": {
@@ -5550,7 +5806,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "id": 53,
       "panels": [],
@@ -5775,7 +6031,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 72
       },
       "id": 57,
       "options": {
@@ -6033,7 +6289,7 @@
         "h": 5,
         "w": 4,
         "x": 12,
-        "y": 64
+        "y": 72
       },
       "id": 58,
       "options": {
@@ -6290,7 +6546,7 @@
         "h": 5,
         "w": 4,
         "x": 16,
-        "y": 64
+        "y": 72
       },
       "id": 60,
       "options": {
@@ -6547,7 +6803,7 @@
         "h": 5,
         "w": 4,
         "x": 20,
-        "y": 64
+        "y": 72
       },
       "id": 59,
       "options": {
@@ -6588,7 +6844,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 77
       },
       "id": 51,
       "panels": [],
@@ -6813,7 +7069,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 70
+        "y": 78
       },
       "id": 54,
       "options": {
@@ -7070,7 +7326,7 @@
         "h": 5,
         "w": 6,
         "x": 12,
-        "y": 70
+        "y": 78
       },
       "id": 55,
       "options": {
@@ -7327,7 +7583,7 @@
         "h": 5,
         "w": 6,
         "x": 18,
-        "y": 70
+        "y": 78
       },
       "id": 56,
       "options": {
@@ -7368,7 +7624,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 83
       },
       "id": 46,
       "panels": [],
@@ -7593,7 +7849,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "id": 47,
       "options": {
@@ -7850,7 +8106,7 @@
         "h": 5,
         "w": 6,
         "x": 12,
-        "y": 76
+        "y": 84
       },
       "id": 48,
       "options": {
@@ -8108,7 +8364,7 @@
         "h": 5,
         "w": 6,
         "x": 18,
-        "y": 76
+        "y": 84
       },
       "id": 49,
       "options": {


### PR DESCRIPTION
The `rabbitmq_process_max_tcp_sockets` metric was removed in RabbitMQ 4.0, affecting the "TCP sockets available" panel on the Overview dashboard.

This commit adds a "File descriptors available" panel using two alternative metrics: `rabbitmq_process_max_fds` and `rabbitmq_process_open_fds`.

The new panel is not exactly identical but should be considered a decent alternative in practice.

Closes #12673. References #15528.
