### PR TITLE
Definitions: refactor JSON to struct mapping

### DIFF
--- a/deps/rabbit/src/rabbit_definitions.erl
+++ b/deps/rabbit/src/rabbit_definitions.erl
@@ -426,8 +426,14 @@ normalize_backend_module(Other) ->
 decode(Keys, Body) ->
     case decode(Body) of
         {ok, J0} ->
-            J = maps:fold(fun(K, V, Acc) ->
-                  Acc#{rabbit_data_coercion:to_atom(K, utf8) => V}
+            J = maps:fold(fun(K, V, Acc) when is_atom(K) ->
+                      Acc#{K => V};
+                  (K, V, Acc) ->
+                      try binary_to_existing_atom(K, utf8) of
+                          Atom -> Acc#{Atom => V}
+                      catch
+                          error:badarg -> Acc
+                      end
                 end, J0, J0),
             Results = [get_or_missing(K, J) || K <- Keys],
             case [E || E = {key_missing, _} <- Results] of
@@ -448,10 +454,15 @@ decode(Body0) ->
     catch error:_ -> {error, not_json}
     end.
 
+%% Only atomize the atoms that already exist.
 atomise_map_keys(Decoded) ->
     maps:fold(fun(K, V, Acc) ->
-        Acc#{rabbit_data_coercion:to_atom(K, utf8) => V}
-              end, Decoded, Decoded).
+        try binary_to_existing_atom(K, utf8) of
+            Atom -> Acc#{Atom => V}
+        catch
+            error:badarg -> Acc
+        end
+    end, #{}, Decoded).
 
 -spec should_skip_if_unchanged() -> boolean().
 should_skip_if_unchanged() ->
@@ -683,9 +694,14 @@ do_concurrent_for_all(List, WorkPoolFun) ->
 
 -spec atomize_keys(#{any() => any()}) -> #{atom() => any()}.
 
+%% Only atomize the atoms that already exist.
 atomize_keys(M) ->
     maps:fold(fun(K, V, Acc) ->
-                maps:put(rabbit_data_coercion:to_atom(K), V, Acc)
+                try
+                    maps:put(rabbit_data_coercion:to_existing_atom(K), V, Acc)
+                catch
+                    error:badarg -> Acc
+                end
               end, #{}, M).
 
 -spec human_readable_category_name(definition_category()) -> string().

--- a/deps/rabbit_common/src/rabbit_data_coercion.erl
+++ b/deps/rabbit_common/src/rabbit_data_coercion.erl
@@ -8,7 +8,7 @@
 -module(rabbit_data_coercion).
 
 -export([to_binary/1, to_list/1, to_atom/1, to_integer/1, to_boolean/1, to_proplist/1, to_map/1, to_map_recursive/1]).
--export([to_atom/2, atomize_keys/1, to_list_of_binaries/1]).
+-export([to_atom/2, to_existing_atom/1, atomize_keys/1, to_list_of_binaries/1]).
 -export([to_utf8_binary/1, to_unicode_charlist/1]).
 -export([as_list/1]).
 
@@ -45,6 +45,11 @@ to_list({V0, V1, V2, V3, V4, V5, V6, V7}=Val)
 to_atom(Val) when is_atom(Val)   -> Val;
 to_atom(Val) when is_list(Val)   -> list_to_atom(Val);
 to_atom(Val) when is_binary(Val) -> binary_to_atom(Val, utf8).
+
+-spec to_existing_atom(Val :: atom() | list() | binary()) -> atom().
+to_existing_atom(Val) when is_atom(Val)   -> Val;
+to_existing_atom(Val) when is_list(Val)   -> list_to_existing_atom(Val);
+to_existing_atom(Val) when is_binary(Val) -> binary_to_existing_atom(Val, utf8).
 
 -spec to_atom(Val :: atom() | list() | binary(), Encoding :: atom()) -> atom().
 to_atom(Val, _Encoding) when is_atom(Val)   -> Val;

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_definitions.erl
@@ -180,12 +180,20 @@ decode(Body0) ->
     Body = rabbit_misc:strip_bom(Body0),
     try
       Decoded = rabbit_json:decode(Body),
-      Normalised = maps:fold(fun(K, V, Acc) ->
-                     Acc#{binary_to_atom(K, utf8) => V}
-                   end, Decoded, Decoded),
+      Normalised = atomise_known_keys(Decoded),
       {ok, Normalised}
     catch error:_ -> {error, not_json}
     end.
+
+%% Only atomize the atoms that already exist.
+atomise_known_keys(Map) ->
+    maps:fold(fun(K, V, Acc) ->
+        try binary_to_existing_atom(K, utf8) of
+            Atom -> Acc#{Atom => V}
+        catch
+            error:badarg -> Acc
+        end
+    end, #{}, Map).
 
 accept(Body, ReqData, Context = #context{user = #user{username = Username}}) ->
     %% At this point the request was fully received.


### PR DESCRIPTION
Note that all the top-level definition keys
are "known" atoms in the sense that they are
definitely used/referenced during node boot before on-boot definition import even has a chance to run.
