### PR TITLE
HTTP API: refactor how QQ replica ops fetch node names

### DIFF
--- a/deps/rabbit_common/test/unit_SUITE.erl
+++ b/deps/rabbit_common/test/unit_SUITE.erl
@@ -26,6 +26,7 @@
 all() ->
     [
         {group, parallel_tests},
+        {group, sequential_tests},
         {group, gen_server2},
         {group, date_time}
     ].
@@ -54,6 +55,9 @@ groups() ->
             data_coercion_to_boolean,
             data_coercion_to_integer,
             data_coercion_to_atom,
+            data_coercion_to_existing_atom,
+            data_coercion_to_existing_atom_rejects_unknown,
+            data_coercion_to_existing_atom_passthrough,
             pget,
             deep_pget,
             encrypt_decrypt,
@@ -67,6 +71,9 @@ groups() ->
             name_type,
             get_erl_path,
             hexify
+        ]},
+        {sequential_tests, [], [
+            data_coercion_to_existing_atom_does_not_create_atoms
         ]},
         {gen_server2, [parallel], [
             stats_timer_is_working,
@@ -312,6 +319,43 @@ data_coercion_to_atom(_Config) ->
     %% to_atom/2 with explicit encoding
     ?assertEqual(hello, rabbit_data_coercion:to_atom(<<"hello">>, utf8)),
     ?assertEqual(hello, rabbit_data_coercion:to_atom(<<"hello">>, latin1)).
+
+data_coercion_to_existing_atom(_Config) ->
+    promotable = rabbit_data_coercion:to_existing_atom(<<"promotable">>),
+    non_voter  = rabbit_data_coercion:to_existing_atom(<<"non_voter">>),
+    voter      = rabbit_data_coercion:to_existing_atom(<<"voter">>),
+    all        = rabbit_data_coercion:to_existing_atom(<<"all">>),
+    even       = rabbit_data_coercion:to_existing_atom(<<"even">>),
+    %% List (string) inputs
+    promotable = rabbit_data_coercion:to_existing_atom("promotable"),
+    all        = rabbit_data_coercion:to_existing_atom("all"),
+    ok.
+
+data_coercion_to_existing_atom_rejects_unknown(_Config) ->
+    ?assertError(badarg,
+                 rabbit_data_coercion:to_existing_atom(<<"xyzzy_not_an_atom_42">>)),
+    ?assertError(badarg,
+                 rabbit_data_coercion:to_existing_atom(<<"fabricated_node@host">>)),
+    ?assertError(badarg,
+                 rabbit_data_coercion:to_existing_atom("xyzzy_not_an_atom_42")),
+    ok.
+
+data_coercion_to_existing_atom_passthrough(_Config) ->
+    hello = rabbit_data_coercion:to_existing_atom(hello),
+    true  = rabbit_data_coercion:to_existing_atom(true),
+    ok.
+
+data_coercion_to_existing_atom_does_not_create_atoms(_Config) ->
+    CountBefore = erlang:system_info(atom_count),
+    InvalidInputs = [<<"abc_made_up_", (integer_to_binary(I))/binary>>
+                     || I <- lists:seq(1, 10_000)],
+    lists:foreach(
+      fun(Bin) ->
+              catch rabbit_data_coercion:to_existing_atom(Bin)
+      end, InvalidInputs),
+    CountAfter = erlang:system_info(atom_count),
+    ?assert(CountAfter - CountBefore =< 50),
+    ok.
 
 data_coercion_to_boolean(_Config) ->
     %% For booleans, this is an identity function

--- a/deps/rabbit_common/test/unit_prop_SUITE.erl
+++ b/deps/rabbit_common/test/unit_prop_SUITE.erl
@@ -25,7 +25,8 @@ groups() ->
         {parallel_tests, [parallel], [
             data_coercion_as_list_property,
             data_coercion_to_binary_roundtrip_property,
-            data_coercion_to_map_recursive_property
+            data_coercion_to_map_recursive_property,
+            data_coercion_to_existing_atom_property
         ]}
     ].
 
@@ -90,6 +91,20 @@ data_coercion_to_map_recursive_property(_Config) ->
           {on_output, fun(".", _) -> ok;
                          (F, A) -> ct:pal(?LOW_IMPORTANCE, F, A)
                       end}])).
+
+data_coercion_to_existing_atom_property(_Config) ->
+    ?assert(
+       proper:quickcheck(
+         ?FORALL(Bin, binary(),
+                 begin
+                     try
+                         rabbit_data_coercion:to_existing_atom(Bin),
+                         true
+                     catch
+                         error:badarg -> true
+                     end
+                 end),
+         [{numtests, 1000} | proper_opts()])).
 
 proplist_or_value() ->
     ?LAZY(oneof([

--- a/deps/rabbitmq_management/src/rabbit_mgmt_nodes.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_nodes.erl
@@ -9,7 +9,10 @@
 
 -export([
     node_name_from_req/1,
-    node_exists/1
+    node_exists/1,
+    parse_node_name/1,
+    require_node_name/1,
+    safe_atom/2
 ]).
 
 %%
@@ -19,12 +22,26 @@
 -spec node_name_from_req(cowboy_req:req()) ->
     {ok, node()} | {error, not_a_cluster_member}.
 node_name_from_req(ReqData) ->
-    try binary_to_existing_atom(rabbit_mgmt_util:id(node, ReqData), utf8) of
-        Node ->
-            case rabbit_nodes:is_member(Node) of
-                true  -> {ok, Node};
-                false -> {error, not_a_cluster_member}
-            end
+    parse_node_name(rabbit_mgmt_util:id(node, ReqData)).
+
+%% Validates a node name given as a binary, list (string), or atom.
+%% Returns {ok, Node} if the atom exists and the node is a cluster member.
+-spec parse_node_name(binary() | atom() | string()) ->
+    {ok, node()} | {error, not_a_cluster_member}.
+parse_node_name(Node) when is_atom(Node) ->
+    case rabbit_nodes:is_member(Node) of
+        true  -> {ok, Node};
+        false -> {error, not_a_cluster_member}
+    end;
+parse_node_name(NodeBin) when is_binary(NodeBin) ->
+    try binary_to_existing_atom(NodeBin, utf8) of
+        Node -> parse_node_name(Node)
+    catch
+        error:badarg -> {error, not_a_cluster_member}
+    end;
+parse_node_name(NodeList) when is_list(NodeList) ->
+    try list_to_existing_atom(NodeList) of
+        Node -> parse_node_name(Node)
     catch
         error:badarg -> {error, not_a_cluster_member}
     end.
@@ -34,4 +51,20 @@ node_exists(ReqData) ->
     case node_name_from_req(ReqData) of
         {ok, _}    -> true;
         {error, _} -> false
+    end.
+
+-spec require_node_name(binary() | atom() | string()) -> node().
+require_node_name(Val) ->
+    case parse_node_name(Val) of
+        {ok, Node} -> Node;
+        {error, _} -> throw({error, <<"Node is not a cluster member">>})
+    end.
+
+-spec safe_atom(atom() | binary() | string(), binary()) -> atom().
+safe_atom(Val, _Label) when is_atom(Val) ->
+    Val;
+safe_atom(Val, Label) ->
+    try rabbit_data_coercion:to_existing_atom(Val)
+    catch error:badarg ->
+            throw({error, <<"Invalid ", Label/binary, " value">>})
     end.

--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -310,11 +310,11 @@ reply_list(Facts, DefaultSorts, ReqData, Context, Pagination) ->
 
     reply(SortList, ReqData, Context).
 
--spec get_sort_reverse(cowboy_req:req()) -> atom().
+-spec get_sort_reverse(cowboy_req:req()) -> boolean().
 get_sort_reverse(ReqData) ->
     case get_value_param(<<"sort_reverse">>, ReqData) of
-        undefined -> false;
-        V -> list_to_atom(V)
+        "true" -> true;
+        _      -> false
     end.
 
 -spec is_pagination_requested(#pagination{} | undefined) -> boolean().

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_node_memory_ets.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_node_memory_ets.erl
@@ -35,12 +35,19 @@ is_authorized(ReqData, {Mode, Context}) ->
 
 %%--------------------------------------------------------------------
 
+-spec get_filter(cowboy_req:req()) -> atom().
 get_filter(ReqData) ->
     case rabbit_mgmt_util:id(filter, ReqData) of
-        none                        -> all;
-        <<"management">>            -> rabbit_mgmt_storage;
-        Other when is_binary(Other) -> list_to_atom(binary_to_list(Other));
-        _                           -> all
+        none ->
+            all;
+        <<"management">> ->
+            rabbit_mgmt_storage;
+        Other when is_binary(Other) ->
+            try binary_to_existing_atom(Other, utf8)
+            catch error:badarg -> undefined
+            end;
+        _ ->
+            all
     end.
 
 augment(Mode, ReqData) ->

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue_get.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_queue_get.erl
@@ -11,6 +11,7 @@
   allowed_methods/2, accept_content/2, content_types_provided/2,
   content_types_accepted/2]).
 -export([variances/2]).
+-export([parse_ackmode/1]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
 -include_lib("amqp_client/include/amqp_client.hrl").
@@ -56,7 +57,7 @@ do_it(ReqData0, Context) ->
               rabbit_mgmt_util:with_channel(
                 VHost, ReqData, Context,
                 fun (Ch) ->
-                        AckMode = list_to_atom(binary_to_list(AckModeBin)),
+                        AckMode = parse_ackmode(AckModeBin),
                         Count = rabbit_mgmt_util:parse_int(CountBin),
                         Enc = case EncBin of
                                   <<"auto">>   -> auto;
@@ -93,10 +94,26 @@ basic_gets(Count, Ch, Q, AckMode, Enc, Trunc) ->
 ackmode_to_requeue(reject_requeue_false) -> false;
 ackmode_to_requeue(reject_requeue_true) -> true.
 
-parse_ackmode(ack_requeue_false) -> true;
-parse_ackmode(ack_requeue_true) -> false;
-parse_ackmode(reject_requeue_false) -> false;
-parse_ackmode(reject_requeue_true) -> false.
+-type ackmode() :: ack_requeue_true | ack_requeue_false |
+                   reject_requeue_true | reject_requeue_false.
+
+-spec parse_ackmode(binary()) -> ackmode().
+parse_ackmode(<<"ack_requeue_true">>)     -> ack_requeue_true;
+parse_ackmode(<<"ack_requeue_false">>)    -> ack_requeue_false;
+parse_ackmode(<<"reject_requeue_true">>)  -> reject_requeue_true;
+parse_ackmode(<<"reject_requeue_false">>) -> reject_requeue_false;
+parse_ackmode(Other) ->
+    throw({error, iolist_to_binary(
+                    [<<"Invalid ackmode value: ">>, Other,
+                     <<". Valid values are: ack_requeue_true, "
+                       "ack_requeue_false, reject_requeue_true, "
+                       "reject_requeue_false">>])}).
+
+-spec ackmode_no_ack(ackmode()) -> boolean().
+ackmode_no_ack(ack_requeue_false)    -> true;
+ackmode_no_ack(ack_requeue_true)     -> false;
+ackmode_no_ack(reject_requeue_false) -> false;
+ackmode_no_ack(reject_requeue_true)  -> false.
 
 
 % the messages must rejects later,
@@ -132,7 +149,7 @@ maybe_reject_or_nack(_Ch, _AckMode, _DeliveryTag) -> ok.
 basic_get(Ch, Q, AckMode, Enc, Trunc) ->
     case amqp_channel:call(Ch,
 			   #'basic.get'{queue = Q,
-					no_ack = parse_ackmode(AckMode)}) of
+					no_ack = ackmode_no_ack(AckMode)}) of
         {#'basic.get_ok'{redelivered   = Redelivered,
                          exchange      = Exchange,
                          routing_key   = RoutingKey,

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_add_member.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_add_member.erl
@@ -37,16 +37,14 @@ accept_content(ReqData, Context) ->
   Res = rabbit_mgmt_util:with_decode(
     [node], ReqData, Context,
     fun([NewReplicaNode], Body, _ReqData) ->
-      Membership = maps:get(<<"membership">>, Body, promotable),
+      Node = rabbit_mgmt_nodes:require_node_name(NewReplicaNode),
+      Membership0 = maps:get(<<"membership">>, Body, promotable),
+      Membership = rabbit_mgmt_nodes:safe_atom(Membership0, <<"membership">>),
       rabbit_amqqueue:with(
         rabbit_misc:r(VHost, queue, QName),
         fun(_Q) ->
                 rabbit_quorum_queue:add_member(
-                  VHost,
-                  QName,
-                  rabbit_data_coercion:to_atom(NewReplicaNode),
-                  rabbit_data_coercion:to_atom(Membership),
-                  ?TIMEOUT)
+                  VHost, QName, Node, Membership, ?TIMEOUT)
         end)
     end),
   case Res of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_delete_member.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_delete_member.erl
@@ -35,10 +35,11 @@ delete_resource(ReqData, Context) ->
   Res = rabbit_mgmt_util:with_decode(
     [node], ReqData, Context,
     fun([NewReplicaNode], _Body, _ReqData) ->
+      Node = rabbit_mgmt_nodes:require_node_name(NewReplicaNode),
       rabbit_amqqueue:with(
         rabbit_misc:r(VHost, queue, QName),
         fun(_Q) ->
-          rabbit_quorum_queue:delete_member(VHost, QName, rabbit_data_coercion:to_atom(NewReplicaNode))
+          rabbit_quorum_queue:delete_member(VHost, QName, Node)
         end)
     end),
   case Res of

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_grow.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_grow.erl
@@ -26,25 +26,22 @@ content_types_accepted(ReqData, Context) ->
   {[{'*', accept_content}], ReqData, Context}.
 
 resource_exists(ReqData, Context) ->
-  case rabbit_mgmt_util:id(node, ReqData) of
-    none -> {false, ReqData, Context};
-    Node ->
-      NodeExists = lists:member(rabbit_data_coercion:to_atom(Node), rabbit_nodes:list_running()),
-      {NodeExists, ReqData, Context}
+  case rabbit_mgmt_nodes:node_name_from_req(ReqData) of
+      {ok, Node} ->
+          {lists:member(Node, rabbit_nodes:list_running()), ReqData, Context};
+      {error, _} ->
+          {false, ReqData, Context}
   end.
 
 accept_content(ReqData, Context) ->
-  NewReplicaNode = rabbit_mgmt_util:id(node, ReqData),
+  {ok, Node} = rabbit_mgmt_nodes:node_name_from_req(ReqData),
   rabbit_mgmt_util:with_decode(
     [vhost_pattern, queue_pattern, strategy], ReqData, Context,
     fun([VHPattern, QPattern, Strategy], Body, _ReqData) ->
-      Membership = maps:get(<<"membership">>, Body, promotable),
-      rabbit_quorum_queue:grow(
-        rabbit_data_coercion:to_atom(NewReplicaNode),
-        VHPattern,
-        QPattern,
-        rabbit_data_coercion:to_atom(Strategy),
-        rabbit_data_coercion:to_atom(Membership))
+      Strat = rabbit_mgmt_nodes:safe_atom(Strategy, <<"strategy">>),
+      Membership0 = maps:get(<<"membership">>, Body, promotable),
+      Membership = rabbit_mgmt_nodes:safe_atom(Membership0, <<"membership">>),
+      rabbit_quorum_queue:grow(Node, VHPattern, QPattern, Strat, Membership)
     end),
   {true, ReqData, Context}.
 

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_shrink.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_quorum_queue_replicas_shrink.erl
@@ -7,7 +7,8 @@
 -module(rabbit_mgmt_wm_quorum_queue_replicas_shrink).
 
 -export([init/2, is_authorized/2, allowed_methods/2,
-  content_types_accepted/2, delete_resource/2, delete_completed/2]).
+  content_types_accepted/2, resource_exists/2,
+  delete_resource/2, delete_completed/2]).
 -export([variances/2]).
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
@@ -23,9 +24,12 @@ allowed_methods(ReqData, Context) ->
 content_types_accepted(ReqData, Context) ->
   {[{'*', accept_content}], ReqData, Context}.
 
+resource_exists(ReqData, Context) ->
+    {rabbit_mgmt_nodes:node_exists(ReqData), ReqData, Context}.
+
 delete_resource(ReqData, Context) ->
-  NodeToRemove = rabbit_mgmt_util:id(node, ReqData),
-  _ = rabbit_quorum_queue:shrink_all(rabbit_data_coercion:to_atom(NodeToRemove)),
+  {ok, Node} = rabbit_mgmt_nodes:node_name_from_req(ReqData),
+  _ = rabbit_quorum_queue:shrink_all(Node),
   {true, ReqData, Context}.
 
 delete_completed(ReqData, Context) ->

--- a/deps/rabbitmq_management/test/unit_SUITE.erl
+++ b/deps/rabbitmq_management/test/unit_SUITE.erl
@@ -1,0 +1,75 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(unit_SUITE).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+    [
+     {group, unit_tests},
+     {group, property_tests}
+    ].
+
+groups() ->
+    [
+     {unit_tests, [parallel], [
+         parse_ackmode_valid_values,
+         parse_ackmode_rejects_unknown
+     ]},
+     {property_tests, [parallel], [
+         parse_ackmode_never_creates_atoms
+     ]}
+    ].
+
+init_per_suite(Config) -> Config.
+end_per_suite(_Config) -> ok.
+init_per_group(_, Config) -> Config.
+end_per_group(_, _Config) -> ok.
+
+%%
+%% parse_ackmode/1
+%%
+
+parse_ackmode_valid_values(_Config) ->
+    ack_requeue_true     = rabbit_mgmt_wm_queue_get:parse_ackmode(<<"ack_requeue_true">>),
+    ack_requeue_false    = rabbit_mgmt_wm_queue_get:parse_ackmode(<<"ack_requeue_false">>),
+    reject_requeue_true  = rabbit_mgmt_wm_queue_get:parse_ackmode(<<"reject_requeue_true">>),
+    reject_requeue_false = rabbit_mgmt_wm_queue_get:parse_ackmode(<<"reject_requeue_false">>),
+    ok.
+
+parse_ackmode_rejects_unknown(_Config) ->
+    lists:foreach(
+      fun(Val) ->
+              ?assertThrow({error, _}, rabbit_mgmt_wm_queue_get:parse_ackmode(Val))
+      end,
+      [<<"">>, <<"nack">>, <<"ack">>, <<"true">>, <<"false">>,
+       <<"ACK_REQUEUE_TRUE">>, <<"ack_requeue_true ">>,
+       <<"reject_requeue">>, <<"unknown_mode">>]),
+    ok.
+
+parse_ackmode_never_creates_atoms(_Config) ->
+    Valid = [<<"ack_requeue_true">>, <<"ack_requeue_false">>,
+             <<"reject_requeue_true">>, <<"reject_requeue_false">>],
+    Prop = ?FORALL(
+        Bin,
+        proper_types:binary(),
+        case lists:member(Bin, Valid) of
+            true ->
+                is_atom(rabbit_mgmt_wm_queue_get:parse_ackmode(Bin));
+            false ->
+                try
+                    rabbit_mgmt_wm_queue_get:parse_ackmode(Bin),
+                    false
+                catch throw:{error, _} ->
+                    true
+                end
+        end),
+    ?assert(proper:quickcheck(Prop, [quiet, {numtests, 500}])).


### PR DESCRIPTION
Follow-up to #15621 #15622 #15625.