### PR TITLE
Add peek function to amqp10 parser

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -16,7 +16,9 @@
 -include("amqp10_framing.hrl").
 
 -export([parse/1,
-         parse_many/2]).
+         parse_many/2,
+         peek/1,
+         peek_value_size/1]).
 
 %% §1.6
 -define(CODE_ULONG, 16#80).
@@ -338,3 +340,57 @@ pm_compound(UnitSize, Bin, O, B) ->
 
 reached_body(Position, DescriptorCode) ->
     [{{pos, Position}, {body, DescriptorCode}}].
+
+%% Returns the descriptor of the described type at the start of the binary,
+%% without parsing the value.
+-spec peek(binary()) -> {ulong, non_neg_integer()} | {symbol, binary()}.
+peek(<<?DESCRIBED, Rest/binary>>) ->
+    {Descriptor, _B1} = parse(Rest),
+    Descriptor;
+peek(<<Type, _/binary>>) ->
+    throw({not_described_type, Type}).
+
+%% Returns the byte size of the AMQP value at the start of the binary
+%% without parsing it (no term construction).
+-spec peek_value_size(binary()) -> non_neg_integer().
+peek_value_size(<<16#40, _/binary>>) -> 1;
+peek_value_size(<<16#41, _/binary>>) -> 1;
+peek_value_size(<<16#42, _/binary>>) -> 1;
+peek_value_size(<<16#43, _/binary>>) -> 1;
+peek_value_size(<<16#44, _/binary>>) -> 1;
+peek_value_size(<<16#45, _/binary>>) -> 1;
+peek_value_size(<<16#50, _/binary>>) -> 2;
+peek_value_size(<<16#51, _/binary>>) -> 2;
+peek_value_size(<<16#52, _/binary>>) -> 2;
+peek_value_size(<<?CODE_SMALL_ULONG, _/binary>>) -> 2;
+peek_value_size(<<16#54, _/binary>>) -> 2;
+peek_value_size(<<16#55, _/binary>>) -> 2;
+peek_value_size(<<16#56, _/binary>>) -> 2;
+peek_value_size(<<16#60, _/binary>>) -> 3;
+peek_value_size(<<16#61, _/binary>>) -> 3;
+peek_value_size(<<16#70, _/binary>>) -> 5;
+peek_value_size(<<16#71, _/binary>>) -> 5;
+peek_value_size(<<16#72, _/binary>>) -> 5;
+peek_value_size(<<16#73, _/binary>>) -> 5;
+peek_value_size(<<16#74, _/binary>>) -> 5;
+peek_value_size(<<?CODE_ULONG, _/binary>>) -> 9;
+peek_value_size(<<16#81, _/binary>>) -> 9;
+peek_value_size(<<16#82, _/binary>>) -> 9;
+peek_value_size(<<16#83, _/binary>>) -> 9;
+peek_value_size(<<16#84, _/binary>>) -> 9;
+peek_value_size(<<16#94, _/binary>>) -> 17;
+peek_value_size(<<16#98, _/binary>>) -> 17;
+peek_value_size(<<16#a0, S:8, _/binary>>) -> 2 + S;
+peek_value_size(<<16#a1, S:8, _/binary>>) -> 2 + S;
+peek_value_size(<<?CODE_SYM_8, S:8, _/binary>>) -> 2 + S;
+peek_value_size(<<?CODE_SYM_32, S:32, _/binary>>) -> 5 + S;
+peek_value_size(<<16#b0, S:32, _/binary>>) -> 5 + S;
+peek_value_size(<<16#b1, S:32, _/binary>>) -> 5 + S;
+peek_value_size(<<16#c0, Size, _/binary>>) -> 2 + Size;
+peek_value_size(<<16#c1, Size, _/binary>>) -> 2 + Size;
+peek_value_size(<<16#d0, Size:32, _/binary>>) -> 5 + Size;
+peek_value_size(<<16#d1, Size:32, _/binary>>) -> 5 + Size;
+peek_value_size(<<16#e0, S:8, _/binary>>) -> 2 + S;
+peek_value_size(<<16#f0, S:32, _/binary>>) -> 5 + S;
+peek_value_size(<<Type, _/binary>>) ->
+    throw({primitive_type_unsupported, Type, peek_value_size}).

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -21,7 +21,12 @@ all_tests() ->
     [
      roundtrip,
      array_with_extra_input,
-     unsupported_type
+     unsupported_type,
+     peek_value_size_fixed,
+     peek_value_size_variable,
+     peek_described_section,
+     peek_non_described_throws,
+     peek_total_size_matches_parse
     ].
 
 groups() ->
@@ -85,3 +90,73 @@ unsupported_type(_Config) ->
     Bin = <<UnsupportedType, "hey">>,
     Expected = {primitive_type_unsupported, UnsupportedType, {position, 0}},
     ?assertThrow(Expected, amqp10_binary_parser:parse_many(Bin, [])).
+
+%%%===================================================================
+%%% peek_value_size/1 and peek/1
+%%%===================================================================
+
+peek_value_size_fixed(_Config) ->
+    %% 1-byte primitives (type code only)
+    ?assertEqual(1, amqp10_binary_parser:peek_value_size(<<16#40, 0>>)),
+    ?assertEqual(1, amqp10_binary_parser:peek_value_size(<<16#41, 0>>)),
+    ?assertEqual(1, amqp10_binary_parser:peek_value_size(<<16#45, 0>>)),
+    %% 2-byte (type + 1 byte)
+    ?assertEqual(2, amqp10_binary_parser:peek_value_size(<<16#50, 42>>)),
+    ?assertEqual(2, amqp10_binary_parser:peek_value_size(<<16#53, 16#75>>)),
+    %% 3-byte (type + 2 bytes)
+    ?assertEqual(3, amqp10_binary_parser:peek_value_size(<<16#60, 0, 1>>)),
+    %% 5-byte (type + 4 bytes)
+    ?assertEqual(5, amqp10_binary_parser:peek_value_size(<<16#70, 0, 0, 0, 0>>)),
+    %% 9-byte (type + 8 bytes)
+    ?assertEqual(9, amqp10_binary_parser:peek_value_size(<<16#80, 0:64>>)),
+    %% 17-byte (uuid)
+    ?assertEqual(17, amqp10_binary_parser:peek_value_size(<<16#98, 0:128>>)).
+
+peek_value_size_variable(_Config) ->
+    %% Binary: 0xa0 + size (1 byte) + payload -> 2 + S
+    ?assertEqual(5, amqp10_binary_parser:peek_value_size(<<16#a0, 3, "foo">>)),
+    %% UTF8: 0xa1 + size + payload
+    ?assertEqual(6, amqp10_binary_parser:peek_value_size(<<16#a1, 4, "test">>)),
+    %% Symbol (CODE_SYM_8 = 0xa3)
+    ?assertEqual(7, amqp10_binary_parser:peek_value_size(<<16#a3, 5, "hello">>)),
+    %% List: 0xc0 + size byte -> 2 + Size
+    ?assertEqual(4, amqp10_binary_parser:peek_value_size(<<16#c0, 2, 0, 16#40>>)).
+
+peek_described_section(_Config) ->
+    %% v1_0.data: described {ulong, 0x75}, value {binary, <<"x">>}
+    DataSection = {described, {ulong, 16#75}, {binary, <<"x">>}},
+    Bin = iolist_to_binary(amqp10_binary_generator:generate(DataSection)),
+    Descriptor = amqp10_binary_parser:peek(Bin),
+    ?assertEqual('v1_0.data', element(1, amqp10_framing0:record_for(Descriptor))),
+    %% v1_0.properties (symbol descriptor) with empty list value
+    PropsSection = {described, {symbol, <<"amqp:properties:list">>}, {list, []}},
+    BinProps = iolist_to_binary(amqp10_binary_generator:generate(PropsSection)),
+    DescriptorProps = amqp10_binary_parser:peek(BinProps),
+    ?assertEqual('v1_0.properties', element(1, amqp10_framing0:record_for(DescriptorProps))).
+
+peek_non_described_throws(_Config) ->
+    %% First byte must be ?DESCRIBED (0); any other type throws
+    ?assertThrow({not_described_type, 16#40}, amqp10_binary_parser:peek(<<16#40>>)),
+    ?assertThrow({not_described_type, 16#41}, amqp10_binary_parser:peek(<<16#41, 0>>)).
+
+peek_total_size_matches_parse(_Config) ->
+    %% For any described type, total size (1 + descriptor size + value size) must equal bytes consumed by parse
+    Sections = [
+        {described, {ulong, 16#75}, {binary, <<>>}},
+        {described, {ulong, 16#75}, {binary, <<"payload">>}},
+        {described, {symbol, <<"amqp:data:binary">>}, {binary, <<"x">>}},
+        {described, {symbol, <<"URL">>}, {utf8, <<"http://example.org">>}}
+    ],
+    lists:foreach(
+      fun(Term) ->
+              Bin = iolist_to_binary(amqp10_binary_generator:generate(Term)),
+              <<0, Rest/binary>> = Bin,
+              {_Descriptor, B1} = amqp10_binary_parser:parse(Rest),
+              <<_:B1/binary, Rest1/binary>> = Rest,
+              B2 = amqp10_binary_parser:peek_value_size(Rest1),
+              TotalSize = 1 + B1 + B2,
+              {_Parsed, BytesParsed} = amqp10_binary_parser:parse(Bin),
+              ?assertEqual(BytesParsed, TotalSize,
+                          "total size must match parse bytes consumed")
+      end,
+      Sections).

--- a/deps/rabbitmq_ct_helpers/src/stream_test_utils.erl
+++ b/deps/rabbitmq_ct_helpers/src/stream_test_utils.erl
@@ -171,7 +171,7 @@ sub_batch_entry_uncompressed(Sequence, AppProps, Bodies) ->
 sub_batch_entry_compressed(Sequence, Bodies) ->
     Uncompressed = lists:foldl(fun(Body, Acc) ->
                                        Bin = iolist_to_binary(amqp10_framing:encode_bin(#'v1_0.data'{content = Body})),
-                                       <<Acc/binary, Bin/binary>>
+                                       <<Acc/binary, 0:1, (byte_size(Bin)):31, Bin/binary>>
                                end, <<>>, Bodies),
     Compressed = zlib:gzip(Uncompressed),
     CompressedLen = byte_size(Compressed),


### PR DESCRIPTION
## Proposed Changes

This PR adds a peek function to the amqp10 parser so that it is possible to know, before parsing the entire coming Amqp 10 section, its total size and the sections's type/name. This PR was generated on the back of the stream browser plugin's PR. 
The goal is to avoid having to parse an entire AMQP 1.0 section which can be a large AMQP data section or a metada section with large number of entries which the stream browser does not need to stream to the client, or it could be a section whose size exceeds the maximum size the stream browser should stream to the client (the management ui).

The PR adds another unrelated change which is a change to stream_test_util.erl module, in particular, a function for compressed subbatches. This change was required to pass tests which tested compressed sub-batches.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
