### PR TITLE
rabbit_deprecated_features: Fix type spec of `is_feature_used_callback_ret/0`

### DIFF
--- a/deps/rabbit/src/rabbit_deprecated_features.erl
+++ b/deps/rabbit/src/rabbit_deprecated_features.erl
@@ -236,7 +236,7 @@
         nodes := [node()]}.
 %% A map passed to {@type is_feature_used_callback()}.
 
--type is_feature_used_callback_ret() :: boolean().
+-type is_feature_used_callback_ret() :: boolean() | undefined.
 %% Return value of the `is_feature_used' callback.
 
 -export_type([deprecated_feature_modattr/0,


### PR DESCRIPTION
## Why

The callback can return `undefined` when it can't tell if the feature is used or not.