### PR TITLE
rabbitmq-diagnostics status: handle nil vm_memory_high_watermark

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
@@ -54,6 +54,10 @@ defmodule RabbitMQ.CLI.Core.Memory do
     |> Enum.sort_by(fn {_key, %{bytes: bytes}} -> bytes end, &>=/2)
   end
 
+  def formatted_watermark(nil) do
+    nil
+  end
+
   def formatted_watermark(val) when is_float(val) do
     %{relative: val}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -161,6 +161,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
         %{:relative => val} -> "#{val} of available memory"
         # absolute value
         %{:absolute => val} -> "#{IU.convert(val, unit)} #{unit}"
+        nil -> "(unknown)"
       end
 
     memory_section =


### PR DESCRIPTION
Fixes #15679

## Why

When a node is in maintenance mode, the `vm_memory_monitor` GenServer is not running. `rabbit_misc:filter_exit_map/2` in `rabbit.erl` silently drops the `:vm_memory_high_watermark` key from the status result keyword list when the process call exits. `Keyword.get(result, :vm_memory_high_watermark)` therefore returns `nil`, and `nil |> Memory.formatted_watermark/1` crashes with a `FunctionClauseError` because no clause matches `nil`.

This crash affects both `rabbitmq-diagnostics status` and `rabbitmqctl status` when run against a node that has been put into maintenance mode.

## Stack Trace

```
** (FunctionClauseError) no function clause matching in RabbitMQ.CLI.Core.Memory.formatted_watermark/1
    lib/rabbitmq/cli/core/memory.ex:57: RabbitMQ.CLI.Core.Memory.formatted_watermark(nil)
    lib/rabbitmq/cli/ctl/commands/status_command.ex:274: RabbitMQ.CLI.Ctl.Commands.StatusCommand.result_map/1
    lib/rabbitmq/cli/ctl/commands/status_command.ex:65: RabbitMQ.CLI.Ctl.Commands.StatusCommand.output/2
    lib/rabbitmqctl.ex:174: RabbitMQCtl.maybe_run_command/3
```

## Changes

- **`memory.ex`**: add a `nil` clause to `formatted_watermark/1` that returns `nil`, so the JSON formatter path completes without crashing.
- **`status_command.ex`**: add a `nil` branch to the `readable_watermark_setting` case expression so the text formatter outputs `(unknown)` instead of crashing.

This is the same crash location as #2964, but triggered by `nil` instead of `{:relative, float}`.

## Checklist

- [x] I have signed the CLA (https://github.com/rabbitmq/cla)
- [x] I have read `CONTRIBUTING.md`
- [ ] I have added tests that prove my fix is effective
- [ ] If relevant, I have added this change to `release-notes/`
