### PR TITLE
`rabbitmq-diagnostics status`: handle `nil` values when target node was put into maintenance mode (originally by @jalju0804)

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/core/memory.ex
@@ -54,10 +54,6 @@ defmodule RabbitMQ.CLI.Core.Memory do
     |> Enum.sort_by(fn {_key, %{bytes: bytes}} -> bytes end, &>=/2)
   end
 
-  def formatted_watermark(nil) do
-    nil
-  end
-
   def formatted_watermark(val) when is_float(val) do
     %{relative: val}
   end

--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -161,7 +161,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
         %{:relative => val} -> "#{val} of available memory"
         # absolute value
         %{:absolute => val} -> "#{IU.convert(val, unit)} #{unit}"
-        nil -> "(unknown)"
+        nil -> "(not available)"
       end
 
     memory_section =
@@ -177,7 +177,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
 
     disk_space_section = [
       "\n#{bright("Free Disk Space")}\n",
-      "Low free disk space watermark: #{IU.convert(m[:disk_free_limit], unit)} #{unit}",
+      "Low free disk space watermark: #{space_as_iu_or_unknown(m[:disk_free_limit], unit)}",
       "Free disk space: #{space_as_iu_or_unknown(m[:disk_free], unit)}"
     ]
 
@@ -265,7 +265,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
       net_ticktime: net_ticktime(result),
       vm_memory_calculation_strategy: Keyword.get(result, :vm_memory_calculation_strategy),
       vm_memory_high_watermark_setting:
-        Keyword.get(result, :vm_memory_high_watermark) |> formatted_watermark,
+        case Keyword.get(result, :vm_memory_high_watermark) do
+          nil -> nil
+          val -> formatted_watermark(val)
+        end,
       vm_memory_high_watermark_limit: Keyword.get(result, :vm_memory_limit),
       disk_free_limit: Keyword.get(result, :disk_free_limit),
       disk_free: Keyword.get(result, :disk_free),
@@ -299,6 +302,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
 
   def space_as_iu_or_unknown(value, unit) do
     case value do
+      nil ->
+        "(not available)"
+
       :NaN ->
         "(not available)"
 


### PR DESCRIPTION
Reported by @jalju0804 in https://github.com/rabbitmq/rabbitmq-server/pull/15678 with a proposed fix in https://github.com/rabbitmq/rabbitmq-server/issues/15679.

The fix is generally on the right track but can be done a bit more thoroughly and cover more keys, plus use a slightly more consistent language.

The `nil`-safe keys in this scenario are now

1. `:vm_memory_high_watermark`
2. `:vm_memory_limit`
3. `:disk_free_limit`
4. `:disk_free`

Closes #15678.