### PR TITLE
Expose peek_value_size only for testing

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -17,8 +17,12 @@
 
 -export([parse/1,
          parse_many/2,
-         peek/1,
-         peek_value_size/1]).
+         peek/1]).
+
+-ifdef(TEST).
+-export([peek_value_size_fixed_test/0,
+         peek_value_size_variable_test/0]).
+-endif.
 
 %% §1.6
 -define(CODE_ULONG, 16#80).
@@ -341,18 +345,20 @@ pm_compound(UnitSize, Bin, O, B) ->
 reached_body(Position, DescriptorCode) ->
     [{{pos, Position}, {body, DescriptorCode}}].
 
-%% Returns the descriptor of the described type at the start of the binary,
-%% without parsing the value.
--spec peek(binary()) -> {ulong, non_neg_integer()} | {symbol, binary()}.
+%% Returns the descriptor and total byte size (1 + B1 + B2) of the described type
+%% at the start of the binary, without parsing the value.
+-spec peek(binary()) ->
+    {({ulong, non_neg_integer()} | {symbol, binary()}), TotalSize :: non_neg_integer()}.
 peek(<<?DESCRIBED, Rest/binary>>) ->
-    {Descriptor, _B1} = parse(Rest),
-    Descriptor;
+    {Descriptor, B1} = parse(Rest),
+    <<_:B1/binary, Rest1/binary>> = Rest,
+    B2 = peek_value_size(Rest1),
+    {Descriptor, 1 + B1 + B2};
 peek(<<Type, _/binary>>) ->
     throw({not_described_type, Type}).
 
 %% Returns the byte size of the AMQP value at the start of the binary
-%% without parsing it (no term construction).
--spec peek_value_size(binary()) -> non_neg_integer().
+%% without parsing it (no term construction). Used by peek/1.
 peek_value_size(<<16#40, _/binary>>) -> 1;
 peek_value_size(<<16#41, _/binary>>) -> 1;
 peek_value_size(<<16#42, _/binary>>) -> 1;
@@ -394,3 +400,35 @@ peek_value_size(<<16#e0, S:8, _/binary>>) -> 2 + S;
 peek_value_size(<<16#f0, S:32, _/binary>>) -> 5 + S;
 peek_value_size(<<Type, _/binary>>) ->
     throw({primitive_type_unsupported, Type, peek_value_size}).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+peek_value_size_fixed_test() ->
+    %% 1-byte primitives (type code only)
+    ?assertEqual(1, peek_value_size(<<16#40, 0>>)),
+    ?assertEqual(1, peek_value_size(<<16#41, 0>>)),
+    ?assertEqual(1, peek_value_size(<<16#45, 0>>)),
+    %% 2-byte (type + 1 byte)
+    ?assertEqual(2, peek_value_size(<<16#50, 42>>)),
+    ?assertEqual(2, peek_value_size(<<16#53, 16#75>>)),
+    %% 3-byte (type + 2 bytes)
+    ?assertEqual(3, peek_value_size(<<16#60, 0, 1>>)),
+    %% 5-byte (type + 4 bytes)
+    ?assertEqual(5, peek_value_size(<<16#70, 0, 0, 0, 0>>)),
+    %% 9-byte (type + 8 bytes)
+    ?assertEqual(9, peek_value_size(<<16#80, 0:64>>)),
+    %% 17-byte (uuid)
+    ?assertEqual(17, peek_value_size(<<16#98, 0:128>>)).
+
+peek_value_size_variable_test() ->
+    %% Binary: 0xa0 + size (1 byte) + payload -> 2 + S
+    ?assertEqual(5, peek_value_size(<<16#a0, 3, "foo">>)),
+    %% UTF8: 0xa1 + size + payload
+    ?assertEqual(6, peek_value_size(<<16#a1, 4, "test">>)),
+    %% Symbol (CODE_SYM_8 = 0xa3)
+    ?assertEqual(7, peek_value_size(<<16#a3, 5, "hello">>)),
+    %% List: 0xc0 + size byte -> 2 + Size
+    ?assertEqual(4, peek_value_size(<<16#c0, 2, 0, 16#40>>)).
+
+-endif.

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -22,8 +22,7 @@ all_tests() ->
      roundtrip,
      array_with_extra_input,
      unsupported_type,
-     peek_value_size_fixed,
-     peek_value_size_variable,
+     peek_described_section_total_sizes,
      peek_described_section,
      peek_non_described_throws,
      peek_total_size_matches_parse
@@ -92,47 +91,43 @@ unsupported_type(_Config) ->
     ?assertThrow(Expected, amqp10_binary_parser:parse_many(Bin, [])).
 
 %%%===================================================================
-%%% peek_value_size/1 and peek/1
+%%% peek/1 (exercises peek_value_size internally via described types)
 %%%===================================================================
 
-peek_value_size_fixed(_Config) ->
-    %% 1-byte primitives (type code only)
-    ?assertEqual(1, amqp10_binary_parser:peek_value_size(<<16#40, 0>>)),
-    ?assertEqual(1, amqp10_binary_parser:peek_value_size(<<16#41, 0>>)),
-    ?assertEqual(1, amqp10_binary_parser:peek_value_size(<<16#45, 0>>)),
-    %% 2-byte (type + 1 byte)
-    ?assertEqual(2, amqp10_binary_parser:peek_value_size(<<16#50, 42>>)),
-    ?assertEqual(2, amqp10_binary_parser:peek_value_size(<<16#53, 16#75>>)),
-    %% 3-byte (type + 2 bytes)
-    ?assertEqual(3, amqp10_binary_parser:peek_value_size(<<16#60, 0, 1>>)),
-    %% 5-byte (type + 4 bytes)
-    ?assertEqual(5, amqp10_binary_parser:peek_value_size(<<16#70, 0, 0, 0, 0>>)),
-    %% 9-byte (type + 8 bytes)
-    ?assertEqual(9, amqp10_binary_parser:peek_value_size(<<16#80, 0:64>>)),
-    %% 17-byte (uuid)
-    ?assertEqual(17, amqp10_binary_parser:peek_value_size(<<16#98, 0:128>>)).
-
-peek_value_size_variable(_Config) ->
-    %% Binary: 0xa0 + size (1 byte) + payload -> 2 + S
-    ?assertEqual(5, amqp10_binary_parser:peek_value_size(<<16#a0, 3, "foo">>)),
-    %% UTF8: 0xa1 + size + payload
-    ?assertEqual(6, amqp10_binary_parser:peek_value_size(<<16#a1, 4, "test">>)),
-    %% Symbol (CODE_SYM_8 = 0xa3)
-    ?assertEqual(7, amqp10_binary_parser:peek_value_size(<<16#a3, 5, "hello">>)),
-    %% List: 0xc0 + size byte -> 2 + Size
-    ?assertEqual(4, amqp10_binary_parser:peek_value_size(<<16#c0, 2, 0, 16#40>>)).
+%% Asserts peek returns total size equal to byte_size for described sections.
+%% Covers the same value-size logic as peek_value_size without calling it,
+%% so the suite works when the dep is built without exporting peek_value_size (e.g. CI).
+peek_described_section_total_sizes(_Config) ->
+    Sections = [
+        {described, {ulong, 16#75}, {binary, <<>>}},
+        {described, {ulong, 16#75}, {binary, <<"x">>}},
+        {described, {ulong, 16#75}, {binary, <<"payload">>}},
+        {described, {symbol, <<"amqp:data:binary">>}, {binary, <<"x">>}},
+        {described, {symbol, <<"amqp:properties:list">>}, {list, []}},
+        {described, {symbol, <<"URL">>}, {utf8, <<"http://example.org">>}}
+    ],
+    lists:foreach(
+      fun(Term) ->
+              Bin = iolist_to_binary(amqp10_binary_generator:generate(Term)),
+              {_Descriptor, TotalSize} = amqp10_binary_parser:peek(Bin),
+              ?assertEqual(byte_size(Bin), TotalSize,
+                          "peek total size must equal section byte size")
+      end,
+      Sections).
 
 peek_described_section(_Config) ->
     %% v1_0.data: described {ulong, 0x75}, value {binary, <<"x">>}
     DataSection = {described, {ulong, 16#75}, {binary, <<"x">>}},
     Bin = iolist_to_binary(amqp10_binary_generator:generate(DataSection)),
-    Descriptor = amqp10_binary_parser:peek(Bin),
+    {Descriptor, TotalSize} = amqp10_binary_parser:peek(Bin),
     ?assertEqual('v1_0.data', element(1, amqp10_framing0:record_for(Descriptor))),
+    ?assertEqual(6, TotalSize),
     %% v1_0.properties (symbol descriptor) with empty list value
     PropsSection = {described, {symbol, <<"amqp:properties:list">>}, {list, []}},
     BinProps = iolist_to_binary(amqp10_binary_generator:generate(PropsSection)),
-    DescriptorProps = amqp10_binary_parser:peek(BinProps),
-    ?assertEqual('v1_0.properties', element(1, amqp10_framing0:record_for(DescriptorProps))).
+    {DescriptorProps, TotalSizeProps} = amqp10_binary_parser:peek(BinProps),
+    ?assertEqual('v1_0.properties', element(1, amqp10_framing0:record_for(DescriptorProps))),
+    ?assertEqual(byte_size(BinProps), TotalSizeProps).
 
 peek_non_described_throws(_Config) ->
     %% First byte must be ?DESCRIBED (0); any other type throws
@@ -140,7 +135,7 @@ peek_non_described_throws(_Config) ->
     ?assertThrow({not_described_type, 16#41}, amqp10_binary_parser:peek(<<16#41, 0>>)).
 
 peek_total_size_matches_parse(_Config) ->
-    %% For any described type, total size (1 + descriptor size + value size) must equal bytes consumed by parse
+    %% For any described type, peek total size must equal bytes consumed by parse
     Sections = [
         {described, {ulong, 16#75}, {binary, <<>>}},
         {described, {ulong, 16#75}, {binary, <<"payload">>}},
@@ -150,13 +145,9 @@ peek_total_size_matches_parse(_Config) ->
     lists:foreach(
       fun(Term) ->
               Bin = iolist_to_binary(amqp10_binary_generator:generate(Term)),
-              <<0, Rest/binary>> = Bin,
-              {_Descriptor, B1} = amqp10_binary_parser:parse(Rest),
-              <<_:B1/binary, Rest1/binary>> = Rest,
-              B2 = amqp10_binary_parser:peek_value_size(Rest1),
-              TotalSize = 1 + B1 + B2,
+              {_Descriptor, TotalSize} = amqp10_binary_parser:peek(Bin),
               {_Parsed, BytesParsed} = amqp10_binary_parser:parse(Bin),
               ?assertEqual(BytesParsed, TotalSize,
-                          "total size must match parse bytes consumed")
+                          "peek total size must match parse bytes consumed")
       end,
       Sections).


### PR DESCRIPTION
## Proposed Changes

Expose peek_value_size only for testing. `peek` returns the descriptor and the full size of the descriptor hence there is no need to expose peek_value_size.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
