### PR TITLE
rabbit_stream_manager: Handle internal_error in stream declaration

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_manager.erl
@@ -556,7 +556,15 @@ do_create_stream(VirtualHost, Reference, StreamQueueArguments, Username) ->
                             ?LOG_WARNING("Error while creating ~tp stream, "
                                                ++ Msg,
                                                [Reference] ++ Args),
-                            {error, validation_failed}
+                            {error, validation_failed};
+                        {protocol_error,
+                         internal_error,
+                         Msg,
+                         Args} ->
+                            ?LOG_WARNING("Error while creating ~tp stream, "
+                                               ++ Msg,
+                                               [Reference] ++ Args),
+                            {error, internal_error}
                     end
                 catch
                     exit:Error ->


### PR DESCRIPTION
`rabbit_stream_queue:declare/2` may fail to declare if the metadata store operation(s) time out, like when the cluster has a minority of online nodes. This would cause a case_clause error in `rabbit_stream_manager:do_create_stream/4`. We can print a warning log and return `{error, internal_error}` instead.