### PR TITLE
Stop using `rabbit_fifo_index` in QQ v8

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1004,6 +1004,8 @@ convert_v7_to_v8(#{system_time := Ts} = _Meta, StateV7) ->
     Pq = queue:fold(fun (I, Acc) ->
                             rabbit_fifo_pq:in(?DEFAULT_PRIORITY, I, Acc)
                     end, Pq0, No),
+    Dlx0 = element(#?STATE.dlx, StateV7),
+    Dlx = Dlx0#?DLX{unused = ?NIL},
     StateV8 = StateV7,
     StateV8#?STATE{cfg = Cfg#cfg{consumer_disconnected_timeout = 60_000,
                                  delayed_retry = disabled},
@@ -1013,6 +1015,7 @@ convert_v7_to_v8(#{system_time := Ts} = _Meta, StateV7) ->
                    waiting_consumers = Waiting,
                    next_consumer_timeout = Timeout,
                    last_command_time = Ts,
+                   dlx = Dlx,
                    delayed = #delayed{}
                   }.
 
@@ -3896,17 +3899,13 @@ dlx_apply(_Meta, {dlx, {settle, MsgIds}}, at_least_once,
         maps:fold(
           fun(MsgId, ?TUPLE(_Rsn, Msg),
               {Sz, #?DLX{consumer = #dlx_consumer{checked_out = Checked} = C,
-                         msg_bytes_checkout = BytesCheckout,
-                         ra_indexes = Indexes0} = S}) ->
-                  Idx = get_msg_idx(Msg),
+                         msg_bytes_checkout = BytesCheckout} = S}) ->
                   Hdr = get_msg_header(Msg),
-                  Indexes = rabbit_fifo_index:delete(Idx, Indexes0),
                   Size = get_header(size, Hdr),
                   {Sz + Size + ?ENQ_OVERHEAD_B,
                    S#?DLX{consumer = C#dlx_consumer{checked_out =
                                                     maps:remove(MsgId, Checked)},
-                          msg_bytes_checkout = BytesCheckout - Size,
-                          ra_indexes = Indexes}}
+                          msg_bytes_checkout = BytesCheckout - Size}}
           end, {0, State0}, Acked),
     {State, DBytes,
      [{mod_call, rabbit_global_counters, messages_dead_lettered_confirmed,
@@ -4065,8 +4064,7 @@ dlx_purge(#?DLX{consumer = Consumer0} = State) ->
     State#?DLX{discards = lqueue:new(),
                msg_bytes = 0,
                msg_bytes_checkout = 0,
-               consumer = Consumer,
-               ra_indexes = rabbit_fifo_index:empty()}.
+               consumer = Consumer}.
 
 dlx_stat(#?DLX{consumer = Con,
                discards = Discards,
@@ -4130,16 +4128,12 @@ discard_or_dead_letter(Msgs, Reason, at_least_once, State0)
                                         Acc + size_in_bytes(M) + ?ENQ_OVERHEAD_B
                                 end, 0, Msgs),
     State = lists:foldl(fun(Msg, #?DLX{discards = D0,
-                                       msg_bytes = B0,
-                                       ra_indexes = I0} = S0) ->
+                                       msg_bytes = B0} = S0) ->
                                 MsgSize = size_in_bytes(Msg),
                                 D = lqueue:in(?TUPLE(Reason, Msg), D0),
                                 B = B0 + MsgSize,
-                                Idx = get_msg_idx(Msg),
-                                I = rabbit_fifo_index:append(Idx, I0),
                                 S0#?DLX{discards = D,
-                                        msg_bytes = B,
-                                        ra_indexes = I}
+                                        msg_bytes = B}
                         end, State0, Msgs),
     {State, RetainedBytes,
      [{mod_call, rabbit_global_counters, messages_dead_lettered,

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -258,9 +258,7 @@
         {consumer :: option(#dlx_consumer{}),
          %% Queue of dead-lettered messages.
          discards = lqueue:new() :: lqueue:lqueue(optimised_tuple(rabbit_dead_letter:reason(), msg())),
-         %% Raft indexes of messages in both discards queue and dlx_consumer's checked_out map
-         %% so that we get the smallest ra index in O(1).
-         ra_indexes = rabbit_fifo_index:empty() :: rabbit_fifo_index:state(),
+         unused = ?NIL,
          msg_bytes = 0 :: non_neg_integer(),
          msg_bytes_checkout = 0 :: non_neg_integer()}).
 
@@ -279,11 +277,6 @@
          % a map containing all the live processes that have ever enqueued
          % a message to this queue
          enqueuers = #{} :: #{pid() => #enqueuer{}},
-         % index of all messages that have been delivered at least once
-         % used to work out the smallest live raft index
-         % rabbit_fifo_index can be slow when calculating the smallest
-         % index when there are large gaps but should be faster than gb_trees
-         % for normal appending operations as it's backed by a map
          last_command_time = 0,
          next_consumer_timeout = infinity :: infinity | milliseconds(),
          % consumers need to reflect consumer state at time of snapshot


### PR DESCRIPTION
The ra_indexes field in the #rabbit_fifo_dlx{} record tracked Raft indexes of dead-lettered messages using rabbit_fifo_index. In v8, this is redundant because smallest_raft_index/1 and live_indexes/1 already compute DLX indexes directly by iterating over discards and the DLX consumer's checked_out map.

The field is kept as `unused` (rather than removed) to preserve the tuple size for compatibility with rabbit_fifo_dlx.erl. The v7-to-v8 conversion clears it to free memory.