### PR TITLE
Report a [more] correct message when running `rabbitmq-plugins` as non-`root` user

### DIFF
--- a/scripts/rabbitmq-script-wrapper
+++ b/scripts/rabbitmq-script-wrapper
@@ -102,9 +102,15 @@ exec_script_as_root() {
 run_script_help_and_fail() {
   "/usr/lib/rabbitmq/bin/$SCRIPT" help
 
-  echo "
-Only root or rabbitmq can run $SCRIPT
-"
+  msg="Only root or rabbitmq can run $SCRIPT"
+  if calling_rabbitmq_plugins
+  then
+    msg="Only root can run $SCRIPT"
+  fi
+
+  echo
+  echo "$msg"
+  echo
   exit 1
 }
 


### PR DESCRIPTION
Addresses the confusion shown in the following:
* https://github.com/rabbitmq/rabbitmq-server/pull/15685#issuecomment-4036305568
* https://github.com/rabbitmq/rabbitmq-server/discussions/15686

Basically, a RabbitMQ user thought they should be able to run the `rabbitmq-plugins` command as either `root` or `rabbitmq`, when, in fact, only the `root` user is allowed.