### PR TITLE
rabbit_stream_coordinator: Make new_stream command idempotent

### DIFF
--- a/deps/rabbit/src/rabbit_stream_coordinator.erl
+++ b/deps/rabbit/src/rabbit_stream_coordinator.erl
@@ -1411,6 +1411,17 @@ filter_command(_Meta, {delete_stream, _StreamId, #{}}, undefined) ->
     %% Attempting to delete a stream which does not exist. Reply 'ok' to the
     %% caller so that this action is idempotent.
     {reply, ok};
+filter_command(#{machine_version := Vsn},
+               {new_stream, _StreamId, #{}},
+               #stream{members = Members}) when ?V7_OR_MORE(Vsn) ->
+    MaybeLeader = [Pid || _Node := #member{state = {running, _, Pid},
+                                           role = {writer, _}} <- Members],
+    case MaybeLeader of
+        [LeaderPid] ->
+            {reply, {ok, LeaderPid}};
+        [] ->
+            {reply, '$ra_no_reply'}
+    end;
 filter_command(_, _, _) ->
     ok.
 
@@ -1420,8 +1431,8 @@ update_stream(Meta, Cmd, Stream) ->
     catch
         _:E:Stacktrace ->
             ?LOG_WARNING(
-              "~ts failed to update stream:~n~W~n~W",
-              [?MODULE, E, 10, Stacktrace, 10]),
+              "~ts failed to update stream:~n~P~n~P",
+              [?MODULE, E, 10, Stacktrace, 30]),
             Stream
     end.
 

--- a/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_coordinator_SUITE.erl
@@ -33,6 +33,7 @@ all_tests() ->
      sac_pre_v7_down_handler_should_use_monitors_map,
      sac_pre_v7_ensure_monitors_should_use_monitors_map,
      new_stream,
+     new_stream_idempotent,
      leader_down,
      leader_down_scenario_1,
      replica_down,
@@ -494,6 +495,31 @@ new_stream(_) ->
                                                    current = undefined,
                                                    state = {running, E, R2Pid}}}},
                  S7),
+
+    ok.
+
+new_stream_idempotent(_) ->
+    S0 = rabbit_stream_coordinator:init(#{machine_version => 7}),
+    StreamId = atom_to_list(?FUNCTION_NAME),
+
+    TypeState = #{name => StreamId,
+                  retention => [],
+                  nodes => [node()]},
+    Q = new_q(list_to_binary(StreamId), TypeState),
+    NewStream = {new_stream, StreamId, #{leader_node => node(),
+                                         retention => [],
+                                         queue => Q}},
+    From = {self(), make_ref()},
+    StartIdx = ?LINE,
+    Meta = (meta(StartIdx))#{from => From},
+    {S1, '$ra_no_reply', _} = apply_cmd(Meta, NewStream, S0),
+    {S1, '$ra_no_reply', []} = apply_cmd(Meta#{index := ?LINE}, NewStream, S1),
+    Pid = self(),
+    {S2, _, _} = apply_cmd(meta(?LINE), {member_started, StreamId,
+                                         #{epoch => 1,
+                                           index => StartIdx,
+                                           pid => Pid}}, S1),
+    {_, {ok, Pid}, []} = apply_cmd(Meta#{index := ?LINE}, NewStream, S2),
 
     ok.
 


### PR DESCRIPTION
This is similar to https://github.com/rabbitmq/rabbitmq-server/pull/14884 but for `new_stream`.

Although its unlikely from the calling code, the stream coordinator can end up with two `{new_stream, StreamId, #{}}` commands in its log for the same `StreamId`. When handling the second `new_stream` it will then warning-log that the stream can't be updated, like so:

```log
2026-03-10 17:31:38.897507+00:00 [warning] <0.14468.0> rabbit_stream_coordinator failed to update stream:
2026-03-10 17:31:38.897507+00:00 [warning] <0.14468.0> function_clause
2026-03-10 17:31:38.897507+00:00 [warning] <0.14468.0> [{rabbit_stream_coordinator,update_stream0,[#{index => 51,system_time => 1773163898892,reply_mode => await_consensus,machine_version => 6,...},{new_stream,[95|...],#{}},{stream,[...],...}],[{file,[114|...]},{line,1397}]},{rabbit_stream_coordinator,update_stream,3,[{file,[...]},{line,...}]},{rabbit_stream_coordinator,apply,3,[{file,...},{...}]},{ra_server,apply_with,2,[{...}|...]},{ra_log,fold,5,[...]},{ra_server,apply_to,5,...},{ra_server,evaluate_commit_index_follower,...},{ra_server,...}]
```

`update_stream0/3` only has a function clause for when there is no stream (i.e. undefined, <https://github.com/rabbitmq/rabbitmq-server/blob/0b951b8b288e4926ff198f38855729b38e876dc8/deps/rabbit/src/rabbit_stream_coordinator.erl#L1397-L1420>). I think it's reasonable to have the new_stream command become idempotent and effectively skip it if it is in the log twice.

I haven't been able to reproduce the scenario where this happened. Next time I will dump Khepri and the coordinator's logs to see what sequence of commands lead to this.