### PR TITLE
HTTP API: refactor `read_complete_body/1`

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_util.erl
@@ -739,8 +739,22 @@ read_complete_body(Req0, Acc, BodySizeLimit) ->
             {error, http_body_limit_exceeded, BodySizeLimit, N};
         false ->
             case cowboy_req:read_body(Req0) of
-                {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};
-                {more, Data, Req} -> read_complete_body(Req, <<Acc/binary, Data/binary>>)
+                {ok, Data, Req} ->
+                    Total = <<Acc/binary, Data/binary>>,
+                    case byte_size(Total) > BodySizeLimit of
+                        true ->
+                            {error, http_body_limit_exceeded, BodySizeLimit, byte_size(Total)};
+                        false ->
+                            {ok, Total, Req}
+                    end;
+                {more, Data, Req} ->
+                    Total = <<Acc/binary, Data/binary>>,
+                    case byte_size(Total) > BodySizeLimit of
+                        true ->
+                            {error, http_body_limit_exceeded, BodySizeLimit, byte_size(Total)};
+                        false ->
+                            read_complete_body(Req, Total, BodySizeLimit)
+                    end
             end
     end.
 
@@ -764,8 +778,16 @@ do_read_complete_body_with_limit(Req0, Acc, BodySizeLimit) ->
             {error, http_body_limit_exceeded, BodySizeLimit, N};
         false ->
             case cowboy_req:read_body(Req0, #{length => BodySizeLimit, period => 30000}) of
-                {ok, Data, Req}   -> {ok, <<Acc/binary, Data/binary>>, Req};
-                {more, Data, Req} -> do_read_complete_body_with_limit(Req, <<Acc/binary, Data/binary>>, BodySizeLimit)
+                {ok, Data, Req} ->
+                    Total = <<Acc/binary, Data/binary>>,
+                    case byte_size(Total) > BodySizeLimit of
+                        true ->
+                            {error, http_body_limit_exceeded, BodySizeLimit, byte_size(Total)};
+                        false ->
+                            {ok, Total, Req}
+                    end;
+                {more, Data, Req} ->
+                    do_read_complete_body_with_limit(Req, <<Acc/binary, Data/binary>>, BodySizeLimit)
             end
     end.
 
@@ -890,16 +912,21 @@ with_vhost_and_props(Fun, ReqData, Context) ->
             not_found(rabbit_data_coercion:to_binary("vhost_not_found"),
                       ReqData, Context);
         VHost ->
-            {ok, Body, ReqData1} = read_complete_body(ReqData),
-            case decode(Body) of
-                {ok, Props} ->
-                    try
-                        Fun(VHost, Props, ReqData1)
-                    catch {error, Error} ->
-                            bad_request(Error, ReqData1, Context)
-                    end;
-                {error, Reason} ->
-                    bad_request(Reason, ReqData1, Context)
+            case read_complete_body(ReqData) of
+                {error, http_body_limit_exceeded, LimitApplied, BytesRead} ->
+                    ?LOG_WARNING("HTTP API: request exceeded maximum allowed payload size (limit: ~tp bytes, payload size: ~tp bytes)", [LimitApplied, BytesRead]),
+                    bad_request("Exceeded HTTP request body size limit", ReqData, Context);
+                {ok, Body, ReqData1} ->
+                    case decode(Body) of
+                        {ok, Props} ->
+                            try
+                                Fun(VHost, Props, ReqData1)
+                            catch {error, Error} ->
+                                    bad_request(Error, ReqData1, Context)
+                            end;
+                        {error, Reason} ->
+                            bad_request(Reason, ReqData1, Context)
+                    end
             end
     end.
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_http_SUITE.erl
@@ -185,6 +185,8 @@ all_tests() -> [
     publish_test,
     publish_large_message_test,
     publish_large_message_exceeding_http_request_body_size_test,
+    publish_body_size_limit_single_chunk_test,
+    direct_request_body_size_limit_test,
     publish_accept_json_test,
     publish_fail_test,
     publish_base64_test,
@@ -3316,6 +3318,32 @@ publish_large_message_exceeding_http_request_body_size_test(Config) ->
                                      Msg, ?BAD_REQUEST),
   http_delete(Config, "/queues/%2F/large_message_exceeding_http_request_body_size_test", {group, '2xx'}),
   passed.
+
+publish_body_size_limit_single_chunk_test(Config) ->
+  rpc(Config, application, set_env, [rabbitmq_management, max_http_body_size, 200]),
+  try
+    Headers = #{'x-forwarding' => [#{uri => <<"amqp://localhost/%2F/upstream">>}]},
+    Body = binary:copy(<<"a">>, 300),
+    Msg = msg(<<"publish_body_size_limit_single_chunk_test">>, Headers, Body),
+    http_put(Config, "/queues/%2F/publish_body_size_limit_single_chunk_test", #{durable => true}, {group, '2xx'}),
+    http_post_accept_json(Config, "/exchanges/%2F/amq.default/publish",
+                          Msg, ?BAD_REQUEST),
+    http_delete(Config, "/queues/%2F/publish_body_size_limit_single_chunk_test", {group, '2xx'}),
+    passed
+  after
+    rpc(Config, application, unset_env, [rabbitmq_management, max_http_body_size])
+  end.
+
+direct_request_body_size_limit_test(Config) ->
+  rpc(Config, application, set_env, [rabbitmq_management, max_http_body_size, 200]),
+  try
+    http_put(Config, "/queues/%2F/test_queue_body_limit", #{durable => true}, {group, '2xx'}),
+    LargeBody = #{durable => true, arguments => #{<<"x-message-ttl">> => 60000, <<"padding">> => binary:copy(<<"x">>, 300)}},
+    http_put(Config, "/queues/%2F/test_queue_body_limit_oversized", LargeBody, ?BAD_REQUEST),
+    passed
+  after
+    rpc(Config, application, unset_env, [rabbitmq_management, max_http_body_size])
+  end.
 
 publish_accept_json_test(Config) ->
     Headers = #{'x-forwarding' => [#{uri => <<"amqp://localhost/%2F/upstream">>}]},


### PR DESCRIPTION
To terminate earlier.