### PR TITLE
Management UI: avoid a confusing error message right after the password is changed

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/dispatcher.js
+++ b/deps/rabbitmq_management/priv/www/js/dispatcher.js
@@ -248,12 +248,13 @@ dispatcher_add(function(sammy) {
             if (isOwnUser) {
                 pause_auto_refresh();
                 window.own_creds_changed_at = Date.now();
-                setTimeout(resume_auto_refresh, 15000);
+                window.own_creds_resume_timer = setTimeout(resume_auto_refresh, 15000);
             }
             if (sync_put(this, '/users/:username')) {
                 go_to('#/users');
             } else {
                 if (isOwnUser) {
+                    clearTimeout(window.own_creds_resume_timer);
                     resume_auto_refresh();
                     window.own_creds_changed_at = null;
                 }

--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -629,6 +629,9 @@ function with_update(fun) {
     var model = [];
     model['extra_content'] = []; // magic key for extension point
     with_reqs(apply_state(current_reqs), model, function(json) {
+            if (json['suppressed']) {
+                return;
+            }
             var html = format(current_template, json);
             fun(html);
             update_status('ok');
@@ -1322,7 +1325,9 @@ function with_reqs(reqs, acc, fun) {
     if (keys(reqs).length > 0) {
         var key = keys(reqs)[0];
         with_req('GET', reqs[key], null, function(resp) {
-                if (key.startsWith("extra_")) {
+                if (resp.suppressed) {
+                    acc['suppressed'] = true;
+                } else if (key.startsWith("extra_")) {
                     var extraContent = acc["extra_content"];
                     extraContent[key] = JSON.parse(resp.responseText);
                     acc["extra_content"] = extraContent;
@@ -1418,14 +1423,7 @@ function with_req(method, path, body, fun, on404fun) {
                 if (window.own_creds_changed_at &&
                     (Date.now() - window.own_creds_changed_at) < 10000) {
                     console.debug("Suppressing 401 on auto-refresh within grace period after credential change");
-                    // Use a dummy empty response to maintain the callback chain and allow
-                    // the page to render with stale data for one refresh, and the updates
-                    // as usual.
-                    var emptyResponse = {
-                        responseText: '{}',
-                        status: 200
-                    };
-                    fun(emptyResponse);
+                    fun({suppressed: true});
                     return;
                 }
             }


### PR DESCRIPTION
When the user changes their password using
the management UI, the request that updates
the credentials will race with an auto-refresh
request, and likely run into a 401 error.

Before the UI is modernized, this is the least
hacky option available to us.

References #15047.