### PR TITLE
Update setup_beam to @v1 everywhere applicable

### DIFF
--- a/.github/workflows/test-make-target.yaml
+++ b/.github/workflows/test-make-target.yaml
@@ -54,19 +54,6 @@ jobs:
         hexpm-mirrors: |
           https://builds.hex.pm
           https://cdn.jsdelivr.net/hex
-        # This currently only applies to Elixir; and can be safely
-        # restricted to the build jobs to avoid duplication in output.
-        disable_problem_matchers: true
-
-    # We install Erlang problem matchers from ci.erlang.mk.
-    - name: CHECKOUT ERLANG PROBLEM MATCHERS
-      uses: actions/checkout@v6
-      with:
-        repository: ninenines/ci.erlang.mk
-        path: ci.erlang.mk
-
-    - name: INSTALL ERLANG PROBLEM MATCHERS
-      run: echo "::add-matcher::ci.erlang.mk/.github/matchers/erlang-matchers.json"
 
     - name: MIXED CLUSTERS - FETCH SIGNING KEYS
       uses: dsaltares/fetch-gh-release-asset@master

--- a/.github/workflows/test-make.yaml
+++ b/.github/workflows/test-make.yaml
@@ -36,7 +36,7 @@ jobs:
         fetch-tags: true
 
     - name: SETUP OTP & ELIXIR
-      uses: erlef/setup-beam@v1.19
+      uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ matrix.erlang_version }}
         elixir-version: ${{ matrix.elixir_version }}

--- a/.github/workflows/test-upgrades.yaml
+++ b/.github/workflows/test-upgrades.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Setup Erlant/OTP
-        uses: erlef/setup-beam@v1.19
+        uses: erlef/setup-beam@v1
         with:
           otp-version: '27' # Erlang/OTP version repeated later in this file.
           elixir-version: '1.18'
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Setup Erlant/OTP
-        uses: erlef/setup-beam@v1.19
+        uses: erlef/setup-beam@v1
         with: # Versions repeated later in this file.
           otp-version: '27'
           elixir-version: '1.18'
@@ -120,7 +120,7 @@ jobs:
           path: ./NEW
 
       - name: Setup Erlant/OTP
-        uses: erlef/setup-beam@v1.19
+        uses: erlef/setup-beam@v1
         with:
           otp-version: '27'
           elixir-version: '1.18'


### PR DESCRIPTION
Setup_beam v1.23 now includes the ci.erlang.mk problem matchers so we no longer need to install those before running tests.