### PR TITLE
Trust store: introduce proper CLI commands

### DIFF
--- a/deps/rabbitmq_trust_store/README.md
+++ b/deps/rabbitmq_trust_store/README.md
@@ -160,25 +160,29 @@ certificates from a directory.
 
 ### Listing certificates
 
-To list the currently loaded certificates use the `rabbitmqctl` utility as follows:
+To list the currently loaded certificates, use `rabbitmqctl`:
 
-```
-    rabbitmqctl eval 'io:format(rabbit_trust_store:list()).'
-```
-
-This will output a formatted list of certificates similar to:
-
-```
-    Name: cert.pem
-    Serial: 1 | 0x1
-    Subject: O=client,CN=snowman.local
-    Issuer: L=87613,CN=MyTestRootCA
-    Validity: "2016-05-24T15:28:25Z - 2026-05-22T15:28:25Z"
+``` sh
+# Available as of RabbitMQ `4.3.0`, `4.2.6`
+rabbitmqctl list_trust_store_certificates
 ```
 
-Note that this command reads each certificate from disk in order to extract
-all the relevant information. If there are a large number of certificates in the
-trust store use this command sparingly.
+This will output a table of certificates similar to:
+
+```
+Listing trust store certificates on node rabbit@hostname...
+name	serial	subject	issuer	validity
+cert.pem	0x1	O=client,CN=snowman.local	L=87613,CN=MyTestRootCA	2016-05-24T15:28:25Z - 2026-05-22T15:28:25Z
+```
+
+### Refreshing certificates
+
+To trigger a manual refresh of the trust store certificates, use `rabbitmqctl`:
+
+``` sh
+# Available as of RabbitMQ `4.3.0`, `4.2.6`
+rabbitmqctl refresh_trust_store
+```
 
 
 ## How it Works
@@ -188,23 +192,11 @@ whitelists the certificates in the given directory, then accepting
 sockets can query the trust-store with their client's certificate. It
 refreshes the whitelist to correspond with changes in the directory's
 contents, installing and removing certificate details, after a refresh
-interval or a manual refresh (by invoking a `rabbitmqctl eval
-'rabbit_trust_store:refresh().'` from the commandline).
-
-
-## Building from Source
-
-See [Plugin Development guide](https://www.rabbitmq.com/plugin-development.html).
-
-TL;DR: running
-
-    make dist
-
-will build the plugin and put build artifacts under the `./plugins` directory.
+interval or a manual refresh (by running `rabbitmqctl refresh_trust_store`).
 
 
 ## Copyright and License
 
-(c) 2007-2024 Broadcom. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+(c) 2007-2026 Broadcom. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 
-Released under the MPL, the same license as RabbitMQ.
+Released under the MPLv2, the same license as RabbitMQ.

--- a/deps/rabbitmq_trust_store/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListTrustStoreCertificatesCommand.erl
+++ b/deps/rabbitmq_trust_store/src/Elixir.RabbitMQ.CLI.Ctl.Commands.ListTrustStoreCertificatesCommand.erl
@@ -1,0 +1,78 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.ListTrustStoreCertificatesCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+         usage/0,
+         usage_doc_guides/0,
+         validate/2,
+         merge_defaults/2,
+         banner/2,
+         run/2,
+         switches/0,
+         aliases/0,
+         output/2,
+         scopes/0,
+         formatter/0,
+         help_section/0,
+         description/0
+        ]).
+
+
+%%
+%% Command Behavior
+%%
+
+usage() ->
+    <<"list_trust_store_certificates">>.
+
+usage_doc_guides() ->
+    [<<"https://rabbitmq.com/docs/ssl">>].
+
+description() ->
+    <<"Lists certificates in the trust store on a node">>.
+
+help_section() ->
+    {plugin, trust_store}.
+
+formatter() ->
+    'Elixir.RabbitMQ.CLI.Formatters.Table'.
+
+validate(_, _) ->
+    ok.
+
+merge_defaults(A, O) ->
+    {A, O}.
+
+banner(_, #{node := Node}) ->
+    erlang:iolist_to_binary([<<"Listing trust store certificates on node ">>,
+                             atom_to_binary(Node, utf8), <<"...">>]).
+
+run(_Args, #{node := Node}) ->
+    case rabbit_misc:rpc_call(Node, rabbit_trust_store, list_certificates, []) of
+        {badrpc, _} = Error ->
+            Error;
+        Certs when is_list(Certs) ->
+            {stream, Certs}
+    end.
+
+switches() ->
+    [].
+
+aliases() ->
+    [].
+
+output({stream, Certs}, _Opts) ->
+    {stream, Certs};
+output(E, _Opts) ->
+    'Elixir.RabbitMQ.CLI.DefaultOutput':output(E).
+
+scopes() ->
+    ['ctl', 'diagnostics'].

--- a/deps/rabbitmq_trust_store/src/Elixir.RabbitMQ.CLI.Ctl.Commands.RefreshTrustStoreCommand.erl
+++ b/deps/rabbitmq_trust_store/src/Elixir.RabbitMQ.CLI.Ctl.Commands.RefreshTrustStoreCommand.erl
@@ -1,0 +1,63 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module('Elixir.RabbitMQ.CLI.Ctl.Commands.RefreshTrustStoreCommand').
+
+-behaviour('Elixir.RabbitMQ.CLI.CommandBehaviour').
+
+-export([
+         usage/0,
+         usage_doc_guides/0,
+         validate/2,
+         merge_defaults/2,
+         banner/2,
+         run/2,
+         aliases/0,
+         output/2,
+         help_section/0,
+         description/0
+        ]).
+
+%%
+%% Command Behavior
+%%
+
+usage() ->
+    <<"refresh_trust_store">>.
+
+usage_doc_guides() ->
+    [<<"https://rabbitmq.com/docs/ssl">>].
+
+description() ->
+    <<"Refreshes trust store certificates on a node">>.
+
+help_section() ->
+    {plugin, trust_store}.
+
+validate(_, _) ->
+    ok.
+
+merge_defaults(A, O) ->
+    {A, O}.
+
+banner(_, #{node := Node}) ->
+    erlang:iolist_to_binary([<<"Refreshing trust store certificates on node ">>,
+                             atom_to_binary(Node, utf8), <<"...">>]).
+
+run(_Args, #{node := Node}) ->
+    case rabbit_misc:rpc_call(Node, rabbit_trust_store, refresh, []) of
+        {badrpc, _} = Error ->
+            Error;
+        ok ->
+            ok
+    end.
+
+aliases() ->
+    [].
+
+output(Output, _Opts) ->
+    'Elixir.RabbitMQ.CLI.DefaultOutput':output(Output).

--- a/deps/rabbitmq_trust_store/src/rabbit_trust_store.erl
+++ b/deps/rabbitmq_trust_store/src/rabbit_trust_store.erl
@@ -9,7 +9,7 @@
 
 -behaviour(gen_server).
 
--export([mode/0, refresh/0, list/0]). %% Console Interface.
+-export([mode/0, refresh/0, list/0, list_certificates/0]). %% Console Interface.
 -export([whitelisted/3, is_whitelisted/1]). %% Client-side Interface.
 -export([start_link/0]).
 -export([init/1, terminate/2,
@@ -86,6 +86,30 @@ list() ->
         end,
         ets:tab2list(table_name())),
     string:join(Formatted, "~n~n").
+
+-spec list_certificates() -> [map()].
+list_certificates() ->
+    lists:map(
+        fun(#entry{
+                name = N,
+                cert_id = CertId,
+                certificate = Cert,
+                issuer_id = {_, Serial}}) ->
+            Name = case N of
+                undefined -> unicode:characters_to_binary(io_lib:format("~tp", [CertId]));
+                _         -> unicode:characters_to_binary(N)
+            end,
+            Validity = unicode:characters_to_binary(rabbit_ssl:peer_cert_validity(Cert)),
+            Subject = unicode:characters_to_binary(rabbit_ssl:peer_cert_subject(Cert)),
+            Issuer = unicode:characters_to_binary(rabbit_ssl:peer_cert_issuer(Cert)),
+            SerialHex = unicode:characters_to_binary(io_lib:format("0x~.16.0B", [Serial])),
+            #{name => Name,
+              serial => SerialHex,
+              subject => Subject,
+              issuer => Issuer,
+              validity => Validity}
+        end,
+        ets:tab2list(table_name())).
 
 %% Client (SSL Socket) Interface
 


### PR DESCRIPTION
for key operations historically invoked via `rabbitmqctl eval`.

Inspired by rabbitmq/rabbitmq-website#2475.