### PR TITLE
Re-submit cuttlefish tls schema for `amqp_client`

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2940,6 +2940,218 @@ fun(Conf) ->
     end
 end}.
 
+%% ----------------------------------------------------------------------------
+%%  AMQP client 1.0 TLS options
+%% ----------------------------------------------------------------------------
+
+{mapping, "amqp10_client.ssl_options", "amqp10_client.ssl_options", [
+    {datatype, {enum, [none]}}
+]}.
+
+{translation, "amqp10_client.ssl_options",
+fun(Conf) ->
+    case cuttlefish:conf_get("amqp10_client.ssl_options", Conf, undefined) of
+        none -> [];
+        _    -> cuttlefish:invalid("Invalid amqp10_client.ssl_options")
+    end
+end}.
+
+{mapping, "amqp10_client.ssl_options.verify", "amqp10_client.ssl_options.verify", [
+    {datatype, {enum, [verify_peer, verify_none]}}]}.
+
+{mapping, "amqp10_client.ssl_options.cacertfile", "amqp10_client.ssl_options.cacertfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "amqp10_client.ssl_options.certfile", "amqp10_client.ssl_options.certfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "amqp10_client.ssl_options.cacerts.$name", "amqp10_client.ssl_options.cacerts",
+    [{datatype, string}]}.
+
+{translation, "amqp10_client.ssl_options.cacerts",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("amqp10_client.ssl_options.cacerts", Conf),
+    [ list_to_binary(V) || {_, V} <- Settings ]
+end}.
+
+{mapping, "amqp10_client.ssl_options.cert", "amqp10_client.ssl_options.cert",
+    [{datatype, string}]}.
+
+{translation, "amqp10_client.ssl_options.cert",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("amqp10_client.ssl_options.cert", Conf))
+end}.
+
+{mapping, "amqp10_client.ssl_options.crl_check", "amqp10_client.ssl_options.crl_check",
+    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "amqp10_client.ssl_options.depth", "amqp10_client.ssl_options.depth",
+    [{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "amqp10_client.ssl_options.key.RSAPrivateKey", "amqp10_client.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "amqp10_client.ssl_options.key.DSAPrivateKey", "amqp10_client.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "amqp10_client.ssl_options.key.PrivateKeyInfo", "amqp10_client.ssl_options.key",
+    [{datatype, string}]}.
+
+{translation, "amqp10_client.ssl_options.key",
+fun(Conf) ->
+    case cuttlefish_variable:filter_by_prefix("amqp10_client.ssl_options.key", Conf) of
+        [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
+        _ -> undefined
+    end
+end}.
+
+{mapping, "amqp10_client.ssl_options.keyfile", "amqp10_client.ssl_options.keyfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "amqp10_client.ssl_options.log_alert", "amqp10_client.ssl_options.log_alert",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "amqp10_client.ssl_options.password", "amqp10_client.ssl_options.password",
+    [{datatype, string}]}.
+
+{mapping, "amqp10_client.ssl_options.psk_identity", "amqp10_client.ssl_options.psk_identity",
+    [{datatype, string}]}.
+
+{mapping, "amqp10_client.ssl_options.reuse_sessions", "amqp10_client.ssl_options.reuse_sessions",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "amqp10_client.ssl_options.secure_renegotiate", "amqp10_client.ssl_options.secure_renegotiate",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "amqp10_client.ssl_options.versions.$version", "amqp10_client.ssl_options.versions",
+    [{datatype, atom}]}.
+
+{translation, "amqp10_client.ssl_options.versions",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("amqp10_client.ssl_options.versions", Conf),
+    [ V || {_, V} <- Settings ]
+end}.
+
+{mapping, "amqp10_client.ssl_options.sni", "amqp10_client.ssl_options.server_name_indication",
+    [{datatype, [{enum, [none]}, string]}]}.
+
+{translation, "amqp10_client.ssl_options.server_name_indication",
+fun(Conf) ->
+    case cuttlefish:conf_get("amqp10_client.ssl_options.sni", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        none      -> cuttlefish:unset();
+        Hostname  -> Hostname
+    end
+end}.
+
+% ===============================
+% AMQP 0.9.1
+% ===============================
+
+%% ----------------------------------------------------------------------------
+%%  AMQP client 0.9.1 TLS options
+%% ----------------------------------------------------------------------------
+
+{mapping, "amqp_client.ssl_options", "amqp_client.ssl_options", [
+    {datatype, {enum, [none]}}
+]}.
+
+{translation, "amqp_client.ssl_options",
+fun(Conf) ->
+    case cuttlefish:conf_get("amqp_client.ssl_options", Conf, undefined) of
+        none -> [];
+        _    -> cuttlefish:invalid("Invalid amqp_client.ssl_options")
+    end
+end}.
+
+{mapping, "amqp_client.ssl_options.verify", "amqp_client.ssl_options.verify", [
+    {datatype, {enum, [verify_peer, verify_none]}}]}.
+
+{mapping, "amqp_client.ssl_options.cacertfile", "amqp_client.ssl_options.cacertfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "amqp_client.ssl_options.certfile", "amqp_client.ssl_options.certfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "amqp_client.ssl_options.cacerts.$name", "amqp_client.ssl_options.cacerts",
+    [{datatype, string}]}.
+
+{translation, "amqp_client.ssl_options.cacerts",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("amqp_client.ssl_options.cacerts", Conf),
+    [ list_to_binary(V) || {_, V} <- Settings ]
+end}.
+
+{mapping, "amqp_client.ssl_options.cert", "amqp_client.ssl_options.cert",
+    [{datatype, string}]}.
+
+{translation, "amqp_client.ssl_options.cert",
+fun(Conf) ->
+    list_to_binary(cuttlefish:conf_get("amqp_client.ssl_options.cert", Conf))
+end}.
+
+{mapping, "amqp_client.ssl_options.crl_check", "amqp_client.ssl_options.crl_check",
+    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "amqp_client.ssl_options.depth", "amqp_client.ssl_options.depth",
+    [{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "amqp_client.ssl_options.key.RSAPrivateKey", "amqp_client.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "amqp_client.ssl_options.key.DSAPrivateKey", "amqp_client.ssl_options.key",
+    [{datatype, string}]}.
+
+{mapping, "amqp_client.ssl_options.key.PrivateKeyInfo", "amqp_client.ssl_options.key",
+    [{datatype, string}]}.
+
+{translation, "amqp_client.ssl_options.key",
+fun(Conf) ->
+    case cuttlefish_variable:filter_by_prefix("amqp_client.ssl_options.key", Conf) of
+        [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
+        _ -> undefined
+    end
+end}.
+
+{mapping, "amqp_client.ssl_options.keyfile", "amqp_client.ssl_options.keyfile",
+    [{datatype, string}, {validators, ["file_accessible"]}]}.
+
+{mapping, "amqp_client.ssl_options.log_alert", "amqp_client.ssl_options.log_alert",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "amqp_client.ssl_options.password", "amqp_client.ssl_options.password",
+    [{datatype, string}]}.
+
+{mapping, "amqp_client.ssl_options.psk_identity", "amqp_client.ssl_options.psk_identity",
+    [{datatype, string}]}.
+
+{mapping, "amqp_client.ssl_options.reuse_sessions", "amqp_client.ssl_options.reuse_sessions",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "amqp_client.ssl_options.secure_renegotiate", "amqp_client.ssl_options.secure_renegotiate",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "amqp_client.ssl_options.versions.$version", "amqp_client.ssl_options.versions",
+    [{datatype, atom}]}.
+
+{translation, "amqp_client.ssl_options.versions",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("amqp_client.ssl_options.versions", Conf),
+    [ V || {_, V} <- Settings ]
+end}.
+
+{mapping, "amqp_client.ssl_options.sni", "amqp_client.ssl_options.server_name_indication",
+    [{datatype, [{enum, [none]}, string]}]}.
+
+{translation, "amqp_client.ssl_options.server_name_indication",
+fun(Conf) ->
+    case cuttlefish:conf_get("amqp_client.ssl_options.sni", Conf, undefined) of
+        undefined -> cuttlefish:unset();
+        none      -> cuttlefish:unset();
+        Hostname  -> Hostname
+    end
+end}.
+
 % ===============================
 % Validators
 % ===============================

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1332,5 +1332,219 @@ credential_validator.regexp = ^abc\\d+",
    [{osiris, [
       {data_dir, "/data/rabbitmq/stream"}
      ]}],
-   []}
+   []},
+
+  %%
+  %% AMQP TLS options
+  %%
+
+ {amqp_client_ssl_options,
+  "amqp_client.ssl_options.cacertfile           = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile             = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile              = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.verify               = verify_peer",
+  [{amqp_client,
+    [
+     {ssl_options,
+      [{cacertfile, "test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,   "test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,    "test/config_schema_SUITE_data/certs/server_key.pem"},
+       {verify, verify_peer}]}
+      ]}],
+  [amqp_client]},
+ {amqp_client_ssl_options_verify_peer,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.verify = verify_peer",
+  [{amqp_client,
+    [
+     {ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {verify,verify_peer}]}]}],
+  []},
+ {amqp_client_ssl_options_password,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.password   = t0p$3kRe7",
+  [{amqp_client,
+    [
+     {ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {password,"t0p$3kRe7"}]}]}],
+  []},
+ {amqp_client_ssl_options_tls_versions,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.versions.tls1_2 = tlsv1.2
+   amqp_client.ssl_options.versions.tls1_1 = tlsv1.1",
+  [],
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {versions,['tlsv1.2','tlsv1.1']}]}
+    ]}],
+  []},
+ {amqp_client_ssl_options_depth,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.depth      = 2
+   amqp_client.ssl_options.verify     = verify_peer",
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {depth,2},
+       {verify,verify_peer}]}]}],
+  []},
+ {amqp_client_ssl_options_sni_disabled,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.versions.tls1_2 = tlsv1.2
+   amqp_client.ssl_options.versions.tls1_1 = tlsv1.1
+   amqp_client.ssl_options.sni = none",
+  [],
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {versions,['tlsv1.2','tlsv1.1']}]
+     }]
+   }],
+  []},
+ {amqp_client_ssl_options_sni_hostname,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.versions.tls1_2 = tlsv1.2
+   amqp_client.ssl_options.versions.tls1_1 = tlsv1.1
+   amqp_client.ssl_options.sni = hostname.dev",
+  [],
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {versions,['tlsv1.2','tlsv1.1']},
+       {server_name_indication, "hostname.dev"}
+      ]}
+    ]}],
+  []},
+
+ {amqp10_client_ssl_options,
+  "amqp10_client.ssl_options.cacertfile           = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile             = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile              = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.verify               = verify_peer",
+  [{amqp10_client,
+    [
+     {ssl_options,
+      [{cacertfile, "test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,   "test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,    "test/config_schema_SUITE_data/certs/server_key.pem"},
+       {verify, verify_peer}]}
+      ]}],
+  [amqp10_client]},
+ {amqp10_client_ssl_options_verify_peer,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.verify = verify_peer",
+  [{amqp10_client,
+    [
+     {ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {verify,verify_peer}]}]}],
+  []},
+ {amqp10_client_ssl_options_password,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.password   = t0p$3kRe7",
+  [{amqp10_client,
+    [
+     {ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {password,"t0p$3kRe7"}]}]}],
+  []},
+ {amqp10_client_ssl_options_tls_versions,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.versions.tls1_2 = tlsv1.2
+   amqp10_client.ssl_options.versions.tls1_1 = tlsv1.1",
+  [],
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {versions,['tlsv1.2','tlsv1.1']}]}
+    ]}],
+  []},
+ {amqp10_client_ssl_options_depth,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.depth      = 2
+   amqp10_client.ssl_options.verify     = verify_peer",
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {depth,2},
+       {verify,verify_peer}]}]}],
+  []},
+ {amqp10_client_ssl_options_sni_disabled,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.versions.tls1_2 = tlsv1.2
+   amqp10_client.ssl_options.versions.tls1_1 = tlsv1.1
+   amqp10_client.ssl_options.sni = none",
+  [],
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {versions,['tlsv1.2','tlsv1.1']}]
+     }]
+   }],
+  []},
+ {amqp10_client_ssl_options_sni_hostname,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.versions.tls1_2 = tlsv1.2
+   amqp10_client.ssl_options.versions.tls1_1 = tlsv1.1
+   amqp10_client.ssl_options.sni = hostname.dev",
+  [],
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {versions,['tlsv1.2','tlsv1.1']},
+       {server_name_indication, "hostname.dev"}
+      ]}
+    ]}],
+  []}
 ].


### PR DESCRIPTION
Follow-up PR to the following:
* Original PR - https://github.com/rabbitmq/rabbitmq-server/pull/11415
* PR that reverted the original - https://github.com/rabbitmq/rabbitmq-server/pull/11531

Having cuttlefish schemas for `amqp_client` and `amqp10_client` still seems useful, so I looked into why this was reverted. Since bazel is no longer used, that reason no longer exists. In my local env, all of these test runs succeed just fine:

```
make -C deps/rabbit ct-config_schema
make -C deps/amqp10_client tests
make -C deps/amqp_client tests
```