### PR TITLE
Improve TLS-related `rabbitmq.conf` settings of `amqp_client`

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -3001,7 +3001,7 @@ end}.
 fun(Conf) ->
     case cuttlefish_variable:filter_by_prefix("amqp10_client.ssl_options.key", Conf) of
         [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
-        _ -> undefined
+        _ -> cuttlefish:unset()
     end
 end}.
 
@@ -3039,7 +3039,7 @@ end}.
 fun(Conf) ->
     case cuttlefish:conf_get("amqp10_client.ssl_options.sni", Conf, undefined) of
         undefined -> cuttlefish:unset();
-        none      -> cuttlefish:unset();
+        none      -> disable;
         Hostname  -> Hostname
     end
 end}.
@@ -3109,7 +3109,7 @@ end}.
 fun(Conf) ->
     case cuttlefish_variable:filter_by_prefix("amqp_client.ssl_options.key", Conf) of
         [{[_,_,Key], Val}|_] -> {list_to_atom(Key), list_to_binary(Val)};
-        _ -> undefined
+        _ -> cuttlefish:unset()
     end
 end}.
 
@@ -3147,7 +3147,7 @@ end}.
 fun(Conf) ->
     case cuttlefish:conf_get("amqp_client.ssl_options.sni", Conf, undefined) of
         undefined -> cuttlefish:unset();
-        none      -> cuttlefish:unset();
+        none      -> disable;
         Hostname  -> Hostname
     end
 end}.

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1420,9 +1420,9 @@ credential_validator.regexp = ^abc\\d+",
       [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
        {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
        {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
-       {versions,['tlsv1.2','tlsv1.1']}]
-     }]
-   }],
+       {server_name_indication, disable},
+       {versions,['tlsv1.2','tlsv1.1']}]}
+    ]}],
   []},
  {amqp_client_ssl_options_sni_hostname,
   "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
@@ -1525,9 +1525,9 @@ credential_validator.regexp = ^abc\\d+",
       [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
        {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
        {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
-       {versions,['tlsv1.2','tlsv1.1']}]
-     }]
-   }],
+       {server_name_indication, disable},
+       {versions,['tlsv1.2','tlsv1.1']}]}
+    ]}],
   []},
  {amqp10_client_ssl_options_sni_hostname,
   "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
@@ -1546,5 +1546,146 @@ credential_validator.regexp = ^abc\\d+",
        {server_name_indication, "hostname.dev"}
       ]}
     ]}],
+  []},
+
+  %%
+  %% AMQP client ssl_options = none
+  %%
+
+ {amqp_client_ssl_options_none,
+  "amqp_client.ssl_options = none",
+  [{amqp_client,
+    [{ssl_options, []}]}],
+  []},
+ {amqp10_client_ssl_options_none,
+  "amqp10_client.ssl_options = none",
+  [{amqp10_client,
+    [{ssl_options, []}]}],
+  []},
+
+  %%
+  %% AMQP client: additional `ssl_options`
+  %%
+
+ {amqp_client_ssl_options_crl_check,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.crl_check  = peer",
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {crl_check, peer},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"}]}]}],
+  []},
+ {amqp_client_ssl_options_log_alert,
+  "amqp_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.log_alert  = true",
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {log_alert, true}]}]}],
+  []},
+ {amqp_client_ssl_options_reuse_sessions,
+  "amqp_client.ssl_options.cacertfile      = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile        = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile         = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.reuse_sessions  = true",
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {reuse_sessions, true}]}]}],
+  []},
+ {amqp_client_ssl_options_secure_renegotiate,
+  "amqp_client.ssl_options.cacertfile           = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile             = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile              = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.secure_renegotiate   = true",
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {secure_renegotiate, true}]}]}],
+  []},
+ {amqp_client_ssl_options_psk_identity,
+  "amqp_client.ssl_options.cacertfile    = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp_client.ssl_options.certfile      = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp_client.ssl_options.keyfile       = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp_client.ssl_options.psk_identity  = my_identity",
+  [{amqp_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {psk_identity, "my_identity"}]}]}],
+  []},
+
+ {amqp10_client_ssl_options_crl_check,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.crl_check  = peer",
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {crl_check, peer},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"}]}]}],
+  []},
+ {amqp10_client_ssl_options_log_alert,
+  "amqp10_client.ssl_options.cacertfile = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile   = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile    = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.log_alert  = true",
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {log_alert, true}]}]}],
+  []},
+ {amqp10_client_ssl_options_reuse_sessions,
+  "amqp10_client.ssl_options.cacertfile      = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile        = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile         = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.reuse_sessions  = true",
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {reuse_sessions, true}]}]}],
+  []},
+ {amqp10_client_ssl_options_secure_renegotiate,
+  "amqp10_client.ssl_options.cacertfile           = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile             = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile              = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.secure_renegotiate   = true",
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {secure_renegotiate, true}]}]}],
+  []},
+ {amqp10_client_ssl_options_psk_identity,
+  "amqp10_client.ssl_options.cacertfile    = test/config_schema_SUITE_data/certs/ca_certificate.pem
+   amqp10_client.ssl_options.certfile      = test/config_schema_SUITE_data/certs/server_certificate.pem
+   amqp10_client.ssl_options.keyfile       = test/config_schema_SUITE_data/certs/server_key.pem
+   amqp10_client.ssl_options.psk_identity  = my_identity",
+  [{amqp10_client,
+    [{ssl_options,
+      [{cacertfile,"test/config_schema_SUITE_data/certs/ca_certificate.pem"},
+       {certfile,"test/config_schema_SUITE_data/certs/server_certificate.pem"},
+       {keyfile,"test/config_schema_SUITE_data/certs/server_key.pem"},
+       {psk_identity, "my_identity"}]}]}],
   []}
 ].


### PR DESCRIPTION
This is #15767 by @lukebakken with some tweaks from me:

1. A few places quietly returned `undefined` instead of using `cuttlefish:unset/0`
2. The SNI key used `cuttlefish:unset/0` where it should have [used `disable`](https://www.erlang.org/docs/27/apps/ssl/ssl.html) when the value is set to `none` in `rabbitmq.conf` (the current behavior ends up deriving the SNI from the local hostname (a dubious behavior in the Erlang/OTP's `ssl` or `inet` apps if you ask me)
3. Added a bunch of `config_schema_SUITE` test cases for less commonly used TLS-related keys

## References

1. https://github.com/rabbitmq/rabbitmq-server/pull/11415
2. https://github.com/rabbitmq/rabbitmq-server/pull/11531
3. https://github.com/rabbitmq/rabbitmq-server/pull/15767