### PR TITLE
Fix local shovels crashing with plugin queue types

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -79,6 +79,10 @@
                     {requires,    pre_boot},
                     {enables,     database}]}).
 
+-rabbit_boot_step({queue_type_registrations,
+                   [{description, "queue type registrations"},
+                    {requires,    rabbit_registry}]}).
+
 -rabbit_boot_step({database,
                    [{mfa,         {rabbit_db, init, []}},
                     {requires,    rabbit_registry},

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -92,7 +92,7 @@
      {cleanup,  {rabbit_registry, unregister,
                  [queue, <<"classic">>]}},
      {requires, rabbit_registry},
-     {enables, [?MODULE, rabbit_policy]}]}).
+     {enables, [?MODULE, rabbit_policy, queue_type_registrations]}]}).
 
 -rabbit_boot_step(
    {?MODULE,

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -120,7 +120,7 @@
      {cleanup,  {rabbit_registry, unregister,
                  [queue, <<"quorum">>]}},
      {requires, rabbit_registry},
-     {enables, rabbit_policy}]}).
+     {enables, [rabbit_policy, queue_type_registrations]}]}).
 
 -rabbit_boot_step(
    {quorum_memory_alarm_handler,

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -130,7 +130,7 @@
      {cleanup,  {rabbit_registry, unregister,
                  [queue, <<"stream">>]}},
      {requires, rabbit_registry},
-     {enables, rabbit_policy}
+     {enables, [rabbit_policy, queue_type_registrations]}
     ]}).
 
 -type client() :: #stream_client{}.

--- a/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_local_shovel.erl
@@ -19,7 +19,7 @@
                    [{description, "global local shovel counters"},
                     {mfa,         {?MODULE, boot_step,
                                    []}},
-                    {requires,    rabbit_global_counters},
+                    {requires,    [rabbit_global_counters, queue_type_registrations]},
                     {enables,     external_infrastructure}]}).
 
 -rabbit_boot_step(
@@ -96,9 +96,10 @@
 boot_step() ->
     Labels = #{protocol => ?PROTOCOL},
     rabbit_global_counters:init(Labels),
-    rabbit_global_counters:init(Labels#{queue_type => rabbit_classic_queue}),
-    rabbit_global_counters:init(Labels#{queue_type => rabbit_quorum_queue}),
-    rabbit_global_counters:init(Labels#{queue_type => rabbit_stream_queue}).
+    lists:foreach(
+      fun(QType) ->
+              rabbit_global_counters:init(Labels#{queue_type => QType})
+      end, rabbit_queue_type:known_queue_type_modules()).
 
 -spec conserve_resources(pid(),
                          rabbit_alarm:resource_alarm_source(),


### PR DESCRIPTION
Local shovels crashed with a badarg error when consuming from plugin queue types such as JMS or delayed queues:

```
crasher:
  initial call: rabbit_shovel_worker:init/1
  pid: <0.1237.0>
  registered_name: []
  exception exit: {badarg,
                      [{persistent_term,get,
                           [{rabbit_global_counters,'local-shovel',
                                rabbit_jms_queue}],
                           [{error_info,#{module => erl_erts_errors}}]},
                       {rabbit_global_counters,fetch,2,
                           [{file,"rabbit_global_counters.erl"},{line,274}]},
                       {rabbit_global_counters,messages_delivered,3,
                           [{file,"rabbit_global_counters.erl"},{line,223}]},
                       {rabbit_local_shovel,'-handle_deliver/3-fun-0-',3,
                           [{file,"rabbit_local_shovel.erl"},{line,667}]},
                       {lists,foldl,3,[{file,"lists.erl"},{line,2466}]},
                       {rabbit_local_shovel,handle_deliver,3,
                           [{file,"rabbit_local_shovel.erl"},{line,665}]},
                       {lists,foldl,3,[{file,"lists.erl"},{line,2466}]},
                       {rabbit_shovel_worker,handle_msg,2,
                           [{file,"rabbit_shovel_worker.erl"},{line,116}]}]}
    in function  gen_server2:terminate/3 (gen_server2.erl:1174)
```

The crash occurred because rabbit_local_shovel:boot_step/0 only initialized global counters for the three core queue types (classic, quorum, stream). When a local shovel delivered a message from a plugin queue type, rabbit_global_counters:messages_delivered/3 attempted to look up a counter that was never created.

The root cause was a missing ordering guarantee between queue type registrations and the local shovel counter initialization during node boot. Previously, the boot step dependency chain was:

```
  pre_boot -> rabbit_global_counters -.
                                       \
                                        -> external_infrastructure
                                       /
  pre_boot -> rabbit_registry --------'
```

Queue type registrations (classic, quorum, stream, JMS, delayed) all required rabbit_registry but had no ordering relationship with the local shovel counter boot step. Both competed to run before external_infrastructure with no mutual dependency.

Introduce a new boot step phase "queue_type_registrations" that serves as a synchronization point:

  - All queue type registration boot steps enable it
  - The local shovel counter boot step requires it (along with rabbit_global_counters)

The resulting dependency chain is:

```
  pre_boot -> rabbit_global_counters -.
                                       \
  pre_boot -> rabbit_registry ----.     -> local shovel counters
                                   \   /
              queue type regs --> queue_type_registrations
```

This guarantees that rabbit_queue_type:known_queue_type_modules() returns all registered queue types when boot_step/0 runs, so counters are initialized for every queue type without hardcoding.

Here are the relevant boot step logs:
```
2026-03-23 12:51:11.142127+01:00 [info] <0.217.0> Running boot step rabbit_classic_queue_type defined by app rabbit
2026-03-23 12:51:11.142138+01:00 [debug] <0.217.0> Applying MFA: M = rabbit_registry, F = register, A = [queue,<<"classic">>,
2026-03-23 12:51:11.142138+01:00 [debug] <0.217.0>                                                       rabbit_classic_queue]
2026-03-23 12:51:11.142191+01:00 [debug] <0.217.0> Finished MFA: M = rabbit_registry, F = register, A = [queue,<<"classic">>,
2026-03-23 12:51:11.142191+01:00 [debug] <0.217.0>                                                       rabbit_classic_queue]
2026-03-23 12:51:11.142210+01:00 [info] <0.217.0> Running boot step rabbit_quorum_queue_type defined by app rabbit
2026-03-23 12:51:11.142229+01:00 [debug] <0.217.0> Applying MFA: M = rabbit_registry, F = register, A = [queue,<<"quorum">>,
2026-03-23 12:51:11.142229+01:00 [debug] <0.217.0>                                                       rabbit_quorum_queue]
2026-03-23 12:51:11.142268+01:00 [debug] <0.217.0> Finished MFA: M = rabbit_registry, F = register, A = [queue,<<"quorum">>,
2026-03-23 12:51:11.142268+01:00 [debug] <0.217.0>                                                       rabbit_quorum_queue]
2026-03-23 12:51:11.142286+01:00 [info] <0.217.0> Running boot step rabbit_stream_queue defined by app rabbit
2026-03-23 12:51:11.142300+01:00 [debug] <0.217.0> Applying MFA: M = rabbit_registry, F = register, A = [queue,<<"stream">>,
2026-03-23 12:51:11.142300+01:00 [debug] <0.217.0>                                                       rabbit_stream_queue]
2026-03-23 12:51:11.142335+01:00 [debug] <0.217.0> Finished MFA: M = rabbit_registry, F = register, A = [queue,<<"stream">>,
2026-03-23 12:51:11.142335+01:00 [debug] <0.217.0>                                                       rabbit_stream_queue]
...
2026-03-23 12:51:11.142702+01:00 [info] <0.217.0> Running boot step delayed_queue_type defined by app rabbitmq_delayed_queue
2026-03-23 12:51:11.142709+01:00 [debug] <0.217.0> Applying MFA: M = rabbit_registry, F = register, A = [queue,<<"delayed">>,
2026-03-23 12:51:11.142709+01:00 [debug] <0.217.0>                                                       rabbitmq_delayed_queue]
2026-03-23 12:51:11.142733+01:00 [debug] <0.217.0> Finished MFA: M = rabbit_registry, F = register, A = [queue,<<"delayed">>,
2026-03-23 12:51:11.142733+01:00 [debug] <0.217.0>                                                       rabbitmq_delayed_queue]
2026-03-23 12:51:11.142745+01:00 [info] <0.217.0> Running boot step jms_queue_type defined by app rabbitmq_jms
2026-03-23 12:51:11.142795+01:00 [debug] <0.217.0> Applying MFA: M = rabbit_registry, F = register, A = [queue,<<"jms">>,
2026-03-23 12:51:11.142795+01:00 [debug] <0.217.0>                                                       rabbit_jms_queue]
2026-03-23 12:51:11.142825+01:00 [debug] <0.217.0> Finished MFA: M = rabbit_registry, F = register, A = [queue,<<"jms">>,
2026-03-23 12:51:11.142825+01:00 [debug] <0.217.0>                                                       rabbit_jms_queue]
2026-03-23 12:51:11.142837+01:00 [info] <0.217.0> Running boot step queue_type_registrations defined by app rabbit
2026-03-23 12:51:11.142847+01:00 [info] <0.217.0> Running boot step rabbit_global_local_shovel_counters defined by app rabbitmq_shovel
2026-03-23 12:51:11.142876+01:00 [debug] <0.217.0> Applying MFA: M = rabbit_local_shovel, F = boot_step, A = []
2026-03-23 12:51:11.143000+01:00 [debug] <0.217.0> Finished MFA: M = rabbit_local_shovel, F = boot_step, A = []
```

This commit makes the following test suite green:
```
make -C deps/rabbitmq_jms ct-jms_queue_shovel
```