### PR TITLE
QQ: fix consumer timeout bug

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -782,25 +782,25 @@ apply_(#{system_time := Ts} = Meta,
                 {State1, Effects0}
         end,
 
-    {State3, Effects2} = update_next_consumer_timeout(State2, Effects1),
     %% activate SAC
-    {State, Effects} = activate_next_consumer({State3, Effects2}),
+    NextConsumerTimeout = next_consumer_timeout(State2),
+    {State, Effects} =
+        activate_next_consumer({State2#?STATE{next_consumer_timeout =
+                                              NextConsumerTimeout},
+                                Effects1}),
     checkout(Meta, State0, State, Effects);
 apply_(_Meta, Cmd, State) ->
     %% handle unhandled commands gracefully
     ?LOG_DEBUG("rabbit_fifo: unhandled command ~W", [Cmd, 10]),
     {State, ok, []}.
 
-update_next_consumer_timeout(#?STATE{consumers = Cons} = State, Effects) ->
-    Next = maps:fold(
-             fun (_, #consumer{checked_out = Ch}, Acc) ->
-                     Min = maps:fold(fun (_, ?C_MSG(T, _), A) ->
-                                             min(T, A)
-                                     end, infinity, Ch),
-                     min(Min, Acc)
-             end, infinity, Cons),
-    {State#?STATE{next_consumer_timeout = Next},
-     [{timer, evaluate_consumer_timeout, Next, {abs, true}} | Effects]}.
+next_consumer_timeout(#?STATE{consumers = Cons}) ->
+    maps:fold(fun (_, #consumer{checked_out = Ch}, Acc) ->
+                      Min = maps:fold(fun (_, ?C_MSG(T, _), A) ->
+                                              min(T, A)
+                                      end, infinity, Ch),
+                      min(Min, Acc)
+              end, infinity, Cons).
 
 
 -spec live_indexes(state()) -> {ra_seq, ra_seq:state()}.
@@ -1114,8 +1114,7 @@ state_enter(leader,
                     waiting_consumers = WaitingConsumers,
                     cfg = #cfg{resource = QRes,
                                dead_letter_handler = DLH},
-                    dlx = DlxState} = State) ->
-    TimerEffs = timer_effect(State, []),
+                    dlx = DlxState}) ->
     % return effects to monitor all current consumers and enqueuers
     Pids = lists:usort(maps:keys(Enqs)
                        ++ [P || ?CONSUMER_PID(P) <- maps:values(Cons)]
@@ -1124,7 +1123,7 @@ state_enter(leader,
     Nots = [{send_msg, P, leader_change, ra_event} || P <- Pids],
     NodeMons = lists:usort([{monitor, node, node(P)} || P <- Pids]),
     NotifyDecs = notify_decorators_startup(QRes),
-    Effects = TimerEffs ++ Mons ++ Nots ++ NodeMons ++ [NotifyDecs],
+    Effects = Mons ++ Nots ++ NodeMons ++ [NotifyDecs],
 
     case DLH of
         at_least_once ->
@@ -1275,7 +1274,8 @@ which_module(8) -> ?MODULE.
 -record(aux_gc, {last_raft_idx = 0 :: ra:index()}).
 -record(?AUX, {name :: atom(),
                last_decorators_state :: term(),
-               unused_1 :: term(),
+               last_consumer_timeout =
+                   infinity :: infinity | non_neg_integer(),
                gc = #aux_gc{} :: #aux_gc{},
                tick_pid :: undefined | pid(),
                cache = #{} :: map(),
@@ -1308,7 +1308,7 @@ handle_aux(RaftState, Tag, Cmd, AuxV3, RaAux)
   when element(1, AuxV3) == aux_v3 ->
     AuxV4 = #?AUX{name = element(2, AuxV3),
                   last_decorators_state = element(3, AuxV3),
-                  unused_1 = undefined,
+                  last_consumer_timeout = infinity,
                   gc = element(5, AuxV3),
                   tick_pid  = element(6, AuxV3),
                   cache = element(7, AuxV3),
@@ -1317,10 +1317,12 @@ handle_aux(RaftState, Tag, Cmd, AuxV3, RaAux)
     handle_aux(RaftState, Tag, Cmd, AuxV4, RaAux);
 handle_aux(leader, cast, eval,
            #?AUX{last_decorators_state = LastDec,
+                 last_consumer_timeout = LastConTimeout0,
                  last_checkpoint = Check0} = Aux0,
            RaAux) ->
 
     #?STATE{cfg = #cfg{resource = QName},
+            next_consumer_timeout = NextConTimeout,
             reclaimable_bytes = ReclaimableBytes} = MacState =
         ra_aux:machine_state(RaAux),
 
@@ -1337,16 +1339,29 @@ handle_aux(leader, cast, eval,
 
     %% this is called after each batch of commands have been applied
     %% set timer for message expire
-    %% should really be the last applied index ts but this will have to do
     Effects1 = timer_effect(MacState, Effects0),
+    %% if the timer has already elapsed (stale time from a prior leadership term)
+    %% then set infinity to ensure a timer is started
+    LastConTimeout = if LastConTimeout0 < Ts ->
+                            infinity;
+                        true ->
+                            LastConTimeout0
+                     end,
+
+    Effects2 = maybe_add_consumer_timeout_effect(NextConTimeout,
+                                                 LastConTimeout,
+                                                 Effects1),
     case query_notify_decorators_info(MacState) of
         LastDec ->
-            {no_reply, Aux0#?AUX{last_checkpoint = Check}, RaAux, Effects1};
+            {no_reply, Aux0#?AUX{last_checkpoint = Check,
+                                 last_consumer_timeout = NextConTimeout}, RaAux, Effects2};
         {MaxActivePriority, IsEmpty} = NewLast ->
             Effects = [notify_decorators_effect(QName, MaxActivePriority, IsEmpty)
-                       | Effects1],
+                       | Effects2],
             {no_reply, Aux0#?AUX{last_checkpoint = Check,
-                                 last_decorators_state = NewLast}, RaAux, Effects}
+                                 last_consumer_timeout = NextConTimeout,
+                                 last_decorators_state = NewLast}, RaAux,
+             Effects}
     end;
 handle_aux(_RaftState, cast, eval,
            #?AUX{last_checkpoint = Check0} = Aux0, RaAux) ->
@@ -2718,9 +2733,7 @@ assign_to_consumer(#{system_time := Ts} = Meta, _Ts, ConsumerKey, Msgs,
     State = update_or_remove_con(Meta, ConsumerKey, Con, State1),
     DelMsgs = lists:reverse(DeliveryMsgs),
     DeliveryEffect = delivery_effect(ConsumerKey, DelMsgs, State),
-    Effects = maybe_add_consumer_timeout_effect(NextConTimeout,
-                                                NextConTimeout0,
-                                                [DeliveryEffect | Effects0]),
+    Effects = [DeliveryEffect | Effects0],
     {State, Effects}.
 
 delayed_in(ReadyAt, Idx, Msg, DeferralToken, #delayed{tree = Tree0,
@@ -2819,45 +2832,45 @@ checkout_one(#{system_time := Ts} = Meta, ExpiredMsg0, InitState0, Effects0) ->
                     %% there are consumers waiting to be serviced
                     %% process consumer checkout
                     case maps:get(ConsumerKey, Cons0) of
-                                #consumer{credit = Credit,
-                                          status = Status}
-                                  when Credit =:= 0 orelse
-                                       Status =/= up ->
-                                    %% not an active consumer but still in the consumers
-                                    %% map - this can happen when draining
-                                    %% or when higher priority single active consumers
-                                    %% take over, recurse without consumer in service
-                                    %% queue
-                                    checkout_one(Meta, ExpiredMsg,
-                                                 InitState#?STATE{service_queue = SQ1},
-                                                 Effects1);
-                                #consumer{checked_out = Checked0,
-                                          next_msg_id = Next,
-                                          credit = Credit,
-                                          delivery_count = DelCnt0,
-                                          cfg = Cfg} = Con0 ->
-                                    Timeout = Ts + Cfg#consumer_cfg.timeout,
-                                    Checked = maps:put(Next, ?C_MSG(Timeout, Msg),
-                                                       Checked0),
-                                    DelCnt = add(DelCnt0, 1),
-                                    Con = Con0#consumer{checked_out = Checked,
-                                                        next_msg_id = Next + 1,
-                                                        credit = Credit - 1,
-                                                        delivery_count = DelCnt},
-                                    Size = get_header(size, get_msg_header(Msg)),
-                                    State1 =
-                                        State0#?STATE{service_queue = SQ1,
-                                                      msg_bytes_checkout = BytesCheckout + Size,
-                                                      msg_bytes_enqueue = BytesEnqueue - Size,
-                                                      next_consumer_timeout = min(Timeout, NextConTimeout)},
-                                    Effects = maybe_add_consumer_timeout_effect(Timeout,
-                                                                                NextConTimeout,
-                                                                                Effects1),
-                                    State = update_or_remove_con(
-                                               Meta, ConsumerKey, Con, State1),
-                                    {success, ConsumerKey, Next, Msg, ExpiredMsg,
-                                     State, Effects}
-                            end;
+                        #consumer{credit = Credit,
+                                  status = Status}
+                          when Credit =:= 0 orelse
+                               Status =/= up ->
+                            %% not an active consumer but still in the consumers
+                            %% map - this can happen when draining
+                            %% or when higher priority single active consumers
+                            %% take over, recurse without consumer in service
+                            %% queue
+                            checkout_one(Meta, ExpiredMsg,
+                                         InitState#?STATE{service_queue = SQ1},
+                                         Effects1);
+                        #consumer{checked_out = Checked0,
+                                  next_msg_id = Next,
+                                  credit = Credit,
+                                  delivery_count = DelCnt0,
+                                  cfg = Cfg} = Con0 ->
+                            Timeout = Ts + Cfg#consumer_cfg.timeout,
+                            Checked = maps:put(Next, ?C_MSG(Timeout, Msg),
+                                               Checked0),
+                            DelCnt = add(DelCnt0, 1),
+                            Con = Con0#consumer{checked_out = Checked,
+                                                next_msg_id = Next + 1,
+                                                credit = Credit - 1,
+                                                delivery_count = DelCnt},
+                            Size = get_header(size, get_msg_header(Msg)),
+                            State1 =
+                                State0#?STATE{service_queue = SQ1,
+                                              msg_bytes_checkout =
+                                                  BytesCheckout + Size,
+                                              msg_bytes_enqueue =
+                                                  BytesEnqueue - Size,
+                                              next_consumer_timeout =
+                                                  min(Timeout, NextConTimeout)},
+                            State = update_or_remove_con(Meta, ConsumerKey,
+                                                         Con, State1),
+                            {success, ConsumerKey, Next, Msg, ExpiredMsg,
+                             State, Effects1}
+                    end;
                 empty ->
                     {nochange, ExpiredMsg, InitState, Effects1}
             end;
@@ -2988,7 +3001,8 @@ timer_effect(#?STATE{messages_total = 0,
                      delayed = #delayed{next = undefined}}, Effects) ->
     Effects;
 timer_effect(#?STATE{messages_total = 0,
-                     delayed = #delayed{next = {NextDelayedTs, _, _}}}, Effects) ->
+                     delayed = #delayed{next = {NextDelayedTs, _, _}}},
+             Effects) ->
     [{timer, expire_msgs, NextDelayedTs, {abs, true}} | Effects];
 timer_effect(#?STATE{returns = Returns,
                      messages = Messages,
@@ -3027,15 +3041,21 @@ timer_effect(#?STATE{returns = Returns,
 
     %% Also consider the next delayed message timestamp
     NextDelayedTs = case Delayed of
-                        #delayed{next = undefined} -> undefined;
-                        #delayed{next = {Ts, _, _}} -> Ts
+                        #delayed{next = undefined} ->
+                            undefined;
+                        #delayed{next = {Ts, _, _}} ->
+                            Ts
                     end,
 
     NextTimeout = case {NextExpiry, NextDelayedTs} of
-                      {undefined, undefined} -> undefined;
-                      {undefined, D} -> D;
-                      {E, undefined} -> E;
-                      {E, D} -> min(E, D)
+                      {undefined, undefined} ->
+                          undefined;
+                      {undefined, D} ->
+                          D;
+                      {E, undefined} ->
+                          E;
+                      {E, D} ->
+                          min(E, D)
                   end,
 
     case NextTimeout of
@@ -4096,7 +4116,8 @@ switch_from(_, _, State) ->
 switch_to(at_least_once, _, Effects) ->
     %% Switch from some other strategy to at-least-once.
     %% Dlx worker needs to be started on the leader.
-    %% The cleanest way to determine the Ra state of this node is delegation to handle_aux.
+    %% The cleanest way to determine the Ra state of this node is
+    %% delegation to handle_aux.
     {#?DLX{}, Effects ++ [{aux, {dlx, setup}}]};
 switch_to(_, State, Effects) ->
     {State, Effects}.

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -445,7 +445,7 @@ credit_and_drain_single_active_consumer_test(Config) ->
 
     % Drain the active consumer.
     {_State4, Effects1} = credit(Config, CK1, ?LINE, 1000, 16#ff_ff_ff_ff, true, State3),
-    ?assertMatch([{timer, _, _, _},
+    ?assertMatch([
                   {log_ext, [1], _Fun, _Local},
                   {send_msg, Self,
                    {credit_reply, Ctag1, _DeliveryCount = 999, _Credit = 0,
@@ -731,7 +731,6 @@ link_state_properties_activation_before_delivery_test(Config) ->
 
     %% The activation credit_reply should appear before the delivery.
     ?assertMatch([
-                  _Timer,
                   {send_msg, Self,
                    #credit_reply{ctag = Ctag2, delivery_count = 0, credit = 10,
                                  available = 1, drain = false,
@@ -917,8 +916,7 @@ enq_enq_deq_test(C) ->
     % get returns a reply value
     {_State3, _,
      [{log, [1], _Fun},
-      {monitor, _, _},
-      _Timer]} =
+      {monitor, _, _}]} =
         apply(meta(C, 3), make_checkout(Cid, {dequeue, unsettled}, #{}),
               State2),
     ok.
@@ -930,8 +928,7 @@ enq_enq_deq_deq_settle_test(Config) ->
     % get returns a reply value
     {State3, '$ra_no_reply',
      [{log, [1], _},
-      {monitor, _, _},
-      {timer, _, _, _}]} =
+      {monitor, _, _}]} =
         apply(meta(Config, 3), make_checkout(Cid, {dequeue, unsettled}, #{}),
               State2),
     {State4, {dequeue, empty}} =
@@ -1219,8 +1216,7 @@ return_auto_checked_out_test(Config) ->
     % any more
     {State1, #{key := CKey,
                next_msg_id := MsgId},
-     [_Timer,
-      _Monitor,
+     [_Monitor,
       {log_ext, [1], _Fun1, _} ]} = checkout(Config, ?LINE, Cid, 1, State0),
     % return should include another delivery
     {State2, _, Effects} = apply(meta(Config, 3),
@@ -1251,7 +1247,7 @@ requeue_test(Config) ->
     % any more
     {State1, #{key := CKey,
                next_msg_id := MsgId},
-     [_Timer, _Monitor,
+     [_Monitor,
       {log_ext, [1], _Fun, _}]} = checkout(Config, ?LINE, Cid, 1, State0),
 
     [{MsgId, {H1, _}}] = rabbit_fifo:get_checked_out(CKey, MsgId, MsgId, State1),
@@ -1308,8 +1304,7 @@ down_with_noproc_consumer_returns_unsettled_test(Config) ->
     Cid = {?FUNCTION_NAME_B, self()},
     {State0, _} = enq(Config, 1, 1, second, test_init(test)),
     {State1, #{key := CKey},
-     [_Timer,
-      {monitor, process, Pid} | _]} = checkout(Config, ?LINE, Cid, 1, State0),
+     [{monitor, process, Pid} | _]} = checkout(Config, ?LINE, Cid, 1, State0),
     {State2, _, _} = apply(meta(Config, 3), {down, Pid, noproc}, State1),
     {_State, #{key := CKey2}, Effects} = checkout(Config, ?LINE, Cid, 1, State2),
     ?assertNotEqual(CKey, CKey2),
@@ -1320,8 +1315,7 @@ removed_consumer_returns_unsettled_test(Config) ->
     Cid = {?FUNCTION_NAME_B, self()},
     {State0, _} = enq(Config, 1, 1, second, test_init(test)),
     {State1, #{key := CKey},
-     [_Timer,
-      {monitor, process, _Pid} | _]} =
+     [{monitor, process, _Pid} | _]} =
         checkout(Config, ?LINE, Cid, 1, State0),
     Remove = rabbit_fifo:make_checkout(Cid, remove, #{}),
     {State2, _, _} = apply(meta(Config, 3), Remove, State1),
@@ -4424,9 +4418,6 @@ consumer_timeout_test(Config) ->
     Timeout = Enq1Idx + 1000,
     Timeout2 = Enq2Idx + 1000,
 
-    % debugger:start(),
-    % int:i(rabbit_fifo),
-    % int:break(rabbit_fifo, 680),
     Entries =
     [
      {CK1, make_checkout(C1, {auto, {simple_prefetch, 2}},
@@ -4437,13 +4428,6 @@ consumer_timeout_test(Config) ->
                           next_consumer_timeout = infinity}
                when Cfg#consumer_cfg.timeout == 1000),
      {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}},
-                          Effs),
-              ok
-      end},
-     drop_effects,
      {Enq2Idx, rabbit_fifo:make_enqueue(self(), 2, two)},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 := #consumer{status = up,
                                                          credit = 0}},
@@ -4454,12 +4438,6 @@ consumer_timeout_test(Config) ->
                                                          credit = 1}},
                           next_consumer_timeout = Timeout2}
                when map_size(Ch) == 1),
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}},
-                          Effs),
-              ok
-      end},
      {Timeout2 + 1, {timeout, evaluate_consumer_timeout}},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 := #consumer{status = {timeout, up},
                                                          checked_out = Ch,
@@ -4477,14 +4455,7 @@ consumer_timeout_test(Config) ->
                                                          credit = 2}},
                           next_consumer_timeout = infinity}
                when map_size(Ch) == 0),
-     drop_effects,
      {Timeout2 + 3, rabbit_fifo:make_settle(CK1, [1])},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}},
-                          Effs),
-              ok
-      end},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 := #consumer{status = up,
                                                          checked_out = Ch,
                                                          credit = 0}},
@@ -4517,21 +4488,17 @@ consumer_timeout_disconnected_test(Config) ->
                           next_consumer_timeout = infinity}
                when Cfg#consumer_cfg.timeout == 1000),
      {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}},
-                          Effs),
-              ok
-      end},
-     drop_effects,
+     ?ASSERT(#rabbit_fifo{next_consumer_timeout = Next}
+               when is_integer(Next)),
      {Timeout + 1, {timeout, evaluate_consumer_timeout}},
      %% message has timed out
      ?ASSERT(#rabbit_fifo{consumers =
                           #{CK1 := #consumer{status = {timeout, up},
                                              timed_out_msg_ids = [_],
                                              checked_out = Ch}},
-                          next_consumer_timeout = _Timeout2}
-               when map_size(Ch) == 0),
+                          next_consumer_timeout = Next}
+               when map_size(Ch) == 0 andalso
+               Next == infinity),
      %% then we got disconnected
      {Enq2Idx, {down, C1Pid, noconnection}},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 :=
@@ -4571,13 +4538,6 @@ consumer_disconnected_timeout_test(Config) ->
                           next_consumer_timeout = infinity}
                when Cfg#consumer_cfg.timeout == 1000),
      {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}},
-                          Effs),
-              ok
-      end},
-     drop_effects,
      {Enq2Idx, {down, C1Pid, noconnection}},
      % {Enq2Idx, rabbit_fifo:make_enqueue(self(), 2, two)},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 :=
@@ -4604,6 +4564,7 @@ consumer_disconnected_timeout_test(Config) ->
     ],
     {_State1, _} = run_log(Config, State0, Entries),
     ok.
+
 consumer_timeout_cancelled_test(Config) ->
     R = rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
     State0 = init(#{name => ?FUNCTION_NAME,
@@ -4624,13 +4585,6 @@ consumer_timeout_cancelled_test(Config) ->
                           next_consumer_timeout = infinity}
                when Cfg#consumer_cfg.timeout == 1000),
      {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}},
-                          Effs),
-              ok
-      end},
-     drop_effects,
      {Enq2Idx, rabbit_fifo:make_checkout(C1, cancel, #{})},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 :=
                                         #consumer{status = cancelled}},
@@ -4642,6 +4596,103 @@ consumer_timeout_cancelled_test(Config) ->
                when map_size(Con) == 0),
      ?ASSERT(#rabbit_fifo{})
     ],
+    {_State1, _} = run_log(Config, State0, Entries),
+    ok.
+
+sac_consumer_timeout_2_test(Config) ->
+    R = rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+    State0 = init(#{name => ?FUNCTION_NAME,
+                    queue_resource => R,
+                    single_active_consumer_on => true}),
+
+    {CK1, {_, _C1Pid} = C1} = {0, {?LINE_B, test_util:fake_pid(n1)}},
+    {CK2, {_, _C2Pid} = C2} = {1, {?LINE_B, test_util:fake_pid(n1)}},
+    {CK3, {_, _C3Pid} = C3} = {2, {?LINE_B, test_util:fake_pid(n1)}},
+    Enq1Idx = 3,
+    Timeout = Enq1Idx + 1000,
+    Timeout2 = Timeout + 3 + 1000,
+
+    Entries =
+    [
+     {CK1, make_checkout(C1, {auto, {simple_prefetch, 2}}, #{timeout => 1000})},
+     {CK2, make_checkout(C2, {auto, {simple_prefetch, 2}}, #{timeout => 1000})},
+     {CK3, make_checkout(C3, {auto, {simple_prefetch, 2}}, #{timeout => 1000})},
+     ?ASSERT(#rabbit_fifo{consumers = #{CK1 := #consumer{cfg = Cfg,
+                                                         status = up,
+                                                         credit = 2}},
+                          next_consumer_timeout = infinity,
+                          waiting_consumers = [_, _]}
+               when Cfg#consumer_cfg.timeout == 1000),
+     {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
+     {Timeout + 1, {timeout, evaluate_consumer_timeout}},
+     ?ASSERT(#rabbit_fifo{consumers = #{CK2 := _} = Con,
+                          waiting_consumers =
+                              [_,
+                               {CK1, #consumer{status = {timeout, up},
+                                               timed_out_msg_ids = [0]}}]}
+               when map_size(Con) == 1),
+     {Timeout + 3, rabbit_fifo:make_settle(CK1, [0])},
+     drop_effects,
+     {Timeout2 + 1, {timeout, evaluate_consumer_timeout}},
+     ?ASSERT(#rabbit_fifo{consumers = #{CK1 := _},
+                          waiting_consumers = [_, _]})
+    ],
+
+    {_State1, _} = run_log(Config, State0, Entries),
+    ok.
+
+sac_consumer_timeout_3_test(Config) ->
+    R = rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+    State0 = init(#{name => ?FUNCTION_NAME,
+                    queue_resource => R,
+                    single_active_consumer_on => true}),
+
+    {CK1, {_, _C1Pid} = C1} = {0, {?LINE_B, test_util:fake_pid(n1)}},
+    Enq1Idx = 3,
+    Enq2Idx = 100,
+    Timeout = Enq1Idx + 1000,
+
+    Entries =
+    [
+     {CK1, make_checkout(C1, {auto, {simple_prefetch, 2}}, #{timeout => 1000})},
+     ?ASSERT(#rabbit_fifo{consumers = #{CK1 := #consumer{cfg = Cfg,
+                                                         status = up,
+                                                         credit = 2}},
+                          next_consumer_timeout = infinity,
+                          waiting_consumers = []}
+               when Cfg#consumer_cfg.timeout == 1000),
+     {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
+     {Enq2Idx, rabbit_fifo:make_enqueue(self(), 2, one)},
+     {Timeout + 1, {timeout, evaluate_consumer_timeout}},
+     ?ASSERT(#rabbit_fifo{consumers =
+                          #{CK1 := #consumer{status = {timeout, up},
+                                             checked_out = #{1 := _},
+                                             timed_out_msg_ids = [0]}},
+                          waiting_consumers = []}),
+     {Timeout + 3, rabbit_fifo:make_settle(CK1, [0])},
+     ?ASSERT(#rabbit_fifo{consumers =
+                          #{CK1 := #consumer{status = up,
+                                             checked_out = #{1 := _,
+                                                             2 := _},
+                                             timed_out_msg_ids = []}},
+                          waiting_consumers = []}),
+     {Timeout + 5, rabbit_fifo:make_settle(CK1, [1])},
+     ?ASSERT(#rabbit_fifo{consumers = #{CK1 := _} = Con,
+                          waiting_consumers = []}
+               when map_size(Con) == 1),
+     {Timeout + 1005, {timeout, evaluate_consumer_timeout}},
+     ?ASSERT(#rabbit_fifo{consumers = _,
+                          waiting_consumers =
+                          [{CK1, #consumer{status = {timeout, up},
+                                           checked_out = #{},
+                                           timed_out_msg_ids = [2]}}]
+                                           }),
+     {Timeout + 1006, rabbit_fifo:make_settle(CK1, [2])},
+     ?ASSERT(#rabbit_fifo{consumers = #{CK1 := _} = Con,
+                          waiting_consumers = []}
+               when map_size(Con) == 1)
+    ],
+
     {_State1, _} = run_log(Config, State0, Entries),
     ok.
 
@@ -4670,13 +4721,10 @@ sac_consumer_timeout_test(Config) ->
                when Cfg#consumer_cfg.timeout == 1000),
      {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
      {Enq2Idx, rabbit_fifo:make_enqueue(self(), 2, two)},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}}, Effs)
-      end},
-     drop_effects,
+     ?ASSERT(#rabbit_fifo{next_consumer_timeout = Next}
+               when is_integer(Next)),
      {Timeout + 1, {timeout, evaluate_consumer_timeout}},
-     %% message has timed out whilst disconnected
+     %%
      ?ASSERT(#rabbit_fifo{consumers =
                           #{CK1 := #consumer{status = {timeout, up},
                                              timed_out_msg_ids = [_],
@@ -4770,11 +4818,6 @@ sac_consumer_timeout_noconnection_test(Config) ->
                when Cfg#consumer_cfg.timeout == 1000),
      {Enq1Idx, rabbit_fifo:make_enqueue(self(), 1, one)},
      {Enq2Idx, rabbit_fifo:make_enqueue(self(), 2, two)},
-     {assert_effs,
-      fun (Effs) ->
-              ?ASSERT_EFF({timer, evaluate_consumer_timeout, _, {abs, true}}, Effs)
-      end},
-     drop_effects,
      {Enq2Idx, {down, C1Pid, noconnection}},
      % {Enq2Idx, rabbit_fifo:make_enqueue(self(), 2, two)},
      ?ASSERT(#rabbit_fifo{consumers = #{CK1 :=


### PR DESCRIPTION

where an infinity timer would be emitted for the same command
but after an actual timer leader to no timer.

Move to a model where consumer timers are handled by the aux
handler after each eval batch to reduce the number of timers
emitted.