### PR TITLE
Clarify 'reclaim_quorum_memory' command description and banner

### DIFF
--- a/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/reclaim_quorum_memory_command.ex
+++ b/deps/rabbitmq_cli/lib/rabbitmq/cli/queues/commands/reclaim_quorum_memory_command.ex
@@ -67,8 +67,8 @@ defmodule RabbitMQ.CLI.Queues.Commands.ReclaimQuorumMemoryCommand do
 
   def description(),
     do:
-      "Flushes quorum queue processes WAL, performs a full sweep GC on all of its local Erlang processes"
+      "Requests a full sweep GC on all of a quorum queue's Erlang processes"
 
   def banner([name], %{}),
-    do: "Will flush Raft WAL of quorum queue #{name} ..."
+    do: "Will garbage collect quorum queue #{name} ..."
 end


### PR DESCRIPTION
The aux effect triggered by `rabbit_quorum_queue:reclaim_memory/2` no longer triggers a WAL rollover, just a `erlang:garbage_collect/0` run. This change updates the description and banner of the `reclaim_quorum_memory` CLI command to remove mentions of WAL rollover.
