### PR TITLE
Fix double counting of reclaimable bytes in `rabbit_fifo`

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -2929,7 +2929,7 @@ expire_shallow(Ts, #?STATE{cfg = #cfg{dead_letter_handler = DLH},
                            messages = Messages0,
                            delayed = Delayed0,
                            dlx = DlxState0,
-                           reclaimable_bytes = ReclaimableBytes0,
+                           reclaimable_bytes = ReclaimableBytes,
                            messages_total = Tot,
                            msg_bytes_enqueue = MsgBytesEnqueue} = State0) ->
 
@@ -2956,7 +2956,7 @@ expire_shallow(Ts, #?STATE{cfg = #cfg{dead_letter_handler = DLH},
 
     ExpMsgs = Expired0 ++ Expired,
 
-    {DlxState, _RetainedBytes, DlxEffects} =
+    {DlxState, RetainedBytes, DlxEffects} =
         discard_or_dead_letter(ExpMsgs, expired, DLH, DlxState0),
 
     NumExpired = length(ExpMsgs),
@@ -2967,13 +2967,13 @@ expire_shallow(Ts, #?STATE{cfg = #cfg{dead_letter_handler = DLH},
                                Acc + get_header(size, Header)
                        end, 0, ExpMsgs),
 
-    DiscardedSize = Size + (NumExpired * ?ENQ_OVERHEAD_B),
+    DiscardedSize = Size + (NumExpired * ?ENQ_OVERHEAD_B) - RetainedBytes,
     State = State0#?STATE{dlx = DlxState,
                           returns = Returns,
                           messages = Messages,
                           delayed = Delayed,
                           messages_total = Tot - NumExpired,
-                          reclaimable_bytes = ReclaimableBytes0 + DiscardedSize,
+                          reclaimable_bytes = ReclaimableBytes + DiscardedSize,
                           msg_bytes_enqueue = MsgBytesEnqueue - Size},
     {State, DlxEffects}.
 
@@ -2982,18 +2982,18 @@ expire(RaCmdTs, State0, Effects) ->
      #?STATE{cfg = #cfg{dead_letter_handler = DLH},
              dlx = DlxState0,
              messages_total = Tot,
-             reclaimable_bytes = ReclaimablBytes0,
+             reclaimable_bytes = ReclaimableBytes,
              msg_bytes_enqueue = MsgBytesEnqueue
             } = State1} =
         take_next_msg(State0),
-    {DlxState, _RetainedBytes, DlxEffects} =
+    {DlxState, RetainedBytes, DlxEffects} =
         discard_or_dead_letter([Msg], expired, DLH, DlxState0),
     Header = get_msg_header(Msg),
     Size = get_header(size, Header),
-    DiscardedSize = Size + ?ENQ_OVERHEAD_B,
+    DiscardedSize = Size + ?ENQ_OVERHEAD_B - RetainedBytes,
     State = State1#?STATE{dlx = DlxState,
                           messages_total = Tot - 1,
-                          reclaimable_bytes = ReclaimablBytes0 + DiscardedSize,
+                          reclaimable_bytes = ReclaimableBytes + DiscardedSize,
                           msg_bytes_enqueue = MsgBytesEnqueue - Size},
     expire_msgs(RaCmdTs, true, State, Effects ++ DlxEffects).
 
@@ -4193,17 +4193,14 @@ discard_or_dead_letter(Msgs0, Reason, {at_most_once, {Mod, Fun, Args}}, State) -
     {State, 0, [Effect]};
 discard_or_dead_letter(Msgs, Reason, at_least_once, State0)
   when Reason =/= maxlen ->
-    RetainedBytes = lists:foldl(fun (M, Acc) ->
-                                        Acc + size_in_bytes(M) + ?ENQ_OVERHEAD_B
-                                end, 0, Msgs),
-    State = lists:foldl(fun(Msg, #?DLX{discards = D0,
-                                       msg_bytes = B0} = S0) ->
-                                MsgSize = size_in_bytes(Msg),
-                                D = lqueue:in(?TUPLE(Reason, Msg), D0),
-                                B = B0 + MsgSize,
-                                S0#?DLX{discards = D,
-                                        msg_bytes = B}
-                        end, State0, Msgs),
+    {State, RetainedBytes} = lists:foldl(
+                               fun(Msg, {#?DLX{discards = D,
+                                              msg_bytes = B} = S, R}) ->
+                                       MsgSize = size_in_bytes(Msg),
+                                       {S#?DLX{discards = lqueue:in(?TUPLE(Reason, Msg), D),
+                                               msg_bytes = B + MsgSize},
+                                        R + MsgSize + ?ENQ_OVERHEAD_B}
+                               end, {State0, 0}, Msgs),
     {State, RetainedBytes,
      [{mod_call, rabbit_global_counters, messages_dead_lettered,
        [Reason, rabbit_quorum_queue, at_least_once, length(Msgs)]}]}.

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -278,6 +278,7 @@ reclaimable_bytes_test(Config) ->
       reclaimable_bytes_count := _DiscBytes27} = rabbit_fifo:overview(State27),
 
     Conf5 = Conf4#{msg_ttl => 1000,
+                   dead_letter_handler => at_least_once,
                    max_length => undefined},
     {State28, ok, _} = apply(meta(Config, ?LINE),
                              rabbit_fifo:make_update_config(Conf5), State27),
@@ -287,9 +288,22 @@ reclaimable_bytes_test(Config) ->
     {State30, _} = enq_ts(Config, ?LINE, 10, Msg, 3000, State29),
     % {State31, _} = enq_ts(Config, ?LINE, 11, Msg, 5000, State30),
 
-    #{num_messages := 1,
+    #{num_messages := 2,
       reclaimable_bytes_count := DiscBytes30} = rabbit_fifo:overview(State30),
-    ?assert(DiscBytes30 - DiscBytes29 > 1000),
+    %% The message is dead-lettered at_least_once, so its bytes are retained
+    %% in the DLX state and should not be added to reclaimable_bytes yet.
+    ?assert(DiscBytes30 - DiscBytes29 < 1000),
+
+    %% Now process the DLX message
+    {State31, _, _} = apply(meta(Config, ?LINE),
+                            rabbit_fifo_dlx:make_checkout(DlxPid, 1),
+                            State30),
+    {State32, _, _} = apply(meta(Config, ?LINE),
+                            rabbit_fifo_dlx:make_settle([0]),
+                            State31),
+    #{reclaimable_bytes_count := DiscBytes32} = rabbit_fifo:overview(State32),
+    %% After settling the DLX message, the bytes should finally be reclaimable
+    ?assert(DiscBytes32 - DiscBytes30 > 1000),
     ok.
 
 enq_enq_checkout_test(Config, Spec) ->


### PR DESCRIPTION
Prior to this commit, when a message expires with at-least-once dead letter strategy, the reclaimable bytes were double counted.