### PR TITLE
Fix `rabbit_khepri` delete-related wrappers

### DIFF
--- a/deps/rabbit/src/rabbit_db_binding.erl
+++ b/deps/rabbit/src/rabbit_db_binding.erl
@@ -616,7 +616,7 @@ clear() ->
              _Kind = ?KHEPRI_WILDCARD_STAR,
              _DstName = ?KHEPRI_WILDCARD_STAR,
              _RoutingKey = ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -585,7 +585,7 @@ clear_exchange_serials_in_khepri() ->
     khepri_delete(Path).
 
 khepri_delete(Path) ->
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_db_maintenance_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_maintenance_m2k_converter.erl
@@ -86,7 +86,7 @@ delete_from_khepri(rabbit_node_maintenance_states = Table, Key, State) ->
 
 clear_data_in_khepri(rabbit_node_maintenance_states) ->
     Path = rabbit_db_maintenance:khepri_maintenance_path(?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_db_msup.erl
+++ b/deps/rabbit/src/rabbit_db_msup.erl
@@ -140,9 +140,9 @@ delete_all(Group) ->
     Pattern = #mirrored_sup_childspec{key = {Group, '_'},
                                       _   = '_'},
     Conditions = [?KHEPRI_WILDCARD_STAR_STAR, #if_data_matches{pattern = Pattern}],
-    rabbit_khepri:delete(khepri_mirrored_supervisor_path(
-                           ?KHEPRI_WILDCARD_STAR,
-                           #if_all{conditions = Conditions})).
+    rabbit_khepri:delete_many(khepri_mirrored_supervisor_path(
+                                ?KHEPRI_WILDCARD_STAR,
+                                #if_all{conditions = Conditions})).
 
 %% -------------------------------------------------------------------
 %% clear().
@@ -153,7 +153,7 @@ delete_all(Group) ->
 clear() ->
     Path = khepri_mirrored_supervisor_path(
              ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_db_queue.erl
+++ b/deps/rabbit/src/rabbit_db_queue.erl
@@ -951,7 +951,7 @@ get_in_khepri_tx(Name) ->
 
 clear() ->
     Path = khepri_queue_path(?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_db_rtparams.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams.erl
@@ -219,7 +219,7 @@ delete(VHostName, Comp, Name)
 
 do_delete(Key) ->
     Path = khepri_rp_path(Key),
-    ok = rabbit_khepri:delete(Path).
+    ok = rabbit_khepri:delete_many(Path).
 
 %% -------------------------------------------------------------------
 %% delete_vhost().

--- a/deps/rabbit/src/rabbit_db_rtparams_m2k_converter.erl
+++ b/deps/rabbit/src/rabbit_db_rtparams_m2k_converter.erl
@@ -90,7 +90,7 @@ rtparams_path(Key) ->
 
 clear_data_in_khepri(rabbit_runtime_parameters) ->
     Path1 = rabbit_db_rtparams:khepri_global_rp_path(?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path1) of
+    case rabbit_khepri:delete_many(Path1) of
         ok -> ok;
         Error1 -> throw(Error1)
     end,
@@ -98,7 +98,7 @@ clear_data_in_khepri(rabbit_runtime_parameters) ->
               ?KHEPRI_WILDCARD_STAR,
               ?KHEPRI_WILDCARD_STAR,
               ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path2) of
+    case rabbit_khepri:delete_many(Path2) of
         ok -> ok;
         Error2 -> throw(Error2)
     end.

--- a/deps/rabbit/src/rabbit_db_user.erl
+++ b/deps/rabbit/src/rabbit_db_user.erl
@@ -336,7 +336,7 @@ clear_matching_user_permissions(Username, VHostName)
   when (is_binary(Username) orelse Username =:= '_') andalso
        (is_binary(VHostName) orelse VHostName =:= '_') ->
     Path = khepri_user_permission_path(any(Username), any(VHostName)),
-    ok = rabbit_khepri:delete(Path).
+    ok = rabbit_khepri:delete_many(Path).
 
 any('_') -> ?KHEPRI_WILDCARD_STAR;
 any(Value) -> Value.
@@ -553,7 +553,7 @@ clear_topic_permissions(Username, VHostName, ExchangeName)
   when is_binary(Username) andalso is_binary(VHostName) andalso
        (is_binary(ExchangeName) orelse ExchangeName =:= '_') ->
     Path = khepri_topic_permission_path(any(Username), any(VHostName), any(ExchangeName)),
-    rabbit_khepri:delete(Path).
+    rabbit_khepri:delete_many(Path).
 
 %% -------------------------------------------------------------------
 %% clear_matching_topic_permissions().
@@ -575,7 +575,7 @@ clear_matching_topic_permissions(Username, VHostName, ExchangeName)
        (is_binary(ExchangeName) orelse ExchangeName =:= '_') ->
     Path = khepri_topic_permission_path(
              any(Username), any(VHostName), any(ExchangeName)),
-    ok = rabbit_khepri:delete(Path).
+    ok = rabbit_khepri:delete_many(Path).
 
 %% -------------------------------------------------------------------
 %% delete().
@@ -610,7 +610,7 @@ delete(Username) when is_binary(Username) ->
 
 clear() ->
     Path = khepri_user_path(?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok    -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_db_vhost.erl
+++ b/deps/rabbit/src/rabbit_db_vhost.erl
@@ -367,7 +367,7 @@ delete(VHostName) when is_binary(VHostName) ->
 
 clear() ->
     Path = khepri_vhost_path(?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok    -> ok;
         Error -> throw(Error)
     end.

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -155,6 +155,7 @@
          adv_update/2, adv_update/3,
 
          delete/1, delete/2,
+         delete_many/1, delete_many/2,
          adv_delete/1, adv_delete/2,
          adv_delete_many/1, adv_delete_many/2,
          clear_payload/1, clear_payload/2,
@@ -1245,6 +1246,13 @@ delete(PathPattern) ->
     delete(PathPattern, #{}).
 
 delete(PathPattern, Options) ->
+    Options1 = maps:merge(?DEFAULT_COMMAND_OPTIONS, Options),
+    khepri:delete(?STORE_ID, PathPattern, Options1).
+
+delete_many(PathPattern) ->
+    delete_many(PathPattern, #{}).
+
+delete_many(PathPattern, Options) ->
     Options1 = maps:merge(?DEFAULT_COMMAND_OPTIONS, Options),
     khepri:delete_many(?STORE_ID, PathPattern, Options1).
 

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange_m2k_converter.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_db_ch_exchange_m2k_converter.erl
@@ -92,7 +92,7 @@ delete_from_khepri(?HASH_RING_STATE_TABLE = Table, Key, State) ->
 clear_data_in_khepri(?HASH_RING_STATE_TABLE) ->
     Path = rabbit_db_ch_exchange:khepri_consistent_hash_path(
              ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok ->
             ok;
         Error ->

--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange_m2k_converter.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_db_jms_exchange_m2k_converter.erl
@@ -90,7 +90,7 @@ delete_from_khepri(?JMS_TOPIC_TABLE = Table, Key, State) ->
 clear_data_in_khepri(?JMS_TOPIC_TABLE) ->
     Path = rabbit_db_jms_exchange:khepri_jms_topic_exchange_path(
              ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    case rabbit_khepri:delete(Path) of
+    case rabbit_khepri:delete_many(Path) of
         ok ->
             ok;
         Error ->

--- a/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange.erl
+++ b/deps/rabbitmq_recent_history_exchange/src/rabbit_db_rh_exchange.erl
@@ -75,7 +75,7 @@ add_to_cache(Cached, Message, Length) ->
 delete() ->
     Path = khepri_recent_history_path(
              ?KHEPRI_WILDCARD_STAR, ?KHEPRI_WILDCARD_STAR),
-    rabbit_khepri:delete(Path).
+    rabbit_khepri:delete_many(Path).
 
 delete(XName) ->
     Path = khepri_recent_history_path(XName),


### PR DESCRIPTION
## Why

The `rabbit_khepri:delete()` and `rabbit_khepri:adv_delete()` wrapper were calling `khepri:delete_many()` and `khepri_adv:delete_many()` respectively, not `khepri{,_adv}:delete()` as the names were suggesting. They are not the same function and have not the same behaviour.

This led to a performance issue with the branch that replaces the "delete queue" transaction by a simple delete (#14902) that was related to this confusion.

## How

The wrappers are renamed to reflect the Khepri APIs being called.

While here, add `rabbit_khepri:delete()` and `rabbit_khepri:adv_delete()` wrappers that call the similarily named Khepri APIs.