### PR TITLE
Optimise message expiry

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -2919,83 +2919,75 @@ expire_msgs(RaCmdTs, Result, State, Effects) ->
     %% because the latter can be much slower than the former.
     case msg_is_expired(RaCmdTs, peek_next_msg(State)) of
         true ->
-            expire(RaCmdTs, State, Effects);
+            expire_batch(RaCmdTs, State, Effects);
         false ->
             {Result, State, Effects}
     end.
 
-expire_shallow(Ts, #?STATE{cfg = #cfg{dead_letter_handler = DLH},
-                           returns = Returns0,
-                           messages = Messages0,
-                           delayed = Delayed0,
-                           dlx = DlxState0,
-                           reclaimable_bytes = ReclaimableBytes,
-                           messages_total = Tot,
-                           msg_bytes_enqueue = MsgBytesEnqueue} = State0) ->
-
+expire_shallow(Ts, #?STATE{returns = Returns0,
+                           delayed = Delayed0} = State0) ->
     %% Promote ready delayed messages to returns queue
     {ReadyMsgs, Delayed} = take_ready_delayed(Ts, Delayed0),
-    Returns1 = lists:foldl(fun (Msg, Acc) -> lqueue:in(Msg, Acc) end,
-                           Returns0, ReadyMsgs),
+    Returns = lists:foldl(fun (Msg, Acc) -> lqueue:in(Msg, Acc) end,
+                          Returns0, ReadyMsgs),
+    State = State0#?STATE{returns = Returns, delayed = Delayed},
+    {_, State1, DlxEffects} = expire_batch(Ts, State, []),
+    {State1, DlxEffects}.
 
-    {Expired0, Returns} = case lqueue:peek(Returns1) of
-                              empty ->
-                                  {[], Returns1};
-                              {value, Returned} ->
-                                  case msg_is_expired(Ts, Returned) of
-                                      true ->
-                                          {[Returned], lqueue:drop(Returns1)};
-                                      false ->
-                                          {[], Returns1}
-                                  end
-                          end,
+%% Batch-collect all expired messages from returns and messages queues,
+%% then process them in a single discard_or_dead_letter call.
+expire_batch(Ts, #?STATE{cfg = #cfg{dead_letter_handler = DLH},
+                         returns = Returns0,
+                         messages = Messages0,
+                         dlx = DlxState0,
+                         reclaimable_bytes = ReclaimableBytes,
+                         messages_total = Tot,
+                         msg_bytes_enqueue = MsgBytesEnqueue} = State0,
+             Effects) ->
+    {ExpiredReturns, Returns} = take_expired_returns(Ts, Returns0),
 
-    {Expired, Messages} = rabbit_fifo_pq:take_while(
-                            fun (Msg) -> msg_is_expired(Ts, Msg) end,
-                            Messages0),
+    {ExpiredMsgs, Messages} = rabbit_fifo_pq:take_while(
+                                fun (Msg) -> msg_is_expired(Ts, Msg) end,
+                                Messages0),
 
-    ExpMsgs = Expired0 ++ Expired,
+    ExpMsgs = ExpiredReturns ++ ExpiredMsgs,
 
     {DlxState, RetainedBytes, DlxEffects} =
         discard_or_dead_letter(ExpMsgs, expired, DLH, DlxState0),
 
-    NumExpired = length(ExpMsgs),
-
-    %% calculate total sizes
-    Size = lists:foldl(fun (Msg, Acc) ->
-                               Header = get_msg_header(Msg),
-                               Acc + get_header(size, Header)
-                       end, 0, ExpMsgs),
+    {NumExpired, Size} = count_and_size(ExpMsgs),
 
     DiscardedSize = Size + (NumExpired * ?ENQ_OVERHEAD_B) - RetainedBytes,
     State = State0#?STATE{dlx = DlxState,
                           returns = Returns,
                           messages = Messages,
-                          delayed = Delayed,
                           messages_total = Tot - NumExpired,
                           reclaimable_bytes = ReclaimableBytes + DiscardedSize,
                           msg_bytes_enqueue = MsgBytesEnqueue - Size},
-    {State, DlxEffects}.
+    {true, State, Effects ++ DlxEffects}.
 
-expire(RaCmdTs, State0, Effects) ->
-    {Msg,
-     #?STATE{cfg = #cfg{dead_letter_handler = DLH},
-             dlx = DlxState0,
-             messages_total = Tot,
-             reclaimable_bytes = ReclaimableBytes,
-             msg_bytes_enqueue = MsgBytesEnqueue
-            } = State1} =
-        take_next_msg(State0),
-    {DlxState, RetainedBytes, DlxEffects} =
-        discard_or_dead_letter([Msg], expired, DLH, DlxState0),
-    Header = get_msg_header(Msg),
-    Size = get_header(size, Header),
-    DiscardedSize = Size + ?ENQ_OVERHEAD_B - RetainedBytes,
-    State = State1#?STATE{dlx = DlxState,
-                          messages_total = Tot - 1,
-                          reclaimable_bytes = ReclaimableBytes + DiscardedSize,
-                          msg_bytes_enqueue = MsgBytesEnqueue - Size},
-    expire_msgs(RaCmdTs, true, State, Effects ++ DlxEffects).
+take_expired_returns(Ts, Returns) ->
+    take_expired_returns(Ts, Returns, []).
+
+take_expired_returns(Ts, Returns0, Acc) ->
+    case lqueue:peek(Returns0) of
+        {value, Msg} ->
+            case msg_is_expired(Ts, Msg) of
+                true ->
+                    take_expired_returns(Ts, lqueue:drop(Returns0),
+                                         [Msg | Acc]);
+                false ->
+                    {lists:reverse(Acc), Returns0}
+            end;
+        empty ->
+            {lists:reverse(Acc), Returns0}
+    end.
+
+count_and_size(Msgs) ->
+    lists:foldl(fun (Msg, {N, Acc}) ->
+                        Header = get_msg_header(Msg),
+                        {N + 1, Acc + get_header(size, Header)}
+                end, {0, 0}, Msgs).
 
 timer_effect(#?STATE{messages_total = 0,
                      delayed = #delayed{next = undefined}}, Effects) ->


### PR DESCRIPTION
Optimise message expiry
Problem
The expire function in rabbit_fifo processed expired messages one at a time in a recursive loop: it would take a single message, call discard_or_dead_letter for that one message, update the state, and then recurse via expire_msgs to check for the next expired message. This meant that if N messages were expired, discard_or_dead_letter was called N times (once per message), and the state record was rebuilt N times.

Similarly, expire_shallow (used by the expire_msgs timer callback) only expired a single returned message from the returns queue before moving on to the messages queue.

Changes
Replace the recursive one-at-a-time expire/expire_msgs loop with a batch-oriented expire_batch that collects all expired messages from both the returns queue and the messages priority queue in one pass, then processes them with a single discard_or_dead_letter call
Extract take_expired_returns/2 to drain all consecutive expired messages from the returns queue (previously only the head was checked)
Extract count_and_size/1 to compute the count and total byte size of expired messages in a single fold
Reuse expire_batch from expire_shallow instead of duplicating the expiry logic
Effect
Reduces the number of discard_or_dead_letter calls from N (one per expired message) to 1 per expiry pass
Reduces intermediate state record allocations from N to 1
Eliminates code duplication between expire_shallow and expire