### PR TITLE
Address two test flakes

### DIFF
--- a/deps/rabbit/test/rabbit_db_topic_exchange_SUITE.erl
+++ b/deps/rabbit/test/rabbit_db_topic_exchange_SUITE.erl
@@ -81,7 +81,6 @@ init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config1, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_db_topic_exchange, clear, []),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 %% ---------------------------------------------------------------------------
@@ -212,20 +211,24 @@ topic_trie_cleanup(Config) ->
                   ct:pal("Khepri version: ~b / ~s", [KhepriVersion2, KhepriVersion1]),
                   if
                       KhepriVersion2 >= 1704 ->
-                          %% Assert that no entries were found for this vhost
-                          %% after deletion.
-                          ?assertEqual([], VHostEntriesAfterDelete);
+                          %% Await until no entries remain for this vhost after
+                          %% deletion. The Khepri projection may lag on followers
+                          %% in a mixed-version cluster.
+                          ?awaitMatch(
+                             [],
+                             read_topic_trie_table(Config, Node, VHost, rabbit_khepri_topic_trie_v3),
+                             30_000);
                       true ->
-                          %% Assert that no entries were found for this vhost
-                          %% after deletion. This node does not have the fixed
-                          %% version of Khepri, so it won't delete the new
-                          %% `#topic_trie_edge_v2{}' correctly, that's why we
-                          %% filter them out.
+                          %% This branch uses a version of Khepri that has a bug,
+                          %% so it won't delete the new `#topic_trie_edge_v2{}`
+                          %% correctly. Therefore we filter those out and await only for the
+                          %% legacy entries to be gone.
                           ct:pal("Consider #topic_trie_edge{} records only"),
-                          ?assertEqual(
+                          ?awaitMatch(
                              [],
                              [E || #topic_trie_edge{} = E
-                                   <- VHostEntriesAfterDelete])
+                                   <- read_topic_trie_table(Config, Node, VHost, rabbit_khepri_topic_trie_v3)],
+                             30_000)
                   end
           end, Nodes),
 

--- a/deps/rabbitmq_shovel/test/shovel_test_utils.erl
+++ b/deps/rabbitmq_shovel/test/shovel_test_utils.erl
@@ -365,7 +365,7 @@ amqp10_expect_count(Session, Address, Count) ->
     Msgs.
 
 await_autodelete(Config, Name) ->
-    await_autodelete(Config, 0, Name, 10_000).
+    await_autodelete(Config, 0, Name, 30_000).
 
 await_autodelete(Config, Node, Name, Timeout) ->
     rabbit_ct_helpers:await_condition(


### PR DESCRIPTION
Discovered as part of https://github.com/rabbitmq/rabbitmq-server/pull/15848, so backporting to `v4.3.x` should not be necessary, this is a forward-port.

(cherry picked from commit 9de2f3ec32ccda2ce60f604c6a47439e60a688d5)
(cherry picked from commit 4903068d4dff35beb24875a662656f9f7928f3b3)
