### PR TITLE
Add config for stream initial cluster size, default to 3

### DIFF
--- a/deps/rabbit/docs/rabbitmq.conf.example
+++ b/deps/rabbit/docs/rabbitmq.conf.example
@@ -481,6 +481,11 @@
 ## at declaration time.
 # quorum_queue.initial_cluster_size = 3
 
+## Sets the initial stream queue replica count for newly declared stream queues.
+## This value can be overridden using the 'x-initial-cluster-size' queue argument
+## at declaration time, or by setting 'initial-cluster-size' in a policy.
+# stream.initial_cluster_size = 3
+
 ## Sets the maximum number of unconfirmed messages a channel can send
 ## before publisher flow control is triggered.
 ## The current default is configured to provide good performance and stability

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2912,6 +2912,11 @@ end}.
     {validators, ["is_supported_information_unit"]}
 ]}.
 
+{mapping, "stream.initial_cluster_size", "rabbit.stream_cluster_size", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
 {mapping, "cluster_tags.$tag", "rabbit.cluster_tags", [
     {datatype, [binary]}
 ]}.

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -1253,7 +1253,7 @@ max_age(Age) ->
     Age.
 
 initial_cluster_size(undefined) ->
-    length(rabbit_nodes:list_members());
+    application:get_env(rabbit, stream_cluster_size, 3);
 initial_cluster_size(Val) ->
     Val.
 

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1161,6 +1161,16 @@ credential_validator.regexp = ^abc\\d+",
    []},
 
   %%
+  %% Stream queues
+  %%
+  {stream_initial_cluster_size,
+   "stream.initial_cluster_size = 5",
+   [{rabbit, [
+      {stream_cluster_size, 5}
+     ]}],
+   []},
+
+  %%
   %% Runtime parameters
   %%
 


### PR DESCRIPTION
This matches the `quorum_queues.initial_cluster_size` config option which also defaults to three. Previously streams defaulted to `length(rabbit_nodes:list_members())` - starting a replica on all members of the cluster:

```
% ENABLED_PLUGINS=rabbitmq_stream NODES=5 make start-cluster
% stream-perf-test --producers 1 --consumers 0 --time 1
% sbin/rabbitmq-streams stream_status -n rabbit-1 stream
Status of stream stream on node rabbit-1@mango2 ...
┌─────────┬─────────────────┬───────┬─────────┬──────────────────┬────────────────────┬──────────────┬─────────┬──────────┐
│ role    │ node            │ epoch │ offset  │ committed_offset │ committed_chunk_id │ first_offset │ readers │ segments │
├─────────┼─────────────────┼───────┼─────────┼──────────────────┼────────────────────┼──────────────┼─────────┼──────────┤
│ writer  │ rabbit-1@mango2 │ 1     │ 1087375 │ 1087375          │ 1086181            │ 0            │ 4       │ 1        │
├─────────┼─────────────────┼───────┼─────────┼──────────────────┼────────────────────┼──────────────┼─────────┼──────────┤
│ replica │ rabbit-2@mango2 │ 1     │ 1087375 │ 1087375          │ 1086181            │ 0            │ 0       │ 1        │
├─────────┼─────────────────┼───────┼─────────┼──────────────────┼────────────────────┼──────────────┼─────────┼──────────┤
│ replica │ rabbit-3@mango2 │ 1     │ 1087375 │ 1087375          │ 1086181            │ 0            │ 0       │ 1        │
├─────────┼─────────────────┼───────┼─────────┼──────────────────┼────────────────────┼──────────────┼─────────┼──────────┤
│ replica │ rabbit-4@mango2 │ 1     │ 1087375 │ 1087375          │ 1086181            │ 0            │ 0       │ 1        │
├─────────┼─────────────────┼───────┼─────────┼──────────────────┼────────────────────┼──────────────┼─────────┼──────────┤
│ replica │ rabbit-5@mango2 │ 1     │ 1087375 │ 1087375          │ 1086181            │ 0            │ 0       │ 1        │
└─────────┴─────────────────┴───────┴─────────┴──────────────────┴────────────────────┴──────────────┴─────────┴──────────┘
```

I think it makes more sense to default to a subset of 3 nodes like quorum queues.