### PR TITLE
Handle delivery-count mismatch between session and QQ

### DIFF
--- a/deps/rabbit/src/rabbit_amqp_session.erl
+++ b/deps/rabbit/src/rabbit_amqp_session.erl
@@ -1715,9 +1715,7 @@ handle_credit_reply0(#credit_reply{ctag = Ctag,
                                              echo = CEcho,
                                              properties = OldProps
                                             } = CFC0,
-                        queue_flow_ctl = #queue_flow_ctl{
-                                            delivery_count = QDeliveryCount
-                                           } = QFC0,
+                        queue_flow_ctl = QFC0,
                         stashed_credit_req = StashedCreditReq
                        } = Link0,
                      #state{cfg = #cfg{writer_pid = Writer,
@@ -1726,20 +1724,19 @@ handle_credit_reply0(#credit_reply{ctag = Ctag,
                             queue_states = QStates0
                            } = State) ->
 
-    %% Our (receiver) delivery-count should be always
-    %% in sync with the delivery-count of the sending queue.
-    case DeliveryCount of
-        QDeliveryCount ->
-            ok;
-        _ ->
-            exit({delivery_count_mismatch, QDeliveryCount, DeliveryCount})
-    end,
+    %% "The receiver's [our] value is calculated based on the last known value
+    %% from the sender [queue]". [2.6.7]
+    %% Therefore, we accept whatever the queue reports because deliveries can be
+    %% lost during leader changes or temporary distribution link outages while the
+    %% Ra credit command that advanced the delivery-count was still committed.
+    QFC = QFC0#queue_flow_ctl{delivery_count = DeliveryCount},
 
     case StashedCreditReq of
         #credit_req{} ->
+            Link = Link0#outgoing_link{queue_flow_ctl = QFC},
             %% We prioritise the stashed client request over finishing the current
             %% top-up rounds because the latest link state from the client applies.
-            pop_credit_req(Handle, Ctag, Link0, State);
+            pop_credit_req(Handle, Ctag, Link, State);
         none when Credit =:= 0 andalso
                   CCredit > 0 ->
             QName = Link0#outgoing_link.queue_name,
@@ -1749,7 +1746,7 @@ handle_credit_reply0(#credit_reply{ctag = Ctag,
                                        QName, Ctag, DeliveryCount, CappedCredit,
                                        false, QStates0),
             Link = Link0#outgoing_link{
-                     queue_flow_ctl = QFC0#queue_flow_ctl{credit = CappedCredit},
+                     queue_flow_ctl = QFC#queue_flow_ctl{credit = CappedCredit},
                      at_least_one_credit_req_in_flight = true},
             State1 = State#state{queue_states = QStates,
                                  outgoing_links = OutgoingLinks#{Handle := Link}},
@@ -1775,12 +1772,6 @@ handle_credit_reply0(#credit_reply{ctag = Ctag,
                 false ->
                     ok
             end,
-            %% Although we (the receiver) usually determine link credit, we set here
-            %% our link credit to what the queue says our link credit is (which is safer
-            %% in case credit requests got applied out of order in quorum queues).
-            %% This should be fine given that we asserted earlier that our delivery-count is
-            %% in sync with the delivery-count of the sending queue.
-            QFC = QFC0#queue_flow_ctl{credit = Credit},
             CFC = CFC0#client_flow_ctl{properties = Props},
             Link = Link0#outgoing_link{client_flow_ctl = CFC,
                                        queue_flow_ctl = QFC,

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -1442,7 +1442,7 @@ handle_aux(_, _, {get_checked_out, ConsumerKey, MsgIds}, Aux0, RaAux0) ->
                                   {S, Acc}
                           end
                   end, {RaAux0, []}, maps:with(MsgIds, Checked)),
-            {reply, {ok,  IdMsgs}, Aux0, RaState};
+            {reply, {ok, lists:keysort(1, IdMsgs)}, Aux0, RaState};
         _ ->
             {reply, {error, consumer_not_found}, Aux0, RaAux0}
     end;

--- a/deps/rabbit/test/amqp_client_SUITE.erl
+++ b/deps/rabbit/test/amqp_client_SUITE.erl
@@ -216,7 +216,8 @@ groups() ->
        list_connections,
        detach_requeues_two_connections_classic_queue,
        detach_requeues_two_connections_quorum_queue,
-       attach_to_down_quorum_queue
+       attach_to_down_quorum_queue,
+       lost_deliveries_quorum_queue
       ]},
 
      {metrics, [shuffle],
@@ -7380,6 +7381,74 @@ attach_to_down_quorum_queue(Config) ->
     ok = rabbit_ct_broker_helpers:start_broker(Config, 2),
     {ok, _} = rabbitmq_amqp_client:delete_queue(LinkPair0, QName),
     ok = close(Init0).
+
+%% This test case used to reproduce the following crash in rabbit_amqp_session
+%% ```
+%% exception exit: {delivery_count_mismatch,0,2}
+%% ```
+lost_deliveries_quorum_queue(Config) ->
+    QName = atom_to_binary(?FUNCTION_NAME),
+    Address = rabbitmq_amqp_address:queue(QName),
+    RaName = ra_name(QName),
+
+    LeaderNode = get_node_config(Config, 0, nodename),
+    NonMemberNode = get_node_config(Config, 2, nodename),
+
+    {_, _, LinkPair} = Init = init(LeaderNode, Config),
+    {ok, #{}} = rabbitmq_amqp_client:declare_queue(
+                  LinkPair, QName,
+                  #{arguments => #{<<"x-queue-type">> => {utf8, <<"quorum">>},
+                                   <<"x-quorum-initial-group-size">> => {ulong, 1}}}),
+
+    OpnConf = connection_config(NonMemberNode, Config),
+    {ok, Connection} = amqp10_client:open_connection(OpnConf),
+    {ok, Session} = amqp10_client:begin_session_sync(Connection),
+
+    {ok, Sender} = amqp10_client:attach_sender_link(Session, <<"test-sender">>, Address),
+    receive {amqp10_event, {link, Sender, attached}} -> ok
+    after 9000 -> ct:fail({missing_event, ?LINE})
+    end,
+    ok = wait_for_credit(Sender),
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"t1">>, <<"m1">>)),
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"t2">>, <<"m2">>)),
+    ok = wait_for_accepted(<<"t1">>),
+    ok = wait_for_accepted(<<"t2">>),
+
+    {ok, Receiver} = amqp10_client:attach_receiver_link(
+                       Session, <<"test-receiver">>, Address, unsettled),
+    receive {amqp10_event, {link, Receiver, attached}} -> ok
+    after 9000 -> ct:fail({missing_event, ?LINE})
+    end,
+
+    %% The following triggers the delivery effects from the LeaderNode to
+    %% NonMemberNode to get lost. After the network recovers, the LeaderNode
+    %% will send a leader_change notification to the NonMemberNode (even
+    %% though the leader did not really change) causing the NonMemberNode to re-send
+    %% the credit request to the LeaderNode. The credit request gets therefore
+    %% applied again (idempotently), but this time the LeaderNode will send
+    %% a credit_reply with the advanced delivery-count **leading** the delivery-count
+    %% of NonMemberNode (due to the lost deliveries).
+    ok = rpc(Config, LeaderNode, sys, suspend, [RaName]),
+    ok = amqp10_client:flow_link_credit(Receiver, 3, never),
+    true = rpc(Config, NonMemberNode, erlang, disconnect_node, [LeaderNode]),
+    ok = rpc(Config, LeaderNode, sys, resume, [RaName]),
+    timer:sleep(100),
+
+    ok = amqp10_client:send_msg(Sender, amqp10_msg:new(<<"t3">>, <<"m3">>)),
+    ok = wait_for_accepted(<<"t3">>),
+
+    [M1, M2, M3] = receive_messages(Receiver, 3),
+    ?assertEqual(<<"m1">>, amqp10_msg:body_bin(M1)),
+    ?assertEqual(<<"m2">>, amqp10_msg:body_bin(M2)),
+    ?assertEqual(<<"m3">>, amqp10_msg:body_bin(M3)),
+    ok = amqp10_client:accept_msg(Receiver, M1),
+    ok = amqp10_client:accept_msg(Receiver, M2),
+    ok = amqp10_client:accept_msg(Receiver, M3),
+
+    ok = detach_link_sync(Sender),
+    ok = detach_link_sync(Receiver),
+    {ok, #{message_count := 0}} = rabbitmq_amqp_client:delete_queue(LinkPair, QName),
+    ok = close(Init).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% internal


### PR DESCRIPTION
Prior to this commit, the following issue could happen: Delivery effects and credit_reply effect and applied notifications get lost from the QQ leader to the session on a non-member node got, e.g. due to network issues. However, the credit command got applied in the machine successfully nevertheless.

When the network recovers, rabbit_fifo_client receives a leader_change notification and re-sends the credit command. The QQ applies the 2nd credit command again (idempotently), but given that the QQ already assigned the messages to the consumer and there are no further messages in the ready queue, the QQ will reply only with a credit_reply effect. This credit_reply now has a delivery-count that **leads** the delivery-count of the session proc.

This commit takes the following fix:
The assertion that the delivery-count from the queue must be in sync with the delivery-count in the session is removed. Instead the session sets the delivery-count from the queue. This is inline with the AMQP spec which writes:
"The delivery-count is initialized by the sender when a link endpoint is created, and is incremented whenever a message is sent. Only the sender MAY independently modify this field. The receiver's value is calculated based on the last known value from the sender" [2.6.7]

The consequence of this fix is that it can happen that the session grants subsequently too many credits to the sending queue. The spec writes for a different use case the following:
"If the link-credit is reduced by the receiver when transfers are in-flight, the receiver MAY either handle the excess messages normally or detach the link with a transfer-limit-exceeded error code." So, the client should either handle the excess messages as well or detach the link. Both is less worse than the previous crash in rabbit_amqp_session.

In the newly added test case, if m3 is omitted from being sent, the client won't receive m1 and m2. That's because rabbit_fifo_client will only get missing deliveries (m1 and m2), if it receives a new out of order delivery (m3). So, rabbit_fifo_client will only get missing deliveries eventually. Maybe a better fix would be that the QQ includes in its leader_change notification also the last sent sequence number for the consumers. This way rabbit_fifo_client can check itself whether it missed any deliveries, and then pro-actively gets missing deliveries when handling the leader_change notification rather than waiting for the next out of order deliveries to arrive.

This commit also fixes another bug where the missing deliveries are fetched from the QQ out of order.
https://github.com/rabbitmq/rabbitmq-server/pull/14386 attempted to fix this, but unfortunately the implementation in that PR was wrong.

The following new test case reproduces the `delivery_count_mismatch` crash in rabbit_amqp_session (without the fixes in this commit applied):
```
make -C deps/rabbit ct-amqp_client t=cluster_size_3:lost_deliveries_quorum_queue FULL=1
```