### PR TITLE
QQ: Add enqueue rate tracking per node for quorum queues

### DIFF
--- a/deps/rabbit/Makefile
+++ b/deps/rabbit/Makefile
@@ -77,6 +77,7 @@ define PROJECT_ENV
 	    {credit_flow_default_credit, {400, 200}},
 	    {quorum_commands_soft_limit, 32},
 	    {quorum_cluster_size, 3},
+	    {quorum_queue_enqueue_rate_window, 900000},
 	    %% see rabbitmq-server#248
 	    %% and rabbitmq-server#667
 	    {channel_operation_timeout, 15000},

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -2753,6 +2753,11 @@ end}.
   {validators, ["non_zero_positive_integer"]}
 ]}.
 
+{mapping, "quorum_queue.enqueue_rate_window", "rabbit.quorum_queue_enqueue_rate_window", [
+  {datatype, integer},
+  {validators, ["non_zero_positive_integer"]}
+]}.
+
 {mapping, "quorum_queue.commands_soft_limit", "rabbit.quorum_commands_soft_limit", [
   {datatype, integer},
   {validators, ["non_zero_positive_integer"]}

--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -281,7 +281,9 @@ apply_(#{reply_mode := {notify, _Corr, EnqPid}} = Meta,
 apply_(Meta, #?ENQ_V2{seq = Seq, msg = RawMsg, size = Size}, State00) ->
     %% untracked
     apply_enqueue(Meta, undefined, Seq, RawMsg, Size, State00);
-apply_(_Meta, #register_enqueuer{pid = Pid},
+apply_(#{index := RaftIdx,
+         system_time := Ts},
+       #register_enqueuer{pid = Pid},
       #?STATE{enqueuers = Enqueuers0,
               cfg = #cfg{overflow_strategy = Overflow}} = State0) ->
     State = case maps:is_key(Pid, Enqueuers0) of
@@ -289,7 +291,9 @@ apply_(_Meta, #register_enqueuer{pid = Pid},
                     %% if the enqueuer exits just echo the overflow state
                     State0;
                 false ->
-                    State0#?STATE{enqueuers = Enqueuers0#{Pid => #enqueuer{}}}
+                    NewEnq = #enqueuer{created = {RaftIdx, Ts},
+                                       enqueued_bytes = 0},
+                    State0#?STATE{enqueuers = Enqueuers0#{Pid => NewEnq}}
             end,
     Res = case is_over_limit(State) of
               true when Overflow == reject_publish ->
@@ -993,7 +997,8 @@ v7_to_v8_consumer(Con, Timeout) ->
                                delivery_count = element(#consumer.delivery_count, Con)
                               }.
 
-convert_v7_to_v8(#{system_time := Ts} = _Meta, StateV7) ->
+convert_v7_to_v8(#{index := RaftIdx,
+                   system_time := Ts}, StateV7) ->
     %% the structure is intact for now
     Cons0 = element(#?STATE.consumers, StateV7),
     Waiting0 = element(#?STATE.waiting_consumers, StateV7),
@@ -1017,11 +1022,18 @@ convert_v7_to_v8(#{system_time := Ts} = _Meta, StateV7) ->
                     end, Pq0, No),
     Dlx0 = element(#?STATE.dlx, StateV7),
     Dlx = Dlx0#?DLX{unused = ?NIL},
+    Enqs0 = element(#?STATE.enqueuers, StateV7),
+    Enqs = maps:map(
+             fun (_Pid, E) ->
+                     E#enqueuer{created = {RaftIdx, Ts},
+                                enqueued_bytes = 0}
+             end, Enqs0),
     StateV8 = StateV7,
     StateV8#?STATE{cfg = Cfg#cfg{consumer_disconnected_timeout = 60_000,
                                  delayed_retry = disabled},
                    reclaimable_bytes = 0,
                    messages = Pq,
+                   enqueuers = Enqs,
                    consumers = Cons,
                    waiting_consumers = Waiting,
                    next_consumer_timeout = Timeout,
@@ -1214,6 +1226,13 @@ overview(#?STATE{consumers = Cons,
                 {?TUPLE(LastTs, _), _} = gb_trees:largest(Tree),
                 {gb_trees:size(Tree), NextTs, LastTs}
         end,
+    {EnqsByNode, EnqBytesByNode} =
+        maps:fold(fun (Pid, #enqueuer{enqueued_bytes = Bytes}, {CountAcc, BytesAcc}) ->
+                          Node = node(Pid),
+                          {CountAcc#{Node => maps:get(Node, CountAcc, 0) + 1},
+                           BytesAcc#{Node => maps:get(Node, BytesAcc, 0) + Bytes}}
+                  end, {#{}, #{}}, Enqs),
+
     Overview = #{type => ?STATE,
                  config => Conf,
                  num_consumers => map_size(Cons),
@@ -1231,7 +1250,9 @@ overview(#?STATE{consumers = Cons,
                  reclaimable_bytes_count => ReclaimableBytes,
                  smallest_raft_index => smallest_raft_index(State),
                  num_active_priorities => NumActivePriorities,
-                 messages_by_priority => Detail
+                 messages_by_priority => Detail,
+                 enqueuers_by_node => EnqsByNode,
+                 enqueue_bytes_by_node => EnqBytesByNode
                  },
     DlxOverview = dlx_overview(DlxState),
     maps:merge(maps:merge(Overview, DlxOverview), SacOverview).
@@ -1279,7 +1300,11 @@ which_module(8) -> ?MODULE.
                gc = #aux_gc{} :: #aux_gc{},
                tick_pid :: undefined | pid(),
                cache = #{} :: map(),
-               last_checkpoint :: tuple() | #snapshot{}
+               last_checkpoint :: tuple() | #snapshot{},
+               enq_node_rates = #{} :: #{node() =>
+                                         {non_neg_integer(), ra_li:state()}},
+               leader_ticks = 0 :: non_neg_integer(),
+               was_leader = false :: boolean()
               }).
 
 init_aux(Name) when is_atom(Name) ->
@@ -1372,7 +1397,8 @@ handle_aux(_RaftState, cast, eval,
     #?STATE{reclaimable_bytes = ReclaimableBytes} = ra_aux:machine_state(RaAux),
     {Check, Effects} = do_snapshot(EffMacVer, Ts, Check0, RaAux,
                                    ReclaimableBytes, false),
-    {no_reply, Aux0#?AUX{last_checkpoint = Check}, RaAux, Effects};
+    {no_reply, Aux0#?AUX{last_checkpoint = Check,
+                         was_leader = false}, RaAux, Effects};
 handle_aux(_RaftState, cast, {#return{msg_ids = MsgIds,
                                       consumer_key = Key} = Ret, Corr, Pid},
            Aux0, RaAux0) ->
@@ -1408,7 +1434,28 @@ handle_aux(_RaftState, cast, {#return{msg_ids = MsgIds,
             {no_reply, Aux0, RaAux0, [{append, Ret, {notify, Corr, Pid}}]}
     end;
 handle_aux(leader, _, {handle_tick, [QName, Overview0, Nodes]},
-           #?AUX{tick_pid = Pid} = Aux, RaAux) ->
+           #?AUX{tick_pid = Pid,
+                 was_leader = WasLeader,
+                 leader_ticks = Ticks0,
+                 enq_node_rates = EnqNodeRates0} = Aux, RaAux) ->
+    {EnqNodeRates1, Ticks} =
+        case WasLeader of
+            true ->
+                {EnqNodeRates0, Ticks0 + 1};
+            false ->
+                {#{}, 1}
+        end,
+    EnqBytesByNode = maps:get(enqueue_bytes_by_node, Overview0, #{}),
+    WindowSize = application:get_env(rabbit, quorum_queue_enqueue_rate_window, 900_000),
+    EnqNodeRates =
+        maps:fold(
+          fun (Node, Bytes, Acc) ->
+                  {Prev, Li0} = maps:get(Node, EnqNodeRates1,
+                                         {Bytes, ra_li:new(WindowSize)}),
+                  Delta = max(0, Bytes - Prev),
+                  Li = ra_li:update(Delta, Li0),
+                  Acc#{Node => {Bytes, Li}}
+          end, #{}, EnqBytesByNode),
     Overview = Overview0#{members_info => ra_aux:members_info(RaAux)},
     NewPid =
         case process_is_alive(Pid) of
@@ -1422,7 +1469,10 @@ handle_aux(leader, _, {handle_tick, [QName, Overview0, Nodes]},
         end,
 
     %% TODO: check consumer timeouts
-    {no_reply, Aux#?AUX{tick_pid = NewPid}, RaAux, []};
+    {no_reply, Aux#?AUX{tick_pid = NewPid,
+                        was_leader = true,
+                        leader_ticks = Ticks,
+                        enq_node_rates = EnqNodeRates}, RaAux, []};
 handle_aux(_, _, {get_checked_out, ConsumerKey, MsgIds}, Aux0, RaAux0) ->
     #?STATE{cfg = #cfg{},
             consumers = Consumers} = ra_aux:machine_state(RaAux0),
@@ -1492,6 +1542,16 @@ handle_aux(_RaState, {call, _From}, {peek, Pos}, Aux0,
         Err ->
             {reply, Err, Aux0, RaAux0}
     end;
+handle_aux(_RaState, {call, _From}, enqueue_node_rates,
+           #?AUX{leader_ticks = Ticks} = Aux, RaAux)
+  when Ticks < 2 ->
+    {reply, {error, not_ready}, Aux, RaAux};
+handle_aux(_RaState, {call, _From}, enqueue_node_rates,
+           #?AUX{enq_node_rates = EnqNodeRates} = Aux, RaAux) ->
+    Rates = maps:map(fun (_Node, {_LastBytes, Li}) ->
+                             ra_li:rate(Li)
+                     end, EnqNodeRates),
+    {reply, {ok, Rates}, Aux, RaAux};
 handle_aux(_, _, garbage_collection, Aux, RaAux) ->
     {no_reply, force_eval_gc(RaAux, Aux), RaAux};
 handle_aux(_RaState, _, force_checkpoint,
@@ -2090,7 +2150,8 @@ maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
     Size = MetaSize + BodySize,
     case maps:get(From, Enqueuers0, undefined) of
         undefined ->
-            State1 = State0#?STATE{enqueuers = Enqueuers0#{From => #enqueuer{}}},
+            NewEnq = #enqueuer{created = {RaftIdx, Ts}},
+            State1 = State0#?STATE{enqueuers = Enqueuers0#{From => NewEnq}},
             {Res, State, Effects} = maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo,
                                                   RawMsg, MsgSize, Effects0,
                                                   State1),
@@ -2103,7 +2164,8 @@ maybe_enqueue(RaftIdx, Ts, From, MsgSeqNo, RawMsg,
             Header0 = maybe_set_msg_ttl(RawMsg, Ts, Size, State0),
             Header = maybe_set_msg_delivery_count(RawMsg, Header0),
             Msg = make_msg(RaftIdx, Header),
-            Enq = Enq0#enqueuer{next_seqno = MsgSeqNo + 1},
+            Enq = Enq0#enqueuer{next_seqno = MsgSeqNo + 1,
+                                enqueued_bytes = Enq0#enqueuer.enqueued_bytes + Size},
             MsgCache = case can_immediately_deliver(State0) of
                            true ->
                                {RaftIdx, RawMsg};

--- a/deps/rabbit/src/rabbit_fifo.hrl
+++ b/deps/rabbit/src/rabbit_fifo.hrl
@@ -207,13 +207,13 @@
 
 -record(enqueuer,
         {next_seqno = 1 :: msg_seqno(),
-         unused = ?NIL,
+         created :: {ra:index(), milliseconds()},
          status = up :: up | suspected_down,
          %% it is useful to have a record of when this was blocked
          %% so that we can retry sending the block effect if
          %% the publisher did not receive the initial one
          blocked :: option(ra:index()),
-         unused_1 = ?NIL,
+         enqueued_bytes = 0 :: non_neg_integer(),
          unused_2 = ?NIL
         }).
 

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -1167,6 +1167,13 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
+  {quorum_queue_enqueue_rate_window,
+   "quorum_queue.enqueue_rate_window = 900000",
+   [{rabbit, [
+      {quorum_queue_enqueue_rate_window, 900000}
+     ]}],
+   []},
+
   {quorum_queue_commands_soft_limit,
    "quorum_queue.commands_soft_limit = 32",
    [{rabbit, [

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -3005,6 +3005,25 @@ register_enqueuer_test(Config) ->
     ?ASSERT_NO_EFF({send_msg, P, go, [ra_event]}, P == Pid2, Efx9),
     ok.
 
+enqueue_node_rates_test(Config) ->
+    State0 = init(#{name => ?FUNCTION_NAME,
+                    queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                    max_length => 2,
+                    max_in_memory_length => 0,
+                    overflow_strategy => reject_publish}),
+    Pid1 = test_util:fake_pid(node()),
+    {State1, ok, [_]} = apply(meta(Config, 1, 100, {notify, 1, Pid1}),
+                              make_register_enqueuer(Pid1), State0),
+    {State2, ok, _} = apply(meta(Config, 2, 101, {notify, 2, Pid1}),
+                            rabbit_fifo:make_enqueue(Pid1, 1, <<"one">>), State1),
+    {State3, ok, _} = apply(meta(Config, 3, 102, {notify, 3, Pid1}),
+                            rabbit_fifo:make_enqueue(Pid1, 2, <<"two">>), State2),
+    Overview = rabbit_fifo:overview(State3),
+    Node = node(),
+    ?assertMatch(#{enqueuers_by_node := #{Node := 1},
+                   enqueue_bytes_by_node := #{Node := Bytes}} when Bytes > 0, Overview),
+    ok.
+
 reject_publish_purge_test(Config) ->
     State0 = init(#{name => ?FUNCTION_NAME,
                     queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
@@ -4004,6 +4023,44 @@ aux_test(_) ->
     ok = meck:new(ra_log, []),
     meck:expect(ra_log, last_index_term, fun (_) -> {0, 0} end),
     {no_reply, _Aux, _, []} = handle_aux(leader, cast, tick, Aux, State0),
+    meck:unload(),
+    ok.
+
+aux_enqueue_node_rates_test(_) ->
+    _ = ra_machine_ets:start_link(),
+    Aux0 = init_aux(aux_test),
+    LastApplied = 0,
+    State0 = #{machine_state =>
+               init(#{name => ?FUNCTION_NAME,
+                      queue_resource => rabbit_misc:r("/", queue, ?FUNCTION_NAME_B),
+                      single_active_consumer_on => false}),
+               log => mock_log,
+               cfg => #cfg{},
+               last_applied => LastApplied},
+    ok = meck:new(ra_log, []),
+    meck:expect(ra_log, last_index_term, fun (_) -> {0, 0} end),
+    ok = meck:new(rabbit_quorum_queue, [passthrough]),
+    meck:expect(rabbit_quorum_queue, handle_tick, fun (_, _, _) -> test_util:fake_pid(node()) end),
+
+    %% Test not ready initially
+    {reply, {error, not_ready}, Aux0, State0} =
+        handle_aux(leader, {call, self()}, enqueue_node_rates, Aux0, State0),
+
+    Node = node(),
+    Overview0 = #{enqueue_bytes_by_node => #{Node => 1000}},
+    {no_reply, Aux1, State0, []} =
+        handle_aux(leader, cast, {handle_tick, [qname, Overview0, [Node]]}, Aux0, State0),
+
+    Overview1 = #{enqueue_bytes_by_node => #{Node => 2000}},
+    {no_reply, Aux2, State0, []} =
+        handle_aux(leader, cast, {handle_tick, [qname, Overview1, [Node]]}, Aux1, State0),
+
+    {reply, {ok, Rates}, Aux2, State0} =
+        handle_aux(leader, {call, self()}, enqueue_node_rates, Aux2, State0),
+
+    %% Rate should be calculated. ra_li:rate() returns something > 0 since we added 1000 bytes
+    ?assertMatch(#{Node := Rate} when Rate > 0, Rates),
+
     meck:unload(),
     ok.
 


### PR DESCRIPTION
This commit introduces tracking of enqueued bytes per node in `rabbit_fifo`
and exposes them via `rabbit_fifo:overview/1`. It also leverages the `ra_aux`
process to calculate enqueue rates per node using `ra_li`.
Key changes:
- Track `enqueuers_by_node` and `enqueue_bytes_by_node` in `rabbit_fifo:overview/1`.
- Calculate enqueue rates per node in the `ra_aux` process using `ra_li`.
- Make the rate calculation window configurable via `quorum_queue.enqueue_rate_window` (defaults to 900,000 ms).
- Add tests in `rabbit_fifo_SUITE` to verify the new overview metrics and the `enqueue_node_rates` aux call.
- Add schema mapping and test snippets for the new configuration key.