### PR TITLE
OAuth 2 management UI: adopt a better approach to skipping optional metadata/context keys than #15148

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/main.js
+++ b/deps/rabbitmq_management/priv/www/js/main.js
@@ -47,8 +47,8 @@ function render_login_oauth(oauth, messages) {
   formatData.resource_servers = oauth.resource_servers;
   formatData.declared_resource_servers_count = oauth.declared_resource_servers_count;
   formatData.oauth_disable_basic_auth = oauth.oauth_disable_basic_auth;
-  formatData.strict_auth_mechanism = oauth.strict_auth_mechanism;
-  formatData.preferred_auth_mechanism = oauth.preferred_auth_mechanism;
+  formatData.strict_auth_mechanism = oauth.strict_auth_mechanism || null;
+  formatData.preferred_auth_mechanism = oauth.preferred_auth_mechanism || null;
 
   if (Array.isArray(messages)) {
     formatData.warnings = messages

--- a/deps/rabbitmq_management/priv/www/js/tmpl/login_oauth.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/login_oauth.ejs
@@ -12,19 +12,19 @@
     <% } %>
   </div>
 <% if (!notAuthorized) { %>
-    <% if (strict_auth_mechanism !== undefined && strict_auth_mechanism.type === "oauth2") { %>
+    <% if (strict_auth_mechanism != null && strict_auth_mechanism.type === "oauth2") { %>
         <button id="login" onclick="oauth_initiateLogin('<%=strict_auth_mechanism.resource_id%>')">Click here to log in</button>
     <% } else if ((typeof resource_servers == 'object' && resource_servers.length == 1) && oauth_disable_basic_auth) { %>
         <button id="login" onclick="oauth_initiateLogin('<%=resource_servers[0].id%>')">Click here to log in</button>
-    <% } else if (typeof resource_servers == 'object' && resource_servers.length >= 1 && strict_auth_mechanism == undefined) { %>
+    <% } else if (typeof resource_servers == 'object' && resource_servers.length >= 1 && strict_auth_mechanism == null) { %>
 
     <b>Login with :</b>
     <p/>
-    <% const OAuth2Visible = (strict_auth_mechanism === undefined || strict_auth_mechanism.type === "oauth2") || 
-      (preferred_auth_mechanism === undefined || preferred_auth_mechanism === "oauth2"); %>  
-    <% const OAuth2Invisible = (preferred_auth_mechanism !== undefined && preferred_auth_mechanism.type !== "oauth2"); %>  
-    <% const OAuth2Hidden = (strict_auth_mechanism !== undefined && strict_auth_mechanism.type !== "oauth2"); %>  
-    <% const preferredResourceId = preferred_auth_mechanism !== undefined && preferred_auth_mechanism.type === "oauth2" ? preferred_auth_mechanism.resource_id : null; %>
+    <% const OAuth2Visible = (strict_auth_mechanism == null || strict_auth_mechanism.type === "oauth2") ||
+      (preferred_auth_mechanism == null || preferred_auth_mechanism === "oauth2"); %>
+    <% const OAuth2Invisible = (preferred_auth_mechanism != null && preferred_auth_mechanism.type !== "oauth2"); %>
+    <% const OAuth2Hidden = (strict_auth_mechanism != null && strict_auth_mechanism.type !== "oauth2"); %>
+    <% const preferredResourceId = preferred_auth_mechanism != null && preferred_auth_mechanism.type === "oauth2" ? preferred_auth_mechanism.resource_id : null; %>
     <!-- begin login with oauth2  -->
     <% if (!OAuth2Hidden) { %>
     <div class="section disable-pref <%= OAuth2Visible ? 'section-visible' : '' %>  <%= OAuth2Invisible ? 'section-invisible' : '' %> " id="login-with-oauth2">
@@ -55,10 +55,10 @@
 <% } %>
 
   <!-- begin login with basic auth   -->  
-  <% const basicAuthVisible = (strict_auth_mechanism !== undefined && strict_auth_mechanism.type === "basic") || 
-    (preferred_auth_mechanism !== undefined && preferred_auth_mechanism.type === "basic"); %> 
-  <% const basicAuthInvisible = (strict_auth_mechanism === undefined && preferred_auth_mechanism === undefined || (preferred_auth_mechanism !== undefined && preferred_auth_mechanism.type !== "basic"));%> 
-  <% const basicAuthHidden = (strict_auth_mechanism !== undefined && strict_auth_mechanism.type !== "basic"); %>
+  <% const basicAuthVisible = (strict_auth_mechanism != null && strict_auth_mechanism.type === "basic") ||
+    (preferred_auth_mechanism != null && preferred_auth_mechanism.type === "basic"); %>
+  <% const basicAuthInvisible = (strict_auth_mechanism == null && preferred_auth_mechanism == null || (preferred_auth_mechanism != null && preferred_auth_mechanism.type !== "basic"));%>
+  <% const basicAuthHidden = (strict_auth_mechanism != null && strict_auth_mechanism.type !== "basic"); %>
   <% if (!oauth_disable_basic_auth && !basicAuthHidden) { %>
   <div class="section disable-pref <%= basicAuthInvisible ? 'section-invisible' : ''%>  <%= basicAuthVisible ? 'section-visible' : ''%> " id="login-with-basic-auth">
     <h2>Basic Authentication</h2>


### PR DESCRIPTION
Avoid comparisons to `undefined` by explicitly initializing the values to `null`.

Closes #15858.