### PR TITLE
By @the-mikedavis: Introduce `rabbit_exchange_type:recover/2`

### DIFF
--- a/deps/rabbit/src/rabbit_db_exchange.erl
+++ b/deps/rabbit/src/rabbit_db_exchange.erl
@@ -496,7 +496,7 @@ delete_serial(XName) ->
       VHostName :: vhost:name().
 %% @doc Recovers all exchanges for a given vhost
 %%
-%% @returns ok
+%% @returns a list of exchange records
 %%
 %% @private
 
@@ -515,11 +515,6 @@ recover(VHost) ->
       fun() ->
               [_ = set_in_khepri_tx(X) || X <- Exchanges]
       end, rw, #{timeout => infinity}),
-    %% TODO: Move this callback back to `rabbit_exchange'.
-    [begin
-         Serial = rabbit_exchange:serial(X),
-         rabbit_exchange:callback(X, create, Serial, [X])
-     end || X <- Exchanges],
     Exchanges.
 
 %% -------------------------------------------------------------------

--- a/deps/rabbit/src/rabbit_exchange.erl
+++ b/deps/rabbit/src/rabbit_exchange.erl
@@ -42,6 +42,24 @@
 
 recover(VHost) ->
     Xs = rabbit_db_exchange:recover(VHost),
+    [begin
+         Serial = rabbit_exchange:serial(X),
+         rabbit_exchange:callback(X, create, Serial, [X])
+     end || X <- Xs],
+    maps:foreach(
+      fun(Type, XsForType) ->
+              Mod = type_to_module(Type),
+              case erlang:function_exported(Mod, recover, 2) of
+                  true ->
+                      {Time, ok} = timer:tc(Mod, recover, [VHost, XsForType],
+                                            millisecond),
+                      ?LOG_INFO("Recovering ~b exchanges of type '~ts' took "
+                                "~bms", [length(XsForType), Type, Time]),
+                      ok;
+                  false ->
+                      ok
+              end
+      end, maps:groups_from_list(fun(#exchange{type = T}) -> T end, Xs)),
     [XName || #exchange{name = XName} <- Xs].
 
 -spec callback

--- a/deps/rabbit/src/rabbit_exchange_type.erl
+++ b/deps/rabbit/src/rabbit_exchange_type.erl
@@ -69,6 +69,11 @@
 
 -callback info(rabbit_types:exchange(), [atom()]) -> [{atom(), term()}].
 
+%% Optional. Called during node boot.
+-callback recover(rabbit_types:vhost(), [rabbit_types:exchange()]) -> 'ok'.
+
+-optional_callbacks([recover/2]).
+
 added_to_rabbit_registry(Type, _ModuleName) ->
     persistent_term:erase(Type),
     ok.

--- a/deps/rabbit/src/rabbit_vhost.erl
+++ b/deps/rabbit/src/rabbit_vhost.erl
@@ -84,6 +84,8 @@ recover(VHost) ->
             end
     end,
 
+    _ = rabbit_exchange:recover(VHost),
+
     {Recovered, _Failed} = rabbit_amqqueue:recover(VHost),
 
     ok = rabbit_amqqueue:start(Recovered),

--- a/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
+++ b/deps/rabbitmq_consistent_hash_exchange/src/rabbit_exchange_type_consistent_hash.erl
@@ -16,8 +16,8 @@
 -export([description/0, serialise_events/0, route/3]).
 -export([validate/1, validate_binding/2,
          create/2, delete/2, policy_changed/2,
-         add_binding/3, remove_bindings/3, assert_args_equivalence/2]).
--export([init/0]).
+         add_binding/3, remove_bindings/3, assert_args_equivalence/2,
+         recover/2]).
 -export([info/1, info/2]).
 -export([ring_state/2]).
 
@@ -31,13 +31,6 @@
      {cleanup,     {rabbit_registry, unregister,
                     [exchange, <<"x-consistent-hash">>]}}]}).
 
--rabbit_boot_step(
-   {rabbit_exchange_type_consistent_hash_metadata_store,
-    [{description, "exchange type x-consistent-hash: shared state"},
-     {mfa,         {?MODULE, init, []}},
-     {requires,    database},
-     {enables,     external_infrastructure}]}).
-
 %% This data model allows for efficient routing and exchange deletion
 %% but less efficient (linear) binding management.
 
@@ -45,10 +38,6 @@
 
 %% OTP 19.3 does not support exs1024s
 -define(SEED_ALGORITHM, exs1024).
-
-init() ->
-    _ = recover(),
-    ok.
 
 info(_X) -> [].
 info(_X, _) -> [].
@@ -116,18 +105,10 @@ maybe_initialise_hash_ring_state(#exchange{name = Name}) ->
 maybe_initialise_hash_ring_state(X = #resource{}) ->
     rabbit_db_ch_exchange:create(X).
 
-recover() ->
-    %% topology recovery has already happened, we have to recover state for any durable
-    %% consistent hash exchanges since plugin activation was moved later in boot process
-    %% starting with RabbitMQ 3.8.4
-    Xs = list_exchanges(),
-    ?LOG_DEBUG("Consistent hashing exchange: have ~b durable exchanges to recover", [length(Xs)]),
+recover(_VHost, Xs) ->
     %% TODO: reset storage if this is the first node in the cluster
-    [recover_exchange_and_bindings(X) || X <- lists:usort(Xs)].
-
-list_exchanges() ->
-    Pattern = #exchange{durable = true, type = 'x-consistent-hash', _ = '_'},
-    rabbit_db_exchange:match(Pattern).
+    _ = [recover_exchange_and_bindings(X) || X <- lists:usort(Xs)],
+    ok.
 
 recover_exchange_and_bindings(#exchange{name = XName} = X) ->
     ?LOG_DEBUG("Consistent hashing exchange: will recover exchange ~ts", [rabbit_misc:rs(XName)]),


### PR DESCRIPTION
This reimplements #15819 by @the-mikedavis on
top of `main` where a few things have changed:

1. The x-modulus-hash exchange was moved to the core
2. Eventual matchers such as `await_condition/2`, `eventually/3`, `?awaitMatch/2` are used as much as possible over `timer:sleep/1`

In addition, this fixes a non-obvious bug in the
original PR: in c1c49eea80 (the Mnesia removal commit), `rabbit_exchange:recover/1` was removed from `rabbit_vhost:recover/1`, directly affecting the consistent hashing exchange in combination with #15819 (it works fine in `main` due to its own `init/0` function).
