### PR TITLE
Exclude another test that flakes specifically in mixed version clusters

### DIFF
--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -279,7 +279,8 @@ init_per_testcase(TestCase, Config)
   when TestCase == replica_recovery
        orelse TestCase == leader_failover
        orelse TestCase == leader_failover_dedupe
-       orelse TestCase == recover_after_leader_and_coordinator_kill ->
+       orelse TestCase == recover_after_leader_and_coordinator_kill
+       orelse TestCase == max_age_policy ->
     case rabbit_ct_helpers:is_mixed_versions() of
         true ->
             %% not supported because of machine version difference


### PR DESCRIPTION
We already exclude several comparable tests in `rabbit_stream_queue_SUITE` for similar reasons: with up to multi-minor Osiris version gaps between versions, very subtle differences in behavior result in node log exceptions (crashes) logged, which are treated as test failures.

Originally spotted and investigated as part of https://github.com/rabbitmq/rabbitmq-server/pull/15903.