### PR TITLE
Test flake chase: make sure proxies have `kernel.prevent_overlapping_partitions` set to `false`

### DIFF
--- a/deps/rabbit/test/clustering_recovery_SUITE.erl
+++ b/deps/rabbit/test/clustering_recovery_SUITE.erl
@@ -446,11 +446,17 @@ start_proxies(Config) ->
     %% goal is to make sure the common_test control node doesn't interfere
     %% with the nodes the RabbitMQ nodes can see, despite the blocking of the
     %% Erlang distribution connection.
+    %%
+    %% Prevent `global' from disconnecting proxy nodes during
+    %% deliberately created partitions.
     Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
     Proxies0 = [begin
                     {ok, Proxy, PeerNode} = peer:start_link(
                                               #{name => peer:random_name(),
                                                 connection => standard_io,
+                                                args => ["-kernel",
+                                                         "prevent_overlapping_partitions",
+                                                         "false"],
                                                 wait_boot => 120000}),
                     ct:pal("Proxy ~0p -> ~0p", [Proxy, PeerNode]),
                     Proxy


### PR DESCRIPTION
Otherwise the proxy can be disconnected from the RabbitMQ nodes under test at exactly the wrong moment in the test.

This is a manual backport of #15925 #15923 because `v4.2.x` already uses the `peer` module (I initially thought that was not the case).

(cherry picked from commit 1926ff6a8f6dc4b69dd5d5aafa2647be06d09669)
(cherry picked from commit bc02ee9bc486e9ca89bdc21dc336517e8157df4c)
