### PR TITLE
Test flake chase: fix a map key order dependency in the CLI's Thoas wrapper tests

### DIFF
--- a/deps/rabbitmq_cli/test/core/json_stream_test.exs
+++ b/deps/rabbitmq_cli/test/core/json_stream_test.exs
@@ -18,7 +18,9 @@ defmodule JsonStreamTest do
 
   test "format_output map with binary keys is converted to JSON object" do
     assert @formatter.format_output(%{"a" => :apple, "b" => :beer}, %{}) ==
-             "{\"a\":\"apple\",\"b\":\"beer\"}"
+             "{\"a\":\"apple\",\"b\":\"beer\"}" or
+             @formatter.format_output(%{"a" => :apple, "b" => :beer}, %{}) ==
+               "{\"b\":\"beer\",\"a\":\"apple\"}"
   end
 
   test "format_output empty binary is converted to empty JSON array" do


### PR DESCRIPTION
A flake introduced in https://github.com/rabbitmq/rabbitmq-server/pull/15964.