### PR TITLE
Fix an EJS artifact that causes some UI field to be hidden when connection state isn't available

### DIFF
--- a/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
+++ b/deps/rabbitmq_management/priv/www/js/tmpl/connection.ejs
@@ -59,12 +59,13 @@
 <% } %>
 </table>
 
-<% if (connection.state) { %>
 <table class="facts">
+<% if (connection.state) { %>
 <tr>
  <th>State</th>
  <td><%= fmt_object_state(connection) %></td>
 </tr>
+<% } %>
 <tr>
  <th>Heartbeat</th>
  <td><%= fmt_time(connection.timeout, 's') %></td>
@@ -78,8 +79,6 @@
  <td><%= connection.channel_max %> channels</td>
 </tr>
 </table>
-
-<% } %>
 
 </div>
 </div>


### PR DESCRIPTION
A drive-by bug found while reviewing and testing https://github.com/rabbitmq/rabbitmq-server/pull/15975.