### PR TITLE
Test flake chase specific to `v4.2.x`: fix two more test flakes

### DIFF
--- a/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
+++ b/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
@@ -283,9 +283,12 @@ recover_bindings(Config) ->
 
     assert_index_table_empty(Config),
     rabbit_ct_broker_helpers:rabbitmqctl(Config, Server, ["import_definitions", Path], 10_000),
-    ?assertEqual(?NUM_BINDINGS_TO_DIRECT_ECHANGE, table_size(Config, ?INDEX_TABLE_NAME)),
+    %% The index table is populated asynchronously.
+    ?awaitMatch(?NUM_BINDINGS_TO_DIRECT_ECHANGE,
+                table_size(Config, ?INDEX_TABLE_NAME), 30_000),
     ok = rabbit_ct_broker_helpers:restart_node(Config, 0),
-    ?assertEqual(?NUM_BINDINGS_TO_DIRECT_ECHANGE_DURABLE, table_size(Config, ?INDEX_TABLE_NAME)),
+    ?awaitMatch(?NUM_BINDINGS_TO_DIRECT_ECHANGE_DURABLE,
+                table_size(Config, ?INDEX_TABLE_NAME), 30_000),
 
     %% cleanup
     {_Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),

--- a/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
@@ -431,7 +431,9 @@ autodelete_quorum_on_confirm_with_rejections(Config) ->
     autodelete_with_quorum_rejections(Config, <<"on-confirm">>, ExpSrc).
 
 autodelete_classic_on_publish_with_rejections(Config) ->
-    autodelete_with_rejections(Config, <<"classic">>, <<"on-publish">>, 1, 5).
+    %% A full dest queue can cause a credit timeout, releasing
+    %% unconsumed messages back to the source queue.
+    autodelete_with_rejections(Config, <<"classic">>, <<"on-publish">>, 6, 5).
 
 autodelete_quorum_on_publish_with_rejections(Config) ->
     ExpSrc = fun(_) -> 0 end,


### PR DESCRIPTION
1. Core `direct_exchange_routing_v2_SUITE`: use an eventual matcher with async index table population
2. Shovel: tolerate credit timeout in autodelete rejection test
