### PR TITLE
Test flake chase: fix a few more test flakes

### DIFF
--- a/deps/amqp10_client/test/system_SUITE.erl
+++ b/deps/amqp10_client/test/system_SUITE.erl
@@ -526,17 +526,24 @@ early_transfer(Config) ->
                                                     Address),
 
     Msg = amqp10_msg:new(<<"my-tag">>, <<"banana">>, true),
-    % TODO: this is a timing issue - should use mock here really
-    {error, half_attached} = amqp10_client:send_msg(Sender, Msg),
-    % wait for credit
+    %% The link may or may not be fully attached by now depending on timing.
+    case amqp10_client:send_msg(Sender, Msg) of
+        {error, half_attached} -> ok;
+        ok -> ok
+    end,
     await_link(Sender, credited, credited_timeout),
     ok = amqp10_client:detach_link(Sender),
-    % attach then immediately detach
+    %% Attach then immediately detach. If the link attaches fast enough,
+    %% detach succeeds; otherwise we get {error, half_attached}.
     LinkName = <<"early-transfer2">>,
     {ok, Sender2} = amqp10_client:attach_sender_link(Session, LinkName,
                                                     Address),
-    {error, half_attached} = amqp10_client:detach_link(Sender2),
-    await_link(Sender2, credited, credited_timeout),
+    case amqp10_client:detach_link(Sender2) of
+        {error, half_attached} ->
+            await_link(Sender2, credited, credited_timeout);
+        ok ->
+            ok
+    end,
     ok = amqp10_client:end_session(Session),
     ok = amqp10_client:close_connection(Connection),
     ok.

--- a/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
+++ b/deps/rabbit/test/direct_exchange_routing_v2_SUITE.erl
@@ -263,9 +263,9 @@ recover_bindings(Config) ->
 
     assert_bindings_list_empty(Config),
     rabbit_ct_broker_helpers:rabbitmqctl(Config, Server, ["import_definitions", Path], 10_000),
-    ?assertEqual(?NUM_BINDINGS_TO_DIRECT_ECHANGE, count_bindings(Config)),
+    ?awaitMatch(?NUM_BINDINGS_TO_DIRECT_ECHANGE, count_bindings(Config), 30_000),
     ok = rabbit_ct_broker_helpers:restart_node(Config, 0),
-    ?assertEqual(?NUM_BINDINGS_TO_DIRECT_ECHANGE_DURABLE, count_bindings(Config)),
+    ?awaitMatch(?NUM_BINDINGS_TO_DIRECT_ECHANGE_DURABLE, count_bindings(Config), 30_000),
 
     %% cleanup
     {_Conn, Ch} = rabbit_ct_client_helpers:open_connection_and_channel(Config, 0),

--- a/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/shovel_dynamic_SUITE.erl
@@ -459,7 +459,9 @@ autodelete_quorum_on_confirm_with_rejections(Config) ->
     autodelete_with_quorum_rejections(Config, <<"on-confirm">>, ExpSrc).
 
 autodelete_classic_on_publish_with_rejections(Config) ->
-    autodelete_with_rejections(Config, <<"classic">>, <<"on-publish">>, 1, 5).
+    %% A full dest queue can cause a credit timeout, releasing
+    %% unconsumed messages back to the source queue.
+    autodelete_with_rejections(Config, <<"classic">>, <<"on-publish">>, 6, 5).
 
 autodelete_quorum_on_publish_with_rejections(Config) ->
     ExpSrc = fun(_) -> 0 end,


### PR DESCRIPTION
1. Shovel: tolerate credit timeout in autodelete rejection test
2. AMQP 1.0 client: fix timing-dependent `early_transfer` assertions
3. Core `direct_exchange_routing_v2_SUITE`: use eventual matchers after restart
