### PR TITLE
Roll #15975 back to its original version

### DIFF
--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_connection.erl
@@ -40,16 +40,7 @@ to_json(ReqData, Context) ->
             false ->
                 conn_stats(ReqData);
             true ->
-                case rabbit_mgmt_db:get_connection(
-                       rabbit_mgmt_util:id(connection, ReqData)) of
-                    not_found ->
-                        %% IMPORTANT: connection_created_stats is empty when
-                        %% the metrics collector is disabled. Fall back to
-                        %% the tracked-connection record.
-                        conn(ReqData);
-                    Stats ->
-                        Stats
-                end
+                rabbit_mgmt_db:get_connection(rabbit_mgmt_util:id(connection, ReqData))
         end,
     ConnStatsWithoutPids = rabbit_mgmt_format:strip_pids(ConnStats),
     ReplyData = maps:from_list(ConnStatsWithoutPids),

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_connections.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_connections.erl
@@ -48,15 +48,6 @@ do_connections_query(ReqData, Context) ->
         false ->
             augmented(ReqData, Context);
         true ->
-            case rabbit_mgmt_agent_config:is_metrics_collector_enabled() of
-                true ->
-                    rabbit_mgmt_util:filter_conn_ch_list(
-                      rabbit_mgmt_db:get_all_connections(), ReqData, Context);
-                false ->
-                    %% IMPORTANT: connection_created_stats is empty when the
-                    %% metrics collector is disabled. Fall back to the
-                    %% tracked-connection list.
-                    rabbit_mgmt_util:filter_tracked_conn_list(
-                      rabbit_connection_tracking:list(), ReqData, Context)
-            end
+            rabbit_mgmt_util:filter_conn_ch_list(
+              rabbit_mgmt_db:get_all_connections(), ReqData, Context)
     end.


### PR DESCRIPTION
This follow-up to #15975 removes a fallback because the idea is to only serve a static set of properties (e.g. the client-provided connection name).
