### PR TITLE
rabbit_khepri: Make Khepri snapshot interval configurable

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -467,6 +467,10 @@ end}.
 {mapping, "metadata_store.khepri.default_timeout", "rabbit.khepri_default_timeout",
     [{datatype, integer}]}.
 
+{mapping, "metadata_store.khepri.snapshot_interval", "rabbit.khepri_snapshot_interval",
+    [{datatype, integer},
+     {validators, ["non_zero_positive_integer"]}]}.
+
 %% ===========================================================================
 
 %% Choose the available SASL mechanism(s) to expose.

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -282,15 +282,18 @@ setup(_Context) ->
     ?LOG_DEBUG("Starting Khepri-based " ?RA_FRIENDLY_NAME),
     ok = ensure_ra_system_started(),
     Timeout = application:get_env(rabbit, khepri_default_timeout, 30000),
+    SnapshotInterval = application:get_env(rabbit, khepri_snapshot_interval, 50000),
     ok = application:set_env(
            [{khepri, [{default_timeout, Timeout},
                       {default_store_id, ?STORE_ID},
                       {default_ra_system, ?RA_SYSTEM}]}],
            [{persistent, true}]),
+    MachineConfig = #{snapshot_interval => SnapshotInterval},
     RaServerConfig = #{cluster_name => ?RA_CLUSTER_NAME,
                        metrics_labels => #{ra_system => ?RA_SYSTEM,
                                            module => ?MODULE},
-                       friendly_name => ?RA_FRIENDLY_NAME},
+                       friendly_name => ?RA_FRIENDLY_NAME,
+                       machine_config => MachineConfig},
     case khepri:start(?RA_SYSTEM, RaServerConfig) of
         {ok, ?STORE_ID} ->
             RetryTimeout = retry_timeout(),

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -293,6 +293,7 @@ setup(_Context) ->
                        metrics_labels => #{ra_system => ?RA_SYSTEM,
                                            module => ?MODULE},
                        friendly_name => ?RA_FRIENDLY_NAME,
+                       min_recovery_checkpoint_interval => 4096,
                        machine_config => MachineConfig},
     case khepri:start(?RA_SYSTEM, RaServerConfig) of
         {ok, ?STORE_ID} ->

--- a/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
+++ b/deps/rabbit/test/config_schema_SUITE_data/rabbit.snippets
@@ -986,6 +986,20 @@ credential_validator.regexp = ^abc\\d+",
      ]}],
    []},
 
+  {khepri_default_timeout,
+   "metadata_store.khepri.default_timeout = 123456",
+   [{rabbit,
+     [{khepri_default_timeout, 123456}]
+    }],
+   []},
+
+  {khepri_snapshot_interval,
+   "metadata_store.khepri.snapshot_interval = 123456",
+   [{rabbit,
+     [{khepri_snapshot_interval, 123456}]
+    }],
+   []},
+
   %%
   %% Definitions
   %%

--- a/deps/rabbit/test/per_vhost_queue_limit_SUITE.erl
+++ b/deps/rabbit/test/per_vhost_queue_limit_SUITE.erl
@@ -49,12 +49,12 @@ cluster_size_1_tests() ->
 cluster_size_2_tests() ->
     [
      most_basic_cluster_queue_count,
+     cluster_node_restart_queue_count, %% Must before `cluster_multiple_vhosts_zero_limit_with_durable_named_queue`.
      cluster_multiple_vhosts_queue_count,
      cluster_multiple_vhosts_limit,
      cluster_multiple_vhosts_zero_limit,
      cluster_multiple_vhosts_limit_with_durable_named_queue,
-     cluster_multiple_vhosts_zero_limit_with_durable_named_queue,
-     cluster_node_restart_queue_count
+     cluster_multiple_vhosts_zero_limit_with_durable_named_queue
     ].
 
 suite() ->
@@ -406,6 +406,7 @@ cluster_node_restart_queue_count(Config) ->
     ?awaitMatch(10, count_queues_in(Config, VHost, 0), ?AWAIT_TIMEOUT),
     ?awaitMatch(10, count_queues_in(Config, VHost, 1), ?AWAIT_TIMEOUT),
 
+    ct:pal("Restart RabbitMQ node 0"),
     rabbit_ct_broker_helpers:restart_broker(Config, 0),
     ?awaitMatch(0, count_queues_in(Config, VHost, 0), ?AWAIT_TIMEOUT),
 
@@ -419,6 +420,7 @@ cluster_node_restart_queue_count(Config) ->
     ?awaitMatch(25, count_queues_in(Config, VHost, 0), ?AWAIT_TIMEOUT),
     ?awaitMatch(25, count_queues_in(Config, VHost, 1), ?AWAIT_TIMEOUT),
 
+    ct:pal("Restart RabbitMQ node 1"),
     rabbit_ct_broker_helpers:restart_broker(Config, 1),
 
     ?awaitMatch(10, count_queues_in(Config, VHost, 0), ?AWAIT_TIMEOUT),


### PR DESCRIPTION
## Why

The default interval of 4096 is not great for RabbitMQ. This parameter is being replaced in Khepri, but in the meantime, let's make it configurable by the user.

## How

We introduce a new `rabbitmq.conf` parameter and change the default.

Here is an example of `rabbitmq.conf`:

```ini
metadata_store.khepri.snapshot_interval = 50000
```

If the value is unset, the default in RabbitMQ is now 50000.

Note that changing the snapshot interval (or even the new default) is only applicable to new deployments. An existing node will continue to use the snapshot interval set at its creation time, thus 4096.

This should hopefully improves the performance during load spike in Khepri in the context of RabbitMQ.

**V2**: While here, we also set the `min_recovery_checkpoint_interval` Ra parameter to 4096. This tells Ra to take a checkpoint on shutdown if there are more than this number of commands unapplied. With the new default snapshot interval, this will happen. This should make the restart/recovery process more efficient.