### PR TITLE
HTTP API: Return a map instead of an empty array/string for `effective_policy_definition` when no policy applies

### DIFF
--- a/deps/rabbit/src/rabbit_amqqueue_process.erl
+++ b/deps/rabbit/src/rabbit_amqqueue_process.erl
@@ -1167,7 +1167,7 @@ i(operator_policy,    #q{q = Q}) ->
     end;
 i(effective_policy_definition,  #q{q = Q}) ->
     case rabbit_policy:effective_definition(Q) of
-        undefined -> [];
+        undefined -> #{};
         Def       -> Def
     end;
 i(exclusive_consumer_pid, #q{active_consumer = {ChPid, _ConsumerTag}, single_active_consumer_on = false}) ->

--- a/deps/rabbit/src/rabbit_classic_queue.erl
+++ b/deps/rabbit/src/rabbit_classic_queue.erl
@@ -564,7 +564,7 @@ i(operator_policy, Q) ->
     end;
 i(effective_policy_definition, Q) ->
     case rabbit_policy:effective_definition(Q) of
-        undefined -> [];
+        undefined -> #{};
         Def       -> Def
     end;
 i(type, _) ->

--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -2020,7 +2020,7 @@ i(operator_policy, Q) ->
     end;
 i(effective_policy_definition, Q) ->
     case rabbit_policy:effective_definition(Q) of
-        undefined -> [];
+        undefined -> #{};
         Def       -> Def
     end;
 i(consumers, Q) when ?is_amqqueue(Q) ->

--- a/deps/rabbit/src/rabbit_stream_queue.erl
+++ b/deps/rabbit/src/rabbit_stream_queue.erl
@@ -849,7 +849,7 @@ i(operator_policy, Q) ->
     end;
 i(effective_policy_definition, Q) ->
     case rabbit_policy:effective_definition(Q) of
-        undefined -> [];
+        undefined -> #{};
         Def       -> Def
     end;
 i(readers, Q) ->

--- a/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
+++ b/deps/rabbit/test/rabbit_stream_queue_SUITE.erl
@@ -2429,7 +2429,7 @@ invalid_policy(Config) ->
 
     ?assertEqual('', proplists:get_value(policy, Info)),
     ?assertEqual('', proplists:get_value(operator_policy, Info)),
-    ?assertEqual([], proplists:get_value(effective_policy_definition, Info)),
+    ?assertEqual(#{}, proplists:get_value(effective_policy_definition, Info)),
     ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"ttl">>),
     rabbit_ct_broker_helpers:rpc(Config, 0, ?MODULE, delete_testcase_queue, [Q]).
 

--- a/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
@@ -51,7 +51,8 @@ groups() ->
          classic_queue_with_stats_disabled_test,
          quorum_queue_with_stats_disabled_test,
          quorum_queue_default_delivery_limit_with_stats_disabled_test,
-         stream_queue_with_stats_disabled_test
+         stream_queue_with_stats_disabled_test,
+         no_policy_effective_definition_type_test
      ]},
      {invalid_config, [], [invalid_config_test]}
     ].
@@ -1611,6 +1612,36 @@ stream_queue_with_stats_disabled_test(Config) ->
     http_delete(Config, "/queues/%2F/test-stream-queue", {group, '2xx'}),
     http_delete(Config, "/policies/%2F/test-policy", {group, '2xx'}),
     http_delete(Config, "/operator-policies/%2F/test-op-policy", {group, '2xx'}),
+
+    passed.
+
+%% Verifies that effective_policy_definition is a JSON object (not a JSON array)
+%% when no policy applies to a queue and management stats collection is disabled.
+%% See rabbitmq/hop#640.
+no_policy_effective_definition_type_test(Config) ->
+    ClassicArgs = #{durable => true},
+    QuorumArgs = #{durable => true,
+                   arguments => #{'x-queue-type' => 'quorum'}},
+    StreamArgs = #{durable => true,
+                   arguments => #{'x-queue-type' => 'stream'}},
+
+    http_put(Config, "/queues/%2F/test-classic-no-policy", ClassicArgs, {group, '2xx'}),
+    http_put(Config, "/queues/%2F/test-quorum-no-policy", QuorumArgs, {group, '2xx'}),
+    http_put(Config, "/queues/%2F/test-stream-no-policy", StreamArgs, {group, '2xx'}),
+
+    Endpoints = ["/queues/%2F/test-classic-no-policy",
+                 "/queues/%2F/test-quorum-no-policy",
+                 "/queues/%2F/test-stream-no-policy"],
+    lists:foreach(
+      fun(Endpoint) ->
+              Queue = http_get(Config, Endpoint, ?OK),
+              ?assert(maps:is_key(effective_policy_definition, Queue)),
+              ?assertEqual(#{}, maps:get(effective_policy_definition, Queue))
+      end, Endpoints),
+
+    http_delete(Config, "/queues/%2F/test-classic-no-policy", {group, '2xx'}),
+    http_delete(Config, "/queues/%2F/test-quorum-no-policy", {group, '2xx'}),
+    http_delete(Config, "/queues/%2F/test-stream-no-policy", {group, '2xx'}),
 
     passed.
 


### PR DESCRIPTION
## Proposed Changes

This is the ages old issue that pops up here in there in the HTTP API:
an empty proplist in Erlang is rendered as an empty JSON string, so
an empty definition must be returned as an empty map instead.

The original commit, 646363c928, has missed these few cases.


## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

References #15182 #15146.
References rabbitmq/hop#640.