### PR TITLE
Allow delivery limit to be changed via policy for quorum queues

### DIFF
--- a/deps/rabbit/src/rabbit_quorum_queue.erl
+++ b/deps/rabbit/src/rabbit_quorum_queue.erl
@@ -884,15 +884,20 @@ system_recover(quorum_queues) ->
     end.
 
 maybe_apply_policies(Q, #{config := CurrentConfig}) ->
-    %% delivery_limit can't be updated from a policy and thus has to be
-    %% excluded from the comparison
-    NewPolicyConfig = maps:without([delivery_limit],
-                                   gather_policy_config(Q, false)),
+    NewPolicyConfig = gather_policy_config(Q, false),
 
     RelevantKeys = maps:keys(NewPolicyConfig),
     CurrentPolicyConfig = maps:with(RelevantKeys, CurrentConfig),
 
-    ShouldUpdate = NewPolicyConfig =/= CurrentPolicyConfig,
+    %% Canonicalize delivery_limit for comparison: map any negative value to undefined.
+    %% rabbit_fifo normalizes negative delivery limits to undefined internally, but
+    %% policies can return any integer value. To prevent spurious updates (e.g. -2 vs -1
+    %% vs undefined all meaning unlimited), canonicalize to undefined which is how
+    %% rabbit_fifo represents unlimited internally.
+    CurrentNorm = canonicalize_delivery_limit(CurrentPolicyConfig),
+    NewNorm = canonicalize_delivery_limit(NewPolicyConfig),
+
+    ShouldUpdate = NewNorm =/= CurrentNorm,
     case ShouldUpdate of
         true ->
             ?LOG_DEBUG("Re-applying policies for ~ts",
@@ -900,6 +905,14 @@ maybe_apply_policies(Q, #{config := CurrentConfig}) ->
             policy_changed(Q),
             ok;
         false -> ok
+    end.
+
+canonicalize_delivery_limit(Config) ->
+    case maps:get(delivery_limit, Config, undefined) of
+        Value when is_integer(Value) orelse
+                   Value < 0 ->
+            Config#{delivery_limit => undefined};
+        _ -> Config
     end.
 
 -spec recover(binary(), [amqqueue:amqqueue()]) ->

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -196,6 +196,7 @@ all_tests() ->
      subscribe_redelivery_limit_disable,
      subscribe_redelivery_limit_many,
      subscribe_redelivery_policy,
+     delivery_limit_policy_update,
      subscribe_redelivery_limit_with_dead_letter,
      purge,
      consumer_metrics,
@@ -4224,6 +4225,52 @@ subscribe_redelivery_policy(Config) ->
 
     wait_for_messages(Config, [[QQ, <<"0">>, <<"0">>, <<"0">>]]),
     ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"delivery-limit">>).
+
+delivery_limit_policy_update(Config) ->
+    [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),
+
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+    QQ = ?config(queue_name, Config),
+
+    %% Declare quorum queue without delivery limit
+    ?assertEqual({'queue.declare_ok', QQ, 0, 0},
+                 declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}])),
+
+    VHost = <<"%2F">>,
+    RaName = binary_to_atom(<<VHost/binary, "_", QQ/binary>>, utf8),
+
+    %% Initially, delivery_limit should be the default (20)
+    ?awaitMatch({ok, #{machine := #{config := #{delivery_limit := 20}}}, _},
+                rpc:call(Server, ra, member_overview, [RaName]),
+                ?DEFAULT_AWAIT),
+
+    %% Set a delivery limit policy
+    ok = rabbit_ct_broker_helpers:set_policy(
+           Config, 0, <<"delivery-limit-test">>, <<".*">>, <<"queues">>,
+           [{<<"delivery-limit">>, 5}]),
+
+    %% Verify that the policy was applied to the queue config
+    ?awaitMatch({ok, #{machine := #{config := #{delivery_limit := 5}}}, _},
+                rpc:call(Server, ra, member_overview, [RaName]),
+                ?DEFAULT_AWAIT),
+
+    %% Update the policy with a new delivery limit
+    ok = rabbit_ct_broker_helpers:set_policy(
+           Config, 0, <<"delivery-limit-test">>, <<".*">>, <<"queues">>,
+           [{<<"delivery-limit">>, 10}]),
+
+    %% Verify that the new policy was applied
+    ?awaitMatch({ok, #{machine := #{config := #{delivery_limit := 10}}}, _},
+                rpc:call(Server, ra, member_overview, [RaName]),
+                ?DEFAULT_AWAIT),
+
+    %% Clear the policy
+    ok = rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"delivery-limit-test">>),
+
+    %% Verify that the default delivery limit is restored
+    ?awaitMatch({ok, #{machine := #{config := #{delivery_limit := 20}}}, _},
+                rpc:call(Server, ra, member_overview, [RaName]),
+                ?DEFAULT_AWAIT).
 
 subscribe_redelivery_limit_with_dead_letter(Config) ->
     [Server | _] = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
The previous implementation excluded delivery_limit from policy comparisons, which prevented queue configuration updates when only the delivery_limit policy parameter changed. Since delivery_limit is already retrieved from policies via args_policy_lookup(), this restriction was unnecessary.

Removing the exclusion allows delivery_limit policy changes to be properly applied to existing quorum queues. However, we must canonicalize delivery_limit values for comparison: map any negative value to undefined (how rabbit_fifo internally represents unlimited). This handles cases where:
- rabbit_fifo stores undefined for older queues
- Policies can return any integer value (including -2, -3, etc.)
- All negative values are semantically equivalent to unlimited

This prevents spurious policy updates from triggering repeatedly when policy returns different negative values.

Add test to verify delivery_limit policy changes are applied correctly.

