### PR TITLE
Set acquired-count across QQ dead-lettering

### DIFF
--- a/deps/rabbit/src/rabbit_fifo.erl
+++ b/deps/rabbit/src/rabbit_fifo.erl
@@ -2325,9 +2325,15 @@ get_header(Key, Header)
 annotate_msg(Header, Msg0) ->
     case mc:is(Msg0) of
         true when is_map(Header) ->
-            Msg = maps:fold(fun (K, V, Acc) ->
-                                    mc:set_annotation(K, V, Acc)
-                            end, Msg0, maps:get(anns, Header, #{})),
+            Msg1 = maps:fold(fun (K, V, Acc) ->
+                                     mc:set_annotation(K, V, Acc)
+                             end, Msg0, maps:get(anns, Header, #{})),
+            Msg = case Header of
+                      #{acquired_count := AcqCount} ->
+                          mc:set_annotation(acquired_count, AcqCount, Msg1);
+                      _ ->
+                          Msg1
+                  end,
             case Header of
                 #{delivery_count := DelCount} ->
                     mc:set_annotation(delivery_count, DelCount, Msg);

--- a/deps/rabbit/test/rabbit_fifo_SUITE.erl
+++ b/deps/rabbit/test/rabbit_fifo_SUITE.erl
@@ -1476,7 +1476,7 @@ discarded_message_with_dead_letter_handler_emits_log_effect_test(Config) ->
                                             Effects2),
     [{mod_call, somemod, somefun, [somearg, rejected, [McOut]]}] = Fun([Msg1]),
 
-    ?assertEqual(undefined, mc:get_annotation(acquired_count, McOut)),
+    ?assertEqual(1, mc:get_annotation(acquired_count, McOut)),
     ?assertEqual(1, mc:get_annotation(delivery_count, McOut)),
     ok.
 


### PR DESCRIPTION
 ## What?

Similar to passing on the delivery-count across dead-lettering from a QQ, also pass on the acquired-count.

 ## Why?

Arguably, it would be unexpected for a client to receive a message with a delivery-count (number of **failed** delivery attempts) to be higher than the acquired-count (number of all - both failed and non-failed - delivery attempts).

Do we want this change at all?