### PR TITLE
Test flake chase: a few more flakes (Apr 13, 2026)

### DIFF
--- a/deps/rabbit/test/amqp_proxy_protocol_SUITE.erl
+++ b/deps/rabbit/test/amqp_proxy_protocol_SUITE.erl
@@ -81,7 +81,6 @@ v1_tls(Config) ->
     [ok = ssl:send(SslSocket, amqp_1_0_frame(FrameType))
      || FrameType <- [header_sasl, sasl_init, header_amqp, open]],
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
-    timer:sleep(1000),
     ConnectionName = rpc(Config, ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:82$">>, [{capture, none}]),
     ok = gen_tcp:close(Socket).

--- a/deps/rabbit/test/policy_SUITE.erl
+++ b/deps/rabbit/test/policy_SUITE.erl
@@ -249,7 +249,7 @@ classic_queue_version_policies(Config) ->
     rabbit_ct_broker_helpers:set_policy(Config, 0, <<"policy">>,
                                         QName, <<"queues">>,
                                         Policy),
-    ?assertMatch(2, check_policy_value(Server, QName, <<"queue-version">>)),
+    ?awaitMatch(2, check_policy_value(Server, QName, <<"queue-version">>), 30_000),
     delete(Ch, QName),
     rabbit_ct_broker_helpers:clear_policy(Config, 0, <<"policy">>),
     rabbit_ct_client_helpers:close_channel(Ch),
@@ -420,7 +420,7 @@ verify_policies(Policy, OperPolicy, VerifyFuns, #{config := Config,
 verify_policy([], _, _) ->
     ok;
 verify_policy([{HA, Expect} | Tail], Server, QName) ->
-    Expect = check_policy_value(Server, QName, HA),
+    ?awaitMatch(Expect, check_policy_value(Server, QName, HA), 30_000),
     verify_policy(Tail, Server, QName).
 
 

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -6044,8 +6044,6 @@ delayed_retry_all(Config) ->
                                         multiple = false,
                                         requeue = true}),
     %% Message should be delayed - not ready
-    timer:sleep(500),
-    % ct:pal("mac ov ~p", [machine_overview({RaName, Server})]),
     wait_for_messages(Config, [[QQ, <<"1">>, <<"0">>, <<"0">>]]),
     %% Verify delayed message count in overview
     Overview1 = machine_overview({RaName, Server}),


### PR DESCRIPTION
Same old: using eventual matchers here, squashing some `timer:sleep/1`s there.