### PR TITLE
Test flake chase (Apr 13, 2026) (round 2)

### DIFF
--- a/deps/rabbit/test/amqp_proxy_protocol_SUITE.erl
+++ b/deps/rabbit/test/amqp_proxy_protocol_SUITE.erl
@@ -83,7 +83,7 @@ v1_tls(Config) ->
     {ok, _Packet} = ssl:recv(SslSocket, 0, ?TIMEOUT),
     ConnectionName = rpc(Config, ?MODULE, connection_name, []),
     match = re:run(ConnectionName, <<"^192.168.1.1:80 -> 192.168.1.2:82$">>, [{capture, none}]),
-    ok = gen_tcp:close(Socket).
+    ok = ssl:close(SslSocket).
 
 v2_local(Config) ->
     ProxyInfo = #{
@@ -127,7 +127,7 @@ split([], Acc) ->
 connection_name() ->
     %% the connection can take some time to show up in the ETS
     %% hence the retry
-    case retry(fun connection_registered/0, 20) of
+    case retry(fun connection_registered/0, 60) of
         true ->
             [{_Key, Values}] = ets:tab2list(connection_created),
             {_, Name} = lists:keyfind(name, 1, Values),

--- a/deps/rabbit/test/amqp_proxy_protocol_SUITE.erl
+++ b/deps/rabbit/test/amqp_proxy_protocol_SUITE.erl
@@ -56,7 +56,7 @@ init_per_testcase(Testcase, Config) ->
     rabbit_ct_helpers:testcase_started(Config, Testcase).
 
 end_per_testcase(Testcase, Config) ->
-    eventually(?_assertEqual(0, rpc(Config, ets, info, [connection_created, size])), 1000, 10),
+    eventually(?_assertEqual(0, rpc(Config, ets, info, [connection_created, size])), 1000, 30),
     rabbit_ct_helpers:testcase_finished(Config, Testcase).
 
 v1(Config) ->

--- a/deps/rabbit/test/dead_lettering_SUITE.erl
+++ b/deps/rabbit/test/dead_lettering_SUITE.erl
@@ -247,6 +247,7 @@ dead_letter_nack(Config) ->
     %% Queue is empty
     consume_empty(Ch, QName),
     %% Consume the first two messages from the dead letter queue
+    wait_for_messages(Config, [[DLXQName, <<"2">>, <<"2">>, <<"0">>]]),
     consume(Ch, DLXQName, [P1, P2]),
     consume_empty(Ch, DLXQName),
     ?assertEqual(3, counted(messages_dead_lettered_rejected_total, Config)).
@@ -1058,6 +1059,7 @@ dead_letter_policy(Config) ->
     wait_for_messages(Config, [[QName, <<"0">>, <<"0">>, <<"0">>]]),
     consume_empty(Ch, QName),
     %% Consume the message from the dead letter queue
+    wait_for_messages(Config, [[DLXQName, <<"1">>, <<"1">>, <<"0">>]]),
     consume(Ch, DLXQName, [P2]),
     consume_empty(Ch, DLXQName).
 

--- a/deps/rabbit/test/dead_lettering_SUITE.erl
+++ b/deps/rabbit/test/dead_lettering_SUITE.erl
@@ -247,7 +247,7 @@ dead_letter_nack(Config) ->
     %% Queue is empty
     consume_empty(Ch, QName),
     %% Consume the first two messages from the dead letter queue
-    wait_for_messages(Config, [[DLXQName, <<"2">>, <<"2">>, <<"0">>]]),
+    wait_for_messages(Config, [[DLXQName, <<"3">>, <<"2">>, <<"1">>]]),
     consume(Ch, DLXQName, [P1, P2]),
     consume_empty(Ch, DLXQName),
     ?assertEqual(3, counted(messages_dead_lettered_rejected_total, Config)).

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -4717,17 +4717,19 @@ status_noproc(Config) ->
     %% hasn't recorded any counters yet
     rabbit_ct_broker_helpers:rpc(Config, N1, ra_counters, delete, [{RaName, N1}]),
 
-    %% check that some status is returned for each node
-    ?assertMatch([?STATUS_MATCH(N1, noproc, T1),
-                  ?STATUS_MATCH(N2, RS2, T2),
-                  ?STATUS_MATCH(N3, RS3, T3)
-                 ] when T1 == <<>> andalso
-                        T2 /= <<>> andalso
-                        T3 /= <<>> andalso
-                        (RS2 == leader orelse RS2 == follower) andalso
-                        (RS3 == leader orelse RS3 == follower),
-                 rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
-                                              status, [<<"/">>, QQ])),
+    %% check that some status is returned for each node;
+    %% N2 and N3 need time to elect a leader after N1's process is killed
+    ?awaitMatch([?STATUS_MATCH(N1, noproc, T1),
+                 ?STATUS_MATCH(N2, RS2, T2),
+                 ?STATUS_MATCH(N3, RS3, T3)
+                ] when T1 == <<>> andalso
+                       T2 /= <<>> andalso
+                       T3 /= <<>> andalso
+                       (RS2 == leader orelse RS2 == follower) andalso
+                       (RS3 == leader orelse RS3 == follower),
+                rabbit_ct_broker_helpers:rpc(Config, 0, rabbit_quorum_queue,
+                                             status, [<<"/">>, QQ]),
+                30_000),
     ok.
 format(Config) ->
     %% tests rabbit_quorum_queue:format/2

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -827,7 +827,7 @@ test_successful_connection_with_keycloak_token(Config) ->
 
 
 test_successful_token_refresh(Config) ->
-    Duration = 5,
+    Duration = 10,
     {_Algo, Token} = generate_expirable_token(Config, [
             <<"rabbitmq.configure:vhost1/*">>,
             <<"rabbitmq.write:vhost1/*">>,
@@ -841,8 +841,8 @@ test_successful_token_refresh(Config) ->
         <<"rabbitmq.configure:vhost1/*">>,
         <<"rabbitmq.write:vhost1/*">>,
         <<"rabbitmq.read:vhost1/*">>]),
-    %% Refresh 1 s before expiry to avoid racing the broker's expiry timer.
-    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration) - 1000),
+    %% Refresh well before expiry to avoid racing the broker's expiry timer on slow CI.
+    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration) - 3000),
     ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2,
         <<"token refresh">>)),
     {ok, Ch2} = amqp_connection:open_channel(Conn),
@@ -915,12 +915,9 @@ test_failed_token_refresh_case1(Config) ->
         <<"rabbitmq.configure:vhost4/*">>,
         <<"rabbitmq.write:vhost4/*">>,
         <<"rabbitmq.read:vhost4/*">>]),
-    %% the error is communicated asynchronously via a connection-level error
-    ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2,
-        <<"token refresh">>)),
-
-    %% The 530 close is async; it may arrive before or after open_channel.
+    %% The 530 close may arrive during update_secret itself or on a subsequent call.
     try
+        amqp_connection:update_secret(Conn, Token2, <<"token refresh">>),
         {ok, Ch2} = amqp_connection:open_channel(Conn),
         ?assertExit({{shutdown, {server_initiated_close, 403, _}}, _},
            amqp_channel:call(Ch2, #'queue.declare'{queue = <<"a.q">>, exclusive = true}))

--- a/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/jwks_SUITE.erl
@@ -841,7 +841,8 @@ test_successful_token_refresh(Config) ->
         <<"rabbitmq.configure:vhost1/*">>,
         <<"rabbitmq.write:vhost1/*">>,
         <<"rabbitmq.read:vhost1/*">>]),
-    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration)),
+    %% Refresh 1 s before expiry to avoid racing the broker's expiry timer.
+    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration) - 1000),
     ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2,
         <<"token refresh">>)),
     {ok, Ch2} = amqp_connection:open_channel(Conn),
@@ -918,9 +919,14 @@ test_failed_token_refresh_case1(Config) ->
     ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2,
         <<"token refresh">>)),
 
-    {ok, Ch2} = amqp_connection:open_channel(Conn),
-    ?assertExit({{shutdown, {server_initiated_close, 403, _}}, _},
-       amqp_channel:call(Ch2, #'queue.declare'{queue = <<"a.q">>, exclusive = true})),
+    %% The 530 close is async; it may arrive before or after open_channel.
+    try
+        {ok, Ch2} = amqp_connection:open_channel(Conn),
+        ?assertExit({{shutdown, {server_initiated_close, 403, _}}, _},
+           amqp_channel:call(Ch2, #'queue.declare'{queue = <<"a.q">>, exclusive = true}))
+    catch
+        exit:{{shutdown, {connection_closing, {server_initiated_close, 530, _}}}, _} -> ok
+    end,
 
     close_connection(Conn).
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -879,7 +879,8 @@ test_successful_token_refresh(Config) ->
     {_, Token2} = generate_valid_token(Config, [<<"rabbitmq.configure:vhost1/*">>,
                                                 <<"rabbitmq.write:vhost1/*">>,
                                                 <<"rabbitmq.read:vhost1/*">>]),
-    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration)),
+    %% Refresh 1 s before expiry to avoid racing the broker's expiry timer.
+    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration) - 1000),
     ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2, <<"token refresh">>)),
 
     {ok, Ch2} = amqp_connection:open_channel(Conn),
@@ -948,9 +949,14 @@ test_failed_token_refresh_case1(Config) ->
     %% the error is communicated asynchronously via a connection-level error
     ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2, <<"token refresh">>)),
 
-    {ok, Ch2} = amqp_connection:open_channel(Conn),
-    ?assertExit({{shutdown, {server_initiated_close, 403, _}}, _},
-       amqp_channel:call(Ch2, #'queue.declare'{queue = <<"a.q">>, exclusive = true})),
+    %% The 530 close is async; it may arrive before or after open_channel.
+    try
+        {ok, Ch2} = amqp_connection:open_channel(Conn),
+        ?assertExit({{shutdown, {server_initiated_close, 403, _}}, _},
+           amqp_channel:call(Ch2, #'queue.declare'{queue = <<"a.q">>, exclusive = true}))
+    catch
+        exit:{{shutdown, {connection_closing, {server_initiated_close, 530, _}}}, _} -> ok
+    end,
 
     catch close_connection(Conn).
 

--- a/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/test/system_SUITE.erl
@@ -868,7 +868,7 @@ test_successful_connection_with_rich_authorization_request_token(Config) ->
     close_connection_and_channel(Conn, Ch).
 
 test_successful_token_refresh(Config) ->
-    Duration = 5,
+    Duration = 10,
     {_, Token} = generate_expirable_token(Config, [<<"rabbitmq.configure:vhost1/*">>,
                                                    <<"rabbitmq.write:vhost1/*">>,
                                                    <<"rabbitmq.read:vhost1/*">>],
@@ -879,8 +879,8 @@ test_successful_token_refresh(Config) ->
     {_, Token2} = generate_valid_token(Config, [<<"rabbitmq.configure:vhost1/*">>,
                                                 <<"rabbitmq.write:vhost1/*">>,
                                                 <<"rabbitmq.read:vhost1/*">>]),
-    %% Refresh 1 s before expiry to avoid racing the broker's expiry timer.
-    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration) - 1000),
+    %% Refresh well before expiry to avoid racing the broker's expiry timer on slow CI.
+    ?UTIL_MOD:wait_for_token_to_expire(timer:seconds(Duration) - 3000),
     ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2, <<"token refresh">>)),
 
     {ok, Ch2} = amqp_connection:open_channel(Conn),
@@ -946,11 +946,9 @@ test_failed_token_refresh_case1(Config) ->
     {_, Token2} = generate_expired_token(Config, [<<"rabbitmq.configure:vhost4/*">>,
                                                   <<"rabbitmq.write:vhost4/*">>,
                                                   <<"rabbitmq.read:vhost4/*">>]),
-    %% the error is communicated asynchronously via a connection-level error
-    ?assertEqual(ok, amqp_connection:update_secret(Conn, Token2, <<"token refresh">>)),
-
-    %% The 530 close is async; it may arrive before or after open_channel.
+    %% The 530 close may arrive during update_secret itself or on a subsequent call.
     try
+        amqp_connection:update_secret(Conn, Token2, <<"token refresh">>),
         {ok, Ch2} = amqp_connection:open_channel(Conn),
         ?assertExit({{shutdown, {server_initiated_close, 403, _}}, _},
            amqp_channel:call(Ch2, #'queue.declare'{queue = <<"a.q">>, exclusive = true}))


### PR DESCRIPTION
A follow-up to https://github.com/rabbitmq/rabbitmq-server/pull/16043.