### PR TITLE
Stream Protocol reader: simplify chunk selector

### DIFF
--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -4139,8 +4139,10 @@ send_close_and_increment(Transport, S) ->
     increase_protocol_counter(?UNKNOWN_FRAME).
 
 get_chunk_selector(Properties) ->
-    binary_to_atom(maps:get(<<"chunk_selector">>, Properties,
-                            <<"user_data">>)).
+    case maps:get(<<"chunk_selector">>, Properties, <<"user_data">>) of
+        <<"all">> -> all;
+        _         -> user_data
+    end.
 
 close_log(undefined) ->
     ok;


### PR DESCRIPTION
It only ever deals with two possible values.