### PR TITLE
JMS topic selector: introduce a new selector parser

### DIFF
--- a/deps/rabbitmq_jms_topic_exchange/src/rabbit_jms_topic_exchange.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/rabbit_jms_topic_exchange.erl
@@ -95,8 +95,20 @@ delete(_Tx, #exchange{name = XName}) ->
     _ = delete_state(XName),
     ok.
 
-% Before add binding
-validate_binding(_X, _B) -> ok.
+%% Sanitize selectors before creating bindings
+validate_binding(_X, #binding{args = Args}) ->
+  case get_string_arg(Args, ?RJMS_COMPILED_SELECTOR_ARG) of
+    error ->
+      ok;
+    Selector ->
+      case decode_term(Selector) of
+        {ok, _} ->
+          ok;
+        {error, Reason} ->
+          {error, {binding_invalid,
+                   "invalid JMS selector: ~tp", [Reason]}}
+      end
+  end.
 
 % A new binding has ben added or recovered
 add_binding( _Tx
@@ -183,15 +195,9 @@ check_fun(CompiledExp) ->
     end
   }.
 
-% get an erlang term from a string
+% Decodes an Erlang term using `sjx_parser:parse_term/1`.
 decode_term(Str) ->
-  try
-    {ok, Ts, _} = erl_scan:string(Str),
-    {ok, Term} = erl_parse:parse_term(Ts),
-    {ok, Term}
-  catch
-    Err -> {error, {invalid_erlang_term, Err}}
-  end.
+  sjx_parser:parse_term(Str).
 
 % Evaluate the selector and check against the Headers
 selector_match(Selector, Headers) ->

--- a/deps/rabbitmq_jms_topic_exchange/src/sjx_parser.erl
+++ b/deps/rabbitmq_jms_topic_exchange/src/sjx_parser.erl
@@ -1,0 +1,277 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%% -----------------------------------------------------------------------------
+
+%% Erlang term parser for JMS topic exchange selectors.
+%%
+%% Only the atoms recognised by this parser are accepted.
+
+%% -----------------------------------------------------------------------------
+-module(sjx_parser).
+
+-export([parse_term/1]).
+
+-define(MAX_NESTING_DEPTH, 16).
+
+-define(ALLOWED_ATOMS, #{
+    %% Expression tags
+    ident       => true,
+    'not'       => true,
+    'and'       => true,
+    'or'        => true,
+    is_null     => true,
+    not_null    => true,
+    like        => true,
+    not_like    => true,
+    between     => true,
+    not_between => true,
+    range       => true,
+    %% Comparison operators
+    '='         => true,
+    '<>'        => true,
+    '>'         => true,
+    '<'         => true,
+    '>='        => true,
+    '<='        => true,
+    %% Set operators
+    in          => true,
+    not_in      => true,
+    %% Arithmetic operators
+    '+'         => true,
+    '-'         => true,
+    '*'         => true,
+    '/'         => true,
+    %% Boolean literals
+    true        => true,
+    false       => true,
+    %% LIKE escape specifiers
+    no_escape   => true,
+    regex       => true
+}).
+
+-spec parse_term(string()) -> {ok, term()} | {error, term()}.
+parse_term(Str) when is_list(Str) ->
+    try
+        {Term, Rest} = do_parse_term(skip_ws(Str), 0),
+        case skip_ws(Rest) of
+            [$. | Tail] ->
+                case skip_ws(Tail) of
+                    [] -> {ok, Term};
+                    _  -> {error, trailing_characters}
+                end;
+            [] ->
+                {ok, Term};
+            _ ->
+                {error, trailing_characters}
+        end
+    catch
+        throw:{parse_error, Reason} -> {error, Reason};
+        error:badarg                -> {error, invalid_term}
+    end.
+
+%% ---------------------------------------------------------------------------
+%% Terms
+%% ---------------------------------------------------------------------------
+
+do_parse_term(_, Depth) when Depth > ?MAX_NESTING_DEPTH ->
+    throw({parse_error, max_depth_exceeded});
+do_parse_term([${ | Rest], Depth) ->
+    parse_tuple(skip_ws(Rest), [], Depth);
+do_parse_term([$[ | Rest], Depth) ->
+    parse_list(skip_ws(Rest), Depth);
+do_parse_term([$<, $< | Rest], _Depth) ->
+    parse_binary(skip_ws(Rest));
+do_parse_term([$" | Rest], _Depth) ->
+    parse_string_chars(Rest, []);
+do_parse_term([$' | Rest], _Depth) ->
+    parse_quoted_atom(Rest, []);
+do_parse_term([$- | Rest0], _Depth) ->
+    Rest = skip_ws(Rest0),
+    case Rest of
+        [C | _] when C >= $0, C =< $9 ->
+            {Num, Rest1} = parse_number(Rest),
+            {-Num, Rest1};
+        _ ->
+            throw({parse_error, unexpected_character})
+    end;
+do_parse_term([$+ | Rest0], _Depth) ->
+    Rest = skip_ws(Rest0),
+    case Rest of
+        [C | _] when C >= $0, C =< $9 ->
+            parse_number(Rest);
+        _ ->
+            throw({parse_error, unexpected_character})
+    end;
+do_parse_term([C | _] = Str, _Depth) when C >= $0, C =< $9 ->
+    parse_number(Str);
+do_parse_term([C | _] = Str, _Depth) when C >= $a, C =< $z ->
+    parse_bare_atom(Str, []);
+do_parse_term([], _Depth) ->
+    throw({parse_error, unexpected_end});
+do_parse_term(_, _Depth) ->
+    throw({parse_error, unexpected_character}).
+
+%% ---------------------------------------------------------------------------
+%% Tuples: {Term, ...}
+%% ---------------------------------------------------------------------------
+
+parse_tuple([$} | Rest], Acc, _Depth) ->
+    {list_to_tuple(lists:reverse(Acc)), Rest};
+parse_tuple(Str, Acc, Depth) ->
+    {Term, Rest} = do_parse_term(Str, Depth + 1),
+    case skip_ws(Rest) of
+        [$, | Rest1] ->
+            parse_tuple(skip_ws(Rest1), [Term | Acc], Depth);
+        [$} | Rest1] ->
+            {list_to_tuple(lists:reverse([Term | Acc])), Rest1};
+        _ ->
+            throw({parse_error, expected_comma_or_closing_brace})
+    end.
+
+%% ---------------------------------------------------------------------------
+%% Lists: [Term, ...] | []
+%% ---------------------------------------------------------------------------
+
+parse_list([$] | Rest], _Depth) ->
+    {[], Rest};
+parse_list(Str, Depth) ->
+    parse_list_elems(Str, [], Depth).
+
+parse_list_elems(Str, Acc, Depth) ->
+    {Term, Rest} = do_parse_term(Str, Depth + 1),
+    case skip_ws(Rest) of
+        [$, | Rest1] ->
+            parse_list_elems(skip_ws(Rest1), [Term | Acc], Depth);
+        [$] | Rest1] ->
+            {lists:reverse([Term | Acc]), Rest1};
+        _ ->
+            throw({parse_error, expected_comma_or_closing_bracket})
+    end.
+
+%% ---------------------------------------------------------------------------
+%% Binaries: <<"...">> | <<>>
+%% ---------------------------------------------------------------------------
+
+parse_binary([$>, $> | Rest]) ->
+    {<<>>, Rest};
+parse_binary([$" | Rest]) ->
+    {Chars, Rest1} = parse_string_chars(Rest, []),
+    case skip_ws(Rest1) of
+        [$>, $> | Rest2] ->
+            {list_to_binary(Chars), Rest2};
+        _ ->
+            throw({parse_error, expected_closing_binary})
+    end;
+parse_binary(_) ->
+    throw({parse_error, invalid_binary}).
+
+%% ---------------------------------------------------------------------------
+%% Strings: "..."
+%% ---------------------------------------------------------------------------
+
+parse_string_chars([$" | Rest], Acc) ->
+    {lists:reverse(Acc), Rest};
+parse_string_chars([$\\, C | Rest], Acc) ->
+    parse_string_chars(Rest, [unescape_char(C) | Acc]);
+parse_string_chars([C | Rest], Acc) ->
+    parse_string_chars(Rest, [C | Acc]);
+parse_string_chars([], _) ->
+    throw({parse_error, unterminated_string}).
+
+unescape_char($n)  -> $\n;
+unescape_char($t)  -> $\t;
+unescape_char($r)  -> $\r;
+unescape_char($\\) -> $\\;
+unescape_char($")  -> $";
+unescape_char(C)   -> C.
+
+%% ---------------------------------------------------------------------------
+%% Quoted atoms: '...'
+%% ---------------------------------------------------------------------------
+
+parse_quoted_atom([$' | Rest], Acc) ->
+    AtomStr = lists:reverse(Acc),
+    {validate_atom(AtomStr), Rest};
+parse_quoted_atom([$\\, C | Rest], Acc) ->
+    parse_quoted_atom(Rest, [C | Acc]);
+parse_quoted_atom([C | Rest], Acc) ->
+    parse_quoted_atom(Rest, [C | Acc]);
+parse_quoted_atom([], _) ->
+    throw({parse_error, unterminated_quoted_atom}).
+
+%% ---------------------------------------------------------------------------
+%% Bare atoms: [a-z][a-zA-Z0-9_@]*
+%% ---------------------------------------------------------------------------
+
+parse_bare_atom([C | Rest], Acc)
+  when (C >= $a andalso C =< $z) orelse
+       (C >= $A andalso C =< $Z) orelse
+       (C >= $0 andalso C =< $9) orelse
+       C =:= $_ orelse C =:= $@ ->
+    parse_bare_atom(Rest, [C | Acc]);
+parse_bare_atom(Rest, Acc) ->
+    AtomStr = lists:reverse(Acc),
+    {validate_atom(AtomStr), Rest}.
+
+%% ---------------------------------------------------------------------------
+%% Numbers: integers and floats (with optional scientific notation)
+%% ---------------------------------------------------------------------------
+
+parse_number(Str) ->
+    {IntDigits, Rest1} = scan_digits(Str),
+    case Rest1 of
+        [$., C | Rest2] when C >= $0, C =< $9 ->
+            {FracDigits, Rest3} = scan_digits([C | Rest2]),
+            FloatStr = IntDigits ++ "." ++ FracDigits,
+            maybe_parse_exponent(FloatStr, Rest3);
+        _ ->
+            {list_to_integer(IntDigits), Rest1}
+    end.
+
+maybe_parse_exponent(FloatStr, [E | Rest]) when E =:= $e; E =:= $E ->
+    {Sign, Rest1} = case Rest of
+        [$+ | R] -> {"+", R};
+        [$- | R] -> {"-", R};
+        R        -> {"", R}
+    end,
+    {ExpDigits, Rest2} = scan_digits(Rest1),
+    {list_to_float(FloatStr ++ [E] ++ Sign ++ ExpDigits), Rest2};
+maybe_parse_exponent(FloatStr, Rest) ->
+    {list_to_float(FloatStr), Rest}.
+
+scan_digits(Str) ->
+    scan_digits(Str, []).
+
+scan_digits([C | Rest], Acc) when C >= $0, C =< $9 ->
+    scan_digits(Rest, [C | Acc]);
+scan_digits(Rest, Acc) ->
+    {lists:reverse(Acc), Rest}.
+
+%% ---------------------------------------------------------------------------
+%% Atom validation
+%% ---------------------------------------------------------------------------
+
+validate_atom(AtomStr) ->
+    try list_to_existing_atom(AtomStr) of
+        Atom ->
+            case maps:is_key(Atom, ?ALLOWED_ATOMS) of
+                true  -> Atom;
+                false -> throw({parse_error, {disallowed_atom, AtomStr}})
+            end
+    catch
+        error:badarg ->
+            throw({parse_error, {unknown_atom, AtomStr}})
+    end.
+
+%% ---------------------------------------------------------------------------
+%% Whitespace
+%% ---------------------------------------------------------------------------
+
+skip_ws([$\s | Rest]) -> skip_ws(Rest);
+skip_ws([$\t | Rest]) -> skip_ws(Rest);
+skip_ws([$\n | Rest]) -> skip_ws(Rest);
+skip_ws([$\r | Rest]) -> skip_ws(Rest);
+skip_ws(Str)          -> Str.

--- a/deps/rabbitmq_jms_topic_exchange/test/rjms_topic_selector_unit_SUITE.erl
+++ b/deps/rabbitmq_jms_topic_exchange/test/rjms_topic_selector_unit_SUITE.erl
@@ -34,7 +34,9 @@ groups() ->
                                     description_test,
                                     serialise_events_test,
                                     validate_test,
-                                    validate_binding_test
+                                    validate_binding_test,
+                                    validate_binding_rejects_unknown_atoms_test,
+                                    validate_binding_no_selector_test
                                    ]}
     ].
 
@@ -75,6 +77,19 @@ validate_test(_Config) ->
 
 validate_binding_test(_Config) ->
   ?assertEqual(ok, validate_binding(dummy_exchange(), dummy_binding())).
+
+validate_binding_rejects_unknown_atoms_test(_Config) ->
+  B = #binding{ key = <<"BindingKey">>
+              , destination = #resource{name = <<"DName">>}
+              , args = [{?RJMS_COMPILED_SELECTOR_ARG, longstr, <<"{xq7fkd9_3jrvm, 42}.">>}]},
+  ?assertMatch({error, {binding_invalid, _, _}},
+               validate_binding(dummy_exchange(), B)).
+
+validate_binding_no_selector_test(_Config) ->
+  B = #binding{ key = <<"BindingKey">>
+              , destination = #resource{name = <<"DName">>}
+              , args = []},
+  ?assertEqual(ok, validate_binding(dummy_exchange(), B)).
 
 dummy_exchange() ->
   #exchange{name = <<"XName">>, arguments = []}.

--- a/deps/rabbitmq_jms_topic_exchange/test/sjx_parser_SUITE.erl
+++ b/deps/rabbitmq_jms_topic_exchange/test/sjx_parser_SUITE.erl
@@ -1,0 +1,296 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%% -----------------------------------------------------------------------------
+
+%% Tests for sjx_parser — safe Erlang term parser
+
+%% -----------------------------------------------------------------------------
+-module(sjx_parser_SUITE).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [
+      {group, parallel_tests}
+    ].
+
+groups() ->
+    [
+      {parallel_tests, [parallel], [
+          atoms_test,
+          quoted_atoms_test,
+          integers_test,
+          floats_test,
+          floats_malformed_test,
+          binaries_test,
+          binaries_with_escapes_test,
+          strings_test,
+          tuples_test,
+          lists_test,
+          trailing_dot_test,
+          whitespace_test,
+          selector_ident_test,
+          selector_comparison_test,
+          selector_logical_test,
+          selector_null_check_test,
+          selector_like_test,
+          selector_between_test,
+          selector_in_test,
+          selector_arithmetic_test,
+          selector_negative_float_in_tuple_test,
+          selector_complex_test,
+          rejects_unknown_atoms_test,
+          rejects_disallowed_atoms_test,
+          rejects_non_atom_identifiers_test,
+          rejects_malformed_input_test,
+          rejects_excessive_nesting_test
+      ]}
+    ].
+
+%% -------------------------------------------------------------------
+%% Test suite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_suite(Config) ->  Config.
+end_per_suite(Config) ->   Config.
+init_per_group(_, Config) ->  Config.
+end_per_group(_, Config) ->   Config.
+init_per_testcase(_, Config) ->  Config.
+end_per_testcase(_, Config) ->   Config.
+
+%% -------------------------------------------------------------------
+%% Atoms
+%% -------------------------------------------------------------------
+
+atoms_test(_) ->
+    ?assertEqual({ok, true},      sjx_parser:parse_term("true.")),
+    ?assertEqual({ok, false},     sjx_parser:parse_term("false.")),
+    ?assertEqual({ok, ident},     sjx_parser:parse_term("ident.")),
+    ?assertEqual({ok, no_escape}, sjx_parser:parse_term("no_escape.")),
+    ?assertEqual({ok, regex},     sjx_parser:parse_term("regex.")).
+
+quoted_atoms_test(_) ->
+    ?assertEqual({ok, '='},  sjx_parser:parse_term("'='.")),
+    ?assertEqual({ok, '<>'}, sjx_parser:parse_term("'<>'.")),
+    ?assertEqual({ok, '>='}, sjx_parser:parse_term("'>='.")),
+    ?assertEqual({ok, '<='}, sjx_parser:parse_term("'<='.")),
+    ?assertEqual({ok, '>'},  sjx_parser:parse_term("'>'.")),
+    ?assertEqual({ok, '<'},  sjx_parser:parse_term("'<'.")),
+    ?assertEqual({ok, '+'},  sjx_parser:parse_term("'+'.")),
+    ?assertEqual({ok, '-'},  sjx_parser:parse_term("'-'.")),
+    ?assertEqual({ok, '*'},  sjx_parser:parse_term("'*'.")),
+    ?assertEqual({ok, '/'},  sjx_parser:parse_term("'/'.")),
+    ?assertEqual({ok, in},   sjx_parser:parse_term("'in'.")).
+
+%% -------------------------------------------------------------------
+%% Numbers
+%% -------------------------------------------------------------------
+
+integers_test(_) ->
+    ?assertEqual({ok, 0},    sjx_parser:parse_term("0.")),
+    ?assertEqual({ok, 42},   sjx_parser:parse_term("42.")),
+    ?assertEqual({ok, 2501}, sjx_parser:parse_term("2501.")),
+    ?assertEqual({ok, -5},   sjx_parser:parse_term("-5.")),
+    ?assertEqual({ok, 100},  sjx_parser:parse_term("+100.")).
+
+floats_test(_) ->
+    ?assertEqual({ok, 3.14},   sjx_parser:parse_term("3.14.")),
+    ?assertEqual({ok, -1.5},   sjx_parser:parse_term("-1.5.")),
+    ?assertEqual({ok, 0.001},  sjx_parser:parse_term("0.001.")),
+    ?assertEqual({ok, 3.0e-2}, sjx_parser:parse_term("3.0e-2.")),
+    ?assertEqual({ok, 1.5e10}, sjx_parser:parse_term("1.5e10.")),
+    ?assertEqual({ok, 1.0e3},  sjx_parser:parse_term("1.0E+3.")).
+
+floats_malformed_test(_) ->
+    ?assertMatch({error, _}, sjx_parser:parse_term("1.0e.")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("1.0e+.")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("1.0e-.")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("9.9e999.")).
+
+%% -------------------------------------------------------------------
+%% Binaries
+%% -------------------------------------------------------------------
+
+binaries_test(_) ->
+    ?assertEqual({ok, <<>>},        sjx_parser:parse_term("<<>>.")),
+    ?assertEqual({ok, <<"hello">>}, sjx_parser:parse_term("<<\"hello\">>.")),
+    ?assertEqual({ok, <<"a b">>},   sjx_parser:parse_term("<<\"a b\">>.")),
+    ?assertEqual({ok, <<"bl%">>},   sjx_parser:parse_term("<<\"bl%\">>.")),
+    ?assertEqual({ok, <<"!">>},     sjx_parser:parse_term("<<\"!\">>.")),
+    ?assertEqual({ok, <<"false">>}, sjx_parser:parse_term("<<\"false\">>.")).
+
+binaries_with_escapes_test(_) ->
+    ?assertEqual({ok, <<"he\nllo">>}, sjx_parser:parse_term("<<\"he\\nllo\">>.")),
+    ?assertEqual({ok, <<"a\\b">>},    sjx_parser:parse_term("<<\"a\\\\b\">>.")),
+    ?assertEqual({ok, <<"q\"r">>},    sjx_parser:parse_term("<<\"q\\\"r\">>."  )).
+
+%% -------------------------------------------------------------------
+%% Strings (Erlang strings = lists of character codes)
+%% -------------------------------------------------------------------
+
+strings_test(_) ->
+    ?assertEqual({ok, "hello"}, sjx_parser:parse_term("\"hello\".")),
+    ?assertEqual({ok, ""},      sjx_parser:parse_term("\"\".")).
+
+%% -------------------------------------------------------------------
+%% Tuples
+%% -------------------------------------------------------------------
+
+tuples_test(_) ->
+    ?assertEqual({ok, {}},          sjx_parser:parse_term("{}.")),
+    ?assertEqual({ok, {true}},      sjx_parser:parse_term("{true}.")),
+    ?assertEqual({ok, {1, 2, 3}},   sjx_parser:parse_term("{1, 2, 3}.")),
+    ?assertEqual({ok, {<<"a">>, no_escape}},
+                 sjx_parser:parse_term("{<<\"a\">>, no_escape}.")).
+
+%% -------------------------------------------------------------------
+%% Lists
+%% -------------------------------------------------------------------
+
+lists_test(_) ->
+    ?assertEqual({ok, []},             sjx_parser:parse_term("[].")),
+    ?assertEqual({ok, [1, 2, 3]},      sjx_parser:parse_term("[1, 2, 3].")),
+    ?assertEqual({ok, [<<"a">>, <<"b">>]},
+                 sjx_parser:parse_term("[<<\"a\">>, <<\"b\">>].")).
+
+%% -------------------------------------------------------------------
+%% Trailing dot and whitespace handling
+%% -------------------------------------------------------------------
+
+trailing_dot_test(_) ->
+    ?assertEqual({ok, true}, sjx_parser:parse_term("true.")),
+    ?assertEqual({ok, true}, sjx_parser:parse_term("true")).
+
+whitespace_test(_) ->
+    ?assertEqual({ok, {ident, <<"x">>}},
+                 sjx_parser:parse_term("  { ident , << \"x\" >> }  .  ")).
+
+%% -------------------------------------------------------------------
+%% Real-world selector expressions
+%% -------------------------------------------------------------------
+
+selector_ident_test(_) ->
+    ?assertEqual({ok, {ident, <<"boolVal">>}},
+                 sjx_parser:parse_term("{ident, <<\"boolVal\">>}.")).
+
+selector_comparison_test(_) ->
+    ?assertEqual({ok, {'=', {ident, <<"colour">>}, <<"blue">>}},
+                 sjx_parser:parse_term("{'=', {ident, <<\"colour\">>}, <<\"blue\">>}.")),
+    ?assertEqual({ok, {'<>', {ident, <<"x">>}, 5}},
+                 sjx_parser:parse_term("{'<>', {ident, <<\"x\">>}, 5}.")),
+    ?assertEqual({ok, {'>', {ident, <<"weight">>}, 2500}},
+                 sjx_parser:parse_term("{'>', {ident, <<\"weight\">>}, 2500}.")),
+    ?assertEqual({ok, {'<=', {ident, <<"weight">>}, 2501}},
+                 sjx_parser:parse_term("{'<=', {ident, <<\"weight\">>}, 2501}.")).
+
+selector_logical_test(_) ->
+    ?assertEqual({ok, {'and', true, false}},
+                 sjx_parser:parse_term("{'and', true, false}.")),
+    ?assertEqual({ok, {'or', true, false}},
+                 sjx_parser:parse_term("{'or', true, false}.")),
+    ?assertEqual({ok, {'not', {ident, <<"x">>}}},
+                 sjx_parser:parse_term("{'not', {ident, <<\"x\">>}}.")).
+
+selector_null_check_test(_) ->
+    ?assertEqual({ok, {is_null, {ident, <<"x">>}}},
+                 sjx_parser:parse_term("{is_null, {ident, <<\"x\">>}}.")),
+    ?assertEqual({ok, {not_null, {ident, <<"x">>}}},
+                 sjx_parser:parse_term("{not_null, {ident, <<\"x\">>}}.")).
+
+selector_like_test(_) ->
+    ?assertEqual({ok, {'like', {ident, <<"colour">>}, <<"bl%">>, no_escape}},
+                 sjx_parser:parse_term("{'like', {ident, <<\"colour\">>}, <<\"bl%\">>, no_escape}.")),
+    ?assertEqual({ok, {'not_like', {ident, <<"colour">>}, <<"l%">>, no_escape}},
+                 sjx_parser:parse_term("{'not_like', {ident, <<\"colour\">>}, <<\"l%\">>, no_escape}.")),
+    ?assertEqual({ok, {'like', {ident, <<"x">>}, <<"b_!_ue">>, <<"!">>}},
+                 sjx_parser:parse_term("{'like', {ident, <<\"x\">>}, <<\"b_!_ue\">>, <<\"!\">>}.")).
+
+selector_between_test(_) ->
+    ?assertEqual({ok, {'between', {ident, <<"weight">>}, {range, 0, 2501}}},
+                 sjx_parser:parse_term("{'between', {ident, <<\"weight\">>}, {range, 0, 2501}}.")),
+    ?assertEqual({ok, {'not_between', 16, {range, 17, 18}}},
+                 sjx_parser:parse_term("{'not_between', 16, {range, 17, 18}}.")).
+
+selector_in_test(_) ->
+    ?assertEqual({ok, {'in', {ident, <<"colour">>}, [<<"blue">>, <<"green">>]}},
+                 sjx_parser:parse_term("{'in', {ident, <<\"colour\">>}, [<<\"blue\">>, <<\"green\">>]}.")),
+    ?assertEqual({ok, {'not_in', {ident, <<"colour">>}, [<<"grue">>]}},
+                 sjx_parser:parse_term("{'not_in', {ident, <<\"colour\">>}, [<<\"grue\">>]}.")).
+
+selector_arithmetic_test(_) ->
+    ?assertEqual({ok, {'+', {ident, <<"x">>}, 1}},
+                 sjx_parser:parse_term("{'+', {ident, <<\"x\">>}, 1}.")),
+    ?assertEqual({ok, {'-', {ident, <<"x">>}}},
+                 sjx_parser:parse_term("{'-', {ident, <<\"x\">>}}.")).
+
+selector_negative_float_in_tuple_test(_) ->
+    ?assertEqual({ok, {'>', {ident, <<"x">>}, -3.14}},
+                 sjx_parser:parse_term("{'>', {ident, <<\"x\">>}, -3.14}.")),
+    ?assertEqual({ok, {'between', {ident, <<"t">>}, {range, -1.5, 1.5}}},
+                 sjx_parser:parse_term("{'between', {ident, <<\"t\">>}, {range, -1.5, 1.5}}.")).
+
+selector_complex_test(_) ->
+    Input = "{'or', {'and', {'like', {ident, <<\"colour\">>}, {<<\"bl%\">>, no_escape}}"
+            ", {'>', {ident, <<\"weight\">>}, 2500}}"
+            ", false}.",
+    Expected = {'or',
+                {'and',
+                 {'like', {ident, <<"colour">>}, {<<"bl%">>, no_escape}},
+                 {'>', {ident, <<"weight">>}, 2500}},
+                false},
+    ?assertEqual({ok, Expected}, sjx_parser:parse_term(Input)).
+
+%% -------------------------------------------------------------------
+%% Rejection tests
+%% -------------------------------------------------------------------
+
+rejects_unknown_atoms_test(_) ->
+    ?assertMatch({error, {unknown_atom, _}},
+                 sjx_parser:parse_term("{xq7fkd9_3jrvm, 42}.")),
+    ?assertMatch({error, {unknown_atom, _}},
+                 sjx_parser:parse_term("'zk4m_w8ntp2v'.")).
+
+rejects_disallowed_atoms_test(_) ->
+    ?assertMatch({error, {disallowed_atom, _}},
+                 sjx_parser:parse_term("erlang.")),
+    ?assertMatch({error, {disallowed_atom, _}},
+                 sjx_parser:parse_term("'apply'.")).
+
+rejects_non_atom_identifiers_test(_) ->
+    ?assertMatch({error, _}, sjx_parser:parse_term("True.")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("_foo.")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("$a.")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("true..")).
+
+rejects_malformed_input_test(_) ->
+    ?assertMatch({error, _}, sjx_parser:parse_term("")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("{")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("}")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("{1, ")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("<<")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("<<\"unterminated")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("'unterminated")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("\"unterminated")),
+    ?assertMatch({error, _}, sjx_parser:parse_term("1 2")).
+
+rejects_excessive_nesting_test(_) ->
+    %% 16 levels of nesting must succeed
+    Depth16 = nest_tuples(16, "1"),
+    ?assertMatch({ok, _}, sjx_parser:parse_term(Depth16)),
+    %% 17 levels must be rejected
+    Depth17 = nest_tuples(17, "1"),
+    ?assertMatch({error, max_depth_exceeded}, sjx_parser:parse_term(Depth17)),
+    %% Lists count as nesting too
+    ListDepth17 = nest_lists(17, "1"),
+    ?assertMatch({error, max_depth_exceeded}, sjx_parser:parse_term(ListDepth17)).
+
+nest_tuples(0, Inner) -> Inner;
+nest_tuples(N, Inner) -> "{" ++ nest_tuples(N - 1, Inner) ++ "}".
+
+nest_lists(0, Inner) -> Inner;
+nest_lists(N, Inner) -> "[" ++ nest_lists(N - 1, Inner) ++ "]".


### PR DESCRIPTION
That avoids the standard Erlang term scanner, parser.
