### PR TITLE
Test flake chase: fix more flakes and one repeatable bug

### DIFF
--- a/deps/amqp_client/test/system_SUITE.erl
+++ b/deps/amqp_client/test/system_SUITE.erl
@@ -761,7 +761,11 @@ channel_multi_open_close(Config) ->
             end
         end) || _ <- lists:seq(1, 50)],
     erlang:yield(),
-    amqp_connection:close(Connection),
+    try amqp_connection:close(Connection)
+    catch
+        exit:{noproc, _}       -> ok;
+        exit:{{shutdown, _}, _} -> ok
+    end,
     wait_for_death(Connection).
 
 %% -------------------------------------------------------------------
@@ -1313,7 +1317,11 @@ bogus_rpc(Config) ->
     end,
     wait_for_death(Channel),
     true = is_process_alive(Connection),
-    amqp_connection:close(Connection).
+    try amqp_connection:close(Connection)
+    catch
+        exit:{noproc, _}       -> ok;
+        exit:{{shutdown, _}, _} -> ok
+    end.
 
 %% -------------------------------------------------------------------
 
@@ -1560,9 +1568,17 @@ setup_publish(Channel, Payload) ->
     {ok, Q}.
 
 teardown(Connection, Channel) ->
-    amqp_channel:close(Channel),
+    try amqp_channel:close(Channel)
+    catch
+        exit:{noproc, _}       -> ok;
+        exit:{{shutdown, _}, _} -> ok
+    end,
     wait_for_death(Channel),
-    ?assertEqual(ok, amqp_connection:close(Connection)),
+    try amqp_connection:close(Connection)
+    catch
+        exit:{noproc, _}       -> ok;
+        exit:{{shutdown, _}, _} -> ok
+    end,
     wait_for_death(Connection).
 
 wait_for_death(Pid) ->

--- a/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
+++ b/deps/rabbitmq_management/test/rabbit_mgmt_only_http_SUITE.erl
@@ -386,30 +386,31 @@ queues_test(Config) ->
     http_put(Config, "/queues/downvhost/bar", Good, {group, '2xx'}),
 
     rabbit_ct_broker_helpers:force_vhost_failure(Config, <<"downvhost">>),
-    %% The vhost is down
     Node = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
     DownVHost = #{name => <<"downvhost">>, tracing => false, cluster_state => #{Node => <<"stopped">>}},
-    assert_item(DownVHost, http_get(Config, "/vhosts/downvhost")),
-
-    DownQueues = http_get(Config, "/queues/downvhost"),
-    DownQueue  = http_get(Config, "/queues/downvhost/foo"),
-
-    assert_list([#{name        => <<"bar">>,
-                   vhost       => <<"downvhost">>,
-                   state       => <<"stopped">>,
-                   durable     => true,
-                   auto_delete => false,
-                   exclusive   => false,
-                   arguments   => #{'x-queue-type' => <<"classic">>}
-                 },
-                 #{name        => <<"foo">>,
-                   vhost       => <<"downvhost">>,
-                   state       => <<"stopped">>,
-                   durable     => true,
-                   auto_delete => false,
-                   exclusive   => false,
-                   arguments   => #{'x-queue-type' => <<"classic">>}
-                  }], DownQueues),
+    await_condition(
+      fun() ->
+              assert_item(DownVHost, http_get(Config, "/vhosts/downvhost")),
+              DownQueues = http_get(Config, "/queues/downvhost"),
+              assert_list([#{name        => <<"bar">>,
+                             vhost       => <<"downvhost">>,
+                             state       => <<"stopped">>,
+                             durable     => true,
+                             auto_delete => false,
+                             exclusive   => false,
+                             arguments   => #{'x-queue-type' => <<"classic">>}
+                           },
+                           #{name        => <<"foo">>,
+                             vhost       => <<"downvhost">>,
+                             state       => <<"stopped">>,
+                             durable     => true,
+                             auto_delete => false,
+                             exclusive   => false,
+                             arguments   => #{'x-queue-type' => <<"classic">>}
+                            }], DownQueues),
+              true
+      end),
+    DownQueue = http_get(Config, "/queues/downvhost/foo"),
     assert_item(#{name        => <<"foo">>,
                   vhost       => <<"downvhost">>,
                   state       => <<"stopped">>,

--- a/deps/rabbitmq_mqtt/test/v5_SUITE.erl
+++ b/deps/rabbitmq_mqtt/test/v5_SUITE.erl
@@ -1030,6 +1030,10 @@ subscription_options_modify_qos(Qos, Config) ->
     Pub = connect(<<"publisher">>, Config),
     Sub = connect(<<"subscriber">>, Config),
     {ok, _, [Qos]} = emqtt:subscribe(Sub, Topic, Qos),
+    %% Confirm that the subscription route is active before starting
+    %% the fast sender loop, otherwise message "1" can be lost.
+    {ok, _} = emqtt:publish(Pub, Topic, <<"warmup">>, qos1),
+    ok = expect_publishes(Sub, Topic, [<<"warmup">>]),
     Sender = spawn_link(?MODULE, send, [self(), Pub, Topic, 0]),
     receive {publish, #{payload := <<"1">>,
                         properties := Props}} ->
@@ -1079,6 +1083,10 @@ session_upgrade_v3_v5_qos(Qos, Config) ->
                     non_clean_sess_opts()),
     ?assertEqual(3, proplists:get_value(proto_ver, emqtt:info(Subv3))),
     {ok, _, [Qos]} = emqtt:subscribe(Subv3, Topic, Qos),
+    %% Use QoS 0 for the warmup so it is not stored for redelivery
+    %% when the session is resumed with clean_start=false.
+    ok = emqtt:publish(Pub, Topic, <<"warmup">>, qos0),
+    ok = expect_publishes(Subv3, Topic, [<<"warmup">>]),
     Sender = spawn_link(?MODULE, send, [self(), Pub, Topic, 0]),
     receive {publish, #{payload := <<"1">>,
                         client_pid := Subv3}} -> ok

--- a/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/amqp091_static_SUITE.erl
@@ -198,7 +198,7 @@ invalid_legacy_configuration1(_Config) ->
         test_broken_shovel_config([{publish_properties, [invalid]} | Config]),
 
     {{invalid_ssl_parameter, fail_if_no_peer_cert, "42", _,
-      {require_boolean, '42'}}, _} =
+      {require_boolean, "42"}}, _} =
         test_broken_shovel_sources([{broker, "amqps://username:password@host:5673/vhost?cacertfile=/path/to/cacert.pem&certfile=/path/to/certfile.pem&keyfile=/path/to/keyfile.pem&verify=verify_peer&fail_if_no_peer_cert=42"}]),
 
     passed.


### PR DESCRIPTION
AMQP 0-9-1 client URI parser now returns strings instead of atoms #16063, and one test was not updated.

Other are flakes.
