### PR TITLE
Remove an endpoint that's fallen out of use

### DIFF
--- a/deps/rabbitmq_management/priv/www/api/index.html
+++ b/deps/rabbitmq_management/priv/www/api/index.html
@@ -1334,17 +1334,6 @@ or:
         </td>
       </tr>
       <tr>
-        <td>X</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td class="path">/api/auth</td>
-        <td>
-          Details about the OAuth2 configuration. It will return HTTP
-          status 200 with body: <pre>{"oauth_enabled":"boolean", "oauth_client_id":"string", "oauth_provider_url":"string"}</pre>
-        </td>
-      </tr>
-      <tr>
         <td></td>
         <td></td>
         <td></td>

--- a/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_dispatcher.erl
@@ -215,7 +215,6 @@ dispatcher() ->
      {"/reset",                                                rabbit_mgmt_wm_reset, []},
      {"/reset/:node",                                          rabbit_mgmt_wm_reset, []},
      {"/rebalance/queues",                                     rabbit_mgmt_wm_rebalance_queues, [{queues, all}]},
-     {"/auth",                                                 rabbit_mgmt_wm_auth, []},
      {"/auth/attempts/:node",                                  rabbit_mgmt_wm_auth_attempts, [all]},
      {"/auth/attempts/:node/source",                           rabbit_mgmt_wm_auth_attempts, [by_source]},
      {"/login",                                                rabbit_mgmt_wm_login, []},

--- a/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
+++ b/deps/rabbitmq_management/src/rabbit_mgmt_wm_auth.erl
@@ -7,8 +7,6 @@
 
 -module(rabbit_mgmt_wm_auth).
 
--export([init/2, to_json/2, content_types_provided/2, is_authorized/2]).
--export([variances/2]).
 -export([authSettings/0]). %% for testing only
 
 -include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
@@ -16,15 +14,6 @@
 -include_lib("kernel/include/logger.hrl").
 
 %%--------------------------------------------------------------------
-
-init(Req, _State) ->
-    {cowboy_rest, rabbit_mgmt_headers:set_common_permission_headers(Req, ?MODULE), #context{}}.
-
-variances(Req, Context) ->
-    {[<<"accept-encoding">>, <<"origin">>], Req, Context}.
-
-content_types_provided(ReqData, Context) ->
-    {rabbit_mgmt_util:responder_map(to_json), ReqData, Context}.
 
 merge_property(Key, List, MapIn) ->
     case proplists:get_value(Key, List) of
@@ -220,12 +209,6 @@ filter_empty_properties(ListOfProperties) ->
 
 to_binary(Value) when is_boolean(Value)-> Value;
 to_binary(Value) -> rabbit_data_coercion:to_binary(Value).
-
-to_json(ReqData, Context) ->
-   rabbit_mgmt_util:reply(authSettings(), ReqData, Context).
-
-is_authorized(ReqData, Context) ->
-    {true, ReqData, Context}.
 
 is_invalid(List) ->
     lists:any(fun(V) -> case V of


### PR DESCRIPTION
This api/auth endpoint is not used since `bootstrap.js` generated file was introduced back in 2023. 
However, bootstrap.js still has credential information required to authenticate users hence it cannot be protected.

I have marked as a bug fix but we are not removing functionality.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI
