### PR TITLE
Startup banner: remove Erlang cookie hash

### DIFF
--- a/deps/rabbit/src/rabbit.erl
+++ b/deps/rabbit/src/rabbit.erl
@@ -1411,7 +1411,6 @@ log_banner() ->
     Settings = [{"node",           node()},
                 {"home dir",       home_dir()},
                 {"config file(s)", config_files()},
-                {"cookie hash",    rabbit_nodes:cookie_hash()},
                 {"log(s)",         FirstLog}] ++
                OtherLogs ++
                [{"data dir",       data_dir()}],


### PR DESCRIPTION
Introduced during a period where CLI/cookie
mismatches were a common source of questions, this
value is both no longer needed and
has become a security audit liability.
