### PR TITLE
`rabbitmq_auth_backend_cache`: delegate `expiry_timestamp/1` and `update_state/2`

### DIFF
--- a/deps/rabbit/src/rabbit_access_control.erl
+++ b/deps/rabbit/src/rabbit_access_control.erl
@@ -403,7 +403,7 @@ check_user_id0(ClaimedUserName, #user{username = ActualUserName,
 
 -spec update_state(User :: rabbit_types:user(), NewState :: term()) ->
     {'ok', rabbit_types:user()} |
-    {'refused', string()} |
+    {'refused', string(), [any()]} |
     {'error', any()}.
 
 update_state(User = #user{authz_backends = Backends0}, NewState) ->

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -1387,7 +1387,7 @@ handle_method0(#'connection.update_secret'{new_secret = NewSecret, reason = Reas
           [dynamic_connection_name(ConnName), Username, Reason]),
         State1 = State#v1{connection = Conn#connection{user = User1}},
         maybe_start_credential_expiry_timer(User1, State1);
-      {refused, Message} ->
+      {refused, Message, _Args} ->
         ?LOG_ERROR("Secret update was refused for user '~ts': ~tp",
                                     [Username, Message]),
         rabbit_misc:protocol_error(not_allowed, "New secret was refused by one of the backends", []);

--- a/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
+++ b/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache.erl
@@ -14,10 +14,15 @@
 
 -export([user_login_authentication/2, user_login_authorization/2,
          check_vhost_access/3, check_resource_access/4, check_topic_access/4,
-         expiry_timestamp/1, clear_cache_cluster_wide/0, clear_cache/0]).
+         update_state/2, expiry_timestamp/1,
+         clear_cache_cluster_wide/0, clear_cache/0]).
 
 %% API
 
+-spec user_login_authentication(rabbit_types:username(), [term()] | map()) ->
+    {'ok', rabbit_types:auth_user()} |
+    {'refused', string(), [any()]} |
+    {'error', any()}.
 user_login_authentication(Username, AuthProps) ->
     with_cache(authn, {user_login_authentication, [Username, AuthProps]},
         fun({ok, _})          -> success;
@@ -26,6 +31,11 @@ user_login_authentication(Username, AuthProps) ->
            (_)                -> unknown
         end).
 
+-spec user_login_authorization(rabbit_types:username(), [term()] | map()) ->
+    {'ok', any()} |
+    {'ok', any(), any()} |
+    {'refused', string(), [any()]} |
+    {'error', any()}.
 user_login_authorization(Username, AuthProps) ->
     with_cache(authz, {user_login_authorization, [Username, AuthProps]},
         fun({ok, _})      -> success;
@@ -35,24 +45,46 @@ user_login_authorization(Username, AuthProps) ->
            (_)                -> unknown
         end).
 
+-spec check_vhost_access(rabbit_types:auth_user(), rabbit_types:vhost(),
+                         rabbit_types:authz_data()) ->
+    boolean() | {'error', any()}.
 check_vhost_access(#auth_user{} = AuthUser, VHostPath, AuthzData) ->
     with_cache(authz,
                {check_vhost_access, [AuthUser, VHostPath, AuthzData]},
                fun convert_backend_result/1).
 
+-spec check_resource_access(rabbit_types:auth_user(), rabbit_types:r(atom()),
+                            rabbit_types:permission_atom(),
+                            rabbit_types:authz_context()) ->
+    boolean() | {'error', any()}.
 check_resource_access(#auth_user{} = AuthUser,
                       #resource{} = Resource, Permission, AuthzContext) ->
     with_cache(authz,
                {check_resource_access, [AuthUser, Resource, Permission, AuthzContext]},
                fun convert_backend_result/1).
 
+-spec check_topic_access(rabbit_types:auth_user(), rabbit_types:r(atom()),
+                         rabbit_types:permission_atom(),
+                         rabbit_types:topic_access_context()) ->
+    boolean() | {'error', any()}.
 check_topic_access(#auth_user{} = AuthUser,
                    #resource{} = Resource, Permission, Context) ->
     with_cache(authz,
                {check_topic_access, [AuthUser, Resource, Permission, Context]},
                fun convert_backend_result/1).
 
-expiry_timestamp(_) -> never.
+-spec expiry_timestamp(rabbit_types:auth_user()) -> integer() | never.
+expiry_timestamp(AuthUser) ->
+    Backend = get_cached_backend(authz),
+    Backend:expiry_timestamp(AuthUser).
+
+-spec update_state(rabbit_types:auth_user(), term()) ->
+    {'ok', rabbit_types:auth_user()} |
+    {'refused', string(), [any()]} |
+    {'error', any()}.
+update_state(AuthUser, NewState) ->
+    Backend = get_cached_backend(authz),
+    Backend:update_state(AuthUser, NewState).
 
 %%
 %% Implementation

--- a/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache_app.erl
+++ b/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_backend_cache_app.erl
@@ -13,6 +13,8 @@
 -behaviour(supervisor).
 -export([init/1]).
 
+-include_lib("kernel/include/logger.hrl").
+
 start(_Type, _StartArgs) ->
     supervisor:start_link({local,?MODULE},?MODULE,[]).
 
@@ -34,4 +36,21 @@ init([]) ->
                   permanent, 5000, worker, [AuthCache]}];
         false -> []
     end,
+    validate_cached_backend(),
     {ok, {{one_for_one,3,10}, ChildSpecs}}.
+
+validate_cached_backend() ->
+    {ok, BackendConfig} = application:get_env(rabbitmq_auth_backend_cache,
+                                              cached_backend),
+    Backends = case BackendConfig of
+                   Mod when is_atom(Mod) -> [Mod];
+                   {N, Z}               -> [N, Z]
+               end,
+    case lists:member(rabbit_auth_backend_cache, Backends) of
+        true ->
+            ?LOG_ERROR(
+                "Auth backend cache: cached_backend must not be set "
+                "to rabbit_auth_backend_cache (the cache cannot wrap itself)");
+        false ->
+            ok
+    end.

--- a/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
+++ b/deps/rabbitmq_auth_backend_oauth2/src/rabbit_auth_backend_oauth2.erl
@@ -93,6 +93,10 @@ check_vhost_access(#auth_user{impl = DecodedTokenFun},
             rabbit_oauth2_scope:vhost_access(VHost, Scopes)
         end).
 
+-spec check_resource_access(rabbit_types:auth_user(), rabbit_types:r(atom()),
+                            rabbit_types:permission_atom(),
+                            rabbit_types:authz_context()) ->
+    boolean() | {'error', any()}.
 check_resource_access(#auth_user{impl = DecodedTokenFun},
                       Resource, Permission, _AuthzContext) ->
     with_decoded_token(DecodedTokenFun(),
@@ -101,6 +105,10 @@ check_resource_access(#auth_user{impl = DecodedTokenFun},
             rabbit_oauth2_scope:resource_access(Resource, Permission, Scopes)
         end).
 
+-spec check_topic_access(rabbit_types:auth_user(), rabbit_types:r(atom()),
+                         rabbit_types:permission_atom(),
+                         rabbit_types:topic_access_context()) ->
+    boolean() | {'error', any()}.
 check_topic_access(#auth_user{impl = DecodedTokenFun},
                    Resource, Permission, Context) ->
     with_decoded_token(DecodedTokenFun(),
@@ -109,6 +117,10 @@ check_topic_access(#auth_user{impl = DecodedTokenFun},
             rabbit_oauth2_scope:topic_access(Resource, Permission, Context, Scopes)
         end).
 
+-spec update_state(rabbit_types:auth_user(), term()) ->
+    {'ok', rabbit_types:auth_user()} |
+    {'refused', string(), [any()]} |
+    {'error', any()}.
 update_state(AuthUser, NewToken) ->
     case resolve_resource_server(NewToken) of
         {error, _} = Err0 -> Err0;
@@ -116,9 +128,9 @@ update_state(AuthUser, NewToken) ->
             case check_token(NewToken, Tuple) of
                 %% avoid logging the token
                 {refused, {error, {invalid_token, error, _Err, _Stacktrace}}} ->
-                    {refused, "Authentication using an OAuth 2/JWT token failed: provided token is invalid"};
+                    {refused, "Authentication using an OAuth 2/JWT token failed: provided token is invalid", []};
                 {refused, Err} ->
-                    {refused, rabbit_misc:format("Authentication using an OAuth 2/JWT token failed: ~tp", [Err])};
+                    {refused, rabbit_misc:format("Authentication using an OAuth 2/JWT token failed: ~tp", [Err]), []};
                 {ok, DecodedToken} ->
                     CurToken = AuthUser#auth_user.impl,
                     case ensure_same_username(
@@ -130,11 +142,12 @@ update_state(AuthUser, NewToken) ->
                                                     impl = fun() -> DecodedToken end}};
                         {error, mismatch_username_after_token_refresh} ->
                             {refused,
-                                "Not allowed to change username on refreshed token"}
+                                "Not allowed to change username on refreshed token", []}
                     end
             end
     end.
 
+-spec expiry_timestamp(rabbit_types:auth_user()) -> integer() | never.
 expiry_timestamp(#auth_user{impl = DecodedTokenFun}) ->
     case DecodedTokenFun() of
         #{<<"exp">> := Exp} when is_integer(Exp) ->


### PR DESCRIPTION
to the wrapped backend.

Note that the previous implementation was that way due to a concern about infinite recursion.

The only scenario where this was possible is now
make impossible by boot time validation performed
by the cache plugin on startup.
