### PR TITLE
LDAP: handle DN template values per RFC 4514

### DIFF
--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_auth_backend_ldap.erl
@@ -246,7 +246,7 @@ evaluate0({for, []}, _Args, _User, _LDAP) ->
 evaluate0({exists, DNPattern}, Args, _User, LDAP) ->
     %% eldap forces us to have a filter. objectClass should always be there.
     Filter = eldap:present("objectClass"),
-    DN = fill(DNPattern, Args),
+    DN = fill_dn(DNPattern, Args),
     R = object_exists(DN, Filter, LDAP),
     ?L1("evaluated exists for \"~ts\": ~tp", [DN, R]),
     R;
@@ -258,7 +258,7 @@ evaluate0({in_group, DNPattern, Desc}, Args,
           #auth_user{impl = ImplFun}, LDAP) ->
     UserDN = (ImplFun())#impl.user_dn,
     Filter = eldap:equalityMatch(Desc, UserDN),
-    DN = fill(DNPattern, Args),
+    DN = fill_dn(DNPattern, Args),
     R = object_exists(DN, Filter, LDAP),
     ?L1("evaluated in_group for \"~ts\": ~tp", [DN, R]),
     R;
@@ -277,7 +277,7 @@ evaluate0({in_group_nested, DNPattern, Desc, Scope}, Args,
                      B ->
                          B
                  end,
-    GroupDN = fill(DNPattern, Args),
+    GroupDN = fill_dn(DNPattern, Args),
     EldapScope =
         case Scope of
             subtree      -> eldap:wholeSubtree();
@@ -368,7 +368,7 @@ evaluate0({string, StringPattern}, Args, _User, _LDAP) ->
     R;
 
 evaluate0({attribute, DNPattern, AttributeName}, Args, _User, LDAP) ->
-    DN = fill(DNPattern, Args),
+    DN = fill_dn(DNPattern, Args),
     R = attribute(DN, AttributeName, LDAP),
     ?L1("evaluated attribute \"~ts\" for \"~ts\": ~tp",
         [AttributeName, DN, format_multi_attr(R)]),
@@ -880,7 +880,9 @@ username_to_dn_prebind(Username) ->
               fun (LDAP) -> dn_lookup(Username, LDAP) end).
 
 username_to_dn(Username, LDAP,  postbind) -> dn_lookup(Username, LDAP);
-username_to_dn(Username, _LDAP, _When)    -> fill_user_dn_pattern(Username).
+username_to_dn(Username, _LDAP, _When)    ->
+    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
+    fill_dn(env(user_dn_pattern), [{username, Username}] ++ ADArgs).
 
 dn_lookup(Username, LDAP) ->
     Filled = fill_user_dn_pattern(Username),
@@ -911,10 +913,11 @@ simple_bind_fill_pattern(Username) ->
     simple_bind_fill_pattern(env(user_bind_pattern), Username).
 
 simple_bind_fill_pattern(none, Username) ->
-    fill_user_dn_pattern(Username);
+    ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
+    fill_dn(env(user_dn_pattern), [{username, Username}] ++ ADArgs);
 simple_bind_fill_pattern(Pattern, Username) ->
     ADArgs = rabbit_auth_backend_ldap_util:get_active_directory_args(Username),
-    fill(Pattern, [{username, Username}] ++ ADArgs).
+    fill_dn(Pattern, [{username, Username}] ++ ADArgs).
 
 creds(User) -> creds(User, env(other_bind)).
 
@@ -982,6 +985,12 @@ fill(Fmt, Args) ->
     ?L2("filling template \"~ts\" with~n            ~tp", [Fmt, Args]),
     R = rabbit_auth_backend_ldap_util:fill(Fmt, Args),
     ?L2("template result: \"~ts\"", [R]),
+    R.
+
+fill_dn(Fmt, Args) ->
+    ?L2("filling DN template \"~ts\" with~n            ~tp", [Fmt, Args]),
+    R = rabbit_ldap_rfc4514:fill_dn(Fmt, Args),
+    ?L2("DN template result: \"~ts\"", [R]),
     R.
 
 log_result({ok, #auth_user{}}) -> ok;

--- a/deps/rabbitmq_auth_backend_ldap/src/rabbit_ldap_rfc4514.erl
+++ b/deps/rabbitmq_auth_backend_ldap/src/rabbit_ldap_rfc4514.erl
@@ -1,0 +1,67 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+%% RFC 4514 — String Representation of Distinguished Names.
+%%
+%% This module escapes values for safe inclusion in DN attribute value
+%% positions, preventing DN injection when untrusted input (usernames,
+%% vhost names, resource names) is substituted into DN templates.
+-module(rabbit_ldap_rfc4514).
+
+-export([escape_value/1, fill_dn/2]).
+
+%% Fills an LDAP DN template with RFC 4514-escaped substitution values.
+%%
+%% Delegates to rabbit_auth_backend_ldap_util:fill/2 after escaping all
+%% values. The `user_dn' key is excluded from escaping because it holds
+%% a complete Distinguished Name (from a prior LDAP lookup or DN
+%% pattern fill), not a component value.
+-spec fill_dn(string(), [{atom(), term()}]) -> string().
+fill_dn(Fmt, Args) ->
+    rabbit_auth_backend_ldap_util:fill(
+      Fmt, [{K, escape_arg(K, V)} || {K, V} <- Args]).
+
+escape_arg(user_dn, V) -> V;
+escape_arg(_, V)        -> escape_value(V).
+
+%% Escapes a value for safe inclusion in an RFC 4514 DN attribute value.
+%%
+%% Per Section 2.4, the following are backslash-escaped:
+%%   - Characters: , + " \ < > ; and NUL
+%%   - A leading SPACE or #
+%%   - A trailing SPACE
+-spec escape_value(term()) -> term().
+escape_value(V) when is_binary(V) ->
+    list_to_binary(escape_value(binary_to_list(V)));
+escape_value(V) when is_atom(V) ->
+    escape_value(atom_to_list(V));
+escape_value([]) ->
+    [];
+escape_value([H | T]) when H =:= $\s; H =:= $# ->
+    [$\\, H | escape_middle(T)];
+escape_value(V) when is_list(V) ->
+    escape_middle(V);
+escape_value(V) ->
+    V.
+
+escape_middle([])      -> [];
+escape_middle([$\s])   -> [$\\, $\s];
+escape_middle([H | T]) ->
+    case is_special(H) of
+        true  -> [$\\, H | escape_middle(T)];
+        false -> [H | escape_middle(T)]
+    end.
+
+is_special($,)  -> true;
+is_special($+)  -> true;
+is_special($")  -> true;
+is_special($\\) -> true;
+is_special($<)  -> true;
+is_special($>)  -> true;
+is_special($;)  -> true;
+is_special(0)   -> true;
+is_special(_)   -> false.

--- a/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/rabbit_ldap_seed.erl
@@ -188,7 +188,12 @@ jimmy() ->
       {"description", ["^RMQ-foobar", "^RMQ-.*$"]}]}.
 
 add(H, {A, B}) ->
-    ok = eldap:add(H, A, B).
+    case eldap:add(H, A, B) of
+        ok -> ok;
+        %% The base entry may already exist when using a container-managed
+        %% slapd instance (e.g. on macOS).
+        {error, entryAlreadyExists} -> ok
+    end.
 
 connect({Host, Port}) ->
     LogOpts = [],

--- a/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/system_SUITE.erl
@@ -146,6 +146,7 @@ init_per_group(Group, Config) ->
                                               base_conf_ldap(LdapPort,
                                                              idle_timeout(Group),
                                                              pool_size(Group))),
+    rabbit_ldap_seed:delete({"localhost", LdapPort}),
     rabbit_ldap_seed:seed({"localhost", LdapPort}),
     Config4 = rabbit_ct_helpers:set_config(Config3, {ldap_port, LdapPort}),
 

--- a/deps/rabbitmq_auth_backend_ldap/test/system_SUITE_data/init-slapd.sh
+++ b/deps/rabbitmq_auth_backend_ldap/test/system_SUITE_data/init-slapd.sh
@@ -13,6 +13,20 @@ readonly binddn="cn=config"
 readonly passwd=secret
 
 case "$(uname -s)" in
+    Darwin)
+        # On macOS, slapd must already be running externally (e.g. in a
+        # container) on the requested port.
+        for seconds in 1 2 3 4 5 6 7 8 9 10; do
+            ldapsearch -x -H "$uri" -b "" -s base namingContexts >/dev/null 2>&1 && break
+            sleep 1
+        done
+        ldapsearch -x -H "$uri" -b "" -s base namingContexts >/dev/null 2>&1 || {
+            echo "ERROR: no LDAP server reachable at $uri" >&2
+            exit 1
+        }
+        echo "SLAPD_PID=0"
+        exit 0
+        ;;
     Linux)
         if [ -x /usr/bin/slapd ]
         then

--- a/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
+++ b/deps/rabbitmq_auth_backend_ldap/test/unit_SUITE.erl
@@ -16,6 +16,8 @@ all() ->
     [
      fill,
      ad_fill,
+     rfc4514_escape_value,
+     rfc4514_fill_dn,
      user_dn_pattern_gh_7161,
      format_different_types_of_ldap_attribute_values
     ].
@@ -32,6 +34,64 @@ fill(_Config) ->
     F("x${usernamex",  [{username,  "ab"}],     "x${usernamex"),
     F("x${username}x", [{username,  "a\\b"}],   "xa\\bx"),
     F("x${username}x", [{username,  "a&b"}],    "xa&bx"),
+    ok.
+
+rfc4514_escape_value(_Config) ->
+    E = fun(V, Res) ->
+                ?assertEqual(Res, rabbit_ldap_rfc4514:escape_value(V))
+        end,
+    %% No escaping needed
+    E("simple", "simple"),
+    E("", ""),
+    E(<<"binary">>, <<"binary">>),
+    E(atom, "atom"),
+    %% Comma — the primary injection vector
+    E("user,ou=Evil", "user\\,ou=Evil"),
+    %% All special characters
+    E("a+b", "a\\+b"),
+    E("a\"b", "a\\\"b"),
+    E("a\\b", "a\\\\b"),
+    E("a<b", "a\\<b"),
+    E("a>b", "a\\>b"),
+    E("a;b", "a\\;b"),
+    %% Leading space and hash
+    E(" leading", "\\ leading"),
+    E("#leading", "\\#leading"),
+    %% Trailing space
+    E("trailing ", "trailing\\ "),
+    %% Leading AND trailing space
+    E(" both ", "\\ both\\ "),
+    %% Middle space is not escaped
+    E("a b", "a b"),
+    %% Multiple specials
+    E("a,b+c", "a\\,b\\+c"),
+    %% Backslash + comma (escape-the-escape attack)
+    E("a\\,b", "a\\\\\\,b"),
+    %% NUL byte
+    E([0], [$\\, 0]),
+    %% Single special characters
+    E(",", "\\,"),
+    E("\\", "\\\\"),
+    %% Non-string passthrough
+    E(42, 42),
+    E({1,2,3}, {1,2,3}),
+    ok.
+
+rfc4514_fill_dn(_Config) ->
+    F = fun(Fmt, Args, Res) ->
+                ?assertEqual(Res, rabbit_ldap_rfc4514:fill_dn(Fmt, Args))
+        end,
+    %% DN injection prevented
+    F("cn=${username},ou=People", [{username, "user,ou=Evil"}],
+      "cn=user\\,ou=Evil,ou=People"),
+    %% user_dn is NOT escaped (it is already a complete DN)
+    F("${user_dn}", [{user_dn, "cn=John,ou=People,dc=example"}],
+      "cn=John,ou=People,dc=example"),
+    %% Mixed: user_dn passed through, username escaped
+    F("${user_dn}", [{user_dn, "cn=a,dc=b"}, {username, "x,y"}],
+      "cn=a,dc=b"),
+    F("cn=${username},dc=b", [{user_dn, "cn=a,dc=b"}, {username, "x,y"}],
+      "cn=x\\,y,dc=b"),
     ok.
 
 ad_fill(_Config) ->


### PR DESCRIPTION
A drive-by change: make `init-slapd.sh` macOS-friendlier.