### PR TITLE
Expand MFAs inside migrations list

### DIFF
--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -2347,22 +2347,6 @@ mnesia_tables_from_mfa(Mod, Fun, Args) ->
     Ret.
 
 do_migrate_mnesia_tables(FeatureName, Migrations) ->
-    Tables = lists:flatmap(
-               fun
-                   ({Table, _Mod}) when is_atom(Table) ->
-                       [Table];
-                   (Table) when is_atom(Table) ->
-                       [Table];
-                   ({{mfa, Mod, Fun, Args}, _Mod}) when is_atom(Mod),
-                                                        is_atom(Fun),
-                                                        is_list(Args) ->
-                       mnesia_tables_from_mfa(Mod, Fun, Args);
-                   ({mfa, Mod, Fun, Args}) when is_atom(Mod),
-                                                is_atom(Fun),
-                                                is_list(Args) ->
-                       mnesia_tables_from_mfa(Mod, Fun, Args)
-               end,
-               Migrations),
     %% Expand MFA-based entries to {Table, Mod} pairs with actual atom table
     %% names so that rabbit_db_m2k_converter can look up converters by table.
     ExpandedMigrations = lists:flatmap(
@@ -2382,6 +2366,14 @@ do_migrate_mnesia_tables(FeatureName, Migrations) ->
                        mnesia_tables_from_mfa(Mod, Fun, Args)
                end,
                Migrations),
+    Tables = lists:map(
+               fun
+                   ({Table, _Mod}) when is_atom(Table) ->
+                       Table;
+                   (Table) when is_atom(Table) ->
+                       Table
+               end,
+               ExpandedMigrations),
     ?LOG_NOTICE(
        "Feature flags: `~ts`: starting migration of ~b tables from Mnesia "
        "to Khepri; expect decrease in performance and increase in memory "

--- a/deps/rabbit/src/rabbit_khepri.erl
+++ b/deps/rabbit/src/rabbit_khepri.erl
@@ -2363,6 +2363,25 @@ do_migrate_mnesia_tables(FeatureName, Migrations) ->
                        mnesia_tables_from_mfa(Mod, Fun, Args)
                end,
                Migrations),
+    %% Expand MFA-based entries to {Table, Mod} pairs with actual atom table
+    %% names so that rabbit_db_m2k_converter can look up converters by table.
+    ExpandedMigrations = lists:flatmap(
+               fun
+                   ({Table, _Mod} = Entry) when is_atom(Table) ->
+                       [Entry];
+                   (Table) when is_atom(Table) ->
+                       [Table];
+                   ({{mfa, Mod, Fun, Args}, ConverterMod}) when is_atom(Mod),
+                                                                is_atom(Fun),
+                                                                is_list(Args) ->
+                       [{T, ConverterMod}
+                        || T <- mnesia_tables_from_mfa(Mod, Fun, Args)];
+                   ({mfa, Mod, Fun, Args}) when is_atom(Mod),
+                                                is_atom(Fun),
+                                                is_list(Args) ->
+                       mnesia_tables_from_mfa(Mod, Fun, Args)
+               end,
+               Migrations),
     ?LOG_NOTICE(
        "Feature flags: `~ts`: starting migration of ~b tables from Mnesia "
        "to Khepri; expect decrease in performance and increase in memory "
@@ -2372,7 +2391,7 @@ do_migrate_mnesia_tables(FeatureName, Migrations) ->
     rabbit_mnesia:wait(Tables, _Retry = true),
     Ret = mnesia_to_khepri:copy_tables(
             ?STORE_ID, ?MIGRATION_ID, Tables,
-            {rabbit_db_m2k_converter, Migrations}),
+            {rabbit_db_m2k_converter, ExpandedMigrations}),
     case Ret of
         ok ->
             ?LOG_NOTICE(


### PR DESCRIPTION
## Proposed Changes

In https://github.com/rabbitmq/rabbitmq-server/pull/16042#issuecomment-4239910356 we introduced a change to allow MFAs to be provided to `rabbit_khepri` through the `rabbit_mnesia_tables_to_khepri_db` module attribute, as an alternative to providing just mnesia table names. 

`rabbit_khepri`, when processing the list of tables to migrate from mnesia to khperi, can process a `{mfa,M, F, A}` in that list by evaluating the mfa to obtain a dynamic (generated in runtime) sublist of tables to migrate.

However, the `Migrations` list needs to be expanded before passing it to `mnesia_to_khepri:copy_tables`, so that we don't pass a `list({{mfa,...}, ConverterMod})` but a `list(Table, ConverterMod)`.

The need for this change has been tested by:
- Cloning this branch.
- Cloning https://github.com/cloudamqp/rabbitmq-delayed-message-exchange/tree/from-mnesia-to-leveled as a rabbit dependency for the previous cloned repo.
- running the `make ct-plugin` suite in the dependency repo.