### PR TITLE
Revert CQ shared store: Delete from index on remove or roll over (#13959)

### DIFF
--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -80,8 +80,6 @@
           current_file_handle,
           %% current write file offset
           current_file_offset,
-          %% messages that were potentially removed from the current write file
-          current_file_removes = [],
           %% TRef for our interval timer
           sync_timer_ref,
           %% files that had removes
@@ -1166,11 +1164,7 @@ write_message(MsgId, Msg, CRef,
               end, CRef, State1)
     end.
 
-remove_message(MsgId, CRef,
-               State = #msstate{
-                        index_ets = IndexEts,
-                        current_file = CurrentFile,
-                        current_file_removes = Removes }) ->
+remove_message(MsgId, CRef, State = #msstate{ index_ets = IndexEts }) ->
     case should_mask_action(CRef, MsgId, State) of
         {true, _Location} ->
             State;
@@ -1182,32 +1176,22 @@ remove_message(MsgId, CRef,
             %% ets:lookup(FileSummaryEts, File),
             State;
         {_Mask, #msg_location { ref_count = RefCount, file = File,
-                                total_size = TotalSize } = Entry}
+                                total_size = TotalSize }}
           when RefCount > 0 ->
             %% only update field, otherwise bad interaction with
             %% concurrent GC
+            Dec = fun () -> index_update_ref_counter(IndexEts, MsgId, -1) end,
             case RefCount of
                 %% Don't remove from cur_file_cache_ets here because
                 %% there may be further writes in the mailbox for the
-                %% same msg. We will remove 0 ref_counts when rolling
-                %% over to the next write file.
-                1 when File =:= CurrentFile ->
-                    index_update_ref_counter(IndexEts, MsgId, -1),
-                    State1 = State#msstate{current_file_removes =
-                        [Entry#msg_location{ref_count=0}|Removes]},
-                    delete_file_if_empty(
-                      File, gc_candidate(File,
-                        adjust_valid_total_size(
-                              File, -TotalSize, State1)));
-                1 ->
-                    index_delete(IndexEts, MsgId),
-                    delete_file_if_empty(
-                      File, gc_candidate(File,
-                        adjust_valid_total_size(
-                              File, -TotalSize, State)));
-                _ ->
-                    index_update_ref_counter(IndexEts, MsgId, -1),
-                    gc_candidate(File, State)
+                %% same msg.
+                1 -> ok = Dec(),
+                     delete_file_if_empty(
+                       File, gc_candidate(File,
+                         adjust_valid_total_size(
+                               File, -TotalSize, State)));
+                _ -> ok = Dec(),
+                     gc_candidate(File, State)
             end
     end.
 
@@ -1269,9 +1253,7 @@ flush_or_roll_to_new_file(
                      cur_file_cache_ets  = CurFileCacheEts,
                      file_size_limit     = FileSizeLimit })
   when Offset >= FileSizeLimit ->
-    %% Cleanup the index of messages that were removed before rolling over.
-    State0 = cleanup_index_on_roll_over(State),
-    State1 = internal_sync(State0),
+    State1 = internal_sync(State),
     ok = writer_close(CurHdl),
     NextFile = CurFile + 1,
     {ok, NextHdl} = writer_open(Dir, NextFile),
@@ -1299,8 +1281,6 @@ write_large_message(MsgId, MsgBodyBin,
                                   index_ets           = IndexEts,
                                   file_summary_ets    = FileSummaryEts,
                                   cur_file_cache_ets  = CurFileCacheEts }) ->
-    %% Cleanup the index of messages that were removed before rolling over.
-    State1 = cleanup_index_on_roll_over(State0),
     {LargeMsgFile, LargeMsgHdl} = case CurOffset of
         %% We haven't written in the file yet. Use it.
         0 ->
@@ -1320,13 +1300,13 @@ write_large_message(MsgId, MsgBodyBin,
     ok = index_insert(IndexEts,
            #msg_location { msg_id = MsgId, ref_count = 1, file = LargeMsgFile,
                            offset = 0, total_size = TotalSize }),
-    State2 = case CurFile of
+    State1 = case CurFile of
         %% We didn't open a new file. We must update the existing value.
         LargeMsgFile ->
             [_,_] = ets:update_counter(FileSummaryEts, LargeMsgFile,
                                        [{#file_summary.valid_total_size, TotalSize},
                                         {#file_summary.file_size,        TotalSize}]),
-            State1;
+            State0;
         %% We opened a new file. We can insert it all at once.
         %% We must also check whether we need to delete the previous
         %% current file, because if there is no valid data this is
@@ -1337,7 +1317,7 @@ write_large_message(MsgId, MsgBodyBin,
                                     valid_total_size = TotalSize,
                                     file_size        = TotalSize,
                                     locked           = false }),
-            delete_file_if_empty(CurFile, State1 #msstate { current_file_handle = LargeMsgHdl,
+            delete_file_if_empty(CurFile, State0 #msstate { current_file_handle = LargeMsgHdl,
                                                             current_file        = LargeMsgFile,
                                                             current_file_offset = TotalSize })
     end,
@@ -1352,21 +1332,10 @@ write_large_message(MsgId, MsgBodyBin,
     %% Delete messages from the cache that were written to disk.
     true = ets:match_delete(CurFileCacheEts, {'_', '_', 0}),
     %% Process confirms (this won't flush; we already did) and continue.
-    State = internal_sync(State2),
+    State = internal_sync(State1),
     State #msstate { current_file_handle = NextHdl,
                      current_file        = NextFile,
                      current_file_offset = 0 }.
-
-cleanup_index_on_roll_over(State = #msstate{
-                           index_ets = IndexEts,
-                           current_file_removes = Removes}) ->
-    lists:foreach(fun(Entry) ->
-        %% We delete objects that have ref_count=0. If a message
-        %% got its ref_count increased, it will not be deleted.
-        %% We thus avoid extra index lookups to check for ref_count.
-        index_delete_object(IndexEts, Entry)
-    end, Removes),
-    State#msstate{current_file_removes=[]}.
 
 contains_message(MsgId, From, State = #msstate{ index_ets = IndexEts }) ->
     MsgLocation = index_lookup_positive_ref_count(IndexEts, MsgId),
@@ -1687,7 +1656,7 @@ index_update(IndexEts, Obj) ->
     ok.
 
 index_update_fields(IndexEts, Key, Updates) ->
-    _ = ets:update_element(IndexEts, Key, Updates),
+    true = ets:update_element(IndexEts, Key, Updates),
     ok.
 
 index_update_ref_counter(IndexEts, Key, RefCount) ->
@@ -2178,9 +2147,9 @@ truncate_file(File, Size, ThresholdTimestamp, #gc_state{ file_summary_ets = File
 
 -spec delete_file(non_neg_integer(), gc_state()) -> ok | defer.
 
-delete_file(File, #gc_state { file_summary_ets = FileSummaryEts,
-                              file_handles_ets = FileHandlesEts,
-                              dir              = Dir }) ->
+delete_file(File, State = #gc_state { file_summary_ets = FileSummaryEts,
+                                      file_handles_ets = FileHandlesEts,
+                                      dir              = Dir }) ->
     case ets:match_object(FileHandlesEts, {{'_', File}, '_'}, 1) of
         {[_|_], _Cont} ->
             ?LOG_DEBUG("Asked to delete file ~p but it has active readers. Deferring.",
@@ -2189,6 +2158,7 @@ delete_file(File, #gc_state { file_summary_ets = FileSummaryEts,
         _ ->
             [#file_summary{ valid_total_size = 0,
                             file_size = FileSize }] = ets:lookup(FileSummaryEts, File),
+            [] = scan_and_vacuum_message_file(File, State),
             ok = file:delete(form_filename(Dir, filenum_to_name(File))),
             true = ets:delete(FileSummaryEts, File),
             ?LOG_DEBUG("Deleted empty file number ~tp; reclaimed ~tp bytes", [File, FileSize]),

--- a/deps/rabbit/src/rabbit_msg_store.erl
+++ b/deps/rabbit/src/rabbit_msg_store.erl
@@ -1180,18 +1180,16 @@ remove_message(MsgId, CRef, State = #msstate{ index_ets = IndexEts }) ->
           when RefCount > 0 ->
             %% only update field, otherwise bad interaction with
             %% concurrent GC
-            Dec = fun () -> index_update_ref_counter(IndexEts, MsgId, -1) end,
+            ok = index_update_ref_counter(IndexEts, MsgId, -1),
             case RefCount of
                 %% Don't remove from cur_file_cache_ets here because
                 %% there may be further writes in the mailbox for the
                 %% same msg.
-                1 -> ok = Dec(),
-                     delete_file_if_empty(
+                1 -> delete_file_if_empty(
                        File, gc_candidate(File,
                          adjust_valid_total_size(
                                File, -TotalSize, State)));
-                _ -> ok = Dec(),
-                     gc_candidate(File, State)
+                _ -> gc_candidate(File, State)
             end
     end.
 
@@ -1656,7 +1654,7 @@ index_update(IndexEts, Obj) ->
     ok.
 
 index_update_fields(IndexEts, Key, Updates) ->
-    true = ets:update_element(IndexEts, Key, Updates),
+    _ = ets:update_element(IndexEts, Key, Updates),
     ok.
 
 index_update_ref_counter(IndexEts, Key, RefCount) ->

--- a/deps/rabbit/src/rabbit_msg_store_gc.erl
+++ b/deps/rabbit/src/rabbit_msg_store_gc.erl
@@ -12,7 +12,7 @@
 -export([start_link/1, compact/2, truncate/4, delete/2, stop/1]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, prioritise_cast/3]).
 
 -record(state,
         { pending,
@@ -50,6 +50,10 @@ delete(Server, File) ->
 
 stop(Server) ->
     gen_server2:call(Server, stop, infinity).
+
+%% TODO replace with priority messages for OTP28+
+prioritise_cast({delete, _}, _Len, _State) -> 5;
+prioritise_cast(_, _Len, _State) -> 0.
 
 %%----------------------------------------------------------------------------
 

--- a/deps/rabbit/src/rabbit_msg_store_gc.erl
+++ b/deps/rabbit/src/rabbit_msg_store_gc.erl
@@ -12,7 +12,7 @@
 -export([start_link/1, compact/2, truncate/4, delete/2, stop/1]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, prioritise_cast/3]).
+         terminate/2, code_change/3]).
 
 -record(state,
         { pending,
@@ -50,10 +50,6 @@ delete(Server, File) ->
 
 stop(Server) ->
     gen_server2:call(Server, stop, infinity).
-
-%% TODO replace with priority messages for OTP28+
-prioritise_cast({delete, _}, _Len, _State) -> 5;
-prioritise_cast(_, _Len, _State) -> 0.
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Reverts 0278980ba0 ("CQ shared store: Delete from index on remove or roll over", PR #13959), which introduced a regression in the classic queue message store GC. Three independent improvements from that commit are retained.

Fixes #16141.

## Problem

PR #13959 replaced the `scan_and_vacuum_message_file` call in `delete_file` with an eager index cleanup mechanism (`current_file_removes`). As a side effect, messages removed from non-current files now produce `not_found` index lookups during `scan_and_vacuum_message_file` instead of `previously_valid` ones. This was noted in the PR review by @gomoripeti but not addressed before merge.

Under high throughput with many queues, the byte-by-byte `scan_next_byte` scanning mode triggered by `not_found` entries causes GC compaction to fall far enough behind the publish rate that disk usage can grow without bound. The stall also causes consumer latency spikes and broker unresponsiveness on established TCP connections.

Reproduction: 100 classic queues at 500 msg/s (120 KB messages) with a slow-ack consumer queue in the same vhost (acks held 1-30 min, up to 1000 in flight). On an m7g.large with a 196 GB EBS volume, disk fell from 185.4 GB to ~169 GB in ~100 minutes. Consumer latency reached a median of 1.5s and a max of 568s.

Reproduction scripts: https://github.com/lukebakken/rmq-gc-lag

## Changes

Two commits:

1. Revert 0278980ba0 in full.
2. Restore three independent improvements from that commit that are unrelated to the broken `current_file_removes` mechanism:
   - Relax `index_update_fields` assertion (`true=` to `_=`) so a missing key does not crash the process
   - Add `prioritise_cast/3` to `rabbit_msg_store_gc` so delete requests are processed before compaction requests, avoiding unnecessary compaction of files already pending deletion
   - `compact_file/2` early-exit guard (file already deleted) was already present after the revert

## Testing

Ran the reproduction workload against this branch for 60 minutes (three consecutive 20-minute monitoring windows) at 500 msg/s with ~1000 unacked messages. Disk held stable in a 0.5 GB oscillation band (184.96-185.47 GB). Ready messages held at 0 throughout. No latency spikes.

For comparison, the same workload against unpatched `main` lost ~16 GB of disk in ~100 minutes with ready messages growing to 3500-4200.
