### PR TITLE
Web MQTT, Web STOMP: optionally validate WebSocket Origin header

### DIFF
--- a/deps/rabbitmq_ct_client_helpers/src/rfc6455_client.erl
+++ b/deps/rabbitmq_ct_client_helpers/src/rfc6455_client.erl
@@ -7,7 +7,7 @@
 
 -module(rfc6455_client).
 
--export([new/2, new/3, new/4, new/5, open/1, recv/1, recv/2, send/2, send_binary/2, close/1, close/2]).
+-export([new/2, new/3, new/4, new/5, new/6, open/1, recv/1, recv/2, send/2, send_binary/2, close/1, close/2]).
 
 -record(state, {host, port, addr, path, ppid, socket, data, phase, transport}).
 
@@ -23,6 +23,9 @@ new(WsUrl, PPid, AuthInfo, Protocols) ->
     new(WsUrl, PPid, AuthInfo, Protocols, <<>>).
 
 new(WsUrl, PPid, AuthInfo, Protocols, TcpPreface) ->
+    new(WsUrl, PPid, AuthInfo, Protocols, TcpPreface, []).
+
+new(WsUrl, PPid, AuthInfo, Protocols, TcpPreface, ExtraHeaders) ->
     _ = application:start(crypto),
     _ = application:ensure_all_started(ssl),
     {Transport, Url} = case WsUrl of
@@ -46,7 +49,7 @@ new(WsUrl, PPid, AuthInfo, Protocols, TcpPreface) ->
                    ppid = PPid,
                    transport = Transport},
     spawn_link(fun () ->
-                  start_conn(State, AuthInfo, Protocols, TcpPreface)
+                  start_conn(State, AuthInfo, Protocols, TcpPreface, ExtraHeaders)
           end).
 
 open(WS) ->
@@ -100,7 +103,7 @@ close(WS, WsReason) ->
 
 %% --------------------------------------------------------------------------
 
-start_conn(State = #state{transport = Transport}, AuthInfo, Protocols, TcpPreface) ->
+start_conn(State = #state{transport = Transport}, AuthInfo, Protocols, TcpPreface, ExtraHeaders) ->
     {ok, Socket} = case TcpPreface of
         <<>> ->
             TlsOpts = case Transport of
@@ -135,6 +138,15 @@ start_conn(State = #state{transport = Transport}, AuthInfo, Protocols, TcpPrefac
         _  -> "Sec-Websocket-Protocol: " ++ string:join(Protocols, ", ") ++ "\r\n"
     end,
 
+    OriginHd = case lists:keyfind("Origin", 1, ExtraHeaders) of
+        {_, ""} -> "";
+        {_, OriginVal} -> "Origin: " ++ OriginVal ++ "\r\n";
+        false -> "Origin: null\r\n"
+    end,
+
+    ExtraHd = lists:flatten([Name ++ ": " ++ Value ++ "\r\n"
+               || {Name, Value} <- ExtraHeaders, Name =/= "Origin"]),
+
     Key = base64:encode_to_string(crypto:strong_rand_bytes(16)),
     Transport:send(Socket,
         "GET " ++ State#state.path ++ " HTTP/1.1\r\n" ++
@@ -144,7 +156,8 @@ start_conn(State = #state{transport = Transport}, AuthInfo, Protocols, TcpPrefac
         AuthHd ++
         ProtocolHd ++
         "Sec-WebSocket-Key: " ++ Key ++ "\r\n" ++
-        "Origin: null\r\n" ++
+        OriginHd ++
+        ExtraHd ++
         "Sec-WebSocket-Version: 13\r\n\r\n"),
 
     loop(State#state{socket = Socket,

--- a/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
+++ b/deps/rabbitmq_web_mqtt/priv/schema/rabbitmq_web_mqtt.schema
@@ -26,6 +26,24 @@
 {mapping, "web_mqtt.ws_path", "rabbitmq_web_mqtt.ws_path",
     [{datatype, string}]}.
 
+{mapping, "web_mqtt.allow_origins", "rabbitmq_web_mqtt.allow_origins", [
+    {datatype, {enum, [none]}}
+]}.
+
+{mapping, "web_mqtt.allow_origins.$name", "rabbitmq_web_mqtt.allow_origins", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_web_mqtt.allow_origins",
+fun(Conf) ->
+    case cuttlefish:conf_get("web_mqtt.allow_origins", Conf, undefined) of
+        none -> [];
+        _ ->
+            Settings = cuttlefish_variable:filter_by_prefix("web_mqtt.allow_origins", Conf),
+            [V || {_, V} <- Settings]
+    end
+end}.
+
 {translation,
     "rabbitmq_web_mqtt.tcp_config",
     fun(Conf) ->

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
 -module(rabbit_web_mqtt_handler).
@@ -102,21 +102,31 @@ takeover(Parent, Ref, Socket, Transport, Opts, Buffer, {Handler, HandlerState}) 
 
 %% cowboy_websocket
 init(Req, Opts) ->
-    case cowboy_req:parse_header(<<"sec-websocket-protocol">>, Req) of
-        undefined ->
-            no_supported_sub_protocol(undefined, Req);
-        Protocol ->
-            case lists:search(fun(P) -> P =:= <<"mqtt">> orelse P =:= <<"mqttv3.1">> end, Protocol) of
-                false ->
-                    no_supported_sub_protocol(Protocol, Req);
-                {value, MatchedProtocol} ->
-                    Req1 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, MatchedProtocol, Req),
-                    State = #state{socket = maps:get(proxy_header, Req, undefined),
-                                   stats_timer = rabbit_event:init_stats_timer()},
-                    WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
-                    WsOpts  = maps:merge(#{compress => true}, WsOpts0),
-                    {?MODULE, Req1, State, WsOpts#{data_delivery => relay}}
-            end
+    case check_origin(Req) of
+        ok ->
+            case cowboy_req:parse_header(<<"sec-websocket-protocol">>, Req) of
+                undefined ->
+                    no_supported_sub_protocol(undefined, Req);
+                Protocol ->
+                    case lists:search(fun(P) -> P =:= <<"mqtt">> orelse P =:= <<"mqttv3.1">> end, Protocol) of
+                        false ->
+                            no_supported_sub_protocol(Protocol, Req);
+                        {value, MatchedProtocol} ->
+                            Req1 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, MatchedProtocol, Req),
+                            State = #state{socket = maps:get(proxy_header, Req, undefined),
+                                           stats_timer = rabbit_event:init_stats_timer()},
+                            WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
+                            WsOpts  = maps:merge(#{compress => true}, WsOpts0),
+                            {?MODULE, Req1, State, WsOpts#{data_delivery => relay}}
+                    end
+            end;
+        {error, origin_not_allowed} ->
+            ?LOG_WARNING("Web MQTT: WebSocket connection rejected, "
+                         "origin not in allow_origins: ~tp",
+                         [cowboy_req:header(<<"origin">>, Req)]),
+            {ok,
+             cowboy_req:reply(403, #{<<"connection">> => <<"close">>}, Req),
+             #state{}}
     end.
 
 %% We cannot use a gen_server call, because the handler process is a
@@ -319,11 +329,27 @@ terminate(_Reason, _Request,
 %% Internal.
 
 no_supported_sub_protocol(Protocol, Req) ->
-    %% The client MUST include “mqtt” in the list of WebSocket Sub Protocols it offers [MQTT-6.0.0-3].
+    %% The client MUST include "mqtt" in the list of WebSocket Sub Protocols it offers [MQTT-6.0.0-3].
     ?LOG_ERROR("Web MQTT: 'mqtt' not included in client offered subprotocols: ~tp", [Protocol]),
     {ok,
      cowboy_req:reply(400, #{<<"connection">> => <<"close">>}, Req),
      #state{}}.
+
+check_origin(Req) ->
+    case application:get_env(?APP, allow_origins, []) of
+        [] ->
+            ok;
+        AllowedOrigins ->
+            case cowboy_req:header(<<"origin">>, Req) of
+                undefined ->
+                    ok;
+                Origin ->
+                    case lists:member(binary_to_list(Origin), AllowedOrigins) of
+                        true -> ok;
+                        false -> {error, origin_not_allowed}
+                    end
+            end
+    end.
 
 handle_data(Data, State0 = #state{}) ->
     case handle_data1(Data, State0) of

--- a/deps/rabbitmq_web_mqtt/test/web_mqtt_origin_SUITE.erl
+++ b/deps/rabbitmq_web_mqtt/test/web_mqtt_origin_SUITE.erl
@@ -1,0 +1,146 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(web_mqtt_origin_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ALLOWED, "https://allowed.example.com").
+-define(ALLOWED2, "https://other.example.com").
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [no_allowlist_allows_any_origin,
+     allowed_origin_connects,
+     disallowed_origin_rejected,
+     no_origin_header_allowed_when_allowlist_set,
+     multiple_allowed_origins].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config,
+                                           [{rmq_nodename_suffix, ?MODULE},
+                                            {protocol, "ws"}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(no_allowlist_allows_any_origin, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, unset_env, [rabbitmq_web_mqtt, allow_origins]),
+    Config;
+init_per_testcase(multiple_allowed_origins, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_mqtt, allow_origins,
+                              [?ALLOWED, ?ALLOWED2]]),
+    Config;
+init_per_testcase(_Testcase, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_mqtt, allow_origins,
+                              [?ALLOWED]]),
+    Config.
+
+end_per_testcase(_Testcase, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, unset_env, [rabbitmq_web_mqtt, allow_origins]),
+    Config.
+
+%% When no allowlist is configured, any Origin is accepted.
+no_allowlist_allows_any_origin(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    WS = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws",
+                            self(), undefined, ["mqtt"], <<>>,
+                            [{"Origin", "https://evil.example.com"}]),
+    {ok, _} = rfc6455_client:open(WS),
+    rfc6455_client:send_binary(WS, rabbit_ws_test_util:mqtt_3_1_1_connect_packet()),
+    {binary, _ConnAck} = rfc6455_client:recv(WS, 5000),
+    rfc6455_client:send_binary(WS, <<224, 0>>),
+    {close, _} = rfc6455_client:recv(WS, 5000),
+    ok.
+
+%% A client presenting a matching Origin is accepted.
+allowed_origin_connects(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    WS = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws",
+                            self(), undefined, ["mqtt"], <<>>,
+                            [{"Origin", ?ALLOWED}]),
+    {ok, _} = rfc6455_client:open(WS),
+    rfc6455_client:send_binary(WS, rabbit_ws_test_util:mqtt_3_1_1_connect_packet()),
+    {binary, _ConnAck} = rfc6455_client:recv(WS, 5000),
+    rfc6455_client:send_binary(WS, <<224, 0>>),
+    {close, _} = rfc6455_client:recv(WS, 5000),
+    ok.
+
+%% A client presenting a non-matching Origin gets HTTP 403.
+disallowed_origin_rejected(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", "https://evil.example.com"}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"403">>)).
+
+%% When an allowlist is set, requests without an Origin header
+%% are still accepted (they originate from non-browser clients).
+no_origin_header_allowed_when_allowlist_set(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, []),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
+
+%% When multiple origins are configured, each one is accepted.
+multiple_allowed_origins(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_mqtt_port_str(Config),
+    Port = list_to_integer(PortStr),
+
+    Resp1 = raw_ws_upgrade(Port, [{"Origin", ?ALLOWED}]),
+    ?assertNotEqual(nomatch, binary:match(Resp1, <<"101">>)),
+
+    Resp2 = raw_ws_upgrade(Port, [{"Origin", ?ALLOWED2}]),
+    ?assertNotEqual(nomatch, binary:match(Resp2, <<"101">>)),
+
+    Resp3 = raw_ws_upgrade(Port, [{"Origin", "https://evil.example.com"}]),
+    ?assertNotEqual(nomatch, binary:match(Resp3, <<"403">>)).
+
+%%
+%% Helpers
+%%
+
+raw_ws_upgrade(Port, Headers) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port,
+                                 [binary, {active, false}]),
+    Key = base64:encode(crypto:strong_rand_bytes(16)),
+    OriginHd = case lists:keyfind("Origin", 1, Headers) of
+        {_, Val} -> ["Origin: ", Val, "\r\n"];
+        false -> []
+    end,
+    Req = [
+        "GET /ws HTTP/1.1\r\n",
+        "Host: 127.0.0.1:", integer_to_list(Port), "\r\n",
+        "Upgrade: websocket\r\n",
+        "Connection: Upgrade\r\n",
+        OriginHd,
+        "Sec-WebSocket-Key: ", Key, "\r\n",
+        "Sec-WebSocket-Protocol: mqtt\r\n",
+        "Sec-WebSocket-Version: 13\r\n",
+        "\r\n"
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
+    gen_tcp:close(Sock),
+    Resp.

--- a/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
+++ b/deps/rabbitmq_web_stomp/priv/schema/rabbitmq_web_stomp.schema
@@ -32,6 +32,24 @@
 {mapping, "web_stomp.ws_path", "rabbitmq_web_stomp.ws_path",
     [{datatype, string}]}.
 
+{mapping, "web_stomp.allow_origins", "rabbitmq_web_stomp.allow_origins", [
+    {datatype, {enum, [none]}}
+]}.
+
+{mapping, "web_stomp.allow_origins.$name", "rabbitmq_web_stomp.allow_origins", [
+    {datatype, string}
+]}.
+
+{translation, "rabbitmq_web_stomp.allow_origins",
+fun(Conf) ->
+    case cuttlefish:conf_get("web_stomp.allow_origins", Conf, undefined) of
+        none -> [];
+        _ ->
+            Settings = cuttlefish_variable:filter_by_prefix("web_stomp.allow_origins", Conf),
+            [V || {_, V} <- Settings]
+    end
+end}.
+
 {mapping, "web_stomp.use_http_auth", "rabbitmq_web_stomp.use_http_auth",
     [{datatype, {enum, [true, false]}}]}.
 

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
 %%
 
 -module(rabbit_web_stomp_handler).
@@ -100,33 +100,43 @@ takeover(Parent, Ref, Socket, Transport, Opts, Buffer, {Handler, HandlerState}) 
 
 %% Websocket.
 init(Req0, Opts) ->
-    logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN}),
-    {PeerAddr, _PeerPort} = maps:get(peer, Req0),
-    {_, KeepaliveSup} = lists:keyfind(keepalive_sup, 1, Opts),
-    SockInfo = maps:get(proxy_header, Req0, undefined),
-    Req = case cowboy_req:parse_header(<<"sec-websocket-protocol">>, Req0) of
-        undefined  -> Req0;
-        Protocols ->
-            case filter_stomp_protocols(Protocols) of
-                [] -> Req0;
-                [StompProtocol|_] ->
-                    cowboy_req:set_resp_header(<<"sec-websocket-protocol">>,
-                        StompProtocol, Req0)
-            end
-    end,
-    WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
-    WsOpts  = maps:merge(#{compress => true}, WsOpts0),
-    {?MODULE, Req, #state{
-        frame_type         = proplists:get_value(type, Opts, text),
-        heartbeat_sup      = KeepaliveSup,
-        heartbeat          = {none, none},
-        heartbeat_mode     = heartbeat,
-        state              = running,
-        conserve_resources = false,
-        socket             = SockInfo,
-        peername           = PeerAddr,
-        auth_hd            = cowboy_req:header(<<"authorization">>, Req)
-    }, WsOpts#{data_delivery => relay}}.
+    case check_origin(Req0) of
+        ok ->
+            logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN}),
+            {PeerAddr, _PeerPort} = maps:get(peer, Req0),
+            {_, KeepaliveSup} = lists:keyfind(keepalive_sup, 1, Opts),
+            SockInfo = maps:get(proxy_header, Req0, undefined),
+            Req = case cowboy_req:parse_header(<<"sec-websocket-protocol">>, Req0) of
+                undefined  -> Req0;
+                Protocols ->
+                    case filter_stomp_protocols(Protocols) of
+                        [] -> Req0;
+                        [StompProtocol|_] ->
+                            cowboy_req:set_resp_header(<<"sec-websocket-protocol">>,
+                                StompProtocol, Req0)
+                    end
+            end,
+            WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
+            WsOpts  = maps:merge(#{compress => true}, WsOpts0),
+            {?MODULE, Req, #state{
+                frame_type         = proplists:get_value(type, Opts, text),
+                heartbeat_sup      = KeepaliveSup,
+                heartbeat          = {none, none},
+                heartbeat_mode     = heartbeat,
+                state              = running,
+                conserve_resources = false,
+                socket             = SockInfo,
+                peername           = PeerAddr,
+                auth_hd            = cowboy_req:header(<<"authorization">>, Req)
+            }, WsOpts#{data_delivery => relay}};
+        {error, origin_not_allowed} ->
+            ?LOG_WARNING("Web STOMP: WebSocket connection rejected, "
+                         "origin not in allow_origins: ~tp",
+                         [cowboy_req:header(<<"origin">>, Req0)]),
+            {ok,
+             cowboy_req:reply(403, #{<<"connection">> => <<"close">>}, Req0),
+             #state{}}
+    end.
 
 websocket_init(State) ->
     process_flag(trap_exit, true),
@@ -330,6 +340,22 @@ safe_terminate(Pid) ->
     end.
 
 %%----------------------------------------------------------------------------
+
+check_origin(Req) ->
+    case application:get_env(?APP, allow_origins, []) of
+        [] ->
+            ok;
+        AllowedOrigins ->
+            case cowboy_req:header(<<"origin">>, Req) of
+                undefined ->
+                    ok;
+                Origin ->
+                    case lists:member(binary_to_list(Origin), AllowedOrigins) of
+                        true -> ok;
+                        false -> {error, origin_not_allowed}
+                    end
+            end
+    end.
 
 %% The protocols v10.stomp, v11.stomp and v12.stomp are registered
 %% at IANA: https://www.iana.org/assignments/websocket/websocket.xhtml

--- a/deps/rabbitmq_web_stomp/test/origin_SUITE.erl
+++ b/deps/rabbitmq_web_stomp/test/origin_SUITE.erl
@@ -1,0 +1,150 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+%%
+
+-module(origin_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ALLOWED, "https://allowed.example.com").
+-define(ALLOWED2, "https://other.example.com").
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [no_allowlist_allows_any_origin,
+     allowed_origin_connects,
+     disallowed_origin_rejected,
+     no_origin_header_allowed_when_allowlist_set,
+     multiple_allowed_origins].
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    Config1 = rabbit_ct_helpers:set_config(Config,
+                                           [{rmq_nodename_suffix, ?MODULE},
+                                            {protocol, "ws"}]),
+    rabbit_ct_helpers:run_setup_steps(
+      Config1,
+      rabbit_ct_broker_helpers:setup_steps()).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(
+      Config,
+      rabbit_ct_broker_helpers:teardown_steps()).
+
+init_per_testcase(no_allowlist_allows_any_origin, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, unset_env, [rabbitmq_web_stomp, allow_origins]),
+    Config;
+init_per_testcase(multiple_allowed_origins, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_stomp, allow_origins,
+                              [?ALLOWED, ?ALLOWED2]]),
+    Config;
+init_per_testcase(_Testcase, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, set_env, [rabbitmq_web_stomp, allow_origins,
+                              [?ALLOWED]]),
+    Config.
+
+end_per_testcase(_Testcase, Config) ->
+    rabbit_ct_broker_helpers:rpc(
+      Config, 0,
+      application, unset_env, [rabbitmq_web_stomp, allow_origins]),
+    Config.
+
+%% When no allowlist is configured, any Origin is accepted.
+no_allowlist_allows_any_origin(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    WS = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws",
+                            self(), undefined, [], <<>>,
+                            [{"Origin", "https://evil.example.com"}]),
+    {ok, _} = rfc6455_client:open(WS),
+    ok = raw_send(WS, "CONNECT", [{"login", "guest"}, {"passcode", "guest"}]),
+    {ok, _} = rfc6455_client:recv(WS),
+    ok = raw_send(WS, "DISCONNECT", []),
+    {close, {1000, _}} = rfc6455_client:recv(WS),
+    ok.
+
+%% A client presenting a matching Origin is accepted.
+allowed_origin_connects(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    WS = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws",
+                            self(), undefined, [], <<>>,
+                            [{"Origin", ?ALLOWED}]),
+    {ok, _} = rfc6455_client:open(WS),
+    ok = raw_send(WS, "CONNECT", [{"login", "guest"}, {"passcode", "guest"}]),
+    {ok, _} = rfc6455_client:recv(WS),
+    ok = raw_send(WS, "DISCONNECT", []),
+    {close, {1000, _}} = rfc6455_client:recv(WS),
+    ok.
+
+%% A client presenting a non-matching Origin gets HTTP 403.
+disallowed_origin_rejected(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, [{"Origin", "https://evil.example.com"}]),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"403">>)).
+
+%% When an allowlist is set, requests without an Origin header
+%% are still accepted (they originate from non-browser clients).
+no_origin_header_allowed_when_allowlist_set(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+    Resp = raw_ws_upgrade(Port, []),
+    ?assertNotEqual(nomatch, binary:match(Resp, <<"101">>)).
+
+%% When multiple origins are configured, each one is accepted.
+multiple_allowed_origins(Config) ->
+    PortStr = rabbit_ws_test_util:get_web_stomp_port_str(Config),
+    Port = list_to_integer(PortStr),
+
+    Resp1 = raw_ws_upgrade(Port, [{"Origin", ?ALLOWED}]),
+    ?assertNotEqual(nomatch, binary:match(Resp1, <<"101">>)),
+
+    Resp2 = raw_ws_upgrade(Port, [{"Origin", ?ALLOWED2}]),
+    ?assertNotEqual(nomatch, binary:match(Resp2, <<"101">>)),
+
+    Resp3 = raw_ws_upgrade(Port, [{"Origin", "https://evil.example.com"}]),
+    ?assertNotEqual(nomatch, binary:match(Resp3, <<"403">>)).
+
+%%
+%% Helpers
+%%
+
+raw_send(WS, Command, Headers) ->
+    Frame = stomp:marshal(Command, Headers, <<>>),
+    rfc6455_client:send(WS, Frame).
+
+raw_ws_upgrade(Port, Headers) ->
+    {ok, Sock} = gen_tcp:connect({127, 0, 0, 1}, Port,
+                                 [binary, {active, false}]),
+    Key = base64:encode(crypto:strong_rand_bytes(16)),
+    OriginHd = case lists:keyfind("Origin", 1, Headers) of
+        {_, Val} -> ["Origin: ", Val, "\r\n"];
+        false -> []
+    end,
+    Req = [
+        "GET /ws HTTP/1.1\r\n",
+        "Host: 127.0.0.1:", integer_to_list(Port), "\r\n",
+        "Upgrade: websocket\r\n",
+        "Connection: Upgrade\r\n",
+        OriginHd,
+        "Sec-WebSocket-Key: ", Key, "\r\n",
+        "Sec-WebSocket-Protocol: v12.stomp\r\n",
+        "Sec-WebSocket-Version: 13\r\n",
+        "\r\n"
+    ],
+    ok = gen_tcp:send(Sock, Req),
+    {ok, Resp} = gen_tcp:recv(Sock, 0, 5000),
+    gen_tcp:close(Sock),
+    Resp.


### PR DESCRIPTION
For each plugin, this introduces a configurable set of allowed Origin header values (not set by default, meaning no restrictions, a backwards-compatible behavior):

 * `web_mqtt.allow_origins.*`
 * `web_stomp.allow_origins.*`
 
 They mimic `management.cors.allow_origins.*`.
 