### PR TITLE
Limit heap size for unauthenticated connections

### DIFF
--- a/deps/rabbit/src/rabbit_access_control.erl
+++ b/deps/rabbit/src/rabbit_access_control.erl
@@ -16,6 +16,8 @@
          check_user_id/2]).
 
 -export([permission_cache_can_expire/1, update_state/2, expiry_timestamp/1]).
+-export([set_max_heap_size_unauthenticated/1,
+         clear_max_heap_size/0]).
 
 %%----------------------------------------------------------------------------
 
@@ -450,3 +452,22 @@ expiry_timestamp(User = #user{authz_backends = Modules}) ->
                                 Ts0
                         end
                 end, never, Modules).
+
+%% Limit heap size for unauthenticated connections as a defense-in-depth
+%% mechanism to protect the RabbitMQ node against pre-authentication memory
+%% exhaustion attacks.
+-spec set_max_heap_size_unauthenticated(atom()) -> ok.
+set_max_heap_size_unauthenticated(App) ->
+    %% 16 MiB by default
+    Default = 16 * 1024 * 1024 div erlang:system_info(wordsize),
+    Size = application:get_env(App, max_heap_size_unauthenticated, Default),
+    _ = erlang:process_flag(max_heap_size, #{size => Size,
+                                             kill => true,
+                                             error_logger => true}),
+    ok.
+
+-spec clear_max_heap_size() -> ok.
+clear_max_heap_size() ->
+    %% "If set to zero, the heap size limit is disabled."
+    _ = erlang:process_flag(max_heap_size, 0),
+    ok.

--- a/deps/rabbit/src/rabbit_amqp_reader.erl
+++ b/deps/rabbit/src/rabbit_amqp_reader.erl
@@ -772,12 +772,13 @@ auth_phase(
         {protocol_error, Msg, Args} ->
             auth_fail(none, State),
             protocol_error(?V_1_0_AMQP_ERROR_DECODE_ERROR, Msg, Args);
-        {challenge, Challenge, AuthState1} ->
-            Challenge = #'v1_0.sasl_challenge'{challenge = {binary, Challenge}},
+        {challenge, ChallengeBin, AuthState1} ->
+            Challenge = #'v1_0.sasl_challenge'{challenge = {binary, ChallengeBin}},
             ok = send_on_channel0(State, Challenge, rabbit_amqp_sasl),
             State1 = State#v1{connection = Conn#v1_connection{auth_state = AuthState1}},
             switch_callback(State1, {frame_header, sasl}, 8);
         {ok, User} ->
+            rabbit_access_control:clear_max_heap_size(),
             Outcome = #'v1_0.sasl_outcome'{code = ?V_1_0_SASL_CODE_OK},
             ok = send_on_channel0(State, Outcome, rabbit_amqp_sasl),
             State1 = State#v1{connection_state = waiting_amqp0100,

--- a/deps/rabbit/src/rabbit_reader.erl
+++ b/deps/rabbit/src/rabbit_reader.erl
@@ -162,9 +162,9 @@ shutdown(Pid, Explanation) ->
 init(Parent, HelperSups, Ref) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN}),
     ?LG_PROCESS_TYPE(reader),
-    {ok, Sock} = rabbit_networking:handshake(Ref,
-        application:get_env(rabbit, proxy_protocol, false),
-        dynamic_buffer),
+    rabbit_access_control:set_max_heap_size_unauthenticated(rabbit),
+    ProxyProtocolEnabled = application:get_env(rabbit, proxy_protocol, false),
+    {ok, Sock} = rabbit_networking:handshake(Ref, ProxyProtocolEnabled, dynamic_buffer),
     Deb = sys:debug_options([]),
     start_connection(Parent, HelperSups, Ref, Deb, Sock).
 
@@ -1539,6 +1539,7 @@ auth_phase(Response,
             State#v1{connection = Connection#connection{
                                     auth_state = AuthState1}};
         {ok, User = #user{username = Username}} ->
+            rabbit_access_control:clear_max_heap_size(),
             case rabbit_access_control:check_user_loopback(Username, PeerHost) of
                 ok ->
                     rabbit_core_metrics:auth_attempt_succeeded(RemoteAddress, Username, amqp091),

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_processor.erl
@@ -199,6 +199,7 @@ process_connect(
         ok ?= check_vhost_connection_limit(VHost),
         {ok, User = #user{username = Username}} ?= check_user_login(VHost, Username2, Password,
                                                                     ClientId, PeerIp, ConnName0),
+        rabbit_access_control:clear_max_heap_size(),
         ok ?= check_user_connection_limit(Username),
         {ok, AuthzCtx} ?= check_vhost_access(VHost, User, ClientId, PeerIp),
         ok ?= check_user_loopback(Username, PeerIp),

--- a/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
+++ b/deps/rabbitmq_mqtt/src/rabbit_mqtt_reader.erl
@@ -71,6 +71,7 @@ close_connection(Pid, Reason) ->
 init(Ref) ->
     process_flag(trap_exit, true),
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN ++ [mqtt]}),
+    rabbit_access_control:set_max_heap_size_unauthenticated(?APP_NAME),
     {ok, Sock} = rabbit_networking:handshake(Ref,
         application:get_env(?APP_NAME, proxy_protocol, false)),
     RealSocket = rabbit_net:unwrap_socket(Sock),

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_processor.erl
@@ -590,6 +590,7 @@ do_login(Username, Passwd, VirtualHost, Heartbeat, AdapterInfo, Version,
                                virtual_host = VirtualHost,
                                adapter_info = AdapterInfo}, Username, Addr) of
         {ok, Connection} ->
+            rabbit_access_control:clear_max_heap_size(),
             link(Connection),
             {ok, Channel} = amqp_connection:open_channel(Connection),
             link(Channel),

--- a/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
+++ b/deps/rabbitmq_stomp/src/rabbit_stomp_reader.erl
@@ -67,6 +67,7 @@ close_connection(Pid, Reason) ->
 init([SupHelperPid, Ref, Configuration]) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN}),
     process_flag(trap_exit, true),
+    rabbit_access_control:set_max_heap_size_unauthenticated(rabbitmq_stomp),
     {ok, Sock} = rabbit_networking:handshake(Ref,
         application:get_env(rabbitmq_stomp, proxy_protocol, false)),
     RealSocket = rabbit_net:unwrap_socket(Sock),

--- a/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
+++ b/deps/rabbitmq_stream/src/rabbit_stream_reader.erl
@@ -146,6 +146,7 @@ init([KeepaliveSup,
         transport := ConnTransport}]) ->
     process_flag(trap_exit, true),
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN}),
+    rabbit_access_control:set_max_heap_size_unauthenticated(rabbitmq_stream),
     {ok, Sock} =
         rabbit_networking:handshake(Ref,
                                     application:get_env(rabbitmq_stream,
@@ -1408,6 +1409,7 @@ handle_frame_pre_auth(Transport,
                              {sasl_authenticate, ?RESPONSE_SASL_CHALLENGE,
                               Challenge}};
                         {ok, User = #user{username = Username}} ->
+                            rabbit_access_control:clear_max_heap_size(),
                             case
                                 rabbit_access_control:check_user_loopback(Username,
                                                                           PeerHost)

--- a/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
+++ b/deps/rabbitmq_web_mqtt/src/rabbit_web_mqtt_handler.erl
@@ -142,11 +142,13 @@ info(Pid, all) ->
 info(Pid, Items) ->
     {ok, Res} = gen:call(Pid, ?MODULE, {info, Items}),
     Res.
+
 -spec websocket_init(state()) ->
     {cowboy_websocket:commands(), state()} |
     {cowboy_websocket:commands(), state(), hibernate}.
 websocket_init(State0 = #state{socket = Sock}) ->
     logger:set_process_metadata(#{domain => ?RMQLOG_DOMAIN_CONN ++ [web_mqtt]}),
+    rabbit_access_control:set_max_heap_size_unauthenticated(?APP_NAME),
     case rabbit_net:connection_string(Sock, inbound) of
         {ok, ConnStr} ->
             ConnName = rabbit_data_coercion:to_binary(ConnStr),

--- a/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
+++ b/deps/rabbitmq_web_stomp/src/rabbit_web_stomp_handler.erl
@@ -140,6 +140,7 @@ init(Req0, Opts) ->
 
 websocket_init(State) ->
     process_flag(trap_exit, true),
+    rabbit_access_control:set_max_heap_size_unauthenticated(rabbitmq_web_stomp),
     {ok, ProcessorState} = init_processor_state(State),
     LoginTimeout = application:get_env(rabbitmq_stomp, login_timeout, 10_000),
     erlang:send_after(LoginTimeout, self(), login_timeout),


### PR DESCRIPTION
This commit introduces a defense-in-depth mechanism to protect the RabbitMQ node against pre-authentication memory exhaustion attacks. Malicious actors can attempt to exploit protocol parsers by sending specially crafted payloads before authenticating.

To mitigate against any kind of such attachs, we now enforce a strict `max_heap_size` limit on all connection processes during the handshake and authentication phase. By default, this is set to 16 MiB. If a process exceeds this limit, the Erlang VM will immediately terminate it (`kill => true`), protecting the rest of the node.

Once a client successfully authenticates, the heap size limit is cleared (`erlang:process_flag(max_heap_size, 0)`). This ensures that authenticated clients can still process large, legitimate messages without being artificially constrained.

This protection is applied consistently across all protocol readers: AMQP 0-9-1, AMQP 1.0, MQTT, STOMP, Stream, Web MQTT, and Web STOMP. The limit is configurable per-application via the
`max_heap_size_unauthenticated` environment variable (specified in words).