### PR TITLE
Support AMQP 1.0 arrays with zero-width element constructors

### DIFF
--- a/deps/amqp10_common/src/amqp10_binary_generator.erl
+++ b/deps/amqp10_common/src/amqp10_binary_generator.erl
@@ -211,7 +211,7 @@ generate2(boolean, true) -> 16#01;
 generate2(boolean, false) -> 16#00;
 generate2(boolean, {boolean, true}) -> 16#01;
 generate2(boolean, {boolean, false}) -> 16#00;
-generate2(null, null) -> 16#40;
+generate2(null, null) -> <<>>;
 generate2(char, {char,V}) when V>=0 andalso V=<16#10ffff -> <<V:32>>;
 generate2(ubyte, {ubyte, V}) -> V;
 generate2(byte, {byte, V}) -> <<V:8/signed>>;

--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -121,8 +121,6 @@ parse(<<16#94, V:16/binary, _/binary>>, B) ->
 parse(<<Type, _/binary>>, B) ->
     throw({primitive_type_unsupported, Type, {position, B}}).
 
-%% array structure is {array, Ctor, [Data]}
-%% e.g. {array, symbol, [<<"amqp:accepted:list">>]}
 parse_array(UnitSize, Bin) ->
     <<Count:UnitSize, Bin1/binary>> = Bin,
     parse_array1(Count, Bin1).
@@ -136,6 +134,17 @@ parse_array1(Count, <<?DESCRIBED, Rest/binary>>) ->
                        end, List),
     % this format cannot represent an empty array of described types
     {array, {described, Descriptor, Type}, Values};
+parse_array1(Count, <<Type, ArrayBin/binary>>)
+  when Type >= 16#40 andalso Type =< 16#45 ->
+    %% This is an array that must have zero octets of data.
+    if byte_size(ArrayBin) > 0 ->
+           exit({failed_to_parse_array_extra_input_remaining, Type, byte_size(ArrayBin)});
+       Count > 10_000 ->
+           exit({failed_to_parse_array_count_exceeds_limit, Type, Count});
+       true ->
+           {Value, _} = parse_array_primitive(Type, <<>>),
+           {array, parse_constructor(Type), lists:duplicate(Count, Value)}
+    end;
 parse_array1(Count, <<Type, ArrayBin/binary>>)
   when Count > byte_size(ArrayBin) ->
     exit({failed_to_parse_array_count_exceeds_input, Type, Count, byte_size(ArrayBin)});
@@ -171,6 +180,11 @@ parse_constructor(16#82) -> double;
 parse_constructor(?CODE_ULONG) -> ulong;
 parse_constructor(16#81) -> long;
 parse_constructor(16#40) -> null;
+parse_constructor(16#41) -> boolean;
+parse_constructor(16#42) -> boolean;
+parse_constructor(16#43) -> uint;
+parse_constructor(16#44) -> ulong;
+parse_constructor(16#45) -> list;
 parse_constructor(16#56) -> boolean;
 parse_constructor(16#83) -> timestamp;
 parse_constructor(16#98) -> uuid;
@@ -181,11 +195,6 @@ parse_constructor(0) -> described;
 parse_constructor(X) ->
     exit({failed_to_parse_constructor, X}).
 
-parse_array_primitive(16#40, <<_:8/unsigned, _/binary>>) -> {null, 1};
-parse_array_primitive(16#41, <<_:8/unsigned, _/binary>>) -> {true, 1};
-parse_array_primitive(16#42, <<_:8/unsigned, _/binary>>) -> {false, 1};
-parse_array_primitive(16#43, <<_:8/unsigned, _/binary>>) -> {{uint, 0}, 1};
-parse_array_primitive(16#44, <<_:8/unsigned, _/binary>>) -> {{ulong, 0}, 1};
 parse_array_primitive(ElementType, Data) ->
     {Val, B} = parse(<<ElementType, Data/binary>>),
     {Val, B-1}.

--- a/deps/amqp10_common/src/amqp10_binary_parser.erl
+++ b/deps/amqp10_common/src/amqp10_binary_parser.erl
@@ -35,6 +35,7 @@
 -define(DESCRIPTOR_CODE_DATA, 16#75).
 -define(DESCRIPTOR_CODE_AMQP_SEQUENCE, 16#76).
 -define(DESCRIPTOR_CODE_AMQP_VALUE, 16#77).
+-define(MAX_ZERO_WIDTH_ARRAY_COUNT, 10_000).
 
 
 %% server_mode is a special parsing mode used by RabbitMQ when parsing
@@ -139,7 +140,7 @@ parse_array1(Count, <<Type, ArrayBin/binary>>)
     %% This is an array that must have zero octets of data.
     if byte_size(ArrayBin) > 0 ->
            exit({failed_to_parse_array_extra_input_remaining, Type, byte_size(ArrayBin)});
-       Count > 10_000 ->
+       Count > ?MAX_ZERO_WIDTH_ARRAY_COUNT ->
            exit({failed_to_parse_array_count_exceeds_limit, Type, Count});
        true ->
            {Value, _} = parse_array_primitive(Type, <<>>),

--- a/deps/amqp10_common/test/binary_parser_SUITE.erl
+++ b/deps/amqp10_common/test/binary_parser_SUITE.erl
@@ -22,6 +22,7 @@ all_tests() ->
      roundtrip,
      array_with_extra_input,
      array32_count_exceeds_data,
+     array_of_zero_width_elements,
      unsupported_type,
      peek_described_section_total_sizes,
      peek_described_section,
@@ -51,6 +52,9 @@ roundtrip(_Config) ->
                {binary, <<"inner value">>}},
               {binary, <<"outer value">>}},
              {array, ubyte, [{ubyte, 1}, {ubyte, 255}]},
+             {array, boolean, [true, false, true]},
+             {array, null, [null, null, null]},
+             {array, null, []},
              true,
              {list, [{utf8, <<"hi">>},
                      {described,
@@ -80,8 +84,8 @@ array_with_extra_input(_Config) ->
     Bin = <<83,16,192,85,10,177,0,0,0,1,48,161,12,114,97,98,98,105,116, 109,113,45,98,111,120,112,255,255,0,0,96,0,50,112,0,0,19,136,163,5,101,110,45,85,83,224,14,2,65,5,102,105,45,70,73,5,101,110,45,85,83,64,64,193,24,2,163,20,68,69,70,69,78,83,73,67,83,46,84,69,83,84,46,83,85,73,84,69,65>>,
 
     Expected = {failed_to_parse_array_extra_input_remaining,
-                %% element type, input, accumulated result
-                65, <<105,45,70,73,5,101,110,45,85,83>>, [true,true]},
+                %% element type, remaining input size
+                65, 12},
 
     ?assertExit(Expected, amqp10_binary_parser:parse_many(Bin, [])).
 
@@ -92,7 +96,7 @@ array32_count_exceeds_data(_Config) ->
     Size = byte_size(ArrayPayload),
     Bin = <<16#f0, Size:32, ArrayPayload/binary>>,
     ?assertExit(
-       {failed_to_parse_array_count_exceeds_input, Type, Count, 0},
+       {failed_to_parse_array_count_exceeds_limit, Type, Count},
        amqp10_binary_parser:parse(Bin)),
     %% Also verify smaller mismatches are caught: 10 elements but only 3 data bytes
     SmallType = 16#50,
@@ -102,6 +106,26 @@ array32_count_exceeds_data(_Config) ->
     ?assertExit(
        {failed_to_parse_array_count_exceeds_input, SmallType, 10, 3},
        amqp10_binary_parser:parse(SmallBin)).
+
+array_of_zero_width_elements(_Config) ->
+    %% Array8 (0xe0), Size=2, Count=10, Null Constructor=0x40 (width 0)
+    {Parsed40, 4} = amqp10_binary_parser:parse(<<16#e0, 2, 10, 16#40>>),
+    ?assertEqual({array, null, lists:duplicate(10, null)}, Parsed40),
+
+    {Parsed41, 4} = amqp10_binary_parser:parse(<<16#e0, 2, 10, 16#41>>),
+    ?assertEqual({array, boolean, lists:duplicate(10, true)}, Parsed41),
+
+    {Parsed42, 4} = amqp10_binary_parser:parse(<<16#e0, 2, 10, 16#42>>),
+    ?assertEqual({array, boolean, lists:duplicate(10, false)}, Parsed42),
+
+    {Parsed43, 4} = amqp10_binary_parser:parse(<<16#e0, 2, 10, 16#43>>),
+    ?assertEqual({array, uint, lists:duplicate(10, {uint, 0})}, Parsed43),
+
+    {Parsed44, 4} = amqp10_binary_parser:parse(<<16#e0, 2, 10, 16#44>>),
+    ?assertEqual({array, ulong, lists:duplicate(10, {ulong, 0})}, Parsed44),
+
+    {Parsed45, 4} = amqp10_binary_parser:parse(<<16#e0, 2, 10, 16#45>>),
+    ?assertEqual({array, list, lists:duplicate(10, {list, []})}, Parsed45).
 
 unsupported_type(_Config) ->
     UnsupportedType = 16#02,


### PR DESCRIPTION
 ## What?
* Update `amqp10_binary_parser` to correctly parse arrays that use zero-width element constructors (`0x40` through `0x45`).
* Add missing constructor mappings for `0x41` through `0x45` (booleans, uint0, ulong0, list0) to prevent parsing errors.
* Fix `amqp10_binary_generator` to correctly serialize `null` array elements as zero bytes.

 ## Why?
* The AMQP 1.0 specification allows arrays to use constructors that encode their data in zero bytes (such as `null`, `true`, `false`, `uint0`, `ulong0`, and `list0`).
* Previously, the parser and serializer incorrectly handled these arrays.
