### PR TITLE
Fix consumer count for quorum queues in queue.declare

### DIFF
--- a/deps/rabbit/src/rabbit_fifo_client.erl
+++ b/deps/rabbit/src/rabbit_fifo_client.erl
@@ -579,7 +579,7 @@ stat(Leader, Timeout) ->
     %% but we use it for backwards compatibilty
     case ra:member_overview(Leader, Timeout) of
       {ok, #{machine := #{num_ready_messages := R,
-                          num_checked_out := C}}, _} ->
+                          num_consumers := C}}, _} ->
             {ok, R, C};
       {error, _} = Error ->
             Error;

--- a/deps/rabbit/test/quorum_queue_SUITE.erl
+++ b/deps/rabbit/test/quorum_queue_SUITE.erl
@@ -216,6 +216,7 @@ all_tests() ->
      consumer_priorities,
      cancel_consumer_gh_3729,
      cancel_consumer_gh_12424,
+     queue_declare_passive_consumer_count,
      cancel_and_consume_with_same_tag,
      validate_messages_on_queue,
      amqpl_headers,
@@ -5239,6 +5240,30 @@ cancel_consumer_gh_12424(Config) ->
     R = #'basic.reject'{delivery_tag = DeliveryTag, requeue = false},
     ok = amqp_channel:cast(Ch, R),
     wait_for_messages(Config, [[QQ, <<"0">>, <<"0">>, <<"0">>]]),
+
+    ok.
+
+queue_declare_passive_consumer_count(Config) ->
+    QQ = ?config(queue_name, Config),
+
+    Server = rabbit_ct_broker_helpers:get_node_config(Config, 0, nodename),
+    Ch = rabbit_ct_client_helpers:open_channel(Config, Server),
+
+    ExpectedDeclareRslt0 = #'queue.declare_ok'{queue = QQ, message_count = 0, consumer_count = 0},
+    DeclareRslt0 = declare(Ch, QQ, [{<<"x-queue-type">>, longstr, <<"quorum">>}]),
+    ?assertMatch(ExpectedDeclareRslt0, DeclareRslt0),
+
+    ok = subscribe(Ch, QQ, false),
+
+    ExpectedDeclareRslt1 = #'queue.declare_ok'{queue = QQ, message_count = 0, consumer_count = 1},
+    DeclareRslt1 = amqp_channel:call(Ch, #'queue.declare'{queue = QQ, passive = true}),
+    ?assertMatch(ExpectedDeclareRslt1, DeclareRslt1),
+
+    ok = cancel(Ch),
+
+    ExpectedDeclareRslt2 = #'queue.declare_ok'{queue = QQ, message_count = 0, consumer_count = 0},
+    DeclareRslt2 = amqp_channel:call(Ch, #'queue.declare'{queue = QQ, passive = true}),
+    ?assertMatch(ExpectedDeclareRslt2, DeclareRslt2),
 
     ok.
 


### PR DESCRIPTION
Previously, `rabbit_fifo_client:stat/2` incorrectly returned the number of checked out messages (`num_checked_out`) instead of the actual number of consumers (`num_consumers`). This caused `queue.declare` operations on quorum queues to return the unacknowledged message count in the `consumer_count` field rather than the true number of active consumers.

This commit:
- Updates `rabbit_fifo_client:stat/2` to correctly extract `num_consumers` from the ra machine overview.
- Adds `queue_declare_passive_consumer_count` to `quorum_queue_SUITE` to verify that passive declares return the correct consumer count when subscribing and cancelling consumers.

